### PR TITLE
feat(session-files): route uploads through active bindings

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/session_resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/session_resources/router.py
@@ -48,7 +48,13 @@ def _domain_error(exc: ValueError) -> HTTPException:
         return HTTPException(status_code=502, detail=code)
     if code == "resource_not_found":
         return HTTPException(status_code=404, detail=code)
-    if code in {"materialize_state_conflict", "transfer_id_mismatch"}:
+    if code in {"target_bot_access_denied"}:
+        return HTTPException(status_code=403, detail=code)
+    if code in {
+        "bot_device_unavailable",
+        "materialize_state_conflict",
+        "transfer_id_mismatch",
+    }:
         return HTTPException(status_code=409, detail=code)
     if code in {"resource_not_ready", "resource_materializing", "resource_missing", "resource_changed"}:
         return HTTPException(status_code=409, detail=code)
@@ -91,6 +97,8 @@ async def create_upload_intents(
                 scope_type=body.scope_type,
                 engine_type=body.engine_type,
                 filename=item.filename,
+                target_entity_id=body.target_entity_id,
+                binding_id=body.binding_id,
                 size_bytes=item.size_bytes,
                 content_hash=item.content_hash,
             )

--- a/src/backend/src/agentclaw/community/adapters/http/session_resources/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/session_resources/schemas.py
@@ -1,7 +1,7 @@
 """HTTP schemas for session resources."""
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class UploadIntentFile(BaseModel):
@@ -15,7 +15,24 @@ class UploadIntentRequest(BaseModel):
     session_key: str
     scope_type: str
     engine_type: str
+    target_entity_id: str | None = Field(default=None, max_length=128)
+    binding_id: int | None = Field(default=None, ge=1)
     files: list[UploadIntentFile] = Field(min_length=1, max_length=20)
+
+    @field_validator("target_entity_id")
+    @classmethod
+    def normalize_target_entity_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @field_validator("binding_id", mode="before")
+    @classmethod
+    def reject_boolean_binding_id(cls, value: object) -> object:
+        if isinstance(value, bool):
+            raise ValueError("binding_id must be a positive integer")
+        return value
 
 
 class UploadCompleteRequest(BaseModel):

--- a/src/backend/src/agentclaw/community/core/session_resources/materialization.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/materialization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 
 from injector import Injector, inject
 
@@ -73,10 +74,17 @@ class SessionResourceMaterializeHandler:
                     task_version,
                 )
                 return Complete()
-            context = self._resolver.resolve_for_bot(
-                record.bot_id,
-                record.owner_id,
-            )
+            if record.binding_id is None:
+                context = self._resolver.resolve_for_bot(
+                    record.bot_id,
+                    record.owner_id,
+                )
+            else:
+                context = self._resolver.resolve_for_binding(
+                    record.binding_id,
+                    record.owner_id,
+                    bot_id=record.bot_id,
+                )
             session_id = None
             if record.transfer_api_version is TransferApiVersion.SESSION_V2:
                 if not record.session_key_ciphertext:
@@ -97,6 +105,7 @@ class SessionResourceMaterializeHandler:
                 "filename": record.filename,
                 "size_bytes": record.size_bytes,
                 "content_hash": record.client_content_hash,
+                "uploaded_at": self._format_uploaded_at(record.gmt_create),
                 "transfer_api_version": record.transfer_api_version.value,
                 "tenant": record.tenant,
                 "session_id": session_id,
@@ -118,10 +127,11 @@ class SessionResourceMaterializeHandler:
             if not isinstance(response, dict) or not response.get("accepted"):
                 raise RuntimeError("Engine did not accept materialization")
             log.info(
-                "session_resource.materialize.dispatch.accepted resource_id=%s task_version=%s provider=%s",
+                "session_resource.materialize.dispatch.accepted resource_id=%s task_version=%s provider=%s upload_time_present=%s",
                 record.resource_id,
                 record.task_version,
                 context.provider,
+                body["uploaded_at"] is not None,
             )
             return Complete()
         except Exception as exc:
@@ -132,6 +142,14 @@ class SessionResourceMaterializeHandler:
                 type(exc).__name__,
             )
             return Retry(error=type(exc).__name__)
+
+    @staticmethod
+    def _format_uploaded_at(uploaded_at: datetime | None) -> str | None:
+        if uploaded_at is None:
+            return None
+        if uploaded_at.tzinfo is None:
+            uploaded_at = uploaded_at.replace(tzinfo=UTC)
+        return uploaded_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 class SessionResourceTaskLifecycle(LifecycleBase):

--- a/src/backend/src/agentclaw/community/core/session_resources/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/repository/models.py
@@ -23,6 +23,7 @@ class SessionResourceModel(Base):
     resource_id = Column(String(128), nullable=False, unique=True)
     owner_id = Column(String(128), nullable=False)
     bot_id = Column(String(128), nullable=False)
+    binding_id = Column(BigInteger, nullable=True)
     scope_type = Column(String(64), nullable=False)
     scope_key_hash = Column(String(128), nullable=False)
     session_key_hash = Column(String(128), nullable=False)
@@ -67,6 +68,7 @@ class SessionResourceModel(Base):
             resource_id=self.resource_id,
             owner_id=self.owner_id,
             bot_id=self.bot_id,
+            binding_id=self.binding_id,
             scope_type=self.scope_type,
             scope_key_hash=self.scope_key_hash,
             session_key_hash=self.session_key_hash,

--- a/src/backend/src/agentclaw/community/core/session_resources/service.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/service.py
@@ -5,7 +5,16 @@ import logging
 import uuid
 from pathlib import Path
 
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.token_vault import TokenVault
+from agentclaw.community.core.bot_public.repository.bot_friend_repository import (
+    BotFriendRepositoryProtocol,
+)
+from agentclaw.community.core.bot_public.repository.models import BotFriendStatus
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceContext,
+    DeviceNotBoundError,
+)
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
@@ -44,6 +53,8 @@ class SessionResourceService:
         token_vault: TokenVault,
         adapter_transport: DeviceAdapterTransport,
         default_tenant: str,
+        bot_repository: BotRepository,
+        bot_friend_repository: BotFriendRepositoryProtocol,
     ) -> None:
         self._repository = repository
         self._baas = baas_client
@@ -52,6 +63,8 @@ class SessionResourceService:
         self._vault = token_vault
         self._adapter_transport = adapter_transport
         self._default_tenant = default_tenant.strip()
+        self._bot_repository = bot_repository
+        self._bot_friend_repository = bot_friend_repository
 
     def create_upload_intent(
         self,
@@ -62,11 +75,19 @@ class SessionResourceService:
         scope_type: str,
         engine_type: str,
         filename: str,
+        target_entity_id: str | None = None,
+        binding_id: int | None = None,
         size_bytes: int | None = None,
         content_hash: str | None = None,
     ) -> SessionUploadIntent:
         safe_filename = self._safe_filename(filename)
-        context = self._resolver.resolve_for_bot(bot_id, owner_id)
+        context, binding_id = self._resolve_upload_context(
+            bot_id=bot_id,
+            requester_id=owner_id,
+            target_entity_id=target_entity_id,
+            scope_type=scope_type,
+            binding_id=binding_id,
+        )
         raw_tenant = context.conn_info.get("tenant")
         raw_bot_uuid = context.conn_info.get("bot_uuid")
         provider = (
@@ -142,6 +163,7 @@ class SessionResourceService:
                 transfer_id=grant.transfer_id,
                 status=SessionResourceStatus.UPLOAD_URL_ISSUED,
                 transfer_api_version=TransferApiVersion.SESSION_V2,
+                binding_id=binding_id,
                 session_key_ciphertext=self._vault.encrypt(session_key),
                 size_bytes=size_bytes,
                 client_content_hash=content_hash,
@@ -255,7 +277,7 @@ class SessionResourceService:
         )
         if record.status is not SessionResourceStatus.READY:
             raise ValueError("resource_not_ready")
-        context = self._resolver.resolve_for_bot(record.bot_id, record.owner_id)
+        context = self._resolve_record_context(record)
         response = await self._adapter_transport.stream(
             context.conn_info,
             "GET",
@@ -449,6 +471,106 @@ class SessionResourceService:
         if not session_id:
             raise ValueError("session_key_missing")
         return session_id
+
+    def _resolve_upload_context(
+        self,
+        *,
+        bot_id: str,
+        requester_id: str,
+        target_entity_id: str | None,
+        scope_type: str,
+        binding_id: int | None,
+    ) -> tuple[DeviceContext, int]:
+        if binding_id is not None:
+            try:
+                context = self._resolver.resolve_for_binding(
+                    binding_id,
+                    requester_id,
+                    bot_id=bot_id,
+                )
+            except DeviceNotBoundError as exc:
+                log.warning(
+                    "session_resource.upload_intent.binding.reject requester_hash=%s bot_hash=%s binding_id=%s reason=binding_unavailable",
+                    hash_identifier(requester_id)[:16],
+                    hash_identifier(bot_id)[:16],
+                    binding_id,
+                )
+                raise ValueError("bot_device_unavailable") from exc
+            log.info(
+                "session_resource.upload_intent.binding.accept requester_hash=%s bot_hash=%s binding_id=%s source=frontend",
+                hash_identifier(requester_id)[:16],
+                hash_identifier(bot_id)[:16],
+                binding_id,
+            )
+            return context, binding_id
+        target_id = target_entity_id or requester_id
+        if target_entity_id and target_entity_id != requester_id:
+            relation = self._bot_friend_repository.get_by_entity_ids(
+                requester_entity_id=requester_id,
+                target_entity_id=target_entity_id,
+                target_bot_id=bot_id,
+            )
+            if not relation or relation.get("status") != BotFriendStatus.ACCEPTED.value:
+                log.warning(
+                    "session_resource.upload_intent.target.reject requester_hash=%s target_hash=%s bot_hash=%s reason=friend_access_denied",
+                    hash_identifier(requester_id)[:16],
+                    hash_identifier(target_entity_id)[:16],
+                    hash_identifier(bot_id)[:16],
+                )
+                raise ValueError("target_bot_access_denied")
+        elif target_entity_id is None and scope_type == "friend_bot_chat":
+            log.warning(
+                "session_resource.upload_intent.target.fallback requester_hash=%s bot_hash=%s reason=missing_target_entity",
+                hash_identifier(requester_id)[:16],
+                hash_identifier(bot_id)[:16],
+            )
+        bot = self._bot_repository.get_by_id_and_owner(bot_id, target_id)
+        binding_id = bot.get("binding_id") if bot else None
+        if (
+            not isinstance(binding_id, int)
+            or isinstance(binding_id, bool)
+            or binding_id <= 0
+        ):
+            log.warning(
+                "session_resource.upload_intent.target.reject requester_hash=%s target_hash=%s bot_hash=%s reason=binding_missing",
+                hash_identifier(requester_id)[:16],
+                hash_identifier(target_id)[:16],
+                hash_identifier(bot_id)[:16],
+            )
+            raise ValueError("bot_device_unavailable")
+        try:
+            context = self._resolver.resolve_for_binding(
+                binding_id,
+                requester_id,
+                bot_id=bot_id,
+            )
+        except DeviceNotBoundError as exc:
+            log.warning(
+                "session_resource.upload_intent.target.reject requester_hash=%s target_hash=%s bot_hash=%s binding_id=%s reason=binding_inactive",
+                hash_identifier(requester_id)[:16],
+                hash_identifier(target_id)[:16],
+                hash_identifier(bot_id)[:16],
+                binding_id,
+            )
+            raise ValueError("bot_device_unavailable") from exc
+        return context, binding_id
+
+    def _resolve_record_context(self, record: SessionResourceRecord) -> DeviceContext:
+        if record.binding_id is None:
+            return self._resolver.resolve_for_bot(record.bot_id, record.owner_id)
+        try:
+            return self._resolver.resolve_for_binding(
+                record.binding_id,
+                record.owner_id,
+                bot_id=record.bot_id,
+            )
+        except DeviceNotBoundError as exc:
+            log.warning(
+                "session_resource.context.reject resource_id=%s binding_id=%s reason=binding_inactive",
+                record.resource_id,
+                record.binding_id,
+            )
+            raise ValueError("bot_device_unavailable") from exc
 
     def _owned(
         self,

--- a/src/backend/src/agentclaw/community/core/session_resources/sql/2026_08_03_session_file_target_binding.sql
+++ b/src/backend/src/agentclaw/community/core/session_resources/sql/2026_08_03_session_file_target_binding.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ac_session_resource
+  ADD COLUMN binding_id BIGINT NULL
+    COMMENT 'target Bot device binding ID for Session File materialization routing';

--- a/src/backend/src/agentclaw/community/core/session_resources/sql/ac_session_resource.sql
+++ b/src/backend/src/agentclaw/community/core/session_resources/sql/ac_session_resource.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS ac_session_resource (
   resource_id VARCHAR(128) NOT NULL,
   owner_id VARCHAR(128) NOT NULL,
   bot_id VARCHAR(128) NOT NULL,
+  binding_id BIGINT NULL,
   scope_type VARCHAR(64) NOT NULL,
   scope_key_hash VARCHAR(128) NOT NULL,
   session_key_hash VARCHAR(128) NOT NULL,

--- a/src/backend/src/agentclaw/community/core/session_resources/types.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/types.py
@@ -54,6 +54,7 @@ class SessionResourceRecord:
     deleted_at: datetime | None = None
     gmt_create: datetime | None = None
     gmt_modified: datetime | None = None
+    binding_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/di/modules/session_resources_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/session_resources_module.py
@@ -8,10 +8,14 @@ from injector import Binder, Module, inject, provider, singleton
 from agentclaw.community.api.session_resource_service import (
     SessionResourceServiceProtocol,
 )
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
 from agentclaw.community.core.bot_management.token_vault import TokenVault
+from agentclaw.community.core.bot_public.repository.bot_friend_repository import (
+    BotFriendRepositoryProtocol,
+)
 from agentclaw.community.di.config import BaasConfig
 from agentclaw.community.core.session_resources.baas_client import (
     SessionResourceBaasClient,
@@ -76,6 +80,8 @@ class SessionResourcesModule(Module):
         token_vault: TokenVault,
         adapter_transport: DeviceAdapterTransport,
         baas_config: BaasConfig,
+        bot_repository: BotRepository,
+        bot_friend_repository: BotFriendRepositoryProtocol,
     ) -> SessionResourceService:
         return SessionResourceService(
             repository=repository,
@@ -85,6 +91,8 @@ class SessionResourcesModule(Module):
             token_vault=token_vault,
             adapter_transport=adapter_transport,
             default_tenant=baas_config.tenant,
+            bot_repository=bot_repository,
+            bot_friend_repository=bot_friend_repository,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/session_resources/test_router.py
+++ b/src/backend/tests/community/adapters/http/session_resources/test_router.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 
 from fastapi import HTTPException
 import pytest
+from pydantic import ValidationError
 
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.adapters.http.session_resources.router import (
@@ -15,6 +16,7 @@ from agentclaw.community.adapters.http.session_resources.router import (
 )
 from agentclaw.community.adapters.http.session_resources.schemas import (
     MaterializedCallbackRequest,
+    UploadIntentRequest,
 )
 from agentclaw.community.core.session_resources.types import (
     SessionResourceRecord,
@@ -87,6 +89,30 @@ class _Service:
                 close=close,
             ),
         )
+
+
+def test_upload_intent_request_accepts_positive_binding_id_only():
+    body = UploadIntentRequest(
+        bot_id="bot-1",
+        session_key="session-raw",
+        scope_type="friend_bot_chat",
+        engine_type="openclaw",
+        binding_id=91,
+        files=[{"filename": "report.txt"}],
+    )
+
+    assert body.binding_id == 91
+
+    with pytest.raises(ValidationError, match="binding_id"):
+        UploadIntentRequest(
+            bot_id="bot-1",
+            session_key="session-raw",
+            scope_type="friend_bot_chat",
+            engine_type="openclaw",
+            binding_id=True,
+            files=[{"filename": "report.txt"}],
+        )
+
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/session_resources/test_materialization.py
+++ b/src/backend/tests/community/core/session_resources/test_materialization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime
 
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.session_resources.materialization import (
@@ -19,8 +20,18 @@ class _Resolver:
     def __init__(self, conn_info=None, *, provider="baas") -> None:
         self._conn_info = conn_info or {"target": "engine"}
         self._provider = provider
+        self.bot_calls = []
+        self.binding_calls = []
 
     def resolve_for_bot(self, bot_id, owner_id):
+        self.bot_calls.append((bot_id, owner_id))
+        return self._context()
+
+    def resolve_for_binding(self, binding_id, operator_id, *, bot_id):
+        self.binding_calls.append((binding_id, operator_id, bot_id))
+        return self._context()
+
+    def _context(self):
         return type(
             "Context",
             (),
@@ -72,6 +83,7 @@ def _record(vault: TokenVault) -> SessionResourceRecord:
         task_version=1,
         size_bytes=1,
         client_content_hash="hash",
+        gmt_create=datetime(2026, 8, 3, 10, 20, 30, tzinfo=UTC),
     )
 
 
@@ -97,6 +109,7 @@ def test_handler_reloads_decrypts_and_dispatches_to_shared_engine_endpoint():
     assert body["session_id"] == "session-raw"
     assert body["transfer_api_version"] == "session_v2"
     assert body["workspace_relative_path"].startswith(".teamclaw/")
+    assert body["uploaded_at"] == "2026-08-03T10:20:30Z"
     assert "owner_id" not in body
 
 
@@ -124,6 +137,40 @@ def test_session_v2_empty_bot_uuid_uses_the_given_arca_proxypass_context():
     assert body["tenant"] == "team_claw"
     assert "bot_uuid" not in body
     assert "bot_uuid" not in path
+
+
+def test_handler_routes_new_resource_with_persisted_binding_to_target_engine():
+    vault = TokenVault(master_key="test-master-key")
+    resolver = _Resolver()
+    transport = _Transport()
+    handler = SessionResourceMaterializeHandler(
+        resolver,
+        transport,
+        _Repo(replace(_record(vault), binding_id=77)),
+        vault,
+    )
+
+    result = handler.handle(_payload())
+
+    assert isinstance(result, Complete)
+    assert resolver.binding_calls == [(77, "owner-1", "bot-1")]
+    assert resolver.bot_calls == []
+
+
+def test_handler_leaves_upload_time_empty_for_legacy_record():
+    vault = TokenVault(master_key="test-master-key")
+    transport = _Transport()
+    handler = SessionResourceMaterializeHandler(
+        _Resolver(),
+        transport,
+        _Repo(replace(_record(vault), gmt_create=None)),
+        vault,
+    )
+
+    result = handler.handle(_payload())
+
+    assert isinstance(result, Complete)
+    assert transport.calls[0][3]["uploaded_at"] is None
 
 
 def test_handler_ignores_stale_task_without_calling_engine():

--- a/src/backend/tests/community/core/session_resources/test_repository.py
+++ b/src/backend/tests/community/core/session_resources/test_repository.py
@@ -38,6 +38,7 @@ def _record() -> SessionResourceRecord:
         status=SessionResourceStatus.UPLOAD_URL_ISSUED,
         transfer_api_version=TransferApiVersion.SESSION_V2,
         session_key_ciphertext="enc:v1:ciphertext",
+        binding_id=42,
     )
 
 
@@ -52,8 +53,9 @@ async def repo():
 
 @pytest.mark.asyncio
 async def test_owned_lookup_requires_owner_bot_and_session(repo):
-    repo.create(_record())
+    created = repo.create(_record())
 
+    assert created.binding_id == 42
     assert repo.get_owned("sr_001", "owner-1", "bot-1", "session-hash") is not None
     assert repo.get_owned("sr_001", "owner-2", "bot-1", "session-hash") is None
     assert repo.get_owned("sr_001", "owner-1", "bot-2", "session-hash") is None

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -18,6 +18,7 @@ from agentclaw.community.core.session_resources.types import (
 from agentclaw.community.plugin_api.device_adapter_transport import (
     DeviceAdapterStreamResponse,
 )
+from agentclaw.community.adapters.http.session_resources.router import _domain_error
 
 
 class _Repo:
@@ -121,8 +122,18 @@ class _Resolver:
             "tenant": "tenant-1",
             "bot_uuid": "bot-uuid-1",
         }
+        self.bot_calls = []
+        self.binding_calls = []
 
     def resolve_for_bot(self, bot_id, owner_id):
+        self.bot_calls.append((bot_id, owner_id))
+        return self._context()
+
+    def resolve_for_binding(self, binding_id, operator_id, *, bot_id):
+        self.binding_calls.append((binding_id, operator_id, bot_id))
+        return self._context()
+
+    def _context(self):
         return type(
             "Context",
             (),
@@ -131,6 +142,35 @@ class _Resolver:
                 "conn_info": self._conn_info,
             },
         )()
+
+
+class _BotRepository:
+    def __init__(self, binding_id=42) -> None:
+        self.binding_id = binding_id
+        self.calls = []
+
+    def get_by_id_and_owner(self, bot_id, owner_id):
+        self.calls.append((bot_id, owner_id))
+        if self.binding_id is None:
+            return None
+        return {"binding_id": self.binding_id}
+
+
+class _BotFriendRepository:
+    def __init__(self, relation=None) -> None:
+        self.relation = relation
+        self.calls = []
+
+    def get_by_entity_ids(
+        self,
+        requester_entity_id,
+        target_entity_id,
+        target_bot_id,
+    ):
+        self.calls.append(
+            (requester_entity_id, target_entity_id, target_bot_id)
+        )
+        return self.relation
 
 
 class _Queue:
@@ -174,6 +214,8 @@ def _service(
     transport=None,
     resolver=None,
     default_tenant="configured-tenant",
+    bot_repository=None,
+    bot_friend_repository=None,
 ):
     repo = _Repo()
     http = _HttpClient(complete_status=complete_status)
@@ -185,6 +227,8 @@ def _service(
         token_vault=TokenVault(master_key="test-master-key"),
         adapter_transport=transport or _Transport(),
         default_tenant=default_tenant,
+        bot_repository=bot_repository or _BotRepository(),
+        bot_friend_repository=bot_friend_repository or _BotFriendRepository(),
     )
     return service, repo, http
 
@@ -218,6 +262,121 @@ def test_upload_intent_uses_session_api_and_persists_encrypted_session_key():
     assert repo.value.session_key_ciphertext != "session/raw value"
     assert repo.value.session_key_hash != "session/raw value"
     assert repo.value.transfer_api_version.value == "session_v2"
+    assert repo.value.binding_id == 42
+
+
+def test_upload_intent_routes_friend_request_to_target_bot_binding():
+    resolver = _Resolver()
+    bot_repository = _BotRepository(binding_id=77)
+    friend_repository = _BotFriendRepository({"status": "ACCEPTED"})
+    service, repo, http = _service(
+        resolver=resolver,
+        bot_repository=bot_repository,
+        bot_friend_repository=friend_repository,
+    )
+
+    intent = service.create_upload_intent(
+        owner_id="requester-1",
+        bot_id="default",
+        session_key="friend-session",
+        scope_type="friend_bot_chat",
+        engine_type="openclaw",
+        filename="report.txt",
+        target_entity_id="target-owner-1",
+        size_bytes=4,
+    )
+
+    assert intent.resource.owner_id == "requester-1"
+    assert intent.resource.binding_id == 77
+    assert friend_repository.calls == [
+        ("requester-1", "target-owner-1", "default")
+    ]
+    assert bot_repository.calls == [("default", "target-owner-1")]
+    assert resolver.binding_calls == [(77, "requester-1", "default")]
+    assert resolver.bot_calls == []
+    assert http.calls[0][1]["json"]["operator"] == "requester-1"
+    assert repo.value == intent.resource
+
+
+def test_upload_intent_uses_frontend_binding_without_target_lookup():
+    resolver = _Resolver()
+    bot_repository = _BotRepository(binding_id=None)
+    friend_repository = _BotFriendRepository({"status": "PENDING"})
+    service, repo, http = _service(
+        resolver=resolver,
+        bot_repository=bot_repository,
+        bot_friend_repository=friend_repository,
+    )
+
+    intent = service.create_upload_intent(
+        owner_id="requester-1",
+        bot_id="default",
+        session_key="friend-session",
+        scope_type="friend_bot_chat",
+        engine_type="openclaw",
+        filename="report.txt",
+        target_entity_id="target-owner-1",
+        binding_id=91,
+        size_bytes=4,
+    )
+
+    assert intent.resource.binding_id == 91
+    assert resolver.binding_calls == [(91, "requester-1", "default")]
+    assert bot_repository.calls == []
+    assert friend_repository.calls == []
+    assert repo.value == intent.resource
+    assert len(http.calls) == 1
+
+
+def test_upload_intent_rejects_unapproved_target_before_baas_call():
+    bot_repository = _BotRepository(binding_id=77)
+    friend_repository = _BotFriendRepository({"status": "PENDING"})
+    service, repo, http = _service(
+        bot_repository=bot_repository,
+        bot_friend_repository=friend_repository,
+    )
+
+    with pytest.raises(ValueError, match="target_bot_access_denied"):
+        service.create_upload_intent(
+            owner_id="requester-1",
+            bot_id="default",
+            session_key="friend-session",
+            scope_type="friend_bot_chat",
+            engine_type="openclaw",
+            filename="report.txt",
+            target_entity_id="target-owner-1",
+            size_bytes=4,
+        )
+
+    assert repo.value is None
+    assert http.calls == []
+    assert bot_repository.calls == []
+
+
+def test_target_routing_errors_use_client_actionable_http_statuses():
+    assert _domain_error(ValueError("target_bot_access_denied")).status_code == 403
+    assert _domain_error(ValueError("bot_device_unavailable")).status_code == 409
+
+
+def test_friend_upload_without_target_entity_uses_requester_binding_and_logs_warning(caplog):
+    caplog.set_level("WARNING", logger="session_resource.service")
+    resolver = _Resolver()
+    service, _, _ = _service(resolver=resolver)
+
+    _intent = service.create_upload_intent(
+        owner_id="requester-1",
+        bot_id="default",
+        session_key="friend-session",
+        scope_type="friend_bot_chat",
+        engine_type="openclaw",
+        filename="report.txt",
+        size_bytes=4,
+    )
+
+    assert resolver.binding_calls == [(42, "requester-1", "default")]
+    assert "target.fallback" in caplog.text
+    assert "requester-1" not in caplog.text
+    assert "friend-session" not in caplog.text
 
 
 def test_upload_intent_defaults_missing_arca_identity_without_logging_raw_values(caplog):
@@ -509,7 +668,8 @@ def test_upload_complete_enqueue_failure_compensates_to_failed():
 @pytest.mark.asyncio
 async def test_content_streams_from_engine_without_baas_download_call():
     transport = _Transport()
-    service, repo, http = _service(transport=transport)
+    resolver = _Resolver()
+    service, repo, http = _service(transport=transport, resolver=resolver)
     intent = _intent(service)
     repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
 
@@ -523,6 +683,7 @@ async def test_content_streams_from_engine_without_baas_download_call():
 
     assert record.resource_id == intent.resource.resource_id
     assert transport.calls[0][2].endswith(f"/{intent.resource.resource_id}/content")
+    assert resolver.binding_calls[-1] == (42, "owner-1", "bot-1")
     assert len(http.calls) == 1
     assert [chunk async for chunk in response.body] == [b"materialized bytes"]
     await response.close()

--- a/src/backend/tests/community/endpoints/test_session_resources.py
+++ b/src/backend/tests/community/endpoints/test_session_resources.py
@@ -16,6 +16,10 @@ from urllib.parse import urlparse
 
 from injector import singleton
 
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_public.repository.bot_friend_repository import (
+    BotFriendRepositoryProtocol,
+)
 from agentclaw.community.core.session_resources.repository.protocol import (
     SessionResourceRepositoryProtocol,
 )
@@ -48,8 +52,10 @@ from tests.community.framework import (
 
 
 _OWNER = "session-resource-user"
+_TARGET_OWNER = "session-resource-target-owner"
 _BOT_ID = "bot-session-resource"
 _DEVICE_ID = "device-session-resource"
+_TARGET_DEVICE_ID = "device-session-resource-target"
 _SESSION_KEY = "session-resource-key"
 _UPSTREAM_ERROR_SESSION_KEY = "session-resource-upstream-error"
 _AUTH_HEADERS = {"x-user-id": _OWNER}
@@ -167,6 +173,39 @@ def _seed_bot(world) -> None:
     )
 
 
+def _seed_friend_target_bot(world) -> None:
+    _use_real_session_file_api(world)
+    make_staff_user(world, user_id=_OWNER)
+    make_staff_user(world, user_id=_TARGET_OWNER)
+    binding_id = make_active_local_device(
+        world,
+        owner_id=_TARGET_OWNER,
+        device_id=_TARGET_DEVICE_ID,
+    )
+    make_bot(
+        world,
+        bot_id=_BOT_ID,
+        owner_id=_TARGET_OWNER,
+        owner_name="Session Resource Target Owner",
+        bot_type="service",
+        status="ACTIVE",
+        binding_id=binding_id,
+    )
+    world.get(BotRepository).update_by_owner(
+        _BOT_ID,
+        _TARGET_OWNER,
+        {"public": "1"},
+    )
+    world.get(BotFriendRepositoryProtocol).insert(
+        {
+            "requester_entity_id": _OWNER,
+            "target_entity_id": _TARGET_OWNER,
+            "target_bot_id": _BOT_ID,
+            "status": "ACCEPTED",
+        }
+    )
+
+
 def _record(
     *,
     resource_id: str = _RESOURCE_ID,
@@ -256,6 +295,11 @@ _UPLOAD_INTENT_BODY = {
         }
     ],
 }
+_FRIEND_UPLOAD_INTENT_BODY = {
+    **_UPLOAD_INTENT_BODY,
+    "scope_type": "friend_bot_chat",
+    "target_entity_id": _TARGET_OWNER,
+}
 _INVALID_UPLOAD_INTENT_BODY = {
     **_UPLOAD_INTENT_BODY,
     "files": [{"filename": "../notes.txt"}],
@@ -303,6 +347,21 @@ _CALLBACK_BODY = {
 )
 def upload_intents_ok():
     """Create an intent through the real service and local HTTP API."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/session-resources/upload-intents",
+    scenario="friend_target_entity_routes_to_target_binding",
+    input=CaseInput(headers=_AUTH_HEADERS, json_body=_FRIEND_UPLOAD_INTENT_BODY),
+    seed=_seed_friend_target_bot,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"files": [{"status": "upload_url_issued"}]},
+    ),
+)
+def upload_intents_friend_target_entity():
+    """Route an interaction user's upload to the approved target Bot binding."""
 
 
 @endpoint_test(

--- a/src/engine/src/engine/community/api/session_files/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_files/tests/test_router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -40,6 +41,7 @@ def _write_ready_file(root: Path, session_key: str, content: bytes = b"report") 
             observed_size=observed.st_size,
             observed_mtime_ns=observed.st_mtime_ns,
             observed_inode=observed.st_ino,
+            uploaded_at=datetime(2026, 8, 3, 10, 20, 30, tzinfo=UTC),
         )
     )
     return target
@@ -94,6 +96,7 @@ def test_list_and_content_are_scoped_to_manifest_session(client):
                 "display_name": "report.txt",
                 "size_bytes": target.stat().st_size,
                 "availability": "ready",
+                "uploaded_at": "2026-08-03T10:20:30Z",
             }
         ]
     }
@@ -101,6 +104,22 @@ def test_list_and_content_are_scoped_to_manifest_session(client):
     assert content.content == b"report"
     assert content.headers["content-disposition"].startswith("attachment;")
     assert cross_session.status_code == 404
+
+
+def test_list_returns_null_upload_time_for_legacy_manifest(client):
+    test_client, root = client
+    _write_ready_file(root, "session-a")
+    entry = ManifestStore(root).get("sr_001")
+    assert entry is not None
+    ManifestStore(root).upsert(entry.model_copy(update={"uploaded_at": None}))
+
+    response = test_client.get(
+        "/api/session-files",
+        params={"sessionKey": "session-a"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["files"][0]["uploaded_at"] is None
 
 
 def test_changed_and_missing_files_are_not_streamed(client):
@@ -130,7 +149,9 @@ def test_changed_and_missing_files_are_not_streamed(client):
     assert changed.status_code == 409
     assert changed.json()["detail"] == "resource_changed"
     assert changed_list.json()["files"][0]["availability"] == "changed"
+    assert changed_list.json()["files"][0]["uploaded_at"] == "2026-08-03T10:20:30Z"
     assert listed.json()["files"][0]["availability"] == "missing"
+    assert listed.json()["files"][0]["uploaded_at"] == "2026-08-03T10:20:30Z"
     assert missing.status_code == 409
     assert missing.json()["detail"] == "resource_missing"
 

--- a/src/engine/src/engine/community/core/resource_materialization/models.py
+++ b/src/engine/src/engine/community/core/resource_materialization/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -33,6 +34,7 @@ class MaterializationRequest(BaseModel):
     filename: str = Field(min_length=1, max_length=255)
     size_bytes: int | None = Field(default=None, ge=0)
     content_hash: str | None = Field(default=None, min_length=1, max_length=128)
+    uploaded_at: datetime | None = None
 
     def model_post_init(self, __context, /) -> None:
         if self.transfer_api_version == "session_v2":
@@ -71,6 +73,7 @@ class ManifestEntry(BaseModel):
     observed_size: int | None = None
     observed_mtime_ns: int | None = None
     observed_inode: int | None = None
+    uploaded_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -278,6 +278,7 @@ class ResourceMaterializationService:
                 observed_size=observed.st_size,
                 observed_mtime_ns=observed.st_mtime_ns,
                 observed_inode=getattr(observed, "st_ino", None),
+                uploaded_at=request.uploaded_at,
             )
             store.upsert(entry)
             log.info(

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -59,6 +60,7 @@ def _request(content: bytes, **overrides) -> MaterializationRequest:
         "filename": "report.txt",
         "size_bytes": len(content),
         "content_hash": hashlib.sha256(content).hexdigest(),
+        "uploaded_at": "2026-08-03T10:20:30Z",
     }
     values.update(overrides)
     return MaterializationRequest(**values)
@@ -91,6 +93,7 @@ async def test_materialize_writes_atomic_file_manifest_and_callback(tmp_path: Pa
     assert entry.observed_size == len(content)
     assert entry.observed_mtime_ns is not None
     assert entry.observed_inode is not None
+    assert entry.uploaded_at == datetime(2026, 8, 3, 10, 20, 30, tzinfo=UTC)
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/core/session_files/models.py
+++ b/src/engine/src/engine/community/core/session_files/models.py
@@ -14,11 +14,13 @@ class SessionFileView:
     display_name: str
     size_bytes: int
     availability: str
+    uploaded_at: str | None
 
-    def as_dict(self) -> dict[str, str | int]:
+    def as_dict(self) -> dict[str, str | int | None]:
         return {
             "resource_id": self.resource_id,
             "display_name": self.display_name,
             "size_bytes": self.size_bytes,
             "availability": self.availability,
+            "uploaded_at": self.uploaded_at,
         }

--- a/src/engine/src/engine/community/core/session_files/service.py
+++ b/src/engine/src/engine/community/core/session_files/service.py
@@ -5,6 +5,7 @@ import hashlib
 import logging
 import mimetypes
 from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import quote
 
@@ -43,16 +44,26 @@ class SessionFileService:
                 display_name=entry.filename,
                 size_bytes=entry.size_bytes,
                 availability=self._inspect(root, entry, force_hash=False)[0],
+                uploaded_at=self._format_uploaded_at(entry.uploaded_at),
             )
             for entry in entries
             if entry.status == "ready" and entry.session_key_hash == session_hash
         ]
         log.info(
-            "engine.session_files.list session_key_hash=%s file_count=%s",
+            "engine.session_files.list session_key_hash=%s file_count=%s upload_time_count=%s",
             session_hash[:16],
             len(files),
+            sum(file.uploaded_at is not None for file in files),
         )
         return files
+
+    @staticmethod
+    def _format_uploaded_at(uploaded_at: datetime | None) -> str | None:
+        if uploaded_at is None:
+            return None
+        if uploaded_at.tzinfo is None:
+            uploaded_at = uploaded_at.replace(tzinfo=UTC)
+        return uploaded_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
     def open_content(
         self,


### PR DESCRIPTION
## Problem

Session File upload intent previously resolved the target Engine from the logged-in user and Bot ID. In friend Bot and service Bot conversations this can select the wrong binding, so upload completion succeeds but asynchronous materialization cannot reach the active Bot container. Engine file listings also lacked the original upload time.

## Solution

- Accept an optional frontend-resolved `binding_id` on upload intents and prefer it when resolving the target device.
- Keep `target_entity_id` as the compatibility fallback, including friend-access validation, and persist the resolved binding on `ac_session_resource` for later materialization and content routing.
- Add the nullable `binding_id` schema migration while preserving legacy resolution for historical rows.
- Propagate the resource creation time through materialization into the Engine manifest and return it as UTC `uploaded_at` from the Session File list API.
- Add structured diagnostic logs and focused Backend/Engine coverage for direct binding, fallback, authorization, materialization, and upload-time behavior.

## Validation

- Engine resource materialization and Session File router tests: `26 passed`.
- Backend Session Resource service, materialization, repository, HTTP router, and endpoint tests: `45 passed`.
- Ruff checks for affected Backend and Engine packages: passed.
- `git diff --check origin/REL20260804...HEAD`: passed.

## Compatibility and risk

`binding_id` and `target_entity_id` remain optional. Existing callers and historical rows without a persisted binding continue through the prior owner/Bot resolution path. Deployments must apply `2026_08_03_session_file_target_binding.sql` before relying on persisted binding routing. Historical Engine manifests return `uploaded_at: null` rather than fabricating a timestamp.
