### PR TITLE
fix(gateway): handle a client that leaves before the relay accepts

### DIFF
--- a/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
+++ b/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from starlette.websockets import WebSocket
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from gateway.community.logger import get_logger
 from gateway.community.spi.auth import AuthError
@@ -169,15 +169,37 @@ async def forward_websocket(websocket: WebSocket) -> None:
     try:
         cm = state.ws_forwarder.connect(request)
         upstream = await cm.__aenter__()
+    # Deliberately ``Exception`` and not ``BaseException``: a cancellation here
+    # has nothing to unwind. The context manager never entered, so there is no
+    # ``__aexit__`` owed, and the socket library releases its own transport when
+    # its dial is cancelled. Catching it would only turn a cancelled worker into
+    # a refusal the caller is no longer there to read.
     except Exception:
         logger.warning("relay upstream unavailable", exc_info=True)
         await _refuse(websocket, _CLOSE_UPSTREAM_UNAVAILABLE, "upstream unavailable")
         return
 
+    # Past this point the upstream is open and the exit is owed unconditionally
+    # — whatever the client does next, and whether the relay ends cleanly, by
+    # exception, or by cancellation.
     try:
-        # Echoed, not guessed: the upstream has already negotiated, so the
-        # client is told exactly what the socket behind it agreed to.
-        await websocket.accept(subprotocol=upstream.subprotocol or None)
+        try:
+            # Echoed, not guessed: the upstream has already negotiated, so the
+            # client is told exactly what the socket behind it agreed to.
+            await websocket.accept(subprotocol=upstream.subprotocol or None)
+        except (RuntimeError, WebSocketDisconnect):
+            # The client gave up while the dial was in flight. Its
+            # ``websocket.disconnect`` is then what ``accept`` reads in place of
+            # the ``websocket.connect`` it expects, and Starlette reports that
+            # mismatch as a ``RuntimeError``. Under load that is an ordinary
+            # race rather than a fault: nobody is left to accept, and nothing
+            # to refuse. Swallowed here rather than left to escape the
+            # endpoint, because one unhandled traceback per abandoned handshake
+            # buries the single warning above that explains a *real* upstream
+            # failure — which is exactly how a capacity investigation loses the
+            # only log line that mattered.
+            logger.debug("client left before the relay accepted", exc_info=True)
+            return
         await _relay(websocket, upstream)
     finally:
         await cm.__aexit__(None, None, None)
@@ -289,9 +311,14 @@ async def _upstream_headers(
 
 
 async def _refuse(websocket: WebSocket, code: int, reason: str) -> None:
-    """Reject the handshake, never having accepted it."""
+    """Reject the handshake, never having accepted it.
+
+    Closed quietly: every refusal races a caller that may already have hung up,
+    and the reason it is being refused is worth more than the failure to say so.
+    Letting that raise would replace the logged cause with a close-time error.
+    """
     logger.info("engine socket refused (%s): %s", code, reason)
-    await websocket.close(code=code, reason=_truncate_reason(reason))
+    await _quietly(websocket.close(code=code, reason=_truncate_reason(reason)))
 
 
 async def _relay(websocket: WebSocket, upstream: WebSocketUpstream) -> None:

--- a/src/gateway/tests/integration/test_relay_ws_route.py
+++ b/src/gateway/tests/integration/test_relay_ws_route.py
@@ -16,7 +16,7 @@ from contextlib import asynccontextmanager
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from gateway.community.adapters.web._forward import _ALL_METHODS, forward_request
 from gateway.community.adapters.web._relay_ws import (
@@ -314,6 +314,55 @@ def test_an_upstream_close_noticed_while_sending_is_carried_to_the_client() -> N
                 ws.receive_text()
     assert caught.value.code == 4200
     assert caught.value.reason == "upstream done"
+
+
+# ── the client that leaves while the gateway is dialling ─────────────────────
+
+
+async def test_a_client_that_leaves_before_accept_still_releases_the_upstream() -> None:
+    """The dial wins the race, the caller does not wait for it.
+
+    The gateway opens the upstream *before* accepting, so a client that gives up
+    while that dial is in flight leaves an upstream already open and a socket
+    with nobody behind it. Both have to be let go: the upstream because it was
+    entered, and the handshake because there is no longer anyone to accept.
+
+    Driven at the ASGI seam rather than through ``TestClient``, because the
+    condition under test is a message ordering — ``websocket.disconnect``
+    arriving where ``websocket.connect`` is expected — that a cooperating test
+    client will not produce.
+    """
+    app, _, forwarder = _build()
+    inbox: asyncio.Queue[dict] = asyncio.Queue()
+    inbox.put_nowait({"type": "websocket.disconnect", "code": 1006})
+    sent: list[dict] = []
+
+    async def _send(message: dict) -> None:
+        sent.append(message)
+
+    path, _, query = _PATH.partition("?")
+    websocket = WebSocket(
+        {
+            "type": "websocket",
+            "app": app,
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": query.encode(),
+            "headers": [],
+            "subprotocols": [],
+        },
+        receive=inbox.get,
+        send=_send,
+    )
+
+    # No exception escapes: an abandoned handshake is a race, not a fault, and
+    # a traceback per occurrence would bury the log line that reports a real
+    # upstream failure.
+    await forward_websocket(websocket)
+
+    assert forwarder.opened, "the upstream was dialled before the client was accepted"
+    assert forwarder.released == forwarder.opened, "the open upstream was released"
+    assert sent == [], "nothing was written to a client that had already gone"
 
 
 # ── refusals ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The WebSocket relay dials the upstream **before** accepting the client, so a
caller that gives up while that dial is in flight leaves `websocket.accept()`
reading a `websocket.disconnect` where it expects a `websocket.connect`.
Starlette reports that mismatch as a `RuntimeError`, which escaped the endpoint
and produced an unhandled ASGI traceback for every abandoned handshake.

Nothing leaked — the upstream exit was already owed unconditionally by the
existing `try/finally`, and that was verified rather than assumed. The cost is
noise: under load the tracebacks bury the single
`logger.warning("relay upstream unavailable")` that explains a *real* upstream
failure.

That is not hypothetical. A recent WebSocket relay capacity investigation spent
several rounds chasing a phantom ~430/500 connection ceiling, and this traceback
spam is part of what obscured the diagnosis. The root cause turned out to be a
capacity harness that attached an unconsumed `subprocess.PIPE` to the gateway's
stdout; once the pipe buffer filled, the gateway blocked in a synchronous write
inside the event loop and stopped accepting. The relay itself sustains 4000/4000
connections at 2 fd per connection with no fd leak. No capacity fix is needed or
included here.

Two smaller gaps surfaced alongside it:

- `_refuse` closed the client socket unguarded. Every refusal races a caller
  that may already have hung up, so a close-time error could replace the logged
  cause of the refusal.
- The dial guard catches `Exception`, which does not cover `CancelledError` on
  Python 3.12. Reviewed and deliberately left as-is, but the reasoning was
  nowhere in the code.

## Solution

Handle the abandoned handshake where it happens: catch `RuntimeError` /
`WebSocketDisconnect` scoped tightly to the `accept()` call, log at debug, and
return. The `finally` still runs, so the upstream is released on this path
exactly as before.

`_refuse` now closes through the existing `_quietly` helper, on the principle
that the reason for a refusal is worth more than the failure to transmit it.

The dial guard is unchanged. A cancellation there has nothing to unwind — the
context manager never entered, and the socket library releases its own transport
when its dial is cancelled — so widening it to `BaseException` would only turn a
cancelled worker into a refusal nobody is left to read. That reasoning is now a
comment rather than an open question a future reader has to re-derive.

Rejected: restructuring the handshake into a different async-context shape. The
existing `try/finally` already discharges the upstream on every path, which was
confirmed by driving Starlette's real `WebSocket` through the ordering; a
rewrite would carry risk without fixing anything.

## Validation

- New regression test `test_a_client_that_leaves_before_accept_still_releases_the_upstream`,
  driven at the ASGI seam because the condition under test is a message ordering
  a cooperating `TestClient` will not produce. Verified it **fails without the
  fix** with exactly `RuntimeError: Expected ASGI message "websocket.connect",
  but got 'websocket.disconnect'`, and passes with it.
- `tests/integration/test_relay_ws_route.py` — 40 passed.
- Full non-e2e suite — 587 passed, 1 failed.
- `ruff check` and `ruff format` clean on both changed files.

Not caused by this change, stated rather than hidden:

- The one non-e2e failure is `tests/architecture/test_ruff_lint_rules.py::test_ruff_formatting_passes`,
  from formatting drift in `src/gateway/community/spi/bot/_ports.py` — a file
  this PR does not touch. Left alone as out of scope.
- `tests/e2e` — 10 failed, 16 passed, all `httpx.ConnectError` from needing a
  live server. Identical counts on a clean tree.

Scale verification of this path is deliberately **not** claimed here. Generating
abandoned handshakes in volume needs the capacity harness, and that run is
tracked separately now that this fix and its unit coverage have landed.

## Compatibility and risk

No contract, schema, config, or migration impact. No client-visible behaviour
change on any path that previously worked: the handled case is one that
previously ended in an unhandled exception, and the endpoint's return value was
already discarded. Rollback is a straight revert of the single commit.

## Spec

`src/gateway/specs/2026-08-02-gateway-websocket-relay-domain/spec.md`

That spec defers concurrency limits under "measure first, then bound". The
measurement now exists and shows no wall below 4000 connections on a high-nofile
host, which supports keeping the limit deferred. No backpressure is added here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F17T4d7t1PpeBeed737aCw)_