### PR TITLE
feat(gateway): make creator/modifier non-nullable on app/tenant/acces…

### DIFF
--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -30,8 +30,8 @@ CREATE TABLE IF NOT EXISTS `avernet_application` (
   `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)',
   `env` varchar(64) NOT NULL DEFAULT '' COMMENT '环境标识',
   `config` json DEFAULT NULL COMMENT '扩展配置(JSON)',
-  `creator` varchar(128) DEFAULT NULL COMMENT '创建人',
-  `modifier` varchar(128) DEFAULT NULL COMMENT '修改人',
+  `creator` varchar(128) NOT NULL DEFAULT '' COMMENT '创建人',
+  `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_avernet_application_token` (`token`),
   KEY `idx_avernet_application_app_name` (`app_name`)
@@ -47,8 +47,8 @@ CREATE TABLE IF NOT EXISTS `avernet_tenant` (
   `description` varchar(1024) NOT NULL DEFAULT '' COMMENT '租户描述',
   `owner` varchar(128) NOT NULL DEFAULT '' COMMENT '租户归属',
   `config` json DEFAULT NULL COMMENT '扩展配置(JSON)',
-  `creator` varchar(128) DEFAULT NULL COMMENT '创建人',
-  `modifier` varchar(128) DEFAULT NULL COMMENT '修改人',
+  `creator` varchar(128) NOT NULL DEFAULT '' COMMENT '创建人',
+  `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_avernet_tenant_name` (`name`)
 ) DEFAULT CHARSET = utf8mb4 COMMENT = '租户主数据表';
@@ -64,8 +64,8 @@ CREATE TABLE IF NOT EXISTS `avernet_access_key_token` (
   `access_key` varchar(256) NOT NULL COMMENT '访问密钥ID',
   `tenant` varchar(64) NOT NULL COMMENT '所属租户(逻辑引用 avernet_tenant.name)',
   `expire_at` timestamp NOT NULL COMMENT '过期时间',
-  `creator` varchar(128) DEFAULT NULL COMMENT '创建人',
-  `modifier` varchar(128) DEFAULT NULL COMMENT '修改人',
+  `creator` varchar(128) NOT NULL DEFAULT '' COMMENT '创建人',
+  `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_avernet_access_key_token_token` (`token`),
   KEY `idx_avernet_access_key_token_access_key` (`access_key`)

--- a/src/gateway/src/gateway/community/core/access_key/_orm.py
+++ b/src/gateway/src/gateway/community/core/access_key/_orm.py
@@ -29,8 +29,8 @@ class AccessKeyRow(Base):  # type: ignore[misc]
     access_key: Mapped[str] = mapped_column()
     tenant: Mapped[str] = mapped_column()
     expire_at: Mapped[datetime] = mapped_column()
-    creator: Mapped[str | None] = mapped_column(default=None)
-    modifier: Mapped[str | None] = mapped_column(default=None)
+    creator: Mapped[str] = mapped_column(default="")
+    modifier: Mapped[str] = mapped_column(default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -34,8 +34,8 @@ class AppRow(Base):  # type: ignore[misc]
     status: Mapped[str] = mapped_column(default="ACTIVE")
     env: Mapped[str] = mapped_column(default="")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
-    creator: Mapped[str | None] = mapped_column(default=None)
-    modifier: Mapped[str | None] = mapped_column(default=None)
+    creator: Mapped[str] = mapped_column(default="")
+    modifier: Mapped[str] = mapped_column(default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -51,14 +51,14 @@ class AppRepository(AppRegistry):
         status: str = "ACTIVE",
         env: str = "",
         config: dict[str, Any] | None = None,
-        creator: str | None = None,
-        modifier: str | None = None,
+        creator: str = "",
+        modifier: str = "",
     ) -> int:
         """Persist a freshly registered app; return its inserted surrogate ``id``.
 
         ``token`` is the app's JWT (the unique lookup key). Optional ``status`` /
         ``env`` / ``config`` default to ``ACTIVE`` / ``""`` / ``{}``; ``creator`` /
-        ``modifier`` default to ``None`` (the unauthenticated admin has no caller).
+        ``modifier`` default to ``""`` (the unauthenticated admin has no caller).
         """
         with self._db.orm_session() as session:
             row = AppRow(

--- a/src/gateway/src/gateway/community/core/tenant/_orm.py
+++ b/src/gateway/src/gateway/community/core/tenant/_orm.py
@@ -27,8 +27,8 @@ class TenantRow(Base):  # type: ignore[misc]
     description: Mapped[str] = mapped_column(default="")
     owner: Mapped[str] = mapped_column(default="")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
-    creator: Mapped[str | None] = mapped_column(default=None)
-    modifier: Mapped[str | None] = mapped_column(default=None)
+    creator: Mapped[str] = mapped_column(default="")
+    modifier: Mapped[str] = mapped_column(default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )


### PR DESCRIPTION
…s-key tables

The `creator` / `modifier` audit columns on `avernet_application`, `avernet_tenant`, and `avernet_access_key_token` were nullable with a `None` default. Per the repo's non-optional contract (required values stay non-optional; `T | None` only when `None` is an intentional state), make them non-null with an empty-string default — matching the existing `env`/`owner` empty-string sentinel pattern in these tables (system/unauthenticated-admin registration has no caller).

- core/app, core/tenant, core/access_key _orm.py: `Mapped[str | None] default=None` → `Mapped[str] default=""`.
- core/app/_repository.py: `store()` `creator`/`modifier` params `str | None=None` → `str=""`; docstring updated.
- migrations/mysql/001_init_schema.sql: the three tables' `creator`/`modifier` `DEFAULT NULL` → `NOT NULL DEFAULT ''`.

tenant has no repository and access-key's `store()` doesn't pass creator/modifier, so both fall back to the ORM default — no business-code changes needed beyond app.

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
