### PR TITLE
fix(bcs): seed group-session test secret from config

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -79,12 +79,19 @@ structured_output = "json_schema"
 type = "mysql"
 
 # Select a linked secret backend in deployments that do not use environment
-# variables. The session-bound WebSocket key is resolved by its fixed name.
+# variables. Group-session WebSocket JWT signing material is resolved through
+# [group_session_ws].signing_key_secret. The default logical name remains
+# "bcn-group-session-ws-jwt" for backward compatibility.
 [secret]
 provider = "env"
 
 [secret.providers.env]
 prefix = "BCS_SECRET_"
+
+[group_session_ws]
+# Optional. Override when the deployment secret backend uses a different
+# logical secret name for group-session WebSocket JWT signing material.
+signing_key_secret = "bcn-group-session-ws-jwt"
 
 [cache]
 type = "redis"

--- a/src/bcs/crates/bootstrap/bcs/CONTEXT.md
+++ b/src/bcs/crates/bootstrap/bcs/CONTEXT.md
@@ -43,9 +43,14 @@
 
 - This crate owns config file discovery, env parsing, and CLI/bootstrap flags.
 - Only this crate selects local, test, or remote concrete implementations.
-- Production resolves `bcn-group-session-ws-jwt` through `EnvSecretAccess`
-  using `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT`; missing or empty material aborts
-  Router construction and is never replaced by another JWT secret.
+- Production resolves group-session WebSocket JWT signing material through the
+  configured `SecretAccessPort` using `[group_session_ws].signing_key_secret`
+  as the logical secret name. The default logical name remains
+  `bcn-group-session-ws-jwt` for backward compatibility; with the default
+  `EnvSecretAccess` prefix this maps to `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT`.
+  Mist or other non-env deployments may set the field to their deployment-specific
+  logical secret name. Missing or empty material aborts Router construction and
+  is never replaced by another JWT secret.
 
 ## Runtime ownership
 

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1268,9 +1268,9 @@ async fn build_gateway_principal_verifier_from_secret_access(
 const GROUP_SESSION_WS_TEST_SIGNING_KEY: &str =
     "test-only-group-session-key-at-least-32-bytes";
 
-fn group_session_test_secret_access() -> Arc<dyn SecretAccessPort> {
+fn group_session_test_secret_access(config: &GroupSessionWsConfig) -> Arc<dyn SecretAccessPort> {
     Arc::new(InMemorySecretAccess::with_entries([(
-        GroupSessionWsConfig::default().signing_key_secret,
+        config.signing_key_secret.trim().to_string(),
         String::new(),
         GROUP_SESSION_WS_TEST_SIGNING_KEY.to_string(),
     )]))
@@ -2851,12 +2851,13 @@ impl BcsServer {
     }
 
     pub fn new_allowing_private_outbound_for_tests(config: BcsConfig) -> Self {
+        let group_session_secret_access = group_session_test_secret_access(&config.group_session_ws);
         Self::new_with_outbound_url_guards(
             config,
             OutboundUrlGuard::allowing_private_networks_for_tests(),
             OutboundUrlGuard::allowing_private_networks_for_tests(),
             OutboundUrlGuard::allowing_private_networks_for_tests(),
-            group_session_test_secret_access(),
+            group_session_secret_access,
             gateway_principal_verifier_for_tests(),
         )
     }
@@ -4416,6 +4417,25 @@ mod tests {
     #[derive(Default)]
     struct RecordingSessionChannelOutbound {
         events: tokio::sync::Mutex<Vec<HumanInputReadyEvent>>,
+    }
+
+    #[tokio::test]
+    async fn new_allowing_private_outbound_for_tests_seeds_configured_group_session_secret() {
+        let tmp = tempfile::TempDir::new().expect("temp dir");
+        let mut config = BcsConfig::default();
+        config.session_files.backend.insert(
+            "data_dir".to_string(),
+            toml::Value::String(tmp.path().to_string_lossy().into_owned()),
+        );
+        config.group_session_ws.signing_key_secret =
+            "custom-group-session-ws-test-secret".to_string();
+
+        let server = BcsServer::new_allowing_private_outbound_for_tests(config);
+
+        let _ = server
+            .build_router()
+            .await
+            .expect("test constructor should seed group-session signing material under configured name");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Group-session WebSocket JWT signing material is configurable via `[group_session_ws].signing_key_secret`, but the test-only BCS server constructor still seeded its in-memory secret store under the default logical secret name. Tests or deployments that exercise a custom signing secret name could fail router construction with a missing `group_session_ws.signing_key_secret` error, even though production lookup already honors the configured name.

## Solution
- Seed the test-only group-session WebSocket signing material under the configured `group_session_ws.signing_key_secret` name.
- Add a regression test covering `new_allowing_private_outbound_for_tests` with a custom group-session signing secret name.
- Document the configurable secret lookup in the BCS example config and bootstrap context notes, including the default env-provider mapping.

## Validation
- Not re-run during commit/push/PR creation per request.
- Previously run locally before commit:
  - `cargo test --manifest-path src/bcs/Cargo.toml -p bcs new_allowing_private_outbound_for_tests -- --nocapture`
  - `cargo test --manifest-path src/bcs/Cargo.toml -p bcs group_session -- --nocapture`
- Push ran the repository pre-push hook in lint-only mode and reported `OCB pre-push gate passed`.

## Compatibility and risk
The production secret lookup remains unchanged. The default logical secret name remains `bcn-group-session-ws-jwt`, which maps to `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT` for the default env secret provider. The change only aligns test-only secret seeding and documentation with the existing configuration contract.

## Related issues
Closes #754.
