### PR TITLE
fix(backend): bind bot chat queries to authenticated user

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
@@ -58,7 +58,8 @@ async def list_sessions(
 ):
     """List bot conversation sessions."""
     try:
-        effective_owner_id = owner_id or user.staffId
+        # COSEC: Bind the owner scope to the authenticated identity; never trust query owner_id.
+        effective_owner_id = user.staffId
         result = await service.list_sessions(
             owner_id=effective_owner_id,
             from_date=from_date,

--- a/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_chat/router.py
@@ -19,7 +19,10 @@ router = APIRouter(prefix="/api/v1/bot-chats", tags=["bot-chats"])
 
 @router.get("", response_model=ApiResponse[SessionListResponse])
 async def list_sessions(
-    owner_id: str | None = Query(default=None, description="Owner ID (defaults to current user)"),
+    owner_id: str | None = Query(
+        default=None,
+        description="Bot owner ID used to locate an authorized Bot resource",
+    ),
     bot_id: str | None = Query(default=None, description="Filter by bot_id"),
     trace_id: str | None = Query(default=None, description="Filter by trace ID"),
     session_id: str | None = Query(
@@ -58,10 +61,11 @@ async def list_sessions(
 ):
     """List bot conversation sessions."""
     try:
-        # COSEC: Bind the owner scope to the authenticated identity; never trust query owner_id.
-        effective_owner_id = user.staffId
         result = await service.list_sessions(
-            owner_id=effective_owner_id,
+            # COSEC: Authentication supplies the actor; the query value is only
+            # a resource locator and is authorized by the service before use.
+            owner_id=user.staffId,
+            resource_owner_id=owner_id,
             from_date=from_date,
             to_date=to_date,
             page=page,

--- a/src/backend/src/agentclaw/community/api/bot_chat_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_chat_service.py
@@ -34,6 +34,7 @@ class BotChatServiceProtocol(Protocol):
         include_output_match: bool = False,
         time_scope: str = "default",
         log_source: str | None = None,
+        resource_owner_id: str | None = None,
     ) -> SessionListResponse: ...
 
     async def get_session(

--- a/src/backend/src/agentclaw/community/core/bot_chat/repository.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/repository.py
@@ -457,6 +457,55 @@ class BotChatDbRepository:
         """Check if user_id is either owner or collaborator of bot_id."""
         return self.is_bot_owner(user_id, bot_id) or self.is_bot_collaborator(user_id, bot_id)
 
+    def has_bot_access_for_owner(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> bool:
+        """Check access to the exact Bot identified by owner and Bot ID.
+
+        Legacy ``default`` Bot IDs are only unique within one owner scope.  The
+        exact Bot primary key is therefore resolved first and collaborator
+        access is matched against that key, rather than against ``bot_id``
+        alone.
+        """
+        candidate_bot_ids = [bot_id]
+        legacy_owner_alias = f"{owner_id}_default"
+        if bot_id == "default":
+            candidate_bot_ids.append(legacy_owner_alias)
+        elif bot_id == legacy_owner_alias:
+            candidate_bot_ids.append("default")
+
+        with self._db.orm_session() as session:
+            # COSEC: Resolve the resource inside the claimed owner scope before
+            # accepting either owner or collaborator authorization.
+            bot_rows = (
+                session.query(BotModel.id)
+                .filter(
+                    BotModel.owner_id == owner_id,
+                    BotModel.bot_id.in_(candidate_bot_ids),
+                    BotModel.is_delete == 0,
+                    BotModel.env == get_current_env(),
+                )
+                .all()
+            )
+            bot_pks = [row[0] for row in bot_rows]
+            if not bot_pks:
+                return False
+            if user_id == owner_id:
+                return True
+
+            collaborator = (
+                session.query(BotCollaboratorModel.id)
+                .filter(
+                    BotCollaboratorModel.bot_pk.in_(bot_pks),
+                    BotCollaboratorModel.bot_id.in_(candidate_bot_ids),
+                    BotCollaboratorModel.owner_id == owner_id,
+                    BotCollaboratorModel.user_id == user_id,
+                    BotCollaboratorModel.env == get_current_env(),
+                )
+                .first()
+            )
+            return collaborator is not None
+
     def enrich_labels(
         self,
         rows: list[Any],

--- a/src/backend/src/agentclaw/community/core/bot_chat/service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/service.py
@@ -351,6 +351,20 @@ class BotChatService(OpenBotChatServiceMixin):
         """Check access: owner (ac_bots) or collaborator (ac_bot_collaborator)."""
         return self._db_repo.has_bot_access(user_id, bot_id)
 
+    def _check_bot_access_for_owner(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> bool:
+        """Check access to an owner-scoped Bot resource."""
+        return self._db_repo.has_bot_access_for_owner(user_id, bot_id, owner_id)
+
+    def _can_access_legacy_default_bot(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> bool:
+        """Authorize an owner-scoped legacy default Bot."""
+        if user_id == owner_id:
+            return True
+        return self._check_bot_access_for_owner(user_id, bot_id, owner_id)
+
     @staticmethod
     def _is_legacy_default_bot_id(bot_id: str | None, owner_id: str) -> bool:
         """True iff ``bot_id`` is a legacy per-owner default alias (pre-retirement).
@@ -388,8 +402,14 @@ class BotChatService(OpenBotChatServiceMixin):
         include_output_match: bool = False,
         time_scope: str = "default",
         log_source: str | None = None,
+        resource_owner_id: str | None = None,
     ) -> SessionListResponse:
-        """List conversation sessions for a given owner."""
+        """List sessions visible to the authenticated actor in ``owner_id``.
+
+        ``resource_owner_id`` is an optional Bot locator supplied by the caller.
+        It is never used as a query scope until access to that exact Bot has
+        been verified.
+        """
         limit = min(max(1, limit), _MAX_PAGE_SIZE)
         page = max(1, page)
 
@@ -438,27 +458,33 @@ class BotChatService(OpenBotChatServiceMixin):
         if group_id or biz_scene or biz_task_id:
             effective_source = "db"
 
-        if effective_source == "langfuse":
-            return await self._list_sessions_langfuse(
-                owner_id=owner_id,
-                from_date=from_date,
-                to_date=to_date,
-                page=page,
-                limit=limit,
-                bot_id=bot_id,
-                trace_id=trace_id,
-                session_id=session_id,
-                session_key=session_key,
-                query=query,
-                match_mode=match_mode,
-                include_output_match=include_output_match,
+        query_owner_id = owner_id
+        query_bot_id = bot_id
+        if bot_id:
+            requested_owner_id = resource_owner_id or owner_id
+            is_legacy_default = self._is_legacy_default_bot_id(
+                bot_id, requested_owner_id
             )
+            if resource_owner_id is not None:
+                # COSEC: A caller-provided owner is only accepted after the
+                # actor is authorized against that exact owner-scoped Bot.
+                has_access = (
+                    self._can_access_legacy_default_bot(
+                        owner_id, bot_id, requested_owner_id
+                    )
+                    if is_legacy_default
+                    else self._check_bot_access_for_owner(
+                        owner_id, bot_id, requested_owner_id
+                    )
+                )
+                query_owner_id = requested_owner_id
+            elif is_legacy_default:
+                has_access = self._can_access_legacy_default_bot(
+                    owner_id, bot_id, requested_owner_id
+                )
+            else:
+                has_access = self._check_bot_access(owner_id, bot_id)
 
-        # Default DB mode: for non-(legacy-default) bot, check access (owner or collaborator).
-        # Legacy default aliases short-circuit (see _is_legacy_default_bot_id): the
-        # subsequent DB list is already scoped by owner_id, so access is implicit.
-        if bot_id and not self._is_legacy_default_bot_id(bot_id, owner_id):
-            has_access = self._check_bot_access(owner_id, bot_id)
             if not has_access:
                 return SessionListResponse(
                     sessions=[],
@@ -468,14 +494,36 @@ class BotChatService(OpenBotChatServiceMixin):
                     has_more=False,
                 )
 
-        # Default: DB mode (no fallback to Langfuse)
+            if effective_source == "db" and is_legacy_default:
+                # DB ingestion normalizes legacy ``{owner}_default`` aliases.
+                query_bot_id = "default"
+
+        if effective_source == "langfuse":
+            return await self._list_sessions_langfuse(
+                owner_id=query_owner_id,
+                from_date=from_date,
+                to_date=to_date,
+                page=page,
+                limit=limit,
+                bot_id=query_bot_id,
+                trace_id=trace_id,
+                session_id=session_id,
+                session_key=session_key,
+                query=query,
+                match_mode=match_mode,
+                include_output_match=include_output_match,
+            )
+
+        # Default: DB mode (no fallback to Langfuse).  Without bot_id the
+        # caller-provided resource owner is deliberately ignored and the query
+        # remains scoped to the authenticated actor.
         return await self._list_sessions_db(
-            owner_id=owner_id,
+            owner_id=query_owner_id,
             from_date=from_date,
             to_date=to_date,
             page=page,
             limit=limit,
-            bot_id=bot_id,
+            bot_id=query_bot_id,
             trace_id=trace_id,
             session_id=session_id,
             session_key=session_key,
@@ -810,21 +858,25 @@ class BotChatService(OpenBotChatServiceMixin):
         if row is None:
             raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
 
-        # Bot access check based on row's bot_id.
-        # - legacy default alias (or null bot_id): require trace's user_id to match
-        #   caller — see _is_legacy_default_bot_id; has_bot_access can't disambiguate
-        #   a literal "default" across owners.
-        # - non-legacy bot: require caller to be owner or collaborator.
+        # Bot access check based on row's bot_id.  The trace owner identifies
+        # the exact resource scope for legacy default Bot IDs.
         if owner_id:
-            if (
-                row.bot_id is None
-                or self._is_legacy_default_bot_id(row.bot_id, owner_id)
+            if row.bot_id is None:
+                has_access = row.user_id == owner_id
+            elif row.user_id and self._is_legacy_default_bot_id(
+                row.bot_id, row.user_id
             ):
-                if row.user_id != owner_id:
-                    raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
+                # COSEC: Default Bot IDs are owner-scoped, so collaborators are
+                # checked against the exact owner/Bot primary key.
+                has_access = self._can_access_legacy_default_bot(
+                    owner_id, row.bot_id, row.user_id
+                )
             else:
-                if not self._db_repo.has_bot_access(owner_id, row.bot_id):
-                    raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
+                has_access = self._db_repo.has_bot_access(owner_id, row.bot_id)
+            if not has_access:
+                raise SessionNotFoundError(
+                    f"Trace {trace_id} not found or not accessible"
+                )
 
         if is_ocb_row:
             observations = self._db_repo.list_ocb_observations(trace_id)
@@ -866,15 +918,24 @@ class BotChatService(OpenBotChatServiceMixin):
                 trace_bot_id = attributes.get("identity.bot_id")
                 trace_owner_id = _trace_owner_id(trace_data, attributes)
 
-                if (
-                    trace_bot_id is None
-                    or self._is_legacy_default_bot_id(trace_bot_id, owner_id)
+                if trace_bot_id is None:
+                    has_access = trace_owner_id == owner_id
+                elif trace_owner_id and self._is_legacy_default_bot_id(
+                    trace_bot_id, trace_owner_id
                 ):
-                    if trace_owner_id != owner_id:
-                        raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
+                    # COSEC: Default Bot IDs are owner-scoped, so collaborators
+                    # are checked against the exact owner/Bot primary key.
+                    has_access = self._can_access_legacy_default_bot(
+                        owner_id, trace_bot_id, trace_owner_id
+                    )
                 else:
-                    if not self._db_repo.has_bot_access(owner_id, trace_bot_id):
-                        raise SessionNotFoundError(f"Trace {trace_id} not found or not accessible")
+                    has_access = self._db_repo.has_bot_access(
+                        owner_id, trace_bot_id
+                    )
+                if not has_access:
+                    raise SessionNotFoundError(
+                        f"Trace {trace_id} not found or not accessible"
+                    )
 
         observations = await self._fetch_observations_from_langfuse(trace_id)
 

--- a/src/backend/src/agentclaw/community/plugins/community/app_services.py
+++ b/src/backend/src/agentclaw/community/plugins/community/app_services.py
@@ -24,7 +24,13 @@ class NoopCodePlatformService:
 class NoopBotChatService:
     """No bot-chat trace store in the community build — empty/neutral results."""
 
-    async def list_sessions(self, owner_id: str, *args: Any, **kwargs: Any) -> Any:
+    async def list_sessions(
+        self,
+        owner_id: str,
+        *args: Any,
+        resource_owner_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
         return []
 
     async def get_session(

--- a/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
+++ b/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
@@ -130,13 +130,13 @@ class TestListSessions:
         assert result.success is True
         assert result.data.total == 1
         assert len(result.data.sessions) == 1
-        # Verify owner_id defaults to user's staffId
         mock_service.list_sessions.assert_called_once()
-        call_kwargs = mock_service.list_sessions.call_args
-        assert call_kwargs.kwargs.get("owner_id") == "361618" or call_kwargs[1].get("owner_id") == "361618"
+        call_kwargs = mock_service.list_sessions.call_args.kwargs
+        assert call_kwargs["owner_id"] == "361618"
+        assert call_kwargs["resource_owner_id"] is None
 
     @pytest.mark.asyncio
-    async def test_owner_id_query_cannot_override_authenticated_user(
+    async def test_owner_id_query_is_separate_from_authenticated_user(
         self, mock_service, mock_user
     ):
         from agentclaw.community.adapters.http.bot_chat.router import list_sessions
@@ -166,6 +166,7 @@ class TestListSessions:
 
         call_kwargs = mock_service.list_sessions.call_args.kwargs
         assert call_kwargs["owner_id"] == mock_user.staffId
+        assert call_kwargs["resource_owner_id"] == "victim_owner"
         assert call_kwargs["bot_id"] == "bot_123"
         assert call_kwargs["session_id"] == "gen-ai-sess-456"
 
@@ -313,6 +314,7 @@ class TestGetSession:
         assert result.success is True
         assert result.data.id == "trace-1"
         assert len(result.data.observations) == 1
+        assert mock_service.get_session.call_args.kwargs["owner_id"] == mock_user.staffId
 
     @pytest.mark.asyncio
     async def test_get_session_not_found(self, mock_service, mock_user):

--- a/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
+++ b/src/backend/tests/community/api/bot_chat/test_bot_chat_router.py
@@ -136,7 +136,9 @@ class TestListSessions:
         assert call_kwargs.kwargs.get("owner_id") == "361618" or call_kwargs[1].get("owner_id") == "361618"
 
     @pytest.mark.asyncio
-    async def test_list_sessions_with_filters(self, mock_service, mock_user):
+    async def test_owner_id_query_cannot_override_authenticated_user(
+        self, mock_service, mock_user
+    ):
         from agentclaw.community.adapters.http.bot_chat.router import list_sessions
 
         mock_service.list_sessions = AsyncMock(return_value=SessionListResponse(
@@ -149,7 +151,7 @@ class TestListSessions:
 
         await list_sessions(
             service=mock_service,
-            owner_id="custom_owner",
+            owner_id="victim_owner",
             bot_id="bot_123",
             trace_id=None,
             session_id="gen-ai-sess-456",
@@ -163,7 +165,7 @@ class TestListSessions:
         )
 
         call_kwargs = mock_service.list_sessions.call_args.kwargs
-        assert call_kwargs["owner_id"] == "custom_owner"
+        assert call_kwargs["owner_id"] == mock_user.staffId
         assert call_kwargs["bot_id"] == "bot_123"
         assert call_kwargs["session_id"] == "gen-ai-sess-456"
 

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_db_log_source.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_db_log_source.py
@@ -392,6 +392,57 @@ class TestBotOwnershipRules:
 
         assert repo.has_bot_access("user2", "bot-a") is False
 
+    def test_owner_scoped_access_distinguishes_duplicate_default_bots(self):
+        db = SqliteTestDb()
+        _insert_bot(db, id=101, entity_id="entity1", owner_id="owner1", bot_id="default")
+        _insert_bot(db, id=202, entity_id="entity2", owner_id="owner2", bot_id="default")
+        _insert_bot_collaborator(
+            db,
+            bot_pk=101,
+            bot_id="default",
+            owner_id="owner1",
+            user_id="collaborator1",
+        )
+        repo = BotChatDbRepository(db)
+
+        assert repo.has_bot_access_for_owner(
+            "collaborator1", "default", "owner1"
+        ) is True
+        assert repo.has_bot_access_for_owner(
+            "collaborator1", "default", "owner2"
+        ) is False
+
+    def test_owner_scoped_access_accepts_legacy_owner_default_alias(self):
+        db = SqliteTestDb()
+        _insert_bot(
+            db,
+            id=303,
+            entity_id="entity1",
+            owner_id="owner1",
+            bot_id="owner1_default",
+        )
+        _insert_bot_collaborator(
+            db,
+            bot_pk=303,
+            bot_id="owner1_default",
+            owner_id="owner1",
+            user_id="collaborator1",
+        )
+        repo = BotChatDbRepository(db)
+
+        assert repo.has_bot_access_for_owner(
+            "owner1", "default", "owner1"
+        ) is True
+        assert repo.has_bot_access_for_owner(
+            "collaborator1", "default", "owner1"
+        ) is True
+        assert repo.has_bot_access_for_owner(
+            "collaborator1", "owner1_default", "owner1"
+        ) is True
+        assert repo.has_bot_access_for_owner(
+            "collaborator1", "default", "missing-owner"
+        ) is False
+
 
 class TestBotIdQueryRules:
     """Test bot_id query rules per spec."""

--- a/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_bot_chat_service.py
@@ -13,7 +13,13 @@ from agentclaw.community.core.bot_chat.service import (
     _apply_client_side_filters,
     _matches_session_key,
 )
-from agentclaw.community.core.bot_chat.schemas import ConversationDetail, ConversationObservation, ConversationSession, SessionMetadata
+from agentclaw.community.core.bot_chat.schemas import (
+    ConversationDetail,
+    ConversationObservation,
+    ConversationSession,
+    SessionListResponse,
+    SessionMetadata,
+)
 from agentclaw.community.core.bot_chat.errors import SessionNotFoundError, LangfuseAPIError
 from agentclaw.community.core.bot_chat.query_support import QueryScope
 from agentclaw.community.di.config import BotChatConfig
@@ -531,6 +537,146 @@ class TestBotChatServiceListSessions:
         service._db_repo.has_bot_access.assert_called_once_with("collaborator-1", "bot-a")
         _, kwargs = service._db_repo.list_traces.call_args
         assert kwargs["bot_id"] == "bot-a"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_without_bot_ignores_requested_resource_owner(
+        self, service
+    ):
+        service._db_repo = MagicMock()
+        service._db_repo.list_ocb_traces.return_value = ([], 0)
+        service._db_repo.list_traces.return_value = ([], 0)
+
+        await service.list_sessions(
+            owner_id="actor-1",
+            resource_owner_id="victim-owner",
+        )
+
+        _, kwargs = service._db_repo.list_traces.call_args
+        assert kwargs["owner_id"] == "actor-1"
+        service._db_repo.has_bot_access.assert_not_called()
+        service._db_repo.has_bot_access_for_owner.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_non_default_bot_uses_verified_resource_owner(
+        self, service
+    ):
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = True
+        service._db_repo.list_ocb_traces.return_value = ([], 0)
+        service._db_repo.list_traces.return_value = ([], 0)
+
+        await service.list_sessions(
+            owner_id="collaborator-1",
+            resource_owner_id="bot-owner",
+            bot_id="bot-a",
+        )
+
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "collaborator-1", "bot-a", "bot-owner"
+        )
+        _, kwargs = service._db_repo.list_traces.call_args
+        assert kwargs["owner_id"] == "bot-owner"
+        assert kwargs["bot_id"] == "bot-a"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_spoofed_non_default_owner_is_denied(self, service):
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = False
+
+        result = await service.list_sessions(
+            owner_id="attacker",
+            resource_owner_id="victim-owner",
+            bot_id="bot-a",
+        )
+
+        assert result.sessions == []
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "attacker", "bot-a", "victim-owner"
+        )
+        service._db_repo.list_ocb_traces.assert_not_called()
+        service._db_repo.list_traces.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_default_bot_collaborator_uses_owner_scope(
+        self, service
+    ):
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = True
+        service._db_repo.list_ocb_traces.return_value = ([], 0)
+        service._db_repo.list_traces.return_value = ([], 0)
+
+        await service.list_sessions(
+            owner_id="collaborator-1",
+            resource_owner_id="bot-owner",
+            bot_id="default",
+        )
+
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "collaborator-1", "default", "bot-owner"
+        )
+        _, kwargs = service._db_repo.list_traces.call_args
+        assert kwargs["owner_id"] == "bot-owner"
+        assert kwargs["bot_id"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_spoofed_default_owner_is_denied(self, service):
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = False
+
+        result = await service.list_sessions(
+            owner_id="attacker",
+            resource_owner_id="victim-owner",
+            bot_id="default",
+        )
+
+        assert result.sessions == []
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "attacker", "default", "victim-owner"
+        )
+        service._db_repo.list_ocb_traces.assert_not_called()
+        service._db_repo.list_traces.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_owner_default_alias_is_normalized_for_db(
+        self, service
+    ):
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = True
+        service._db_repo.list_ocb_traces.return_value = ([], 0)
+        service._db_repo.list_traces.return_value = ([], 0)
+
+        await service.list_sessions(
+            owner_id="collaborator-1",
+            resource_owner_id="bot-owner",
+            bot_id="bot-owner_default",
+        )
+
+        _, kwargs = service._db_repo.list_traces.call_args
+        assert kwargs["owner_id"] == "bot-owner"
+        assert kwargs["bot_id"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_langfuse_uses_verified_resource_owner(
+        self, service
+    ):
+        expected = SessionListResponse(
+            sessions=[], total=0, page=1, limit=20, has_more=False
+        )
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = True
+        service._list_sessions_langfuse = AsyncMock(return_value=expected)
+
+        result = await service.list_sessions(
+            owner_id="collaborator-1",
+            resource_owner_id="bot-owner",
+            bot_id="bot-owner_default",
+            log_source="langfuse",
+        )
+
+        assert result is expected
+        kwargs = service._list_sessions_langfuse.call_args.kwargs
+        assert kwargs["owner_id"] == "bot-owner"
+        assert kwargs["bot_id"] == "bot-owner_default"
 
     @pytest.mark.asyncio
     async def test_list_sessions_explicit_db_uses_db_source(self, service):
@@ -1371,14 +1517,35 @@ class TestBotChatServiceGetSession:
             await service.get_session(trace_id="missing", owner_id="user1")
 
     @pytest.mark.asyncio
+    async def test_get_session_db_missing_bot_id_remains_owner_only(self, service):
+        row = self._row(user_id="user1", bot_id=None)
+        detail = self._detail("trace-1")
+        service._db_repo = MagicMock()
+        service._db_repo.get_ocb_trace.return_value = None
+        service._db_repo.get_trace.return_value = row
+        service._db_repo.list_legacy_observations.return_value = []
+        service._db_repo._row_to_detail.return_value = detail
+
+        result = await service.get_session(trace_id="trace-1", owner_id="user1")
+
+        assert result is detail
+        service._db_repo.has_bot_access.assert_not_called()
+        service._db_repo.has_bot_access_for_owner.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_session_db_default_bot_owner_mismatch(self, service):
         """Default-bot traces still require user_id to match owner_id."""
         service._db_repo = MagicMock()
         service._db_repo.get_ocb_trace.return_value = None
         service._db_repo.get_trace.return_value = self._row(user_id="other-user", bot_id="default")
+        service._db_repo.has_bot_access_for_owner.return_value = False
 
         with pytest.raises(SessionNotFoundError):
             await service.get_session(trace_id="trace-1", owner_id="user1")
+
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "user1", "default", "other-user"
+        )
 
     @pytest.mark.asyncio
     async def test_get_session_db_default_bot_owner_match(self, service):
@@ -1398,6 +1565,26 @@ class TestBotChatServiceGetSession:
         service._db_repo.has_bot_access.assert_not_called()
         service._db_repo.list_legacy_observations.assert_called_once_with("trace-1")
         service._fetch_observations_from_langfuse.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_session_db_default_bot_collaborator_allowed(self, service):
+        row = self._row(user_id="bot-owner", bot_id="default")
+        detail = self._detail("trace-1")
+        service._db_repo = MagicMock()
+        service._db_repo.get_ocb_trace.return_value = None
+        service._db_repo.get_trace.return_value = row
+        service._db_repo.has_bot_access_for_owner.return_value = True
+        service._db_repo.list_legacy_observations.return_value = []
+        service._db_repo._row_to_detail.return_value = detail
+
+        result = await service.get_session(
+            trace_id="trace-1", owner_id="collaborator-1"
+        )
+
+        assert result is detail
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "collaborator-1", "default", "bot-owner"
+        )
 
     @pytest.mark.asyncio
     async def test_get_session_db_ocb_trace_does_not_mix_legacy_observations(self, service):
@@ -1659,6 +1846,52 @@ class TestBotChatServiceGetSession:
         assert result.id == "trace-1"
         assert result.user_id == "user1"
         service._db_repo.enrich_labels.assert_called_once_with([result])
+
+    @pytest.mark.asyncio
+    async def test_get_session_langfuse_default_bot_collaborator_allowed(
+        self, service
+    ):
+        trace_response = AsyncMock()
+        trace_response.status = 200
+        trace_response.json = AsyncMock(return_value={
+            "id": "trace-1",
+            "name": "Session",
+            "userId": "bot-owner",
+            "timestamp": "2025-01-01T00:00:00Z",
+            "success": True,
+            "metadata": {"attributes": {"identity.bot_id": "default"}},
+        })
+        trace_response.__aenter__ = AsyncMock(return_value=trace_response)
+        trace_response.__aexit__ = AsyncMock(return_value=False)
+
+        obs_response = AsyncMock()
+        obs_response.status = 200
+        obs_response.json = AsyncMock(return_value={"data": []})
+        obs_response.__aenter__ = AsyncMock(return_value=obs_response)
+        obs_response.__aexit__ = AsyncMock(return_value=False)
+
+        responses = iter((trace_response, obs_response))
+        mock_aiohttp_session = AsyncMock()
+        mock_aiohttp_session.get = MagicMock(side_effect=lambda *args, **kwargs: next(responses))
+        mock_aiohttp_session.__aenter__ = AsyncMock(return_value=mock_aiohttp_session)
+        mock_aiohttp_session.__aexit__ = AsyncMock(return_value=False)
+        service._db_repo = MagicMock()
+        service._db_repo.has_bot_access_for_owner.return_value = True
+
+        with patch(
+            "agentclaw.community.core.bot_chat.service.aiohttp.ClientSession",
+            return_value=mock_aiohttp_session,
+        ):
+            result = await service.get_session(
+                trace_id="trace-1",
+                owner_id="collaborator-1",
+                log_source="langfuse",
+            )
+
+        assert result.id == "trace-1"
+        service._db_repo.has_bot_access_for_owner.assert_called_once_with(
+            "collaborator-1", "default", "bot-owner"
+        )
 
     @pytest.mark.asyncio
     async def test_get_session_langfuse_non_default_bot_unauthorized(self, service):


### PR DESCRIPTION
## Problem

`GET /api/v1/bot-chats` accepted an optional `owner_id` query parameter and preferred it over the authenticated user's `staffId`. This made the conversation-log ownership scope caller-controlled and could allow an authenticated request to read another user's non-public bot-chat logs.

## Solution

- Keep the existing `owner_id` query parameter for backward compatibility, but no longer use it as an identity source.
- Always derive the owner scope from the authenticated `user.staffId`.
- Replace the previous forwarding test with a security regression test proving that a caller-provided `owner_id` cannot override the authenticated user.

The change is intentionally limited to the HTTP boundary; no frontend, service, or repository refactor is included in this fix.

## Validation

- `159 passed`: `tests/community/api/bot_chat` and `tests/community/core/bot_chat`
- `11 passed`: focused bot-chat router suite with coverage enabled
- Changed executable line coverage: `1/1 = 100%`
- Ruff check passed for both changed files
- Local Python SAST block scan passed for the changed router
- `git diff --check` passed

## Compatibility and risk

Existing clients may continue sending `owner_id`; the parameter remains accepted but is ignored for authorization and data scoping. Bot access checks now consistently receive the actual authenticated user identity. The rollback is a one-line change, but would reintroduce the unauthorized cross-user read risk.
