### PR TITLE
fix baas openapi

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -190,13 +190,27 @@ class SerializingExecutor:
 def _rebuild_context(
     api_key_prefix: str,
     api_key_repository: APIKeyRepository,
+    metadata: dict[str, Any] | None = None,
 ) -> BotChatContext:
-    """通过 api_key_prefix 查 api_key 记录重建 BotChatContext。
+    """重建 BotChatContext。
 
-    进入 Worker 后已离开 HTTP 请求生命周期，无法访问 cookie / header。
-    参照 BCN 的 _build_chat_context 方式，从 api_key 记录获取
-    app_id / app_type / tenant，用 BotChatContext.from_api_key 构造。
+    优先从 metadata 中的 app_id / app_type / tenant 重建（Runner 入库时写入），
+    避免 gateway 路径的 api_key_prefix（resource_key[:8]）无法反查 baas_api_key 表。
+    若 metadata 缺失，则 fallback 到 api_key_repository.get_by_prefix 反查。
     """
+    metadata = metadata or {}
+    app_id = metadata.get("app_id")
+    app_type = metadata.get("app_type")
+    tenant = metadata.get("tenant")
+
+    if app_id is not None:
+        return BotChatContext.from_api_key(
+            api_key_prefix=api_key_prefix,
+            app_id=app_id,
+            app_type=app_type or "UNKNOWN",
+            tenant=tenant or "",
+        )
+
     api_key_record = api_key_repository.get_by_prefix(api_key_prefix)
     if not api_key_record:
         raise ValueError(f"api key not found: {api_key_prefix}")
@@ -257,7 +271,9 @@ class BotRunRequestExecutor:
         timeout_sec = metadata.get("timeout")
         chat_metadata = build_chat_metadata(metadata, run.run_id)
 
-        context = _rebuild_context(run.api_key_prefix, self._api_key_repository)
+        context = _rebuild_context(
+            run.api_key_prefix, self._api_key_repository, metadata
+        )
         lifecycle_stage = extract_lifecycle_stage(metadata)
         binding_info = await self._resolve_binding(run.bot_id, lifecycle_stage)
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py
@@ -383,8 +383,8 @@ class QueueTaskMessageDispatcher:
         if session_id:
             metadata["session_id"] = session_id
         if context:
-            metadata.setdefault("app_id", context.app_id)
-            metadata.setdefault("app_type", context.app_type)
-            metadata.setdefault("tenant", context.tenant)
+            metadata["app_id"] = context.app_id
+            metadata["app_type"] = context.app_type
+            metadata["tenant"] = context.tenant
         metadata["request_type"] = request_type
         return metadata

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -664,7 +664,14 @@ class BotRunner:
         context: BotChatContext,
         metadata: dict[str, Any],
     ) -> None:
-        """入库 PENDING 记录（DB-first）"""
+        """入库 PENDING 记录（DB-first）
+
+        将 context 的 app_id / app_type / tenant 写入 metadata，
+        供 Worker 端 ``_rebuild_context`` 重建 BotChatContext。
+        """
+        metadata["app_id"] = context.app_id
+        metadata["app_type"] = context.app_type
+        metadata["tenant"] = context.tenant
         try:
             self._run_repository.insert_run(
                 run_id=run_id,

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -140,6 +140,33 @@ def test_rebuild_context_from_api_key():
     assert ctx.build_auth_token() == "OPEN_API:app:sk-abc"
 
 
+def test_rebuild_context_from_metadata():
+    """metadata 中有 app_id 时直接重建，不查 api_key_repository。"""
+    repo = MagicMock()
+    repo.get_by_prefix.side_effect = AssertionError("should not call get_by_prefix")
+    ctx = _rebuild_context(
+        "rk-prefix",
+        repo,
+        metadata={"app_id": "app-x", "app_type": "app", "tenant": "tn"},
+    )
+    assert ctx.api_key_prefix == "rk-prefix"
+    assert ctx.app_id == "app-x"
+    assert ctx.app_type == "app"
+    assert ctx.tenant == "tn"
+    assert ctx.build_auth_token() == "OPEN_API:app:rk-prefix"
+
+
+def test_rebuild_context_metadata_without_app_id_falls_back():
+    """metadata 中无 app_id 时 fallback 到 api_key_repository 反查。"""
+    ctx = _rebuild_context(
+        "sk-abc",
+        _api_key_repo("sk-abc"),
+        metadata={"request_type": "chat"},
+    )
+    assert ctx.api_key_prefix == "sk-abc"
+    assert ctx.app_id == "app-1"
+
+
 def test_rebuild_context_api_key_not_found():
     repo = MagicMock()
     repo.get_by_prefix.return_value = None


### PR DESCRIPTION
## Problem

Gateway 路径（JWT 认证）投递消息后，worker 执行时 `_rebuild_context` 崩溃，报 `ValueError: api key not found`。

根因：gateway 的 `get_bot_chat_context`（`dependencies.py:130`）将 `api_key_prefix` 设为 `resource_key[:8]`，来自 `baas_resource_key` 表。但 worker 的 `_rebuild_context`（`_executor.py:260`）用这个值去查 `baas_api_key` 表——两套不同的认证体系，查不到记录。

## Solution

在 runner 入库时将 context 的身份信息写入 metadata，worker 重建 context 时优先从 metadata 读取，不再依赖 `baas_api_key` 表反查。

**`_runner.py` — `_insert_run`**：入库前将 `context.app_id`/`app_type`/`tenant` 直接写入 metadata（非 `setdefault`，防止用户通过 `request.metadata` 注入伪造身份字段）。

**`_executor.py` — `_rebuild_context`**：新增 `metadata` 参数，优先从 metadata 中的 `app_id`/`app_type`/`tenant` 重建 `BotChatContext`。仅当 metadata 无 `app_id` 时，fallback 到原有 `api_key_repository.get_by_prefix` 逻辑，兼容修改前入库的旧 `baas_bot_run` 记录。

被否方案：在 `_rebuild_context` 中增加 `resource_key_repository` fallback 查 `baas_resource_key` 表——但 `resource_key[:8]` 无法精确匹配完整 `resource_key`，且需要向 executor 注入额外依赖。

## Validation

- `tests/unit/core/service/bot_run/test_bot_run_executor.py`：34 passed
- `tests/unit/core/service/bot_run/` 全量：805 passed, 8 xpassed

新增测试：
- `test_rebuild_context_from_metadata`：验证 metadata 有 `app_id` 时直接重建，不查 `api_key_repository`
- `test_rebuild_context_metadata_without_app_id_falls_back`：验证 metadata 无 `app_id` 时 fallback 到 api_key 反查

## Compatibility and risk

- **旧数据兼容**：修改前入库的 `baas_bot_run` 记录 metadata 中无 `app_id`，worker 重跑时走 fallback 分支，行为不变。
- **无 schema 变更**：不修改 `baas_bot_run` 表结构，仅利用已有的 `metadata` JSON 列。
- **回滚**：回退代码即可，无数据迁移风险。旧记录重跑恢复为原有行为（gateway 路径仍会失败，但不会比修改前更差）。

## Files changed

- `src/secbaas/community/core/service/bot_run/_runner.py` — `_insert_run` 写入 context 身份信息到 metadata
- `src/secbaas/community/core/service/bot_run/_executor.py` — `_rebuild_context` 优先从 metadata 重建
- `src/secbaas/community/core/service/bot_run/_queue_task_message_dispatcher.py` — `_build_metadata` 同步改为直接赋值（死代码，保持一致）
- `tests/unit/core/service/bot_run/test_bot_run_executor.py` — 新增 2 个测试