### PR TITLE
fix(skills-pool): canonicalize Desktop repo and converge cutover mappings

### DIFF
--- a/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
+++ b/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
@@ -270,7 +270,9 @@ active root 的软链。Cloud 把 OSS 内容直接挂载到 Pool repo；Desktop 
 把 target、临时解压、单份 backup 与 ETag 状态放在同一 Pool root 下。Desktop
 preparation 原子迁移旧真实 repo 后，只在 cutover 前保留
 `legacy_repo -> pool_repo` 反向兼容桥；cutover 验证逐 Skill mapping 后移除 active
-root 可达的完整 corpus 入口。
+root 可达的完整 corpus 入口。同一 runtime 内，canonical repo move、历史 locator
+bridge 发布与结构校验在 Pool root 的本地 advisory directory lock 内完成，使并发启动
+收敛到同一布局；该锁不跨 Bot、不持久化业务状态，也不是分布式 rollout 锁。
 
 SC 接入后，`skills-center` 作为 `skills-pool` 下与 `skills-repo`、`skills-local` 并列的第三个内容目录；它同样不进入 active-skill-dir，只能通过逐 Skill 激活入口暴露给 Agent。
 

--- a/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
+++ b/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
@@ -265,6 +265,13 @@ P3 的多引擎目录契约如下：
 | Hermes | `~/.hermes/skills` | `~/.hermes/workspace/skills-pool/skills-repo` | `~/.hermes/workspace/skills-pool/skills-local` |
 | Teclaw | 不参与本期文件型 Pool 协议 | 不变 | 不变 |
 
+Pool repo 是完整 Git corpus 的 canonical 真实目录或挂载点，不能是指回 Legacy
+active root 的软链。Cloud 把 OSS 内容直接挂载到 Pool repo；Desktop downloader
+把 target、临时解压、单份 backup 与 ETag 状态放在同一 Pool root 下。Desktop
+preparation 原子迁移旧真实 repo 后，只在 cutover 前保留
+`legacy_repo -> pool_repo` 反向兼容桥；cutover 验证逐 Skill mapping 后移除 active
+root 可达的完整 corpus 入口。
+
 SC 接入后，`skills-center` 作为 `skills-pool` 下与 `skills-repo`、`skills-local` 并列的第三个内容目录；它同样不进入 active-skill-dir，只能通过逐 Skill 激活入口暴露给 Agent。
 
 `skills-repo` 与 `skills-center` 只读是架构约束，而不是实现细节。已发布 Skill 的运行时内容不可被 Agent 对话直接修改；写操作必须经过相应的治理和发布路径。
@@ -397,6 +404,13 @@ Engine 对外提供统一的 Skill 激活 API，并在内部完成以下工作�
 ```
 
 过渡期间，如果 Backend 必须持久化物理 locator，Engine Runtime 应返回已解析的 locator 与校验证据；Backend 只保存结果，不再自行重建路径。
+
+产品激活集合是受管逐 Skill mapping 的权威源。若 activate/deactivate 与数据面
+cutover 并发，Backend 在 cutover 提交后重读最新集合，并把旧快照中已退出的精确
+identity 作为 `retired_mappings` 与最新完整 mapping 一起发布和验证；提交
+`POOL_ACTIVE` 前再次确认快照稳定。快照变化只重跑 post-cutover mapping 收敛，
+不重复数据面 cutover。Engine 只删除仍指向该精确旧受管 source 的入口，同名最新
+mapping、未登记文件系统 entry 与外部 entry 均必须保留。
 
 这样，Backend、部署工具和镜像启动脚本不再各自维护引擎路径常量；它们只负责向 Engine Runtime 请求解析或提供内容分发所需的输入，目录布局的演进由 Engine 单点维护。
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
@@ -1,0 +1,161 @@
+"""Converge post-cutover runtime mappings to current product state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    merge_retired_logical_skill_mappings,
+    retired_logical_skill_mappings,
+)
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+from agentclaw.community.core.skills_pool.ports import (
+    SkillsPoolRuntimeProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.repository.protocol import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+_MAPPING_CONVERGENCE_LIMIT = 4
+
+
+class MappingConvergenceStatus(StrEnum):
+    CONVERGED = "converged"
+    LEASE_NOT_HELD = "lease_not_held"
+    INVALID = "invalid"
+    PUBLISH_FAILED = "publish_failed"
+    VERIFY_FAILED = "verify_failed"
+    SNAPSHOT_CHANGED = "snapshot_changed"
+
+
+@dataclass(frozen=True, slots=True)
+class MappingConvergenceResult:
+    status: MappingConvergenceStatus
+    evidence: dict[str, object]
+
+
+async def converge_post_cutover_mappings(
+    *,
+    layouts: SkillsPoolLayoutRepositoryProtocol,
+    skills: SkillsPoolSkillRepositoryProtocol,
+    runtime: SkillsPoolRuntimeProtocol,
+    scope: BotSkillLayoutScope,
+    generation: str,
+    lease_owner: str,
+    user_id: str,
+    engine: str,
+    cutover_mappings: list[PoolSkillMapping],
+    durable_retired_mappings: list[PoolSkillMapping],
+) -> MappingConvergenceResult:
+    """Publish until Engine state matches one stable product-state snapshot."""
+
+    if not layouts.holds_lease(
+        scope=scope,
+        migration_generation=generation,
+        lease_owner=lease_owner,
+    ):
+        return MappingConvergenceResult(
+            MappingConvergenceStatus.LEASE_NOT_HELD,
+            {},
+        )
+    try:
+        mappings = build_logical_skill_mappings(
+            skills.list_bot_active_assets(
+                env=scope.env,
+                bot_id=scope.bot_id,
+                user_id=user_id,
+                engine=engine,
+            )
+        )
+    except ValueError as error:
+        return MappingConvergenceResult(
+            MappingConvergenceStatus.INVALID,
+            {"reason": str(error)},
+        )
+    retired_mappings = merge_retired_logical_skill_mappings(
+        durable_retired_mappings,
+        retired_logical_skill_mappings(cutover_mappings, mappings),
+        current=mappings,
+    )
+
+    for convergence_attempt in range(1, _MAPPING_CONVERGENCE_LIMIT + 1):
+        if not layouts.holds_lease(
+            scope=scope,
+            migration_generation=generation,
+            lease_owner=lease_owner,
+        ):
+            return MappingConvergenceResult(
+                MappingConvergenceStatus.LEASE_NOT_HELD,
+                {},
+            )
+        evidence: dict[str, object] = {
+            "mapping_count": len(mappings),
+            "retired_mappings": [mapping.to_dict() for mapping in retired_mappings],
+            "convergence_attempt": convergence_attempt,
+        }
+        if not await runtime.publish_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+            retired_mappings=retired_mappings,
+        ):
+            return MappingConvergenceResult(
+                MappingConvergenceStatus.PUBLISH_FAILED,
+                evidence,
+            )
+        if not await runtime.verify_mappings(
+            bot_id=scope.bot_id,
+            user_id=user_id,
+            mappings=mappings,
+            retired_mappings=retired_mappings,
+        ):
+            return MappingConvergenceResult(
+                MappingConvergenceStatus.VERIFY_FAILED,
+                evidence,
+            )
+        try:
+            observed_mappings = build_logical_skill_mappings(
+                skills.list_bot_active_assets(
+                    env=scope.env,
+                    bot_id=scope.bot_id,
+                    user_id=user_id,
+                    engine=engine,
+                )
+            )
+        except ValueError as error:
+            return MappingConvergenceResult(
+                MappingConvergenceStatus.INVALID,
+                {**evidence, "reason": str(error)},
+            )
+        if set(observed_mappings) == set(mappings):
+            return MappingConvergenceResult(
+                MappingConvergenceStatus.CONVERGED,
+                evidence,
+            )
+        retired_mappings = merge_retired_logical_skill_mappings(
+            retired_mappings,
+            retired_logical_skill_mappings(mappings, observed_mappings),
+            current=observed_mappings,
+        )
+        mappings = observed_mappings
+
+    return MappingConvergenceResult(
+        MappingConvergenceStatus.SNAPSHOT_CHANGED,
+        {
+            "mapping_count": len(mappings),
+            "retired_mappings": [mapping.to_dict() for mapping in retired_mappings],
+            "convergence_attempt": _MAPPING_CONVERGENCE_LIMIT,
+        },
+    )
+
+
+__all__ = [
+    "MappingConvergenceResult",
+    "MappingConvergenceStatus",
+    "converge_post_cutover_mappings",
+]

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -62,15 +62,96 @@ def build_logical_skill_mappings(
     return mappings
 
 
+def retired_logical_skill_mappings(
+    previous: list[PoolSkillMapping],
+    current: list[PoolSkillMapping],
+) -> list[PoolSkillMapping]:
+    """Return exact previous identities no longer selected by product state."""
+
+    current_by_target = {mapping.link_name: mapping for mapping in current}
+    return [
+        mapping
+        for mapping in previous
+        if current_by_target.get(mapping.link_name) != mapping
+    ]
+
+
+def merge_retired_logical_skill_mappings(
+    *groups: list[PoolSkillMapping],
+    current: list[PoolSkillMapping],
+) -> list[PoolSkillMapping]:
+    """Keep durable retirements unless the exact identity became active again."""
+
+    active = set(current)
+    merged: list[PoolSkillMapping] = []
+    seen: set[PoolSkillMapping] = set()
+    for group in groups:
+        for mapping in group:
+            if mapping in active or mapping in seen:
+                continue
+            seen.add(mapping)
+            merged.append(mapping)
+    return merged
+
+
+def logical_skill_mappings_from_evidence(
+    evidence: dict[str, object] | None,
+) -> list[PoolSkillMapping]:
+    """Parse durable retirement candidates without trusting stored JSON."""
+
+    if not isinstance(evidence, dict) or "retired_mappings" not in evidence:
+        return []
+    raw_mappings = evidence["retired_mappings"]
+    if not isinstance(raw_mappings, list):
+        raise ValueError("invalid retired mapping evidence")
+    parsed: list[PoolSkillMapping] = []
+    targets: dict[str, PoolSkillMapping] = {}
+    for raw in raw_mappings:
+        if not isinstance(raw, dict) or set(raw) != {
+            "corpus",
+            "relative_path",
+            "link_name",
+        }:
+            raise ValueError("invalid retired mapping evidence")
+        corpus = raw.get("corpus")
+        relative_path = raw.get("relative_path")
+        link_name = raw.get("link_name")
+        if (
+            corpus not in {"local", "repo"}
+            or not isinstance(relative_path, str)
+            or not isinstance(link_name, str)
+        ):
+            raise ValueError("invalid retired mapping evidence")
+        path = PurePosixPath(relative_path)
+        if (
+            not relative_path
+            or relative_path.strip() != relative_path
+            or path.is_absolute()
+            or ".." in path.parts
+            or path.as_posix() != relative_path
+            or path.name != link_name
+        ):
+            raise ValueError("invalid retired mapping evidence")
+        mapping = PoolSkillMapping(
+            corpus=corpus,
+            relative_path=relative_path,
+            link_name=link_name,
+        )
+        if link_name in targets and targets[link_name] != mapping:
+            raise ValueError("ambiguous retired mapping evidence")
+        targets[link_name] = mapping
+        if mapping not in parsed:
+            parsed.append(mapping)
+    return parsed
+
+
 def local_locators_from_evidence(
     assets: list[RegisteredSkillAsset],
     names: list[str],
     evidence: dict[str, object] | None,
 ) -> dict[int, str]:
     raw_locators = (
-        evidence.get("local_locators")
-        if isinstance(evidence, dict)
-        else None
+        evidence.get("local_locators") if isinstance(evidence, dict) else None
     )
     if not isinstance(raw_locators, dict) or set(raw_locators) != set(names):
         raise ValueError(
@@ -80,24 +161,23 @@ def local_locators_from_evidence(
     for asset, name in zip(assets, names, strict=True):
         locator = raw_locators.get(name)
         if not isinstance(locator, str) or not locator.startswith("local:///"):
-            raise ValueError(
-                f"Engine returned an invalid local locator for {name}"
-            )
+            raise ValueError(f"Engine returned an invalid local locator for {name}")
         path = PurePosixPath(locator[len("local://") :])
         if (
             not path.is_absolute()
             or ".." in path.parts
             or path.as_posix() != locator[len("local://") :]
         ):
-            raise ValueError(
-                f"Engine returned an invalid local locator for {name}"
-            )
+            raise ValueError(f"Engine returned an invalid local locator for {name}")
         locators[asset.skill_id] = locator
     return locators
 
 
 __all__ = [
     "build_logical_skill_mappings",
+    "logical_skill_mappings_from_evidence",
     "local_locators_from_evidence",
     "local_skill_name",
+    "merge_retired_logical_skill_mappings",
+    "retired_logical_skill_mappings",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
@@ -83,6 +84,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool: ...
 
@@ -92,6 +94,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool: ...
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -1,8 +1,4 @@
-"""已认领 Bot 的 Skills Pool 激活闭环。
-
-本模块只编排控制面步骤；最终同步和原子 bridge 由当前运行时完成，数据库
-仓储负责 locator 与 ``POOL_ACTIVE`` 的同事务提交。
-"""
+"""编排已认领 Bot 的 Skills Pool 激活闭环。"""
 
 from __future__ import annotations
 
@@ -32,8 +28,13 @@ from agentclaw.community.core.skills_pool.models import (
 )
 from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
+    logical_skill_mappings_from_evidence,
     local_locators_from_evidence,
     local_skill_name,
+)
+from agentclaw.community.core.skills_pool.mapping_convergence import (
+    MappingConvergenceStatus,
+    converge_post_cutover_mappings,
 )
 from agentclaw.community.core.skills_pool.repository.protocol import (
     SkillsPoolLayoutRepositoryProtocol,
@@ -345,6 +346,9 @@ class SkillsPoolReconcileService:
         try:
             local_names = [local_skill_name(asset) for asset in local_assets]
             mappings = build_logical_skill_mappings(active_assets)
+            durable_retired_mappings = logical_skill_mappings_from_evidence(
+                state.last_failure_evidence
+            )
         except ValueError as error:
             evidence = {"reason": str(error)}
             recorded = self._record_failure_for_boundary(
@@ -643,44 +647,56 @@ class SkillsPoolReconcileService:
                     )
             locator_evidence = cutover.evidence
 
-        if not self._layouts.holds_lease(
+        convergence = await converge_post_cutover_mappings(
+            layouts=self._layouts,
+            skills=self._skills,
+            runtime=self._runtime,
             scope=scope,
-            migration_generation=generation,
+            generation=generation,
             lease_owner=lease_owner,
-        ):
+            user_id=user_id,
+            engine=engine,
+            cutover_mappings=mappings,
+            durable_retired_mappings=durable_retired_mappings,
+        )
+        if convergence.status is MappingConvergenceStatus.LEASE_NOT_HELD:
             return SkillsPoolReconcileResult(
                 SkillsPoolReconcileOutcome.LEASE_NOT_HELD,
                 preparation_id=probe.preparation_id,
             )
-        if not await self._runtime.publish_mappings(
-            bot_id=scope.bot_id,
-            user_id=user_id,
-            mappings=mappings,
-        ):
+        convergence_failure = {
+            MappingConvergenceStatus.INVALID: (
+                SkillsPoolReconcileOutcome.INVALID,
+                "MAPPING_DATA_INVALID",
+                "mapping_snapshot",
+            ),
+            MappingConvergenceStatus.PUBLISH_FAILED: (
+                SkillsPoolReconcileOutcome.MAPPING_FAILED,
+                "MAPPING_PUBLISH_FAILED",
+                "mapping_publish",
+            ),
+            MappingConvergenceStatus.VERIFY_FAILED: (
+                SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
+                "MAPPING_VERIFY_FAILED",
+                "mapping_verify",
+            ),
+            MappingConvergenceStatus.SNAPSHOT_CHANGED: (
+                SkillsPoolReconcileOutcome.MAPPING_FAILED,
+                "MAPPING_SNAPSHOT_CHANGED",
+                "mapping_convergence",
+            ),
+        }.get(convergence.status)
+        if convergence_failure is not None:
+            outcome, failure_code, failure_stage = convergence_failure
             return self._record_post_cutover_failure(
                 scope=scope,
                 generation=generation,
                 lease_owner=lease_owner,
                 preparation_id=probe.preparation_id,
-                outcome=SkillsPoolReconcileOutcome.MAPPING_FAILED,
-                failure_code="MAPPING_PUBLISH_FAILED",
-                failure_stage="mapping_publish",
-                evidence={"mapping_count": len(mappings)},
-            )
-        if not await self._runtime.verify_mappings(
-            bot_id=scope.bot_id,
-            user_id=user_id,
-            mappings=mappings,
-        ):
-            return self._record_post_cutover_failure(
-                scope=scope,
-                generation=generation,
-                lease_owner=lease_owner,
-                preparation_id=probe.preparation_id,
-                outcome=SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
-                failure_code="MAPPING_VERIFY_FAILED",
-                failure_stage="mapping_verify",
-                evidence={"mapping_count": len(mappings)},
+                outcome=outcome,
+                failure_code=failure_code,
+                failure_stage=failure_stage,
+                evidence=convergence.evidence,
             )
 
         try:
@@ -859,6 +875,7 @@ class SkillsPoolReconcileService:
                 bot_id=scope.bot_id,
                 user_id=str(owner_id),
                 mappings=mappings,
+                retired_mappings=[],
             ):
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.MAPPING_FAILED,
@@ -869,6 +886,7 @@ class SkillsPoolReconcileService:
                 bot_id=scope.bot_id,
                 user_id=str(owner_id),
                 mappings=mappings,
+                retired_mappings=[],
             ):
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,
@@ -977,10 +995,3 @@ class SkillsPoolReconcileService:
             SkillsPoolReconcileOutcome.BOT_CHANGED,
             evidence=evidence,
         )
-
-
-__all__ = [
-    "SkillsPoolReconcileOutcome",
-    "SkillsPoolReconcileResult",
-    "SkillsPoolReconcileService",
-]

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -96,9 +96,7 @@ class SkillsPoolRecoveryService:
         resolution: ManualRepairResolution,
     ) -> SkillsPoolRecoveryResult:
         if not operator.strip() or not note.strip():
-            return SkillsPoolRecoveryResult(
-                SkillsPoolRecoveryOutcome.INVALID_REQUEST
-            )
+            return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.INVALID_REQUEST)
         state = self._layouts.get(scope)
         if not state.persisted:
             return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.NOT_FOUND)
@@ -119,9 +117,7 @@ class SkillsPoolRecoveryService:
                 SkillsPoolRecoveryOutcome.NOT_REPAIR_REQUIRED
             )
         if state.migration_generation != migration_generation:
-            return SkillsPoolRecoveryResult(
-                SkillsPoolRecoveryOutcome.STALE_GENERATION
-            )
+            return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.STALE_GENERATION)
 
         if not retrying_resolved_enqueue:
             committed = resolution is ManualRepairResolution.POOL_COMMITTED
@@ -159,9 +155,7 @@ class SkillsPoolRecoveryService:
                 scope.bot_id,
                 migration_generation,
             )
-            return SkillsPoolRecoveryResult(
-                SkillsPoolRecoveryOutcome.RETRIGGER_FAILED
-            )
+            return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.RETRIGGER_FAILED)
         return SkillsPoolRecoveryResult(SkillsPoolRecoveryOutcome.RETRIGGERED)
 
 
@@ -248,9 +242,7 @@ class SkillsPoolRollbackService:
             value.strip()
             for value in (rollback_generation, lease_owner, operator, note)
         ):
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.INVALID_REQUEST
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.INVALID_REQUEST)
 
         state = self._layouts.get(scope)
         began_rollback = False
@@ -274,23 +266,17 @@ class SkillsPoolRollbackService:
             SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
             SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
         }:
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.NOT_POOL_ACTIVE
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.NOT_POOL_ACTIVE)
 
         if state.migration_generation != rollback_generation:
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.STALE_GENERATION
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.STALE_GENERATION)
         if not began_rollback and not self._layouts.try_acquire_rollback_lease(
             scope=scope,
             rollback_generation=rollback_generation,
             lease_owner=lease_owner,
             lease_seconds=self._LEASE_SECONDS,
         ):
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.STATE_RACE_LOST
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.STATE_RACE_LOST)
 
         bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
         if bot is None or bot.get("env") != scope.env:
@@ -330,9 +316,7 @@ class SkillsPoolRollbackService:
                 code="ROLLBACK_ENGINE_UNSUPPORTED",
                 stage="rollback_bot_validation",
                 retryable=False,
-                evidence={
-                    "reason": f"engine Pool layout not implemented: {engine}"
-                },
+                evidence={"reason": f"engine Pool layout not implemented: {engine}"},
             )
         user_id = str(owner_id)
 
@@ -390,9 +374,7 @@ class SkillsPoolRollbackService:
                 evidence={"reason": str(error)},
             )
 
-        locator_evidence = self._persisted_rollback_evidence(
-            state.last_probe_evidence
-        )
+        locator_evidence = self._persisted_rollback_evidence(state.last_probe_evidence)
         if state.phase is SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING:
             # Pool cutover retires Legacy local storage, so Legacy mappings
             # cannot be published until the runtime has rebuilt that corpus.
@@ -477,9 +459,7 @@ class SkillsPoolRollbackService:
                 retryable=True,
                 evidence={"local_locator_count": len(local_locators)},
             )
-        return SkillsPoolRollbackResult(
-            SkillsPoolRollbackOutcome.LEGACY_ACTIVE
-        )
+        return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.LEGACY_ACTIVE)
 
     async def _publish_and_verify_mappings(
         self,
@@ -494,6 +474,7 @@ class SkillsPoolRollbackService:
             bot_id=scope.bot_id,
             user_id=user_id,
             mappings=mappings,
+            retired_mappings=[],
             source_layout=SkillMappingSourceLayout.LEGACY,
         ):
             return self._failure(
@@ -510,6 +491,7 @@ class SkillsPoolRollbackService:
             bot_id=scope.bot_id,
             user_id=user_id,
             mappings=mappings,
+            retired_mappings=[],
             source_layout=SkillMappingSourceLayout.LEGACY,
         ):
             return self._failure(
@@ -545,9 +527,7 @@ class SkillsPoolRollbackService:
             retryable=retryable,
             evidence=evidence,
         ):
-            return SkillsPoolRollbackResult(
-                SkillsPoolRollbackOutcome.STATE_RACE_LOST
-            )
+            return SkillsPoolRollbackResult(SkillsPoolRollbackOutcome.STATE_RACE_LOST)
         return SkillsPoolRollbackResult(
             outcome,
             evidence=evidence,

--- a/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
+++ b/src/backend/src/agentclaw/community/plugins/skills_pool_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from injector import inject
@@ -131,6 +132,7 @@ class SkillsPoolRuntime:
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         try:
@@ -141,6 +143,9 @@ class SkillsPoolRuntime:
                 body={
                     "mapping_contract_version": MAPPING_CONTRACT_VERSION,
                     "mappings": [mapping.to_dict() for mapping in mappings],
+                    "retired_mappings": [
+                        mapping.to_dict() for mapping in retired_mappings
+                    ],
                     "source_layout": source_layout.value,
                 },
             )
@@ -271,6 +276,7 @@ class SkillsPoolRuntime:
         bot_id: str,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
     ) -> bool:
         try:
@@ -281,6 +287,9 @@ class SkillsPoolRuntime:
                 body={
                     "mapping_contract_version": MAPPING_CONTRACT_VERSION,
                     "mappings": [mapping.to_dict() for mapping in mappings],
+                    "retired_mappings": [
+                        mapping.to_dict() for mapping in retired_mappings
+                    ],
                     "source_layout": source_layout.value,
                 },
             )

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -419,6 +419,13 @@ class FakeRuntime:
         self.probe_results: list[RuntimeLayoutProbeResult] = []
         self.publish_success = True
         self.verify_success = True
+        self.publish_results: list[bool] = []
+        self.verify_results: list[bool] = []
+        self.after_cutover = None
+        self.after_publish = None
+        self.after_verify = None
+        self.published_batches: list[dict[str, list[dict[str, str]]]] = []
+        self.verified_batches: list[dict[str, list[dict[str, str]]]] = []
         self.physical_cutovers = 0
         self.expected_registered_local_names = ["local-a", "local-b"]
         self.cutover_result = PoolCutoverResult(
@@ -486,7 +493,7 @@ class FakeRuntime:
         ):
             self.physical_cutovers += 1
         if self.cutover_result.committed:
-            return replace(
+            result = replace(
                 self.cutover_result,
                 evidence={
                     **self.cutover_result.evidence,
@@ -496,14 +503,42 @@ class FakeRuntime:
                     },
                 },
             )
-        return self.cutover_result
+        else:
+            result = self.cutover_result
+        if self.after_cutover is not None:
+            self.after_cutover()
+        return result
 
     async def publish_mappings(self, **kwargs: object) -> bool:
         self.events.append("mapping")
+        self.published_batches.append(
+            {
+                "mappings": [mapping.to_dict() for mapping in kwargs["mappings"]],
+                "retired_mappings": [
+                    mapping.to_dict() for mapping in kwargs["retired_mappings"]
+                ],
+            }
+        )
+        if self.after_publish is not None:
+            self.after_publish()
+        if self.publish_results:
+            return self.publish_results.pop(0)
         return self.publish_success
 
     async def verify_mappings(self, **kwargs: object) -> bool:
         self.events.append("verify")
+        self.verified_batches.append(
+            {
+                "mappings": [mapping.to_dict() for mapping in kwargs["mappings"]],
+                "retired_mappings": [
+                    mapping.to_dict() for mapping in kwargs["retired_mappings"]
+                ],
+            }
+        )
+        if self.after_verify is not None:
+            self.after_verify()
+        if self.verify_results:
+            return self.verify_results.pop(0)
         return self.verify_success
 
 
@@ -544,6 +579,254 @@ async def test_ready_claimed_bot_completes_pool_activation() -> None:
             "local:///home/admin/.openclaw/workspace/skills-pool/skills-local/local-b"
         ),
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+async def test_product_deactivation_during_cutover_retires_stale_mapping(
+    engine: str,
+) -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository(engine)
+    runtime = FakeRuntime(engine=engine)
+    runtime.after_cutover = lambda: skills.active.pop()
+
+    result = await build_service(
+        layouts,
+        runtime,
+        engine=engine,
+        skills=skills,
+    ).reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.physical_cutovers == 1
+    assert runtime.published_batches == [
+        {
+            "mappings": [
+                {
+                    "corpus": "local",
+                    "relative_path": "local-a",
+                    "link_name": "local-a",
+                },
+                {
+                    "corpus": "local",
+                    "relative_path": "local-b",
+                    "link_name": "local-b",
+                },
+            ],
+            "retired_mappings": [
+                {
+                    "corpus": "repo",
+                    "relative_path": "business/repo-skill",
+                    "link_name": "repo-skill",
+                }
+            ],
+        }
+    ]
+    assert runtime.verified_batches == runtime.published_batches
+
+
+@pytest.mark.asyncio
+async def test_product_activation_after_verify_republishes_without_recutover() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+    late = RegisteredSkillAsset(
+        skill_id=22,
+        name="late",
+        git_path="git://business/late",
+    )
+
+    def activate_after_first_verify() -> None:
+        if late not in skills.active:
+            skills.active.append(late)
+            runtime.after_verify = None
+
+    runtime.after_verify = activate_after_first_verify
+
+    result = await build_service(
+        layouts,
+        runtime,
+        skills=skills,
+    ).reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.physical_cutovers == 1
+    assert runtime.events == [
+        "probe",
+        "cutover",
+        "mapping",
+        "verify",
+        "mapping",
+        "verify",
+    ]
+    assert runtime.published_batches[-1]["mappings"][-1] == {
+        "corpus": "repo",
+        "relative_path": "business/late",
+        "link_name": "late",
+    }
+
+
+@pytest.mark.asyncio
+async def test_same_name_recreated_during_cutover_retires_old_identity() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+
+    def replace_repo_skill() -> None:
+        skills.active[-1] = RegisteredSkillAsset(
+            skill_id=22,
+            name="repo-skill",
+            git_path="git://replacement/repo-skill",
+        )
+
+    runtime.after_cutover = replace_repo_skill
+
+    result = await build_service(
+        layouts,
+        runtime,
+        skills=skills,
+    ).reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.published_batches[0]["mappings"][-1] == {
+        "corpus": "repo",
+        "relative_path": "replacement/repo-skill",
+        "link_name": "repo-skill",
+    }
+    assert runtime.published_batches[0]["retired_mappings"] == [
+        {
+            "corpus": "repo",
+            "relative_path": "business/repo-skill",
+            "link_name": "repo-skill",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mapping_publish_retry_keeps_retirement_candidate() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+    runtime.after_cutover = lambda: skills.active.pop()
+    runtime.publish_results = [False, True]
+    service = build_service(layouts, runtime, skills=skills)
+
+    first = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+
+    second = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.physical_cutovers == 1
+    assert runtime.published_batches[1]["retired_mappings"] == [
+        {
+            "corpus": "repo",
+            "relative_path": "business/repo-skill",
+            "link_name": "repo-skill",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mapping_verify_retry_keeps_retirement_candidate() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+    runtime.after_cutover = lambda: skills.active.pop()
+    runtime.verify_results = [False, True]
+    service = build_service(layouts, runtime, skills=skills)
+
+    first = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED
+
+    second = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.physical_cutovers == 1
+    assert runtime.verified_batches[1]["retired_mappings"] == [
+        {
+            "corpus": "repo",
+            "relative_path": "business/repo-skill",
+            "link_name": "repo-skill",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exact_reactivation_cancels_durable_retirement() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    original = skills.active[-1]
+    runtime = FakeRuntime()
+    runtime.after_cutover = lambda: skills.active.pop()
+    runtime.publish_results = [False, True]
+    service = build_service(layouts, runtime, skills=skills)
+
+    first = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    skills.active.append(original)
+
+    second = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert second.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.published_batches[1]["retired_mappings"] == []
+    assert runtime.published_batches[1]["mappings"][-1]["link_name"] == ("repo-skill")
+
+
+@pytest.mark.asyncio
+async def test_continuous_product_churn_is_bounded_without_database_commit() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+    late = RegisteredSkillAsset(
+        skill_id=22,
+        name="late",
+        git_path="git://business/late",
+    )
+
+    def toggle_after_verify() -> None:
+        if late in skills.active:
+            skills.active.remove(late)
+        else:
+            skills.active.append(late)
+
+    runtime.after_verify = toggle_after_verify
+
+    result = await build_service(
+        layouts,
+        runtime,
+        skills=skills,
+    ).reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    assert result.retryable is True
+    assert layouts.state.last_failure_code == "MAPPING_SNAPSHOT_CHANGED"
+    assert runtime.physical_cutovers == 1
+    assert len(runtime.published_batches) == 4
+    assert "database" not in layouts.events
+
+
+@pytest.mark.asyncio
+async def test_malformed_durable_retirement_fails_before_retry_mutation() -> None:
+    layouts = FakeLayoutRepository()
+    skills = FakeSkillRepository()
+    runtime = FakeRuntime()
+    runtime.after_cutover = lambda: skills.active.pop()
+    runtime.publish_results = [False]
+    service = build_service(layouts, runtime, skills=skills)
+
+    first = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+    assert first.outcome is SkillsPoolReconcileOutcome.MAPPING_FAILED
+    layouts.state = replace(
+        layouts.state,
+        last_failure_evidence={"retired_mappings": "not-a-list"},
+    )
+
+    second = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert second.outcome is SkillsPoolReconcileOutcome.INVALID
+    assert len(runtime.published_batches) == 1
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -141,11 +141,13 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
         bot_id="bot-1",
         user_id="owner-1",
         mappings=mappings,
+        retired_mappings=mappings,
     )
     verified = await runtime.verify_mappings(
         bot_id="bot-1",
         user_id="owner-1",
         mappings=mappings,
+        retired_mappings=mappings,
     )
 
     assert cutover.committed
@@ -177,6 +179,8 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
             == "skills-pool-mapping-v2"
         )
         assert transport.calls[index]["body"]["mappings"] == [logical_mapping]
+    for index in (2, 3):
+        assert transport.calls[index]["body"]["retired_mappings"] == [logical_mapping]
 
 
 @pytest.mark.asyncio

--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -1092,6 +1092,13 @@ class SkillExecutionResult:
       "relative_path": "business/reviewer",
       "link_name": "reviewer"
     }
+  ],
+  "retired_mappings": [
+    {
+      "corpus": "repo",
+      "relative_path": "legacy/reviewer",
+      "link_name": "reviewer"
+    }
   ]
 }
 ```
@@ -1104,6 +1111,12 @@ class SkillExecutionResult:
   home 投影物理 source/active target；publish/verify 返回
   `resolved_mappings`，activation/rollback 返回 `local_locators`。这些路径是
   Engine evidence，Backend 只能校验和持久化，不能按 engine 重建。
+- `retired_mappings` 是可选的精确旧 logical identity 集合，用于数据面 cutover
+  与产品 activate/deactivate 并发时删除旧受管入口。Engine 必须先整批校验
+  `mappings` 与 `retired_mappings`，且只删除 target 仍指向声明旧 source 的项；
+  同名最新 mapping、外部 entry 和未登记文件系统 entry 不得被旧快照覆盖或删除。
+  Backend 在 `POOL_ACTIVE` 提交前重读产品集合；变化时只重复 publish/verify，
+  不重复物理 cutover。
 - READY Probe 已进入 cutover evidence（存在 active marker）后，
   `checks.stable_repo_bridge_valid` 只在 AICoding/Hermes 已进入 `active`
   且稳定 repo bridge 已实际校验时存在并为 `true`。OpenClaw/Claude Code

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -5,6 +5,7 @@ Engine-specific behaviour (filesystem symlinks under
 AiCoding) lives in the engine's ``skills`` plugin. The router only
 marshals HTTP↔Plugin types and applies capability guards.
 """
+
 from __future__ import annotations
 
 import logging
@@ -73,6 +74,7 @@ log = logging.getLogger("api-skills")
 
 def _skills_plugin():
     from engine.community.manager import EngineManager
+
     return EngineManager.get_instance().skills
 
 
@@ -251,9 +253,11 @@ async def verify_runtime_skill_mappings(
         else {}
     )
     if body.mapping_contract_version is not None:
-        layout_kwargs["mapping_contract_version"] = (
-            body.mapping_contract_version
-        )
+        layout_kwargs["mapping_contract_version"] = body.mapping_contract_version
+    if body.retired_mappings:
+        layout_kwargs["retired_mappings"] = [
+            _mapping_command(item) for item in body.retired_mappings
+        ]
     try:
         result = await plugin.verify_pool_mappings(
             [_mapping_command(item) for item in body.mappings],
@@ -283,9 +287,11 @@ async def publish_runtime_skill_mappings(
         else {}
     )
     if body.mapping_contract_version is not None:
-        layout_kwargs["mapping_contract_version"] = (
-            body.mapping_contract_version
-        )
+        layout_kwargs["mapping_contract_version"] = body.mapping_contract_version
+    if body.retired_mappings:
+        layout_kwargs["retired_mappings"] = [
+            _mapping_command(item) for item in body.retired_mappings
+        ]
     try:
         result = await plugin.publish_pool_mappings(
             [_mapping_command(item) for item in body.mappings],
@@ -305,7 +311,9 @@ async def publish_runtime_skill_mappings(
 @router.post("/symlink", response_model=ApiResponse)
 async def sync_symlinks(body: SyncSymlinkRequest) -> ApiResponse:
     warning = check_capability(Capability.SKILLS_SYNC_SYMLINKS)
-    items = [SymlinkItem(source=i.source, target=i.target) for i in (body.symlinks or [])]
+    items = [
+        SymlinkItem(source=i.source, target=i.target) for i in (body.symlinks or [])
+    ]
     try:
         plugin = _skills_plugin()
         result = await plugin.sync_symlinks(SyncSymlinksRequest(symlinks=items))
@@ -391,7 +399,9 @@ async def clean_symlinks(body: CleanSymlinkRequest) -> ApiResponse:
 @router.post("/center/ensure", response_model=ApiResponse)
 async def ensure_center_skills(body: CenterEnsureRequestSchema) -> ApiResponse:
     warning = check_capability(Capability.SKILLS_CENTER_ENSURE)
-    items = [CenterEnsureItem(skill_uuid=i.skill_uuid, version=i.version) for i in body.items]
+    items = [
+        CenterEnsureItem(skill_uuid=i.skill_uuid, version=i.version) for i in body.items
+    ]
     try:
         plugin = _skills_plugin()
         result = await plugin.ensure_center_skills(CenterEnsureRequest(items=items))
@@ -401,7 +411,9 @@ async def ensure_center_skills(body: CenterEnsureRequestSchema) -> ApiResponse:
     return ApiResponse(
         success=True,
         data={
-            "ok": [{"skill_uuid": x.skill_uuid, "version": x.version} for x in result.ok],
+            "ok": [
+                {"skill_uuid": x.skill_uuid, "version": x.version} for x in result.ok
+            ],
             "failed": [
                 {"skill_uuid": x.skill_uuid, "version": x.version, "reason": x.reason}
                 for x in result.failed

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -1,9 +1,10 @@
 """Skills router HTTP schemas."""
+
 from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from engine.community.api.response import ApiResponse
 
@@ -127,6 +128,9 @@ class PoolLayoutActivateApiResponse(ApiResponse):
 class PoolMappingVerifyRequest(BaseModel):
     mapping_contract_version: str | None = None
     mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping]
+    retired_mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping] = Field(
+        default_factory=list
+    )
     source_layout: Literal["pool", "legacy"] = "pool"
 
 

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -5,6 +5,7 @@ behavior of the OpenClawSkillsService via the router. This file covers the
 dispatch contract: calls land on `manager.skills.*`, the capability guard
 501s when the engine doesn't declare the skill bulk capabilities.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -118,7 +119,9 @@ class TestSyncSymlinks:
         plugin = MagicMock()
         plugin.sync_symlinks = AsyncMock(
             return_value=SyncSymlinksResult(
-                total=1, created=["a"], base_dir="/tmp/x",
+                total=1,
+                created=["a"],
+                base_dir="/tmp/x",
             )
         )
         rich_manager._active_engine._skills = plugin
@@ -142,9 +145,7 @@ class TestSyncSymlinks:
 class TestSyncBindpaths:
     def test_dispatches(self, rich_manager, client):
         plugin = MagicMock()
-        plugin.sync_bindpaths = AsyncMock(
-            return_value=SyncSymlinksResult(total=0)
-        )
+        plugin.sync_bindpaths = AsyncMock(return_value=SyncSymlinksResult(total=0))
         rich_manager._active_engine._skills = plugin
 
         resp = client.post(
@@ -169,7 +170,8 @@ class TestCleanSymlinksDispatch:
         plugin = MagicMock()
         plugin.clean_symlinks = AsyncMock(
             return_value=CleanSymlinksResult(
-                directories_scanned=2, removed=["/a/b"],
+                directories_scanned=2,
+                removed=["/a/b"],
             )
         )
         rich_manager._active_engine._skills = plugin
@@ -185,7 +187,8 @@ class TestCleanSymlinksDispatch:
 
     def test_501(self, lean_manager, client):
         resp = client.post(
-            "/api/skills/symlink/clean", json={"directories": ["/x"]},
+            "/api/skills/symlink/clean",
+            json={"directories": ["/x"]},
         )
         assert resp.status_code == 501
 
@@ -213,17 +216,23 @@ def test_ensure_center_skills_route_success(rich_manager, client):
             captured["items"] = list(req.items)
             return CenterEnsureResult(
                 ok=[CenterEnsureItem(skill_uuid="u1", version="1.0.0")],
-                failed=[CenterEnsureFailure(skill_uuid="u2", version="2.0.0", reason="missing")],
+                failed=[
+                    CenterEnsureFailure(
+                        skill_uuid="u2", version="2.0.0", reason="missing"
+                    )
+                ],
             )
 
     rich_manager._active_engine._skills = _FakePlugin()
 
     resp = client.post(
         "/api/skills/center/ensure",
-        json={"items": [
-            {"skill_uuid": "u1", "version": "1.0.0"},
-            {"skill_uuid": "u2", "version": "2.0.0"},
-        ]},
+        json={
+            "items": [
+                {"skill_uuid": "u1", "version": "1.0.0"},
+                {"skill_uuid": "u2", "version": "2.0.0"},
+            ]
+        },
     )
 
     assert resp.status_code == 200
@@ -236,9 +245,7 @@ def test_ensure_center_skills_route_success(rich_manager, client):
     assert len(captured["items"]) == 2
 
 
-def test_runtime_layout_probe_has_no_engine_capability_dependency(
-    client, rich_manager
-):
+def test_runtime_layout_probe_has_no_engine_capability_dependency(client, rich_manager):
     plugin = MagicMock()
     plugin.probe_pool_layout = AsyncMock(
         return_value=PoolLayoutProbeResult(
@@ -322,9 +329,7 @@ def test_runtime_layout_probe_rejects_unknown_contract_before_dispatch(
     plugin.probe_pool_layout.assert_not_awaited()
 
 
-def test_runtime_layout_probe_rejects_plugin_engine_mismatch(
-    client, rich_manager
-):
+def test_runtime_layout_probe_rejects_plugin_engine_mismatch(client, rich_manager):
     plugin = MagicMock()
     plugin.probe_pool_layout = AsyncMock(
         return_value=PoolLayoutProbeResult(
@@ -363,9 +368,7 @@ def test_runtime_layout_probe_rejects_real_openclaw_plugin_engine_mismatch(
     client,
     rich_manager,
 ) -> None:
-    rich_manager._active_engine._skills = OpenClawSkillsAdapter(
-        OpenClawPluginImpl()
-    )
+    rich_manager._active_engine._skills = OpenClawSkillsAdapter(OpenClawPluginImpl())
 
     response = client.post(
         "/api/skills/layout/probe",
@@ -478,9 +481,7 @@ def test_pool_activation_and_mapping_routes_are_capability_independent(
     )
 
 
-def test_pool_mapping_routes_propagate_logical_v2_contract(
-    client, rich_manager
-):
+def test_pool_mapping_routes_propagate_logical_v2_contract(client, rich_manager):
     plugin = MagicMock()
     plugin.activate_pool_layout = AsyncMock(
         return_value=PoolLayoutActivationResult(
@@ -501,6 +502,11 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
         "relative_path": "business/reviewer",
         "link_name": "reviewer",
     }
+    retired_mapping = {
+        "corpus": "repo",
+        "relative_path": "legacy/writer",
+        "link_name": "writer",
+    }
     version = "skills-pool-mapping-v2"
 
     activation = client.post(
@@ -518,6 +524,7 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
         json={
             "mapping_contract_version": version,
             "mappings": [mapping],
+            "retired_mappings": [retired_mapping],
         },
     )
     verified = client.post(
@@ -525,14 +532,22 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
         json={
             "mapping_contract_version": version,
             "mappings": [mapping],
+            "retired_mappings": [retired_mapping],
         },
     )
 
-    assert activation.status_code == published.status_code == verified.status_code == 200
+    assert (
+        activation.status_code == published.status_code == verified.status_code == 200
+    )
     intent = PoolSkillMappingIntent(
         corpus="repo",
         relative_path="business/reviewer",
         link_name="reviewer",
+    )
+    retired_intent = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="legacy/writer",
+        link_name="writer",
     )
     request = plugin.activate_pool_layout.await_args.args[0]
     assert request.mapping_contract_version == version
@@ -540,10 +555,12 @@ def test_pool_mapping_routes_propagate_logical_v2_contract(
     plugin.publish_pool_mappings.assert_awaited_once_with(
         [intent],
         mapping_contract_version=version,
+        retired_mappings=[retired_intent],
     )
     plugin.verify_pool_mappings.assert_awaited_once_with(
         [intent],
         mapping_contract_version=version,
+        retired_mappings=[retired_intent],
     )
 
 
@@ -594,9 +611,7 @@ def test_pool_mapping_routes_map_invalid_request_errors_to_400(
     response = client.post(path, json=payload)
 
     assert response.status_code == 400
-    assert response.json()["detail"] == (
-        "mapping_contract_version is unsupported"
-    )
+    assert response.json()["detail"] == ("mapping_contract_version is unsupported")
 
 
 @pytest.mark.parametrize(
@@ -609,27 +624,21 @@ def test_pool_mapping_routes_map_invalid_request_errors_to_400(
                 "preparation_id": "preparation-1",
                 "registered_local_names": [],
                 "mapping_contract_version": "skills-pool-mapping-v2",
-                "mappings": [
-                    {"source": "/pool/a", "target": "/active/a"}
-                ],
+                "mappings": [{"source": "/pool/a", "target": "/active/a"}],
             },
         ),
         (
             "/api/skills/layout/mappings/publish",
             {
                 "mapping_contract_version": "skills-pool-mapping-v2",
-                "mappings": [
-                    {"source": "/pool/a", "target": "/active/a"}
-                ],
+                "mappings": [{"source": "/pool/a", "target": "/active/a"}],
             },
         ),
         (
             "/api/skills/layout/mappings/verify",
             {
                 "mapping_contract_version": "skills-pool-mapping-v2",
-                "mappings": [
-                    {"source": "/pool/a", "target": "/active/a"}
-                ],
+                "mappings": [{"source": "/pool/a", "target": "/active/a"}],
             },
         ),
     ],
@@ -640,9 +649,7 @@ def test_pool_mapping_routes_reject_v2_physical_shape_via_real_adapter(
     path: str,
     payload: dict[str, object],
 ) -> None:
-    rich_manager._active_engine._skills = OpenClawSkillsAdapter(
-        OpenClawPluginImpl()
-    )
+    rich_manager._active_engine._skills = OpenClawSkillsAdapter(OpenClawPluginImpl())
 
     response = client.post(path, json=payload)
 

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -30,6 +30,7 @@ OpenClaw keeps those operations outside its adapter.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from engine.community.core.engine.context import AuthContext
@@ -452,6 +453,7 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
@@ -460,6 +462,10 @@ class ClaudeCodeSkillsAdapter(SkillsService):
             "mappings": [_serialize_pool_mapping(item) for item in mappings],
             "source_layout": source_layout.value,
         }
+        if retired_mappings:
+            payload["retired_mappings"] = [
+                _serialize_pool_mapping(item) for item in retired_mappings
+            ]
         if mapping_contract_version is not None:
             payload["mapping_contract_version"] = mapping_contract_version
         raw = await self._port.publish_pool_mappings(payload)
@@ -472,6 +478,7 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
@@ -480,6 +487,10 @@ class ClaudeCodeSkillsAdapter(SkillsService):
             "mappings": [_serialize_pool_mapping(item) for item in mappings],
             "source_layout": source_layout.value,
         }
+        if retired_mappings:
+            payload["retired_mappings"] = [
+                _serialize_pool_mapping(item) for item in retired_mappings
+            ]
         if mapping_contract_version is not None:
             payload["mapping_contract_version"] = mapping_contract_version
         raw = await self._port.verify_pool_mappings(payload)

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -19,7 +19,10 @@ Capability matrix:
   ``update_skill``, ``enable_skill``, ``disable_skill``, ``execute_skill``,
   ``validate_skill``, ``discover_skills`` (10 ops).
 """
+
 from __future__ import annotations
+
+from collections.abc import Sequence
 
 from engine.community.core.engine.capability import Capability
 from engine.community.core.engine.context import AuthContext
@@ -180,14 +183,10 @@ class OpenClawSkillsAdapter(SkillsService):
         evidence = dict(raw.get("evidence") or {})
         if status is PoolLayoutActivationStatus.UNKNOWN:
             evidence["raw_status"] = raw_status
-        committed = (
-            raw.get("committed") is True
-            and status
-            in {
-                PoolLayoutActivationStatus.COMMITTED,
-                PoolLayoutActivationStatus.ALREADY_COMMITTED,
-            }
-        )
+        committed = raw.get("committed") is True and status in {
+            PoolLayoutActivationStatus.COMMITTED,
+            PoolLayoutActivationStatus.ALREADY_COMMITTED,
+        }
         return PoolLayoutActivationResult(
             committed=committed,
             status=status,
@@ -266,6 +265,7 @@ class OpenClawSkillsAdapter(SkillsService):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
@@ -274,6 +274,10 @@ class OpenClawSkillsAdapter(SkillsService):
             "mappings": [_serialize_pool_mapping(item) for item in mappings],
             "source_layout": source_layout.value,
         }
+        if retired_mappings:
+            payload["retired_mappings"] = [
+                _serialize_pool_mapping(item) for item in retired_mappings
+            ]
         if mapping_contract_version is not None:
             payload["mapping_contract_version"] = mapping_contract_version
         raw = await self._port.publish_pool_mappings(payload)
@@ -286,6 +290,7 @@ class OpenClawSkillsAdapter(SkillsService):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
@@ -294,6 +299,10 @@ class OpenClawSkillsAdapter(SkillsService):
             "mappings": [_serialize_pool_mapping(item) for item in mappings],
             "source_layout": source_layout.value,
         }
+        if retired_mappings:
+            payload["retired_mappings"] = [
+                _serialize_pool_mapping(item) for item in retired_mappings
+            ]
         if mapping_contract_version is not None:
             payload["mapping_contract_version"] = mapping_contract_version
         raw = await self._port.verify_pool_mappings(payload)
@@ -305,22 +314,29 @@ class OpenClawSkillsAdapter(SkillsService):
     # ── Per-skill ops (not exposed by OpenClaw) ───────────────────────────────
 
     async def list_skills(
-        self, auth: AuthContext | None = None,
+        self,
+        auth: AuthContext | None = None,
     ) -> list[Skill]:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_LIST)
 
     async def get_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> Skill | None:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_LIST)
 
     async def install_skill(
-        self, config: SkillConfig, auth: AuthContext | None = None,
+        self,
+        config: SkillConfig,
+        auth: AuthContext | None = None,
     ) -> Skill:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_INSTALL)
 
     async def uninstall_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_UNINSTALL)
 
@@ -333,12 +349,16 @@ class OpenClawSkillsAdapter(SkillsService):
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_UPDATE)
 
     async def enable_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_INSTALL)
 
     async def disable_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_UNINSTALL)
 
@@ -350,12 +370,16 @@ class OpenClawSkillsAdapter(SkillsService):
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_EXECUTE)
 
     async def validate_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> list[str]:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_LIST)
 
     async def discover_skills(
-        self, source: str, auth: AuthContext | None = None,
+        self,
+        source: str,
+        auth: AuthContext | None = None,
     ) -> list[Skill]:
         raise CapabilityNotSupportedError("openclaw", Capability.SKILLS_DISCOVER)
 

--- a/src/engine/src/engine/community/core/skills/protocol.py
+++ b/src/engine/src/engine/community/core/skills/protocol.py
@@ -25,8 +25,10 @@ should raise :class:`CapabilityNotSupportedError`.
 The versioned Pool mapping wire contract and compatibility rules are recorded
 in ``src/engine/docs/heterogeneous-engine-architecture.md`` §7.3.
 """
+
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol, runtime_checkable
 
 from engine.community.core.engine.context import AuthContext
@@ -66,25 +68,32 @@ class SkillsService(Protocol):
 
     # ── Per-skill management ──
     async def list_skills(
-        self, auth: AuthContext | None = None,
+        self,
+        auth: AuthContext | None = None,
     ) -> list[Skill]:
         """List all skills known to the engine, installed or otherwise."""
         ...
 
     async def get_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> Skill | None:
         """Look up a single skill by id."""
         ...
 
     async def install_skill(
-        self, config: SkillConfig, auth: AuthContext | None = None,
+        self,
+        config: SkillConfig,
+        auth: AuthContext | None = None,
     ) -> Skill:
         """Install a skill from the given configuration."""
         ...
 
     async def uninstall_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         """Uninstall a skill. Returns True if it was installed and is now removed."""
         ...
@@ -99,13 +108,17 @@ class SkillsService(Protocol):
         ...
 
     async def enable_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         """Enable a previously disabled skill."""
         ...
 
     async def disable_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> bool:
         """Disable a skill without uninstalling it."""
         ...
@@ -120,7 +133,9 @@ class SkillsService(Protocol):
         ...
 
     async def validate_skill(
-        self, skill_id: str, auth: AuthContext | None = None,
+        self,
+        skill_id: str,
+        auth: AuthContext | None = None,
     ) -> list[str]:
         """Validate a skill's configuration. Returns an empty list when valid,
         otherwise a list of human-readable error messages."""
@@ -128,7 +143,9 @@ class SkillsService(Protocol):
 
     # ── Skill discovery ──
     async def discover_skills(
-        self, source: str, auth: AuthContext | None = None,
+        self,
+        source: str,
+        auth: AuthContext | None = None,
     ) -> list[Skill]:
         """Enumerate skills available to install from the given source."""
         ...
@@ -222,6 +239,7 @@ class SkillsService(Protocol):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,
@@ -241,6 +259,7 @@ class SkillsService(Protocol):
         self,
         mappings: list[PoolSkillMappingIntent | SymlinkItem],
         *,
+        retired_mappings: Sequence[PoolSkillMappingIntent | SymlinkItem] = (),
         source_layout: PoolMappingSourceLayout = PoolMappingSourceLayout.POOL,
         mapping_contract_version: str | None = None,
         auth: AuthContext | None = None,

--- a/src/engine/src/engine/community/core/skills/skills_repo_download.py
+++ b/src/engine/src/engine/community/core/skills/skills_repo_download.py
@@ -28,6 +28,7 @@
   - 启动时清理上次进程被 kill 残留的 ``.skills-repo-extract-*`` 临时目录。
   - 失败非致命：下载或解压失败只打日志，不阻断 engine。
 """
+
 from __future__ import annotations
 
 import json
@@ -48,6 +49,13 @@ from engine.community.config import (
     load_engine_config,
 )
 from engine.community.core.engine.naming import normalize
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    SkillLayoutResolutionError,
+    resolve_filesystem_skill_layout,
+)
 from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.skills_pool.desktop_preparation import (
     prepare_desktop_pool,
@@ -78,7 +86,9 @@ def _get_internal_default_meta_url_template() -> str:
         from engine import internal_defaults
     except ImportError:
         return ""
-    return (getattr(internal_defaults, "SKILLS_REPO_META_URL_TEMPLATE", "") or "").strip()
+    return (
+        getattr(internal_defaults, "SKILLS_REPO_META_URL_TEMPLATE", "") or ""
+    ).strip()
 
 
 def _format_meta_url_template(template: str) -> str:
@@ -118,15 +128,63 @@ def _get_default_meta_url() -> str:
     return ""
 
 
-TARGET_DIR = workspace_root() / "skills" / "skills-repo"
-BACKUP_DIR = workspace_root() / "skills" / ".skills-repo-backups"
-ETAG_FILE = workspace_root() / "skills" / ".skills-repo-etag"
+def _repo_download_paths(
+    *,
+    engine: str,
+    home: Path,
+    openclaw_workspace: Path,
+) -> tuple[Path, Path, Path, Path]:
+    """Resolve canonical target, backup, ETag, and historical target paths."""
+
+    legacy_target = openclaw_workspace / "skills" / "skills-repo"
+    if engine == "openclaw":
+        # Preserve per-Bot OPENCLAW_WORKSPACE_DIR overrides used by Desktop.
+        pool_root = openclaw_workspace / "skills-pool"
+    else:
+        pool_root = resolve_filesystem_skill_layout(
+            LayoutIdentity(
+                engine_type=engine,
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            ),
+            RuntimeLayoutContext(home=home),
+        ).pool_root
+    return (
+        pool_root / "skills-repo",
+        pool_root / ".skills-repo-backups",
+        pool_root / ".skills-repo-etag",
+        legacy_target,
+    )
+
+
+_DOWNLOAD_ENGINE = normalize(load_engine_config().default_engine)
+try:
+    TARGET_DIR, BACKUP_DIR, ETAG_FILE, LEGACY_TARGET_DIR = _repo_download_paths(
+        engine=_DOWNLOAD_ENGINE,
+        home=Path.home(),
+        openclaw_workspace=workspace_root(),
+    )
+    _DOWNLOAD_LAYOUT_CAPABLE = True
+except SkillLayoutResolutionError:
+    _DOWNLOAD_LAYOUT_CAPABLE = False
+    LEGACY_TARGET_DIR = workspace_root() / "skills" / "skills-repo"
+    _fallback_root = workspace_root() / "skills-pool"
+    TARGET_DIR = _fallback_root / "skills-repo"
+    BACKUP_DIR = _fallback_root / ".skills-repo-backups"
+    ETAG_FILE = _fallback_root / ".skills-repo-etag"
 EXTRACT_TMP_PREFIX = ".skills-repo-extract-"
 BACKUP_RETENTION_DAYS = 7
 MAX_BACKUP_COUNT = 1
 MAX_RETRIES = 3
 BASE_DELAY_SECONDS = 2
 SYNC_INTERVAL_SECONDS = 300  # 5 分钟同步一次
+
+
+def _lexical_target(path: Path) -> Path:
+    target = path.readlink()
+    if not target.is_absolute():
+        target = path.parent / target
+    return Path(os.path.abspath(target))
+
 
 def _is_agentbox_env() -> bool:
     """识别当前是否运行在 agentbox（桌面版）容器内。
@@ -135,7 +193,7 @@ def _is_agentbox_env() -> bool:
     该环境变量。只在 agentbox 内才需要拉取 skills-repo，避免线上容器产
     生临时目录与备份目录的小文件污染。
     """
-    return is_agentbox_runtime()
+    return _DOWNLOAD_LAYOUT_CAPABLE and is_agentbox_runtime()
 
 
 def _cleanup_stale_extract_dirs() -> None:
@@ -255,18 +313,46 @@ def _extract_atomic(tar_path: Path) -> bool:
     else:
         source_dir = Path(extract_tmp)
 
-    # 替换前备份现有仓库
-    _backup_existing_repo()
+    # 替换前备份现有仓库。已有内容无法完成备份时必须保留最后一份可用 corpus。
+    had_existing_repo = TARGET_DIR.exists()
+    had_existing_content = had_existing_repo and any(TARGET_DIR.iterdir())
+    backup_path = _backup_existing_repo()
+    if had_existing_content and backup_path is None:
+        log.error("Existing skills-repo backup failed; preserving current repo")
+        shutil.rmtree(extract_tmp, ignore_errors=True)
+        return False
+    if had_existing_repo and not had_existing_content:
+        try:
+            # rmdir is intentionally conditional: if another writer populated
+            # the directory after the inventory above, preserve its winner.
+            TARGET_DIR.rmdir()
+        except OSError as exc:
+            log.warning(
+                "Empty skills-repo changed before publish; preserving it: %s", exc
+            )
+            shutil.rmtree(extract_tmp, ignore_errors=True)
+            return False
 
     try:
-        # 如果备份失败导致 TARGET_DIR 仍存在，先删掉再搬入新内容
+        # 备份后目标重新出现说明有另一个 updater 赢得发布，不能删除它。
         if TARGET_DIR.exists():
-            shutil.rmtree(TARGET_DIR)
+            log.warning("Skills-repo target reappeared during update; aborting publish")
+            return False
         shutil.move(str(source_dir), str(TARGET_DIR))
         log.info("Atomically swapped skills-repo into %s", TARGET_DIR)
         return True
     except OSError as exc:
         log.error("Failed to swap extracted repo into place: %s", exc)
+        if backup_path is not None and backup_path.is_dir() and not TARGET_DIR.exists():
+            try:
+                os.replace(backup_path, TARGET_DIR)
+                log.info("Restored previous skills-repo after publish failure")
+            except OSError as restore_error:
+                log.error(
+                    "Failed to restore previous skills-repo %s: %s",
+                    backup_path,
+                    restore_error,
+                )
         return False
     finally:
         # 清理临时解压目录（如果我们从里面搬出了一个子目录，
@@ -302,7 +388,9 @@ def download_and_extract(url: str, timeout: int = 300) -> bool:
                             f.write(chunk)
                 break  # 成功，跳出重试循环
             except requests.RequestException as exc:
-                log.warning("Download attempt %d/%d failed: %s", attempt, MAX_RETRIES, exc)
+                log.warning(
+                    "Download attempt %d/%d failed: %s", attempt, MAX_RETRIES, exc
+                )
                 if attempt >= MAX_RETRIES:
                     log.error("All %d download attempts exhausted", MAX_RETRIES)
                     return False
@@ -444,7 +532,9 @@ def _get_download_info() -> tuple[str | None, str | None]:
     )
 
     if not available:
-        log.warning("Meta info indicates skills-repo is not available (available=%s)", available)
+        log.warning(
+            "Meta info indicates skills-repo is not available (available=%s)", available
+        )
         return None, None
 
     if not url:
@@ -473,14 +563,23 @@ def prepare_pool_layout(*, home: Path | None = None) -> None:
         return
     try:
         engine = normalize(load_engine_config().default_engine)
+        repo_source = TARGET_DIR
+        if LEGACY_TARGET_DIR != TARGET_DIR and (
+            LEGACY_TARGET_DIR.exists() or LEGACY_TARGET_DIR.is_symlink()
+        ):
+            legacy_is_canonical_bridge = (
+                LEGACY_TARGET_DIR.is_symlink()
+                and _lexical_target(LEGACY_TARGET_DIR) == TARGET_DIR
+            )
+            if not legacy_is_canonical_bridge:
+                repo_source = LEGACY_TARGET_DIR
         result = prepare_desktop_pool(
             engine=engine,
-            repo_source=TARGET_DIR,
+            repo_source=repo_source,
             home=home or Path.home(),
         )
         log.info(
-            "Desktop skills Pool preparation: status=%s preparation_id=%s "
-            "reason=%s",
+            "Desktop skills Pool preparation: status=%s preparation_id=%s reason=%s",
             result.status.value,
             result.preparation_id,
             result.reason,
@@ -508,22 +607,22 @@ def bootstrap_on_startup() -> None:
 
     if not _is_agentbox_env():
         log.info(
-            "Skills-repo bootstrap skipped: not running in agentbox "
-            "(%s != true)",
+            "Skills-repo bootstrap skipped: not running in agentbox (%s != true)",
             AGENTBOX_ENV_VAR,
         )
         return
 
     log.info("Skills-repo bootstrap starting...")
+    # Upgrade old Desktop storage before the downloader decides which corpus
+    # needs refreshing. Failure is non-fatal and leaves the old runtime intact.
+    prepare_pool_layout()
     url, etag = _get_download_info()
     if not url:
         log.info("No skills-repo URL available — skipping bootstrap download")
-        prepare_pool_layout()
         return
 
     if not _should_download(url, etag):
         log.info("Skills-repo unchanged on startup, skipping download")
-        prepare_pool_layout()
         return
 
     log.info("Skills-repo bootstrap: starting download")
@@ -540,14 +639,13 @@ def bootstrap_on_startup() -> None:
 def _sync_once() -> None:
     """Run one periodic repo refresh and keep Pool preparation in sync."""
 
+    prepare_pool_layout()
     url, etag = _get_download_info()
     if not url:
         log.info("Background sync: no URL available, skipping")
-        prepare_pool_layout()
         return
     if not _should_download(url, etag):
         log.info("Background sync: no changes (ETag match), skipping")
-        prepare_pool_layout()
         return
     log.info("Background sync: downloading latest skills-repo...")
     ok = _download_and_save(url, etag)
@@ -570,8 +668,7 @@ def start_background_sync(interval_seconds: int = SYNC_INTERVAL_SECONDS) -> None
     """
     if not _is_agentbox_env():
         log.info(
-            "Skills-repo background sync skipped: not running in agentbox "
-            "(%s != true)",
+            "Skills-repo background sync skipped: not running in agentbox (%s != true)",
             AGENTBOX_ENV_VAR,
         )
         return

--- a/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/aicoding/layout_pool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from engine.community.plugins.skills_pool.layout_activation import (
@@ -43,17 +43,19 @@ def inspect_aicoding_runtime_layout(
         mapping_contract_version=mapping_contract_version,
         home=home,
         repo_is_mounted=repo_is_mounted,
-)
+    )
 
 
 def publish_aicoding_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="aicoding",
         source_layout=source_layout,
@@ -63,11 +65,13 @@ def publish_aicoding_pool_mappings(
 def verify_aicoding_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="aicoding",
         source_layout=source_layout,

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -58,11 +58,12 @@ class _SkillsPortMixin:
         params: dict[str, Any],
         *,
         source_layout: MappingSourceLayout,
+        key: str = "mappings",
     ) -> ResolvedMappingPayload:
         return resolve_mapping_payload(
             engine="claude_code",
             source_layout=source_layout,
-            payload=params.get("mappings", []),
+            payload=params.get(key, []),
             mapping_contract_version=params.get("mapping_contract_version"),
         )
 
@@ -91,9 +92,7 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             rollback_claude_code_pool,
             rollback_generation=params["rollback_generation"],
-            registered_local_names=list(
-                params.get("registered_local_names", [])
-            ),
+            registered_local_names=list(params.get("registered_local_names", [])),
         )
         return result.to_data()
 
@@ -133,18 +132,28 @@ class _SkillsPortMixin:
                 )
             ),
         )
-        result = await asyncio.to_thread(
-            publish_claude_code_pool_mappings,
-            mappings=list(resolved.mappings),
+        retired = self._pool_mappings(
+            params,
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
+            key="retired_mappings",
+        )
+        publish_kwargs: dict[str, Any] = {
+            "mappings": list(resolved.mappings),
+            "source_layout": MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
+        }
+        if retired.mappings:
+            publish_kwargs["retired_mappings"] = list(retired.mappings)
+        result = await asyncio.to_thread(
+            publish_claude_code_pool_mappings,
+            **publish_kwargs,
         )
         data = result.to_data()
         if result.published and resolved.resolved_locators:
-            data["evidence"]["resolved_mappings"] = list(
-                resolved.resolved_locators
-            )
+            data["evidence"]["resolved_mappings"] = list(resolved.resolved_locators)
         return data
 
     async def verify_pool_mappings(
@@ -160,18 +169,28 @@ class _SkillsPortMixin:
                 )
             ),
         )
-        result = await asyncio.to_thread(
-            verify_claude_code_pool_mappings,
-            mappings=list(resolved.mappings),
+        retired = self._pool_mappings(
+            params,
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
+            key="retired_mappings",
+        )
+        verify_kwargs: dict[str, Any] = {
+            "mappings": list(resolved.mappings),
+            "source_layout": MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
+        }
+        if retired.mappings:
+            verify_kwargs["retired_mappings"] = list(retired.mappings)
+        result = await asyncio.to_thread(
+            verify_claude_code_pool_mappings,
+            **verify_kwargs,
         )
         data = result.to_data()
         if result.valid and resolved.resolved_locators:
-            data["evidence"]["resolved_mappings"] = list(
-                resolved.resolved_locators
-            )
+            data["evidence"]["resolved_mappings"] = list(resolved.resolved_locators)
         return data
 
     async def skills_list(self, token: str | None = None) -> list[dict]:

--- a/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
@@ -8,7 +8,7 @@ engine-view seam to its plugin.
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from engine.community.plugins.skills_pool.layout_activation import (
@@ -54,11 +54,13 @@ def inspect_claude_code_runtime_layout(
 def publish_claude_code_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="claude_code",
         source_layout=source_layout,
@@ -68,11 +70,13 @@ def publish_claude_code_pool_mappings(
 def verify_claude_code_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="claude_code",
         source_layout=source_layout,

--- a/src/engine/src/engine/community/plugins/hermes/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/hermes/layout_pool.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from engine.community.plugins.skills_pool.layout_activation import (
@@ -49,11 +49,13 @@ def inspect_hermes_runtime_layout(
 def publish_hermes_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingPublishResult:
     return _publish_pool_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="hermes",
         source_layout=source_layout,
@@ -63,11 +65,13 @@ def publish_hermes_pool_mappings(
 def verify_hermes_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
     home: str | Path = "/home/admin",
 ) -> MappingVerificationResult:
     return _verify_skill_mappings(
         mappings=mappings,
+        retired_mappings=retired_mappings,
         home=home,
         engine="hermes",
         source_layout=source_layout,

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -2,6 +2,7 @@
 
 Also contains _SkillsEnsureError (relocated from engines/openclaw/skills.py).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -63,11 +64,12 @@ class _SkillsPortMixin:
         params: dict[str, Any],
         *,
         source_layout: MappingSourceLayout,
+        key: str = "mappings",
     ) -> ResolvedMappingPayload:
         return resolve_mapping_payload(
             engine="openclaw",
             source_layout=source_layout,
-            payload=params.get("mappings", []),
+            payload=params.get(key, []),
             mapping_contract_version=params.get("mapping_contract_version"),
         )
 
@@ -78,9 +80,7 @@ class _SkillsPortMixin:
             activate_openclaw_pool,
             migration_generation=params["migration_generation"],
             preparation_id=params["preparation_id"],
-            registered_local_names=list(
-                params.get("registered_local_names", [])
-            ),
+            registered_local_names=list(params.get("registered_local_names", [])),
             mappings=list(
                 self._pool_mappings(
                     params,
@@ -96,15 +96,11 @@ class _SkillsPortMixin:
         result = await asyncio.to_thread(
             rollback_openclaw_pool,
             rollback_generation=params["rollback_generation"],
-            registered_local_names=list(
-                params.get("registered_local_names", [])
-            ),
+            registered_local_names=list(params.get("registered_local_names", [])),
         )
         return PoolLayoutActivationPortResult(**result.to_data())
 
-    async def cleanup_pool_quarantine(
-        self, params: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def cleanup_pool_quarantine(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await asyncio.to_thread(
             cleanup_quarantine,
             engine="openclaw",
@@ -113,9 +109,7 @@ class _SkillsPortMixin:
         )
         return result.to_data()
 
-    async def probe_pool_layout(
-        self, params: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def probe_pool_layout(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await asyncio.to_thread(
             inspect_runtime_layout,
             engine="openclaw",
@@ -124,9 +118,7 @@ class _SkillsPortMixin:
         )
         return result.to_data()
 
-    async def publish_pool_mappings(
-        self, params: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def publish_pool_mappings(self, params: dict[str, Any]) -> dict[str, Any]:
         resolved = self._pool_mappings(
             params,
             source_layout=MappingSourceLayout(
@@ -136,23 +128,31 @@ class _SkillsPortMixin:
                 )
             ),
         )
-        result = await asyncio.to_thread(
-            publish_pool_mappings,
-            mappings=list(resolved.mappings),
+        retired = self._pool_mappings(
+            params,
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
+            key="retired_mappings",
+        )
+        publish_kwargs: dict[str, Any] = {
+            "mappings": list(resolved.mappings),
+            "source_layout": MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
+        }
+        if retired.mappings:
+            publish_kwargs["retired_mappings"] = list(retired.mappings)
+        result = await asyncio.to_thread(
+            publish_pool_mappings,
+            **publish_kwargs,
         )
         data = result.to_data()
         if result.published and resolved.resolved_locators:
-            data["evidence"]["resolved_mappings"] = list(
-                resolved.resolved_locators
-            )
+            data["evidence"]["resolved_mappings"] = list(resolved.resolved_locators)
         return data
 
-    async def verify_pool_mappings(
-        self, params: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def verify_pool_mappings(self, params: dict[str, Any]) -> dict[str, Any]:
         resolved = self._pool_mappings(
             params,
             source_layout=MappingSourceLayout(
@@ -162,18 +162,28 @@ class _SkillsPortMixin:
                 )
             ),
         )
-        result = await asyncio.to_thread(
-            verify_skill_mappings,
-            mappings=list(resolved.mappings),
+        retired = self._pool_mappings(
+            params,
             source_layout=MappingSourceLayout(
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
+            key="retired_mappings",
+        )
+        verify_kwargs: dict[str, Any] = {
+            "mappings": list(resolved.mappings),
+            "source_layout": MappingSourceLayout(
+                params.get("source_layout", MappingSourceLayout.POOL.value)
+            ),
+        }
+        if retired.mappings:
+            verify_kwargs["retired_mappings"] = list(retired.mappings)
+        result = await asyncio.to_thread(
+            verify_skill_mappings,
+            **verify_kwargs,
         )
         data = result.to_data()
         if result.valid and resolved.resolved_locators:
-            data["evidence"]["resolved_mappings"] = list(
-                resolved.resolved_locators
-            )
+            data["evidence"]["resolved_mappings"] = list(resolved.resolved_locators)
         return data
 
     def _skills_resolve_base_dir(self) -> Path:
@@ -183,7 +193,8 @@ class _SkillsPortMixin:
         ``engines/openclaw/skills.py:OpenClawSkillsService._resolve_base_dir``.
         """
         base = os.getenv(
-            self._SKILLS_LINK_BASE_DIR_ENV, self._DEFAULT_SKILLS_LINK_BASE_DIR,
+            self._SKILLS_LINK_BASE_DIR_ENV,
+            self._DEFAULT_SKILLS_LINK_BASE_DIR,
         ).strip()
         if not base:
             base = self._DEFAULT_SKILLS_LINK_BASE_DIR
@@ -194,10 +205,9 @@ class _SkillsPortMixin:
     def _get_ensure_lock(cls, key: str) -> Any:
         import asyncio as _asyncio
         from collections import defaultdict
+
         if not hasattr(cls, "_skills_ensure_locks_store"):
-            cls._skills_ensure_locks_store: dict[str, Any] = defaultdict(
-                _asyncio.Lock
-            )
+            cls._skills_ensure_locks_store: dict[str, Any] = defaultdict(_asyncio.Lock)
         return cls._skills_ensure_locks_store[key]
 
     @staticmethod
@@ -340,12 +350,17 @@ class _SkillsPortMixin:
         ``engines/openclaw/skills.py:OpenClawSkillsService.ensure_center_skills``.
         """
         log.info("[skills.ensure] start")
-        nas_root = Path(os.environ.get(
-            self._SKILLS_CENTER_NAS_ROOT_ENV, self._DEFAULT_SKILLS_CENTER_NAS_ROOT
-        ))
-        local_root = Path(os.environ.get(
-            self._SKILLS_CENTER_LOCAL_ROOT_ENV, self._DEFAULT_SKILLS_CENTER_LOCAL_ROOT
-        ))
+        nas_root = Path(
+            os.environ.get(
+                self._SKILLS_CENTER_NAS_ROOT_ENV, self._DEFAULT_SKILLS_CENTER_NAS_ROOT
+            )
+        )
+        local_root = Path(
+            os.environ.get(
+                self._SKILLS_CENTER_LOCAL_ROOT_ENV,
+                self._DEFAULT_SKILLS_CENTER_LOCAL_ROOT,
+            )
+        )
 
         ok: list[dict[str, Any]] = []
         failed: list[dict[str, Any]] = []
@@ -360,17 +375,23 @@ class _SkillsPortMixin:
                 # (→ HTTP 500) rather than being silently logged as failures.
                 log.warning(
                     "[skills.ensure] failed uuid=%s ver=%s: %s",
-                    item.get("skill_uuid"), item.get("version"), e,
+                    item.get("skill_uuid"),
+                    item.get("version"),
+                    e,
                 )
-                failed.append({
-                    "skill_uuid": item.get("skill_uuid", ""),
-                    "version": item.get("version", ""),
-                    "reason": str(e),
-                })
+                failed.append(
+                    {
+                        "skill_uuid": item.get("skill_uuid", ""),
+                        "version": item.get("version", ""),
+                        "reason": str(e),
+                    }
+                )
 
         log.info(
             "[skills.ensure] done total=%d ok=%d failed=%d",
-            len(params.get("items", [])), len(ok), len(failed),
+            len(params.get("items", [])),
+            len(ok),
+            len(failed),
         )
         return {"ok": ok, "failed": failed}
 
@@ -437,7 +458,11 @@ class _SkillsPortMixin:
 
         log.info(
             "[skills.symlink] sync done total=%d created=%d updated=%d kept=%d removed=%d",
-            len(desired), len(created), len(updated), len(kept), len(removed),
+            len(desired),
+            len(created),
+            len(updated),
+            len(kept),
+            len(removed),
         )
         return {
             "total": len(desired),
@@ -462,7 +487,8 @@ class _SkillsPortMixin:
         clean_target_dir = params.get("clean_target_dir", True)
         log.info(
             "[skills.bindpath] start sync requested_count=%d clean_target_dir=%s",
-            len(requested), clean_target_dir,
+            len(requested),
+            clean_target_dir,
         )
 
         desired: dict[Path, Path] = {}
@@ -479,7 +505,10 @@ class _SkillsPortMixin:
             target = _convert_path(str(target_raw))
             log.info(
                 "[skills.bindpath] item source_raw=%s → %s target_raw=%s → %s",
-                source_raw, source, target_raw, target,
+                source_raw,
+                source,
+                target_raw,
+                target,
             )
             if target in desired:
                 raise ValueError(f"target 重复: {target}")
@@ -535,7 +564,11 @@ class _SkillsPortMixin:
 
         log.info(
             "[skills.bindpath] sync done total=%d created=%d updated=%d kept=%d removed=%d",
-            len(desired), len(created), len(updated), len(kept), len(removed),
+            len(desired),
+            len(created),
+            len(updated),
+            len(kept),
+            len(removed),
         )
         return {
             "total": len(desired),
@@ -565,7 +598,8 @@ class _SkillsPortMixin:
             dir_path = _convert_path(str(dir_raw))
             log.info(
                 "[skills.clean] dir_raw=%s → %s",
-                dir_raw, dir_path,
+                dir_raw,
+                dir_path,
             )
             if not dir_path.is_dir():
                 continue
@@ -577,6 +611,7 @@ class _SkillsPortMixin:
 
         log.info(
             "[skills.clean] scanned=%d removed=%d",
-            directories_scanned, len(removed),
+            directories_scanned,
+            len(removed),
         )
         return {"directories_scanned": directories_scanned, "removed": removed}

--- a/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -63,6 +66,21 @@ def _publish_repo_delivery_bridge(path: Path, source: Path) -> None:
         temporary.unlink(missing_ok=True)
 
 
+@contextmanager
+def _exclusive_directory_lock(path: Path) -> Iterator[None]:
+    """Serialize one local filesystem transition without persistent lock state."""
+
+    directory_fd = os.open(path, os.O_RDONLY)
+    try:
+        fcntl.flock(directory_fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(directory_fd, fcntl.LOCK_UN)
+    finally:
+        os.close(directory_fd)
+
+
 def _canonicalize_downloaded_repo(
     *,
     pool_repo: Path,
@@ -78,6 +96,18 @@ def _canonicalize_downloaded_repo(
     pool_repo = Path(os.path.abspath(pool_repo))
     repo_source = Path(os.path.abspath(repo_source))
     pool_repo.parent.mkdir(parents=True, exist_ok=True)
+    with _exclusive_directory_lock(pool_repo.parent):
+        _canonicalize_downloaded_repo_locked(
+            pool_repo=pool_repo,
+            repo_source=repo_source,
+        )
+
+
+def _canonicalize_downloaded_repo_locked(
+    *,
+    pool_repo: Path,
+    repo_source: Path,
+) -> None:
     if repo_source == pool_repo:
         if not pool_repo.is_dir() or pool_repo.is_symlink():
             raise OSError(f"Canonical Pool repo is not a directory: {pool_repo}")
@@ -101,14 +131,15 @@ def _canonicalize_downloaded_repo(
     try:
         os.replace(repo_source, pool_repo)
         moved_repo = True
-    except FileNotFoundError:
-        if (
-            pool_repo.is_dir()
-            and not pool_repo.is_symlink()
-            and (not repo_source.exists() and not repo_source.is_symlink())
-        ):
-            _publish_repo_delivery_bridge(repo_source, pool_repo)
-            return
+    except OSError as error:
+        if pool_repo.is_dir() and not pool_repo.is_symlink():
+            if repo_source.is_symlink() and _lexical_target(repo_source) == pool_repo:
+                return
+            if isinstance(error, FileNotFoundError) and (
+                not repo_source.exists() and not repo_source.is_symlink()
+            ):
+                _publish_repo_delivery_bridge(repo_source, pool_repo)
+                return
         raise
     try:
         _publish_repo_delivery_bridge(repo_source, pool_repo)
@@ -291,27 +322,28 @@ def prepare_desktop_pool(
             staging_root=staging,
             remove_missing=False,
         )
-        _canonicalize_downloaded_repo(
-            pool_repo=layout.pool_repo,
-            repo_source=repo_source,
-        )
-        if layout.legacy_repo != repo_source:
-            _publish_legacy_repo_bridge(
-                path=layout.legacy_repo,
-                pool_repo=layout.pool_repo,
-                previous_source=repo_source,
+        with _exclusive_directory_lock(layout.pool_repo.parent):
+            _canonicalize_downloaded_repo_locked(
+                pool_repo=Path(os.path.abspath(layout.pool_repo)),
+                repo_source=repo_source,
             )
-        with os.scandir(layout.pool_repo):
-            pass
+            if layout.legacy_repo != repo_source:
+                _publish_legacy_repo_bridge(
+                    path=layout.legacy_repo,
+                    pool_repo=layout.pool_repo,
+                    previous_source=repo_source,
+                )
+            with os.scandir(layout.pool_repo):
+                pass
 
-        structural_bridges = _pre_cutover_structural_bridges(
-            engine=engine,
-            pool_repo=layout.pool_repo,
-            local_bridge=layout.local_bridge,
-            legacy_local=layout.legacy_local,
-            repo_bridge=layout.repo_bridge,
-            legacy_repo=layout.legacy_repo,
-        )
+            structural_bridges = _pre_cutover_structural_bridges(
+                engine=engine,
+                pool_repo=layout.pool_repo,
+                local_bridge=layout.local_bridge,
+                legacy_local=layout.legacy_local,
+                repo_bridge=layout.repo_bridge,
+                legacy_repo=layout.legacy_repo,
+            )
         if any(bridge["valid"] is not True for bridge in structural_bridges):
             raise OSError("pre-cutover structural bridge is invalid")
 

--- a/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
@@ -53,7 +53,7 @@ def _publish_repo_delivery_bridge(path: Path, source: Path) -> None:
     if path.is_symlink() and _lexical_target(path) == source:
         return
     if path.exists() and not path.is_symlink():
-        raise OSError(f"Pool repo entry is not a symlink: {path}")
+        raise OSError(f"Repo compatibility entry is not a symlink: {path}")
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{uuid4().hex}.prepare")
     try:
@@ -63,10 +63,79 @@ def _publish_repo_delivery_bridge(path: Path, source: Path) -> None:
         temporary.unlink(missing_ok=True)
 
 
+def _canonicalize_downloaded_repo(
+    *,
+    pool_repo: Path,
+    repo_source: Path,
+) -> None:
+    """Move one legacy Desktop download into canonical Pool storage.
+
+    The source is replaced by a temporary reverse compatibility bridge. A
+    pre-existing independent Pool tree is never overwritten or merged because
+    that would silently select between two complete corpora.
+    """
+
+    pool_repo = Path(os.path.abspath(pool_repo))
+    repo_source = Path(os.path.abspath(repo_source))
+    pool_repo.parent.mkdir(parents=True, exist_ok=True)
+    if repo_source == pool_repo:
+        if not pool_repo.is_dir() or pool_repo.is_symlink():
+            raise OSError(f"Canonical Pool repo is not a directory: {pool_repo}")
+        return
+    if pool_repo.is_symlink():
+        raise OSError(f"Canonical Pool repo must not be a symlink: {pool_repo}")
+    if pool_repo.exists():
+        if not pool_repo.is_dir():
+            raise OSError(f"Canonical Pool repo is not a directory: {pool_repo}")
+        if repo_source.is_symlink() and _lexical_target(repo_source) == pool_repo:
+            return
+        if not repo_source.exists() and not repo_source.is_symlink():
+            _publish_repo_delivery_bridge(repo_source, pool_repo)
+            return
+        raise OSError("Legacy and Pool repo directories both exist")
+    if repo_source.is_symlink():
+        raise OSError(f"Legacy repo source points elsewhere: {repo_source}")
+    if not repo_source.is_dir():
+        raise OSError(f"Legacy repo source is not a directory: {repo_source}")
+    moved_repo = False
+    try:
+        os.replace(repo_source, pool_repo)
+        moved_repo = True
+    except FileNotFoundError:
+        if (
+            pool_repo.is_dir()
+            and not pool_repo.is_symlink()
+            and (not repo_source.exists() and not repo_source.is_symlink())
+        ):
+            _publish_repo_delivery_bridge(repo_source, pool_repo)
+            return
+        raise
+    try:
+        _publish_repo_delivery_bridge(repo_source, pool_repo)
+    except OSError:
+        if moved_repo and not repo_source.exists() and not repo_source.is_symlink():
+            os.replace(pool_repo, repo_source)
+        raise
+
+
+def _publish_legacy_repo_bridge(
+    *,
+    path: Path,
+    pool_repo: Path,
+    previous_source: Path,
+) -> None:
+    if path.is_symlink() and _lexical_target(path) not in {
+        Path(os.path.abspath(previous_source)),
+        Path(os.path.abspath(pool_repo)),
+    }:
+        raise OSError(f"Legacy repo entry points elsewhere: {path}")
+    _publish_repo_delivery_bridge(path, pool_repo)
+
+
 def _pre_cutover_structural_bridges(
     *,
     engine: str,
-    repo_source: Path,
+    pool_repo: Path,
     local_bridge: Path,
     legacy_local: Path,
     repo_bridge: Path,
@@ -86,18 +155,17 @@ def _pre_cutover_structural_bridges(
                 ),
             }
         )
-        bridges.append(
-            {
-                "name": "legacy_repo_delivery",
-                "path": str(legacy_repo),
-                "target": str(repo_source),
-                "valid": (
-                    legacy_repo.is_symlink()
-                    and _lexical_target(legacy_repo)
-                    == Path(os.path.abspath(repo_source))
-                ),
-            }
-        )
+    bridges.append(
+        {
+            "name": "legacy_repo_delivery",
+            "path": str(legacy_repo),
+            "target": str(pool_repo),
+            "valid": (
+                legacy_repo.is_symlink()
+                and _lexical_target(legacy_repo) == Path(os.path.abspath(pool_repo))
+            ),
+        }
+    )
     if engine == "claude_code":
         bridges.append(
             {
@@ -182,19 +250,6 @@ def prepare_desktop_pool(
         )
 
     repo_source = Path(os.path.abspath(repo_source))
-    try:
-        if not repo_source.is_dir():
-            return DesktopPreparationResult(
-                DesktopPreparationStatus.FAILED,
-                reason="repo_source_not_directory",
-            )
-        with os.scandir(repo_source):
-            pass
-    except OSError:
-        return DesktopPreparationResult(
-            DesktopPreparationStatus.FAILED,
-            reason="repo_source_unreadable",
-        )
 
     existing = inspect_runtime_layout(
         engine=engine,
@@ -225,14 +280,10 @@ def prepare_desktop_pool(
             raise OSError(f"Pool local is not a directory: {layout.pool_local}")
         layout.pool_local.mkdir(exist_ok=True)
         if layout.legacy_local.is_symlink():
-            raise OSError(
-                f"Legacy local is not a directory: {layout.legacy_local}"
-            )
+            raise OSError(f"Legacy local is not a directory: {layout.legacy_local}")
         layout.legacy_local.mkdir(parents=True, exist_ok=True)
         if not layout.legacy_local.is_dir():
-            raise OSError(
-                f"Legacy local is not a directory: {layout.legacy_local}"
-            )
+            raise OSError(f"Legacy local is not a directory: {layout.legacy_local}")
 
         mirror_local_tree(
             source_root=layout.legacy_local,
@@ -240,20 +291,29 @@ def prepare_desktop_pool(
             staging_root=staging,
             remove_missing=False,
         )
-        _publish_repo_delivery_bridge(layout.pool_repo, repo_source)
+        _canonicalize_downloaded_repo(
+            pool_repo=layout.pool_repo,
+            repo_source=repo_source,
+        )
+        if layout.legacy_repo != repo_source:
+            _publish_legacy_repo_bridge(
+                path=layout.legacy_repo,
+                pool_repo=layout.pool_repo,
+                previous_source=repo_source,
+            )
+        with os.scandir(layout.pool_repo):
+            pass
 
         structural_bridges = _pre_cutover_structural_bridges(
             engine=engine,
-            repo_source=repo_source,
+            pool_repo=layout.pool_repo,
             local_bridge=layout.local_bridge,
             legacy_local=layout.legacy_local,
             repo_bridge=layout.repo_bridge,
             legacy_repo=layout.legacy_repo,
         )
         if any(bridge["valid"] is not True for bridge in structural_bridges):
-            raise OSError(
-                "pre-cutover structural bridge is invalid"
-            )
+            raise OSError("pre-cutover structural bridge is invalid")
 
         preparation_id = str(uuid4())
         prepared_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -265,7 +325,7 @@ def prepare_desktop_pool(
             "pool_local_root": str(layout.pool_local),
             "pool_repo_root": str(layout.pool_repo),
             "repo_delivery": RepoDelivery.DOWNLOAD.value,
-            "repo_delivery_source": str(repo_source),
+            "repo_delivery_source": str(layout.pool_repo),
             "validation_summary": {
                 "all_valid": True,
                 "pool_local": {
@@ -274,13 +334,13 @@ def prepare_desktop_pool(
                 },
                 "pool_repo": {
                     "path": str(layout.pool_repo),
-                    "source": str(repo_source),
+                    "source": str(layout.pool_repo),
                     "readable_delivery": True,
                     "valid": True,
                 },
-                "repo_delivery_bridge": {
+                "repo_delivery_root": {
                     "path": str(layout.pool_repo),
-                    "target": str(repo_source),
+                    "actual_directory": True,
                     "valid": True,
                 },
                 "structural_bridges": structural_bridges,
@@ -295,11 +355,7 @@ def prepare_desktop_pool(
                         layout.pool_repo,
                     ),
                 ),
-                **(
-                    {"legacy_bridge_verified": True}
-                    if engine == "hermes"
-                    else {}
-                ),
+                **({"legacy_bridge_verified": True} if engine == "hermes" else {}),
             },
         }
         _write_marker(layout.ready_marker, marker)

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -226,10 +226,7 @@ def _retired_storage_entries(
     entries = [layout.legacy_local, layout.local_bridge]
     if engine == "aicoding":
         entries.append(layout.active_root / "skills-repo")
-    if engine in {"openclaw", "claude_code"} and not (
-        engine == "openclaw"
-        and current_repo_delivery() is RepoDelivery.DOWNLOAD
-    ):
+    if engine in {"openclaw", "claude_code"}:
         entries.append(layout.repo_bridge)
     return tuple(dict.fromkeys(entries))
 
@@ -240,6 +237,15 @@ class _MappingPlan:
     external: tuple[Path, ...]
     failures: tuple[dict[str, str], ...]
     conflicts: tuple[dict[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _MappingRetirementPlan:
+    remove: tuple[Path, ...]
+    absent: tuple[Path, ...]
+    replaced: tuple[Path, ...]
+    external: tuple[Path, ...]
+    failures: tuple[dict[str, str], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -396,9 +402,7 @@ def _restore_legacy_repo_bridge(
     """Restore the descriptor's Legacy repo view after rollback."""
 
     repo_delivery = current_repo_delivery()
-    if repo_delivery is RepoDelivery.DOWNLOAD and engine == "openclaw":
-        return
-    if repo_delivery is RepoDelivery.MOUNT:
+    if repo_delivery is RepoDelivery.MOUNT or engine == "openclaw":
         target = layout.pool_repo
     elif layout.repo_bridge != layout.legacy_repo:
         target = layout.legacy_repo
@@ -510,10 +514,7 @@ def _finalize_active_root(
     repo_delivery = current_repo_delivery()
     if repo_delivery is RepoDelivery.DOWNLOAD and engine in {"aicoding", "hermes"}:
         _publish_structural_bridge(layout.repo_bridge, layout.pool_repo)
-    if engine in {"openclaw", "claude_code"} and not (
-        engine == "openclaw"
-        and repo_delivery is RepoDelivery.DOWNLOAD
-    ):
+    if engine in {"openclaw", "claude_code"}:
         _retire_bridge(
             layout.repo_bridge,
             allowed_targets=(layout.legacy_repo, layout.pool_repo),
@@ -792,6 +793,7 @@ def _mapping_plan(
     layout: _Layout,
     mappings: list[SkillMapping],
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
+    retired_targets: frozenset[Path] = frozenset(),
 ) -> _MappingPlan:
     desired: dict[Path, Path] = {}
     failures: list[dict[str, str]] = []
@@ -850,6 +852,8 @@ def _mapping_plan(
 
     discovered, external, occupied = _active_entry_inventory(layout)
     for target, pool_source in discovered.items():
+        if target in retired_targets:
+            continue
         source = _source_for_layout(
             layout,
             pool_source,
@@ -899,6 +903,134 @@ def _mapping_plan(
         external=external,
         failures=tuple(failures),
         conflicts=tuple(conflicts),
+    )
+
+
+def _mapping_target_invalid(layout: _Layout, target: Path) -> bool:
+    return (
+        not target.is_absolute()
+        or target.parent != layout.active_root
+        or target
+        in {
+            layout.legacy_local,
+            layout.legacy_repo,
+            layout.local_bridge,
+            layout.repo_bridge,
+        }
+        or (
+            layout.engine_type == "aicoding"
+            and target == layout.active_root / "skills-repo"
+        )
+    )
+
+
+def _mapping_source_outside_layout(
+    layout: _Layout,
+    source: Path,
+    *,
+    source_layout: MappingSourceLayout,
+) -> bool:
+    roots = (
+        (layout.legacy_local, layout.legacy_repo)
+        if source_layout is MappingSourceLayout.LEGACY
+        else (layout.pool_local, layout.pool_repo)
+    )
+    normalized = Path(os.path.abspath(source))
+    return not any(
+        normalized.is_relative_to(Path(os.path.abspath(root))) for root in roots
+    )
+
+
+def _retirement_plan(
+    *,
+    layout: _Layout,
+    mappings: list[SkillMapping],
+    retired_mappings: list[SkillMapping],
+    source_layout: MappingSourceLayout,
+) -> _MappingRetirementPlan:
+    """Validate exact managed identities that may be removed.
+
+    Retirement is deliberately narrower than full-set cleanup: an entry is
+    removed only while it still points lexically to the exact old managed
+    source. Filesystem-only managed entries and external symlinks remain
+    outside Backend product-state authority.
+    """
+
+    desired = {
+        Path(item.target): Path(os.path.abspath(Path(item.source)))
+        for item in mappings
+        if Path(item.target).is_absolute()
+    }
+    remove: list[Path] = []
+    absent: list[Path] = []
+    replaced: list[Path] = []
+    external: list[Path] = []
+    failures: list[dict[str, str]] = []
+    seen: dict[Path, Path] = {}
+    for mapping in retired_mappings:
+        source_input = Path(mapping.source)
+        source = Path(os.path.abspath(source_input))
+        target = Path(mapping.target)
+        reason = ""
+        if not source_input.is_absolute() or _mapping_source_outside_layout(
+            layout,
+            source,
+            source_layout=source_layout,
+        ):
+            reason = (
+                "source_outside_legacy"
+                if source_layout is MappingSourceLayout.LEGACY
+                else "source_outside_pool"
+            )
+        elif _mapping_target_invalid(layout, target):
+            reason = "target_invalid"
+        elif target in seen and seen[target] != source:
+            reason = "retired_target_ambiguous"
+        if reason:
+            failures.append(
+                {"source": str(source), "target": str(target), "reason": reason}
+            )
+            continue
+        seen[target] = source
+        if desired.get(target) == source:
+            replaced.append(target)
+            continue
+        if not target.exists() and not target.is_symlink():
+            absent.append(target)
+            continue
+        if not target.is_symlink():
+            failures.append(
+                {
+                    "source": str(source),
+                    "target": str(target),
+                    "reason": "retired_target_occupied",
+                }
+            )
+            continue
+        current = _lexical_target(target)
+        if current == source:
+            remove.append(target)
+            continue
+        if _canonical_pool_source(layout, current) is None:
+            external.append(target)
+            continue
+        if desired.get(target) == current:
+            replaced.append(target)
+            continue
+        failures.append(
+            {
+                "source": str(source),
+                "target": str(target),
+                "existing_source": str(current),
+                "reason": "retired_target_identity_mismatch",
+            }
+        )
+    return _MappingRetirementPlan(
+        remove=tuple(remove),
+        absent=tuple(absent),
+        replaced=tuple(replaced),
+        external=tuple(external),
+        failures=tuple(failures),
     )
 
 
@@ -2143,6 +2275,7 @@ def rollback_hermes_pool(
 def verify_skill_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
@@ -2150,12 +2283,24 @@ def verify_skill_mappings(
     """验证受管激活入口精确解析到声明 layout 的 source。"""
 
     layout = _Layout.for_engine(engine, Path(home))
+    retirement = _retirement_plan(
+        layout=layout,
+        mappings=mappings,
+        retired_mappings=list(retired_mappings),
+        source_layout=source_layout,
+    )
     plan = _mapping_plan(
         layout=layout,
         mappings=mappings,
         source_layout=source_layout,
+        retired_targets=frozenset(Path(item.target) for item in retired_mappings),
     )
     failures: list[dict[str, str]] = []
+    failures.extend(retirement.failures)
+    for target in retirement.remove:
+        failures.append(
+            {"target": str(target), "reason": "retired_target_still_present"}
+        )
     failures.extend(plan.failures)
     for conflict in plan.conflicts:
         failures.append({**conflict, "reason": "managed_source_conflict"})
@@ -2175,6 +2320,8 @@ def verify_skill_mappings(
             "checked": len(mappings),
             "managed_checked": len(plan.managed),
             "external_ignored": len(plan.external),
+            "retired_checked": len(retired_mappings),
+            "retired_external_ignored": len(retirement.external),
             "failures": failures,
         },
     )
@@ -2183,6 +2330,7 @@ def verify_skill_mappings(
 def publish_pool_mappings(
     *,
     mappings: list[SkillMapping],
+    retired_mappings: Sequence[SkillMapping] = (),
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
@@ -2190,10 +2338,17 @@ def publish_pool_mappings(
     """按声明 layout 对齐全部受管 mapping，并保留外部入口。"""
 
     layout = _Layout.for_engine(engine, Path(home))
+    retirement = _retirement_plan(
+        layout=layout,
+        mappings=mappings,
+        retired_mappings=list(retired_mappings),
+        source_layout=source_layout,
+    )
     plan = _mapping_plan(
         layout=layout,
         mappings=mappings,
         source_layout=source_layout,
+        retired_targets=frozenset(Path(item.target) for item in retired_mappings),
     )
     if plan.conflicts:
         return MappingPublishResult(
@@ -2201,6 +2356,14 @@ def publish_pool_mappings(
             evidence={
                 "reason": "managed_active_entry_conflict",
                 "conflicts": list(plan.conflicts),
+            },
+        )
+    if retirement.failures:
+        return MappingPublishResult(
+            published=False,
+            evidence={
+                "reason": "retired_mapping_invalid",
+                "failures": list(retirement.failures),
             },
         )
     if plan.failures:
@@ -2217,6 +2380,9 @@ def publish_pool_mappings(
     kept: list[str] = []
     removed: list[str] = []
     try:
+        for target in retirement.remove:
+            target.unlink()
+            removed.append(str(target))
         for target, source in plan.managed.items():
             if target.is_symlink():
                 if _lexical_target(target) == Path(os.path.abspath(source)):
@@ -2254,6 +2420,9 @@ def publish_pool_mappings(
             "kept": kept,
             "removed": removed,
             "external_ignored": [str(path) for path in plan.external],
+            "retired_absent": [str(path) for path in retirement.absent],
+            "retired_replaced": [str(path) for path in retirement.replaced],
+            "retired_external_ignored": [str(path) for path in retirement.external],
         },
     )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -206,17 +206,16 @@ def _marker_contract_valid(
         return False
     if repo_delivery is RepoDelivery.DOWNLOAD:
         delivery_source = marker.get("repo_delivery_source")
-        delivery_bridge = summary.get("repo_delivery_bridge")
+        delivery_root = summary.get("repo_delivery_root")
         delivery_valid = (
             marker.get("repo_delivery") == RepoDelivery.DOWNLOAD.value
-            and isinstance(delivery_source, str)
-            and bool(delivery_source)
+            and delivery_source == str(layout.pool_repo)
             and pool_repo.get("readable_delivery") is True
             and pool_repo.get("source") == delivery_source
-            and isinstance(delivery_bridge, dict)
-            and delivery_bridge.get("path") == str(layout.pool_repo)
-            and delivery_bridge.get("target") == delivery_source
-            and delivery_bridge.get("valid") is True
+            and isinstance(delivery_root, dict)
+            and delivery_root.get("path") == str(layout.pool_repo)
+            and delivery_root.get("actual_directory") is True
+            and delivery_root.get("valid") is True
         )
         if not delivery_valid:
             return False
@@ -230,14 +229,14 @@ def _marker_contract_valid(
                     "valid": True,
                 }
             )
-            expected_bridges.append(
-                {
-                    "name": "legacy_repo_delivery",
-                    "path": str(layout.legacy_repo),
-                    "target": delivery_source,
-                    "valid": True,
-                }
-            )
+        expected_bridges.append(
+            {
+                "name": "legacy_repo_delivery",
+                "path": str(layout.legacy_repo),
+                "target": str(layout.pool_repo),
+                "valid": True,
+            }
+        )
         if expected_engine == "claude_code":
             expected_bridges.append(
                 {
@@ -606,11 +605,10 @@ def inspect_runtime_layout(
             )
     else:
         try:
-            delivery_source = Path(str(marker["repo_delivery_source"]))
             pool_repo_delivered = (
-                layout.pool_repo.is_symlink()
-                and _lexical_symlink_target(layout.pool_repo)
-                == Path(os.path.abspath(delivery_source))
+                layout.pool_repo.is_dir()
+                and not layout.pool_repo.is_symlink()
+                and marker.get("repo_delivery_source") == str(layout.pool_repo)
             )
         except OSError as error:
             return _transient(
@@ -830,17 +828,12 @@ def inspect_runtime_layout(
             ),
         )
     if effective_repo_delivery is RepoDelivery.DOWNLOAD:
-        required_bridges = []
+        required_bridges = [
+            ("legacy_repo_delivery", layout.legacy_repo, layout.pool_repo)
+        ]
         if engine != "openclaw":
-            required_bridges.append(
-                ("stable_local", layout.local_bridge, layout.legacy_local)
-            )
-            required_bridges.append(
-                (
-                    "legacy_repo_delivery",
-                    layout.legacy_repo,
-                    Path(str(marker["repo_delivery_source"])),
-                )
+            required_bridges.insert(
+                0, ("stable_local", layout.local_bridge, layout.legacy_local)
             )
         if engine == "claude_code":
             required_bridges.append(

--- a/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.community.plugins.skills_pool.layout_activation import (
+    SkillMapping,
+    _Layout,
+    publish_pool_mappings,
+    verify_skill_mappings,
+)
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+def test_retired_product_mapping_is_removed_without_touching_other_entries(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+
+    keep_source = layout.pool_local / "keep"
+    retired_source = layout.pool_local / "retired"
+    filesystem_only_source = layout.pool_local / "filesystem-only"
+    for source in (keep_source, retired_source, filesystem_only_source):
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text(source.name)
+
+    keep_target = layout.active_root / "keep"
+    retired_target = layout.active_root / "retired"
+    filesystem_only_target = layout.active_root / "filesystem-only"
+    keep_target.symlink_to(keep_source, target_is_directory=True)
+    retired_target.symlink_to(retired_source, target_is_directory=True)
+    filesystem_only_target.symlink_to(
+        filesystem_only_source,
+        target_is_directory=True,
+    )
+
+    external_source = tmp_path / "external"
+    external_source.mkdir()
+    external_target = layout.active_root / "external"
+    external_target.symlink_to(external_source, target_is_directory=True)
+
+    desired = [SkillMapping(str(keep_source), str(keep_target))]
+    retired = [SkillMapping(str(retired_source), str(retired_target))]
+
+    published = publish_pool_mappings(
+        mappings=desired,
+        retired_mappings=retired,
+        home=home,
+        engine=engine,
+    )
+    verified = verify_skill_mappings(
+        mappings=desired,
+        retired_mappings=retired,
+        home=home,
+        engine=engine,
+    )
+
+    assert published.published
+    assert published.evidence["removed"] == [str(retired_target)]
+    assert verified.valid
+    assert not retired_target.exists()
+    assert not retired_target.is_symlink()
+    assert filesystem_only_target.readlink() == filesystem_only_source
+    assert external_target.readlink() == external_source
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+def test_retired_mapping_allows_same_name_product_replacement(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+    old_source = layout.pool_repo / "old" / "shared"
+    new_source = layout.pool_repo / "new" / "shared"
+    old_source.mkdir(parents=True)
+    new_source.mkdir(parents=True)
+    target = layout.active_root / "shared"
+    target.symlink_to(old_source, target_is_directory=True)
+
+    published = publish_pool_mappings(
+        mappings=[SkillMapping(str(new_source), str(target))],
+        retired_mappings=[SkillMapping(str(old_source), str(target))],
+        home=home,
+        engine=engine,
+    )
+    verified = verify_skill_mappings(
+        mappings=[SkillMapping(str(new_source), str(target))],
+        retired_mappings=[SkillMapping(str(old_source), str(target))],
+        home=home,
+        engine=engine,
+    )
+
+    assert published.published
+    assert target.readlink() == new_source
+    assert verified.valid
+
+
+def test_invalid_retired_mapping_fails_before_desired_mapping_mutation(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home" / "admin"
+    layout = _Layout.for_engine("openclaw", home)
+    layout.active_root.mkdir(parents=True)
+    source = layout.pool_local / "keep"
+    source.mkdir(parents=True)
+    target = layout.active_root / "keep"
+    old_target = tmp_path / "outside-active-root"
+
+    published = publish_pool_mappings(
+        mappings=[SkillMapping(str(source), str(target))],
+        retired_mappings=[SkillMapping(str(source), str(old_target))],
+        home=home,
+        engine="openclaw",
+    )
+
+    assert not published.published
+    assert published.evidence["reason"] == "retired_mapping_invalid"
+    assert not target.exists()
+    assert not target.is_symlink()
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+def test_absent_retired_mapping_is_idempotent(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+    old_source = layout.pool_local / "old"
+    old_source.mkdir(parents=True)
+    retired = SkillMapping(
+        str(old_source),
+        str(layout.active_root / "old"),
+    )
+
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=[retired],
+        home=home,
+        engine=engine,
+    )
+    verified = verify_skill_mappings(
+        mappings=[],
+        retired_mappings=[retired],
+        home=home,
+        engine=engine,
+    )
+
+    assert published.published
+    assert verified.valid
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+def test_retired_target_rebound_to_external_is_preserved(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+    old_source = layout.pool_local / "old"
+    old_source.mkdir(parents=True)
+    external_source = tmp_path / "external"
+    external_source.mkdir()
+    target = layout.active_root / "old"
+    target.symlink_to(external_source, target_is_directory=True)
+
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=[SkillMapping(str(old_source), str(target))],
+        home=home,
+        engine=engine,
+    )
+
+    assert published.published
+    assert target.is_symlink()
+    assert target.readlink() == external_source
+
+
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+def test_retired_target_rebound_to_other_managed_identity_fails_before_mutation(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine(engine, home)
+    layout.active_root.mkdir(parents=True)
+    old_source = layout.pool_local / "old"
+    other_source = layout.pool_local / "other"
+    desired_source = layout.pool_local / "desired"
+    for source in (old_source, other_source, desired_source):
+        source.mkdir(parents=True)
+    retired_target = layout.active_root / "old"
+    retired_target.symlink_to(other_source, target_is_directory=True)
+    desired_target = layout.active_root / "desired"
+
+    published = publish_pool_mappings(
+        mappings=[SkillMapping(str(desired_source), str(desired_target))],
+        retired_mappings=[
+            SkillMapping(str(old_source), str(retired_target))
+        ],
+        home=home,
+        engine=engine,
+    )
+
+    assert not published.published
+    assert published.evidence["reason"] == "retired_mapping_invalid"
+    assert retired_target.is_symlink()
+    assert retired_target.readlink() == other_source
+    assert not desired_target.exists()

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -166,6 +166,11 @@ async def test_claude_code_adapter_propagates_logical_mapping_version() -> None:
         relative_path="business/reviewer",
         link_name="reviewer",
     )
+    retired_mapping = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="legacy/writer",
+        link_name="writer",
+    )
     version = "skills-pool-mapping-v2"
 
     await adapter.activate_pool_layout(
@@ -178,10 +183,12 @@ async def test_claude_code_adapter_propagates_logical_mapping_version() -> None:
     )
     await adapter.publish_pool_mappings(
         [mapping],
+        retired_mappings=[retired_mapping],
         mapping_contract_version=version,
     )
     await adapter.verify_pool_mappings(
         [mapping],
+        retired_mappings=[retired_mapping],
         mapping_contract_version=version,
     )
 
@@ -190,17 +197,24 @@ async def test_claude_code_adapter_propagates_logical_mapping_version() -> None:
         "relative_path": "business/reviewer",
         "link_name": "reviewer",
     }
+    expected_retired_mapping = {
+        "corpus": "repo",
+        "relative_path": "legacy/writer",
+        "link_name": "writer",
+    }
     activation = port.activate_pool_layout.await_args.args[0]
     assert activation["mapping_contract_version"] == version
     assert activation["mappings"] == [expected_mapping]
     assert port.publish_pool_mappings.await_args.args[0] == {
         "mapping_contract_version": version,
         "mappings": [expected_mapping],
+        "retired_mappings": [expected_retired_mapping],
         "source_layout": "pool",
     }
     assert port.verify_pool_mappings.await_args.args[0] == {
         "mapping_contract_version": version,
         "mappings": [expected_mapping],
+        "retired_mappings": [expected_retired_mapping],
         "source_layout": "pool",
     }
 

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -180,14 +180,17 @@ async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
     port.publish_pool_mappings = AsyncMock(
         return_value={"published": True, "evidence": {}}
     )
-    port.verify_pool_mappings = AsyncMock(
-        return_value={"valid": True, "evidence": {}}
-    )
+    port.verify_pool_mappings = AsyncMock(return_value={"valid": True, "evidence": {}})
     adapter = OpenClawSkillsAdapter(port)
     mapping = PoolSkillMappingIntent(
         corpus="repo",
         relative_path="business/reviewer",
         link_name="reviewer",
+    )
+    retired_mapping = PoolSkillMappingIntent(
+        corpus="repo",
+        relative_path="legacy/writer",
+        link_name="writer",
     )
     version = "skills-pool-mapping-v2"
 
@@ -201,10 +204,12 @@ async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
     )
     await adapter.publish_pool_mappings(
         [mapping],
+        retired_mappings=[retired_mapping],
         mapping_contract_version=version,
     )
     await adapter.verify_pool_mappings(
         [mapping],
+        retired_mappings=[retired_mapping],
         mapping_contract_version=version,
     )
 
@@ -212,6 +217,11 @@ async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
         "corpus": "repo",
         "relative_path": "business/reviewer",
         "link_name": "reviewer",
+    }
+    expected_retired_mapping = {
+        "corpus": "repo",
+        "relative_path": "legacy/writer",
+        "link_name": "writer",
     }
     assert port.activate_pool_layout.await_args.args[0] == {
         "migration_generation": "generation-1",
@@ -223,11 +233,13 @@ async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
     assert port.publish_pool_mappings.await_args.args[0] == {
         "mapping_contract_version": version,
         "mappings": [expected_mapping],
+        "retired_mappings": [expected_retired_mapping],
         "source_layout": "pool",
     }
     assert port.verify_pool_mappings.await_args.args[0] == {
         "mapping_contract_version": version,
         "mappings": [expected_mapping],
+        "retired_mappings": [expected_retired_mapping],
         "source_layout": "pool",
     }
 
@@ -238,9 +250,7 @@ async def test_openclaw_adapter_keeps_unversioned_physical_mapping() -> None:
     port.publish_pool_mappings = AsyncMock(
         return_value={"published": True, "evidence": {}}
     )
-    port.verify_pool_mappings = AsyncMock(
-        return_value={"valid": True, "evidence": {}}
-    )
+    port.verify_pool_mappings = AsyncMock(return_value={"valid": True, "evidence": {}})
     adapter = OpenClawSkillsAdapter(port)
     mapping = SymlinkItem(source="/pool/writer", target="/active/writer")
 
@@ -248,9 +258,7 @@ async def test_openclaw_adapter_keeps_unversioned_physical_mapping() -> None:
     await adapter.verify_pool_mappings([mapping])
 
     expected = {
-        "mappings": [
-            {"source": "/pool/writer", "target": "/active/writer"}
-        ],
+        "mappings": [{"source": "/pool/writer", "target": "/active/writer"}],
         "source_layout": "pool",
     }
     port.publish_pool_mappings.assert_awaited_once_with(expected)

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
@@ -122,14 +122,19 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
     )
 
     assert activated.status is PoolActivationStatus.COMMITTED
-    assert (repo_source / "business/reviewer/SKILL.md").read_text() == "repo"
-    assert layout.pool_repo.is_symlink()
-    assert _target(layout.pool_repo) == repo_source
+    assert (layout.pool_repo / "business/reviewer/SKILL.md").read_text() == (
+        "repo"
+    )
+    assert layout.pool_repo.is_dir()
+    assert not layout.pool_repo.is_symlink()
     assert _target(layout.active_root / "handmade") == (
         layout.pool_local / "handmade"
     )
     if engine in {"aicoding", "hermes"}:
         assert _target(layout.repo_bridge) == layout.pool_repo
+    else:
+        assert not layout.repo_bridge.exists()
+        assert not layout.repo_bridge.is_symlink()
     active = inspect_runtime_layout(
         engine=engine,
         home=home,
@@ -164,6 +169,8 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
     assert rolled_back.status is PoolActivationStatus.COMMITTED
     assert (layout.legacy_local / "handmade/SKILL.md").read_text() == "pool"
     assert (repo_source / "business/reviewer/SKILL.md").read_text() == "repo"
+    assert repo_source.is_symlink()
+    assert _target(repo_source) == layout.pool_repo
     legacy_ready = inspect_runtime_layout(
         engine=engine,
         home=home,

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import tarfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
@@ -16,6 +17,7 @@ from engine.community.core.skills.layout_planner import (
     resolve_filesystem_skill_layout,
 )
 from engine.community.plugins.skills_pool import desktop_preparation
+from engine.community.core.skills import skills_repo_download
 from engine.community.plugins.skills_pool.desktop_preparation import (
     DesktopPreparationStatus,
     prepare_desktop_pool,
@@ -23,6 +25,13 @@ from engine.community.plugins.skills_pool.desktop_preparation import (
 from engine.community.plugins.skills_pool.layout_probe import (
     RuntimeLayoutInspectionStatus,
     inspect_runtime_layout,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    PoolActivationStatus,
+    SkillMapping,
+    activate_claude_code_pool,
+    activate_hermes_pool,
+    activate_openclaw_pool,
 )
 
 FILESYSTEM_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
@@ -168,11 +177,6 @@ def test_preparation_reuses_downloaded_repo_and_preserves_legacy_layout(
 ) -> None:
     home = tmp_path / "home/admin"
     layout, repo_source, managed, external = _legacy_runtime(home, engine)
-    repo_bridge_before = (
-        _target(layout.repo_bridge)
-        if layout.repo_bridge.is_symlink()
-        else layout.repo_bridge
-    )
     managed_before = _target(managed)
     external_before = _target(external)
 
@@ -186,20 +190,23 @@ def test_preparation_reuses_downloaded_repo_and_preserves_legacy_layout(
     assert result.preparation_id is not None
     assert (layout.pool_local / "registered/SKILL.md").read_text() == "registered"
     assert (layout.pool_local / "handmade/SKILL.md").read_text() == "handmade"
-    assert layout.pool_repo.is_symlink()
-    assert _target(layout.pool_repo) == repo_source
+    assert layout.pool_repo.is_dir()
+    assert not layout.pool_repo.is_symlink()
+    assert (layout.pool_repo / "business/reviewer/SKILL.md").read_text() == "repo"
+    assert repo_source.is_symlink()
+    assert _target(repo_source) == layout.pool_repo
     assert _target(managed) == managed_before
     assert _target(external) == external_before
     assert layout.legacy_local.is_dir() and not layout.legacy_local.is_symlink()
-    assert (
-        _target(layout.repo_bridge)
-        if layout.repo_bridge.is_symlink()
-        else layout.repo_bridge
-    ) == repo_bridge_before
+    assert layout.legacy_repo.is_symlink()
+    assert _target(layout.legacy_repo) == layout.pool_repo
+    if engine == "claude_code":
+        assert layout.repo_bridge.is_symlink()
+        assert _target(layout.repo_bridge) == layout.legacy_repo
 
     marker = json.loads(layout.ready_marker.read_text())
     assert marker["repo_delivery"] == "download"
-    assert marker["repo_delivery_source"] == str(repo_source)
+    assert marker["repo_delivery_source"] == str(layout.pool_repo)
     probe = inspect_runtime_layout(
         engine=engine,
         home=home,
@@ -215,6 +222,73 @@ def test_preparation_reuses_downloaded_repo_and_preserves_legacy_layout(
     )
     assert repeated.status is DesktopPreparationStatus.ALREADY_PREPARED
     assert repeated.preparation_id == result.preparation_id
+
+
+@pytest.mark.parametrize(
+    ("engine", "activate"),
+    [
+        ("openclaw", activate_openclaw_pool),
+        ("claude_code", activate_claude_code_pool),
+        ("hermes", activate_hermes_pool),
+    ],
+)
+def test_downloaded_repo_cutover_leaves_corpus_outside_active_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+    activate,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source, _managed, external = _legacy_runtime(home, engine)
+    prepared = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+    assert prepared.status is DesktopPreparationStatus.PREPARED
+    monkeypatch.setenv("MAC_CONTAINER", "true")
+    mapping = SkillMapping(
+        source=str(layout.pool_repo / "business/reviewer"),
+        target=str(layout.active_root / "reviewer"),
+    )
+
+    activated = activate(
+        migration_generation="generation-1",
+        preparation_id=prepared.preparation_id,
+        registered_local_names=["registered"],
+        mappings=[mapping],
+        home=home,
+    )
+
+    assert activated.status is PoolActivationStatus.COMMITTED
+    assert layout.pool_repo.is_dir() and not layout.pool_repo.is_symlink()
+    assert (layout.active_root / "reviewer").is_symlink()
+    assert _target(layout.active_root / "reviewer") == (
+        layout.pool_repo / "business/reviewer"
+    )
+    assert external.is_symlink()
+    if engine in {"openclaw", "claude_code"}:
+        assert not layout.repo_bridge.exists()
+        assert not layout.repo_bridge.is_symlink()
+    else:
+        assert layout.repo_bridge.is_symlink()
+        assert _target(layout.repo_bridge) == layout.pool_repo
+
+    refreshed = tmp_path / f"{engine}-repo-refresh"
+    (refreshed / "business/reviewer").mkdir(parents=True)
+    (refreshed / "business/reviewer/SKILL.md").write_text("refreshed")
+    archive = tmp_path / f"{engine}-repo-refresh.tar.gz"
+    with tarfile.open(archive, "w:gz") as stream:
+        stream.add(refreshed, arcname="skills-repo")
+    monkeypatch.setattr(skills_repo_download, "TARGET_DIR", layout.pool_repo)
+    monkeypatch.setattr(
+        skills_repo_download,
+        "BACKUP_DIR",
+        layout.pool_root / ".skills-repo-backups",
+    )
+
+    assert skills_repo_download._extract_atomic(archive)
+    assert (layout.active_root / "reviewer/SKILL.md").read_text() == ("refreshed")
 
 
 @pytest.mark.parametrize("engine", ("teclaw", "unknown"))
@@ -375,3 +449,53 @@ def test_wrong_legacy_repo_delivery_never_publishes_ready_marker(
     assert result.status is DesktopPreparationStatus.FAILED
     assert not layout.ready_marker.exists()
     assert _target(layout.legacy_repo) == wrong
+
+
+def test_two_independent_repo_corpora_fail_without_selecting_either(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, "openclaw")
+    (repo_source / "legacy.txt").write_text("legacy")
+    layout.pool_repo.mkdir(parents=True)
+    (layout.pool_repo / "pool.txt").write_text("pool")
+
+    result = prepare_desktop_pool(
+        engine="openclaw",
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.FAILED
+    assert (repo_source / "legacy.txt").read_text() == "legacy"
+    assert (layout.pool_repo / "pool.txt").read_text() == "pool"
+    assert not layout.ready_marker.exists()
+
+
+def test_repo_bridge_publish_failure_restores_legacy_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, "openclaw")
+    (repo_source / "legacy.txt").write_text("legacy")
+
+    def fail_bridge(path: Path, source: Path) -> None:
+        raise OSError("injected bridge publish failure")
+
+    monkeypatch.setattr(
+        desktop_preparation,
+        "_publish_repo_delivery_bridge",
+        fail_bridge,
+    )
+    result = prepare_desktop_pool(
+        engine="openclaw",
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.FAILED
+    assert repo_source.is_dir() and not repo_source.is_symlink()
+    assert (repo_source / "legacy.txt").read_text() == "legacy"
+    assert not layout.pool_repo.exists()
+    assert not layout.ready_marker.exists()

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
@@ -10,6 +10,7 @@ from threading import Barrier
 import pytest
 
 from engine.community.config import RepoDelivery
+from engine.community.core.skills import skills_repo_download
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     LayoutIdentity,
@@ -17,14 +18,9 @@ from engine.community.core.skills.layout_planner import (
     resolve_filesystem_skill_layout,
 )
 from engine.community.plugins.skills_pool import desktop_preparation
-from engine.community.core.skills import skills_repo_download
 from engine.community.plugins.skills_pool.desktop_preparation import (
     DesktopPreparationStatus,
     prepare_desktop_pool,
-)
-from engine.community.plugins.skills_pool.layout_probe import (
-    RuntimeLayoutInspectionStatus,
-    inspect_runtime_layout,
 )
 from engine.community.plugins.skills_pool.layout_activation import (
     PoolActivationStatus,
@@ -32,6 +28,10 @@ from engine.community.plugins.skills_pool.layout_activation import (
     activate_claude_code_pool,
     activate_hermes_pool,
     activate_openclaw_pool,
+)
+from engine.community.plugins.skills_pool.layout_probe import (
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
 )
 
 FILESYSTEM_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
@@ -354,14 +354,16 @@ def test_preparation_preserves_pool_only_local_content(tmp_path: Path) -> None:
     assert (pool_only / "SKILL.md").read_text() == "preserve"
 
 
+@pytest.mark.parametrize("engine", FILESYSTEM_ENGINES)
 def test_concurrent_startup_preparation_converges_without_shared_staging(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    engine: str,
 ) -> None:
     home = tmp_path / "home/admin"
     layout, repo_source, _managed, _external = _legacy_runtime(
         home,
-        "openclaw",
+        engine,
     )
     barrier = Barrier(2)
     original_mirror = desktop_preparation.mirror_local_tree
@@ -379,7 +381,7 @@ def test_concurrent_startup_preparation_converges_without_shared_staging(
         results = list(
             executor.map(
                 lambda _: prepare_desktop_pool(
-                    engine="openclaw",
+                    engine=engine,
                     repo_source=repo_source,
                     home=home,
                 ),
@@ -387,18 +389,65 @@ def test_concurrent_startup_preparation_converges_without_shared_staging(
             )
         )
 
-    assert {result.status for result in results} <= {
-        DesktopPreparationStatus.PREPARED,
-        DesktopPreparationStatus.ALREADY_PREPARED,
-    }
+    failures = [
+        result
+        for result in results
+        if result.status
+        not in {
+            DesktopPreparationStatus.PREPARED,
+            DesktopPreparationStatus.ALREADY_PREPARED,
+        }
+    ]
+    assert not failures, [result.reason for result in failures]
     assert layout.ready_marker.is_file()
     assert not list(layout.pool_root.glob(".preparation-staging-*"))
     probe = inspect_runtime_layout(
-        engine="openclaw",
+        engine=engine,
         home=home,
         repo_delivery=RepoDelivery.DOWNLOAD,
     )
     assert probe.status is RuntimeLayoutInspectionStatus.READY
+
+
+@pytest.mark.parametrize(
+    "replace_error",
+    (FileNotFoundError, IsADirectoryError),
+)
+def test_repo_move_loser_accepts_winner_published_reverse_bridge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replace_error: type[OSError],
+) -> None:
+    """A loser accepts either POSIX error after the winner publishes the bridge."""
+
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, "openclaw")
+    (repo_source / "legacy.txt").write_text("legacy")
+    original_replace = desktop_preparation.os.replace
+
+    def winner_completed_replace(source: Path, target: Path) -> None:
+        if Path(source) == repo_source and Path(target) == layout.pool_repo:
+            original_replace(source, target)
+            repo_source.symlink_to(layout.pool_repo, target_is_directory=True)
+            raise replace_error("concurrent winner completed repo migration")
+        original_replace(source, target)
+
+    monkeypatch.setattr(
+        desktop_preparation.os,
+        "replace",
+        winner_completed_replace,
+    )
+
+    desktop_preparation._canonicalize_downloaded_repo(
+        pool_repo=layout.pool_repo,
+        repo_source=repo_source,
+    )
+
+    assert layout.pool_repo.is_dir()
+    assert not layout.pool_repo.is_symlink()
+    assert (layout.pool_repo / "legacy.txt").read_text() == "legacy"
+    assert repo_source.is_symlink()
+    assert _target(repo_source) == layout.pool_repo
 
 
 def test_invalid_existing_claude_repo_bridge_never_publishes_ready_marker(

--- a/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download.py
@@ -4,6 +4,7 @@ Covers every public and private function except the long-running background
 thread loop.  All filesystem and network I/O is mocked so tests run fast
 and deterministically.
 """
+
 from __future__ import annotations
 
 import importlib
@@ -57,17 +58,17 @@ def mod(tmp_root: Path):
 
 @pytest.fixture()
 def target_dir(mod, tmp_root: Path) -> Path:
-    return tmp_root / "skills" / "skills-repo"
+    return tmp_root / "skills-pool" / "skills-repo"
 
 
 @pytest.fixture()
 def backup_dir(mod, tmp_root: Path) -> Path:
-    return tmp_root / "skills" / ".skills-repo-backups"
+    return tmp_root / "skills-pool" / ".skills-repo-backups"
 
 
 @pytest.fixture()
 def etag_file(mod, tmp_root: Path) -> Path:
-    return tmp_root / "skills" / ".skills-repo-etag"
+    return tmp_root / "skills-pool" / ".skills-repo-etag"
 
 
 def _make_tar(root: Path, name: str = "skills-repo") -> Path:
@@ -129,42 +130,68 @@ class TestIsAgentboxEnv:
 
 class TestGetMetaUrl:
     def test_default_no_env_returns_empty(self, mod):
-        env = {k: v for k, v in os.environ.items()
-               if k not in (
-                   "AGENTCLAW_ENV",
-                   "SKILLS_REPO_META_URL",
-                   "SKILLS_REPO_META_URL_TEMPLATE",
-               )}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "AGENTCLAW_ENV",
+                "SKILLS_REPO_META_URL",
+                "SKILLS_REPO_META_URL_TEMPLATE",
+            )
+        }
         with patch.dict(os.environ, env, clear=True):
-            with patch.object(mod, "_get_internal_default_meta_url_template", return_value=""):
+            with patch.object(
+                mod, "_get_internal_default_meta_url_template", return_value=""
+            ):
                 assert mod._get_default_meta_url() == ""
 
     def test_meta_url_env_overrides_template(self, mod):
-        with patch.dict(os.environ, {
-            "SKILLS_REPO_META_URL": " https://custom/meta.json ",
-            "SKILLS_REPO_META_URL_TEMPLATE": "https://template/meta-{env}.json",
-            "AGENTCLAW_ENV": "pre",
-        }, clear=True):
+        with patch.dict(
+            os.environ,
+            {
+                "SKILLS_REPO_META_URL": " https://custom/meta.json ",
+                "SKILLS_REPO_META_URL_TEMPLATE": "https://template/meta-{env}.json",
+                "AGENTCLAW_ENV": "pre",
+            },
+            clear=True,
+        ):
             assert mod._get_meta_url() == "https://custom/meta.json"
 
     def test_meta_url_template_uses_agentclaw_env(self, mod):
-        with patch.dict(os.environ, {
-            "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/skills-repo-meta-{env}.json",
-            "AGENTCLAW_ENV": "PRE",
-        }, clear=True):
-            assert mod._get_meta_url() == "https://example.com/skills-repo-meta-pre.json"
+        with patch.dict(
+            os.environ,
+            {
+                "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/skills-repo-meta-{env}.json",
+                "AGENTCLAW_ENV": "PRE",
+            },
+            clear=True,
+        ):
+            assert (
+                mod._get_meta_url() == "https://example.com/skills-repo-meta-pre.json"
+            )
 
     def test_meta_url_template_defaults_env_to_dev(self, mod):
-        with patch.dict(os.environ, {
-            "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/skills-repo-meta-{env}.json",
-        }, clear=True):
-            assert mod._get_meta_url() == "https://example.com/skills-repo-meta-dev.json"
+        with patch.dict(
+            os.environ,
+            {
+                "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/skills-repo-meta-{env}.json",
+            },
+            clear=True,
+        ):
+            assert (
+                mod._get_meta_url() == "https://example.com/skills-repo-meta-dev.json"
+            )
 
     def test_invalid_meta_url_template_returns_empty(self, mod):
-        with patch.dict(os.environ, {
-            "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/{missing}.json",
-            "AGENTCLAW_ENV": "pre",
-        }, clear=True):
+        with patch.dict(
+            os.environ,
+            {
+                "SKILLS_REPO_META_URL_TEMPLATE": "https://example.com/{missing}.json",
+                "AGENTCLAW_ENV": "pre",
+            },
+            clear=True,
+        ):
             assert mod._get_meta_url() == ""
 
     def test_internal_default_template_is_fallback(self, mod):
@@ -174,13 +201,21 @@ class TestGetMetaUrl:
                 "_get_internal_default_meta_url_template",
                 return_value="https://example.com/internal-skills-repo-meta-{env}.json",
             ):
-                assert mod._get_meta_url() == "https://example.com/internal-skills-repo-meta-pre.json"
+                assert (
+                    mod._get_meta_url()
+                    == "https://example.com/internal-skills-repo-meta-pre.json"
+                )
 
     def test_meta_url_env_absent_returns_empty(self, mod):
-        env = {k: v for k, v in os.environ.items()
-               if k not in ("SKILLS_REPO_META_URL", "SKILLS_REPO_META_URL_TEMPLATE")}
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("SKILLS_REPO_META_URL", "SKILLS_REPO_META_URL_TEMPLATE")
+        }
         with patch.dict(os.environ, env, clear=True):
-            with patch.object(mod, "_get_internal_default_meta_url_template", return_value=""):
+            with patch.object(
+                mod, "_get_internal_default_meta_url_template", return_value=""
+            ):
                 assert mod._get_meta_url() == ""
 
 
@@ -191,7 +226,7 @@ class TestGetMetaUrl:
 
 class TestCleanupStaleExtractDirs:
     def test_removes_stale_dirs(self, mod, tmp_root: Path):
-        parent = tmp_root / "skills"
+        parent = tmp_root / "skills-pool"
         parent.mkdir(parents=True)
         stale = parent / ".skills-repo-extract-abc123"
         stale.mkdir()
@@ -200,7 +235,7 @@ class TestCleanupStaleExtractDirs:
         assert not stale.exists()
 
     def test_keeps_non_prefixed_dirs(self, mod, tmp_root: Path):
-        parent = tmp_root / "skills"
+        parent = tmp_root / "skills-pool"
         parent.mkdir(parents=True)
         keep = parent / "skills-repo"
         keep.mkdir()
@@ -212,11 +247,14 @@ class TestCleanupStaleExtractDirs:
         mod._cleanup_stale_extract_dirs()
 
     def test_handles_rmtree_failure(self, mod, tmp_root: Path):
-        parent = tmp_root / "skills"
+        parent = tmp_root / "skills-pool"
         parent.mkdir(parents=True)
         stale = parent / ".skills-repo-extract-bad"
         stale.mkdir()
-        with patch("engine.community.core.skills.skills_repo_download.shutil.rmtree", side_effect=OSError("boom")):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.shutil.rmtree",
+            side_effect=OSError("boom"),
+        ):
             mod._cleanup_stale_extract_dirs()  # should log warning, not raise
         assert stale.exists()  # not removed
 
@@ -233,6 +271,7 @@ class TestCleanupOldBackups:
         old.mkdir()
         # mtime is recent at creation; force it old
         import os as _os
+
         _os.utime(str(old), (1000000000, 1000000000))
         mod._cleanup_old_backups()
         assert not old.exists()
@@ -256,6 +295,7 @@ class TestCleanupOldBackups:
         # iterdir() order (filesystem-dependent) and make this test flaky.
         now = time.time()
         import os as _os
+
         _os.utime(str(b1), (now - 100, now - 100))
         _os.utime(str(b2), (now, now))
         mod._cleanup_old_backups()
@@ -284,7 +324,9 @@ class TestBackupExistingRepo:
     def test_backs_up_to_timestamped_dir(self, mod, target_dir: Path, backup_dir: Path):
         target_dir.mkdir(parents=True)
         (target_dir / "file.txt").write_text("content")
-        with patch("engine.community.core.skills.skills_repo_download.int", return_value=12345):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.int", return_value=12345
+        ):
             result = mod._backup_existing_repo()
         assert result is not None
         assert result.name == "skills-repo-12345"
@@ -297,7 +339,9 @@ class TestBackupExistingRepo:
         (backup_dir / "skills-repo-12345").mkdir()
         target_dir.mkdir(parents=True)
         (target_dir / "file.txt").write_text("content")
-        with patch("engine.community.core.skills.skills_repo_download.int", return_value=12345):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.int", return_value=12345
+        ):
             result = mod._backup_existing_repo()
         assert result is not None
         assert result.name == "skills-repo-12345-1"
@@ -307,7 +351,9 @@ class TestBackupExistingRepo:
         target_dir.mkdir(parents=True)
         (target_dir / "a").mkdir()
         (target_dir / "a" / "b.txt").write_text("nested")
-        with patch("engine.community.core.skills.skills_repo_download.int", return_value=99):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.int", return_value=99
+        ):
             result = mod._backup_existing_repo()
         assert (result / "a" / "b.txt").read_text() == "nested"
 
@@ -341,45 +387,87 @@ class TestExtractAtomic:
     def test_cleans_up_tmp_dir_on_success(self, mod, tmp_root: Path):
         tar_path = _make_tar(tmp_root, "skills-repo")
         mod._extract_atomic(tar_path)
-        parent = tmp_root / "skills"
-        leftover = [d for d in parent.iterdir()
-                    if d.is_dir() and d.name.startswith(".skills-repo-extract-")]
+        parent = tmp_root / "skills-pool"
+        leftover = [
+            d
+            for d in parent.iterdir()
+            if d.is_dir() and d.name.startswith(".skills-repo-extract-")
+        ]
         assert leftover == []
 
     def test_cleans_up_tmp_dir_on_failure(self, mod, tmp_root: Path):
         bad_tar = tmp_root / "bad.tar.gz"
         bad_tar.write_bytes(b"garbage")
         mod._extract_atomic(bad_tar)
-        parent = tmp_root / "skills"
-        leftover = [d for d in parent.iterdir()
-                    if d.is_dir() and d.name.startswith(".skills-repo-extract-")]
+        parent = tmp_root / "skills-pool"
+        leftover = [
+            d
+            for d in parent.iterdir()
+            if d.is_dir() and d.name.startswith(".skills-repo-extract-")
+        ]
         assert leftover == []
 
     def test_backs_up_existing_before_swap(self, mod, target_dir: Path, tmp_root: Path):
         target_dir.mkdir(parents=True)
         (target_dir / "old.txt").write_text("old")
         tar_path = _make_tar(tmp_root, "skills-repo")
-        with patch("engine.community.core.skills.skills_repo_download.int", return_value=42):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.int", return_value=42
+        ):
             mod._extract_atomic(tar_path)
         # new content should be in place
         assert (target_dir / "hello.txt").read_text() == "world"
         # old content should be in backup
-        backup_dir = tmp_root / "skills" / ".skills-repo-backups"
+        backup_dir = tmp_root / "skills-pool" / ".skills-repo-backups"
         backups = list(backup_dir.iterdir())
         assert len(backups) == 1
         assert (backups[0] / "old.txt").read_text() == "old"
 
-    def test_removes_target_if_backup_failed(self, mod, target_dir: Path, tmp_root: Path):
-        """If _backup_existing_repo fails (returns None), the old TARGET_DIR
-        is still removed before the new one is moved in."""
+    def test_replaces_existing_empty_repo(self, mod, target_dir: Path, tmp_root: Path):
+        """An empty canonical directory has no state that requires a backup."""
+        target_dir.mkdir(parents=True)
+        tar_path = _make_tar(tmp_root, "skills-repo")
+
+        ok = mod._extract_atomic(tar_path)
+
+        assert ok is True
+        assert (target_dir / "hello.txt").read_text() == "world"
+
+    def test_preserves_target_if_backup_failed(
+        self, mod, target_dir: Path, tmp_root: Path
+    ):
+        """A failed backup must not destroy the last usable repo."""
         target_dir.mkdir(parents=True)
         (target_dir / "stale.txt").write_text("stale")
         tar_path = _make_tar(tmp_root, "skills-repo")
-        with patch("engine.community.core.skills.skills_repo_download._backup_existing_repo", return_value=None):
+        with patch(
+            "engine.community.core.skills.skills_repo_download._backup_existing_repo",
+            return_value=None,
+        ):
             ok = mod._extract_atomic(tar_path)
-        assert ok is True
-        assert (target_dir / "hello.txt").read_text() == "world"
-        assert not (target_dir / "stale.txt").exists()
+        assert ok is False
+        assert (target_dir / "stale.txt").read_text() == "stale"
+        assert not (target_dir / "hello.txt").exists()
+
+    def test_swap_failure_restores_previous_repo(
+        self, mod, target_dir: Path, tmp_root: Path
+    ):
+        target_dir.mkdir(parents=True)
+        (target_dir / "old.txt").write_text("old")
+        tar_path = _make_tar(tmp_root, "skills-repo")
+        real_move = mod.shutil.move
+
+        def fail_new_publish(source: str, target: str):
+            if Path(target) == target_dir:
+                raise OSError("injected repo publish failure")
+            return real_move(source, target)
+
+        with patch.object(mod.shutil, "move", side_effect=fail_new_publish):
+            ok = mod._extract_atomic(tar_path)
+
+        assert ok is False
+        assert (target_dir / "old.txt").read_text() == "old"
+        assert not (target_dir / "hello.txt").exists()
 
 
 # ===================================================================
@@ -396,12 +484,17 @@ class TestDownloadAndExtract:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.iter_content = MagicMock(return_value=[tar_bytes])
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            return_value=mock_resp,
+        ):
             ok = mod.download_and_extract("https://example.com/repo.tar.gz")
         assert ok is True
         assert (target_dir / "hello.txt").read_text() == "world"
 
-    def test_retries_on_network_error_then_succeeds(self, mod, target_dir: Path, tmp_root: Path):
+    def test_retries_on_network_error_then_succeeds(
+        self, mod, target_dir: Path, tmp_root: Path
+    ):
         import requests as _req
 
         tar_path = _make_tar(tmp_root, "skills-repo")
@@ -420,7 +513,10 @@ class TestDownloadAndExtract:
                 raise _req.RequestException("connection reset")
             return mock_resp
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get", side_effect=_flaky_get):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            side_effect=_flaky_get,
+        ):
             with patch("engine.community.core.skills.skills_repo_download.time.sleep"):
                 ok = mod.download_and_extract("https://example.com/repo.tar.gz")
         assert ok is True
@@ -429,8 +525,10 @@ class TestDownloadAndExtract:
     def test_returns_false_after_max_retries(self, mod):
         import requests as _req
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get",
-                    side_effect=_req.RequestException("down")):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            side_effect=_req.RequestException("down"),
+        ):
             with patch("engine.community.core.skills.skills_repo_download.time.sleep"):
                 ok = mod.download_and_extract("https://example.com/repo.tar.gz")
         assert ok is False
@@ -455,8 +553,14 @@ class TestDownloadAndExtract:
             created_files.append(Path(f.name))
             return f
 
-        with patch("engine.community.core.skills.skills_repo_download.tempfile.NamedTemporaryFile", _tracking_ntf):
-            with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.tempfile.NamedTemporaryFile",
+            _tracking_ntf,
+        ):
+            with patch(
+                "engine.community.core.skills.skills_repo_download.requests.get",
+                return_value=mock_resp,
+            ):
                 mod.download_and_extract("https://example.com/repo.tar.gz")
 
         for p in created_files:
@@ -510,20 +614,27 @@ class TestShouldDownload:
         # etag_file doesn't exist yet
         assert mod._should_download("https://x.com/tar", '"remote"') is True
 
-    def test_false_when_etags_match_locally(self, mod, target_dir: Path, etag_file: Path):
+    def test_false_when_etags_match_locally(
+        self, mod, target_dir: Path, etag_file: Path
+    ):
         target_dir.mkdir(parents=True)
         etag_file.parent.mkdir(parents=True, exist_ok=True)
         etag_file.write_text('"same"')
         assert mod._should_download("https://x.com/tar", '"same"') is False
 
-    def test_true_when_etags_differ_and_head_200(self, mod, target_dir: Path, etag_file: Path):
+    def test_true_when_etags_differ_and_head_200(
+        self, mod, target_dir: Path, etag_file: Path
+    ):
         target_dir.mkdir(parents=True)
         etag_file.parent.mkdir(parents=True, exist_ok=True)
         etag_file.write_text('"local"')
 
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        with patch("engine.community.core.skills.skills_repo_download.requests.head", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.head",
+            return_value=mock_resp,
+        ):
             result = mod._should_download("https://x.com/tar", '"remote"')
         assert result is True
 
@@ -534,19 +645,26 @@ class TestShouldDownload:
 
         mock_resp = MagicMock()
         mock_resp.status_code = 304
-        with patch("engine.community.core.skills.skills_repo_download.requests.head", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.head",
+            return_value=mock_resp,
+        ):
             result = mod._should_download("https://x.com/tar", '"remote"')
         assert result is False
 
-    def test_true_when_head_fails_fallback_to_download(self, mod, target_dir: Path, etag_file: Path):
+    def test_true_when_head_fails_fallback_to_download(
+        self, mod, target_dir: Path, etag_file: Path
+    ):
         import requests as _req
 
         target_dir.mkdir(parents=True)
         etag_file.parent.mkdir(parents=True, exist_ok=True)
         etag_file.write_text('"local"')
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.head",
-                    side_effect=_req.RequestException("timeout")):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.head",
+            side_effect=_req.RequestException("timeout"),
+        ):
             result = mod._should_download("https://x.com/tar", '"remote"')
         assert result is True
 
@@ -559,7 +677,10 @@ class TestShouldDownload:
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.head", return_value=mock_resp) as mock_head:
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.head",
+            return_value=mock_resp,
+        ) as mock_head:
             mod._should_download("https://x.com/tar", '"remote-etag"')
             mock_head.assert_called_once_with(
                 "https://x.com/tar",
@@ -576,8 +697,12 @@ class TestShouldDownload:
 class TestFetchMetaInfo:
     def test_returns_none_when_meta_url_not_configured(self, mod):
         with patch.dict(os.environ, {}, clear=True):
-            with patch.object(mod, "_get_internal_default_meta_url_template", return_value=""):
-                with patch("engine.community.core.skills.skills_repo_download.requests.get") as mock_get:
+            with patch.object(
+                mod, "_get_internal_default_meta_url_template", return_value=""
+            ):
+                with patch(
+                    "engine.community.core.skills.skills_repo_download.requests.get"
+                ) as mock_get:
                     result = mod._fetch_meta_info()
         assert result is None
         mock_get.assert_not_called()
@@ -593,17 +718,30 @@ class TestFetchMetaInfo:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json = MagicMock(return_value=payload)
 
-        with patch.dict(os.environ, {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"}, clear=True):
-            with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch.dict(
+            os.environ,
+            {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"},
+            clear=True,
+        ):
+            with patch(
+                "engine.community.core.skills.skills_repo_download.requests.get",
+                return_value=mock_resp,
+            ):
                 result = mod._fetch_meta_info()
         assert result == payload
 
     def test_returns_none_on_network_error(self, mod):
         import requests as _req
 
-        with patch.dict(os.environ, {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"}, clear=True):
-            with patch("engine.community.core.skills.skills_repo_download.requests.get",
-                        side_effect=_req.RequestException("timeout")):
+        with patch.dict(
+            os.environ,
+            {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"},
+            clear=True,
+        ):
+            with patch(
+                "engine.community.core.skills.skills_repo_download.requests.get",
+                side_effect=_req.RequestException("timeout"),
+            ):
                 result = mod._fetch_meta_info()
         assert result is None
 
@@ -612,8 +750,15 @@ class TestFetchMetaInfo:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json = MagicMock(side_effect=ValueError("bad json"))
 
-        with patch.dict(os.environ, {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"}, clear=True):
-            with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch.dict(
+            os.environ,
+            {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"},
+            clear=True,
+        ):
+            with patch(
+                "engine.community.core.skills.skills_repo_download.requests.get",
+                return_value=mock_resp,
+            ):
                 result = mod._fetch_meta_info()
         assert result is None
 
@@ -623,8 +768,15 @@ class TestFetchMetaInfo:
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock(side_effect=_req.HTTPError("404"))
 
-        with patch.dict(os.environ, {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"}, clear=True):
-            with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch.dict(
+            os.environ,
+            {"SKILLS_REPO_META_URL": "https://meta.example.com/meta.json"},
+            clear=True,
+        ):
+            with patch(
+                "engine.community.core.skills.skills_repo_download.requests.get",
+                return_value=mock_resp,
+            ):
                 result = mod._fetch_meta_info()
         assert result is None
 
@@ -737,7 +889,9 @@ class TestPreparePoolLayout:
 
 
 class TestDownloadAndSave:
-    def test_saves_etag_on_success(self, mod, target_dir: Path, tmp_root: Path, etag_file: Path):
+    def test_saves_etag_on_success(
+        self, mod, target_dir: Path, tmp_root: Path, etag_file: Path
+    ):
         tar_path = _make_tar(tmp_root, "skills-repo")
         tar_bytes = tar_path.read_bytes()
 
@@ -745,7 +899,10 @@ class TestDownloadAndSave:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.iter_content = MagicMock(return_value=[tar_bytes])
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            return_value=mock_resp,
+        ):
             with patch.object(mod, "prepare_pool_layout") as mock_prepare:
                 ok = mod._download_and_save(
                     "https://x.com/repo.tar.gz",
@@ -758,14 +915,18 @@ class TestDownloadAndSave:
     def test_does_not_save_etag_on_failure(self, mod, etag_file: Path):
         import requests as _req
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get",
-                    side_effect=_req.RequestException("down")):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            side_effect=_req.RequestException("down"),
+        ):
             with patch("engine.community.core.skills.skills_repo_download.time.sleep"):
                 ok = mod._download_and_save("https://x.com/repo.tar.gz", '"etag1"')
         assert ok is False
         assert not etag_file.exists()
 
-    def test_ok_without_etag(self, mod, target_dir: Path, tmp_root: Path, etag_file: Path):
+    def test_ok_without_etag(
+        self, mod, target_dir: Path, tmp_root: Path, etag_file: Path
+    ):
         tar_path = _make_tar(tmp_root, "skills-repo")
         tar_bytes = tar_path.read_bytes()
 
@@ -773,7 +934,10 @@ class TestDownloadAndSave:
         mock_resp.raise_for_status = MagicMock()
         mock_resp.iter_content = MagicMock(return_value=[tar_bytes])
 
-        with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+        with patch(
+            "engine.community.core.skills.skills_repo_download.requests.get",
+            return_value=mock_resp,
+        ):
             ok = mod._download_and_save("https://x.com/repo.tar.gz", None)
         assert ok is True
         assert not etag_file.exists()  # no etag → no etag file
@@ -787,14 +951,16 @@ class TestDownloadAndSave:
 class TestBootstrapOnStartup:
     def test_cleans_up_even_in_non_agentbox(self, mod, tmp_root: Path):
         """Cleanup of stale dirs should run regardless of MAC_CONTAINER."""
-        parent = tmp_root / "skills"
+        parent = tmp_root / "skills-pool"
         parent.mkdir(parents=True)
         stale = parent / ".skills-repo-extract-xyz"
         stale.mkdir()
 
         env = {k: v for k, v in os.environ.items() if k != "MAC_CONTAINER"}
         with patch.dict(os.environ, env, clear=True):
-            mod._is_agentbox_env.cache_clear() if hasattr(mod._is_agentbox_env, "cache_clear") else None
+            mod._is_agentbox_env.cache_clear() if hasattr(
+                mod._is_agentbox_env, "cache_clear"
+            ) else None
             mod.bootstrap_on_startup()
 
         assert not stale.exists()
@@ -806,7 +972,9 @@ class TestBootstrapOnStartup:
                 mod.bootstrap_on_startup()
                 mock_dl.assert_not_called()
 
-    def test_downloads_when_agentbox_and_url_available(self, mod, target_dir: Path, tmp_root: Path):
+    def test_downloads_when_agentbox_and_url_available(
+        self, mod, target_dir: Path, tmp_root: Path
+    ):
         tar_path = _make_tar(tmp_root, "skills-repo")
         tar_bytes = tar_path.read_bytes()
 
@@ -816,9 +984,16 @@ class TestBootstrapOnStartup:
 
         with patch.dict(os.environ, {"MAC_CONTAINER": "true"}):
             with patch.object(mod, "_is_agentbox_env", return_value=True):
-                with patch.object(mod, "_get_download_info", return_value=("https://x.com/tar", '"e1"')):
+                with patch.object(
+                    mod,
+                    "_get_download_info",
+                    return_value=("https://x.com/tar", '"e1"'),
+                ):
                     with patch.object(mod, "_should_download", return_value=True):
-                        with patch("engine.community.core.skills.skills_repo_download.requests.get", return_value=mock_resp):
+                        with patch(
+                            "engine.community.core.skills.skills_repo_download.requests.get",
+                            return_value=mock_resp,
+                        ):
                             mod.bootstrap_on_startup()
 
         assert (target_dir / "hello.txt").read_text() == "world"
@@ -826,10 +1001,16 @@ class TestBootstrapOnStartup:
     def test_skips_download_when_should_download_false(self, mod):
         with patch.dict(os.environ, {"MAC_CONTAINER": "true"}):
             with patch.object(mod, "_is_agentbox_env", return_value=True):
-                with patch.object(mod, "_get_download_info", return_value=("https://x.com/tar", '"e1"')):
+                with patch.object(
+                    mod,
+                    "_get_download_info",
+                    return_value=("https://x.com/tar", '"e1"'),
+                ):
                     with patch.object(mod, "_should_download", return_value=False):
                         with patch.object(mod, "_download_and_save") as mock_ds:
-                            with patch.object(mod, "prepare_pool_layout") as mock_prepare:
+                            with patch.object(
+                                mod, "prepare_pool_layout"
+                            ) as mock_prepare:
                                 mod.bootstrap_on_startup()
                                 mock_ds.assert_not_called()
                                 mock_prepare.assert_called_once_with()
@@ -912,7 +1093,9 @@ class TestStartBackgroundSync:
                 call_count += 1
 
             with patch.object(mod, "_get_download_info", return_value=(None, None)):
-                with patch("engine.community.core.skills.skills_repo_download.threading.Thread") as MockThread:
+                with patch(
+                    "engine.community.core.skills.skills_repo_download.threading.Thread"
+                ) as MockThread:
                     mod.start_background_sync(interval_seconds=60)
                     # Verify Thread was created with daemon=True
                     MockThread.assert_called_once()

--- a/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download_paths.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download_paths.py
@@ -1,4 +1,5 @@
 """Test that skill_repo_download module-level path constants follow workspace_root()."""
+
 from __future__ import annotations
 
 import importlib
@@ -6,6 +7,8 @@ import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 
 def _reload_skills_repo_download():
@@ -20,11 +23,17 @@ def _reload_skills_repo_download():
 
 def test_paths_use_env_root_when_set():
     """env 设了 → TARGET_DIR / BACKUP_DIR / ETAG_FILE 都含 env path"""
-    with patch.dict(os.environ, {"OPENCLAW_WORKSPACE_DIR": "/tmp/per-bot-X/openclaw/workspace"}):
+    with patch.dict(
+        os.environ, {"OPENCLAW_WORKSPACE_DIR": "/tmp/per-bot-X/openclaw/workspace"}
+    ):
         mod = _reload_skills_repo_download()
-    assert mod.TARGET_DIR == Path("/tmp/per-bot-X/openclaw/workspace/skills/skills-repo")
-    assert mod.BACKUP_DIR == Path("/tmp/per-bot-X/openclaw/workspace/skills/.skills-repo-backups")
-    assert mod.ETAG_FILE  == Path("/tmp/per-bot-X/openclaw/workspace/skills/.skills-repo-etag")
+    pool_root = Path("/tmp/per-bot-X/openclaw/workspace/skills-pool")
+    assert mod.TARGET_DIR == pool_root / "skills-repo"
+    assert mod.BACKUP_DIR == pool_root / ".skills-repo-backups"
+    assert mod.ETAG_FILE == pool_root / ".skills-repo-etag"
+    assert mod.LEGACY_TARGET_DIR == Path(
+        "/tmp/per-bot-X/openclaw/workspace/skills/skills-repo"
+    )
 
 
 def test_paths_fallback_to_home_when_unset():
@@ -32,7 +41,39 @@ def test_paths_fallback_to_home_when_unset():
     env_without = {k: v for k, v in os.environ.items() if k != "OPENCLAW_WORKSPACE_DIR"}
     with patch.dict(os.environ, env_without, clear=True):
         mod = _reload_skills_repo_download()
-    home_skills = Path.home() / ".openclaw" / "workspace" / "skills"
-    assert mod.TARGET_DIR == home_skills / "skills-repo"
-    assert mod.BACKUP_DIR == home_skills / ".skills-repo-backups"
-    assert mod.ETAG_FILE  == home_skills / ".skills-repo-etag"
+    workspace = Path.home() / ".openclaw" / "workspace"
+    pool_root = workspace / "skills-pool"
+    assert mod.TARGET_DIR == pool_root / "skills-repo"
+    assert mod.BACKUP_DIR == pool_root / ".skills-repo-backups"
+    assert mod.ETAG_FILE == pool_root / ".skills-repo-etag"
+    assert mod.LEGACY_TARGET_DIR == workspace / "skills/skills-repo"
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected_pool_root"),
+    [
+        ("openclaw", ".openclaw/workspace/skills-pool"),
+        ("claude_code", ".claude_code/workspace/skills-pool"),
+        ("hermes", ".hermes/workspace/skills-pool"),
+    ],
+)
+def test_download_paths_follow_each_engine_planner(
+    tmp_path: Path,
+    engine: str,
+    expected_pool_root: str,
+) -> None:
+    mod = _reload_skills_repo_download()
+    home = tmp_path / "home/admin"
+    openclaw_workspace = home / ".openclaw/workspace"
+
+    target, backup, etag, legacy = mod._repo_download_paths(
+        engine=engine,
+        home=home,
+        openclaw_workspace=openclaw_workspace,
+    )
+
+    pool_root = home / expected_pool_root
+    assert target == pool_root / "skills-repo"
+    assert backup == pool_root / ".skills-repo-backups"
+    assert etag == pool_root / ".skills-repo-etag"
+    assert legacy == openclaw_workspace / "skills/skills-repo"


### PR DESCRIPTION
## Summary

- make the Planner Pool repo the canonical Desktop download directory, with Legacy as a temporary reverse compatibility bridge
- retire active-root corpus bridges after cutover so OpenClaw recursive discovery cannot reach the complete repo
- converge post-cutover mappings against the latest Backend product state, including exact mapping retirement for activate/deactivate races
- preserve external/filesystem-only entries and fail before mutation on ambiguous identities
- harden download backup/publish recovery and serialize the local canonical-repo/compatibility-bridge transition across concurrent startup

Closes #455 follow-up gap identified during Desktop acceptance.

## Validation

- Backend full CI: 10349 passed; line coverage 84.84%; changed-line coverage 84.11%
- Engine full CI: 2206 passed, 5 repo-defined deselections; line coverage 92.72%; changed-line coverage 90.64%
- concurrent Desktop preparation: 200 repeated two-caller schedules across OpenClaw, Claude Code, AICoding, and Hermes, plus deterministic POSIX loser-error cases (1200 passed)
- focused OCB corp adapters: 42 passed across Claude Code, AICoding, and Hermes
- Python SAST gates passed for Backend and Engine
- diff-check passed

## Integration

The OCB corp-adapter and Spec follow-up is prepared separately and will pin the exact merge SHA only after this PR is merged and synchronized to the internal mirror.