### PR TITLE
fix: 支持 Teclaw 文件夹下载

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
@@ -197,7 +197,8 @@ def _resolve_walk_device_fs(
     """The device-fs to walk for search/zip, or ``None`` → local-FS fallback.
 
     ``publish_id`` → the published stage binding (``resolve_for_binding``); else the
-    bot's draft device when it's a container-backed provider (arca / baas service).
+    bot's draft device when it's a container-backed provider (arca / baas service /
+    teclaw).
     All providers address files uniformly via the ``workspace/<rel>`` namespace, so
     the caller just walks ``list_dir`` — no arca-specific path here.
 
@@ -216,7 +217,7 @@ def _resolve_walk_device_fs(
             entity_id=owner_id, bot_id=bot_id, engine_type=engine_type,
         )
     device_provider, _ = device_info_lookup.get_device_info(bot_id, owner_id, bot_repo)
-    if device_provider not in ("arca", "baas"):
+    if device_provider not in ("arca", "baas", "teclaw"):
         return None
     return _device_fs_for_bot(
         bot_id, owner_id, engine_type, resolver, dispatcher, device_uuid=device_uuid,
@@ -235,7 +236,7 @@ def _device_fs_for_bot(
     ``list_files`` takes (``resolve_for_bot`` → ``dispatch_addressed``).
 
     Used by search/zip for any container-backed draft device (arca + baas
-    service bot): both address files uniformly via the ``workspace/<rel>``
+    service + teclaw): all address files uniformly via the ``workspace/<rel>``
     namespace, so the caller just walks ``list_dir`` / reads ``read_file`` — no
     provider branching here. (Desktop baas bots keep files local and are handled
     by the caller before this.)
@@ -504,7 +505,7 @@ async def download_directory(
     resolver: DeviceContextResolver = Injected(DeviceContextResolver),
     device_fs_dispatcher: DeviceFilesystemDispatcher = Injected(DeviceFilesystemDispatcher),
 ):
-    """Download a directory as a streamed zip. Supports local FS + Arca + BaaS only."""
+    """Download a directory as a streamed zip. Supports local FS, Arca, BaaS, and Teclaw."""
     _reject_traversal(path)
     eid, ebid, eeng = _resolve_params(ctx, bot_id, engine_type, owner_id, bot_repo=bot_repo)
     workspace_dir = get_bot_workspace_dir(path_factory, eid, ebid, eeng, "staff")
@@ -547,7 +548,7 @@ async def download_directory(
         if total > _ZIP_DOWNLOAD_TOTAL_LIMIT:
             raise HTTPException(status_code=413, detail=f"Folder too large to download ({total} bytes, max {_ZIP_DOWNLOAD_TOTAL_LIMIT} bytes)")
 
-    # arca + baas-service + published-stage devices all walk + read uniformly via
+    # arca + baas-service + teclaw + published-stage devices all walk + read uniformly via
     # the device-fs (workspace/<rel> namespace); local/unbound → local-FS below.
     if device_fs is not None:
         entries = await _walk_device_fs(

--- a/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/resources/file_search_download_router.py
@@ -193,12 +193,14 @@ def _resolve_walk_device_fs(
     resolver: DeviceContextResolver,
     dispatcher: DeviceFilesystemDispatcher,
     device_uuid: Optional[str] = None,
+    include_teclaw: bool = False,
 ):
     """The device-fs to walk for search/zip, or ``None`` → local-FS fallback.
 
     ``publish_id`` → the published stage binding (``resolve_for_binding``); else the
-    bot's draft device when it's a container-backed provider (arca / baas service /
-    teclaw).
+    bot's draft device when it's a container-backed provider (arca / baas service).
+    ``include_teclaw`` is opt-in while individual endpoints adopt the Teclaw
+    filesystem contract.
     All providers address files uniformly via the ``workspace/<rel>`` namespace, so
     the caller just walks ``list_dir`` — no arca-specific path here.
 
@@ -217,7 +219,8 @@ def _resolve_walk_device_fs(
             entity_id=owner_id, bot_id=bot_id, engine_type=engine_type,
         )
     device_provider, _ = device_info_lookup.get_device_info(bot_id, owner_id, bot_repo)
-    if device_provider not in ("arca", "baas", "teclaw"):
+    supported_providers = ("arca", "baas", "teclaw") if include_teclaw else ("arca", "baas")
+    if device_provider not in supported_providers:
         return None
     return _device_fs_for_bot(
         bot_id, owner_id, engine_type, resolver, dispatcher, device_uuid=device_uuid,
@@ -235,8 +238,8 @@ def _device_fs_for_bot(
     """Build the addressed device-fs for a bot's draft device — the same path
     ``list_files`` takes (``resolve_for_bot`` → ``dispatch_addressed``).
 
-    Used by search/zip for any container-backed draft device (arca + baas
-    service + teclaw): all address files uniformly via the ``workspace/<rel>``
+    Used by search/zip for any selected container-backed draft device: all address
+    files uniformly via the ``workspace/<rel>``
     namespace, so the caller just walks ``list_dir`` / reads ``read_file`` — no
     provider branching here. (Desktop baas bots keep files local and are handled
     by the caller before this.)
@@ -522,6 +525,7 @@ async def download_directory(
             publish_id=publish_id, bot_id=ebid, owner_id=eid, operator_id=ctx.user_id,
             engine_type=eeng, publish_repo=publish_repo, bot_repo=bot_repo,
             resolver=resolver, dispatcher=device_fs_dispatcher, device_uuid=device_uuid,
+            include_teclaw=True,
         )
     except Exception as e:
         logger.warning("[download_directory] device-fs resolve failed bot=%s: %s", ebid, e)

--- a/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
+++ b/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
@@ -367,7 +367,8 @@ class TestDownloadDirectoryDeviceFsDoubleJoin:
     """
 
     @pytest.mark.asyncio
-    async def test_subdir_read_path_is_flat_join_no_double(self, tmp_path):
+    @pytest.mark.parametrize("provider", ["arca", "teclaw"])
+    async def test_subdir_read_path_is_flat_join_no_double(self, tmp_path, provider):
         list_tree = {
             "": [_entry("memory", is_dir=True)],
             "memory": [_entry("foo.txt", size=3), _entry("bar.txt", size=3)],
@@ -378,14 +379,14 @@ class TestDownloadDirectoryDeviceFsDoubleJoin:
         }
         fs = _RecordingDeviceFs(list_tree, read_payload)
         resolver = MagicMock()
-        resolver.resolve_for_bot.return_value = SimpleNamespace(provider="arca")
+        resolver.resolve_for_bot.return_value = SimpleNamespace(provider=provider)
 
         with patch(
             "agentclaw.community.adapters.http.resources.file_router.resolve_engine_for_bot",
             return_value="openclaw",
         ), patch(
             "agentclaw.community.core.devices.services.device_info.get_device_info",
-            return_value=("arca", "sbx"),
+            return_value=(provider, "sbx"),
         ), patch(
             "agentclaw.community.adapters.http.resources.file_search_download_router.get_bot_workspace_dir",
             return_value=tmp_path,

--- a/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
+++ b/src/backend/tests/community/adapters/http/resources/test_file_search_download_helpers.py
@@ -123,6 +123,24 @@ class TestResolveWalkDeviceFs:
             )
         assert fs is None
 
+    def test_teclaw_draft_requires_endpoint_opt_in(self):
+        resolver = MagicMock()
+        dispatcher = MagicMock()
+        dispatcher.dispatch_addressed.return_value = "teclaw-fs"
+        with patch(
+            "agentclaw.community.core.devices.services.device_info.get_device_info",
+            return_value=("teclaw", "teclaw-device"),
+        ):
+            common_args = dict(
+                publish_id=None, bot_id="b1", owner_id="o1", operator_id="u1",
+                engine_type="teclaw", publish_repo=MagicMock(), bot_repo=MagicMock(),
+                resolver=resolver, dispatcher=dispatcher,
+            )
+            assert _resolve_walk_device_fs(**common_args) is None
+            assert _resolve_walk_device_fs(**common_args, include_teclaw=True) == "teclaw-fs"
+
+        resolver.resolve_for_bot.assert_called_once_with("b1", "o1", device_uuid=None)
+
 
 # ── _abs_path ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 问题
Teclaw Bot 的普通文件列表可正常读取，但 `/api/resources/files/download-dir` 未将 `teclaw` 识别为设备文件系统提供方，错误回退到本地文件系统并返回 404。

## 修复
- 将 `teclaw` 纳入草稿态目录下载的设备文件系统分流。
- 复用既有 `TeclawDeviceFileSystem.list_dir` / `read_file` 与 ZIP 生成流程。
- 参数化现有目录下载回归测试，覆盖 `teclaw`。

## 验证
`uv run pytest tests/community/adapters/http/resources/test_file_search_download_helpers.py tests/community/plugins/prod/test_teclaw_device_filesystem.py tests/community/endpoints/test_resources_teclaw_reads.py`

结果：43 passed。