### PR TITLE
fix(backend): enforce six-route Skills contract

### DIFF
--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -367,10 +367,12 @@ def test_openapi_declares_exactly_the_six_ratified_skills_operations():
     upload = schema["paths"]["/openapi/v1/bots/skills/upload"]["post"]
     assert {"200", "201", "413"} <= set(upload["responses"])
     assert set(upload["requestBody"]["content"]) == {"application/zip"}
-    assert upload["responses"]["413"]["content"]["application/json"]["example"] == {
+    error_example = upload["responses"]["413"]["content"]["application/json"]["example"]
+    assert {**error_example, "data": error_example.get("data")} == {
         "code": 413101,
         "message": "Skill package is too large",
         "request_id": "",
+        "data": None,
     }
     error_schema = upload["responses"]["413"]["content"]["application/json"]["schema"]
     assert error_schema["$ref"].endswith("ErrorEnvelope")


### PR DESCRIPTION
## Problem

The assembled public Skills OpenAPI still advertised three obsolete definition-only routes in addition to the six ratified lifecycle operations. The final Track B gate also required an executable tenant-isolation proof, release-safe schema guidance, and an honest pre-production status.

## Solution

- Restrict the generated public Skills surface to list, raw application/zip upload, detail, activate, deactivate, and delete. The collection active filter remains the sole Active-list mechanism; 413 is documented only on upload with the standard ErrorEnvelope schema.
- Add full-app, real-repository Track A tenant-guard coverage across list, detail, upload-or-replace, activate, deactivate, and delete, including same-shaped cross-tenant data.
- Preserve the stable six-digit Skills codes and existing category contracts through the assembled OpenAPI and conformance suites.
- Publish the English PRE-PROD PENDING acceptance runbook, including owner lifecycle, same-name replacement, collaborator attribution, tenant-negative checks, evidence, rollback, and the #725 deploy-before-code DDL gate.

## Validation

- BACKEND_CI_SKIP_INSTALL=1 src/backend/scripts/ci_test.sh --base 53aa860cafb0db0451d692ccc53d260df8bd776a --head HEAD — passed: 10,389/10,389; 84.89% line coverage; changed executable lines: none, gate passed.
- cd src/backend && uv run pytest tests/community -q — passed: 10,389 passed, 406 warnings, exit 0.
- Focused public OpenAPI/tenant/error-schema tests — 22 passed.
- scripts/ci/python_sast_local.sh src/backend 1 --base 53aa860cafb0db0451d692ccc53d260df8bd776a --head HEAD; Ruff; format; diff check; Standards and Spec review — passed.

## Compatibility and risk

This intentionally removes the obsolete, unimplemented GET/POST /openapi/v1/bots/{bot_id}/skills and DELETE /openapi/v1/bots/{bot_id}/skills/{skill_id} declarations. They raised NotImplementedError and were not ratified operations. Generated-client and contract-test consumers must use the six ratified routes; runtime skill data is unaffected. Rollback is a revert of this PR.

No DDL is introduced here, and the #726 baseline adds no DDL. #725's ac_local_skill_cleanup_work DDL must be deployed and verified before this code; the runbook provides exact rollout verification and safe rollback steps. No production or pre-production DDL was executed.

PRE-PROD PENDING: no authorized pre-production credentials, real Bot, owner, or collaborator were available. Local implementation and CI completion do not mean Track B release completion.

## Spec

Implements the final integration/release-gate requirements for #727 against the Track B local specification and the OpenAPI v1 handoff.

## Related issues

Closes #727

Prerequisite: #684.

Stacked dependencies: #728, #729, #730, #731, #732, #734.