### PR TITLE
fix(bcs): configure group session WebSocket signing secret

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -331,6 +331,38 @@ fn default_gateway_principal_signing_key_env() -> String {
     "AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE".to_string()
 }
 
+/// Group-session WebSocket JWT signing-key lookup configuration.
+///
+/// The signing key material is resolved through the configured SecretAccessPort
+/// using `signing_key_secret` as the logical secret name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GroupSessionWsConfig {
+    #[serde(default = "default_group_session_ws_signing_key_secret")]
+    pub signing_key_secret: String,
+}
+
+impl Default for GroupSessionWsConfig {
+    fn default() -> Self {
+        Self {
+            signing_key_secret: default_group_session_ws_signing_key_secret(),
+        }
+    }
+}
+
+impl GroupSessionWsConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.signing_key_secret.trim().is_empty() {
+            return Err("group_session_ws.signing_key_secret must not be blank".to_string());
+        }
+        Ok(())
+    }
+}
+
+fn default_group_session_ws_signing_key_secret() -> String {
+    "bcn-group-session-ws-jwt".to_string()
+}
+
 /// BCS configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -382,6 +414,10 @@ pub struct BcsConfig {
     /// Gateway-signed Principal verification trust configuration.
     #[serde(default)]
     pub gateway_principal: GatewayPrincipalConfig,
+
+    /// Group-session WebSocket JWT signing-key lookup configuration.
+    #[serde(default)]
+    pub group_session_ws: GroupSessionWsConfig,
 
     /// Leader election configuration for distributed deployment.
     /// When enabled, uses a configured election provider to elect one leader per environment.
@@ -820,6 +856,7 @@ impl Default for BcsConfig {
             dingtalk_accounts: Vec::new(),
             auth_token: None,
             gateway_principal: GatewayPrincipalConfig::default(),
+            group_session_ws: GroupSessionWsConfig::default(),
             leader_election: None,
             cache: CacheConfig::default(),
             database: DatabaseConfig::default(),
@@ -1246,6 +1283,10 @@ fn validate_loaded_config(config: &BcsConfig) -> Result<(), Box<dyn std::error::
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
     })?;
+    config.group_session_ws.validate().map_err(|e| {
+        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            as Box<dyn std::error::Error>
+    })?;
     config.telemetry.validate().map_err(|e| {
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
@@ -1298,6 +1339,48 @@ mod tests {
         assert_eq!(config.async_chat_run_timeout_ms, 7_500_000);
         assert!(config.security.outbound_url.block_private_networks);
         assert!(!config.security.outbound_url.allow_loopback);
+        assert_eq!(
+            config.group_session_ws.signing_key_secret,
+            "bcn-group-session-ws-jwt"
+        );
+    }
+
+    #[test]
+    fn group_session_ws_signing_key_secret_can_be_configured() {
+        let toml = r#"
+            bots_base_dir = "/bots"
+
+            [group_session_ws]
+            signing_key_secret = "other_manual_teamclawgw_principal_signing_key"
+        "#;
+
+        let config: BcsConfig = toml::from_str(toml)
+            .expect("parse configurable group-session WebSocket secret name");
+
+        assert_eq!(
+            config.group_session_ws.signing_key_secret,
+            "other_manual_teamclawgw_principal_signing_key"
+        );
+    }
+
+    #[test]
+    fn blank_group_session_ws_signing_key_secret_is_rejected() {
+        let tmp = tempfile::TempDir::new().expect("temp config dir");
+        std::fs::write(
+            tmp.path().join("bcs-config.toml"),
+            r#"
+            bots_base_dir = "/bots"
+
+            [group_session_ws]
+            signing_key_secret = " "
+            "#,
+        )
+        .expect("write config");
+
+        let err = BcsConfig::try_load_with_env(Some(&tmp.path().to_path_buf()))
+            .expect_err("blank group-session WebSocket secret name rejected");
+
+        assert!(err.contains("group_session_ws.signing_key_secret must not be blank"));
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -27,8 +27,8 @@ use tracing::{debug, info, warn};
 use crate::Result;
 use crate::auth_wiring::AuthPluginFactory;
 use crate::config::{
-    BcsConfig, CollaborationTemplateStorageKind, GatewayPrincipalConfig, LlmConfig,
-    LlmProviderType,
+    BcsConfig, CollaborationTemplateStorageKind, GatewayPrincipalConfig, GroupSessionWsConfig,
+    LlmConfig, LlmProviderType,
 };
 use crate::lifecycle::LifecycleOrchestrator;
 use crate::plugins::{
@@ -1265,13 +1265,12 @@ async fn build_gateway_principal_verifier_from_secret_access(
     build_gateway_principal_verifier_from_process(config)
 }
 
-const GROUP_SESSION_WS_SECRET_NAME: &str = "bcn-group-session-ws-jwt";
 const GROUP_SESSION_WS_TEST_SIGNING_KEY: &str =
     "test-only-group-session-key-at-least-32-bytes";
 
 fn group_session_test_secret_access() -> Arc<dyn SecretAccessPort> {
     Arc::new(InMemorySecretAccess::with_entries([(
-        GROUP_SESSION_WS_SECRET_NAME,
+        GroupSessionWsConfig::default().signing_key_secret,
         String::new(),
         GROUP_SESSION_WS_TEST_SIGNING_KEY.to_string(),
     )]))
@@ -1291,29 +1290,32 @@ fn build_secret_access_blocking(config: &BcsConfig) -> crate::Result<Arc<dyn Sec
 }
 
 async fn build_group_session_token_port(
+    config: &GroupSessionWsConfig,
     secret_access: Arc<dyn SecretAccessPort>,
 ) -> crate::Result<Arc<dyn GroupSessionTokenPort>> {
+    let secret_name = config.signing_key_secret.trim();
     let secret = secret_access
-        .get_secret(GROUP_SESSION_WS_SECRET_NAME)
+        .get_secret(secret_name)
         .await
         .map_err(|_| {
-            crate::BcsError::InvalidConfig(
-                "BCS_SECRET_BCN_GROUP_SESSION_WS_JWT is required".to_string(),
-            )
+            crate::BcsError::InvalidConfig(format!(
+                "group_session_ws.signing_key_secret '{secret_name}' is required"
+            ))
         })?;
     let tokens = GroupSessionJwtService::new(&secret.value).map_err(|_| {
-        crate::BcsError::InvalidConfig(
-            "BCS_SECRET_BCN_GROUP_SESSION_WS_JWT must be non-empty".to_string(),
-        )
+        crate::BcsError::InvalidConfig(format!(
+            "group_session_ws.signing_key_secret '{secret_name}' must resolve to non-empty material"
+        ))
     })?;
     Ok(Arc::new(tokens))
 }
 
 async fn build_group_session_connection_service(
     sessions: Arc<dyn bcs_service_api::application::v1::SessionService>,
+    config: &GroupSessionWsConfig,
     secret_access: Arc<dyn SecretAccessPort>,
 ) -> crate::Result<Arc<dyn GroupSessionConnectionService>> {
-    let tokens = build_group_session_token_port(secret_access).await?;
+    let tokens = build_group_session_token_port(config, secret_access).await?;
     Ok(Arc::new(GroupSessionConnectionServiceImpl::new(
         sessions, tokens,
     )))
@@ -1520,20 +1522,26 @@ mod gateway_principal_tests {
     async fn group_session_websocket_signing_key_is_required_and_non_empty() {
         let missing: Arc<dyn bcs_service_api::port::SecretAccessPort> =
             Arc::new(InMemorySecretAccess::new());
-        let missing_error = match build_group_session_token_port(missing).await {
+        let config = GroupSessionWsConfig::default();
+        let missing_error = match build_group_session_token_port(&config, missing).await {
             Ok(_) => panic!("missing group-session WebSocket key must fail"),
             Err(error) => error,
         };
         assert!(matches!(missing_error, crate::BcsError::InvalidConfig(_)));
+        assert!(
+            missing_error
+                .to_string()
+                .contains("group_session_ws.signing_key_secret 'bcn-group-session-ws-jwt' is required")
+        );
 
         let empty: Arc<dyn bcs_service_api::port::SecretAccessPort> = Arc::new(
             InMemorySecretAccess::with_entries([(
-                GROUP_SESSION_WS_SECRET_NAME,
+                config.signing_key_secret.clone(),
                 String::new(),
                 "   ".to_string(),
             )]),
         );
-        let empty_error = match build_group_session_token_port(empty).await {
+        let empty_error = match build_group_session_token_port(&config, empty).await {
             Ok(_) => panic!("empty group-session WebSocket key must fail"),
             Err(error) => error,
         };
@@ -1544,15 +1552,18 @@ mod gateway_principal_tests {
     #[tokio::test]
     async fn explicit_group_session_websocket_signing_key_is_accepted() {
         let secret_material = "test-only-group-session-key-at-least-32-bytes";
+        let config = GroupSessionWsConfig {
+            signing_key_secret: "other_manual_teamclawgw_principal_signing_key".to_string(),
+        };
         let access: Arc<dyn bcs_service_api::port::SecretAccessPort> = Arc::new(
             InMemorySecretAccess::with_entries([(
-                GROUP_SESSION_WS_SECRET_NAME,
+                config.signing_key_secret.clone(),
                 String::new(),
                 secret_material.to_string(),
             )]),
         );
 
-        let result = build_group_session_token_port(access).await;
+        let result = build_group_session_token_port(&config, access).await;
 
         if let Err(error) = result {
             let message = error.to_string();
@@ -3942,6 +3953,7 @@ impl BcsServer {
         );
         let group_session_connections = build_group_session_connection_service(
             self.state.openapi_v1.session_service.clone(),
+            &self.config.group_session_ws,
             self.state.group_session_secret_access.clone(),
         )
         .await?;
@@ -4437,7 +4449,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("BCS_SECRET_BCN_GROUP_SESSION_WS_JWT is required")
+                .contains("group_session_ws.signing_key_secret 'bcn-group-session-ws-jwt' is required")
         );
     }
 


### PR DESCRIPTION
## Summary

This PR makes the group-session WebSocket JWT signing secret lookup configurable through `BcsConfig`, instead of using a hard-coded Mist logical secret name.

## Changes

- Added a new `[group_session_ws]` configuration section with `signing_key_secret`.
- Preserved the existing default logical secret name: `bcn-group-session-ws-jwt`.
- Updated group-session WebSocket token bootstrap to resolve the signing key via the configured `signing_key_secret` using `SecretAccessPort`.
- Replaced the misleading env-style startup error with config-oriented messages.
- Added validation to reject blank `group_session_ws.signing_key_secret` values.
- Added and updated focused tests for default config, custom secret names, blank config rejection, missing secret material, and public constructor behavior.

## Motivation

Internal deployments need to choose the Mist logical secret name from config, matching the existing `gateway_principal.signing_key_secret` pattern. This avoids forcing a fixed secret name or an environment-variable-shaped requirement for group-session WebSocket JWT signing.

## Testing

Ran the following focused test commands successfully:

```bash
cargo test --manifest-path src/bcs/Cargo.toml -p bcs group_session_ws_signing_key_secret -- --nocapture
cargo test --manifest-path src/bcs/Cargo.toml -p bcs group_session_websocket_signing_key -- --nocapture
cargo test --manifest-path src/bcs/Cargo.toml -p bcs public_constructor_does_not_install_test_group_session_signing_key -- --nocapture
```
