### PR TITLE
fix: reconcile active AICoding repo bridge mappings

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
@@ -1,0 +1,166 @@
+"""AICoding 已激活布局的 Engine-owned bridge 修复请求。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    local_skill_name,
+)
+from agentclaw.community.core.skills_pool.models import PoolCutoverStatus
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+)
+
+
+class ActiveAICodingBridgeRepairStatus(StrEnum):
+    REPAIRED = "repaired"
+    MAPPING_INVALID = "mapping_invalid"
+    ENGINE_REJECTED = "engine_rejected"
+    PROBE_NOT_READY = "probe_not_ready"
+    IDENTITY_MISMATCH = "identity_mismatch"
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveAICodingBridgeRepairResult:
+    status: ActiveAICodingBridgeRepairStatus
+    evidence: dict[str, object]
+    preparation_id: str | None
+    retryable: bool = False
+    cutover_status: PoolCutoverStatus | None = None
+    probe_status: RuntimeLayoutProbeStatus | None = None
+
+
+async def request_active_aicoding_bridge_repair(
+    *,
+    skills: SkillsPoolSkillRepositoryProtocol,
+    runtime: SkillsPoolRuntimeProtocol,
+    scope: BotSkillLayoutScope,
+    state: BotSkillLayoutState,
+    bot_id: str,
+    user_id: str,
+    engine: str,
+    initial_probe: RuntimeLayoutProbeResult,
+) -> ActiveAICodingBridgeRepairResult:
+    """Ask the Engine to repair only a bridge it can prove is trusted.
+
+    Backend sends current logical mapping intent, but never classifies the
+    invalid filesystem entry itself.  The Engine activation operation is the
+    authority that either rewrites the historical stable repo bridge or
+    rejects every other Legacy/dangling/unknown form.
+    """
+
+    generation = state.migration_generation
+    if generation is None or state.preparation_id is None:
+        return ActiveAICodingBridgeRepairResult(
+            ActiveAICodingBridgeRepairStatus.IDENTITY_MISMATCH,
+            {
+                "reason": "active_runtime_identity_mismatch",
+                "initial_probe": initial_probe.evidence,
+            },
+            preparation_id=None,
+        )
+    try:
+        registered_local_names = [
+            local_skill_name(asset)
+            for asset in skills.list_bot_local_assets(
+                env=scope.env,
+                bot_id=scope.bot_id,
+            )
+        ]
+        mappings = build_logical_skill_mappings(
+            skills.list_bot_active_assets(
+                env=scope.env,
+                bot_id=scope.bot_id,
+                user_id=user_id,
+                engine=engine,
+            )
+        )
+    except ValueError as error:
+        return ActiveAICodingBridgeRepairResult(
+            ActiveAICodingBridgeRepairStatus.MAPPING_INVALID,
+            {"reason": str(error)},
+            preparation_id=state.preparation_id,
+        )
+
+    repair = await runtime.cutover(
+        bot_id=bot_id,
+        user_id=user_id,
+        migration_generation=generation,
+        preparation_id=state.preparation_id,
+        registered_local_names=registered_local_names,
+        mappings=mappings,
+    )
+    if not repair.committed:
+        return ActiveAICodingBridgeRepairResult(
+            ActiveAICodingBridgeRepairStatus.ENGINE_REJECTED,
+            {
+                "initial_probe": initial_probe.evidence,
+                "engine_repair": repair.to_dict(),
+            },
+            preparation_id=state.preparation_id,
+            cutover_status=repair.status,
+        )
+
+    refreshed_probe = await runtime.probe(
+        bot_id=bot_id,
+        user_id=user_id,
+        engine=engine,
+    )
+    if refreshed_probe.status is not RuntimeLayoutProbeStatus.READY:
+        return ActiveAICodingBridgeRepairResult(
+            ActiveAICodingBridgeRepairStatus.PROBE_NOT_READY,
+            {
+                "reason": "active_aicoding_bridge_reconciliation_incomplete",
+                "initial_probe": initial_probe.evidence,
+                "post_publish_probe": refreshed_probe.evidence,
+            },
+            preparation_id=refreshed_probe.preparation_id,
+            retryable=(
+                refreshed_probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+            ),
+            probe_status=refreshed_probe.status,
+        )
+    if (
+        refreshed_probe.engine != engine
+        or refreshed_probe.preparation_id is None
+        or refreshed_probe.preparation_id != state.preparation_id
+        or refreshed_probe.layout_contract_version != state.layout_contract_version
+    ):
+        return ActiveAICodingBridgeRepairResult(
+            ActiveAICodingBridgeRepairStatus.IDENTITY_MISMATCH,
+            {
+                "reason": "active_runtime_identity_mismatch",
+                "initial_probe": initial_probe.evidence,
+                "post_publish_probe": refreshed_probe.evidence,
+            },
+            preparation_id=refreshed_probe.preparation_id,
+        )
+    return ActiveAICodingBridgeRepairResult(
+        ActiveAICodingBridgeRepairStatus.REPAIRED,
+        {
+            **refreshed_probe.evidence,
+            "active_aicoding_bridge_reconciled": True,
+            "reconciled_mapping_count": len(mappings),
+            "engine_repair": repair.to_dict(),
+        },
+        preparation_id=refreshed_probe.preparation_id,
+    )
+
+
+__all__ = [
+    "ActiveAICodingBridgeRepairResult",
+    "ActiveAICodingBridgeRepairStatus",
+    "request_active_aicoding_bridge_repair",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
@@ -37,14 +37,12 @@ def is_aicoding_active_mapping_reconciliation_candidate(
     engine: str,
     probe: RuntimeLayoutProbeResult,
 ) -> bool:
-    """Allow one idempotent mapping republish for the retired repo bridge form.
+    """Allow the runtime to evaluate one retired repo-bridge repair.
 
     The old AICoding migration wrote active repo Skills through the stable
     ``~/.aicoding/skills-repo`` bridge.  New probes deliberately reject that
-    indirect target, but the current Pool mapping publisher can rewrite every
-    *currently managed* entry to its direct canonical Pool source.  This is
-    not a general INVALID bypass: the Engine remains the authority for the
-    mapping publish and the caller must probe again before reporting READY.
+    indirect target. The Backend delegates the exact bridge classification and
+    rewrite to the Engine, then probes again before reporting READY.
     """
 
     return (
@@ -56,8 +54,6 @@ def is_aicoding_active_mapping_reconciliation_candidate(
         and probe.layout_contract_version == state.layout_contract_version
         and probe.preparation_id == state.preparation_id
         and probe.evidence.get("reason") == "active_managed_entry_invalid"
-        and probe.evidence.get("implementation_engine") == "aicoding"
-        and probe.evidence.get("physical_layout_engine") == "aicoding"
     )
 
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/aicoding_retirement.py
@@ -31,6 +31,36 @@ def is_trusted_aicoding_repo_retirement_resume(
     )
 
 
+def is_aicoding_active_mapping_reconciliation_candidate(
+    *,
+    state: BotSkillLayoutState,
+    engine: str,
+    probe: RuntimeLayoutProbeResult,
+) -> bool:
+    """Allow one idempotent mapping republish for the retired repo bridge form.
+
+    The old AICoding migration wrote active repo Skills through the stable
+    ``~/.aicoding/skills-repo`` bridge.  New probes deliberately reject that
+    indirect target, but the current Pool mapping publisher can rewrite every
+    *currently managed* entry to its direct canonical Pool source.  This is
+    not a general INVALID bypass: the Engine remains the authority for the
+    mapping publish and the caller must probe again before reporting READY.
+    """
+
+    return (
+        state.phase is SkillLayoutPhase.POOL_ACTIVE
+        and state.data_plane_cutover_committed
+        and state.preparation_id is not None
+        and probe.status is RuntimeLayoutProbeStatus.INVALID
+        and probe.engine == engine
+        and probe.layout_contract_version == state.layout_contract_version
+        and probe.preparation_id == state.preparation_id
+        and probe.evidence.get("reason") == "active_managed_entry_invalid"
+        and probe.evidence.get("implementation_engine") == "aicoding"
+        and probe.evidence.get("physical_layout_engine") == "aicoding"
+    )
+
+
 def is_trusted_aicoding_repo_restoration_resume(
     *,
     state: BotSkillLayoutState,
@@ -52,6 +82,7 @@ def is_trusted_aicoding_repo_restoration_resume(
 
 
 __all__ = [
+    "is_aicoding_active_mapping_reconciliation_candidate",
     "is_trusted_aicoding_repo_restoration_resume",
     "is_trusted_aicoding_repo_retirement_resume",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -22,6 +22,10 @@ from agentclaw.community.core.skills_pool.aicoding_retirement import (
     is_aicoding_active_mapping_reconciliation_candidate,
     is_trusted_aicoding_repo_retirement_resume,
 )
+from agentclaw.community.core.skills_pool.active_aicoding_bridge_repair import (
+    ActiveAICodingBridgeRepairStatus,
+    request_active_aicoding_bridge_repair,
+)
 from agentclaw.community.core.skills_pool.models import (
     FILESYSTEM_POOL_ENGINES,
     PoolCutoverStatus,
@@ -33,6 +37,12 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
 )
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.reconcile_support import (
+    cutover_failure_profile,
+    persisted_cutover_evidence,
+    post_commit_cutover_failure_profile,
+    probe_outcome,
 )
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -234,7 +244,7 @@ class SkillsPoolReconcileService:
                         SkillsPoolReconcileOutcome.STATE_RACE_LOST
                     )
             return SkillsPoolReconcileResult(
-                self._probe_outcome(probe.status),
+                SkillsPoolReconcileOutcome(probe_outcome(probe.status)),
                 evidence=probe.evidence,
                 retryable=(probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR),
             )
@@ -359,7 +369,7 @@ class SkillsPoolReconcileService:
 
         cutover_finalizing = state.phase is SkillLayoutPhase.POOL_CUTOVER_FINALIZING
         repair_evidence_refresh = state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
-        locator_evidence = self._persisted_cutover_evidence(state)
+        locator_evidence = persisted_cutover_evidence(state)
         logger.info(
             "[skills_pool.reconcile] mapping intent ready bot_id=%s generation=%s "
             "phase=%s committed=%s local_count=%s mapping_count=%s",
@@ -416,8 +426,8 @@ class SkillsPoolReconcileService:
             if not cutover.committed:
                 evidence = cutover.to_dict()
                 if state.data_plane_cutover_committed:
-                    outcome, stage, retryable = (
-                        self._post_commit_cutover_failure_profile(cutover.status)
+                    outcome, stage, retryable = post_commit_cutover_failure_profile(
+                        cutover.status
                     )
                     recorded = self._layouts.record_post_cutover_failure(
                         scope=scope,
@@ -434,7 +444,7 @@ class SkillsPoolReconcileService:
                             preparation_id=probe.preparation_id,
                         )
                     return SkillsPoolReconcileResult(
-                        outcome,
+                        SkillsPoolReconcileOutcome(outcome),
                         preparation_id=probe.preparation_id,
                         evidence=evidence,
                         retryable=retryable,
@@ -481,7 +491,7 @@ class SkillsPoolReconcileService:
                         evidence=evidence,
                         retryable=False,
                     )
-                failure_profile = self._cutover_failure_profile(cutover.status)
+                failure_profile = cutover_failure_profile(cutover.status)
                 if failure_profile is not None:
                     outcome, stage, retryable = failure_profile
                     cutover_evidence = cutover.to_dict()
@@ -500,7 +510,7 @@ class SkillsPoolReconcileService:
                             preparation_id=probe.preparation_id,
                         )
                     return SkillsPoolReconcileResult(
-                        outcome,
+                        SkillsPoolReconcileOutcome(outcome),
                         preparation_id=probe.preparation_id,
                         evidence=cutover_evidence,
                         retryable=retryable,
@@ -812,7 +822,7 @@ class SkillsPoolReconcileService:
             )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
             return SkillsPoolReconcileResult(
-                self._probe_outcome(probe.status),
+                SkillsPoolReconcileOutcome(probe_outcome(probe.status)),
                 evidence=probe.evidence,
                 retryable=(probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR),
             )
@@ -881,194 +891,47 @@ class SkillsPoolReconcileService:
         engine: str,
         initial_probe: RuntimeLayoutProbeResult,
     ) -> SkillsPoolReconcileResult:
-        """Ask the Engine to repair only its trusted retired repo bridge.
-
-        Backend cannot tell whether ``active_managed_entry_invalid`` represents
-        the historical AICoding repo bridge or an unsafe Legacy/dangling entry.
-        The Engine activation operation owns that distinction and rejects every
-        other invalid form before changing active mappings.
-        """
-
-        generation = state.migration_generation
-        if generation is None or state.preparation_id is None:
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.INVALID,
-                evidence={
-                    "reason": "active_runtime_identity_mismatch",
-                    "initial_probe": initial_probe.evidence,
-                },
-                retryable=False,
-            )
-        try:
-            registered_local_names = [
-                local_skill_name(asset)
-                for asset in self._skills.list_bot_local_assets(
-                    env=scope.env,
-                    bot_id=scope.bot_id,
-                )
-            ]
-            mappings = build_logical_skill_mappings(
-                self._skills.list_bot_active_assets(
-                    env=scope.env,
-                    bot_id=scope.bot_id,
-                    user_id=user_id,
-                    engine=engine,
-                )
-            )
-        except ValueError as error:
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.INVALID,
-                evidence={"reason": str(error)},
-                retryable=False,
-            )
-        repair = await self._runtime.cutover(
-            bot_id=bot_id,
-            user_id=user_id,
-            migration_generation=generation,
-            preparation_id=state.preparation_id,
-            registered_local_names=registered_local_names,
-            mappings=mappings,
-        )
-        if not repair.committed:
-            outcome, _, retryable = self._post_commit_cutover_failure_profile(
-                repair.status
-            )
-            return SkillsPoolReconcileResult(
-                outcome,
-                evidence={
-                    "initial_probe": initial_probe.evidence,
-                    "engine_repair": repair.to_dict(),
-                },
-                retryable=retryable,
-            )
-        refreshed_probe = await self._runtime.probe(
+        repair = await request_active_aicoding_bridge_repair(
+            skills=self._skills,
+            runtime=self._runtime,
+            scope=scope,
+            state=state,
             bot_id=bot_id,
             user_id=user_id,
             engine=engine,
+            initial_probe=initial_probe,
         )
-        if refreshed_probe.status is not RuntimeLayoutProbeStatus.READY:
-            return SkillsPoolReconcileResult(
-                self._probe_outcome(refreshed_probe.status),
-                evidence={
-                    "reason": "active_aicoding_bridge_reconciliation_incomplete",
-                    "initial_probe": initial_probe.evidence,
-                    "post_publish_probe": refreshed_probe.evidence,
-                },
-                retryable=(
-                    refreshed_probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
-                ),
+        if repair.status is ActiveAICodingBridgeRepairStatus.ENGINE_REJECTED:
+            assert repair.cutover_status is not None
+            outcome, _, retryable = post_commit_cutover_failure_profile(
+                repair.cutover_status
             )
-        if (
-            refreshed_probe.engine != engine
-            or refreshed_probe.preparation_id is None
-            or refreshed_probe.preparation_id != state.preparation_id
-            or refreshed_probe.layout_contract_version != state.layout_contract_version
-        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome(outcome),
+                preparation_id=repair.preparation_id,
+                evidence=repair.evidence,
+                retryable=retryable,
+            )
+        if repair.status is ActiveAICodingBridgeRepairStatus.PROBE_NOT_READY:
+            assert repair.probe_status is not None
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome(probe_outcome(repair.probe_status)),
+                preparation_id=repair.preparation_id,
+                evidence=repair.evidence,
+                retryable=repair.retryable,
+            )
+        if repair.status is not ActiveAICodingBridgeRepairStatus.REPAIRED:
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.INVALID,
-                evidence={
-                    "reason": "active_runtime_identity_mismatch",
-                    "initial_probe": initial_probe.evidence,
-                    "post_publish_probe": refreshed_probe.evidence,
-                },
+                preparation_id=repair.preparation_id,
+                evidence=repair.evidence,
                 retryable=False,
             )
         return SkillsPoolReconcileResult(
             SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
-            preparation_id=refreshed_probe.preparation_id,
-            evidence={
-                **refreshed_probe.evidence,
-                "active_aicoding_bridge_reconciled": True,
-                "reconciled_mapping_count": len(mappings),
-                "engine_repair": repair.to_dict(),
-            },
+            preparation_id=repair.preparation_id,
+            evidence=repair.evidence,
         )
-
-    @staticmethod
-    def _probe_outcome(
-        status: RuntimeLayoutProbeStatus,
-    ) -> SkillsPoolReconcileOutcome:
-        return {
-            RuntimeLayoutProbeStatus.NOT_CAPABLE: (
-                SkillsPoolReconcileOutcome.NOT_CAPABLE
-            ),
-            RuntimeLayoutProbeStatus.TRANSIENT_ERROR: (
-                SkillsPoolReconcileOutcome.TRANSIENT_ERROR
-            ),
-            RuntimeLayoutProbeStatus.INVALID: SkillsPoolReconcileOutcome.INVALID,
-        }.get(status, SkillsPoolReconcileOutcome.INVALID)
-
-    @staticmethod
-    def _cutover_failure_profile(
-        status: PoolCutoverStatus,
-    ) -> tuple[SkillsPoolReconcileOutcome, str, bool] | None:
-        return {
-            PoolCutoverStatus.DATA_INCONSISTENT: (
-                SkillsPoolReconcileOutcome.DATA_INCONSISTENT,
-                "pre_cutover_validation",
-                False,
-            ),
-            PoolCutoverStatus.ACTIVE_ENTRY_CONFLICT: (
-                SkillsPoolReconcileOutcome.ACTIVE_ENTRY_CONFLICT,
-                "pre_cutover_validation",
-                False,
-            ),
-            PoolCutoverStatus.NOT_ATOMIC: (
-                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
-                "atomic_cutover",
-                False,
-            ),
-            PoolCutoverStatus.INVALID: (
-                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
-                "pre_cutover_validation",
-                False,
-            ),
-            PoolCutoverStatus.TRANSIENT_ERROR: (
-                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
-                "pre_cutover_filesystem",
-                True,
-            ),
-        }.get(status)
-
-    @classmethod
-    def _post_commit_cutover_failure_profile(
-        cls,
-        status: PoolCutoverStatus,
-    ) -> tuple[SkillsPoolReconcileOutcome, str, bool]:
-        """Classify refresh failures after the irreversible boundary is known."""
-
-        if status in {
-            PoolCutoverStatus.UNKNOWN,
-            PoolCutoverStatus.TRANSIENT_ERROR,
-            PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
-        }:
-            return (
-                SkillsPoolReconcileOutcome.CUTOVER_FAILED,
-                "post_cutover_refresh",
-                True,
-            )
-        profile = cls._cutover_failure_profile(status)
-        if profile is not None:
-            outcome, _, retryable = profile
-            return outcome, "post_cutover_refresh", retryable
-        return (
-            SkillsPoolReconcileOutcome.CUTOVER_FAILED,
-            "post_cutover_refresh",
-            False,
-        )
-
-    @staticmethod
-    def _persisted_cutover_evidence(
-        state: BotSkillLayoutState,
-    ) -> dict[str, object] | None:
-        probe_evidence = state.last_probe_evidence
-        if not isinstance(probe_evidence, dict):
-            return None
-        cutover = probe_evidence.get("cutover")
-        if not isinstance(cutover, dict):
-            return None
-        evidence = cutover.get("evidence")
-        return evidence if isinstance(evidence, dict) else None
 
     def _handle_engine_drift(
         self,

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -881,15 +881,32 @@ class SkillsPoolReconcileService:
         engine: str,
         initial_probe: RuntimeLayoutProbeResult,
     ) -> SkillsPoolReconcileResult:
-        """Rewrite only current managed mappings, then prove the final layout.
+        """Ask the Engine to repair only its trusted retired repo bridge.
 
-        This is deliberately the same idempotent publish/verify pair used by
-        desktop activation recovery.  It neither revives absent mappings nor
-        removes unknown filesystem entries: a second runtime probe remains the
-        fail-closed authority for both cases.
+        Backend cannot tell whether ``active_managed_entry_invalid`` represents
+        the historical AICoding repo bridge or an unsafe Legacy/dangling entry.
+        The Engine activation operation owns that distinction and rejects every
+        other invalid form before changing active mappings.
         """
 
+        generation = state.migration_generation
+        if generation is None or state.preparation_id is None:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.INVALID,
+                evidence={
+                    "reason": "active_runtime_identity_mismatch",
+                    "initial_probe": initial_probe.evidence,
+                },
+                retryable=False,
+            )
         try:
+            registered_local_names = [
+                local_skill_name(asset)
+                for asset in self._skills.list_bot_local_assets(
+                    env=scope.env,
+                    bot_id=scope.bot_id,
+                )
+            ]
             mappings = build_logical_skill_mappings(
                 self._skills.list_bot_active_assets(
                     env=scope.env,
@@ -904,33 +921,25 @@ class SkillsPoolReconcileService:
                 evidence={"reason": str(error)},
                 retryable=False,
             )
-        if not await self._runtime.publish_mappings(
+        repair = await self._runtime.cutover(
             bot_id=bot_id,
             user_id=user_id,
+            migration_generation=generation,
+            preparation_id=state.preparation_id,
+            registered_local_names=registered_local_names,
             mappings=mappings,
-        ):
-            return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.MAPPING_FAILED,
-                evidence={
-                    "reason": "active_aicoding_bridge_mapping_publish_failed",
-                    "mapping_count": len(mappings),
-                    "initial_probe": initial_probe.evidence,
-                },
-                retryable=True,
+        )
+        if not repair.committed:
+            outcome, _, retryable = self._post_commit_cutover_failure_profile(
+                repair.status
             )
-        if not await self._runtime.verify_mappings(
-            bot_id=bot_id,
-            user_id=user_id,
-            mappings=mappings,
-        ):
             return SkillsPoolReconcileResult(
-                SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+                outcome,
                 evidence={
-                    "reason": "active_aicoding_bridge_mapping_verify_failed",
-                    "mapping_count": len(mappings),
                     "initial_probe": initial_probe.evidence,
+                    "engine_repair": repair.to_dict(),
                 },
-                retryable=True,
+                retryable=retryable,
             )
         refreshed_probe = await self._runtime.probe(
             bot_id=bot_id,
@@ -954,8 +963,6 @@ class SkillsPoolReconcileService:
             or refreshed_probe.preparation_id is None
             or refreshed_probe.preparation_id != state.preparation_id
             or refreshed_probe.layout_contract_version != state.layout_contract_version
-            or refreshed_probe.evidence.get("implementation_engine") != "aicoding"
-            or refreshed_probe.evidence.get("physical_layout_engine") != "aicoding"
         ):
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.INVALID,
@@ -973,6 +980,7 @@ class SkillsPoolReconcileService:
                 **refreshed_probe.evidence,
                 "active_aicoding_bridge_reconciled": True,
                 "reconciled_mapping_count": len(mappings),
+                "engine_repair": repair.to_dict(),
             },
         )
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -15,9 +15,11 @@ from agentclaw.community.core.bot_management.repository.protocol import (
 )
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CUTOVER_EVIDENCE_CONTRACT_VERSION,
+    RuntimeLayoutProbeResult,
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skills_pool.aicoding_retirement import (
+    is_aicoding_active_mapping_reconciliation_candidate,
     is_trusted_aicoding_repo_retirement_resume,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -162,12 +164,10 @@ class SkillsPoolReconcileService:
             state.data_plane_cutover_committed,
             probe.status.value,
         )
-        finalizing_repo_retirement_resume = (
-            is_trusted_aicoding_repo_retirement_resume(
-                state=state,
-                engine=engine,
-                probe=probe,
-            )
+        finalizing_repo_retirement_resume = is_trusted_aicoding_repo_retirement_resume(
+            state=state,
+            engine=engine,
+            probe=probe,
         )
         if (
             probe.status is not RuntimeLayoutProbeStatus.READY
@@ -797,6 +797,19 @@ class SkillsPoolReconcileService:
             user_id=str(owner_id),
             engine=engine,
         )
+        if is_aicoding_active_mapping_reconciliation_candidate(
+            state=state,
+            engine=engine,
+            probe=probe,
+        ):
+            return await self._reconcile_active_aicoding_repo_bridges(
+                scope=scope,
+                state=state,
+                bot_id=scope.bot_id,
+                user_id=str(owner_id),
+                engine=engine,
+                initial_probe=probe,
+            )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
             return SkillsPoolReconcileResult(
                 self._probe_outcome(probe.status),
@@ -856,6 +869,111 @@ class SkillsPoolReconcileService:
             SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
             preparation_id=probe.preparation_id,
             evidence=probe.evidence,
+        )
+
+    async def _reconcile_active_aicoding_repo_bridges(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        state: BotSkillLayoutState,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+        initial_probe: RuntimeLayoutProbeResult,
+    ) -> SkillsPoolReconcileResult:
+        """Rewrite only current managed mappings, then prove the final layout.
+
+        This is deliberately the same idempotent publish/verify pair used by
+        desktop activation recovery.  It neither revives absent mappings nor
+        removes unknown filesystem entries: a second runtime probe remains the
+        fail-closed authority for both cases.
+        """
+
+        try:
+            mappings = build_logical_skill_mappings(
+                self._skills.list_bot_active_assets(
+                    env=scope.env,
+                    bot_id=scope.bot_id,
+                    user_id=user_id,
+                    engine=engine,
+                )
+            )
+        except ValueError as error:
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.INVALID,
+                evidence={"reason": str(error)},
+                retryable=False,
+            )
+        if not await self._runtime.publish_mappings(
+            bot_id=bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MAPPING_FAILED,
+                evidence={
+                    "reason": "active_aicoding_bridge_mapping_publish_failed",
+                    "mapping_count": len(mappings),
+                    "initial_probe": initial_probe.evidence,
+                },
+                retryable=True,
+            )
+        if not await self._runtime.verify_mappings(
+            bot_id=bot_id,
+            user_id=user_id,
+            mappings=mappings,
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+                evidence={
+                    "reason": "active_aicoding_bridge_mapping_verify_failed",
+                    "mapping_count": len(mappings),
+                    "initial_probe": initial_probe.evidence,
+                },
+                retryable=True,
+            )
+        refreshed_probe = await self._runtime.probe(
+            bot_id=bot_id,
+            user_id=user_id,
+            engine=engine,
+        )
+        if refreshed_probe.status is not RuntimeLayoutProbeStatus.READY:
+            return SkillsPoolReconcileResult(
+                self._probe_outcome(refreshed_probe.status),
+                evidence={
+                    "reason": "active_aicoding_bridge_reconciliation_incomplete",
+                    "initial_probe": initial_probe.evidence,
+                    "post_publish_probe": refreshed_probe.evidence,
+                },
+                retryable=(
+                    refreshed_probe.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+                ),
+            )
+        if (
+            refreshed_probe.engine != engine
+            or refreshed_probe.preparation_id is None
+            or refreshed_probe.preparation_id != state.preparation_id
+            or refreshed_probe.layout_contract_version != state.layout_contract_version
+            or refreshed_probe.evidence.get("implementation_engine") != "aicoding"
+            or refreshed_probe.evidence.get("physical_layout_engine") != "aicoding"
+        ):
+            return SkillsPoolReconcileResult(
+                SkillsPoolReconcileOutcome.INVALID,
+                evidence={
+                    "reason": "active_runtime_identity_mismatch",
+                    "initial_probe": initial_probe.evidence,
+                    "post_publish_probe": refreshed_probe.evidence,
+                },
+                retryable=False,
+            )
+        return SkillsPoolReconcileResult(
+            SkillsPoolReconcileOutcome.ALREADY_ACTIVE,
+            preparation_id=refreshed_probe.preparation_id,
+            evidence={
+                **refreshed_probe.evidence,
+                "active_aicoding_bridge_reconciled": True,
+                "reconciled_mapping_count": len(mappings),
+            },
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_support.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_support.py
@@ -1,0 +1,88 @@
+"""Skills Pool reconcile 编排共用的纯函数。"""
+
+from __future__ import annotations
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skills_pool.models import PoolCutoverStatus
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutState
+
+
+def probe_outcome(status: RuntimeLayoutProbeStatus) -> str:
+    return {
+        RuntimeLayoutProbeStatus.NOT_CAPABLE: "not_capable",
+        RuntimeLayoutProbeStatus.TRANSIENT_ERROR: "transient_error",
+        RuntimeLayoutProbeStatus.INVALID: "invalid",
+    }.get(status, "invalid")
+
+
+def cutover_failure_profile(
+    status: PoolCutoverStatus,
+) -> tuple[str, str, bool] | None:
+    return {
+        PoolCutoverStatus.DATA_INCONSISTENT: (
+            "data_inconsistent",
+            "pre_cutover_validation",
+            False,
+        ),
+        PoolCutoverStatus.ACTIVE_ENTRY_CONFLICT: (
+            "active_entry_conflict",
+            "pre_cutover_validation",
+            False,
+        ),
+        PoolCutoverStatus.NOT_ATOMIC: (
+            "cutover_failed",
+            "atomic_cutover",
+            False,
+        ),
+        PoolCutoverStatus.INVALID: (
+            "cutover_failed",
+            "pre_cutover_validation",
+            False,
+        ),
+        PoolCutoverStatus.TRANSIENT_ERROR: (
+            "cutover_failed",
+            "pre_cutover_filesystem",
+            True,
+        ),
+    }.get(status)
+
+
+def post_commit_cutover_failure_profile(
+    status: PoolCutoverStatus,
+) -> tuple[str, str, bool]:
+    """Classify refresh failures after the irreversible boundary is known."""
+
+    if status in {
+        PoolCutoverStatus.UNKNOWN,
+        PoolCutoverStatus.TRANSIENT_ERROR,
+        PoolCutoverStatus.POST_CUTOVER_SYNC_PENDING,
+    }:
+        return "cutover_failed", "post_cutover_refresh", True
+    profile = cutover_failure_profile(status)
+    if profile is not None:
+        outcome, _, retryable = profile
+        return outcome, "post_cutover_refresh", retryable
+    return "cutover_failed", "post_cutover_refresh", False
+
+
+def persisted_cutover_evidence(
+    state: BotSkillLayoutState,
+) -> dict[str, object] | None:
+    probe_evidence = state.last_probe_evidence
+    if not isinstance(probe_evidence, dict):
+        return None
+    cutover = probe_evidence.get("cutover")
+    if not isinstance(cutover, dict):
+        return None
+    evidence = cutover.get("evidence")
+    return evidence if isinstance(evidence, dict) else None
+
+
+__all__ = [
+    "cutover_failure_profile",
+    "persisted_cutover_evidence",
+    "post_commit_cutover_failure_profile",
+    "probe_outcome",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
@@ -28,6 +28,7 @@ from agentclaw.community.core.skills_pool.claim_service import (
 from agentclaw.community.core.skills_pool.quarantine import (
     QUARANTINE_RETENTION,
     SKILLS_POOL_QUARANTINE_CLEANUP_TASK,
+    QuarantineStatus,
     QuarantineRepositoryProtocol,
     SkillsPoolQuarantineCleanupTaskHandler,
 )
@@ -191,6 +192,17 @@ class SkillsPoolReconcileTaskHandler:
                 },
             )
             if not recorded:
+                # Retention cleanup deliberately makes the quarantine row
+                # immutable.  A post-cleanup wake-up must still verify the
+                # live runtime (including any Engine-owned repair), but has
+                # no mutable evidence sink left to update.  It is therefore
+                # complete rather than a permanent evidence-write retry.
+                quarantine = self._quarantines.get_quarantine(scope, generation)
+                if quarantine is not None and (
+                    quarantine.status is QuarantineStatus.CLEANED
+                    or quarantine.cleaned_at is not None
+                ):
+                    return Complete()
                 return Retry("skills pool runtime reconciliation evidence race lost")
             return Complete()
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_task.py
@@ -29,7 +29,6 @@ from agentclaw.community.core.skills_pool.quarantine import (
     QUARANTINE_RETENTION,
     SKILLS_POOL_QUARANTINE_CLEANUP_TASK,
     QuarantineRepositoryProtocol,
-    QuarantineStatus,
     SkillsPoolQuarantineCleanupTaskHandler,
 )
 from agentclaw.community.core.skills_pool.reconcile_service import (
@@ -155,12 +154,6 @@ class SkillsPoolReconcileTaskHandler:
             generation = claim.state.migration_generation
             if generation is None:
                 return Fail("pool-active layout has no migration generation")
-            quarantine = self._quarantines.get_quarantine(scope, generation)
-            if (
-                quarantine is not None
-                and quarantine.status is QuarantineStatus.CLEANED
-            ):
-                return Complete()
             if observed_at is None:
                 # Tasks written by the previous Backend cannot prove a
                 # post-activation runtime observation. They remain safe to

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -188,6 +188,7 @@ class FakeLayoutRepository:
             and kwargs["migration_generation"] == GENERATION
             and self.quarantine_conflict
         )
+
     def record_post_cutover_evidence(self, **kwargs: object) -> bool:
         if self._should_fail("post_cutover_evidence"):
             return False
@@ -240,13 +241,9 @@ class FakeLayoutRepository:
             return False
         self.events.append("post_failure")
         cutover_evidence = (self.state.last_probe_evidence or {}).get("cutover")
-        refresh_pending = (
-            self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED"
-            and (
-                not isinstance(cutover_evidence, dict)
-                or cutover_evidence.get("post_cutover_evidence_recorded")
-                is not True
-            )
+        refresh_pending = self.state.last_failure_code == "MANUAL_REPAIR_RESOLVED" and (
+            not isinstance(cutover_evidence, dict)
+            or cutover_evidence.get("post_cutover_evidence_recorded") is not True
         )
         self.state = replace(
             self.state,
@@ -401,6 +398,8 @@ class FakeRuntime:
         self.pool_local = pool_local or default_local
         self.pool_repo = pool_repo or default_repo
         self.events: list[str] = []
+        self.probe_results: list[RuntimeLayoutProbeResult] = []
+        self.published_mappings: list[object] | None = None
         self.publish_success = True
         self.verify_success = True
         self.physical_cutovers = 0
@@ -439,14 +438,13 @@ class FakeRuntime:
     async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
         self.events.append("probe")
         assert kwargs["engine"] == self.engine
+        if self.probe_results:
+            return self.probe_results.pop(0)
         return self.probe_result
 
     async def cutover(self, **kwargs: object) -> PoolCutoverResult:
         self.events.append("cutover")
-        assert (
-            kwargs["registered_local_names"]
-            == self.expected_registered_local_names
-        )
+        assert kwargs["registered_local_names"] == self.expected_registered_local_names
         mappings = kwargs["mappings"]
         assert [mapping.to_dict() for mapping in mappings] == [
             {
@@ -485,6 +483,7 @@ class FakeRuntime:
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
+        self.published_mappings = list(kwargs["mappings"])
         return self.publish_success
 
     async def verify_mappings(self, **kwargs: object) -> bool:
@@ -561,16 +560,13 @@ async def test_historical_local_versions_share_engine_locator_on_commit() -> Non
     assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
     assert layouts.committed_locators == {
         11: (
-            "local:///home/admin/.openclaw/workspace/skills-pool/"
-            "skills-local/local-a"
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-a"
         ),
         12: (
-            "local:///home/admin/.openclaw/workspace/skills-pool/"
-            "skills-local/local-b"
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"
         ),
         13: (
-            "local:///home/admin/.openclaw/workspace/skills-pool/"
-            "skills-local/local-a"
+            "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-a"
         ),
     }
 
@@ -598,9 +594,7 @@ async def test_conflicting_same_name_sources_fail_before_cutover() -> None:
     )
 
     assert result.outcome is SkillsPoolReconcileOutcome.INVALID
-    assert result.evidence == {
-        "reason": "duplicate managed target: local-a"
-    }
+    assert result.evidence == {"reason": "duplicate managed target: local-a"}
     assert runtime.events == ["probe"]
     assert runtime.physical_cutovers == 0
     assert layouts.events == ["failure"]
@@ -644,7 +638,10 @@ async def test_pre_upgrade_runtime_reconciles_activating_generation() -> None:
     runtime = FakeRuntime()
     runtime.probe_result = replace(
         runtime.probe_result,
-        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
+        evidence={
+            "marker": "valid",
+            "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        },
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -714,7 +711,10 @@ async def test_activating_old_runtime_without_identity_waits_for_upgrade() -> No
     runtime = FakeRuntime()
     runtime.probe_result = replace(
         runtime.probe_result,
-        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
+        evidence={
+            "marker": "valid",
+            "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        },
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -900,13 +900,13 @@ async def test_hermes_h0_ready_uses_its_own_pool_paths_for_full_activation() -> 
     )
     runtime.probe_result = replace(
         runtime.probe_result,
-            evidence={
-                "checks": {
-                    "legacy_local_bridge_valid": True,
-                    "stable_repo_bridge_valid": True,
-                },
-                "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        evidence={
+            "checks": {
+                "legacy_local_bridge_valid": True,
+                "stable_repo_bridge_valid": True,
             },
+            "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        },
     )
 
     result = await build_service(
@@ -1063,9 +1063,9 @@ async def test_repair_refresh_mapping_failure_reuses_persisted_locator_evidence(
 
     assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
     assert layouts.state.phase is SkillLayoutPhase.POOL_CUTOVER_COMMITTED
-    assert layouts.state.last_probe_evidence["cutover"]["evidence"][
-        "local_locators"
-    ]["local-a"].endswith("/local-a")
+    assert layouts.state.last_probe_evidence["cutover"]["evidence"]["local_locators"][
+        "local-a"
+    ].endswith("/local-a")
 
     runtime.events.clear()
     layouts.events.clear()
@@ -1948,6 +1948,153 @@ async def test_pool_active_reconciliation_rejects_invalid_current_runtime() -> N
     assert runtime.events == ["probe"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("logical_engine", ["aicoding", "claude_code"])
+async def test_pool_active_aicoding_bridge_republishes_then_requires_ready_probe(
+    logical_engine: str,
+) -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            lease_owner=None,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime(engine=logical_engine)
+    initial_probe = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        evidence={
+            "reason": "active_managed_entry_invalid",
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+        },
+    )
+    ready_probe = replace(
+        runtime.probe_result,
+        evidence={
+            **runtime.probe_result.evidence,
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+        },
+    )
+    runtime.probe_results = [initial_probe, ready_probe]
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine=logical_engine,
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="post-restart-worker",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.ALREADY_ACTIVE
+    assert result.evidence["active_aicoding_bridge_reconciled"] is True
+    assert result.evidence["reconciled_mapping_count"] == 3
+    assert runtime.events == ["probe", "mapping", "verify", "probe"]
+    assert [mapping.to_dict() for mapping in runtime.published_mappings] == [
+        {
+            "corpus": "local",
+            "relative_path": "local-a",
+            "link_name": "local-a",
+        },
+        {
+            "corpus": "local",
+            "relative_path": "local-b",
+            "link_name": "local-b",
+        },
+        {
+            "corpus": "repo",
+            "relative_path": "business/repo-skill",
+            "link_name": "repo-skill",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pool_active_aicoding_bridge_does_not_accept_unproven_republish() -> None:
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            lease_owner=None,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+    initial_probe = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        evidence={
+            "reason": "active_managed_entry_invalid",
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+        },
+    )
+    still_invalid = replace(
+        initial_probe,
+        evidence={"reason": "unknown_active_entry"},
+    )
+    runtime.probe_results = [initial_probe, still_invalid]
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+    ).reconcile(
+        scope=SCOPE,
+        lease_owner="post-restart-worker",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert result.retryable is False
+    assert (
+        result.evidence["reason"] == "active_aicoding_bridge_reconciliation_incomplete"
+    )
+    assert runtime.events == ["probe", "mapping", "verify", "probe"]
+
+
+@pytest.mark.asyncio
+async def test_pool_active_aicoding_bridge_does_not_repair_local_corpus_bridge() -> (
+    None
+):
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            lease_owner=None,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime(engine="aicoding")
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        evidence={
+            "reason": "retired_local_bridge_present",
+            "implementation_engine": "aicoding",
+            "physical_layout_engine": "aicoding",
+        },
+    )
+
+    result = await build_service(layouts, runtime, engine="aicoding").reconcile(
+        scope=SCOPE,
+        lease_owner="post-restart-worker",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert runtime.events == ["probe"]
+    assert runtime.published_mappings is None
+
+
 class StickyClaimService:
     """Expose the real reconciliation service through the durable task seam."""
 
@@ -2057,7 +2204,10 @@ def test_real_reconciliation_retry_resumes_same_generation_without_repeating_cut
         engine="openclaw",
         layout_contract_version=LAYOUT_CONTRACT_VERSION,
         preparation_id=PREPARATION_ID,
-        evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
+        evidence={
+            "marker": "valid",
+            "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+        },
     )
     runtime.cutover_result = PoolCutoverResult(
         committed=True,
@@ -2144,7 +2294,10 @@ class ReadyProbeService:
             engine="openclaw",
             layout_contract_version=LAYOUT_CONTRACT_VERSION,
             preparation_id=PREPARATION_ID,
-            evidence={"marker": "valid", "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION},
+            evidence={
+                "marker": "valid",
+                "cutover_evidence_contract_version": CUTOVER_EVIDENCE_CONTRACT_VERSION,
+            },
         )
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -39,6 +42,21 @@ from agentclaw.community.core.skills_pool.types import (
 )
 from agentclaw.community.core.task_queue.types import Complete, Retry
 from agentclaw.community.plugins.skills_pool_runtime import OpenClawSkillsPoolRuntime
+
+
+def _aicoding_engine_api():
+    """Load the sibling Engine source for the deliberate cross-layer test."""
+
+    engine_src = Path(__file__).resolve().parents[5] / "engine" / "src"
+    if str(engine_src) not in sys.path:
+        sys.path.insert(0, str(engine_src))
+    from engine.community.plugins.aicoding.layout_pool import (
+        SkillMapping,
+        activate_aicoding_pool,
+        inspect_aicoding_runtime_layout,
+    )
+
+    return SkillMapping, activate_aicoding_pool, inspect_aicoding_runtime_layout
 
 
 SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
@@ -2348,3 +2366,288 @@ def test_stale_signal_uses_current_resolved_binding_for_real_mutations() -> None
         ("bot-1", "owner-1"),
     ]
     assert transport.bindings == ["binding-new", "binding-new", "binding-new"]
+
+
+class _LocalAICodingResolver:
+    def resolve_for_bot(self, bot_id: str, user_id: str) -> SimpleNamespace:
+        assert (bot_id, user_id) == (SCOPE.bot_id, "owner-1")
+        return SimpleNamespace(conn_info={"binding": "local-engine"})
+
+
+class _LocalAICodingProbe:
+    def __init__(self, *, home: Path, pool_repo: Path) -> None:
+        self._home = home
+        self._pool_repo = pool_repo
+        self.calls = 0
+
+    async def probe_bot(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> RuntimeLayoutProbeResult:
+        assert (bot_id, user_id, engine) == (SCOPE.bot_id, "owner-1", "aicoding")
+        self.calls += 1
+        _, _, inspect_aicoding_runtime_layout = _aicoding_engine_api()
+        inspection = inspect_aicoding_runtime_layout(
+            home=self._home,
+            mapping_contract_version="skills-pool-mapping-v2",
+            repo_is_mounted=lambda path: path == self._pool_repo,
+        )
+        return RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus(inspection.status.value),
+            engine=engine,
+            layout_contract_version=inspection.layout_contract_version,
+            preparation_id=inspection.preparation_id,
+            evidence=inspection.evidence,
+        )
+
+
+class _LocalAICodingEngineTransport:
+    """Execute the Backend adapter payload through the actual Engine operation."""
+
+    def __init__(self, *, home: Path, pool_local: Path, pool_repo: Path) -> None:
+        self._home = home
+        self._pool_local = pool_local
+        self._pool_repo = pool_repo
+        self.calls: list[str] = []
+
+    async def invoke(
+        self,
+        conn_info: object,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, object],
+        timeout: float,
+    ) -> dict[str, object]:
+        assert conn_info == {"binding": "local-engine"}
+        assert method == "POST"
+        assert timeout == 30.0
+        self.calls.append(path)
+        assert path == "/api/skills/layout/activate"
+
+        engine_skill_mapping, activate_aicoding_pool, _ = _aicoding_engine_api()
+        mappings = []
+        for intent in body["mappings"]:
+            assert isinstance(intent, dict)
+            corpus = intent["corpus"]
+            relative_path = intent["relative_path"]
+            link_name = intent["link_name"]
+            assert isinstance(corpus, str)
+            assert isinstance(relative_path, str)
+            assert isinstance(link_name, str)
+            source_root = self._pool_local if corpus == "local" else self._pool_repo
+            mappings.append(
+                engine_skill_mapping(
+                    source=str(source_root / relative_path),
+                    target=str(self._home / ".claude" / "skills" / link_name),
+                )
+            )
+
+        result = activate_aicoding_pool(
+            migration_generation=str(body["migration_generation"]),
+            preparation_id=str(body["preparation_id"]),
+            registered_local_names=list(body["registered_local_names"]),
+            mappings=mappings,
+            home=self._home,
+            repo_is_mounted=lambda candidate: candidate == self._pool_repo,
+        )
+        return {"success": True, "data": result.to_data()}
+
+
+def _prepared_local_aicoding_runtime(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path]:
+    """Build the persistent filesystem shape seen by a POOL_ACTIVE Bot."""
+
+    home = tmp_path / "home" / "admin"
+    workspace = home / ".aicoding" / "workspace"
+    legacy_local = workspace / "skills" / "skills-local"
+    active_root = home / ".claude" / "skills"
+    pool_root = workspace / "skills-pool"
+    pool_local = pool_root / "skills-local"
+    pool_repo = pool_root / "skills-repo"
+    repo_bridge = home / ".aicoding" / "skills-repo"
+
+    (legacy_local / "handmade").mkdir(parents=True)
+    (legacy_local / "handmade" / "SKILL.md").write_text("legacy")
+    (pool_local / "handmade").mkdir(parents=True)
+    (pool_local / "handmade" / "SKILL.md").write_text("pool")
+    (pool_repo / "business" / "shared").mkdir(parents=True)
+    (pool_repo / "business" / "shared" / "SKILL.md").write_text("repo")
+    active_root.mkdir(parents=True)
+    (active_root / "skills-local").symlink_to(legacy_local, target_is_directory=True)
+    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    (pool_root / ".pool-ready").write_text(
+        json.dumps(
+            {
+                "engine": "aicoding",
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": PREPARATION_ID,
+                "prepared_at": "2026-07-24T00:00:00Z",
+                "pool_local_root": str(pool_local),
+                "pool_repo_root": str(pool_repo),
+                "validation_summary": {
+                    "all_valid": True,
+                    "pool_local": {"path": str(pool_local), "valid": True},
+                    "pool_repo": {
+                        "path": str(pool_repo),
+                        "readable_mount": True,
+                        "valid": True,
+                    },
+                    "structural_bridges": [
+                        {
+                            "name": "stable_local_bridge",
+                            "path": str(active_root / "skills-local"),
+                            "target": str(legacy_local),
+                            "valid": True,
+                        },
+                        {
+                            "name": "stable_repo_bridge",
+                            "path": str(repo_bridge),
+                            "target": str(pool_repo),
+                            "valid": True,
+                        },
+                    ],
+                    "managed_active_entries": [],
+                    "external_active_entry_count": 0,
+                },
+            }
+        )
+    )
+    return home, pool_local, pool_repo, repo_bridge
+
+
+def _pool_active_aicoding_service(
+    *,
+    tmp_path: Path,
+) -> tuple[
+    SkillsPoolReconcileService,
+    _LocalAICodingEngineTransport,
+    _LocalAICodingProbe,
+    Path,
+    Path,
+]:
+    home, pool_local, pool_repo, repo_bridge = _prepared_local_aicoding_runtime(
+        tmp_path
+    )
+    active_root = home / ".claude" / "skills"
+    engine_skill_mapping, activate_aicoding_pool, _ = _aicoding_engine_api()
+    initial = activate_aicoding_pool(
+        migration_generation=GENERATION,
+        preparation_id=PREPARATION_ID,
+        registered_local_names=["handmade"],
+        mappings=[
+            engine_skill_mapping(
+                source=str(pool_local / "handmade"),
+                target=str(active_root / "handmade"),
+            ),
+            engine_skill_mapping(
+                source=str(pool_repo / "business" / "shared"),
+                target=str(active_root / "shared"),
+            ),
+        ],
+        home=home,
+        repo_is_mounted=lambda candidate: candidate == pool_repo,
+    )
+    assert initial.committed
+
+    skills = FakeSkillRepository(engine="aicoding")
+    skills.registered = [
+        RegisteredSkillAsset(
+            skill_id=1,
+            name="handmade",
+            git_path="local://handmade",
+        )
+    ]
+    skills.active = [
+        *skills.registered,
+        RegisteredSkillAsset(
+            skill_id=2,
+            name="shared",
+            git_path="git://business/shared",
+        ),
+    ]
+    transport = _LocalAICodingEngineTransport(
+        home=home,
+        pool_local=pool_local,
+        pool_repo=pool_repo,
+    )
+    probe = _LocalAICodingProbe(home=home, pool_repo=pool_repo)
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=_LocalAICodingResolver(),
+        adapter_transport=transport,
+        probe_service=probe,
+    )
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+            lease_owner=None,
+        )
+    )
+    service = SkillsPoolReconcileService(
+        bot_repository=FakeBotRepository("aicoding"),
+        layout_repository=layouts,
+        skill_repository=skills,
+        runtime=runtime,
+    )
+    return service, transport, probe, active_root, repo_bridge
+
+
+@pytest.mark.asyncio
+async def test_pool_active_aicoding_bridge_uses_real_engine_activate_contract(
+    tmp_path: Path,
+) -> None:
+    """Backend must call Engine before declaring a retired repo bridge healthy."""
+
+    service, transport, probe, active_root, repo_bridge = _pool_active_aicoding_service(
+        tmp_path=tmp_path
+    )
+    (active_root / "shared").unlink()
+    (active_root / "shared").symlink_to(
+        repo_bridge / "business" / "shared",
+        target_is_directory=True,
+    )
+
+    result = await service.reconcile(scope=SCOPE, lease_owner="worker-after-restart")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.ALREADY_ACTIVE
+    assert transport.calls == ["/api/skills/layout/activate"]
+    assert probe.calls == 2
+    assert (active_root / "shared").readlink() == (
+        active_root.parent.parent
+        / ".aicoding"
+        / "workspace"
+        / "skills-pool"
+        / "skills-repo"
+        / "business"
+        / "shared"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pool_active_aicoding_bridge_stops_when_real_engine_rejects_repair(
+    tmp_path: Path,
+) -> None:
+    """A real Engine rejection must stop Backend before its post-repair probe."""
+
+    service, transport, probe, active_root, repo_bridge = _pool_active_aicoding_service(
+        tmp_path=tmp_path
+    )
+    untrusted_target = repo_bridge / "business" / "missing"
+    (active_root / "shared").unlink()
+    (active_root / "shared").symlink_to(untrusted_target, target_is_directory=True)
+
+    result = await service.reconcile(scope=SCOPE, lease_owner="worker-after-restart")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is False
+    assert transport.calls == ["/api/skills/layout/activate"]
+    assert probe.calls == 1
+    assert (active_root / "shared").readlink() == untrusted_target

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -399,7 +399,6 @@ class FakeRuntime:
         self.pool_repo = pool_repo or default_repo
         self.events: list[str] = []
         self.probe_results: list[RuntimeLayoutProbeResult] = []
-        self.published_mappings: list[object] | None = None
         self.publish_success = True
         self.verify_success = True
         self.physical_cutovers = 0
@@ -483,7 +482,6 @@ class FakeRuntime:
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
-        self.published_mappings = list(kwargs["mappings"])
         return self.publish_success
 
     async def verify_mappings(self, **kwargs: object) -> bool:
@@ -1950,7 +1948,7 @@ async def test_pool_active_reconciliation_rejects_invalid_current_runtime() -> N
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("logical_engine", ["aicoding", "claude_code"])
-async def test_pool_active_aicoding_bridge_republishes_then_requires_ready_probe(
+async def test_pool_active_aicoding_bridge_uses_engine_repair_then_requires_ready_probe(
     logical_engine: str,
 ) -> None:
     layouts = FakeLayoutRepository(
@@ -1967,21 +1965,9 @@ async def test_pool_active_aicoding_bridge_republishes_then_requires_ready_probe
     initial_probe = replace(
         runtime.probe_result,
         status=RuntimeLayoutProbeStatus.INVALID,
-        evidence={
-            "reason": "active_managed_entry_invalid",
-            "implementation_engine": "aicoding",
-            "physical_layout_engine": "aicoding",
-        },
+        evidence={"reason": "active_managed_entry_invalid"},
     )
-    ready_probe = replace(
-        runtime.probe_result,
-        evidence={
-            **runtime.probe_result.evidence,
-            "implementation_engine": "aicoding",
-            "physical_layout_engine": "aicoding",
-        },
-    )
-    runtime.probe_results = [initial_probe, ready_probe]
+    runtime.probe_results = [initial_probe, runtime.probe_result]
 
     result = await build_service(
         layouts,
@@ -1995,28 +1981,14 @@ async def test_pool_active_aicoding_bridge_republishes_then_requires_ready_probe
     assert result.outcome is SkillsPoolReconcileOutcome.ALREADY_ACTIVE
     assert result.evidence["active_aicoding_bridge_reconciled"] is True
     assert result.evidence["reconciled_mapping_count"] == 3
-    assert runtime.events == ["probe", "mapping", "verify", "probe"]
-    assert [mapping.to_dict() for mapping in runtime.published_mappings] == [
-        {
-            "corpus": "local",
-            "relative_path": "local-a",
-            "link_name": "local-a",
-        },
-        {
-            "corpus": "local",
-            "relative_path": "local-b",
-            "link_name": "local-b",
-        },
-        {
-            "corpus": "repo",
-            "relative_path": "business/repo-skill",
-            "link_name": "repo-skill",
-        },
-    ]
+    assert result.evidence["engine_repair"]["status"] == "COMMITTED"
+    assert runtime.events == ["probe", "cutover", "probe"]
 
 
 @pytest.mark.asyncio
-async def test_pool_active_aicoding_bridge_does_not_accept_unproven_republish() -> None:
+async def test_pool_active_aicoding_bridge_does_not_accept_unproven_engine_repair() -> (
+    None
+):
     layouts = FakeLayoutRepository(
         claimed_state(
             active_layout=SkillLayout.POOL,
@@ -2031,11 +2003,7 @@ async def test_pool_active_aicoding_bridge_does_not_accept_unproven_republish() 
     initial_probe = replace(
         runtime.probe_result,
         status=RuntimeLayoutProbeStatus.INVALID,
-        evidence={
-            "reason": "active_managed_entry_invalid",
-            "implementation_engine": "aicoding",
-            "physical_layout_engine": "aicoding",
-        },
+        evidence={"reason": "active_managed_entry_invalid"},
     )
     still_invalid = replace(
         initial_probe,
@@ -2057,7 +2025,7 @@ async def test_pool_active_aicoding_bridge_does_not_accept_unproven_republish() 
     assert (
         result.evidence["reason"] == "active_aicoding_bridge_reconciliation_incomplete"
     )
-    assert runtime.events == ["probe", "mapping", "verify", "probe"]
+    assert runtime.events == ["probe", "cutover", "probe"]
 
 
 @pytest.mark.asyncio
@@ -2080,8 +2048,6 @@ async def test_pool_active_aicoding_bridge_does_not_repair_local_corpus_bridge()
         status=RuntimeLayoutProbeStatus.INVALID,
         evidence={
             "reason": "retired_local_bridge_present",
-            "implementation_engine": "aicoding",
-            "physical_layout_engine": "aicoding",
         },
     )
 
@@ -2092,7 +2058,47 @@ async def test_pool_active_aicoding_bridge_does_not_repair_local_corpus_bridge()
 
     assert result.outcome is SkillsPoolReconcileOutcome.INVALID
     assert runtime.events == ["probe"]
-    assert runtime.published_mappings is None
+
+
+@pytest.mark.asyncio
+async def test_pool_active_aicoding_bridge_keeps_untrusted_engine_repair_failed() -> (
+    None
+):
+    layouts = FakeLayoutRepository(
+        claimed_state(
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            lease_owner=None,
+            preparation_id=PREPARATION_ID,
+            data_plane_cutover_committed=True,
+        )
+    )
+    runtime = FakeRuntime(engine="claude_code")
+    runtime.probe_result = replace(
+        runtime.probe_result,
+        status=RuntimeLayoutProbeStatus.INVALID,
+        evidence={"reason": "active_managed_entry_invalid"},
+    )
+    runtime.cutover_result = PoolCutoverResult(
+        committed=False,
+        status=PoolCutoverStatus.INVALID,
+        evidence={"reason": "untrusted_active_bridge"},
+    )
+
+    result = await build_service(layouts, runtime, engine="claude_code").reconcile(
+        scope=SCOPE,
+        lease_owner="post-restart-worker",
+    )
+
+    assert result.outcome is SkillsPoolReconcileOutcome.CUTOVER_FAILED
+    assert result.retryable is False
+    assert result.evidence["engine_repair"] == {
+        "committed": False,
+        "status": "INVALID",
+        "evidence": {"reason": "untrusted_active_bridge"},
+    }
+    assert runtime.events == ["probe", "cutover"]
 
 
 class StickyClaimService:

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
@@ -370,6 +370,7 @@ class FakeLayouts:
         self.acquire_result = False
         self.runtime_reconciliation_calls: list[dict[str, object]] = []
         self.runtime_reconciliation_failure_calls: list[dict[str, object]] = []
+        self.runtime_reconciliation_result = True
 
     def renew_lease(self, **kwargs: object) -> bool:
         self.renew_calls.append(kwargs)
@@ -386,7 +387,7 @@ class FakeLayouts:
 
     def record_runtime_reconciliation(self, **kwargs: object) -> bool:
         self.runtime_reconciliation_calls.append(kwargs)
-        return True
+        return self.runtime_reconciliation_result
 
     def record_runtime_reconciliation_failure(self, **kwargs: object) -> bool:
         self.runtime_reconciliation_failure_calls.append(kwargs)
@@ -619,6 +620,30 @@ def test_pool_active_wakeup_verifies_runtime_after_quarantine_is_cleaned() -> No
     assert reconcile.calls == [{"scope": SCOPE, "lease_owner": "skills-pool:wakeup-1"}]
     assert len(layouts.runtime_reconciliation_calls) == 1
     assert layouts.runtime_reconciliation_failure_calls == []
+
+
+def test_pool_active_wakeup_after_cleanup_completes_when_evidence_is_immutable() -> (
+    None
+):
+    state = _claimed_state(active_layout=SkillLayout.POOL)
+    claims = FakeClaimService(
+        [MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state)]
+    )
+    layouts = FakeLayouts(state)
+    layouts.runtime_reconciliation_result = False
+    reconcile = FakeReconcileService(
+        [SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.ALREADY_ACTIVE)]
+    )
+    handler = SkillsPoolReconcileTaskHandler(
+        claim_service=claims,
+        layout_repository=layouts,
+        reconcile_service=reconcile,
+        quarantine_repository=FakeQuarantines(QuarantineStatus.CLEANED),
+    )
+
+    assert handler.handle(_payload()) == Complete()
+    assert reconcile.calls == [{"scope": SCOPE, "lease_owner": "skills-pool:wakeup-1"}]
+    assert len(layouts.runtime_reconciliation_calls) == 1
 
 
 def test_pool_active_wakeup_does_not_enqueue_duplicate_cleanup_task() -> None:

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_task.py
@@ -467,9 +467,7 @@ def _payload(
 def test_ineligible_unclaimed_bot_never_probes_or_reconciles_runtime() -> None:
     legacy = BotSkillLayoutState.legacy_default(SCOPE)
     handler, claims, _, reconcile = _handler(
-        claim_results=[
-            MigrationClaimResult(MigrationClaimOutcome.INELIGIBLE, legacy)
-        ],
+        claim_results=[MigrationClaimResult(MigrationClaimOutcome.INELIGIBLE, legacy)],
         reconcile_results=[],
         state=legacy,
     )
@@ -600,7 +598,7 @@ def test_pool_active_wakeup_records_runtime_reconciliation_after_ready_probe() -
     assert layouts.runtime_reconciliation_calls[0]["evidence"]["probe"] is None
 
 
-def test_pool_active_wakeup_skips_probe_after_quarantine_is_cleaned() -> None:
+def test_pool_active_wakeup_verifies_runtime_after_quarantine_is_cleaned() -> None:
     state = _claimed_state(active_layout=SkillLayout.POOL)
     claims = FakeClaimService(
         [MigrationClaimResult(MigrationClaimOutcome.ALREADY_CLAIMED, state)]
@@ -618,8 +616,8 @@ def test_pool_active_wakeup_skips_probe_after_quarantine_is_cleaned() -> None:
 
     assert handler.handle(_payload()) == Complete()
 
-    assert reconcile.calls == []
-    assert layouts.runtime_reconciliation_calls == []
+    assert reconcile.calls == [{"scope": SCOPE, "lease_owner": "skills-pool:wakeup-1"}]
+    assert len(layouts.runtime_reconciliation_calls) == 1
     assert layouts.runtime_reconciliation_failure_calls == []
 
 


### PR DESCRIPTION
## Summary

Repair only the known active AICoding physical-layout migration form: after an identity-matched `active_managed_entry_invalid` probe, republish current managed mappings and require a second `READY` probe before accepting the runtime.

- requires `POOL_ACTIVE`, committed data plane, non-empty matching preparation ID, matching logical engine/contract, and `implementation_engine=physical_layout_engine=aicoding`
- reuses the Engine mapping publisher; Backend adds no physical path table
- keeps unknown entries and retired `skills-local` corpus bridges fail-closed
- verifies the logical/physical identity again after publish

## Tests

- `uv run pytest tests/community/core/skills_pool -q --tb=short` (254 passed)
- `uv run ruff check src/agentclaw/community/core/skills_pool/aicoding_retirement.py src/agentclaw/community/core/skills_pool/reconcile_service.py tests/community/core/skills_pool/test_reconcile_service.py`