### PR TITLE
fix(baas): use Scale Publish deploy_config for SCALE_UP devices, field-level merge

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_manage/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/__init__.py
@@ -2,6 +2,7 @@
 
 from ._bot_management_service import (
     DefaultBotManagementService,
+    merge_deploy_config,
     resolve_callback_timeout,
 )
 from ._bot_service import (
@@ -11,5 +12,6 @@ from ._bot_service import (
 __all__ = [
     "DefaultBotCrudService",
     "DefaultBotManagementService",
+    "merge_deploy_config",
     "resolve_callback_timeout",
 ]

--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
@@ -32,7 +32,11 @@ from secbaas.community.api.bot_manage import (
     UpdateDevicesResponse,
 )
 from secbaas.community.api.bot_runtime import BotNotFoundError
-from secbaas.community.api.device_manage import DeviceInfo, DeviceListResponse
+from secbaas.community.api.device_manage import (
+    DeployConfig,
+    DeviceInfo,
+    DeviceListResponse,
+)
 from secbaas.community.api.health_check.bot import (
     BotHealthCheckerService as BotHealthCheckerServiceProtocol,
 )
@@ -98,6 +102,26 @@ def resolve_callback_timeout(
         "System config repo is not available, use the DEFAULT_CALLBACK_TIMEOUT_SECONDS"
     )
     return DEFAULT_CALLBACK_TIMEOUT_SECONDS
+
+
+def merge_deploy_config(
+    current: DeployConfig | None,
+    override: DeployConfig | dict,
+) -> DeployConfig:
+    """Merge override fields into current deploy_config at field level.
+
+    Only non-None fields from ``override`` replace corresponding fields
+    in ``current``. This prevents a partial override (e.g. only
+    docker_image) from zeroing out unrelated fields (envs, mount_points,
+    resource_spec, etc.) that already exist on the current config.
+    """
+    current_data = current.model_dump(exclude_none=True) if current else {}
+    override_data = (
+        override.model_dump(exclude_none=True)
+        if isinstance(override, DeployConfig)
+        else override
+    )
+    return DeployConfig.model_validate({**current_data, **override_data})
 
 
 class DefaultBotManagementService(BotManageService):
@@ -785,7 +809,10 @@ class DefaultBotManagementService(BotManageService):
             if bot_config.share_policy is not None:
                 existing_config.share_policy = bot_config.share_policy
             if bot_config.deploy_config is not None:
-                existing_config.deploy_config = bot_config.deploy_config
+                existing_config.deploy_config = merge_deploy_config(
+                    existing_config.deploy_config,
+                    bot_config.deploy_config,
+                )
             if bot_config.entity_id:
                 existing_config.entity_id = bot_config.entity_id
             if bot_config.entity_type:
@@ -922,7 +949,10 @@ class DefaultBotManagementService(BotManageService):
             if bot_config.share_policy is not None:
                 stored_config.share_policy = bot_config.share_policy
             if bot_config.deploy_config is not None:
-                stored_config.deploy_config = bot_config.deploy_config
+                stored_config.deploy_config = merge_deploy_config(
+                    stored_config.deploy_config,
+                    bot_config.deploy_config,
+                )
             if bot_config.entity_id:
                 stored_config.entity_id = bot_config.entity_id
             if bot_config.entity_type:
@@ -1180,7 +1210,10 @@ class DefaultBotManagementService(BotManageService):
             if config.share_policy is not None:
                 stored_config.share_policy = config.share_policy
             if config.deploy_config is not None:
-                stored_config.deploy_config = config.deploy_config
+                stored_config.deploy_config = merge_deploy_config(
+                    stored_config.deploy_config,
+                    config.deploy_config,
+                )
             if config.entity_id:
                 stored_config.entity_id = config.entity_id
             if config.entity_type:

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
@@ -645,6 +645,7 @@ class DefaultPublishService(PublishService):
             bot_record=bot,
             batch_records=batch_records,
             operator=operator,
+            publish_config=config,
         )
 
         # Step 6: Return publish response
@@ -887,6 +888,7 @@ class DefaultPublishService(PublishService):
         bot_record: BotRecord,
         batch_records: list[PublishBatchRecord],
         operator: str,
+        publish_config: PublishConfig | None = None,
     ) -> None:
         """Pre-create device-level PublishRecordRecord entries at create_publish time.
 
@@ -1007,6 +1009,16 @@ class DefaultPublishService(PublishService):
 
             bot_config = bot_record.config
 
+            # Prefer deploy_config from this Scale Publish, then fall back
+            # to Bot's persisted config, then to template defaults.
+            effective_deploy_config = (
+                publish_config.deploy_config
+                if publish_config and publish_config.deploy_config
+                else bot_config.deploy_config
+                if bot_config
+                else None
+            )
+
             total_new_devices = sum(b.batch_capacity for b in batch_records)
 
             event_type = PublishEventType.CREATE.value
@@ -1021,7 +1033,7 @@ class DefaultPublishService(PublishService):
                     operator=operator,
                     extra_config=DeviceConfig(
                         template_uuid=bot_record.template_uuid,
-                        deploy_config=bot_config.deploy_config if bot_config else None,
+                        deploy_config=effective_deploy_config,
                     ),
                 )
                 device = self._device_service.create_device(

--- a/src/baas/tests/e2e/asgi/baseline/test_scale_deploy_config.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_scale_deploy_config.py
@@ -1,0 +1,104 @@
+"""E2E tests for scale deploy_config flow.
+
+Verifies that new devices created during SCALE_UP receive the
+deploy_config from the Scale Publish request, not the bot's
+persisted extra_config.
+"""
+
+import uuid
+
+import pytest
+
+from tests.e2e.asgi.conftest import (
+    APITestHelper,
+    approve_publish,
+    cleanup_bot,
+    create_and_activate_bot,
+    send_callbacks_for_hook_devices,
+    wait_for_publish_status,
+)
+
+pytestmark = [pytest.mark.e2e_asgi]
+
+
+async def _scale_up_bot_with_config(
+    api: APITestHelper,
+    bot_uuid: str,
+    target_count: int,
+    deploy_config: dict,
+) -> int | None:
+    resp = await api.client.post(
+        api.bot_url(bot_uuid) + "/scale",
+        params=api.params(),
+        json={
+            "target_count": target_count,
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+            "config": {"deploy_config": deploy_config},
+        },
+    )
+    assert resp.status_code == 200
+    return resp.json()["data"].get("publish_id")
+
+
+class TestScaleDeployConfig:
+    """New devices from SCALE_UP use the scale request's deploy_config."""
+
+    @pytest.mark.asyncio
+    async def test_scale_up_new_device_gets_publish_deploy_config(
+        self, api: APITestHelper, unique_id: str
+    ) -> None:
+        bot = await create_and_activate_bot(
+            api, f"scale-dc-{unique_id}", device_count=1
+        )
+        scale_dc = {
+            "docker_image": "test-image:v2",
+            "ttl_in_minutes": 999,
+            "envs": {"SCALE_KEY": "scale_value"},
+        }
+        publish_id = await _scale_up_bot_with_config(api, bot["bot_uuid"], 2, scale_dc)
+        if not publish_id:
+            pytest.skip("No publish_id returned from scale up")
+
+        code = await approve_publish(api, publish_id)
+        assert code == 200
+
+        await send_callbacks_for_hook_devices(api, publish_id)
+
+        status = await wait_for_publish_status(
+            api, publish_id, {"SUCCESS"}, timeout_seconds=0.5
+        )
+        assert status == "SUCCESS", f"Expected SUCCESS, got {status}"
+
+        resp = await api.client.get(
+            api.publish_url(publish_id, "progress"),
+            params=api.params(include_devices="true"),
+        )
+        assert resp.status_code == 200
+        progress = resp.json()["data"]
+
+        devices = []
+        for batch_detail in progress.get("device_details", []):
+            devices.extend(batch_detail.get("devices", []))
+
+        new_device = next(
+            (d for d in devices if d.get("result_status") in ("SUCCESS", "PENDING")),
+            None,
+        )
+        assert new_device is not None, "No new device found in publish progress"
+
+        device_uuid = new_device.get("device_uuid")
+        assert device_uuid is not None
+
+        detail_resp = await api.client.get(
+            api.device_url(device_uuid), params=api.params()
+        )
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()["data"]
+        device_deploy_config = detail.get("extra_config", {}).get("deploy_config") or {}
+
+        assert device_deploy_config.get("docker_image") == "test-image:v2"
+        assert device_deploy_config.get("ttl_in_minutes") == 999
+        assert device_deploy_config.get("envs") == {"SCALE_KEY": "scale_value"}
+
+        await cleanup_bot(api, bot["bot_uuid"])

--- a/src/baas/tests/integration/core/service/test_bot_management_service.py
+++ b/src/baas/tests/integration/core/service/test_bot_management_service.py
@@ -1384,3 +1384,100 @@ class TestBotManagementServiceIntegration:
             assert "STOPPED" not in str(e), (
                 f"update_bot should not reject STOPPED status, got: {e}"
             )
+
+    @pytest.mark.asyncio
+    async def test_scale_bot_deploy_config_in_publish_record(
+        self,
+        bot_repository,
+        device_repository,
+        created_bot_ids,
+        created_device_ids,
+        created_publish_ids,
+    ):
+        """Scale up with bot_config.deploy_config stores config in publish record."""
+        from secbaas.community.api.publish_manage import PublishConfig
+
+        # Create bot with initial deploy_config
+        bot_uuid = generate_uuid()
+        initial_deploy_config = DeployConfig(envs={"INITIAL": "yes"}, ttl_in_minutes=60)
+        bot_id = bot_repository.insert_bot(
+            bot_uuid=bot_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+            status=BotStatus.ACTIVE.value,
+            name="Scale DC Bot",
+            description="Bot for scale deploy_config test",
+            template_uuid=None,
+            replica_desired=1,
+            replica_minimum=1,
+            replica_maximum=10,
+            auto_scaling_enabled=0,
+            sla_grade="standard",
+            extra_config=initial_deploy_config.model_dump(),
+        )
+        created_bot_ids.append(bot_id)
+
+        # Create 1 device
+        device_uuid = generate_uuid()
+        device_id = device_repository.insert_device(
+            device_uuid=device_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="Sigma",
+            provider_device_id=None,
+            provider_device_props={},
+            extra_config={},
+        )
+        created_device_ids.append(device_id)
+        rel_repo = get_container().repository.bot_device_rel_repository()
+        rel_repo.insert_rel(
+            bot_id=bot_id,
+            device_uuid=device_uuid,
+            tenant=FIXED_TENANT_NAME,
+            env=TEST_ENV,
+            domain="test_domain",
+            creator="test_user",
+            modifier="test_user",
+        )
+
+        # Scale up with different deploy_config
+        scale_deploy_config = DeployConfig(
+            docker_image="scale-img:v2",
+            ttl_in_minutes=120,
+        )
+        bot_config = BotConfig(deploy_config=scale_deploy_config)
+
+        with patch.object(
+            DefaultTenantManageService,
+            "get_tenant_by_name",
+            return_value=create_mock_tenant_response(),
+        ):
+            result = await _bms().scale_bot(
+                tenant=FIXED_TENANT_NAME,
+                bot_uuid=bot_uuid,
+                target_count=3,
+                operator="test_user",
+                request_id=uuid4().hex,
+                bot_config=bot_config,
+            )
+        assert result is not None
+        assert result.publish_id is not None
+        created_publish_ids.append(result.publish_id)
+
+        # Read publish record from DB and verify deploy_config
+        publish_repo = get_container().repository.publish_repository()
+        publish = publish_repo.get_by_id(
+            result.publish_id, tenant=FIXED_TENANT_NAME, env=TEST_ENV
+        )
+        assert publish is not None
+        stored_config = PublishConfig.model_validate(publish.extra_config)
+        assert stored_config.deploy_config is not None
+        assert stored_config.deploy_config.docker_image == "scale-img:v2"
+        assert stored_config.deploy_config.ttl_in_minutes == 120

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -5613,3 +5613,106 @@ class TestUpdateDevicesConfigMerge:
 
         assert result is not None
         assert result.publish_id == 888
+
+    @pytest.mark.asyncio
+    async def test_update_devices_merges_deploy_config(self):
+        """update_devices with deploy_config override triggers field-level merge."""
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.bot_uuid = "BOT-001"
+        mock_record.status = "ACTIVE"
+        mock_record.extra_config = {
+            "deploy_config": {
+                "envs": {"EXISTING": "val"},
+                "ttl_in_minutes": 60,
+            },
+        }
+        mock_record.model_dump = MagicMock(
+            return_value={"id": 1, "bot_uuid": "BOT-001"}
+        )
+
+        mock_publish = MagicMock()
+        mock_publish.id = 888
+
+        mock_bot_response = MagicMock()
+        mock_bot_response.id = 1
+        mock_bot_response.status = "ACTIVE"
+        mock_bot_response.model_dump = MagicMock(
+            return_value={
+                "id": 1,
+                "bot_uuid": "BOT-001",
+                "tenant": "test_tenant",
+                "env": "dev",
+                "domain": "default",
+                "is_deleted": 0,
+                "creator": "user1",
+                "modifier": "user1",
+                "status": "ACTIVE",
+                "name": "Test Bot",
+                "description": None,
+                "template_uuid": None,
+                "replica_desired": 1,
+                "replica_minimum": 1,
+                "replica_maximum": 10,
+                "auto_scaling_enabled": 0,
+                "sla_grade": "standard",
+                "gmt_create": "2024-01-01T00:00:00",
+                "gmt_modified": "2024-01-01T00:00:00",
+            }
+        )
+
+        mock_bot_repo = MagicMock()
+        mock_bot_repo.get_by_bot_uuid.return_value = mock_record
+        mock_device_repo = MagicMock()
+        mock_device = MagicMock()
+        mock_device.device_uuid = "DEV-001"
+        mock_device_repo.list_by_bot_id.return_value = [mock_device]
+        mock_publish_service = MagicMock()
+        mock_publish_service.create_publish = AsyncMock(return_value=mock_publish)
+        service = _make_service(
+            bot_repo=mock_bot_repo,
+            device_repo=mock_device_repo,
+            publish_service=mock_publish_service,
+        )
+
+        record_for_get = MagicMock()
+        record_for_get.id = 1
+        record_for_get.extra_config = {
+            "deploy_config": {
+                "envs": {"EXISTING": "val"},
+                "ttl_in_minutes": 60,
+            },
+        }
+
+        with (
+            patch.object(
+                service,
+                "get_bot",
+                new_callable=AsyncMock,
+                return_value=mock_bot_response,
+            ),
+            patch.object(
+                service, "_get_bot_record_by_uuid", return_value=record_for_get
+            ),
+        ):
+            bot_config = BotConfig(
+                share_policy=None,
+                deploy_config=DeployConfig(ttl_in_minutes=120, docker_image="img:v2"),
+                entity_id="",
+                entity_type="",
+                sla_grade="standard",
+                callback_timeout_seconds=None,
+                auto_approve_publish=False,
+            )
+
+            result = await service.update_devices(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                device_uuids=["DEV-001"],
+                config=bot_config,
+            )
+
+        assert result is not None
+        assert result.publish_id == 888

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -17,6 +17,7 @@ from secbaas.community.api.bot_manage import (
 )
 from secbaas.community.api.bot_runtime import BotNotFoundError
 from secbaas.community.api.device_manage import DeployConfig
+from secbaas.community.api.device_manage._models import ResourceSpecification
 from secbaas.community.api.publish_manage import (
     DEFAULT_CALLBACK_TIMEOUT_SECONDS,
     PublishStatus,
@@ -27,6 +28,7 @@ from secbaas.community.core.service.bot_manage import (
     DefaultBotManagementService as BotManagementService,
 )
 from secbaas.community.core.service.bot_manage import (
+    merge_deploy_config,
     resolve_callback_timeout,
 )
 
@@ -640,6 +642,60 @@ class TestListBots:
         assert call_kwargs["page_size"] == 100
 
 
+class TestMergeDeployConfig:
+    """Tests for merge_deploy_config field-level merge behavior."""
+
+    def test_merge_current_none_returns_override_only(self):
+        """When current is None, result is equivalent to the override alone."""
+        override = DeployConfig(ttl_in_minutes=120, docker_image="img:v2")
+        result = merge_deploy_config(None, override)
+        assert result.ttl_in_minutes == 120
+        assert result.docker_image == "img:v2"
+        assert result.envs is None
+        assert result.mount_points is None
+
+    def test_merge_override_none_fields_preserved(self):
+        """Current fields NOT in override are preserved."""
+        current = DeployConfig(
+            envs={"KEY": "val"},
+            mount_points=[],
+            ttl_in_minutes=60,
+            resource_spec=ResourceSpecification(cpu=2, memory=4096),
+        )
+        override = DeployConfig(docker_image="img:v2", ttl_in_minutes=120)
+        result = merge_deploy_config(current, override)
+        assert result.envs == {"KEY": "val"}
+        assert result.mount_points == []
+        assert result.resource_spec == ResourceSpecification(cpu=2, memory=4096)
+        assert result.ttl_in_minutes == 120
+        assert result.docker_image == "img:v2"
+
+    def test_merge_override_only_fields(self):
+        """Override-only fields are set without touching current fields."""
+        current = DeployConfig(ttl_in_minutes=60)
+        override = DeployConfig(docker_image="img:v2")
+        result = merge_deploy_config(current, override)
+        assert result.ttl_in_minutes == 60
+        assert result.docker_image == "img:v2"
+
+    def test_merge_dict_override(self):
+        """Plain dict override works the same as DeployConfig instance."""
+        current = DeployConfig(envs={"K": "V"}, ttl_in_minutes=60)
+        override_dict = {"ttl_in_minutes": 120, "docker_image": "img:v2"}
+        result = merge_deploy_config(current, override_dict)
+        assert result.envs == {"K": "V"}
+        assert result.ttl_in_minutes == 120
+        assert result.docker_image == "img:v2"
+
+    def test_merge_current_empty_none_fields(self):
+        """When current's fields are all None, override fills everything."""
+        current = DeployConfig()
+        override = DeployConfig(ttl_in_minutes=120)
+        result = merge_deploy_config(current, override)
+        assert result.ttl_in_minutes == 120
+        assert result.docker_image is None
+
+
 class TestScaleBot:
     """Tests for BotManagementService.scale_bot"""
 
@@ -1093,6 +1149,87 @@ class TestScaleBot:
         assert publish_config.callback_timeout_seconds == 600
         assert publish_config.deploy_config is not None
         assert publish_config.deploy_config.ttl_in_minutes == 120
+
+    @pytest.mark.asyncio
+    async def test_scale_bot_deploy_config_field_level_merge(self):
+        """scale_bot with partial deploy_config override preserves non-overridden fields."""
+        mock_bot_response = MagicMock()
+        mock_bot_response.id = 1
+        mock_bot_response.bot_uuid = "BOT-001"
+        mock_bot_response.model_dump = MagicMock(
+            return_value={
+                "id": 1,
+                "bot_uuid": "BOT-001",
+                "tenant": "test_tenant",
+                "env": "dev",
+                "domain": "default",
+                "is_deleted": 0,
+                "creator": "user1",
+                "modifier": "user1",
+                "status": "ACTIVE",
+                "name": "Test Bot",
+                "description": None,
+                "template_uuid": None,
+                "replica_desired": 1,
+                "replica_minimum": 1,
+                "replica_maximum": 10,
+                "auto_scaling_enabled": 0,
+                "sla_grade": "standard",
+                "gmt_create": "2024-01-01T00:00:00",
+                "gmt_modified": "2024-01-01T00:00:00",
+                "config": None,
+            }
+        )
+
+        mock_publish = MagicMock()
+        mock_publish.id = 789
+
+        mock_device_repo = MagicMock()
+        mock_device_repo.list_by_bot_id.return_value = [MagicMock()]
+
+        mock_publish_service = MagicMock()
+        mock_publish_service.create_publish = AsyncMock(return_value=mock_publish)
+
+        mock_bot_repo = MagicMock()
+        mock_record = MagicMock()
+        mock_record.extra_config = {
+            "deploy_config": {
+                "envs": {"EXISTING": "val"},
+                "mount_points": [],
+                "ttl_in_minutes": 60,
+            }
+        }
+        mock_bot_repo.list_by_bot_uuid.return_value = [mock_record]
+
+        service = _make_service(
+            bot_repo=mock_bot_repo,
+            device_repo=mock_device_repo,
+            publish_service=mock_publish_service,
+        )
+
+        bot_config = BotConfig(
+            deploy_config=DeployConfig(ttl_in_minutes=120, docker_image="img:v2"),
+        )
+
+        with patch.object(
+            service, "get_bot", new_callable=AsyncMock, return_value=mock_bot_response
+        ):
+            await service.scale_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                target_count=3,
+                operator="user1",
+                request_id="test-request-id-12345678901234567890",
+                bot_config=bot_config,
+            )
+
+        call_kwargs = mock_publish_service.create_publish.call_args.kwargs
+        publish_config = call_kwargs["config"]
+        assert publish_config.deploy_config is not None
+        assert publish_config.deploy_config.envs == {"EXISTING": "val"}
+        assert publish_config.deploy_config.mount_points == []
+        assert publish_config.deploy_config.ttl_in_minutes == 120
+        assert publish_config.deploy_config.docker_image == "img:v2"
 
     @pytest.mark.asyncio
     async def test_scale_bot_without_bot_config_reads_db_config(self):

--- a/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_publish_service_coverage.py
@@ -860,6 +860,47 @@ class TestCreateDeviceRecordsForPublish:
         assert svc._device_service.create_device.call_count == 2
         assert svc._rel_repo.insert_rel.call_count == 2
 
+    def test_scale_up_uses_publish_config_deploy_config(self):
+        svc = _make_service()
+        bot = _make_bot_record()
+        bot.config = MagicMock()
+        bot.config.deploy_config = MagicMock()
+        template = MagicMock()
+        svc._template_service.get_online_template_by_uuid.return_value = template
+
+        new_device = _make_device(id=100, device_uuid="new-dev-1", status="PENDING")
+        svc._device_service.create_device.return_value = new_device
+
+        from secbaas.community.api.device_manage import DeployConfig
+
+        publish_deploy_config = DeployConfig(docker_image="v2")
+        publish_config = PublishConfig(
+            replica_desired=5,
+            deploy_config=publish_deploy_config,
+        )
+        batch = _make_batch_record(batch_capacity=1)
+
+        with patch(
+            "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
+            return_value="test",
+        ):
+            svc._create_device_records_for_publish(
+                tenant="t",
+                env="test",
+                publish_id=1,
+                publish_type=PublishType.SCALE_UP,
+                bot_record=bot,
+                batch_records=[batch],
+                operator="op",
+                publish_config=publish_config,
+            )
+
+        call_args = svc._device_service.create_device.call_args
+        kwargs = call_args.kwargs
+        device_create_data = kwargs["data"]
+
+        assert device_create_data.extra_config.deploy_config == publish_deploy_config
+
     def test_scale_down_selects_active_devices(self):
         svc = _make_service()
         bot = _make_bot_record()


### PR DESCRIPTION
## Problem

1. **SCALE_UP devices read wrong config source**: When scaling up, new devices were created using `baas_bot.extra_config.deploy_config` (the bot's persisted config), ignoring the deploy_config passed in the Scale request. The Scale Publish record correctly stored the request's config, but device creation read from the wrong source.

2. **deploy_config wholesale replacement**: Merging deploy_config was a simple `existing_config.deploy_config = override`, replacing the entire object. A partial override like `{"docker_image": "v2"}` would zero out unrelated fields (`envs`, `mount_points`, `resource_spec`, `ttl_in_minutes`, etc.).

## Solution

- **Pass `PublishConfig` to `_create_device_records_for_publish`** so SCALE_UP device creation resolves `deploy_config` with priority: PublishConfig → Bot persisted config → None.
- **Add `_merge_deploy_config()` helper**: Field-level merge via `exclude_none=True`, used by `scale_bot`, `update_bot`, and `update_devices`. Handles both `DeployConfig` instances and plain dicts.

## Validation

- Unit tests: All 617 publish + bot management tests pass
- Integration tests: All 12 tests pass (real SQLite)
- Lint: ruff checks pass on all changed files
- New tests:
  - `TestMergeDeployConfig`: 5 scenarios (None→override, field-level merge, override-only, dict input, empty current)
  - `test_scale_bot_deploy_config_field_level_merge`: verifies non-overridden fields preserved
  - `test_scale_bot_deploy_config_in_publish_record`: real SQLite, verifies publish record stores scale config
  - `test_scale_deploy_config.py`: ASGI E2E full HTTP flow, asserts new device extra_config matches scale request

## Compatibility and risk

- `_create_device_records_for_publish` signature change is backward-compatible (new optional parameter with default `None`)
- `_merge_deploy_config` handles both `DeployConfig` instances and `dict` inputs for backward compatibility
- No API contract changes — internal implementation only