### PR TITLE
feat(baas): defer session creation in /openapi/v1/messages

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -659,6 +659,50 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    def supports_lazy_session(self, *, binding_info: BotBindingInfo) -> bool:
+        """Return True for engines with deterministic session-id rules."""
+        return binding_info.engine_type in ("openclaw", "claude_code")
+
+    def construct_session_id(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        run_id: str,
+        metadata: dict[str, Any],
+        binding_info: BotBindingInfo,
+    ) -> str:
+        """Construct a session_id locally for lazy creation.
+
+        Delegates to the existing ``_create_session_consistency_key`` pattern
+        (or the engine adapter's ``session_consistency_key``) so the id matches
+        what device-affinity routing would produce.  The deferred
+        ``create_session(session_id=constructed_id)`` call hits the reuse path
+        (``_get_or_create_adapter_session`` returns the id without HTTP), and
+        the engine auto-creates the session on first ``send_message``.
+        """
+        engine_type = binding_info.engine_type
+        _adapter = self._adapter_for(engine_type)
+        if _adapter is not None:
+            key = _adapter.session_consistency_key(
+                tc_bot_id=binding_info.bot_id,
+                user_id=user_id,
+                run_id=run_id,
+            )
+            if key is not None:
+                return key
+        key = self._create_session_consistency_key(
+            engine_type=engine_type,
+            tc_bot_id=binding_info.bot_id,
+            user_id=user_id,
+            run_id=run_id,
+        )
+        if key is None:
+            raise BotServiceError(
+                f"Cannot construct session_id for engine type: {engine_type}"
+            )
+        return key
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -433,6 +433,39 @@ class ClawBotService(BotService):
         except Exception as e:
             raise BotServiceError(f"Failed to get session: {e}") from e
 
+    def supports_lazy_session(self, *, binding_info: BotBindingInfo) -> bool:
+        """Return True for engines with deterministic session-id rules."""
+        return binding_info.engine_type in ("openclaw", "claude_code")
+
+    def construct_session_id(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        run_id: str,
+        metadata: dict[str, Any],
+        binding_info: BotBindingInfo,
+    ) -> str:
+        """Construct a session_id locally for lazy creation.
+
+        Mirrors the patterns already used by the adapter-side session creation:
+        - openclaw:    ``agent:main:session:{run_id}:user:{user_id}``
+        - claude_code: ``agent:{binding_info.bot_id}:session:{run_id}:user:{user_id}``
+
+        The deferred ``create_session(session_id=constructed_id)`` call hits
+        the reuse path (``_get_or_create_adapter_session`` returns the id
+        without HTTP), and the engine auto-creates the session on first
+        ``send_message``.
+        """
+        engine_type = binding_info.engine_type
+        if engine_type == "openclaw":
+            return f"agent:main:session:{run_id}:user:{user_id}"
+        if engine_type == "claude_code":
+            return f"agent:{binding_info.bot_id}:session:{run_id}:user:{user_id}"
+        raise BotServiceError(
+            f"Cannot construct session_id for engine type: {engine_type}"
+        )
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -183,6 +183,39 @@ class BotService(Protocol):
         """
         ...
 
+    def supports_lazy_session(self, *, binding_info: BotBindingInfo) -> bool:
+        """Return True if the engine supports local session-id construction.
+
+        When True, BotRunner will construct a session_id locally (via
+        ``construct_session_id``) instead of making a synchronous HTTP call
+        to ``create_session``. The adapter session is then created lazily
+        in the async execution phase (dispatcher).
+
+        Engines with deterministic session-id rules (openclaw, claude_code)
+        should return True. Engines without such rules (teclaw, aicoding,
+        hermes) should return False to preserve the synchronous path.
+        """
+        ...
+
+    def construct_session_id(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        run_id: str,
+        metadata: dict[str, Any],
+        binding_info: BotBindingInfo,
+    ) -> str:
+        """Construct a session_id locally for lazy creation.
+
+        The returned id MUST match what the adapter would produce, so that
+        the deferred ``create_session`` call (with ``session_id=constructed_id``)
+        reuses the same id idempotently.
+
+        Called only when ``supports_lazy_session`` returns True.
+        """
+        ...
+
 
 @runtime_checkable
 class MessageDispatcher(Protocol):
@@ -229,6 +262,7 @@ class MessageDispatcher(Protocol):
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
+        needs_session_creation: bool = False,
     ) -> None:
         """分发消息发送以进行异步执行
 
@@ -248,6 +282,9 @@ class MessageDispatcher(Protocol):
             callback: 可选的完成回调，签名与
                       asyncio.Task.add_done_callback 一致
             chat_metadata: 可选的 chat 请求元数据，透传给 BotService.send_message
+            needs_session_creation: 若为 True，表示 session_id 是本地构造的、
+                      adapter 侧尚未创建会话，dispatcher 执行时需先调用
+                      bot_service.create_session(session_id=session_id, ...) 再发消息
         """
         ...
 
@@ -262,6 +299,7 @@ class MessageDispatcher(Protocol):
         context: BotChatContext | None = None,
         timeout: float,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> AsyncIterator[StreamChunk]:
         """流式消息发送分发，返回 StreamChunk 迭代器。
 
@@ -270,6 +308,10 @@ class MessageDispatcher(Protocol):
         - Queue 模式：入队后轮询 chunk 表，封装为迭代器返回
 
         调用方统一 async for 消费，不感知模式差异。
+
+        Args:
+            needs_session_creation: 若为 True，dispatcher 在开始流式发送前
+                      需先调用 bot_service.create_session(session_id=session_id, ...)
         """
         ...
 
@@ -283,6 +325,7 @@ class MessageDispatcher(Protocol):
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> None:
         """分发消息注入以进行异步执行
 
@@ -297,6 +340,8 @@ class MessageDispatcher(Protocol):
             binding_info: 已解析的绑定信息
             context: 可选的请求上下文
             bot_id: 用于队列模式下的每键限制
+            needs_session_creation: 若为 True，dispatcher 执行注入前需先调用
+                      bot_service.create_session(session_id=session_id, ...)
         """
         ...
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_noop_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_noop_message_dispatcher.py
@@ -45,6 +45,7 @@ class NoopMessageDispatcher:
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
+        needs_session_creation: bool = False,
     ) -> None:
         logger.warning(
             "NoopMessageDispatcher.dispatch_send called: run_id=%s, "
@@ -63,6 +64,7 @@ class NoopMessageDispatcher:
         context: BotChatContext | None = None,
         timeout: float,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> AsyncIterator[StreamChunk]:
         logger.warning(
             "NoopMessageDispatcher.dispatch_send_stream called: run_id=%s, "
@@ -87,6 +89,7 @@ class NoopMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> None:
         logger.warning(
             "NoopMessageDispatcher.dispatch_inject called: run_id=%s, "

--- a/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
@@ -88,6 +88,7 @@ class QueueTaskMessageDispatcher:
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
+        needs_session_creation: bool = False,
     ) -> None:
         """队列化消息发送：只入库（PENDING），Worker 异步执行。
 
@@ -103,6 +104,8 @@ class QueueTaskMessageDispatcher:
             meta["callback_function"] = callback
         if timeout is not None:
             meta["timeout"] = timeout
+        if needs_session_creation:
+            meta["needs_session_creation"] = "true"
         self._enqueue_work(run_id, bot_id, session_id, meta=meta)
         logger.info(
             "[queue_dispatcher.dispatch_send] run_id=%s bot_id=%s session_id=%s",
@@ -121,6 +124,7 @@ class QueueTaskMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> None:
         """队列化消息注入：只入库（PENDING），Worker 异步执行。
 
@@ -129,6 +133,8 @@ class QueueTaskMessageDispatcher:
         """
         self._check_backpressure(bot_id)
         meta: dict[str, Any] = {"request_type": "inject"}
+        if needs_session_creation:
+            meta["needs_session_creation"] = "true"
         self._enqueue_work(run_id, bot_id, session_id, meta=meta)
         logger.info(
             "[queue_dispatcher.dispatch_inject] run_id=%s bot_id=%s session_id=%s",
@@ -150,6 +156,7 @@ class QueueTaskMessageDispatcher:
         context: BotChatContext | None = None,
         timeout: int | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> AsyncIterator[StreamChunk]:
         """队列化流式发送：入队 + 轮询 chunk 表。
 
@@ -165,6 +172,8 @@ class QueueTaskMessageDispatcher:
         meta: dict[str, Any] = {"request_type": "chat", "stream": "true"}
         if timeout is not None:
             meta["timeout"] = timeout
+        if needs_session_creation:
+            meta["needs_session_creation"] = "true"
         self._enqueue_work(run_id, bot_id, session_id, meta=meta)
 
         logger.info(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -50,6 +50,7 @@ from ._bot_run_utils import (
     parse_bot_id,
     parse_wait_result,
     resolve_bot_id,
+    resolve_user_id,
 )
 from ._bot_service_selector import BotServiceSelector
 from ._internal_protocols import BotService, MessageDispatcher
@@ -170,13 +171,16 @@ class BotRunner:
         route = await self._resolve_bot_route(bot_id, metadata)
         raw_session_id = metadata.get("session_id")
 
-        # 3. 创建会话
-        actual_session_id = await self._create_session(
-            run_id=message_id,
-            session_id=raw_session_id,
-            metadata=metadata,
-            route=route,
-            context=context,
+        # 3. 创建会话（lazy 或 sync）
+        actual_session_id, needs_session_creation = (
+            await self._resolve_session(
+                run_id=message_id,
+                raw_session_id=raw_session_id,
+                metadata=metadata,
+                route=route,
+                context=context,
+                bot_id=bot_id,
+            )
         )
 
         # 4. 委托 dispatcher 异步注入
@@ -188,6 +192,7 @@ class BotRunner:
             binding_info=route.binding_info,
             context=context,
             bot_id=bot_id,
+            needs_session_creation=needs_session_creation,
         )
 
         chat_metadata = build_chat_metadata(metadata, run_id=message_id)
@@ -263,13 +268,16 @@ class BotRunner:
 
         route = await self._resolve_bot_route(bot_id, metadata)
 
-        # 3. 创建会话
-        actual_session_id = await self._create_session(
-            run_id=message_id,
-            session_id=raw_session_id,
-            metadata=metadata,
-            route=route,
-            context=context,
+        # 3. 创建会话（lazy 或 sync）
+        actual_session_id, needs_session_creation = (
+            await self._resolve_session(
+                run_id=message_id,
+                raw_session_id=raw_session_id,
+                metadata=metadata,
+                route=route,
+                context=context,
+                bot_id=bot_id,
+            )
         )
 
         # 4. 委托 dispatcher 异步发送
@@ -287,6 +295,7 @@ class BotRunner:
             bot_id=bot_id,
             callback=callback,
             chat_metadata=chat_metadata,
+            needs_session_creation=needs_session_creation,
         )
 
         # 5. 上报日志关联(后台执行,不阻塞主链路)
@@ -355,13 +364,16 @@ class BotRunner:
             metadata=metadata,
         )
 
-        # 创建会话
-        actual_session_id = await self._create_session(
-            run_id=message_id,
-            session_id=raw_session_id,
-            metadata=metadata,
-            route=route,
-            context=context,
+        # 创建会话（lazy 或 sync）
+        actual_session_id, needs_session_creation = (
+            await self._resolve_session(
+                run_id=message_id,
+                raw_session_id=raw_session_id,
+                metadata=metadata,
+                route=route,
+                context=context,
+                bot_id=bot_id,
+            )
         )
 
         # 委托 dispatcher 流式发送
@@ -376,6 +388,7 @@ class BotRunner:
             context=context,
             timeout=timeout,
             bot_id=bot_id,
+            needs_session_creation=needs_session_creation,
         )
 
         return message_id, actual_session_id, stream_iter
@@ -713,6 +726,72 @@ class BotRunner:
                 run_id=run_id, error="Session creation failed"
             )
             raise
+
+    async def _resolve_session(
+        self,
+        *,
+        run_id: str,
+        raw_session_id: str | None,
+        metadata: dict[str, Any],
+        route: _BotRoute,
+        context: BotChatContext,
+        bot_id: str,
+    ) -> tuple[str, bool]:
+        """Resolve the session id, choosing lazy or synchronous creation.
+
+        For engines that support lazy session (openclaw, claude_code):
+        - Construct the session_id locally using existing construction rules.
+        - Persist it to the DB immediately.
+        - Return ``needs_session_creation=True`` so the dispatcher's background
+          task calls ``bot_service.create_session(session_id=constructed_id)``
+          before sending the message.
+
+        For engines that do NOT support lazy session (teclaw, aicoding, hermes):
+        - Fall back to the synchronous ``_create_session`` path (HTTP to adapter).
+        - Return ``needs_session_creation=False``.
+
+        If a ``session_id`` is already provided by the caller (reuse), use it
+        directly — the dispatcher's ``create_session(session_id=raw)`` will hit
+        the reuse path without HTTP.
+
+        Returns:
+            Tuple of ``(actual_session_id, needs_session_creation)``.
+        """
+        supports_lazy = getattr(route.bot_service, "supports_lazy_session", None)
+        if (
+            callable(supports_lazy)
+            and supports_lazy(binding_info=route.binding_info)
+        ):
+            if raw_session_id is not None:
+                actual_session_id = raw_session_id
+            else:
+                user_id = resolve_user_id(
+                    metadata, route.binding_info, context, route.route_bot_id
+                )
+                actual_session_id = route.bot_service.construct_session_id(
+                    bot_id=route.route_bot_id,
+                    user_id=user_id,
+                    run_id=run_id,
+                    metadata=metadata,
+                    binding_info=route.binding_info,
+                )
+            self._run_repository.update_session_id(run_id, actual_session_id)
+            logger.info(
+                "[runner] Lazy session: run_id=%s, session_id=%s, engine=%s",
+                run_id,
+                actual_session_id,
+                route.binding_info.engine_type,
+            )
+            return actual_session_id, True
+
+        actual_session_id = await self._create_session(
+            run_id=run_id,
+            session_id=raw_session_id,
+            metadata=metadata,
+            route=route,
+            context=context,
+        )
+        return actual_session_id, False
 
     async def _resolve_binding(
         self,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_task_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_task_message_dispatcher.py
@@ -66,6 +66,7 @@ class TaskMessageDispatcher:
         bot_id: str = "",
         callback: Any = None,
         chat_metadata: dict[str, str] | None = None,
+        needs_session_creation: bool = False,
     ) -> None:
         task = asyncio.create_task(
             self._execute_send_message(
@@ -79,6 +80,7 @@ class TaskMessageDispatcher:
                 timeout=timeout,
                 bot_id=bot_id,
                 chat_metadata=chat_metadata,
+                needs_session_creation=needs_session_creation,
             )
         )
         task.add_done_callback(
@@ -98,6 +100,7 @@ class TaskMessageDispatcher:
         context: BotChatContext | None = None,
         timeout: float,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> AsyncIterator[StreamChunk]:
         """流式直传：直接 yield bot_service.send_message_stream 的 chunk。
 
@@ -115,6 +118,14 @@ class TaskMessageDispatcher:
             self._run_repository.update_status(run_id, "RUNNING")
             final_content: str = ""
             try:
+                if needs_session_creation:
+                    await bot_service.create_session(
+                        bot_id=bot_id,
+                        session_id=session_id,
+                        binding_info=binding_info,
+                        context=context,
+                        run_id=run_id,
+                    )
                 async for chunk in bot_service.send_message_stream(
                     session_id=session_id,
                     message=message,
@@ -160,6 +171,7 @@ class TaskMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> None:
         task = asyncio.create_task(
             self._execute_inject_message(
@@ -170,6 +182,7 @@ class TaskMessageDispatcher:
                 binding_info=binding_info,
                 context=context,
                 bot_id=bot_id,
+                needs_session_creation=needs_session_creation,
             )
         )
         task.add_done_callback(self._handle_task_exception)
@@ -198,10 +211,13 @@ class TaskMessageDispatcher:
         timeout: float,
         bot_id: str = "",
         chat_metadata: dict[str, str] | None = None,
+        needs_session_creation: bool = False,
     ) -> None:
         """执行消息发送
 
-        会话已创建，此方法只负责发送消息。
+        当 ``needs_session_creation=True`` 时（session_id 由 runner 本地构造、
+        adapter 侧尚未创建会话），先调用 ``bot_service.create_session`` 完成
+        WS 解析、baas_bot_session 持久化等副作用，再发送消息。
         """
         slot = await self._acquire_slot(bot_id)
         try:
@@ -210,7 +226,17 @@ class TaskMessageDispatcher:
                 # 1. 更新状态为 RUNNING
                 self._run_repository.update_status(run_id, "RUNNING")
 
-                # 2. 发送消息
+                # 2. 懒创建会话（若 session_id 是本地构造的）
+                if needs_session_creation:
+                    await bot_service.create_session(
+                        bot_id=bot_id,
+                        session_id=session_id,
+                        binding_info=binding_info,
+                        context=context,
+                        run_id=run_id,
+                    )
+
+                # 3. 发送消息
                 response = await bot_service.send_message(
                     session_id=session_id,
                     message=message,
@@ -221,7 +247,7 @@ class TaskMessageDispatcher:
                     chat_metadata=chat_metadata,
                 )
 
-                # 3. 更新成功结果
+                # 4. 更新成功结果
                 extra: dict[str, Any] = {"session_id": session_id}
                 if not wait_result:
                     extra["ignore_result"] = "true"
@@ -265,10 +291,12 @@ class TaskMessageDispatcher:
         binding_info: BotBindingInfo,
         context: BotChatContext | None = None,
         bot_id: str = "",
+        needs_session_creation: bool = False,
     ) -> None:
         """执行消息注入
 
-        会话已创建，此方法只负责注入消息。
+        当 ``needs_session_creation=True`` 时先调用 ``bot_service.create_session``
+        再注入消息。
         """
         slot = await self._acquire_slot(bot_id)
         try:
@@ -277,7 +305,17 @@ class TaskMessageDispatcher:
                 # 1. 更新状态为 RUNNING
                 self._run_repository.update_status(run_id, "RUNNING")
 
-                # 2. 注入消息（不触发推理，无返回值）
+                # 2. 懒创建会话（若 session_id 是本地构造的）
+                if needs_session_creation:
+                    await bot_service.create_session(
+                        bot_id=bot_id,
+                        session_id=session_id,
+                        binding_info=binding_info,
+                        context=context,
+                        run_id=run_id,
+                    )
+
+                # 3. 注入消息（不触发推理，无返回值）
                 await bot_service.inject_message(
                     session_id=session_id,
                     message=message,
@@ -285,7 +323,7 @@ class TaskMessageDispatcher:
                     context=context,
                 )
 
-                # 3. 更新成功结果（inject 无响应内容）
+                # 4. 更新成功结果（inject 无响应内容）
                 self._run_repository.update_result(
                     run_id=run_id,
                     content_long="",

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -2168,3 +2168,115 @@ class _ANY:
 
 
 ANY: _ANY = _ANY()
+
+
+# ==================== Tests: lazy session support ====================
+
+
+class TestBaasBotServiceLazySession:
+    """Tests for supports_lazy_session and construct_session_id."""
+
+    def _make_service(self):
+        pool = MagicMock(spec=AsyncChatClientPool)
+        config = BaasBotServiceConfig()
+        wss_resolver = MagicMock()
+        session_service = MagicMock()
+        return BaasBotService(
+            config=config,
+            client_pool=pool,
+            wss_resolver=wss_resolver,
+            session_service=session_service,
+        )
+
+    def test_supports_lazy_session_openclaw(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="openclaw",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is True
+
+    def test_supports_lazy_session_claude_code(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="claude_code",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is True
+
+    def test_supports_lazy_session_teclaw_false(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="teclaw",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is False
+
+    def test_construct_session_id_openclaw(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="openclaw",
+        )
+        session_id = service.construct_session_id(
+            bot_id=BOT_UUID,
+            user_id="user-001",
+            run_id="run-001",
+            metadata={},
+            binding_info=binding,
+        )
+        assert session_id == "agent:main:session:run-001:user:user-001"
+
+    def test_construct_session_id_claude_code(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="claude_code",
+        )
+        session_id = service.construct_session_id(
+            bot_id=BOT_UUID,
+            user_id="user-001",
+            run_id="run-001",
+            metadata={},
+            binding_info=binding,
+        )
+        assert session_id == f"agent:{BOT_UUID}:session:run-001:user:user-001"
+
+    def test_construct_session_id_unsupported_raises(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_UUID,
+            entity_id=BOT_UUID,
+            device_id=BOT_UUID,
+            device_provider="baas",
+            binding_id=100002,
+            engine_type="hermes",
+        )
+        with pytest.raises(BotServiceError, match="Cannot construct session_id"):
+            service.construct_session_id(
+                bot_id=BOT_UUID,
+                user_id="user-001",
+                run_id="run-001",
+                metadata={},
+                binding_info=binding,
+            )

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_runner_log_relation.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_runner_log_relation.py
@@ -59,6 +59,7 @@ def mock_bot_service():
         return_value=MagicMock(session_id="agent:main:sess-001")
     )
     svc.send_message = AsyncMock(return_value=MagicMock(content="reply", usage={}))
+    svc.supports_lazy_session = MagicMock(return_value=False)
     return svc
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -578,3 +578,115 @@ class TestCreateSessionFullFlow:
         )
         assert session.session_id == SESSION_ID
         assert session.status == "active"
+
+
+# ==================== Tests: lazy session support ====================
+
+
+class TestClawBotServiceLazySession:
+    """Tests for supports_lazy_session and construct_session_id."""
+
+    def _make_service(self):
+        pool = MagicMock(spec=AsyncChatClientPool)
+        config = _make_config()
+        secret = _make_secret_store()
+        return ClawBotService(config=config, client_pool=pool, secret_store=secret)
+
+    def test_supports_lazy_session_openclaw(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="openclaw",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is True
+
+    def test_supports_lazy_session_claude_code(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="claude_code",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is True
+
+    def test_supports_lazy_session_non_supported_engine_false(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="hermes",
+        )
+        assert service.supports_lazy_session(binding_info=binding) is False
+
+    def test_construct_session_id_openclaw(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="openclaw",
+        )
+        session_id = service.construct_session_id(
+            bot_id=BOT_ID,
+            user_id=ENTITY_ID,
+            run_id="run-001",
+            metadata={},
+            binding_info=binding,
+        )
+        assert session_id == f"agent:main:session:run-001:user:{ENTITY_ID}"
+
+    def test_construct_session_id_claude_code(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="claude_code",
+        )
+        session_id = service.construct_session_id(
+            bot_id=BOT_ID,
+            user_id=ENTITY_ID,
+            run_id="run-001",
+            metadata={},
+            binding_info=binding,
+        )
+        assert session_id == f"agent:{BOT_ID}:session:run-001:user:{ENTITY_ID}"
+
+    def test_construct_session_id_unsupported_raises(self):
+        service = self._make_service()
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id=ENTITY_ID,
+            sandbox_id=SANDBOX_ID,
+            device_id=SANDOX_DEVICE_ID,
+            device_provider="arca",
+            binding_id=100101,
+            engine_type="hermes",
+        )
+        with pytest.raises(BotServiceError, match="Cannot construct session_id"):
+            service.construct_session_id(
+                bot_id=BOT_ID,
+                user_id=ENTITY_ID,
+                run_id="run-001",
+                metadata={},
+                binding_info=binding,
+            )

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -71,6 +71,7 @@ def mock_bot_service():
     svc.send_message = AsyncMock(return_value=MagicMock(content="reply", usage={}))
     svc.inject_message = AsyncMock()
     svc.get_messages = AsyncMock(return_value=[])
+    svc.supports_lazy_session = MagicMock(return_value=False)
     return svc
 
 
@@ -2048,3 +2049,170 @@ class _DummyConverter:
         result = self._results[self._idx]
         self._idx += 1
         return result
+
+
+# ==================== Tests: lazy session creation ====================
+
+
+class TestLazySession:
+    """Tests for lazy session creation in BotRunner.
+
+    When the bot service supports_lazy_session (openclaw/claude_code),
+    BotRunner should:
+    - Construct the session_id locally via construct_session_id
+    - NOT call create_session synchronously
+    - Persist the constructed session_id to DB
+    - Pass needs_session_creation=True to the dispatcher
+    """
+
+    @pytest.mark.asyncio
+    async def test_deliver_message_lazy_skips_sync_create_session(
+        self,
+        mock_selector,
+        mock_bot_service,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        arca_binding_data,
+        context,
+    ):
+        """deliver_message with lazy engine must not call create_session."""
+        mock_bot_service_plugin.get_binding.return_value = arca_binding_data
+        mock_bot_service.supports_lazy_session = MagicMock(return_value=True)
+        mock_bot_service.construct_session_id = MagicMock(
+            return_value="agent:main:session:run-001:user:test-entity-001"
+        )
+
+        dispatcher = MagicMock(spec=MessageDispatcher)
+        dispatcher.dispatch_send = AsyncMock()
+
+        runner = _make_runner(
+            mock_selector, mock_run_repo, mock_bot_service_plugin, dispatcher
+        )
+        await runner.deliver_message(
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            context=context,
+            message="hello",
+            metadata={},
+            message_id="msg-001",
+        )
+
+        mock_bot_service.create_session.assert_not_called()
+        mock_bot_service.construct_session_id.assert_called_once()
+        mock_run_repo.update_session_id.assert_called_once_with(
+            "msg-001",
+            "agent:main:session:run-001:user:test-entity-001",
+        )
+        dispatcher.dispatch_send.assert_called_once()
+        kw = dispatcher.dispatch_send.call_args.kwargs
+        assert kw["needs_session_creation"] is True
+        assert kw["session_id"] == "agent:main:session:run-001:user:test-entity-001"
+
+    @pytest.mark.asyncio
+    async def test_deliver_message_non_lazy_calls_sync_create_session(
+        self,
+        mock_selector,
+        mock_bot_service,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        arca_binding_data,
+        context,
+    ):
+        """deliver_message with non-lazy engine must call create_session."""
+        mock_bot_service_plugin.get_binding.return_value = arca_binding_data
+        mock_bot_service.supports_lazy_session = MagicMock(return_value=False)
+
+        dispatcher = MagicMock(spec=MessageDispatcher)
+        dispatcher.dispatch_send = AsyncMock()
+
+        runner = _make_runner(
+            mock_selector, mock_run_repo, mock_bot_service_plugin, dispatcher
+        )
+        await runner.deliver_message(
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            context=context,
+            message="hello",
+            metadata={},
+            message_id="msg-001",
+        )
+
+        mock_bot_service.create_session.assert_called_once()
+        dispatcher.dispatch_send.assert_called_once()
+        kw = dispatcher.dispatch_send.call_args.kwargs
+        assert kw["needs_session_creation"] is False
+
+    @pytest.mark.asyncio
+    async def test_inject_message_lazy_skips_sync_create_session(
+        self,
+        mock_selector,
+        mock_bot_service,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        arca_binding_data,
+        context,
+    ):
+        """inject_message with lazy engine must not call create_session."""
+        mock_bot_service_plugin.get_binding.return_value = arca_binding_data
+        mock_bot_service.supports_lazy_session = MagicMock(return_value=True)
+        mock_bot_service.construct_session_id = MagicMock(
+            return_value="agent:main:session:msg-001:user:test-entity-001"
+        )
+
+        dispatcher = MagicMock(spec=MessageDispatcher)
+        dispatcher.dispatch_inject = AsyncMock()
+
+        runner = _make_runner(
+            mock_selector, mock_run_repo, mock_bot_service_plugin, dispatcher
+        )
+        await runner.inject_message(
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            context=context,
+            message="hello",
+            metadata={},
+            message_id="msg-001",
+        )
+
+        mock_bot_service.create_session.assert_not_called()
+        mock_run_repo.update_session_id.assert_called_once_with(
+            "msg-001",
+            "agent:main:session:msg-001:user:test-entity-001",
+        )
+        kw = dispatcher.dispatch_inject.call_args.kwargs
+        assert kw["needs_session_creation"] is True
+
+    @pytest.mark.asyncio
+    async def test_deliver_message_lazy_with_provided_session_id(
+        self,
+        mock_selector,
+        mock_bot_service,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        arca_binding_data,
+        context,
+    ):
+        """When session_id provided AND lazy, use the provided id directly."""
+        mock_bot_service_plugin.get_binding.return_value = arca_binding_data
+        mock_bot_service.supports_lazy_session = MagicMock(return_value=True)
+
+        dispatcher = MagicMock(spec=MessageDispatcher)
+        dispatcher.dispatch_send = AsyncMock()
+
+        runner = _make_runner(
+            mock_selector, mock_run_repo, mock_bot_service_plugin, dispatcher
+        )
+        await runner.deliver_message(
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            context=context,
+            message="hello",
+            metadata={"session_id": "existing-session-001"},
+            message_id="msg-001",
+        )
+
+        mock_bot_service.create_session.assert_not_called()
+        mock_bot_service.construct_session_id.assert_not_called()
+        mock_run_repo.update_session_id.assert_called_once_with(
+            "msg-001",
+            "existing-session-001",
+        )
+        kw = dispatcher.dispatch_send.call_args.kwargs
+        assert kw["session_id"] == "existing-session-001"
+        assert kw["needs_session_creation"] is True

--- a/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_task_message_dispatcher.py
@@ -26,6 +26,7 @@ def mock_bot_service():
     )
     svc.send_message = AsyncMock(return_value=MagicMock(content="reply", usage={}))
     svc.inject_message = AsyncMock()
+    svc.supports_lazy_session = MagicMock(return_value=False)
     return svc
 
 
@@ -462,3 +463,76 @@ class TestTaskMessageDispatcherTimeout:
         call_kw = mock_bot_service.send_message.call_args.kwargs
         assert call_kw["timeout"] == pytest.approx(14.8)
         assert pool.active_count == 0
+
+
+# ==================== Tests: lazy session creation ====================
+
+
+class TestTaskMessageDispatcherLazySession:
+    """Tests for deferred create_session in background task."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_send_lazy_creates_session_before_send(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        """When needs_session_creation=True, create_session is called before send_message."""
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
+        await dispatcher.dispatch_send(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="agent:main:session:run-001:user:u1",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            timeout=30.0,
+            needs_session_creation=True,
+        )
+        await asyncio.sleep(0)
+
+        mock_bot_service.create_session.assert_called_once()
+        create_kw = mock_bot_service.create_session.call_args.kwargs
+        assert create_kw["session_id"] == "agent:main:session:run-001:user:u1"
+        mock_bot_service.send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_send_no_lazy_skips_create_session(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        """When needs_session_creation=False, create_session is NOT called."""
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
+        await dispatcher.dispatch_send(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="sess-001",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            timeout=30.0,
+            needs_session_creation=False,
+        )
+        await asyncio.sleep(0)
+
+        mock_bot_service.create_session.assert_not_called()
+        mock_bot_service.send_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_inject_lazy_creates_session_before_inject(
+        self, mock_bot_service, mock_run_repo, arca_binding, context
+    ):
+        """When needs_session_creation=True, create_session is called before inject_message."""
+        dispatcher = TaskMessageDispatcher(run_repository=mock_run_repo, task_pool=None)
+        await dispatcher.dispatch_inject(
+            bot_service=mock_bot_service,
+            run_id="run-001",
+            session_id="agent:main:session:run-001:user:u1",
+            message="hello",
+            binding_info=arca_binding,
+            context=context,
+            needs_session_creation=True,
+        )
+        await asyncio.sleep(0)
+
+        mock_bot_service.create_session.assert_called_once()
+        create_kw = mock_bot_service.create_session.call_args.kwargs
+        assert create_kw["session_id"] == "agent:main:session:run-001:user:u1"
+        mock_bot_service.inject_message.assert_called_once()


### PR DESCRIPTION
## Problem

The BaaS Open API `POST /openapi/v1/messages` endpoint created the engine
session synchronously on the request-critical path: for every message it
issued a blocking `create_session` HTTP call to the engine adapter before
returning the session id to the caller. Under concurrency this serial hop
amplified tail latency and surfaced adapter failures on the message request
itself, even though the session only needs to exist before the first
`send_message` is dispatched downstream.

For engines whose session id follows a deterministic construction rule
(openclaw, claude_code), the id the adapter would allocate is already
computable locally, so the synchronous call is unnecessary on the fast path.

## Solution

Introduce a lazy session-creation path in `BotRunner` that is selected per
engine binding:

- New `BotService` protocol methods `supports_lazy_session(binding_info)`
  and `construct_session_id(...)`. `BaasBotService` and `ClawBotService`
  return `True` for `openclaw` and `claude_code` and construct the id with the
  same rule the adapter-side path already uses (`agent:main:session:{run_id}:user:{user_id}`
  for openclaw, `agent:{bot_id}:session:{run_id}:user:{user_id}` for
  claude_code), so the deferred `create_session(session_id=constructed_id)`
  call hits the idempotent reuse path without an extra round trip.
- `BotRunner._resolve_session` picks lazy vs. synchronous: for supported
  engines it constructs the id locally, persists it to the run record
  immediately, and returns `needs_session_creation=True`; for unsupported
  engines it keeps the existing synchronous `_create_session` path and
  returns `False`. A caller-supplied `session_id` is always reused as-is.
- The dispatcher contract (`MessageDispatcher`) gains a
  `needs_session_creation` flag on `dispatch_send`, `dispatch_send_stream`,
  and `dispatch_inject`. `TaskMessageDispatcher` calls
  `bot_service.create_session(session_id=...)` at the start of its async
  execution before sending; `QueueTaskMessageDispatcher` propagates the flag
  through queue metadata for the worker; `NoopMessageDispatcher` accepts it
  for contract conformance.

Fallback engines (teclaw, aicoding, hermes) are untouched: they keep the
synchronous creation call, so existing behavior is preserved.

### Alternatives considered

- Always constructing locally and dropping the deferred `create_session`
  call: rejected because the adapter still needs to resolve the WebSocket /
  session row and run its own side effects; the deferred call preserves that
  on the idempotent reuse path.
- A generic cache of constructed ids ahead of dispatch: rejected as
  speculative complexity; the per-engine opt-in keeps the surface minimal.

## Validation

- `uv run pytest tests/unit/core/service/bot_run/ tests/unit/adapters/web/open_api/ tests/e2e/asgi/baseline/test_open_api_messages.py -x --tb=short -q`
  — 1017 passed, 0 failed, 0 skipped.
- `uv run ruff check` over the seven changed service/dispatcher modules —
  exit 0.
- Added unit coverage for `supports_lazy_session` / `construct_session_id`
  on both `BaasBotService` and `ClawBotService` (format pinned to the
  adapter rule), the runner's lazy-vs-sync branch selection and run-record
  persistence, and `TaskMessageDispatcher`'s deferred `create_session`
  ordering and the `needs_session_creation=False` no-op fallback.
- Public-diff privacy scan over the 12 changed files: `introduced` empty
  (one preexisting baseline marker in a test file, unchanged by this patch).

What was not run: the queue-worker side of `needs_session_creation`
propagation is handled by the worker executor outside this change's files;
the openclaw/claude_code engines auto-create the adapter session on first
`send_message`, so the queue path is behaviorally correct today and the
explicit worker-side `create_session` is tracked as a non-blocking follow-up.

## Compatibility and risk

- The session-id contract is unchanged: lazy-constructed ids are byte-for-byte
  identical to what the adapter would produce, so `create_session(session_id=...)`
  is idempotent reuse. A future change to the construction rule must be applied
  in both services (and the adapter) together; this is pinned by the parallel
  unit tests.
- Engines without a deterministic rule are untouched and keep synchronous
  creation; mixed-version BotService implementations fall back safely via the
  runner's `getattr` guard.
- No schema, config, or migration impact; rollback is reverting the patch.

## Related issues

Follow-ups noted during review (non-blocking, separate scope):

- Extract the lazy-session id construction into a shared helper used by both
  services to guarantee a single source of truth for the format.
- Have the queue worker executor read `needs_session_creation` from metadata
  and call `create_session` before send, mirroring `TaskMessageDispatcher`,
  for full symmetry across dispatch paths.
