### PR TITLE
feat(backend): expose Bot-scoped Local Skill reads

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -79,6 +79,10 @@ from agentclaw.community.core.resources.service import (
     FileTooLargeError,
     ResourceNotFoundError,
 )
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillNotFoundError,
+    LocalSkillOwnerAmbiguousError,
+)
 from agentclaw.community.core.services.identity import (
     InvalidIdentityEntityTypeError,
     InvalidIdentityFileTypeError,
@@ -183,6 +187,8 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # str(exc), which would leak internal ids/paths to external callers.
     DuplicateResourceError: (409, "Resource already exists"),
     ResourceNotFoundError: (404, "Not found"),
+    LocalSkillNotFoundError: (404, "Not found"),
+    LocalSkillOwnerAmbiguousError: (409, "Ambiguous Local Skill owner"),
     FileTooLargeError: (413, "File too large for preview"),
     # Identity domain errors — ValueError subclasses raised by IdentityService
     # validate_entity_type / validate_file_type.
@@ -262,6 +268,13 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # re-raise and the app's catch-all would answer with {"detail": ...}, which
     # is not an Envelope and breaks the public contract.
     BotServiceError: (500, "Internal error"),
+}
+
+# Most public categories retain the ordinary ``xxx000`` business code.  A
+# small, explicit override table lets a category expose a stable actionable
+# subcode without changing any existing public response.
+ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
+    LocalSkillOwnerAmbiguousError: 409104,
 }
 
 
@@ -346,6 +359,7 @@ def _error_response(
     request: Request,
     *,
     headers: Mapping[str, str] | None = None,
+    code: int | None = None,
 ) -> JSONResponse:
     # ``ErrorEnvelope``, not ``Envelope``: it is the model every route documents
     # for failures (``ERROR_RESPONSES``), and since ``Envelope`` gained the
@@ -354,7 +368,7 @@ def _error_response(
     # error body has no partial payload to caveat, so ``warning`` has no meaning
     # here.
     body = ErrorEnvelope(
-        code=http_status * 1000,
+        code=code if code is not None else http_status * 1000,
         message=message,
         data=None,
         request_id=_trace_id(request),
@@ -417,5 +431,10 @@ def mapped_error_response(exc: Exception, request: Request) -> JSONResponse | No
     """
     for error_type, (http_status, message) in ENVELOPE_ERRORS.items():
         if isinstance(exc, error_type):
-            return _error_response(http_status, message, request)
+            return _error_response(
+                http_status,
+                message,
+                request,
+                code=ENVELOPE_ERROR_CODES.get(error_type),
+            )
     return None

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -1,15 +1,16 @@
-"""Public contract stubs for Bot-owned Local Skill lifecycle operations.
+"""Public lifecycle routes for Bot-owned Local Skills.
 
-The public surface deliberately has no catalog, marketplace, or installation
-relationship. Every operation requires an authenticated principal; Track B
-implementation slices wire these definitions to the domain services.
+This router deliberately exposes only the six ratified Local Skill operations.
+Git, Center, marketplace, and install semantics remain on their separate,
+non-public surfaces.
 """
 
 from __future__ import annotations
 
-from typing import Annotated
+import json
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, Query
+from fastapi import APIRouter, Body, Depends, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
@@ -22,6 +23,16 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     Principal,
     require_principal,
 )
+from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+    page as page_envelope,
+)
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
+from agentclaw.community.di import Injected
 
 from .schemas import Skill, SkillState, SkillUpload
 
@@ -30,29 +41,76 @@ router = APIRouter(prefix="/openapi/v1/bots/skills", tags=["skills"])
 PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 
+def _tags(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(tag) for tag in value]
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return [value] if value else []
+        return [str(tag) for tag in parsed] if isinstance(parsed, list) else []
+    return []
+
+
+def _to_skill(record: dict[str, Any]) -> Skill:
+    return Skill(
+        skill_id=str(record["id"]),
+        name=str(record["name"]),
+        description=record.get("description"),
+        category=record.get("category"),
+        tags=_tags(record.get("tags")),
+        active=bool(record["active"]),
+        created_at=record.get("gmt_created"),
+        updated_at=record.get("gmt_modified"),
+    )
+
+
 @router.get("", response_model=Envelope[Page[Skill]])
+@envelope_errors
 async def list_skills(
     page: PageParamsDep,
     principal: PrincipalDep,
+    request: Request,
     bot_id: str = Query(..., description="Bot ID whose Local Skills are listed."),
     owner_entity_id: str | None = Query(
         default=None, description="Verified Bot owner locator."
     ),
-    active: bool | None = Query(
-        default=None, description="Filter by desired Active state."
-    ),
-    keyword: str | None = Query(
-        default=None, description="Case-insensitive name or description filter."
+    active: bool | None = Query(default=None),
+    keyword: str | None = Query(default=None),
+    query_service: LocalSkillQueryServiceProtocol = Injected(
+        LocalSkillQueryServiceProtocol
     ),
 ) -> Envelope[Page[Skill]]:
-    """List one Bot's Local Skills from persisted desired state."""
-    raise NotImplementedError
+    """List exact Bot-owned Local Skills from database desired state."""
+    actor_id = caller_owner_id(principal)
+    total, records = query_service.list_local_skills(
+        bot_id=bot_id,
+        owner_id=owner_entity_id or actor_id,
+        actor_id=actor_id,
+        page=page.page,
+        page_size=page.page_size,
+        active=active,
+        keyword=keyword,
+    )
+    return page_envelope(total, [_to_skill(record) for record in records], request)
 
 
 @router.get("/{skill_id}", response_model=Envelope[Skill])
-async def get_skill(skill_id: str, principal: PrincipalDep) -> Envelope[Skill]:
-    """Get public metadata for one Local Skill selected by its Skill ID."""
-    raise NotImplementedError
+@envelope_errors
+async def get_skill(
+    skill_id: str,
+    principal: PrincipalDep,
+    request: Request,
+    query_service: LocalSkillQueryServiceProtocol = Injected(
+        LocalSkillQueryServiceProtocol
+    ),
+) -> Envelope[Skill]:
+    """Get public metadata for one Local Skill; the Skill ID selects its Bot."""
+    record = query_service.get_local_skill(
+        skill_id=skill_id, actor_id=caller_owner_id(principal)
+    )
+    return envelope(_to_skill(record), request)
 
 
 @router.post(
@@ -82,21 +140,13 @@ async def upload_skill(
     raise NotImplementedError
 
 
-@router.post(
-    "/{skill_id}/activate",
-    response_model=Envelope[SkillState],
-)
-async def activate_skill(
-    skill_id: str, principal: PrincipalDep
-) -> Envelope[SkillState]:
+@router.post("/{skill_id}/activate", response_model=Envelope[SkillState])
+async def activate_skill(skill_id: str, principal: PrincipalDep) -> Envelope[SkillState]:
     """Set one Local Skill's desired state to Active."""
     raise NotImplementedError
 
 
-@router.post(
-    "/{skill_id}/deactivate",
-    response_model=Envelope[SkillState],
-)
+@router.post("/{skill_id}/deactivate", response_model=Envelope[SkillState])
 async def deactivate_skill(
     skill_id: str, principal: PrincipalDep
 ) -> Envelope[SkillState]:

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -69,6 +69,7 @@ internal_dependencies:
   - agentclaw.community.core.service_bot.services.baas_service  # BotWsConnectionInfoResponse / HttpConnectionInfo — typed in baas_service.py (BaasService is a plain core service)
   - agentclaw.community.core.service_bot.types       # PublishStage enum — typed in baas_service.py
   - agentclaw.community.core.skills_pool             # Skills Pool rollout/query/recovery domain DTOs used by operator Service API Protocols
+  - agentclaw.community.core.skill_center            # Local Skill desired-state query service DTOs
   - agentclaw.community.kernel.device_dto            # OutBoundOperationRule — typed in baas_service.py Protocol (B6)
   - agentclaw.community.plugin_api.auth              # AuthRequestContext — typed in caller_iam_token_service.py
   - agentclaw.community.plugin_api.passport          # PassportPlugin — typed in caller_identity_service.py

--- a/src/backend/src/agentclaw/community/api/local_skill_query_service.py
+++ b/src/backend/src/agentclaw/community/api/local_skill_query_service.py
@@ -1,0 +1,24 @@
+"""Service API for public Bot-scoped Local Skill reads."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LocalSkillQueryServiceProtocol(Protocol):
+    """Read desired-state metadata for Local Skills visible to one actor."""
+
+    def list_local_skills(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        actor_id: str,
+        page: int,
+        page_size: int,
+        active: bool | None,
+        keyword: str | None,
+    ) -> tuple[int, list[dict[str, Any]]]: ...
+
+    def get_local_skill(self, *, skill_id: str, actor_id: str) -> dict[str, Any]: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -14,8 +14,10 @@ provides:
   - "GitSyncService"
   - "SkillAuthService"
   - "CurrentRuntimeLayoutProbeService"
+  - "LocalSkillQueryService"
 consumes:
   - "BotRepository"
+  - "CollaboratorServiceProtocol"
   - "Events"
   - "core/mcp services"
   - "CachePlugin"
@@ -29,6 +31,7 @@ consumes:
   - "SkillRepoSyncPlugin"
 internal_dependencies:
   - agentclaw.community.core.access
+  - agentclaw.community.core.bot_collaborator
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.config
   - agentclaw.community.core.devices

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -11,3 +11,11 @@ class SkillReferencedBySkillSetError(RuntimeError):
     def __init__(self, skill_set_ids: list[str]) -> None:
         super().__init__("skill is still referenced by a skill set")
         self.skill_set_ids = skill_set_ids
+
+
+class LocalSkillNotFoundError(Exception):
+    """A Local Skill or its authorized Bot scope is not visible to the actor."""
+
+
+class LocalSkillOwnerAmbiguousError(Exception):
+    """Legacy Local Skill ownership cannot be resolved without guessing."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_query_service.py
@@ -1,0 +1,112 @@
+"""Desired-state Local Skill queries for the public API.
+
+This service deliberately has no device or runtime dependency: database desired
+state remains readable while a Bot is offline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from injector import inject
+
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_collaborator.protocols import (
+    CollaboratorServiceProtocol,
+)
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillNotFoundError,
+    LocalSkillOwnerAmbiguousError,
+)
+from agentclaw.community.core.skill_center.services.repositories import SkillRepository
+
+
+class LocalSkillQueryService:
+    """Authorize a Bot scope then project only exact ``local://`` rows."""
+
+    @inject
+    def __init__(
+        self,
+        skill_repo: SkillRepository,
+        bot_repo: BotRepository,
+        collaborator_service: CollaboratorServiceProtocol,
+    ) -> None:
+        self._skill_repo = skill_repo
+        self._bot_repo = bot_repo
+        self._collaborator_service = collaborator_service
+
+    def list_local_skills(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        actor_id: str,
+        page: int,
+        page_size: int,
+        active: bool | None,
+        keyword: str | None,
+    ) -> tuple[int, list[dict[str, Any]]]:
+        self._require_view_access(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
+        return self._skill_repo.list_bot_local_skills(
+            bot_id=bot_id,
+            user_id=owner_id,
+            page=page,
+            page_size=page_size,
+            active=active,
+            keyword=keyword,
+        )
+
+    def get_local_skill(self, *, skill_id: str, actor_id: str) -> dict[str, Any]:
+        if not skill_id.isdecimal():
+            raise LocalSkillNotFoundError()
+        skill = self._skill_repo.get_by_id(skill_id)
+        if not self._is_exact_local_skill(skill):
+            if self._is_unresolvable_legacy_local_skill(skill):
+                raise LocalSkillOwnerAmbiguousError()
+            raise LocalSkillNotFoundError()
+        owner_id = str(skill["user_id"])
+        bot_id = str(skill["bolt_id"])
+        self._require_view_access(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
+        return (
+            self._skill_repo.get_bot_local_skill(
+                skill_id=skill_id, bot_id=bot_id, user_id=owner_id
+            )
+            or self._not_found()
+        )
+
+    @staticmethod
+    def _is_exact_local_skill(skill: dict[str, Any] | None) -> bool:
+        return bool(
+            skill
+            and skill.get("user_id")
+            and skill.get("bolt_id")
+            and str(skill.get("git_path") or "").startswith("local://")
+        )
+
+    @staticmethod
+    def _is_unresolvable_legacy_local_skill(skill: dict[str, Any] | None) -> bool:
+        """Whether a legacy default Local row lacks its trusted owner field."""
+        return bool(
+            skill
+            and skill.get("bolt_id") == "default"
+            and not skill.get("user_id")
+            and str(skill.get("git_path") or "").startswith("local://")
+        )
+
+    def _require_view_access(
+        self, *, bot_id: str, owner_id: str, actor_id: str
+    ) -> None:
+        if self._bot_repo.get_by_id_and_owner(bot_id, owner_id) is None:
+            raise LocalSkillNotFoundError()
+        if actor_id == owner_id:
+            return
+        permission = self._collaborator_service.check_collaborator_permission(
+            bot_id, owner_id, actor_id, PermissionLevel.MEMBER
+        )
+        if not permission.get("has_permission"):
+            raise LocalSkillNotFoundError()
+
+    @staticmethod
+    def _not_found() -> dict[str, Any]:
+        raise LocalSkillNotFoundError()

--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -45,6 +45,25 @@ class SkillRepository(Protocol):
         """精确查询 Bot 自有的同名 local 技能，不包含全局行。"""
         ...
 
+    def list_bot_local_skills(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        page: int,
+        page_size: int,
+        active: bool | None,
+        keyword: str | None,
+    ) -> tuple[int, list[dict]]:
+        """Page exact Bot-owned ``local://`` desired-state Skill metadata."""
+        ...
+
+    def get_bot_local_skill(
+        self, *, skill_id: str, bot_id: str, user_id: str
+    ) -> dict | None:
+        """Return one exact Bot-owned ``local://`` Skill with desired state."""
+        ...
+
     def create(self, skill_data: dict) -> dict:
         ...
 

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -62,6 +62,9 @@ from agentclaw.community.api.skill_set_service_factory import (
 from agentclaw.community.api.skill_set_switcher_factory import (
     SkillSetSwitcherFactoryProtocol,
 )
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
 from agentclaw.community.di import config as cfg
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.devices.services.device_context_resolver import (
@@ -127,6 +130,12 @@ from agentclaw.community.core.skills_pool.types import (
 )
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
     SkillSymlinkListener,
+)
+from agentclaw.community.core.skill_center.services.local_skill_query_service import (
+    LocalSkillQueryService,
+)
+from agentclaw.community.core.bot_collaborator.protocols import (
+    CollaboratorServiceProtocol,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.cache import CachePlugin
@@ -242,6 +251,22 @@ class SkillCenterModule(Module):
         )
 
         return UnifiedSkillSetRepository(db)
+
+    @singleton
+    @provider
+    @inject
+    def local_skill_query_service(
+        self,
+        skill_repo: SkillRepository,
+        bot_repo: BotRepository,
+        collaborator_service: CollaboratorServiceProtocol,
+    ) -> LocalSkillQueryServiceProtocol:
+        """Bind the public Local-Skill desired-state query service."""
+        return LocalSkillQueryService(
+            skill_repo=skill_repo,
+            bot_repo=bot_repo,
+            collaborator_service=collaborator_service,
+        )
 
     @singleton
     @provider
@@ -638,8 +663,7 @@ class SkillCenterModule(Module):
             entity_id = bot.get("entity_id")
             bot_id = bot.get("bot_id")
             if not all(
-                isinstance(value, str) and value
-                for value in (env, entity_id, bot_id)
+                isinstance(value, str) and value for value in (env, entity_id, bot_id)
             ):
                 return None
             state = layout_repository.get(

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -359,6 +359,99 @@ class SkillRepository:
             row = query.order_by(self.Skill.gmt_created.desc()).first()
             return _skill_to_dict(row) if row is not None else None
 
+    @staticmethod
+    def _public_local_skill(row, active: bool) -> dict:
+        data = _skill_to_dict(row)
+        data["active"] = bool(active)
+        return data
+
+    def list_bot_local_skills(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        page: int,
+        page_size: int,
+        active: bool | None,
+        keyword: str | None,
+    ) -> tuple[int, list[dict]]:
+        """Page exact Bot-owned ``local://`` rows by desired active state."""
+        from agentclaw.community.plugins.local.sqlite_models import (
+            DefaultSkillsetSkillExclusion,
+        )
+
+        with self._db.orm_session() as db:
+            excluded = (
+                db.query(DefaultSkillsetSkillExclusion.id)
+                .filter(
+                    DefaultSkillsetSkillExclusion.user_id
+                    == _normalize_user_id(user_id),
+                    DefaultSkillsetSkillExclusion.bot_id == bot_id,
+                    DefaultSkillsetSkillExclusion.skill_id == self.Skill.id,
+                )
+                .exists()
+            )
+            query = db.query(self.Skill, (~excluded).label("active")).filter(
+                self.Skill.env == get_current_env(),
+                self.Skill.bolt_id == bot_id,
+                self.Skill.user_id == _normalize_user_id(user_id),
+                self.Skill.git_path.like("local://%"),
+            )
+            if keyword and keyword.strip():
+                term = f"%{keyword.strip().lower()}%"
+                query = query.filter(
+                    or_(
+                        func.lower(self.Skill.name).like(term),
+                        func.lower(func.coalesce(self.Skill.description, "")).like(
+                            term
+                        ),
+                    )
+                )
+            if active is not None:
+                query = query.filter((~excluded) == active)
+            total = query.count()
+            rows = (
+                query.order_by(self.Skill.gmt_modified.desc(), self.Skill.id.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+                .all()
+            )
+            return total, [
+                self._public_local_skill(row, is_active) for row, is_active in rows
+            ]
+
+    def get_bot_local_skill(
+        self, *, skill_id: str, bot_id: str, user_id: str
+    ) -> dict | None:
+        """Return one exact Bot-owned ``local://`` row or no row."""
+        from agentclaw.community.plugins.local.sqlite_models import (
+            DefaultSkillsetSkillExclusion,
+        )
+
+        with self._db.orm_session() as db:
+            excluded = (
+                db.query(DefaultSkillsetSkillExclusion.id)
+                .filter(
+                    DefaultSkillsetSkillExclusion.user_id
+                    == _normalize_user_id(user_id),
+                    DefaultSkillsetSkillExclusion.bot_id == bot_id,
+                    DefaultSkillsetSkillExclusion.skill_id == self.Skill.id,
+                )
+                .exists()
+            )
+            row = (
+                db.query(self.Skill, (~excluded).label("active"))
+                .filter(
+                    self.Skill.id == int(skill_id),
+                    self.Skill.env == get_current_env(),
+                    self.Skill.bolt_id == bot_id,
+                    self.Skill.user_id == _normalize_user_id(user_id),
+                    self.Skill.git_path.like("local://%"),
+                )
+                .one_or_none()
+            )
+            return self._public_local_skill(*row) if row else None
+
     def list_bot_local_assets(
         self,
         *,

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -1,0 +1,312 @@
+"""HTTP contract tests for #722's Bot-scoped Local Skill read routes."""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+
+import jwt
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    PRINCIPAL_HEADER,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.skills.router import router
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillNotFoundError,
+    LocalSkillOwnerAmbiguousError,
+)
+from agentclaw.community.core.skill_center.services.local_skill_query_service import (
+    LocalSkillQueryService,
+)
+from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.plugin_api.secret_resolver import SecretResolver
+from agentclaw.community.plugins.bot_repository import BotRepository
+from agentclaw.community.plugins.local.sqlite_models import (
+    DefaultSkillsetSkillExclusion,
+)
+from agentclaw.community.plugins.skill_repository import SkillRepository
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+    reset_principal_verifier_config_cache,
+)
+
+
+class _Query:
+    def __init__(self) -> None:
+        self.list_args = None
+
+    def list_local_skills(self, **kwargs):
+        self.list_args = kwargs
+        return 1, [
+            {
+                "id": "7",
+                "name": "weather",
+                "description": "Forecast",
+                "category": "tools",
+                "tags": '["daily"]',
+                "active": False,
+                "gmt_created": "2026-08-04T00:00:00",
+                "gmt_modified": "2026-08-04T01:00:00",
+                "git_path": "local://weather",
+                "user_id": "owner",
+                "bolt_id": "bot-1",
+            }
+        ]
+
+    def get_local_skill(self, **kwargs):
+        if kwargs["skill_id"] == "hidden":
+            raise LocalSkillNotFoundError()
+        if kwargs["skill_id"] == "ambiguous":
+            raise LocalSkillOwnerAmbiguousError()
+        return self.list_local_skills()[1][0]
+
+
+def _client(query: _Query) -> TestClient:
+    class Bindings(Module):
+        def configure(self, binder):
+            binder.bind(LocalSkillQueryServiceProtocol, to=query)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
+    attach_injector(app, Injector([Bindings()]))
+    return TestClient(app)
+
+
+def test_list_uses_verified_actor_and_exposes_only_public_metadata():
+    query = _Query()
+    response = _client(query).get(
+        "/openapi/v1/bots/skills?bot_id=bot-1&owner_entity_id=owner&active=false&keyword=cast&page=2&page_size=7"
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data == {
+        "total": 1,
+        "items": [
+            {
+                "skill_id": "7",
+                "name": "weather",
+                "description": "Forecast",
+                "category": "tools",
+                "tags": ["daily"],
+                "active": False,
+                "created_at": "2026-08-04T00:00:00",
+                "updated_at": "2026-08-04T01:00:00",
+            }
+        ],
+    }
+    assert query.list_args == {
+        "bot_id": "bot-1",
+        "owner_id": "owner",
+        "actor_id": "actor",
+        "page": 2,
+        "page_size": 7,
+        "active": False,
+        "keyword": "cast",
+    }
+
+
+def test_detail_derives_scope_from_skill_id_and_masks_invisible_rows():
+    query = _Query()
+    client = _client(query)
+
+    visible = client.get("/openapi/v1/bots/skills/7")
+    assert visible.status_code == 200
+    assert visible.json()["data"]["skill_id"] == "7"
+
+    hidden = client.get("/openapi/v1/bots/skills/hidden")
+    assert hidden.status_code == 404
+    assert hidden.json()["code"] == 404000
+
+    ambiguous = client.get("/openapi/v1/bots/skills/ambiguous")
+    assert ambiguous.status_code == 409
+    assert ambiguous.json()["code"] == 409104
+
+
+def test_list_requires_bot_id_and_shared_page_limits():
+    client = _client(_Query())
+    assert client.get("/openapi/v1/bots/skills").status_code == 422
+    assert (
+        client.get("/openapi/v1/bots/skills?bot_id=bot&page_size=101").status_code
+        == 422
+    )
+
+
+class _Database:
+    def __init__(self, engine) -> None:
+        self._session = sessionmaker(bind=engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._session()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+def test_router_uses_verified_principal_and_real_tenant_guard(tmp_path):
+    """A verified HTTP request reaches the Track A-guarded ORM query."""
+    key = "skills-router-test-key-at-least-32-bytes"
+
+    class _Secret:
+        secret_user = "gateway"
+        secret_value = key
+
+    class _Resolver(SecretResolver):
+        def get_secret(self, secret_name: str):
+            return _Secret()
+
+    init_principal_verifier_config(
+        _Resolver(), "gateway_principal_signing_key", strict=False
+    )
+    engine = create_engine(f"sqlite:///{tmp_path / 'skills-router.db'}")
+    for model in (BotModel, Skill, DefaultSkillsetSkillExclusion):
+        model.__table__.create(engine)
+    db = _Database(engine)
+    bots, skills = BotRepository(db), SkillRepository(db)
+    with avernet_tenant_scope("tenant-a"):
+        bots.insert(
+            {
+                "bot_id": "bot",
+                "entity_id": "owner",
+                "entity_type": "staff",
+                "creator_id": "owner",
+                "owner_id": "owner",
+            }
+        )
+        skills.create(
+            {
+                "name": "tenant-a",
+                "git_path": "local://tenant-a",
+                "user_id": "owner",
+                "bolt_id": "bot",
+            }
+        )
+        git_default = skills.create(
+            {
+                "name": "git-default",
+                "git_path": "git://market/git-default",
+                "user_id": "owner",
+                "bolt_id": "default",
+            }
+        )
+
+    class Bindings(Module):
+        def configure(self, binder):
+            binder.bind(
+                LocalSkillQueryServiceProtocol,
+                to=LocalSkillQueryService(skills, bots, object()),
+            )
+
+    now = int(time.time())
+
+    def token(tenant: str) -> str:
+        return jwt.encode(
+            {
+                "iss": "gateway",
+                "aud": "backend",
+                "iat": now,
+                "exp": now + 60,
+                "principals": [
+                    {
+                        "type": "user",
+                        "tenant": tenant,
+                        "subject": {"id": "owner", "username": "owner@example.com"},
+                    }
+                ],
+            },
+            key,
+            algorithm="HS256",
+        )
+
+    app = FastAPI()
+    app.add_middleware(AvernetTenantMiddleware)
+    app.include_router(router)
+    attach_injector(app, Injector([Bindings()]))
+    client = TestClient(app)
+    try:
+        visible = client.get(
+            "/openapi/v1/bots/skills?bot_id=bot",
+            headers={PRINCIPAL_HEADER: token("tenant-a")},
+        )
+        hidden = client.get(
+            "/openapi/v1/bots/skills?bot_id=bot",
+            headers={PRINCIPAL_HEADER: token("tenant-b")},
+        )
+        invisible_git = client.get(
+            f"/openapi/v1/bots/skills/{git_default['id']}",
+            headers={PRINCIPAL_HEADER: token("tenant-a")},
+        )
+    finally:
+        reset_principal_verifier_config_cache()
+    assert visible.status_code == 200 and visible.json()["data"]["total"] == 1
+    assert hidden.status_code == 404 and hidden.json()["code"] == 404000
+    assert invisible_git.status_code == 404 and invisible_git.json()["code"] == 404000
+
+
+def test_default_bot_scope_is_owner_distinguished(tmp_path):
+    """Two valid legacy ``default`` Bots must not make either owner ambiguous."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'default-owner.db'}")
+    for model in (BotModel, Skill, DefaultSkillsetSkillExclusion):
+        model.__table__.create(engine)
+    db = _Database(engine)
+    bots, skills = BotRepository(db), SkillRepository(db)
+    with avernet_tenant_scope("tenant"):
+        for owner in ("owner-a", "owner-b"):
+            bots.insert(
+                {
+                    "bot_id": "default",
+                    "entity_id": owner,
+                    "entity_type": "staff",
+                    "creator_id": owner,
+                    "owner_id": owner,
+                }
+            )
+            skills.create(
+                {
+                    "name": owner,
+                    "git_path": f"local://{owner}",
+                    "user_id": owner,
+                    "bolt_id": "default",
+                }
+            )
+        service = LocalSkillQueryService(skills, bots, object())
+        _, a_skills = service.list_local_skills(
+            bot_id="default",
+            owner_id="owner-a",
+            actor_id="owner-a",
+            page=1,
+            page_size=20,
+            active=None,
+            keyword=None,
+        )
+        _, b_skills = service.list_local_skills(
+            bot_id="default",
+            owner_id="owner-b",
+            actor_id="owner-b",
+            page=1,
+            page_size=20,
+            active=None,
+            keyword=None,
+        )
+    assert [skill["name"] for skill in a_skills] == ["owner-a"]
+    assert [skill["name"] for skill in b_skills] == ["owner-b"]

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -31,6 +31,7 @@ discovery walk: most Protocols in ``api/`` still declare
 listing them here would assert nothing while implying coverage. Add a pair when
 its Protocol is given real signatures.
 """
+
 from __future__ import annotations
 
 import inspect
@@ -42,9 +43,15 @@ from agentclaw.community.api.engine_connection_service import (
     EngineConnectionServiceProtocol,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
 from agentclaw.community.core.engine_runtime.connection import EngineConnectionService
 from agentclaw.community.core.engine_runtime.relay import EngineRuntimeRelay
 from agentclaw.community.core.services.engine_config import EngineConfigService
+from agentclaw.community.core.skill_center.services.local_skill_query_service import (
+    LocalSkillQueryService,
+)
 
 
 # (Protocol, ConcreteService) pairs whose Protocol declares real signatures.
@@ -52,6 +59,7 @@ _PAIRS = [
     (EngineConfigServiceProtocol, EngineConfigService),
     (EngineRuntimeRelayProtocol, EngineRuntimeRelay),
     (EngineConnectionServiceProtocol, EngineConnectionService),
+    (LocalSkillQueryServiceProtocol, LocalSkillQueryService),
 ]
 
 _IDS = [f"{p.__name__}->{c.__name__}" for p, c in _PAIRS]
@@ -96,7 +104,9 @@ def test_protocol_signatures_match_the_implementation(protocol, concrete) -> Non
         actual = inspect.signature(impl)
 
         # Awaitability: adapters `await` these, so async→sync breaks every call.
-        if inspect.iscoroutinefunction(declared_fn) != inspect.iscoroutinefunction(impl):
+        if inspect.iscoroutinefunction(declared_fn) != inspect.iscoroutinefunction(
+            impl
+        ):
             mismatches.append(
                 f"{name}: protocol "
                 f"{'async' if inspect.iscoroutinefunction(declared_fn) else 'sync'} "
@@ -106,10 +116,7 @@ def test_protocol_signatures_match_the_implementation(protocol, concrete) -> Non
         # Names, kinds AND defaults — a keyword-only parameter turning
         # positional-only keeps the name but breaks every keyword call site.
         def _shape(sig: inspect.Signature) -> list[tuple[str, int, object]]:
-            return [
-                (p.name, p.kind.value, p.default)
-                for p in sig.parameters.values()
-            ]
+            return [(p.name, p.kind.value, p.default) for p in sig.parameters.values()]
 
         if _shape(declared) != _shape(actual):
             mismatches.append(

--- a/src/backend/tests/community/plugins/test_local_skill_query_tenant_isolation.py
+++ b/src/backend/tests/community/plugins/test_local_skill_query_tenant_isolation.py
@@ -1,0 +1,87 @@
+"""#722 repository seam: Local Skill reads use the real Track A tenant guard."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.plugins.local.sqlite_models import (
+    DefaultSkillsetSkillExclusion,
+)
+from agentclaw.community.plugins.skill_repository import SkillRepository
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+
+class _Database:
+    def __init__(self, engine) -> None:
+        self._session = sessionmaker(bind=engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._session()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+def test_exact_local_skill_query_is_tenant_scoped_and_reports_desired_state(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'skills.db'}")
+    Skill.__table__.create(engine)
+    DefaultSkillsetSkillExclusion.__table__.create(engine)
+    repo = SkillRepository(_Database(engine))
+
+    with avernet_tenant_scope("tenant-a"):
+        created = repo.create(
+            {
+                "name": "forecast",
+                "description": "Daily Forecast",
+                "git_path": "local://forecast",
+                "user_id": "owner",
+                "bolt_id": "bot",
+                "tags": ["weather"],
+            }
+        )
+        repo.create(
+            {
+                "name": "market",
+                "git_path": "git://market",
+                "user_id": "owner",
+                "bolt_id": "bot",
+            }
+        )
+        total, rows = repo.list_bot_local_skills(
+            bot_id="bot",
+            user_id="owner",
+            page=1,
+            page_size=20,
+            active=None,
+            keyword="FORE",
+        )
+        assert total == 1
+        assert rows[0]["id"] == created["id"]
+        assert rows[0]["active"] is True
+
+    with avernet_tenant_scope("tenant-b"):
+        total, rows = repo.list_bot_local_skills(
+            bot_id="bot",
+            user_id="owner",
+            page=1,
+            page_size=20,
+            active=None,
+            keyword=None,
+        )
+        assert total == 0 and rows == []
+        assert (
+            repo.get_bot_local_skill(
+                skill_id=created["id"], bot_id="bot", user_id="owner"
+            )
+            is None
+        )


### PR DESCRIPTION
## Problem
Public callers could not read Bot-owned Local Skill desired-state metadata safely.

## Solution
Add the read-only Local Skill query service and expose `GET /openapi/v1/bots/skills` plus `GET /openapi/v1/bots/skills/{skill_id}`. Queries are tenant-guarded, owner-scoped, collaborator-view checked, deterministic, and expose metadata only. Legacy `bot_id=default` uses the verified owner as part of its scope, so distinct owners remain isolated.

## Validation
- `uv run pytest tests/community -q`
- Focused HTTP, tenant-isolation, module-boundary, service-conformance tests
- Ruff and pre-push SAST/lint gate

## Compatibility and risk
Adds two read-only public routes and a service API. No DDL or mutation endpoints; #723 and later lifecycle work are intentionally excluded.

## Related issues
Closes #722