### PR TITLE
feat(backend): replace Local Skills atomically and clean associations

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, Query, Request
+from fastapi import APIRouter, Body, Depends, Query, Request, Response
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
@@ -125,6 +125,10 @@ async def get_skill(
     status_code=201,
     response_model=Envelope[SkillUpload],
     responses={
+        200: {
+            "model": Envelope[SkillUpload],
+            "description": "Existing Local Skill safely replaced.",
+        },
         413: {
             "model": ErrorEnvelope,
             "description": "ZIP package exceeds an upload limit.",
@@ -145,6 +149,7 @@ async def get_skill(
 async def upload_skill(
     principal: PrincipalDep,
     request: Request,
+    response: Response,
     package: bytes = Body(..., media_type="application/zip"),
     bot_id: str = Query(..., description="Ready Bot that owns the Local Skill."),
     owner_entity_id: str | None = Query(
@@ -167,11 +172,14 @@ async def upload_skill(
         actor_id=actor_id,
         package=package,
     )
+    operation = str(result["operation"])
+    if operation == "updated":
+        response.status_code = 200
     return envelope(
-        SkillUpload(operation="created", skill=_to_skill(result["skill"])),
+        SkillUpload(operation=operation, skill=_to_skill(result["skill"])),
         request,
-        code=201000,
-        message="Created",
+        code=201000 if operation == "created" else 200000,
+        message="Created" if operation == "created" else "OK",
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
@@ -24,7 +24,7 @@ class Skill(BaseModel):
 class SkillUpload(BaseModel):
     """Response for a first-time Skill upload."""
 
-    operation: Literal["created"]
+    operation: Literal["created", "updated"]
     skill: Skill
 
 

--- a/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class LocalSkillUploadServiceProtocol(Protocol):
-    """Create one inactive Local Skill from one raw ZIP package."""
+    """Create or safely replace one Bot-owned Local Skill from a ZIP package."""
 
     async def upload_local_skill(
         self, *, bot_id: str, owner_id: str, actor_id: str, package: bytes

--- a/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
@@ -1,4 +1,4 @@
-"""Service API for first-time public Local Skill uploads."""
+"""Service API for Local Skill create-or-replace uploads."""
 
 from __future__ import annotations
 

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -73,11 +73,15 @@ internal_dependencies:
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
 
 Local Skill replacement stages a complete package before switching the existing
-Skill metadata.  Failed post-switch obsolete-byte deletion is recorded through
+Skill metadata. Its old-package cleanup work is persisted before an Active
+runtime switch can commit; a rollback cancels that old-locator work before the
+old package becomes authoritative again. Failed post-switch obsolete-byte deletion is recorded through
 `LocalSkillCleanupRepository` in the exact deployment-wide Bot scope
 `(env, owner_id, bot_id)`.  The next serialized Local Skill mutation retries
 pending work; it marks successful work `cleaned` and retains failures with an
 attempt count and a stable operator-safe error.  A task that follows a failed
 Active rollback retains its staged bytes and restores the old runtime mapping
-before it attempts byte cleanup.  Apply
+before it attempts byte cleanup. Cleanup identity uses the full SHA-256 of the
+locator, while retaining the locator itself for execution; a digest collision
+fails closed. Apply
 `sql/2026_08_04_local_skill_cleanup_work.sql` before deploying this behavior.

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -34,6 +34,7 @@ consumes:
   - "SkillCenterClient"
   - "SkillRepoSyncPlugin"
   - "WorkspacePathFactory"
+  - "LocalSkillCleanupRepository"
 internal_dependencies:
   - agentclaw.community.core.access
   - agentclaw.community.core.base
@@ -52,6 +53,8 @@ internal_dependencies:
   - agentclaw.community.kernel
   - agentclaw.community.log
   - agentclaw.community.plugin_api.cache
+  - agentclaw.community.plugin_api.local_skill_cleanup
+  - agentclaw.community.plugin_api.models
   - agentclaw.community.plugin_api.device_adapter_transport
   - agentclaw.community.plugin_api.devices
   - agentclaw.community.plugin_api.mcp_center
@@ -68,3 +71,13 @@ internal_dependencies:
 ### Change impact
 
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
+
+Local Skill replacement stages a complete package before switching the existing
+Skill metadata.  Failed post-switch obsolete-byte deletion is recorded through
+`LocalSkillCleanupRepository` in the exact deployment-wide Bot scope
+`(env, owner_id, bot_id)`.  The next serialized Local Skill mutation retries
+pending work; it marks successful work `cleaned` and retains failures with an
+attempt count and a stable operator-safe error.  A task that follows a failed
+Active rollback retains its staged bytes and restores the old runtime mapping
+before it attempts byte cleanup.  Apply
+`sql/2026_08_04_local_skill_cleanup_work.sql` before deploying this behavior.

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -17,6 +17,7 @@ provides:
   - "LocalSkillQueryService"
   - "LocalSkillUploadService"
   - "LocalSkillStateService"
+  - "LocalSkillCleanupWorkModel"
 consumes:
   - "BotRepository"
   - "BotCollabLogRepositoryProtocol"
@@ -35,6 +36,7 @@ consumes:
   - "WorkspacePathFactory"
 internal_dependencies:
   - agentclaw.community.core.access
+  - agentclaw.community.core.base
   - agentclaw.community.core.bot_collaborator
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.config

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -76,6 +76,11 @@ class LocalSkillPackageStorage:
         self._filesystem = filesystem
         self._device_directory = device_directory
 
+    @property
+    def directory(self) -> str:
+        """The internal device locator this storage instance owns."""
+        return self._device_directory
+
     async def write(self, files: list[tuple[str, bytes]]) -> None:
         for relative_path, content in files:
             await self._filesystem.write_file(
@@ -199,8 +204,14 @@ class SkillServiceFactory:
         is_desktop: bool,
         is_teclaw: bool,
         name: str,
+        directory_name: str | None = None,
     ) -> tuple[str, LocalSkillPackageStorage]:
-        """Return the canonical Local Skill locator and its device-I/O port."""
+        """Return a Bot-local package storage port.
+
+        ``directory_name`` is intentionally internal.  A replacement writes a
+        complete package to an isolated versioned directory before its metadata
+        points runtime at it; first creation keeps the historical name path.
+        """
         service = self.create(
             entity_id=entity_id,
             bot_owner_id=owner_id,
@@ -217,13 +228,34 @@ class SkillServiceFactory:
                 is_desktop=is_desktop,
                 is_teclaw=is_teclaw,
             )
-        directory = str(local_dir / name)
+        directory = str(local_dir / (directory_name or name))
         local_skill_path_adapter = service._local_skill_path_adapter
         if is_teclaw and not service.runtime_uses_pool_paths:
             local_skill_path_adapter = to_local_skill_engine_path
         return directory, LocalSkillPackageStorage(
             service._device_fs_factory(bot_id, owner_id),
             local_skill_path_adapter(directory),
+        )
+
+    def local_skill_package_storage_for_locator(
+        self,
+        *,
+        entity_id: str,
+        owner_id: str,
+        bot_id: str,
+        engine_type: str | None,
+        locator: str,
+    ) -> LocalSkillPackageStorage:
+        """Re-open an existing internal Local package locator for cleanup."""
+        service = self.create(
+            entity_id=entity_id,
+            bot_owner_id=owner_id,
+            bot_id=bot_id,
+            engine_type=engine_type,
+        )
+        return LocalSkillPackageStorage(
+            service._device_fs_factory(bot_id, owner_id),
+            service._local_skill_path_adapter(locator),
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -244,6 +244,9 @@ class SkillServiceFactory:
         owner_id: str,
         bot_id: str,
         engine_type: str | None,
+        entity_type: str,
+        is_desktop: bool,
+        is_teclaw: bool,
         locator: str,
     ) -> LocalSkillPackageStorage:
         """Re-open an existing internal Local package locator for cleanup."""
@@ -253,9 +256,28 @@ class SkillServiceFactory:
             bot_id=bot_id,
             engine_type=engine_type,
         )
+        local_dir = service.local_dir
+        if not service.runtime_uses_pool_paths:
+            local_dir = self._path_factory.get_bot_skills_local_dir(
+                entity_id,
+                bot_id,
+                engine_type or "openclaw",
+                entity_type,
+                is_desktop=is_desktop,
+                is_teclaw=is_teclaw,
+            )
+        resolved_locator = Path(locator)
+        if not resolved_locator.is_absolute():
+            if resolved_locator.parts[:1] == (local_dir.name,):
+                resolved_locator = local_dir.parent / resolved_locator
+            else:
+                resolved_locator = local_dir / resolved_locator
+        local_skill_path_adapter = service._local_skill_path_adapter
+        if is_teclaw and not service.runtime_uses_pool_paths:
+            local_skill_path_adapter = to_local_skill_engine_path
         return LocalSkillPackageStorage(
             service._device_fs_factory(bot_id, owner_id),
-            service._local_skill_path_adapter(locator),
+            local_skill_path_adapter(str(resolved_locator)),
         )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -272,6 +272,18 @@ class SkillServiceFactory:
                 resolved_locator = local_dir.parent / resolved_locator
             else:
                 resolved_locator = local_dir / resolved_locator
+        resolved_base = local_dir.resolve()
+        resolved_candidate = resolved_locator.resolve()
+        try:
+            relative_locator = resolved_candidate.relative_to(resolved_base)
+        except ValueError as exc:
+            raise ValueError("Local Skill cleanup locator escapes skills-local") from exc
+        if not relative_locator.parts:
+            raise ValueError("Local Skill cleanup locator must name a package")
+        # Keep the original path form for the device adapter (notably Teclaw's
+        # relative ``skills-local`` namespace), after lexical containment has
+        # been proven against an absolute normalized base.
+        resolved_locator = local_dir / relative_locator
         local_skill_path_adapter = service._local_skill_path_adapter
         if is_teclaw and not service.runtime_uses_pool_paths:
             local_skill_path_adapter = to_local_skill_engine_path

--- a/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
@@ -1,0 +1,44 @@
+"""Durable, Bot-scoped cleanup work for obsolete Local Skill packages."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text, UniqueConstraint, func
+
+from agentclaw.community.core.base import Base
+
+
+class LocalSkillCleanupWorkModel(Base):
+    """An internal retry record for one obsolete package locator.
+
+    The record is strictly scoped by the deployment-wide unique
+    ``(env, owner_id, bot_id)`` Bot identity.  It is not a tenant catalog.
+    """
+
+    __tablename__ = "ac_local_skill_cleanup_work"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    env = Column(String(20), nullable=False)
+    owner_id = Column(String(128), nullable=False)
+    bot_id = Column(String(100), nullable=False)
+    skill_id = Column(Integer, nullable=False)
+    package_locator = Column(String(1024), nullable=False)
+    status = Column(String(20), nullable=False, default="pending")
+    attempts = Column(Integer, nullable=False, default=0)
+    last_error = Column(Text, nullable=True)
+    cleaned_at = Column(DateTime, nullable=True)
+    gmt_create = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    __table_args__ = (
+        UniqueConstraint("env", "owner_id", "bot_id", "package_locator", name="uk_local_skill_cleanup_scope_locator"),
+        Index("idx_local_skill_cleanup_pending", "env", "status", "gmt_create"),
+    )
+
+
+@runtime_checkable
+class LocalSkillCleanupRepository(Protocol):
+    """Persistence boundary for observable, retriable obsolete-byte cleanup."""
+
+    def record_pending(
+        self, *, env: str, owner_id: str, bot_id: str, skill_id: str, package_locator: str
+    ) -> bool: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
-
 from sqlalchemy import Column, DateTime, Index, Integer, String, Text, UniqueConstraint, func
 
 from agentclaw.community.core.base import Base
+from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
 
 
 class LocalSkillCleanupWorkModel(Base):
@@ -17,12 +16,13 @@ class LocalSkillCleanupWorkModel(Base):
     """
 
     __tablename__ = "ac_local_skill_cleanup_work"
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
     env = Column(String(20), nullable=False)
     owner_id = Column(String(128), nullable=False)
     bot_id = Column(String(100), nullable=False)
     skill_id = Column(Integer, nullable=False)
     package_locator = Column(String(1024), nullable=False)
+    requires_runtime_restore = Column(Integer, nullable=False, default=0)
     status = Column(String(20), nullable=False, default="pending")
     attempts = Column(Integer, nullable=False, default=0)
     last_error = Column(Text, nullable=True)
@@ -33,12 +33,3 @@ class LocalSkillCleanupWorkModel(Base):
         UniqueConstraint("env", "owner_id", "bot_id", "package_locator", name="uk_local_skill_cleanup_scope_locator"),
         Index("idx_local_skill_cleanup_pending", "env", "status", "gmt_create"),
     )
-
-
-@runtime_checkable
-class LocalSkillCleanupRepository(Protocol):
-    """Persistence boundary for observable, retriable obsolete-byte cleanup."""
-
-    def record_pending(
-        self, *, env: str, owner_id: str, bot_id: str, skill_id: str, package_locator: str
-    ) -> bool: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/local_skill_cleanup.py
@@ -22,6 +22,7 @@ class LocalSkillCleanupWorkModel(Base):
     bot_id = Column(String(100), nullable=False)
     skill_id = Column(Integer, nullable=False)
     package_locator = Column(String(1024), nullable=False)
+    package_locator_hash = Column(String(64), nullable=False)
     requires_runtime_restore = Column(Integer, nullable=False, default=0)
     status = Column(String(20), nullable=False, default="pending")
     attempts = Column(Integer, nullable=False, default=0)
@@ -30,6 +31,9 @@ class LocalSkillCleanupWorkModel(Base):
     gmt_create = Column(DateTime, nullable=False, server_default=func.now())
     gmt_modified = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
     __table_args__ = (
-        UniqueConstraint("env", "owner_id", "bot_id", "package_locator", name="uk_local_skill_cleanup_scope_locator"),
+        UniqueConstraint(
+            "env", "owner_id", "bot_id", "package_locator_hash",
+            name="uk_local_skill_cleanup_scope_locator_hash",
+        ),
         Index("idx_local_skill_cleanup_pending", "env", "status", "gmt_create"),
     )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -319,6 +319,8 @@ class LocalSkillUploadService:
             "user_id": skill.get("user_id"),
         }
         switched = False
+        old_cleanup_work_id: int | None = None
+        runtime_sync_attempted = False
         try:
             await staged.write(files)
             updated = self._skill_repo.update(
@@ -332,6 +334,14 @@ class LocalSkillUploadService:
             if updated is None:
                 raise RuntimeError("Local Skill metadata switch failed")
             switched = True
+            # Register deletion before runtime sync makes the committed switch
+            # recoverable even if a later obsolete-byte purge cannot start.
+            old_cleanup_work_id = self._record_cleanup(
+                bot, owner_id, bot_id, str(skill["id"]), old_locator
+            )
+            if old_cleanup_work_id is None:
+                raise LocalSkillStorageError()
+            runtime_sync_attempted = bool(skill["active"])
             if bool(skill["active"]) and not self._sync_runtime(bot, owner_id, bot_id):
                 raise LocalSkillRuntimeSyncError()
             self._audit_log_repo.insert(
@@ -354,6 +364,8 @@ class LocalSkillUploadService:
                 staged=staged,
                 staged_locator=new_locator,
                 switched=switched,
+                old_cleanup_work_id=old_cleanup_work_id,
+                runtime_sync_attempted=runtime_sync_attempted,
             )
             raise
         except Exception as exc:
@@ -367,6 +379,8 @@ class LocalSkillUploadService:
                     staged=staged,
                     staged_locator=new_locator,
                     switched=True,
+                    old_cleanup_work_id=old_cleanup_work_id,
+                    runtime_sync_attempted=runtime_sync_attempted,
                 )
             else:
                 await self._discard_or_record(
@@ -378,15 +392,18 @@ class LocalSkillUploadService:
                     locator=new_locator,
                 )
             raise LocalSkillStorageError() from exc
-        # The new authority is committed.  Old bytes are now garbage, never a
-        # reason to undo a working replacement.  A failed purge is durable work.
+        # The old locator already has durable work.  Its purge is never a
+        # reason to undo a working replacement.
         try:
             cleaned = await old_storage.cleanup()
         except Exception:
             cleaned = False
-        if not cleaned:
-            if not self._record_cleanup(
-                bot, owner_id, bot_id, str(skill["id"]), old_locator
+        if cleaned:
+            if not self._cleanup_repo.mark_cleaned(
+                work_id=old_cleanup_work_id,
+                env=str(bot["env"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
             ):
                 raise LocalSkillStorageError()
         return {
@@ -411,25 +428,40 @@ class LocalSkillUploadService:
         staged,
         staged_locator: str,
         switched: bool,
+        old_cleanup_work_id: int | None,
+        runtime_sync_attempted: bool,
     ) -> None:
         if switched:
             restored = self._skill_repo.update(skill["id"], old_metadata)
             if restored is None:
                 raise LocalSkillStorageError()
-            if bool(skill["active"]) and not self._sync_runtime(bot, owner_id, bot_id):
+            if (
+                runtime_sync_attempted
+                and bool(skill["active"])
+                and not self._sync_runtime(bot, owner_id, bot_id)
+            ):
                 # Runtime may have switched partway before reporting failure.
                 # Keep the complete staged package until a later serialized
                 # mutation can restore the old mapping before deleting it.
-                if not self._record_cleanup(
-                    bot=bot,
-                    owner_id=owner_id,
-                    bot_id=bot_id,
-                    skill_id=str(skill["id"]),
-                    locator=staged_locator,
-                    requires_runtime_restore=True,
+                if (
+                    self._record_cleanup(
+                        bot=bot,
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        skill_id=str(skill["id"]),
+                        locator=staged_locator,
+                        requires_runtime_restore=True,
+                    )
+                    is None
                 ):
                     raise LocalSkillStorageError()
+                self._cancel_cleanup_if_registered(
+                    old_cleanup_work_id, bot, owner_id, bot_id
+                )
                 raise LocalSkillRuntimeSyncError()
+            self._cancel_cleanup_if_registered(
+                old_cleanup_work_id, bot, owner_id, bot_id
+            )
         await self._discard_or_record(
             bot=bot,
             owner_id=owner_id,
@@ -454,7 +486,7 @@ class LocalSkillUploadService:
                 return
         except Exception:
             pass
-        if not self._record_cleanup(bot, owner_id, bot_id, skill_id, locator):
+        if self._record_cleanup(bot, owner_id, bot_id, skill_id, locator) is None:
             raise LocalSkillStorageError()
 
     def _record_cleanup(
@@ -466,17 +498,30 @@ class LocalSkillUploadService:
         locator: str,
         *,
         requires_runtime_restore: bool = False,
-    ) -> bool:
-        return bool(
-            self._cleanup_repo.record_pending(
-                env=str(bot["env"]),
-                owner_id=owner_id,
-                bot_id=bot_id,
-                skill_id=skill_id,
-                package_locator=locator,
-                requires_runtime_restore=requires_runtime_restore,
-            )
+    ) -> int | None:
+        return self._cleanup_repo.record_pending(
+            env=str(bot["env"]),
+            owner_id=owner_id,
+            bot_id=bot_id,
+            skill_id=skill_id,
+            package_locator=locator,
+            requires_runtime_restore=requires_runtime_restore,
         )
+
+    def _cancel_cleanup_if_registered(
+        self,
+        work_id: int | None,
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+    ) -> None:
+        if work_id is not None and not self._cleanup_repo.cancel_pending(
+            work_id=work_id,
+            env=str(bot["env"]),
+            owner_id=owner_id,
+            bot_id=bot_id,
+        ):
+            raise LocalSkillStorageError()
 
     async def _retry_pending_cleanup(
         self, *, bot: dict[str, Any], owner_id: str, bot_id: str
@@ -485,16 +530,22 @@ class LocalSkillUploadService:
         for work in self._cleanup_repo.list_pending(
             env=str(bot["env"]), owner_id=owner_id, bot_id=bot_id
         ):
+            if self._cleanup_target_is_authoritative(work):
+                self._cancel_cleanup_if_registered(
+                    int(work["id"]), bot, owner_id, bot_id
+                )
+                continue
             if bool(work.get("requires_runtime_restore")) and not self._sync_runtime(
                 bot, owner_id, bot_id
             ):
-                self._cleanup_repo.mark_failed(
+                if not self._cleanup_repo.mark_failed(
                     work_id=int(work["id"]),
                     env=str(bot["env"]),
                     owner_id=owner_id,
                     bot_id=bot_id,
                     error="runtime restore before cleanup failed",
-                )
+                ):
+                    raise LocalSkillStorageError()
                 continue
             storage = (
                 self._skill_service_factory.local_skill_package_storage_for_locator(
@@ -510,20 +561,31 @@ class LocalSkillUploadService:
             except Exception:
                 cleaned = False
             if cleaned:
-                self._cleanup_repo.mark_cleaned(
+                if not self._cleanup_repo.mark_cleaned(
                     work_id=int(work["id"]),
                     env=str(bot["env"]),
                     owner_id=owner_id,
                     bot_id=bot_id,
-                )
+                ):
+                    raise LocalSkillStorageError()
             else:
-                self._cleanup_repo.mark_failed(
+                if not self._cleanup_repo.mark_failed(
                     work_id=int(work["id"]),
                     env=str(bot["env"]),
                     owner_id=owner_id,
                     bot_id=bot_id,
                     error="obsolete package cleanup failed",
-                )
+                ):
+                    raise LocalSkillStorageError()
+
+    def _cleanup_target_is_authoritative(self, work: dict[str, Any]) -> bool:
+        skill_id = work.get("skill_id")
+        if skill_id is None:
+            return False
+        skill = self._skill_repo.get_by_id(str(skill_id))
+        return bool(
+            skill and skill.get("git_path") == f"local://{work['package_locator']}"
+        )
 
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -602,7 +602,19 @@ class LocalSkillUploadService:
             )
 
             raise LocalSkillOwnerAmbiguousError()
-        return owned
+        # ``list_bot_local_by_name`` intentionally returns metadata-only rows
+        # for duplicate detection.  Replacement also needs the current desired
+        # activation state, which is derived from the default-set exclusion and
+        # is exposed by the exact single-row query.
+        matches: list[dict[str, Any]] = []
+        for row in owned:
+            current = self._skill_repo.get_bot_local_skill(
+                skill_id=str(row["id"]), bot_id=bot_id, user_id=owner_id
+            )
+            if current is None:
+                continue
+            matches.append({**row, "active": bool(current["active"])})
+        return matches
 
     def _sync_runtime(self, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -10,7 +10,7 @@ import io
 import json
 import re
 import zipfile
-from typing import Any
+from typing import Any, Callable, TYPE_CHECKING
 from uuid import uuid4
 
 import yaml
@@ -52,6 +52,11 @@ from agentclaw.community.core.skills_pool.edit_guard import (
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 
+if TYPE_CHECKING:
+    from agentclaw.community.core.devices.services.device_context_resolver import (
+        DeviceContextResolver,
+    )
+
 _MAX_COMPRESSED = 10 * 1024 * 1024
 _MAX_EXPANDED = 50 * 1024 * 1024
 _MAX_FILE = 10 * 1024 * 1024
@@ -74,6 +79,7 @@ class LocalSkillUploadService:
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
         cleanup_repo: LocalSkillCleanupRepository,
+        device_context_resolver_provider: Callable[[], "DeviceContextResolver"],
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
@@ -84,6 +90,7 @@ class LocalSkillUploadService:
         self._audit_log_repo = audit_log_repo
         self._edit_guard = edit_guard
         self._cleanup_repo = cleanup_repo
+        self._device_context_resolver_provider = device_context_resolver_provider
 
     async def upload_local_skill(
         self, *, bot_id: str, owner_id: str, actor_id: str, package: bytes
@@ -106,7 +113,13 @@ class LocalSkillUploadService:
                 raise LocalSkillNotFoundError()
             if not is_bot_ready(bot):
                 raise LocalSkillNotReadyError()
-            await self._retry_pending_cleanup(bot=bot, owner_id=owner_id, bot_id=bot_id)
+            is_teclaw = self._is_teclaw(bot_id=bot_id, owner_id=owner_id)
+            await self._retry_pending_cleanup(
+                bot=bot,
+                owner_id=owner_id,
+                bot_id=bot_id,
+                is_teclaw=is_teclaw,
+            )
             name, description, files = self._unpack(package)
             # Re-read same-name candidates, owner, readiness and default state
             # under the edit lock.  Uploader identity is intentionally absent.
@@ -130,6 +143,7 @@ class LocalSkillUploadService:
                     name=name,
                     description=description,
                     files=files,
+                    is_teclaw=is_teclaw,
                 )
             return await self._create(
                 bot=bot,
@@ -140,6 +154,7 @@ class LocalSkillUploadService:
                 description=description,
                 files=files,
                 default_set=default_set,
+                is_teclaw=is_teclaw,
             )
         finally:
             self._edit_guard.release(lease)
@@ -155,6 +170,7 @@ class LocalSkillUploadService:
         description: str,
         files: list[tuple[str, bytes]],
         default_set: dict[str, Any],
+        is_teclaw: bool,
     ) -> dict[str, Any]:
         directory, storage = self._skill_service_factory.local_skill_package_storage(
             entity_id=str(bot["entity_id"]),
@@ -163,7 +179,7 @@ class LocalSkillUploadService:
             engine_type=bot.get("active_engine"),
             entity_type=str(bot.get("entity_type") or "staff"),
             is_desktop=bot.get("bot_type") == "desktop",
-            is_teclaw=bot.get("device_provider") == "teclaw",
+            is_teclaw=is_teclaw,
             name=name,
         )
         skill: dict[str, Any] | None = None
@@ -289,6 +305,7 @@ class LocalSkillUploadService:
         name: str,
         description: str,
         files: list[tuple[str, bytes]],
+        is_teclaw: bool,
     ) -> dict[str, Any]:
         """Stage a complete replacement, then atomically switch its locator authority."""
         old_locator = str(skill["git_path"])[len("local://") :]
@@ -300,7 +317,7 @@ class LocalSkillUploadService:
             engine_type=bot.get("active_engine"),
             entity_type=str(bot.get("entity_type") or "staff"),
             is_desktop=bot.get("bot_type") == "desktop",
-            is_teclaw=bot.get("device_provider") == "teclaw",
+            is_teclaw=is_teclaw,
             name=name,
             directory_name=version_dir,
         )
@@ -310,6 +327,9 @@ class LocalSkillUploadService:
                 owner_id=owner_id,
                 bot_id=bot_id,
                 engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
                 locator=old_locator,
             )
         )
@@ -524,7 +544,12 @@ class LocalSkillUploadService:
             raise LocalSkillStorageError()
 
     async def _retry_pending_cleanup(
-        self, *, bot: dict[str, Any], owner_id: str, bot_id: str
+        self,
+        *,
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        is_teclaw: bool,
     ) -> None:
         """Retry durable obsolete-byte work on a later serialized Bot mutation."""
         for work in self._cleanup_repo.list_pending(
@@ -553,6 +578,9 @@ class LocalSkillUploadService:
                     owner_id=owner_id,
                     bot_id=bot_id,
                     engine_type=bot.get("active_engine"),
+                    entity_type=str(bot.get("entity_type") or "staff"),
+                    is_desktop=bot.get("bot_type") == "desktop",
+                    is_teclaw=is_teclaw,
                     locator=str(work["package_locator"]),
                 )
             )
@@ -577,6 +605,15 @@ class LocalSkillUploadService:
                     error="obsolete package cleanup failed",
                 ):
                     raise LocalSkillStorageError()
+
+    def _is_teclaw(self, *, bot_id: str, owner_id: str) -> bool:
+        try:
+            context = self._device_context_resolver_provider().resolve_for_bot(
+                bot_id, owner_id
+            )
+        except Exception as exc:
+            raise LocalSkillStorageError() from exc
+        return context.provider == "teclaw"
 
     def _cleanup_target_is_authoritative(self, work: dict[str, Any]) -> bool:
         skill_id = work.get("skill_id")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -1,4 +1,4 @@
-"""First-upload lifecycle for a Bot-owned Local Skill.
+"""Create-or-replace lifecycle for a Bot-owned Local Skill.
 
 The service owns validation and compensation; the HTTP adapter only translates
 the raw request body and maps the public response.
@@ -43,7 +43,7 @@ from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
     SkillSetServiceFactory,
 )
-from agentclaw.community.core.skill_center.local_skill_cleanup import (
+from agentclaw.community.plugin_api.local_skill_cleanup import (
     LocalSkillCleanupRepository,
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
@@ -106,6 +106,7 @@ class LocalSkillUploadService:
                 raise LocalSkillNotFoundError()
             if not is_bot_ready(bot):
                 raise LocalSkillNotReadyError()
+            await self._retry_pending_cleanup(bot=bot, owner_id=owner_id, bot_id=bot_id)
             name, description, files = self._unpack(package)
             # Re-read same-name candidates, owner, readiness and default state
             # under the edit lock.  Uploader identity is intentionally absent.
@@ -416,6 +417,18 @@ class LocalSkillUploadService:
             if restored is None:
                 raise LocalSkillStorageError()
             if bool(skill["active"]) and not self._sync_runtime(bot, owner_id, bot_id):
+                # Runtime may have switched partway before reporting failure.
+                # Keep the complete staged package until a later serialized
+                # mutation can restore the old mapping before deleting it.
+                if not self._record_cleanup(
+                    bot=bot,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    skill_id=str(skill["id"]),
+                    locator=staged_locator,
+                    requires_runtime_restore=True,
+                ):
+                    raise LocalSkillStorageError()
                 raise LocalSkillRuntimeSyncError()
         await self._discard_or_record(
             bot=bot,
@@ -451,6 +464,8 @@ class LocalSkillUploadService:
         bot_id: str,
         skill_id: str,
         locator: str,
+        *,
+        requires_runtime_restore: bool = False,
     ) -> bool:
         return bool(
             self._cleanup_repo.record_pending(
@@ -459,23 +474,73 @@ class LocalSkillUploadService:
                 bot_id=bot_id,
                 skill_id=skill_id,
                 package_locator=locator,
+                requires_runtime_restore=requires_runtime_restore,
             )
         )
+
+    async def _retry_pending_cleanup(
+        self, *, bot: dict[str, Any], owner_id: str, bot_id: str
+    ) -> None:
+        """Retry durable obsolete-byte work on a later serialized Bot mutation."""
+        for work in self._cleanup_repo.list_pending(
+            env=str(bot["env"]), owner_id=owner_id, bot_id=bot_id
+        ):
+            if bool(work.get("requires_runtime_restore")) and not self._sync_runtime(
+                bot, owner_id, bot_id
+            ):
+                self._cleanup_repo.mark_failed(
+                    work_id=int(work["id"]),
+                    env=str(bot["env"]),
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    error="runtime restore before cleanup failed",
+                )
+                continue
+            storage = (
+                self._skill_service_factory.local_skill_package_storage_for_locator(
+                    entity_id=str(bot["entity_id"]),
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    engine_type=bot.get("active_engine"),
+                    locator=str(work["package_locator"]),
+                )
+            )
+            try:
+                cleaned = await storage.cleanup()
+            except Exception:
+                cleaned = False
+            if cleaned:
+                self._cleanup_repo.mark_cleaned(
+                    work_id=int(work["id"]),
+                    env=str(bot["env"]),
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                )
+            else:
+                self._cleanup_repo.mark_failed(
+                    work_id=int(work["id"]),
+                    env=str(bot["env"]),
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    error="obsolete package cleanup failed",
+                )
 
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str
     ) -> list[dict[str, Any]]:
         rows = self._skill_repo.list_bot_local_by_name(bot_id=bot_id, name=name)
-        if bot_id != "default":
-            return rows
-        unknown = [row for row in rows if not row.get("user_id")]
-        if unknown:
+        owned = [row for row in rows if str(row.get("user_id")) == owner_id]
+        unowned = [row for row in rows if not row.get("user_id")]
+        # Only an absent owner is ambiguous legacy data.  A foreign owner is
+        # known and belongs to another exact Bot scope, so it is never a
+        # replacement candidate and never changes this caller's zero-match.
+        if unowned:
             from agentclaw.community.core.skill_center.errors import (
                 LocalSkillOwnerAmbiguousError,
             )
 
             raise LocalSkillOwnerAmbiguousError()
-        return [row for row in rows if str(row.get("user_id")) == owner_id]
+        return owned
 
     def _sync_runtime(self, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -11,6 +11,7 @@ import json
 import re
 import zipfile
 from typing import Any
+from uuid import uuid4
 
 import yaml
 from injector import inject
@@ -28,6 +29,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillEditPausedError,
     LocalSkillInvalidPackageError,
     LocalSkillNotReadyError,
+    LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
     LocalSkillTooLargeError,
 )
@@ -37,7 +39,13 @@ from agentclaw.community.core.skill_center.services.repositories import (
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
-from agentclaw.community.core.skill_center.factories import SkillServiceFactory
+from agentclaw.community.core.skill_center.factories import (
+    SkillServiceFactory,
+    SkillSetServiceFactory,
+)
+from agentclaw.community.core.skill_center.local_skill_cleanup import (
+    LocalSkillCleanupRepository,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
     SkillsPoolEditPausedError,
@@ -62,20 +70,26 @@ class LocalSkillUploadService:
         bot_repo: BotRepository,
         collaborator_service: CollaboratorServiceProtocol,
         skill_service_factory: SkillServiceFactory,
+        skill_set_service_factory: SkillSetServiceFactory,
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
+        cleanup_repo: LocalSkillCleanupRepository,
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
         self._bot_repo = bot_repo
         self._collaborators = collaborator_service
         self._skill_service_factory = skill_service_factory
+        self._skill_set_service_factory = skill_set_service_factory
         self._audit_log_repo = audit_log_repo
         self._edit_guard = edit_guard
+        self._cleanup_repo = cleanup_repo
 
     async def upload_local_skill(
         self, *, bot_id: str, owner_id: str, actor_id: str, package: bytes
     ) -> dict[str, Any]:
+        # The pre-lock read exists only to address the distributed lock.  Every
+        # authoritative decision is deliberately repeated after acquisition.
         initial_bot = self._authorize(bot_id, owner_id, actor_id)
         scope = self._scope_for(initial_bot, bot_id)
         try:
@@ -90,37 +104,57 @@ class LocalSkillUploadService:
                 )
 
                 raise LocalSkillNotFoundError()
-            return await self._upload_locked(
-                bot=bot,
-                bot_id=bot_id,
+            if not is_bot_ready(bot):
+                raise LocalSkillNotReadyError()
+            name, description, files = self._unpack(package)
+            # Re-read same-name candidates, owner, readiness and default state
+            # under the edit lock.  Uploader identity is intentionally absent.
+            default_set = self._ensure_default_set(
                 owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+            )
+            matches = self._same_name_matches(
+                bot_id=bot_id, owner_id=owner_id, name=name
+            )
+            if len(matches) > 1:
+                raise LocalSkillDuplicateError()
+            if matches:
+                return await self._replace(
+                    skill=matches[0],
+                    bot=bot,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    actor_id=actor_id,
+                    name=name,
+                    description=description,
+                    files=files,
+                )
+            return await self._create(
+                bot=bot,
+                owner_id=owner_id,
+                bot_id=bot_id,
                 actor_id=actor_id,
-                package=package,
+                name=name,
+                description=description,
+                files=files,
+                default_set=default_set,
             )
         finally:
             self._edit_guard.release(lease)
 
-    async def _upload_locked(
+    async def _create(
         self,
         *,
         bot: dict[str, Any],
-        bot_id: str,
         owner_id: str,
+        bot_id: str,
         actor_id: str,
-        package: bytes,
+        name: str,
+        description: str,
+        files: list[tuple[str, bytes]],
+        default_set: dict[str, Any],
     ) -> dict[str, Any]:
-        if not is_bot_ready(bot):
-            raise LocalSkillNotReadyError()
-        name, description, files = self._unpack(package)
-        if (
-            self._skill_repo.get_bot_local_by_name(
-                bot_id=bot_id, name=name, user_id=owner_id
-            )
-            is not None
-        ):
-            # #725 owns replacement.  Never overwrite a package in this ticket.
-            raise LocalSkillDuplicateError()
-
         directory, storage = self._skill_service_factory.local_skill_package_storage(
             entity_id=str(bot["entity_id"]),
             owner_id=owner_id,
@@ -241,6 +275,225 @@ class LocalSkillUploadService:
                 "is_active": False,
                 "engine_type": engine_type,
             }
+        )
+
+    async def _replace(
+        self,
+        *,
+        skill: dict[str, Any],
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        actor_id: str,
+        name: str,
+        description: str,
+        files: list[tuple[str, bytes]],
+    ) -> dict[str, Any]:
+        """Stage a complete replacement, then atomically switch its locator authority."""
+        old_locator = str(skill["git_path"])[len("local://") :]
+        version_dir = f".{name}.replacement-{uuid4().hex}"
+        new_locator, staged = self._skill_service_factory.local_skill_package_storage(
+            entity_id=str(bot["entity_id"]),
+            owner_id=owner_id,
+            bot_id=bot_id,
+            engine_type=bot.get("active_engine"),
+            entity_type=str(bot.get("entity_type") or "staff"),
+            is_desktop=bot.get("bot_type") == "desktop",
+            is_teclaw=bot.get("device_provider") == "teclaw",
+            name=name,
+            directory_name=version_dir,
+        )
+        old_storage = (
+            self._skill_service_factory.local_skill_package_storage_for_locator(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                locator=old_locator,
+            )
+        )
+        old_metadata = {
+            "description": skill.get("description"),
+            "git_path": skill.get("git_path"),
+            "user_id": skill.get("user_id"),
+        }
+        switched = False
+        try:
+            await staged.write(files)
+            updated = self._skill_repo.update(
+                skill["id"],
+                {
+                    "description": description,
+                    "git_path": f"local://{new_locator}",
+                    "user_id": owner_id,
+                },
+            )
+            if updated is None:
+                raise RuntimeError("Local Skill metadata switch failed")
+            switched = True
+            if bool(skill["active"]) and not self._sync_runtime(bot, owner_id, bot_id):
+                raise LocalSkillRuntimeSyncError()
+            self._audit_log_repo.insert(
+                {
+                    "bot_id": bot_id,
+                    "owner_id": owner_id,
+                    "operator_id": actor_id,
+                    "detail": json.dumps(
+                        {"action": "local_skill_replace", "skill_id": skill["id"]}
+                    ),
+                }
+            )
+        except LocalSkillRuntimeSyncError:
+            await self._restore_replacement(
+                skill=skill,
+                old_metadata=old_metadata,
+                bot=bot,
+                owner_id=owner_id,
+                bot_id=bot_id,
+                staged=staged,
+                staged_locator=new_locator,
+                switched=switched,
+            )
+            raise
+        except Exception as exc:
+            if switched:
+                await self._restore_replacement(
+                    skill=skill,
+                    old_metadata=old_metadata,
+                    bot=bot,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    staged=staged,
+                    staged_locator=new_locator,
+                    switched=True,
+                )
+            else:
+                await self._discard_or_record(
+                    bot=bot,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    skill_id=str(skill["id"]),
+                    storage=staged,
+                    locator=new_locator,
+                )
+            raise LocalSkillStorageError() from exc
+        # The new authority is committed.  Old bytes are now garbage, never a
+        # reason to undo a working replacement.  A failed purge is durable work.
+        try:
+            cleaned = await old_storage.cleanup()
+        except Exception:
+            cleaned = False
+        if not cleaned:
+            if not self._record_cleanup(
+                bot, owner_id, bot_id, str(skill["id"]), old_locator
+            ):
+                raise LocalSkillStorageError()
+        return {
+            "operation": "updated",
+            "skill": {
+                **skill,
+                "description": description,
+                "git_path": f"local://{new_locator}",
+                "user_id": owner_id,
+            },
+            "actor_id": actor_id,
+        }
+
+    async def _restore_replacement(
+        self,
+        *,
+        skill: dict[str, Any],
+        old_metadata: dict[str, Any],
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        staged,
+        staged_locator: str,
+        switched: bool,
+    ) -> None:
+        if switched:
+            restored = self._skill_repo.update(skill["id"], old_metadata)
+            if restored is None:
+                raise LocalSkillStorageError()
+            if bool(skill["active"]) and not self._sync_runtime(bot, owner_id, bot_id):
+                raise LocalSkillRuntimeSyncError()
+        await self._discard_or_record(
+            bot=bot,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            skill_id=str(skill["id"]),
+            storage=staged,
+            locator=staged_locator,
+        )
+
+    async def _discard_or_record(
+        self,
+        *,
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        skill_id: str,
+        storage,
+        locator: str,
+    ) -> None:
+        try:
+            if await storage.cleanup():
+                return
+        except Exception:
+            pass
+        if not self._record_cleanup(bot, owner_id, bot_id, skill_id, locator):
+            raise LocalSkillStorageError()
+
+    def _record_cleanup(
+        self,
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        skill_id: str,
+        locator: str,
+    ) -> bool:
+        return bool(
+            self._cleanup_repo.record_pending(
+                env=str(bot["env"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                skill_id=skill_id,
+                package_locator=locator,
+            )
+        )
+
+    def _same_name_matches(
+        self, *, bot_id: str, owner_id: str, name: str
+    ) -> list[dict[str, Any]]:
+        rows = self._skill_repo.list_bot_local_by_name(bot_id=bot_id, name=name)
+        if bot_id != "default":
+            return rows
+        unknown = [row for row in rows if not row.get("user_id")]
+        if unknown:
+            from agentclaw.community.core.skill_center.errors import (
+                LocalSkillOwnerAmbiguousError,
+            )
+
+            raise LocalSkillOwnerAmbiguousError()
+        return [row for row in rows if str(row.get("user_id")) == owner_id]
+
+    def _sync_runtime(self, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
+        try:
+            service = self._skill_set_service_factory.create(
+                user_id=owner_id,
+                entity_id=str(bot["entity_id"]),
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=bot.get("entity_type"),
+            )
+            return bool(service.sync_runtime())
+        except Exception:
+            return False
+
+    @staticmethod
+    def _scope_for(bot: dict[str, Any], bot_id: str) -> BotSkillLayoutScope:
+        return BotSkillLayoutScope(
+            env=str(bot["env"]), entity_id=str(bot["entity_id"]), bot_id=bot_id
         )
 
     def _authorize(self, bot_id: str, owner_id: str, actor_id: str) -> dict[str, Any]:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/repositories.py
@@ -45,6 +45,14 @@ class SkillRepository(Protocol):
         """精确查询 Bot 自有的同名 local 技能，不包含全局行。"""
         ...
 
+    def list_bot_local_by_name(self, *, bot_id: str, name: str) -> list[dict]:
+        """Return every exact Bot-local same-name row for ambiguity handling.
+
+        The caller resolves legacy owner semantics after it holds the Bot Skill
+        layout edit lock; this method deliberately does not pick a winner.
+        """
+        ...
+
     def list_bot_local_skills(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1303,8 +1303,12 @@ class SkillSetService:
                     )
                 else:
                     # 相对名称格式: skill-name
-                    link_name = path_part.split('/')[-1] if '/' in path_part else path_part
-                    source = str(skills_local_dir / link_name)
+                    source_name = path_part.split('/')[-1] if '/' in path_part else path_part
+                    # Replacement packages are staged under a temporary
+                    # directory (for example ``.foo.replacement-*``), but
+                    # their runtime link must retain the logical Skill name.
+                    link_name = skill_name or source_name
+                    source = str(skills_local_dir / source_name)
                 target = str(base_skills_dir / link_name)
                 symlinks.append(SynlinkMappingInfo(source=source, target=target))
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1295,7 +1295,7 @@ class SkillSetService:
                 # 从路径中提取技能名称（最后一个目录名）
                 if path_part.startswith('/'):
                     # 绝对路径格式: /aidesktop/.../skills-local/skill-name
-                    skill_name = path_part.rstrip('/').split('/')[-1]
+                    link_name = skill_name or path_part.rstrip('/').split('/')[-1]
                     source = (
                         canonical_pool_local_path(path_part, skills_local_dir)
                         if pool_layout_paths is not None
@@ -1303,9 +1303,9 @@ class SkillSetService:
                     )
                 else:
                     # 相对名称格式: skill-name
-                    skill_name = path_part.split('/')[-1] if '/' in path_part else path_part
-                    source = str(skills_local_dir / skill_name)
-                target = str(base_skills_dir / skill_name)
+                    link_name = path_part.split('/')[-1] if '/' in path_part else path_part
+                    source = str(skills_local_dir / link_name)
+                target = str(base_skills_dir / link_name)
                 symlinks.append(SynlinkMappingInfo(source=source, target=target))
 
         logger.info(f"[get_symlink_mappings] 生成软链配置完成: symlinks_count={len(symlinks)}")

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
@@ -10,6 +10,7 @@ CREATE TABLE `ac_local_skill_cleanup_work` (
   `bot_id` VARCHAR(100) NOT NULL,
   `skill_id` BIGINT NOT NULL,
   `package_locator` VARCHAR(1024) NOT NULL,
+  `package_locator_hash` CHAR(64) NOT NULL,
   `requires_runtime_restore` TINYINT(1) NOT NULL DEFAULT 0,
   `status` VARCHAR(20) NOT NULL DEFAULT 'pending',
   `attempts` INT NOT NULL DEFAULT 0,
@@ -18,7 +19,7 @@ CREATE TABLE `ac_local_skill_cleanup_work` (
   `gmt_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `gmt_modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_local_skill_cleanup_scope_locator` (`env`, `owner_id`, `bot_id`, `package_locator`),
+  UNIQUE KEY `uk_local_skill_cleanup_scope_locator_hash` (`env`, `owner_id`, `bot_id`, `package_locator_hash`),
   KEY `idx_local_skill_cleanup_pending` (`env`, `status`, `gmt_create`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -27,8 +28,13 @@ CREATE TABLE `ac_local_skill_cleanup_work` (
 --   SELECT COUNT(*) FROM information_schema.statistics
 --     WHERE table_schema = DATABASE()
 --       AND table_name = 'ac_local_skill_cleanup_work'
---       AND index_name IN ('uk_local_skill_cleanup_scope_locator',
+--       AND index_name IN ('uk_local_skill_cleanup_scope_locator_hash',
 --                          'idx_local_skill_cleanup_pending');
+-- The unique key is bounded at 20 + 128 + 100 utf8mb4 characters plus a
+-- 64-byte ASCII SHA-256 digest (under 1,056 maximum bytes), rather than an
+-- unbounded 1,024-character locator. Verify target limits before rollout:
+--   SELECT @@version, @@character_set_server;
+--   SHOW CREATE TABLE ac_local_skill_cleanup_work;
 -- Roll back only before application deployment: DROP TABLE ac_local_skill_cleanup_work;
 -- After code rollout, retain work rows until they reach status='cleaned'; use
 -- a forward repair rather than dropping the table, so no obsolete bytes lose

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
@@ -1,4 +1,6 @@
--- Deploy before application code that can commit Local Skill replacement.
+-- RELEASE GATE: deploy this DDL and verify it before deploying application
+-- code that can commit Local Skill replacement.  The application has no
+-- compatibility fallback for an absent cleanup-work table.
 -- Strict Bot scope (env, owner_id, bot_id) is deployment-wide unique, therefore
 -- this operational table intentionally is not a tenant-leading catalog.
 CREATE TABLE `ac_local_skill_cleanup_work` (
@@ -8,6 +10,7 @@ CREATE TABLE `ac_local_skill_cleanup_work` (
   `bot_id` VARCHAR(100) NOT NULL,
   `skill_id` BIGINT NOT NULL,
   `package_locator` VARCHAR(1024) NOT NULL,
+  `requires_runtime_restore` TINYINT(1) NOT NULL DEFAULT 0,
   `status` VARCHAR(20) NOT NULL DEFAULT 'pending',
   `attempts` INT NOT NULL DEFAULT 0,
   `last_error` TEXT NULL,
@@ -19,5 +22,14 @@ CREATE TABLE `ac_local_skill_cleanup_work` (
   KEY `idx_local_skill_cleanup_pending` (`env`, `status`, `gmt_create`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- Verify: SHOW CREATE TABLE ac_local_skill_cleanup_work;
--- Roll back before code deployment only: DROP TABLE ac_local_skill_cleanup_work;
+-- Verify before application rollout:
+--   SHOW CREATE TABLE ac_local_skill_cleanup_work;
+--   SELECT COUNT(*) FROM information_schema.statistics
+--     WHERE table_schema = DATABASE()
+--       AND table_name = 'ac_local_skill_cleanup_work'
+--       AND index_name IN ('uk_local_skill_cleanup_scope_locator',
+--                          'idx_local_skill_cleanup_pending');
+-- Roll back only before application deployment: DROP TABLE ac_local_skill_cleanup_work;
+-- After code rollout, retain work rows until they reach status='cleaned'; use
+-- a forward repair rather than dropping the table, so no obsolete bytes lose
+-- their durable retry record.

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql
@@ -1,0 +1,23 @@
+-- Deploy before application code that can commit Local Skill replacement.
+-- Strict Bot scope (env, owner_id, bot_id) is deployment-wide unique, therefore
+-- this operational table intentionally is not a tenant-leading catalog.
+CREATE TABLE `ac_local_skill_cleanup_work` (
+  `id` BIGINT NOT NULL AUTO_INCREMENT,
+  `env` VARCHAR(20) NOT NULL,
+  `owner_id` VARCHAR(128) NOT NULL,
+  `bot_id` VARCHAR(100) NOT NULL,
+  `skill_id` BIGINT NOT NULL,
+  `package_locator` VARCHAR(1024) NOT NULL,
+  `status` VARCHAR(20) NOT NULL DEFAULT 'pending',
+  `attempts` INT NOT NULL DEFAULT 0,
+  `last_error` TEXT NULL,
+  `cleaned_at` TIMESTAMP NULL,
+  `gmt_create` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `gmt_modified` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_local_skill_cleanup_scope_locator` (`env`, `owner_id`, `bot_id`, `package_locator`),
+  KEY `idx_local_skill_cleanup_pending` (`env`, `status`, `gmt_create`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Verify: SHOW CREATE TABLE ac_local_skill_cleanup_work;
+-- Roll back before code deployment only: DROP TABLE ac_local_skill_cleanup_work;

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -71,7 +71,12 @@ class SkillsPoolEditGuard:
     async def acquire_for_edit_wait(
         self, *, scope: BotSkillLayoutScope, timeout_seconds: float = 30.0
     ) -> SkillsPoolEditLease:
-        """Wait for an ordinary edit while still failing closed for rollback."""
+        """Wait for another ordinary Local Skill edit, never bypass its lock.
+
+        Layout rollback remains an immediate pause; only a held edit lease is
+        retried.  This gives concurrent same-name uploads one serialized
+        authoritative read rather than a lock-contention race.
+        """
         deadline = time.monotonic() + timeout_seconds
         while True:
             try:

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -147,6 +147,9 @@ from agentclaw.community.core.skill_center.services.local_skill_state_service im
 from agentclaw.community.api.local_skill_state_service import (
     LocalSkillStateServiceProtocol,
 )
+from agentclaw.community.core.skill_center.local_skill_cleanup import (
+    LocalSkillCleanupRepository,
+)
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
 )
@@ -175,6 +178,9 @@ from agentclaw.community.plugins.skill_center_sync_log_repository import (
 )
 from agentclaw.community.plugins.skill_propagation_log_repository import (
     SkillPropagationLogRepository as UnifiedSkillPropagationLogRepository,
+)
+from agentclaw.community.plugins.local_skill_cleanup_repository import (
+    SqlLocalSkillCleanupRepository,
 )
 
 
@@ -294,8 +300,10 @@ class SkillCenterModule(Module):
         bot_repo: BotRepository,
         collaborator_service: CollaboratorServiceProtocol,
         skill_service_factory: SkillServiceFactory,
+        skill_set_service_factory: SkillSetServiceFactory,
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
+        cleanup_repo: LocalSkillCleanupRepository,
     ) -> LocalSkillUploadServiceProtocol:
         return LocalSkillUploadService(
             skill_repo,
@@ -303,9 +311,19 @@ class SkillCenterModule(Module):
             bot_repo,
             collaborator_service,
             skill_service_factory,
+            skill_set_service_factory,
             audit_log_repo,
             edit_guard,
+            cleanup_repo,
         )
+
+    @singleton
+    @provider
+    @inject
+    def local_skill_cleanup_repository(
+        self, db: DatabasePlugin
+    ) -> LocalSkillCleanupRepository:
+        return SqlLocalSkillCleanupRepository(db)
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -304,6 +304,7 @@ class SkillCenterModule(Module):
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
         cleanup_repo: LocalSkillCleanupRepository,
+        injector: Injector,
     ) -> LocalSkillUploadServiceProtocol:
         return LocalSkillUploadService(
             skill_repo,
@@ -315,6 +316,7 @@ class SkillCenterModule(Module):
             audit_log_repo,
             edit_guard,
             cleanup_repo,
+            lambda: injector.get(DeviceContextResolver),
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -147,7 +147,7 @@ from agentclaw.community.core.skill_center.services.local_skill_state_service im
 from agentclaw.community.api.local_skill_state_service import (
     LocalSkillStateServiceProtocol,
 )
-from agentclaw.community.core.skill_center.local_skill_cleanup import (
+from agentclaw.community.plugin_api.local_skill_cleanup import (
     LocalSkillCleanupRepository,
 )
 from agentclaw.community.core.bot_collaborator.protocols import (

--- a/src/backend/src/agentclaw/community/plugin_api/local_skill_cleanup.py
+++ b/src/backend/src/agentclaw/community/plugin_api/local_skill_cleanup.py
@@ -18,7 +18,7 @@ class LocalSkillCleanupRepository(Protocol):
         skill_id: str,
         package_locator: str,
         requires_runtime_restore: bool,
-    ) -> bool: ...
+    ) -> int | None: ...
 
     def list_pending(self, *, env: str, owner_id: str, bot_id: str) -> list[dict]: ...
 
@@ -28,4 +28,8 @@ class LocalSkillCleanupRepository(Protocol):
 
     def mark_failed(
         self, *, work_id: int, env: str, owner_id: str, bot_id: str, error: str
+    ) -> bool: ...
+
+    def cancel_pending(
+        self, *, work_id: int, env: str, owner_id: str, bot_id: str
     ) -> bool: ...

--- a/src/backend/src/agentclaw/community/plugin_api/local_skill_cleanup.py
+++ b/src/backend/src/agentclaw/community/plugin_api/local_skill_cleanup.py
@@ -1,0 +1,31 @@
+"""Plugin API for durable cleanup of obsolete Bot-owned Local Skill packages."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LocalSkillCleanupRepository(Protocol):
+    """Persist and progress retryable cleanup work within one exact Bot scope."""
+
+    def record_pending(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        skill_id: str,
+        package_locator: str,
+        requires_runtime_restore: bool,
+    ) -> bool: ...
+
+    def list_pending(self, *, env: str, owner_id: str, bot_id: str) -> list[dict]: ...
+
+    def mark_cleaned(
+        self, *, work_id: int, env: str, owner_id: str, bot_id: str
+    ) -> bool: ...
+
+    def mark_failed(
+        self, *, work_id: int, env: str, owner_id: str, bot_id: str, error: str
+    ) -> bool: ...

--- a/src/backend/src/agentclaw/community/plugins/local/database.py
+++ b/src/backend/src/agentclaw/community/plugins/local/database.py
@@ -142,6 +142,7 @@ class SqliteDB(MockSeam, DatabasePlugin, LifecycleBase):
         # matters.
         import agentclaw.community.plugin_api.models  # noqa: F401  ac_bots / ac_resource / ac_channel_config
         import agentclaw.community.core.models  # noqa: F401  ac_skill* / ac_skill_set_mcp / ac_user_mcp_config / propagation_log / center_sync_log
+        import agentclaw.community.core.skill_center.local_skill_cleanup  # noqa: F401  obsolete Local Skill package cleanup work
         import agentclaw.community.core.access.sqlite_models  # noqa: F401  ac_access_control_policy / ac_user_info
         import agentclaw.community.core.service_bot.repository.models  # noqa: F401  ac_bot_publish
         import agentclaw.community.core.bot_public.repository.models  # noqa: F401  ac_bot_friend

--- a/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
+
 from injector import inject
 from sqlalchemy import func
 
@@ -28,21 +30,38 @@ class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
         skill_id: str,
         package_locator: str,
         requires_runtime_restore: bool,
-    ) -> bool:
+    ) -> int | None:
+        locator_hash = self._locator_hash(package_locator)
         with self._db.orm_session() as db:
             row = db.query(LocalSkillCleanupWorkModel).filter(
                 LocalSkillCleanupWorkModel.env == env,
                 LocalSkillCleanupWorkModel.owner_id == owner_id,
                 LocalSkillCleanupWorkModel.bot_id == bot_id,
-                LocalSkillCleanupWorkModel.package_locator == package_locator,
+                LocalSkillCleanupWorkModel.package_locator_hash == locator_hash,
             ).one_or_none()
             if row is None:
-                db.add(LocalSkillCleanupWorkModel(
+                row = LocalSkillCleanupWorkModel(
                     env=env, owner_id=owner_id, bot_id=bot_id,
                     skill_id=int(skill_id), package_locator=package_locator,
+                    package_locator_hash=locator_hash,
                     requires_runtime_restore=requires_runtime_restore,
-                ))
-            return True
+                )
+                db.add(row)
+                db.flush()
+            elif row.package_locator != package_locator:
+                raise ValueError("Local Skill cleanup package locator hash collision")
+            else:
+                row.requires_runtime_restore = bool(
+                    row.requires_runtime_restore or requires_runtime_restore
+                )
+                row.status = "pending"
+                row.last_error = None
+                row.cleaned_at = None
+            return int(row.id)
+
+    @staticmethod
+    def _locator_hash(package_locator: str) -> str:
+        return sha256(package_locator.encode("utf-8")).hexdigest()
 
     def list_pending(self, *, env: str, owner_id: str, bot_id: str) -> list[dict]:
         with self._db.orm_session() as db:
@@ -55,6 +74,7 @@ class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
             return [
                 {
                     "id": row.id,
+                    "skill_id": str(row.skill_id),
                     "package_locator": row.package_locator,
                     "requires_runtime_restore": bool(row.requires_runtime_restore),
                 }
@@ -86,5 +106,20 @@ class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
                     "attempts": LocalSkillCleanupWorkModel.attempts + 1,
                     "last_error": error,
                 },
+                synchronize_session=False,
+            ) == 1
+
+    def cancel_pending(
+        self, *, work_id: int, env: str, owner_id: str, bot_id: str
+    ) -> bool:
+        with self._db.orm_session() as db:
+            return db.query(LocalSkillCleanupWorkModel).filter(
+                LocalSkillCleanupWorkModel.id == work_id,
+                LocalSkillCleanupWorkModel.env == env,
+                LocalSkillCleanupWorkModel.owner_id == owner_id,
+                LocalSkillCleanupWorkModel.bot_id == bot_id,
+                LocalSkillCleanupWorkModel.status == "pending",
+            ).update(
+                {"status": "cancelled", "last_error": "cleanup target became authoritative"},
                 synchronize_session=False,
             ) == 1

--- a/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
@@ -1,0 +1,34 @@
+"""ORM persistence for Local Skill obsolete-package cleanup work."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.skill_center.local_skill_cleanup import (
+    LocalSkillCleanupRepository,
+    LocalSkillCleanupWorkModel,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
+    """Persist one retryable record per exact Bot scope and stale locator."""
+
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+
+    def record_pending(self, *, env: str, owner_id: str, bot_id: str, skill_id: str, package_locator: str) -> bool:
+        with self._db.orm_session() as db:
+            row = db.query(LocalSkillCleanupWorkModel).filter(
+                LocalSkillCleanupWorkModel.env == env,
+                LocalSkillCleanupWorkModel.owner_id == owner_id,
+                LocalSkillCleanupWorkModel.bot_id == bot_id,
+                LocalSkillCleanupWorkModel.package_locator == package_locator,
+            ).one_or_none()
+            if row is None:
+                db.add(LocalSkillCleanupWorkModel(
+                    env=env, owner_id=owner_id, bot_id=bot_id,
+                    skill_id=int(skill_id), package_locator=package_locator,
+                ))
+            return True

--- a/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/local_skill_cleanup_repository.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from injector import inject
+from sqlalchemy import func
 
 from agentclaw.community.core.skill_center.local_skill_cleanup import (
-    LocalSkillCleanupRepository,
     LocalSkillCleanupWorkModel,
 )
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.local_skill_cleanup import LocalSkillCleanupRepository
 
 
 class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
@@ -18,7 +19,16 @@ class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
 
-    def record_pending(self, *, env: str, owner_id: str, bot_id: str, skill_id: str, package_locator: str) -> bool:
+    def record_pending(
+        self,
+        *,
+        env: str,
+        owner_id: str,
+        bot_id: str,
+        skill_id: str,
+        package_locator: str,
+        requires_runtime_restore: bool,
+    ) -> bool:
         with self._db.orm_session() as db:
             row = db.query(LocalSkillCleanupWorkModel).filter(
                 LocalSkillCleanupWorkModel.env == env,
@@ -30,5 +40,51 @@ class SqlLocalSkillCleanupRepository(LocalSkillCleanupRepository):
                 db.add(LocalSkillCleanupWorkModel(
                     env=env, owner_id=owner_id, bot_id=bot_id,
                     skill_id=int(skill_id), package_locator=package_locator,
+                    requires_runtime_restore=requires_runtime_restore,
                 ))
             return True
+
+    def list_pending(self, *, env: str, owner_id: str, bot_id: str) -> list[dict]:
+        with self._db.orm_session() as db:
+            rows = db.query(LocalSkillCleanupWorkModel).filter(
+                LocalSkillCleanupWorkModel.env == env,
+                LocalSkillCleanupWorkModel.owner_id == owner_id,
+                LocalSkillCleanupWorkModel.bot_id == bot_id,
+                LocalSkillCleanupWorkModel.status == "pending",
+            ).order_by(LocalSkillCleanupWorkModel.id.asc()).all()
+            return [
+                {
+                    "id": row.id,
+                    "package_locator": row.package_locator,
+                    "requires_runtime_restore": bool(row.requires_runtime_restore),
+                }
+                for row in rows
+            ]
+
+    def mark_cleaned(self, *, work_id: int, env: str, owner_id: str, bot_id: str) -> bool:
+        with self._db.orm_session() as db:
+            return db.query(LocalSkillCleanupWorkModel).filter(
+                LocalSkillCleanupWorkModel.id == work_id,
+                LocalSkillCleanupWorkModel.env == env,
+                LocalSkillCleanupWorkModel.owner_id == owner_id,
+                LocalSkillCleanupWorkModel.bot_id == bot_id,
+                LocalSkillCleanupWorkModel.status == "pending",
+            ).update({"status": "cleaned", "cleaned_at": func.now()}, synchronize_session=False) == 1
+
+    def mark_failed(
+        self, *, work_id: int, env: str, owner_id: str, bot_id: str, error: str
+    ) -> bool:
+        with self._db.orm_session() as db:
+            return db.query(LocalSkillCleanupWorkModel).filter(
+                LocalSkillCleanupWorkModel.id == work_id,
+                LocalSkillCleanupWorkModel.env == env,
+                LocalSkillCleanupWorkModel.owner_id == owner_id,
+                LocalSkillCleanupWorkModel.bot_id == bot_id,
+                LocalSkillCleanupWorkModel.status == "pending",
+            ).update(
+                {
+                    "attempts": LocalSkillCleanupWorkModel.attempts + 1,
+                    "last_error": error,
+                },
+                synchronize_session=False,
+            ) == 1

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -359,6 +359,22 @@ class SkillRepository:
             row = query.order_by(self.Skill.gmt_created.desc()).first()
             return _skill_to_dict(row) if row is not None else None
 
+    def list_bot_local_by_name(self, *, bot_id: str, name: str) -> list[dict]:
+        """Return all exact same-name Local rows; never hide legacy duplicates."""
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self.Skill)
+                .filter(
+                    self.Skill.env == get_current_env(),
+                    self.Skill.bolt_id == bot_id,
+                    self.Skill.name == name,
+                    self.Skill.git_path.like("local://%"),
+                )
+                .order_by(self.Skill.id.asc())
+                .all()
+            )
+            return [_skill_to_dict(row) for row in rows]
+
     @staticmethod
     def _public_local_skill(row, active: bool) -> dict:
         data = _skill_to_dict(row)

--- a/src/backend/src/agentclaw/community/plugins/skill_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/skill_repository.py
@@ -161,11 +161,12 @@ class SkillRepository:
 
     @inject
     def __init__(self, db: DatabasePlugin):
-        from agentclaw.community.core.models import Skill, SkillSet
+        from agentclaw.community.core.models import Skill, SkillSet, SkillSetSkill
 
         self._db = db
         self.Skill = Skill
         self.SkillSet = SkillSet
+        self.SkillSetSkill = SkillSetSkill
 
     def get_by_id(self, skill_id: str) -> Optional[dict]:
         with self._db.orm_session() as db:
@@ -672,7 +673,19 @@ class SkillRepository:
         return self.get_by_id(skill_id)
 
     def delete(self, skill_id: str) -> bool:
-        with self._db.orm_session() as db:
+        """Delete one Skill and its set associations as one transaction.
+
+        This remains a bulk-delete repository method, so SQLAlchemy cannot
+        apply ``Skill.skill_sets``' ORM cascade. Remove matching association
+        rows explicitly before deleting the Skill. A real transaction keeps
+        association cleanup and the Skill-row delete atomic and propagates
+        every database error to the caller.
+        """
+        with self._db.transactional_orm_session() as db:
+            db.query(self.SkillSetSkill).filter(
+                self.SkillSetSkill.skill_id == int(skill_id),
+                self.SkillSetSkill.env == get_current_env(),
+            ).delete(synchronize_session=False)
             rowcount = (
                 db.query(self.Skill)
                 .filter(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
@@ -80,5 +80,5 @@ def test_operation_responses_use_the_ratified_local_skill_models() -> None:
         ].endswith("Envelope_SkillState_")
 
     assert schema["components"]["schemas"]["SkillUpload"]["properties"]["operation"][
-        "const"
-    ] == "created"
+        "enum"
+    ] == ["created", "updated"]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -304,9 +304,9 @@ def test_openapi_declares_exact_state_command_paths_and_response_shape():
     assert {"200", "201", "413"} <= set(upload["responses"])
     for status in ("200", "201"):
         assert upload["responses"][status]["content"]["application/json"]["schema"]["$ref"].endswith(
-            "Envelope_LocalSkillUpload_"
+            "Envelope_SkillUpload_"
         )
-    assert schema["components"]["schemas"]["LocalSkillUpload"]["properties"]["operation"]["enum"] == [
+    assert schema["components"]["schemas"]["SkillUpload"]["properties"]["operation"]["enum"] == [
         "created", "updated"
     ]
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -302,6 +302,13 @@ def test_openapi_declares_exact_state_command_paths_and_response_shape():
     assert state_schema["required"] == ["skill", "changed"]
     upload = schema["paths"]["/openapi/v1/bots/skills/upload"]["post"]
     assert {"200", "201", "413"} <= set(upload["responses"])
+    for status in ("200", "201"):
+        assert upload["responses"][status]["content"]["application/json"]["schema"]["$ref"].endswith(
+            "Envelope_LocalSkillUpload_"
+        )
+    assert schema["components"]["schemas"]["LocalSkillUpload"]["properties"]["operation"]["enum"] == [
+        "created", "updated"
+    ]
 
 
 class _Database:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -88,10 +88,12 @@ class _Query:
 
 
 class _Upload:
+    operation = "created"
+
     async def upload_local_skill(self, **kwargs):
         self.args = kwargs
         return {
-            "operation": "created",
+            "operation": self.operation,
             "skill": {
                 "id": "8",
                 "name": "new-skill",
@@ -160,6 +162,30 @@ def test_upload_accepts_only_raw_zip_and_returns_created_inactive_skill():
             "updated_at": "2026-08-04T00:00:00",
         },
     }
+
+
+def test_upload_replacement_returns_200_and_updated_operation():
+    class _UpdatedUpload(_Upload):
+        operation = "updated"
+
+    class Bindings(Module):
+        def configure(self, binder):
+            binder.bind(LocalSkillQueryServiceProtocol, to=_Query())
+            binder.bind(LocalSkillUploadServiceProtocol, to=_UpdatedUpload())
+            binder.bind(LocalSkillStateServiceProtocol, to=_State())
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
+    attach_injector(app, Injector([Bindings()]))
+    client = TestClient(app)
+    response = client.post(
+        "/openapi/v1/bots/skills/upload?bot_id=bot-1",
+        content=b"PK\x03\x04", headers={"content-type": "application/zip"},
+    )
+    assert response.status_code == 200
+    assert response.json()["code"] == 200000
+    assert response.json()["data"]["operation"] == "updated"
 
 
 def test_upload_rejects_multipart_and_other_content_types_before_service_call():
@@ -274,6 +300,8 @@ def test_openapi_declares_exact_state_command_paths_and_response_shape():
         assert response_schema["$ref"].endswith("Envelope_SkillState_")
     state_schema = schema["components"]["schemas"]["SkillState"]
     assert state_schema["required"] == ["skill", "changed"]
+    upload = schema["paths"]["/openapi/v1/bots/skills/upload"]["post"]
+    assert {"200", "201", "413"} <= set(upload["responses"])
 
 
 class _Database:

--- a/src/backend/tests/community/contracts/test_local_skill_cleanup.py
+++ b/src/backend/tests/community/contracts/test_local_skill_cleanup.py
@@ -1,0 +1,42 @@
+"""Conformance coverage for durable Local Skill cleanup persistence."""
+
+from agentclaw.community.plugin_api.local_skill_cleanup import LocalSkillCleanupRepository
+
+
+def test_cleanup_repository_persists_and_progresses_one_bot_scoped_work_item(world) -> None:
+    repo = world.get(LocalSkillCleanupRepository)
+    assert repo.record_pending(
+        env="dev", owner_id="cleanup-owner", bot_id="cleanup-bot",
+        skill_id="7", package_locator="pool/local/obsolete-version",
+        requires_runtime_restore=False,
+    )
+    pending = repo.list_pending(env="dev", owner_id="cleanup-owner", bot_id="cleanup-bot")
+    assert len(pending) == 1
+    assert pending[0]["package_locator"] == "pool/local/obsolete-version"
+    scope = {"env": "dev", "owner_id": "cleanup-owner", "bot_id": "cleanup-bot"}
+    assert repo.mark_failed(
+        work_id=pending[0]["id"], error="obsolete package cleanup failed", **scope
+    )
+    assert repo.mark_cleaned(work_id=pending[0]["id"], **scope)
+    assert repo.list_pending(env="dev", owner_id="cleanup-owner", bot_id="cleanup-bot") == []
+
+
+def test_cleanup_repository_isolated_by_the_full_deployment_wide_bot_scope(world) -> None:
+    repo = world.get(LocalSkillCleanupRepository)
+    values = {
+        "env": "dev",
+        "bot_id": "shared-bot-id",
+        "skill_id": "8",
+        "package_locator": "pool/local/obsolete-version",
+        "requires_runtime_restore": False,
+    }
+    assert repo.record_pending(owner_id="owner-a", **values)
+    assert repo.record_pending(owner_id="owner-a", **values)  # idempotent retry enqueue
+    assert repo.record_pending(owner_id="owner-b", **values)
+
+    owner_a = repo.list_pending(env="dev", owner_id="owner-a", bot_id="shared-bot-id")
+    assert len(owner_a) == 1
+    assert len(repo.list_pending(env="dev", owner_id="owner-b", bot_id="shared-bot-id")) == 1
+    assert not repo.mark_cleaned(
+        work_id=owner_a[0]["id"], env="dev", owner_id="owner-b", bot_id="shared-bot-id"
+    )

--- a/src/backend/tests/community/contracts/test_local_skill_cleanup.py
+++ b/src/backend/tests/community/contracts/test_local_skill_cleanup.py
@@ -1,5 +1,12 @@
 """Conformance coverage for durable Local Skill cleanup persistence."""
 
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from agentclaw.community.core.skill_center.local_skill_cleanup import LocalSkillCleanupWorkModel
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.local_skill_cleanup import LocalSkillCleanupRepository
 
 
@@ -40,3 +47,64 @@ def test_cleanup_repository_isolated_by_the_full_deployment_wide_bot_scope(world
     assert not repo.mark_cleaned(
         work_id=owner_a[0]["id"], env="dev", owner_id="owner-b", bot_id="shared-bot-id"
     )
+
+
+def test_cleanup_upsert_reopens_work_and_monotonically_requires_runtime_restore(world) -> None:
+    repo = world.get(LocalSkillCleanupRepository)
+    scope = {"env": "dev", "owner_id": "owner", "bot_id": "bot"}
+    locator = "pool/local/replacement-version"
+    assert repo.record_pending(
+        **scope, skill_id="9", package_locator=locator,
+        requires_runtime_restore=False,
+    )
+    pending = repo.list_pending(**scope)
+    assert repo.mark_failed(
+        work_id=pending[0]["id"], error="cleanup failed", **scope
+    )
+    assert repo.record_pending(
+        **scope, skill_id="9", package_locator=locator,
+        requires_runtime_restore=True,
+    )
+    pending = repo.list_pending(**scope)
+    assert len(pending) == 1
+    assert pending[0]["requires_runtime_restore"] is True
+    with world.get(DatabasePlugin).orm_session() as db:
+        row = db.query(LocalSkillCleanupWorkModel).one()
+        assert row.status == "pending"
+        assert row.last_error is None
+
+
+def test_cleanup_uses_full_locator_hash_and_rejects_a_hash_collision(world, monkeypatch) -> None:
+    repo = world.get(LocalSkillCleanupRepository)
+    scope = {"env": "dev", "owner_id": "owner", "bot_id": "bot"}
+    locator = "pool/" + "a" * 1019
+    assert repo.record_pending(
+        **scope, skill_id="9", package_locator=locator,
+        requires_runtime_restore=False,
+    )
+    with world.get(DatabasePlugin).orm_session() as db:
+        row = db.query(LocalSkillCleanupWorkModel).one()
+        assert row.package_locator_hash == sha256(locator.encode("utf-8")).hexdigest()
+
+    monkeypatch.setattr(repo, "_locator_hash", lambda _locator: "f" * 64)
+    first = "pool/first"
+    second = "pool/second"
+    assert repo.record_pending(
+        **scope, skill_id="9", package_locator=first,
+        requires_runtime_restore=False,
+    )
+    with pytest.raises(ValueError, match="hash collision"):
+        repo.record_pending(
+            **scope, skill_id="9", package_locator=second,
+            requires_runtime_restore=False,
+        )
+
+
+def test_cleanup_ddl_uses_a_bounded_full_locator_digest_as_its_unique_key() -> None:
+    sql = (
+        Path(__file__).parents[3]
+        / "src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql"
+    ).read_text()
+    assert "`package_locator_hash` CHAR(64) NOT NULL" in sql
+    assert "`uk_local_skill_cleanup_scope_locator_hash` (`env`, `owner_id`, `bot_id`, `package_locator_hash`)" in sql
+    assert "`uk_local_skill_cleanup_scope_locator` (`env`, `owner_id`, `bot_id`, `package_locator`)" not in sql

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -9,9 +9,9 @@ import zipfile
 import pytest
 
 from agentclaw.community.core.skill_center.errors import (
-    LocalSkillDuplicateError,
     LocalSkillInvalidPackageError,
     LocalSkillNotReadyError,
+    LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
 )
 from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
@@ -41,8 +41,17 @@ class _Repo:
     def get_bot_local_by_name(self, **kwargs):
         return None
 
+    def list_bot_local_by_name(self, **kwargs):
+        return []
+
     def create(self, row):
-        row = {**row, "id": "9", "gmt_created": None, "gmt_modified": None}
+        row = {
+            **row,
+            "id": "9",
+            "active": False,
+            "gmt_created": None,
+            "gmt_modified": None,
+        }
         self.created.append(row)
         return row
 
@@ -122,7 +131,11 @@ class _Filesystem:
         self.deleted.append(path)
         result = next(self.cleanup_results, True)
         if result:
-            self.files.clear()
+            self.files = {
+                file_path: content
+                for file_path, content in self.files.items()
+                if not file_path.startswith(f"{path}/")
+            }
         return result
 
     async def exists(self, path):
@@ -149,7 +162,9 @@ class _Factory:
         is_desktop,
         is_teclaw,
         name,
+        directory_name=None,
     ):
+        directory = str(self.local_dir / (directory_name or name))
         self.storage_calls.append(
             {
                 "entity_id": entity_id,
@@ -162,9 +177,10 @@ class _Factory:
                 "name": name,
             }
         )
-        return str(self.local_dir / name), _Storage(
-            self._filesystem, str(self.local_dir / name)
-        )
+        return directory, _Storage(self._filesystem, directory)
+
+    def local_skill_package_storage_for_locator(self, *, locator, **kwargs):
+        return _Storage(self._filesystem, locator)
 
     def _local_skill_path_adapter(self, path):
         return path
@@ -228,6 +244,91 @@ class _Guard:
         return True
 
 
+class _Cleanup:
+    def __init__(self):
+        self.rows = []
+
+    def record_pending(self, **kwargs):
+        self.rows.append(kwargs)
+        return True
+
+
+class _RuntimeFactory:
+    def create(self, **kwargs):
+        return self
+
+    def sync_runtime(self):
+        return True
+
+
+class _ReplacementRepo(_Repo):
+    def __init__(self, rows):
+        super().__init__()
+        self.rows = rows
+        self.updates = []
+
+    def list_bot_local_by_name(self, **_kwargs):
+        return self.rows
+
+    def update(self, skill_id, values):
+        self.updates.append((skill_id, values))
+        row = next(row for row in self.rows if row["id"] == skill_id)
+        row.update(values)
+        return row
+
+
+class _ConcurrentRepo(_ReplacementRepo):
+    def __init__(self):
+        super().__init__([])
+
+    def create(self, row):
+        row = {
+            **row,
+            "id": "9",
+            "active": False,
+            "gmt_created": None,
+            "gmt_modified": None,
+        }
+        self.rows.append(row)
+        return row
+
+
+class _ReplacementFactory(_Factory):
+    def local_skill_package_storage(self, *, name, directory_name=None, **_kwargs):
+        directory = str(self.local_dir / (directory_name or name))
+        return directory, _Storage(self._filesystem, directory)
+
+    def local_skill_package_storage_for_locator(self, *, locator, **_kwargs):
+        return _Storage(self._filesystem, locator)
+
+
+class _ReplacementRuntime:
+    def __init__(self, results):
+        self.results = iter(results)
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        return self
+
+    def sync_runtime(self):
+        self.calls += 1
+        return next(self.results)
+
+
+def _replacement_service(filesystem, repo, runtime, cleanup=None, guard=None):
+    return LocalSkillUploadService(
+        repo,
+        _Sets(),
+        _Bot(),
+        _Collaborators(),
+        _ReplacementFactory(filesystem),
+        runtime,
+        _Audit(),
+        guard or _Guard(),
+        cleanup or _Cleanup(),
+    )
+
+
 def _service(
     filesystem,
     *,
@@ -245,34 +346,11 @@ def _service(
         bot or _Bot(status),
         collaborators or _Collaborators(),
         factory or _Factory(filesystem),
+        _RuntimeFactory(),
         audit or _Audit(),
         _Guard(),
+        _Cleanup(),
     )
-
-
-@pytest.mark.asyncio
-async def test_concurrent_same_name_uploads_are_serialized_before_duplicate_check():
-    class _StatefulRepo(_Repo):
-        def get_bot_local_by_name(self, **_kwargs):
-            return self.created[-1] if self.created else None
-
-    filesystem = _Filesystem()
-    repo = _StatefulRepo()
-    service = _service(filesystem, repo=repo)
-    package = _zip({"SKILL.md": b"---\nname: upload-skill\ndescription: useful\n---\n"})
-
-    results = await asyncio.gather(
-        service.upload_local_skill(
-            bot_id="bot", owner_id="owner", actor_id="owner", package=package
-        ),
-        service.upload_local_skill(
-            bot_id="bot", owner_id="owner", actor_id="owner", package=package
-        ),
-        return_exceptions=True,
-    )
-
-    assert len(repo.created) == 1
-    assert sum(isinstance(result, LocalSkillDuplicateError) for result in results) == 1
 
 
 @pytest.mark.asyncio
@@ -623,3 +701,157 @@ async def test_existing_orphan_must_clear_before_a_retry_writes_new_files():
     assert repo.created == []
     assert filesystem.files
     assert filesystem.deleted == ["/private/skills-local/upload-skill"] * 2
+
+
+def _existing_skill(*, active=True):
+    return {
+        "id": "9",
+        "name": "upload-skill",
+        "description": "old description",
+        "git_path": "local:///private/skills-local/upload-skill",
+        "user_id": "owner",
+        "bolt_id": "bot",
+        "active": active,
+        "gmt_created": None,
+        "gmt_modified": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_same_name_replacement_preserves_id_owner_and_desired_state_after_staging():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    result = await _replacement_service(
+        filesystem, repo, _ReplacementRuntime([True])
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="collaborator",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+    assert result["operation"] == "updated"
+    assert result["skill"]["id"] == "9"
+    assert result["skill"]["user_id"] == "owner"
+    assert result["skill"]["active"] is False
+    assert result["skill"]["git_path"] != "local:///private/skills-local/upload-skill"
+    assert "/private/skills-local/upload-skill" in filesystem.deleted
+    assert any("replacement-" in path for path in filesystem.files)
+
+
+@pytest.mark.asyncio
+async def test_active_replacement_runtime_failure_restores_old_metadata_and_runtime_mapping():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
+    old = _existing_skill(active=True)
+    repo = _ReplacementRepo([old])
+    runtime = _ReplacementRuntime([False, True])
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await _replacement_service(filesystem, repo, runtime).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+            ),
+        )
+    assert old["git_path"] == "local:///private/skills-local/upload-skill"
+    assert old["description"] == "old description"
+    assert runtime.calls == 2
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == b"old"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_legacy_matches_fail_without_writing_or_selecting_a_candidate():
+    filesystem = _Filesystem()
+    repo = _ReplacementRepo([_existing_skill(), {**_existing_skill(), "id": "10"}])
+    with pytest.raises(upload_module.LocalSkillDuplicateError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+            ),
+        )
+    assert filesystem.files == {}
+    assert repo.updates == []
+
+
+@pytest.mark.asyncio
+async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_update():
+    filesystem = _Filesystem(cleanup_results=[False])
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    cleanup = _Cleanup()
+    result = await _replacement_service(
+        filesystem, repo, _ReplacementRuntime([True]), cleanup
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+    assert result["operation"] == "updated"
+    assert cleanup.rows == [
+        {
+            "env": "test",
+            "owner_id": "owner",
+            "bot_id": "bot",
+            "skill_id": "9",
+            "package_locator": "/private/skills-local/upload-skill",
+        }
+    ]
+
+
+class _ConcurrentGuard:
+    def __init__(self):
+        self.lock = asyncio.Lock()
+
+    async def acquire_for_edit_wait(self, **_kwargs):
+        await self.lock.acquire()
+        return object()
+
+    def release(self, _lease):
+        self.lock.release()
+        return True
+
+
+class _YieldingFilesystem(_Filesystem):
+    async def write_file(self, path, content):
+        await asyncio.sleep(0)
+        await super().write_file(path, content)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
+    repo = _ConcurrentRepo()
+    filesystem = _YieldingFilesystem()
+    guard = _ConcurrentGuard()
+    package = _zip({"SKILL.md": b"name: upload-skill\ndescription: concurrent\n"})
+    first, second = await asyncio.gather(
+        _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True]), guard=guard
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=package,
+        ),
+        _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True]), guard=guard
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="collaborator",
+            package=package,
+        ),
+    )
+    assert {first["operation"], second["operation"]} == {"created", "updated"}
+    assert len(repo.rows) == 1
+    assert first["skill"]["id"] == second["skill"]["id"] == "9"

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -332,6 +332,11 @@ class _ReplacementRepo(_Repo):
     def list_bot_local_by_name(self, **_kwargs):
         return self.rows
 
+    def get_bot_local_skill(self, *, skill_id, **_kwargs):
+        return next(
+            (row for row in self.rows if str(row["id"]) == str(skill_id)), None
+        )
+
     def update(self, skill_id, values):
         self.updates.append((skill_id, values))
         row = next(row for row in self.rows if row["id"] == skill_id)
@@ -801,6 +806,30 @@ async def test_same_name_replacement_preserves_id_owner_and_desired_state_after_
     assert result["skill"]["git_path"] != "local:///private/skills-local/upload-skill"
     assert "/private/skills-local/upload-skill" in filesystem.deleted
     assert any("replacement-" in path for path in filesystem.files)
+
+
+@pytest.mark.asyncio
+async def test_replacement_reads_desired_state_from_exact_local_skill_query():
+    """The duplicate scan is metadata-only in production and has no ``active``."""
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
+    repo = _ReplacementRepo([_existing_skill(active=True)])
+    repo.list_bot_local_by_name = lambda **_kwargs: [
+        {key: value for key, value in repo.rows[0].items() if key != "active"}
+    ]
+    runtime = _ReplacementRuntime([True])
+
+    result = await _replacement_service(filesystem, repo, runtime).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+
+    assert result["operation"] == "updated"
+    assert runtime.calls == 1
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -1,4 +1,4 @@
-"""Core fault-injection seam for first Local Skill ZIP uploads."""
+"""Core fault-injection seam for Local Skill create-or-replace uploads."""
 
 from __future__ import annotations
 
@@ -20,6 +20,12 @@ from agentclaw.community.core.skill_center.services.local_skill_upload_service i
 from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage
 from agentclaw.community.core.skill_center.services import (
     local_skill_upload_service as upload_module,
+)
+from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
 )
 
 
@@ -251,6 +257,44 @@ class _Cleanup:
     def record_pending(self, **kwargs):
         self.rows.append(kwargs)
         return True
+
+    def list_pending(self, **_kwargs):
+        return []
+
+    def mark_cleaned(self, **_kwargs):
+        return True
+
+    def mark_failed(self, **_kwargs):
+        return True
+
+
+class _PendingCleanup(_Cleanup):
+    def __init__(self):
+        super().__init__()
+        self.completed: list[int] = []
+        self.failed: list[tuple[int, str]] = []
+
+    def list_pending(self, **_kwargs):
+        return [{"id": 12, "package_locator": "/private/skills-local/obsolete"}]
+
+    def mark_cleaned(self, *, work_id, **_kwargs):
+        self.completed.append(work_id)
+        return True
+
+    def mark_failed(self, *, work_id, error, **_kwargs):
+        self.failed.append((work_id, error))
+        return True
+
+
+class _RuntimeRestoreCleanup(_PendingCleanup):
+    def list_pending(self, **_kwargs):
+        return [
+            {
+                "id": 12,
+                "package_locator": "/private/skills-local/staged",
+                "requires_runtime_restore": True,
+            }
+        ]
 
 
 class _RuntimeFactory:
@@ -764,6 +808,31 @@ async def test_active_replacement_runtime_failure_restores_old_metadata_and_runt
 
 
 @pytest.mark.asyncio
+async def test_active_replacement_restore_sync_failure_keeps_original_authority_and_records_staged_cleanup():
+    filesystem = _Filesystem(cleanup_results=[False])
+    old = _existing_skill(active=True)
+    cleanup = _Cleanup()
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await _replacement_service(
+            filesystem,
+            _ReplacementRepo([old]),
+            _ReplacementRuntime([False, False]),
+            cleanup,
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+            ),
+        )
+    assert old["git_path"] == "local:///private/skills-local/upload-skill"
+    assert "replacement-" in cleanup.rows[0]["package_locator"]
+    assert cleanup.rows[0]["requires_runtime_restore"] is True
+    assert filesystem.deleted == []
+
+
+@pytest.mark.asyncio
 async def test_duplicate_legacy_matches_fail_without_writing_or_selecting_a_candidate():
     filesystem = _Filesystem()
     repo = _ReplacementRepo([_existing_skill(), {**_existing_skill(), "id": "10"}])
@@ -780,6 +849,28 @@ async def test_duplicate_legacy_matches_fail_without_writing_or_selecting_a_cand
         )
     assert filesystem.files == {}
     assert repo.updates == []
+
+
+@pytest.mark.asyncio
+async def test_foreign_owner_same_name_is_excluded_from_this_owner_scope():
+    filesystem = _Filesystem()
+    foreign = {**_existing_skill(), "user_id": "other-owner"}
+    repo = _ReplacementRepo([foreign])
+    result = await _replacement_service(
+        filesystem,
+        repo,
+        _ReplacementRuntime([True]),
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+    assert result["operation"] == "created"
+    assert repo.updates == []
+    assert foreign["git_path"] == "local:///private/skills-local/upload-skill"
 
 
 @pytest.mark.asyncio
@@ -805,21 +896,85 @@ async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_
             "bot_id": "bot",
             "skill_id": "9",
             "package_locator": "/private/skills-local/upload-skill",
+            "requires_runtime_restore": False,
         }
     ]
 
 
-class _ConcurrentGuard:
+@pytest.mark.asyncio
+async def test_later_serialized_upload_retries_durable_cleanup_work():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/obsolete/SKILL.md"] = b"obsolete"
+    cleanup = _PendingCleanup()
+    result = await _replacement_service(
+        filesystem,
+        _ReplacementRepo([_existing_skill(active=False)]),
+        _ReplacementRuntime([True]),
+        cleanup,
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+    assert result["operation"] == "updated"
+    assert cleanup.completed == [12]
+    assert cleanup.failed == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_restore_work_keeps_staged_bytes_until_old_mapping_is_restored():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/staged/SKILL.md"] = b"staged"
+    cleanup = _RuntimeRestoreCleanup()
+    runtime = _ReplacementRuntime([True])
+    await _replacement_service(
+        filesystem,
+        _ReplacementRepo([_existing_skill(active=False)]),
+        runtime,
+        cleanup,
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+    assert runtime.calls == 1
+    assert cleanup.completed == [12]
+    assert "/private/skills-local/staged/SKILL.md" not in filesystem.files
+
+
+class _LockingCache:
     def __init__(self):
-        self.lock = asyncio.Lock()
+        self.held: dict[str, str] = {}
 
-    async def acquire_for_edit_wait(self, **_kwargs):
-        await self.lock.acquire()
-        return object()
+    def acquire_lock(self, key, ttl=30):
+        if key in self.held:
+            return None
+        self.held[key] = "token"
+        return "token"
 
-    def release(self, _lease):
-        self.lock.release()
+    def release_lock(self, key, token):
+        if self.held.get(key) != token:
+            return False
+        del self.held[key]
         return True
+
+
+class _PoolLayouts:
+    def get(self, scope):
+        return BotSkillLayoutState(
+            scope=scope,
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            migration_generation="generation-1",
+            persisted=True,
+        )
 
 
 class _YieldingFilesystem(_Filesystem):
@@ -832,7 +987,7 @@ class _YieldingFilesystem(_Filesystem):
 async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
     repo = _ConcurrentRepo()
     filesystem = _YieldingFilesystem()
-    guard = _ConcurrentGuard()
+    guard = SkillsPoolEditGuard(cache=_LockingCache(), layout_repository=_PoolLayouts())
     package = _zip({"SKILL.md": b"name: upload-skill\ndescription: concurrent\n"})
     first, second = await asyncio.gather(
         _replacement_service(

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import zipfile
+from types import SimpleNamespace
 
 import pytest
 
@@ -361,11 +362,12 @@ class _ConcurrentRepo(_ReplacementRepo):
 
 
 class _ReplacementFactory(_Factory):
-    def local_skill_package_storage(self, *, name, directory_name=None, **_kwargs):
-        directory = str(self.local_dir / (directory_name or name))
-        return directory, _Storage(self._filesystem, directory)
+    def __init__(self, filesystem):
+        super().__init__(filesystem)
+        self.locator_calls: list[dict] = []
 
-    def local_skill_package_storage_for_locator(self, *, locator, **_kwargs):
+    def local_skill_package_storage_for_locator(self, *, locator, **kwargs):
+        self.locator_calls.append({"locator": locator, **kwargs})
         return _Storage(self._filesystem, locator)
 
 
@@ -382,7 +384,17 @@ class _ReplacementRuntime:
         return next(self.results)
 
 
-def _replacement_service(filesystem, repo, runtime, cleanup=None, guard=None):
+class _DeviceResolver:
+    def __init__(self, provider="local"):
+        self.provider = provider
+
+    def resolve_for_bot(self, _bot_id, _owner_id):
+        return SimpleNamespace(provider=self.provider)
+
+
+def _replacement_service(
+    filesystem, repo, runtime, cleanup=None, guard=None, *, provider="local"
+):
     return LocalSkillUploadService(
         repo,
         _Sets(),
@@ -393,6 +405,7 @@ def _replacement_service(filesystem, repo, runtime, cleanup=None, guard=None):
         _Audit(),
         guard or _Guard(),
         cleanup or _Cleanup(),
+        lambda: _DeviceResolver(provider),
     )
 
 
@@ -406,6 +419,7 @@ def _service(
     audit=None,
     bot=None,
     factory=None,
+    provider="local",
 ):
     return LocalSkillUploadService(
         repo or _Repo(),
@@ -417,6 +431,7 @@ def _service(
         audit or _Audit(),
         _Guard(),
         _Cleanup(),
+        lambda: _DeviceResolver(provider),
     )
 
 
@@ -830,6 +845,33 @@ async def test_replacement_reads_desired_state_from_exact_local_skill_query():
 
     assert result["operation"] == "updated"
     assert runtime.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_teclaw_replacement_resolves_provider_before_staging():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    service = _replacement_service(
+        filesystem,
+        repo,
+        _ReplacementRuntime([True]),
+        provider="teclaw",
+    )
+
+    result = await service.upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip(
+            {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+        ),
+    )
+
+    factory = service._skill_service_factory
+    assert result["operation"] == "updated"
+    assert factory.storage_calls[0]["is_teclaw"] is True
+    assert factory.locator_calls[0]["is_teclaw"] is True
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -253,10 +253,11 @@ class _Guard:
 class _Cleanup:
     def __init__(self):
         self.rows = []
+        self.cancelled: list[int] = []
 
     def record_pending(self, **kwargs):
         self.rows.append(kwargs)
-        return True
+        return len(self.rows)
 
     def list_pending(self, **_kwargs):
         return []
@@ -266,6 +267,15 @@ class _Cleanup:
 
     def mark_failed(self, **_kwargs):
         return True
+
+    def cancel_pending(self, *, work_id, **_kwargs):
+        self.cancelled.append(work_id)
+        return True
+
+
+class _CleanupRecordFailure(_Cleanup):
+    def record_pending(self, **_kwargs):
+        return None
 
 
 class _PendingCleanup(_Cleanup):
@@ -295,6 +305,14 @@ class _RuntimeRestoreCleanup(_PendingCleanup):
                 "requires_runtime_restore": True,
             }
         ]
+
+
+class _UnwritableCleanupProgress(_PendingCleanup):
+    def mark_cleaned(self, **_kwargs):
+        return False
+
+    def mark_failed(self, **_kwargs):
+        return False
 
 
 class _RuntimeFactory:
@@ -827,8 +845,11 @@ async def test_active_replacement_restore_sync_failure_keeps_original_authority_
             ),
         )
     assert old["git_path"] == "local:///private/skills-local/upload-skill"
-    assert "replacement-" in cleanup.rows[0]["package_locator"]
-    assert cleanup.rows[0]["requires_runtime_restore"] is True
+    staged_work = next(
+        row for row in cleanup.rows if "replacement-" in row["package_locator"]
+    )
+    assert staged_work["requires_runtime_restore"] is True
+    assert cleanup.cancelled == [1]
     assert filesystem.deleted == []
 
 
@@ -902,6 +923,32 @@ async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_
 
 
 @pytest.mark.asyncio
+async def test_cleanup_registration_failure_restores_old_authority_before_runtime_or_purge():
+    filesystem = _Filesystem()
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
+    old = _existing_skill(active=True)
+    runtime = _ReplacementRuntime([True])
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem,
+            _ReplacementRepo([old]),
+            runtime,
+            _CleanupRecordFailure(),
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+            ),
+        )
+    assert old["git_path"] == "local:///private/skills-local/upload-skill"
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == b"old"
+    assert runtime.calls == 0
+    assert not any("replacement-" in path for path in filesystem.files)
+
+
+@pytest.mark.asyncio
 async def test_later_serialized_upload_retries_durable_cleanup_work():
     filesystem = _Filesystem()
     filesystem.files["/private/skills-local/obsolete/SKILL.md"] = b"obsolete"
@@ -920,8 +967,33 @@ async def test_later_serialized_upload_retries_durable_cleanup_work():
         ),
     )
     assert result["operation"] == "updated"
-    assert cleanup.completed == [12]
+    assert 12 in cleanup.completed
     assert cleanup.failed == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_results", [None, [False]])
+async def test_cleanup_progress_write_failure_blocks_the_next_replacement(
+    cleanup_results,
+):
+    filesystem = _Filesystem(cleanup_results=cleanup_results)
+    filesystem.files["/private/skills-local/obsolete/SKILL.md"] = b"obsolete"
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem,
+            repo,
+            _ReplacementRuntime([True]),
+            _UnwritableCleanupProgress(),
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: new description\n"}
+            ),
+        )
+    assert repo.updates == []
 
 
 @pytest.mark.asyncio
@@ -944,7 +1016,7 @@ async def test_runtime_restore_work_keeps_staged_bytes_until_old_mapping_is_rest
         ),
     )
     assert runtime.calls == 1
-    assert cleanup.completed == [12]
+    assert 12 in cleanup.completed
     assert "/private/skills-local/staged/SKILL.md" not in filesystem.files
 
 

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -413,6 +413,41 @@ def test_desktop_pool_mapping_uses_canonical_pool_sources(test_injector):
     ]
 
 
+def test_local_replacement_mapping_keeps_stable_skill_link_name(test_injector):
+    factory = test_injector.get(SkillSetServiceFactory)
+    factory._bot_repo.get_by_id_and_owner = lambda *_: {"bot_type": "desktop"}
+    factory._pool_layout_paths = lambda *_: (
+        "/home/admin/.openclaw/workspace/skills",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+    )
+    svc = factory.create(
+        user_id="u1",
+        entity_id="e1",
+        bot_id="b1",
+        engine_type="openclaw",
+    )
+    svc.get_active_skills = lambda **_: [
+        {
+            "name": "handmade",
+            "git_path": (
+                "local:///home/admin/.openclaw/workspace/skills/skills-local/"
+                ".handmade.replacement-123"
+            ),
+        },
+    ]
+
+    mappings = svc.get_symlink_mappings(user_id="u1", bolt_id="b1")
+
+    assert [(item.source, item.target) for item in mappings] == [
+        (
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local/"
+            ".handmade.replacement-123",
+            "/home/admin/.openclaw/workspace/skills/handmade",
+        ),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_real_skill_parameter_service_factory_create(test_injector):
     """Async factory: builds the per-bot device_fs and constructs the

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -524,6 +524,42 @@ def test_local_replacement_mapping_keeps_stable_skill_link_name(test_injector):
     ]
 
 
+def test_relative_local_replacement_mapping_keeps_stable_skill_link_name(
+    test_injector,
+    monkeypatch,
+):
+    monkeypatch.setenv("DEPLOY_PROFILE", "production")
+    factory = test_injector.get(SkillSetServiceFactory)
+    factory._bot_repo.get_by_id_and_owner = lambda *_: {"bot_type": "teclaw"}
+    factory._pool_layout_paths = lambda *_: (
+        "/home/admin/.openclaw/workspace/skills",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-local",
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+    )
+    svc = factory.create(
+        user_id="u1",
+        entity_id="e1",
+        bot_id="b1",
+        engine_type="openclaw",
+    )
+    svc.get_active_skills = lambda **_: [
+        {
+            "name": "handmade",
+            "git_path": "local://skills-local/.handmade.replacement-123",
+        },
+    ]
+
+    mappings = svc.get_symlink_mappings(user_id="u1", bolt_id="b1")
+
+    assert [(item.source, item.target) for item in mappings] == [
+        (
+            "/home/admin/.openclaw/workspace/skills-pool/skills-local/"
+            ".handmade.replacement-123",
+            "/home/admin/.openclaw/workspace/skills/handmade",
+        ),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_real_skill_parameter_service_factory_create(test_injector):
     """Async factory: builds the per-bot device_fs and constructs the

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -241,6 +241,32 @@ def test_legacy_relative_locator_cleanup_resolves_against_bot_local_dir(
     )
 
 
+@pytest.mark.parametrize("locator", ["../skills-repo", "skills-local/.."])
+def test_legacy_locator_cleanup_rejects_paths_outside_bot_local_dir(
+    test_injector, locator
+):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: None
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+    factory._path_factory.get_bot_skills_local_dir = (
+        lambda entity_id, bot_id, *_args, **_kwargs: Path(
+            f"/bots/{entity_id}/{bot_id}/skills-local"
+        )
+    )
+
+    with pytest.raises(ValueError, match="escapes skills-local"):
+        factory.local_skill_package_storage_for_locator(
+            entity_id="project-42",
+            owner_id="owner-7",
+            bot_id="bot-1",
+            engine_type="openclaw",
+            entity_type="proj",
+            is_desktop=False,
+            is_teclaw=False,
+            locator=locator,
+        )
+
+
 def test_teclaw_legacy_locator_cleanup_reapplies_workspace_adapter(test_injector):
     factory = test_injector.get(SkillServiceFactory)
     factory._pool_layout_paths = lambda *_: None

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -213,6 +213,56 @@ def test_teclaw_legacy_local_skill_package_storage_uses_workspace_adapter(
     assert storage._device_directory == "workspace/skills-local/reviewer"
 
 
+def test_legacy_relative_locator_cleanup_resolves_against_bot_local_dir(
+    test_injector,
+):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: None
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+    factory._path_factory.get_bot_skills_local_dir = (
+        lambda entity_id, bot_id, *_args, **_kwargs: Path(
+            f"/bots/{entity_id}/{bot_id}/skills-local"
+        )
+    )
+
+    storage = factory.local_skill_package_storage_for_locator(
+        entity_id="project-42",
+        owner_id="owner-7",
+        bot_id="bot-1",
+        engine_type="openclaw",
+        entity_type="proj",
+        is_desktop=False,
+        is_teclaw=False,
+        locator="reviewer",
+    )
+
+    assert storage._device_directory == (
+        "/bots/project-42/bot-1/skills-local/reviewer"
+    )
+
+
+def test_teclaw_legacy_locator_cleanup_reapplies_workspace_adapter(test_injector):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: None
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+    factory._path_factory.get_bot_skills_local_dir = (
+        lambda _entity_id, _bot_id, *_args, **_kwargs: Path("skills-local")
+    )
+
+    storage = factory.local_skill_package_storage_for_locator(
+        entity_id="project-42",
+        owner_id="owner-7",
+        bot_id="bot-1",
+        engine_type="openclaw",
+        entity_type="proj",
+        is_desktop=False,
+        is_teclaw=True,
+        locator="skills-local/reviewer",
+    )
+
+    assert storage._device_directory == "workspace/skills-local/reviewer"
+
+
 def test_legacy_local_skill_packages_are_isolated_for_same_name_across_bots(
     test_injector,
 ):

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -87,6 +87,11 @@ class _RuntimeFactory:
         return True
 
 
+class _DeviceContextResolverStub:
+    def resolve_for_bot(self, _bot_id, _owner_id):
+        return type("DeviceContextStub", (), {"provider": "local"})()
+
+
 class _Cleanup:
     def record_pending(self, **_kwargs):
         return True
@@ -193,6 +198,7 @@ def _seed_uploadable_bot(world) -> None:
             world.get(BotCollabLogRepositoryProtocol),
             world.get(SkillsPoolEditGuard),
             _Cleanup(),
+            lambda: _DeviceContextResolverStub(),
         ),
         scope=None,
     )

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -91,6 +91,15 @@ class _Cleanup:
     def record_pending(self, **_kwargs):
         return True
 
+    def list_pending(self, **_kwargs):
+        return []
+
+    def mark_cleaned(self, **_kwargs):
+        return True
+
+    def mark_failed(self, **_kwargs):
+        return True
+
 
 def _package() -> bytes:
     payload = io.BytesIO()

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -9,17 +9,38 @@ import zipfile
 import jwt
 
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
-from agentclaw.community.api.local_skill_upload_service import LocalSkillUploadServiceProtocol
-from agentclaw.community.core.bot_collaborator.protocols import CollaboratorServiceProtocol
-from agentclaw.community.core.bot_collaborator.repository.protocol import BotCollabLogRepositoryProtocol
+from agentclaw.community.api.local_skill_upload_service import (
+    LocalSkillUploadServiceProtocol,
+)
+from agentclaw.community.core.bot_collaborator.protocols import (
+    CollaboratorServiceProtocol,
+)
+from agentclaw.community.core.bot_collaborator.repository.protocol import (
+    BotCollabLogRepositoryProtocol,
+)
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
-from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage, SkillServiceFactory
-from agentclaw.community.core.skill_center.services.local_skill_upload_service import LocalSkillUploadService
-from agentclaw.community.core.skill_center.services.repositories import SkillRepository, SkillSetRepository
+from agentclaw.community.core.skill_center.factories import (
+    LocalSkillPackageStorage,
+    SkillServiceFactory,
+)
+from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
+    LocalSkillUploadService,
+)
+from agentclaw.community.core.skill_center.services.repositories import (
+    SkillRepository,
+    SkillSetRepository,
+)
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
-from agentclaw.community.utils.gateway_principal_config import init_principal_verifier_config
-from tests.community.framework import CaseInput, ExpectError, ExpectSuccess, endpoint_test
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
 
 
 _OWNER = "upload-owner"
@@ -50,10 +71,25 @@ class _Storage:
 
 
 class _StorageFactory:
-    def local_skill_package_storage(self, **_kwargs) -> tuple[str, LocalSkillPackageStorage]:
+    def local_skill_package_storage(
+        self, **_kwargs
+    ) -> tuple[str, LocalSkillPackageStorage]:
         # HTTP, tenant, and Core persistence are real here; filesystem faults
         # belong to the Core fault-injection matrix.
         return "test-local/raw-upload", _Storage()  # type: ignore[return-value]
+
+
+class _RuntimeFactory:
+    def create(self, **_kwargs):
+        return self
+
+    def sync_runtime(self):
+        return True
+
+
+class _Cleanup:
+    def record_pending(self, **_kwargs):
+        return True
 
 
 def _package() -> bytes:
@@ -144,8 +180,10 @@ def _seed_uploadable_bot(world) -> None:
             world.get(BotRepository),
             world.get(CollaboratorServiceProtocol),
             storage_factory,
+            _RuntimeFactory(),
             world.get(BotCollabLogRepositoryProtocol),
             world.get(SkillsPoolEditGuard),
+            _Cleanup(),
         ),
         scope=None,
     )
@@ -161,7 +199,9 @@ def _assert_associated_to_owning_bot_default(response, world) -> None:
         assert default_set["bolt_id"] == _BOT_ID
         assert skill_id in {
             skill["id"]
-            for skill in world.get(SkillSetRepository).get_skills_in_set(default_set["id"])
+            for skill in world.get(SkillSetRepository).get_skills_in_set(
+                default_set["id"]
+            )
         }
 
 
@@ -180,7 +220,10 @@ def _assert_associated_to_owning_bot_default(response, world) -> None:
         status=201,
         json_contains={
             "code": 201000,
-            "data": {"operation": "created", "skill": {"name": "raw-upload", "active": False}},
+            "data": {
+                "operation": "created",
+                "skill": {"name": "raw-upload", "active": False},
+            },
         },
     ),
 )

--- a/src/backend/tests/community/plugins/test_skill_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_skill_repository_unified.py
@@ -13,7 +13,7 @@ uk_user_bot_skillset_mcp).
 from contextlib import contextmanager
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.models import Skill, SkillSet, SkillSetSkill
@@ -28,12 +28,14 @@ from agentclaw.community.plugins.skill_repository import (
     SkillRepository,
     SkillSetRepository,
 )
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 pytestmark = pytest.mark.integration
 
 
 class _FileSqliteDB:
     def __init__(self, engine):
+        self.engine = engine
         self._factory = sessionmaker(
             bind=engine, autocommit=False, autoflush=False
         )
@@ -49,6 +51,9 @@ class _FileSqliteDB:
             raise
         finally:
             db.close()
+
+    def transactional_orm_session(self):
+        return self.orm_session()
 
     session = orm_session
 
@@ -103,6 +108,110 @@ def test_skill_create_get_update_delete(skills):
     assert skills.delete(sid) is True
     assert skills.get_by_id(sid) is None  # hard delete
     assert skills.delete(sid) is False
+
+
+def test_delete_removes_all_associations_for_active_and_inactive_local_skills(
+    skills, sets, db
+):
+    active_skill = skills.create(
+        {"name": "active-local", "git_path": "local:///skills/active"}
+    )
+    inactive_skill = skills.create(
+        {"name": "inactive-local", "git_path": "local:///skills/inactive"}
+    )
+    active_set = sets.create({"name": "active", "is_active": True})
+    inactive_set = sets.create({"name": "inactive", "is_active": False})
+    extra_set = sets.create({"name": "extra", "is_active": True})
+    sets.add_skill_to_set(active_set["id"], active_skill["id"])
+    sets.add_skill_to_set(extra_set["id"], active_skill["id"])
+    sets.add_skill_to_set(inactive_set["id"], inactive_skill["id"])
+
+    assert skills.delete(active_skill["id"]) is True
+    assert skills.delete(inactive_skill["id"]) is True
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).count() == 0
+        assert session.query(Skill).count() == 0
+
+
+def test_delete_succeeds_for_skill_without_an_association(skills, db):
+    skill = skills.create(
+        {"name": "unassociated", "git_path": "local:///skills/unassociated"}
+    )
+
+    assert skills.delete(skill["id"]) is True
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).count() == 0
+        assert session.query(Skill).count() == 0
+
+
+def test_delete_rolls_back_when_association_cleanup_fails(skills, sets, db):
+    skill = skills.create({"name": "rollback-association"})
+    skill_set = sets.create({"name": "set"})
+    sets.add_skill_to_set(skill_set["id"], skill["id"])
+
+    def fail_association_delete(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ):
+        if statement.lstrip().lower().startswith("delete from ac_skill_set_skill"):
+            raise RuntimeError("injected association delete failure")
+
+    event.listen(db.engine, "before_cursor_execute", fail_association_delete)
+    try:
+        with pytest.raises(RuntimeError, match="injected association delete failure"):
+            skills.delete(skill["id"])
+    finally:
+        event.remove(db.engine, "before_cursor_execute", fail_association_delete)
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).count() == 1
+        assert session.query(Skill).count() == 1
+
+
+def test_delete_rolls_back_association_cleanup_when_skill_delete_fails(
+    skills, sets, db
+):
+    skill = skills.create({"name": "rollback-skill"})
+    skill_set = sets.create({"name": "set"})
+    sets.add_skill_to_set(skill_set["id"], skill["id"])
+
+    def fail_skill_delete(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ):
+        if statement.lstrip().lower().startswith("delete from ac_skill "):
+            raise RuntimeError("injected skill delete failure")
+
+    event.listen(db.engine, "before_cursor_execute", fail_skill_delete)
+    try:
+        with pytest.raises(RuntimeError, match="injected skill delete failure"):
+            skills.delete(skill["id"])
+    finally:
+        event.remove(db.engine, "before_cursor_execute", fail_skill_delete)
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).count() == 1
+        assert session.query(Skill).count() == 1
+
+
+def test_delete_cannot_remove_a_skill_or_association_from_another_tenant(
+    skills, sets, db
+):
+    with avernet_tenant_scope("tenant-b"):
+        skill = skills.create({"name": "tenant-b-skill"})
+        skill_set = sets.create({"name": "tenant-b-set"})
+        sets.add_skill_to_set(skill_set["id"], skill["id"])
+
+    with avernet_tenant_scope("tenant-a"):
+        assert skills.delete(skill["id"]) is False
+        with db.orm_session() as session:
+            assert session.query(SkillSetSkill).count() == 0
+            assert session.query(Skill).count() == 0
+
+    with avernet_tenant_scope("tenant-b"):
+        with db.orm_session() as session:
+            assert session.query(SkillSetSkill).count() == 1
+            assert session.query(Skill).count() == 1
 
 
 def test_skill_create_is_plain_insert_not_upsert(skills):


### PR DESCRIPTION
## Problem

Same-name Local Skill uploads need an atomic replacement path, and deleting a Skill must not leave SkillSet or MCP association rows behind.

## Solution

- Serialize create-or-replace uploads with the Bot Skill layout edit lock.
- Stage and switch replacement packages while preserving Skill identity, ownership, desired state, and existing links.
- Persist retryable old-package cleanup using a SHA-256 locator identity.
- Remove SkillSet and MCP association rows as part of Skill deletion.
- Return created for first upload and updated for replacement, with matching OpenAPI contracts.
- Fold the former #732 delivery into this PR.

## Validation

- Full backend suite: 10572 passed.
- Focused Core, HTTP, contract, DDL, architecture, and association-cleanup tests passed.
- Ruff and git diff --check passed.

## Compatibility and risk

Deploy-before-code DDL gate: apply and verify src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_04_local_skill_cleanup_work.sql before rolling out this application code. The application has no fallback when the cleanup-work table is absent.

The unique key uses env, owner_id, bot_id, package_locator_hash, where the digest is CHAR(64) SHA-256. Before application rollout only, rollback may drop the table; after rollout use forward repair and retain pending work.

## Related issues

Closes #725
Closes #684

Depends on #730.
Supersedes #732.