### PR TITLE
feat(backend): pin ARKA image across service bot lifecycle

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -27,12 +27,14 @@ consumes:
   - "PolicyService"
   - "TaskQueueService"
   - "HandlerRegistry"
+  - "CommonConfigService"
 internal_dependencies:
   - agentclaw.community.api.policy_service
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_collaborator
   - agentclaw.community.core.config
   - agentclaw.community.core.config_compose
+  - agentclaw.community.core.common_config
   - agentclaw.community.core.cron.services.aicoding.cron_auto_setup
   - agentclaw.community.core.desktop_bot
   - agentclaw.community.core.mcp

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     )
     from agentclaw.community.core.cron.services.aicoding.cron_auto_setup import CronAutoSetupService
     from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
+    from agentclaw.community.core.common_config.service import CommonConfigService
     # Type-only: importing ``agentclaw.community.di`` at runtime would form a cycle
     # (di/__init__ -> container -> aicoding_module -> workspace_service ->
     # bot_service). ``BotService`` is provider-constructed, so this
@@ -66,6 +67,12 @@ from agentclaw.community.core.workspace.path_factory import (
 )
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    apply_image_pin_to_ext,
+    copy_image_pin_to_ext,
+    overlay_image_pin_on_template_config,
+    resolve_current_arka_image,
+)
 from agentclaw.community.utils.avernet_tenant import (
     bind_current_avernet_tenant,
 )
@@ -308,6 +315,7 @@ class BotService:
         baas_template_resolver: "BaasTemplateResolverProtocol | None" = None,
         baas_service_provider: "Callable[[], BaasService] | None" = None,
         task_queue_service: "TaskQueueService | None" = None,
+        common_config_service: "CommonConfigService | None" = None,
     ) -> None:
         self._repository = repository
         self._allocation_config = allocation_config
@@ -355,6 +363,61 @@ class BotService:
         self._policy_service = policy_service
         self._baas_template_resolver = baas_template_resolver
         self._task_queue_service = task_queue_service
+        self._common_config_service = common_config_service
+
+    def _resolve_service_bot_arka_image_pin(
+        self,
+        bot: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Resolve draft ARKA Pin in memory without changing persistent state."""
+        if bot.get("bot_type") != "service" or self.is_teclaw_bot(
+            bot.get("active_engine")
+        ):
+            return bot
+        image = resolve_current_arka_image(
+            getattr(self, "_common_config_service", None),
+            env=get_current_env(),
+        )
+        updated_ext = apply_image_pin_to_ext(bot.get("ext"), image)
+        if updated_ext == (bot.get("ext") or {}):
+            return bot
+        updated_bot = dict(bot)
+        updated_bot["ext"] = updated_ext
+        return updated_bot
+
+    def _persist_service_bot_arka_image_pin(
+        self,
+        bot: Dict[str, Any],
+        *,
+        user_id: str,
+    ) -> None:
+        """Persist an accepted draft restart's Pin snapshot to Bot and Draft."""
+        if bot.get("bot_type") != "service" or self.is_teclaw_bot(
+            bot.get("active_engine")
+        ):
+            return
+
+        bot_id = str(bot["bot_id"])
+        updated_ext = dict(bot.get("ext") or {})
+        self._repository.update_by_owner(bot_id, user_id, {"ext": updated_ext})
+
+        draft = self._bot_publish_repo.get_draft_by_publish_bot_id(
+            publish_bot_id=bot_id,
+            env=get_current_env(),
+        )
+        if draft is None:
+            return
+        draft_ext = copy_image_pin_to_ext(updated_ext, draft.ext) or {}
+        updated_draft = self._bot_publish_repo.update_status_with_ext(
+            publish_id=draft.id,
+            target_status=draft.status,
+            ext=draft_ext,
+            source_status=draft.status,
+        )
+        if updated_draft is None:
+            raise BotServiceError(
+                f"Draft publish {draft.id} image Pin persistence conflicted"
+            )
 
     def _build_engine_extra_envs(
         self,
@@ -1169,6 +1232,17 @@ class BotService:
             resolved_engine_types = [*resolved_engine_types, resolved_active_engine]
         resolved_bot_type = bot_type or "personal"
 
+        if resolved_bot_type == "service" and not self.is_teclaw_bot(
+            resolved_active_engine
+        ):
+            ext = apply_image_pin_to_ext(
+                ext,
+                resolve_current_arka_image(
+                    getattr(self, "_common_config_service", None),
+                    env=get_current_env(),
+                ),
+            ) or None
+
         # Resolve bot name according to naming rules
         resolved_bot_name = self._resolve_bot_name(bot_name, bot_id, user_id, nick_name)
 
@@ -1316,6 +1390,10 @@ class BotService:
                         engine_type=resolved_active_engine,
                         template_type=template_type,
                         template_config=template_config,
+                    )
+                    device_template_config = overlay_image_pin_on_template_config(
+                        device_template_config,
+                        bot_record.get("ext"),
                     )
                     extra_envs = self._build_engine_extra_envs(
                         bot_id=str(bot_id),
@@ -1514,6 +1592,7 @@ class BotService:
         force_nas: bool = False,
         device_provider: Optional[str] = None,
         restart_lock_key: Optional[Tuple[str, str, str, str]] = None,
+        bot_ext_override: Optional[Dict[str, Any]] = None,
     ):
         """
         Allocate device asynchronously in background thread.
@@ -1634,6 +1713,15 @@ class BotService:
                     template_type=bot_template_type,
                     template_config=resolved_template_config,
                 )
+                effective_bot_ext = (
+                    bot_ext_override
+                    if bot_ext_override is not None
+                    else (bot_record.get("ext") if bot_record else None)
+                )
+                device_template_config = overlay_image_pin_on_template_config(
+                    device_template_config,
+                    effective_bot_ext,
+                )
                 logger.info(
                     f"[bot_service._allocate_device_async] allocation requested: "
                     f"bot_id={bot_id}, user_id={user_id}, entity_id={entity_id}, "
@@ -1690,14 +1778,22 @@ class BotService:
 
                 # Update bot with binding_id, device_id and final status
                 # Use update_by_owner to ensure we only update the owner's bot
-                updated = self._repository.update_by_owner(bot_id, user_id, {
+                bot_update = {
                     "binding_id": binding_id,
                     "device_id": device_id,
-                    "status": final_status
-                })
+                    "status": final_status,
+                }
+                if bot_ext_override is not None:
+                    bot_update["ext"] = bot_ext_override
+                updated = self._repository.update_by_owner(bot_id, user_id, bot_update)
                 if not updated:
                     logger.error(f"[bot_service._allocate_device_async] Failed to update bot {bot_id} for user {user_id}: bot not found or not owner")
                     return
+                if bot_ext_override is not None:
+                    self._persist_service_bot_arka_image_pin(
+                        {**(bot_record or {}), "bot_id": bot_id, "ext": bot_ext_override},
+                        user_id=user_id,
+                    )
 
                 logger.info(f"[bot_service._allocate_device_async] Bot {bot_id} updated with binding_id={binding_id}, status={final_status}")
 
@@ -3536,6 +3632,7 @@ class BotService:
         force_nas: bool = False,
         device_provider: Optional[str] = None,
         restart_lock_key: Optional[Tuple[str, str, str, str]] = None,
+        bot_ext_override: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Start a bot by triggering async device allocation.
 
@@ -3637,6 +3734,7 @@ class BotService:
             force_nas=force_nas,
             device_provider=device_provider,
             restart_lock_key=restart_lock_key,
+            bot_ext_override=bot_ext_override,
         )
 
         # The allocation thread is now spawned and (for the restart flow) owns
@@ -3853,6 +3951,10 @@ class BotService:
         lock_key = (env, entity_id, bot_id, lock.lock_token)
         handed_off = False
         try:
+            if bot.get("bot_type") == "service" and not self.is_teclaw_bot(
+                bot.get("active_engine")
+            ):
+                bot = self._resolve_service_bot_arka_image_pin(bot)
             if (
                 binding_id
                 and current_device_provider == "baas"
@@ -3894,6 +3996,12 @@ class BotService:
                 nick_name=nick_name,
                 device_provider=current_device_provider,
                 restart_lock_key=lock_key,
+                bot_ext_override=(
+                    bot.get("ext")
+                    if bot.get("bot_type") == "service"
+                    and not self.is_teclaw_bot(bot.get("active_engine"))
+                    else None
+                ),
             )
             handed_off = True
 
@@ -4015,6 +4123,10 @@ class BotService:
                 bot_id, e,
             )
             device_template_config = resolved_template_config
+        device_template_config = overlay_image_pin_on_template_config(
+            device_template_config,
+            bot.get("ext"),
+        )
 
         import uuid as _uuid
         request_id = _uuid.uuid4().hex
@@ -4042,6 +4154,7 @@ class BotService:
         if template_uuid is not None:
             upgrade_kwargs["template_uuid"] = template_uuid
         result = self._baas_service_provider().upgrade_bot(**upgrade_kwargs)
+        self._persist_service_bot_arka_image_pin(bot, user_id=user_id)
 
         # 取 publish_id；置 bot/binding 双 PENDING；通过 durable queue 持久化轮询。
         # publish_id 缺失 / enqueue 异常仅 log，不影响重启返回（前端轮 status 自然

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -56,6 +56,9 @@ from agentclaw.community.core.service_bot.services.baas_service import (
     BaasServiceError,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
@@ -137,6 +140,7 @@ class ExpertChatInstanceService:
             bot_id, owner_id
         )
         version = publish_record.version or 1
+        image_pin = resolve_publish_image_pin(publish_record)
 
         # --- Step 1: look up / create instance row ---
         instance = self._instance_repo.get_instance(user_id, bot_id, owner_id)
@@ -196,6 +200,7 @@ class ExpertChatInstanceService:
                     user_id=user_id,
                     migration_path=migration_path,
                     version=version,
+                    docker_image=image_pin.docker_image,
                 )
                 bot_uuid = order["bot_uuid"]
                 baas_publish_id = order.get("publish_id")
@@ -217,6 +222,7 @@ class ExpertChatInstanceService:
                     owner_id=owner_id,
                     migration_path=migration_path,
                     version=version,
+                    docker_image=image_pin.docker_image,
                 )
                 bot_uuid = upgraded["bot_uuid"]
                 baas_publish_id = upgraded.get("publish_id")
@@ -394,6 +400,7 @@ class ExpertChatInstanceService:
         user_id: str,
         migration_path: Optional[str],
         version: int = 1,
+        docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """Call ``release_async`` and return the publish order.
 
@@ -421,6 +428,7 @@ class ExpertChatInstanceService:
                 device_count=1,
                 publish_stage=PublishStage.ONLINE,
                 version=str(version),
+                docker_image=docker_image,
             )
         except Exception as e:
             logger.error(
@@ -474,6 +482,7 @@ class ExpertChatInstanceService:
         owner_id: str,
         migration_path: Optional[str],
         version: int = 1,
+        docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """Upgrade a RELEASED container, preferring ``bot_uuid`` preservation.
 
@@ -501,6 +510,7 @@ class ExpertChatInstanceService:
                 device_count=1,
                 publish_stage=PublishStage.ONLINE,
                 version=str(version),
+                docker_image=docker_image,
             )
             logger.info(
                 "[ExpertChatInstance] upgrade_async succeeded: bot_uuid=%s",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
@@ -1,0 +1,112 @@
+"""ARKA service-bot image pin policy helpers.
+
+The environment switch lives in ``ac_common_config``.  Bot and publish ``ext``
+only carry the resolved snapshot so later operations (notably scale-up) do not
+silently move to a newer image.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agentclaw.community.core.common_config.service import CommonConfigService
+from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+IMAGE_PIN_BUSINESS_CODE = "service_bot"
+IMAGE_PIN_PARAM_CODE = "sbot_pin_image"
+IMAGE_PIN_ENABLED_KEY = "sbot_pin_image"
+IMAGE_PIN_VALUE_KEY = "sbot_docker_image"
+
+
+@dataclass(frozen=True)
+class ServiceBotImagePin:
+    """Immutable ARKA image snapshot resolved from one publish record."""
+
+    enabled: bool
+    docker_image: str | None
+
+
+def resolve_current_arka_image(
+    common_config_service: CommonConfigService | None,
+    *,
+    env: str,
+) -> str | None:
+    """Return the enabled ARKA image, or ``None`` for disabled/invalid config."""
+    if common_config_service is None:
+        return None
+    value = common_config_service.get_value(
+        business_code=IMAGE_PIN_BUSINESS_CODE,
+        param_code=IMAGE_PIN_PARAM_CODE,
+        env=env,
+        default=None,
+        only_enabled=True,
+    )
+    image = value.get("image") if isinstance(value, dict) else None
+    if isinstance(image, str) and image.strip():
+        return image.strip()
+    if value is not None:
+        logger.warning(
+            "[arka_image_pin] ignore invalid enabled config: env=%s value=%r",
+            env,
+            value,
+        )
+    return None
+
+
+def apply_image_pin_to_ext(
+    ext: dict[str, Any] | None,
+    image: str | None,
+) -> dict[str, Any]:
+    """Update only image-pin-owned keys while preserving unrelated Bot ext."""
+    updated = dict(ext or {})
+    updated.pop(IMAGE_PIN_ENABLED_KEY, None)
+    updated.pop(IMAGE_PIN_VALUE_KEY, None)
+    if image:
+        updated[IMAGE_PIN_ENABLED_KEY] = True
+        updated[IMAGE_PIN_VALUE_KEY] = image
+    return updated
+
+
+def read_image_pin_from_ext(ext: dict[str, Any] | None) -> str | None:
+    """Read a valid immutable image snapshot from Bot/publish ext."""
+    if not isinstance(ext, dict) or ext.get(IMAGE_PIN_ENABLED_KEY) is not True:
+        return None
+    image = ext.get(IMAGE_PIN_VALUE_KEY)
+    return image.strip() if isinstance(image, str) and image.strip() else None
+
+
+def resolve_publish_image_pin(
+    publish_record: BotPublishRecord,
+) -> ServiceBotImagePin:
+    """Resolve the ARKA image snapshot owned by ``publish_record``.
+
+    Published lifecycle operations must be reproducible, so this resolver never
+    falls back to the environment's current common-config value.
+    """
+    image = read_image_pin_from_ext(publish_record.ext)
+    return ServiceBotImagePin(enabled=image is not None, docker_image=image)
+
+
+def copy_image_pin_to_ext(
+    source_ext: dict[str, Any] | None,
+    target_ext: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Whitelist-copy the Bot image snapshot into a publish ext."""
+    target = apply_image_pin_to_ext(target_ext, read_image_pin_from_ext(source_ext))
+    return target or None
+
+
+def overlay_image_pin_on_template_config(
+    template_config: dict[str, Any] | None,
+    bot_ext: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Overlay a pinned image for one ARKA operation without mutating templates."""
+    image = read_image_pin_from_ext(bot_ext)
+    if not image:
+        return template_config
+    updated = dict(template_config or {})
+    updated["image"] = image
+    return updated

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -792,6 +792,7 @@ class BaasService:  # pragma: no cover
         auto_approve_publish: bool = True,
         ext_info: Optional[Dict[str, Any]] = None,
         extra_envs: Optional[Dict[str, Any]] = None,
+        template_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """调用 BaaS 层 API 创建 Bot。
 
@@ -811,6 +812,7 @@ class BaasService:  # pragma: no cover
             version: str = "1",发布版本
             auto_approve_publish: 是否由 BaaS 创建后自动审批发布单
             ext_info: Bot 额外信息
+            template_config: 沙箱覆写配置（镜像/规格/envs）
 
         Returns:
             BaaS 层返回的 Bot 信息，包含：
@@ -860,6 +862,7 @@ class BaasService:  # pragma: no cover
             auto_approve_publish=auto_approve_publish,
             ext_info=ext_info,
             extra_envs=extra_envs,
+            template_config=template_config,
         )
 
         logger.info(
@@ -1272,6 +1275,7 @@ class BaasService:  # pragma: no cover
         request_id: str,
         target_count: int,
         auto_approve_publish: bool = False,
+        config: BotConfig | Dict[str, Any] | None = None,
     ) -> Dict[str, Any]:
         """调用 BaaS 层 API 扩缩容 Bot。
 
@@ -1314,6 +1318,15 @@ class BaasService:  # pragma: no cover
             "request_id": request_id,
             "auto_approve_publish": auto_approve_publish,
         }
+        if config is not None:
+            # Scale config is a patch. Accept a sparse wire dict so callers can
+            # override only docker_image without materializing BotDeployConfig
+            # defaults (TTL/hooks), which would overwrite the frozen publish
+            # configuration in BaaS. Existing BotConfig callers keep the legacy
+            # full serialization behavior.
+            payload["config"] = (
+                config.to_dict() if isinstance(config, BotConfig) else dict(config)
+            )
 
         logger.info(
             f"[BaasService.scale_bot] "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -455,6 +455,7 @@ class BotBuildService:
         delivery: DeliveryArtifact = DeliveryArtifact(None),
         ext_info: Optional[Dict[str, Any]] = None,
         extra_envs: Optional[Dict[str, Any]] = None,
+        docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """发布 Bot 到 BaaS 层。
 
@@ -550,6 +551,8 @@ class BotBuildService:
                 )
                 if template_uuid is not None:
                     create_kwargs["template_uuid"] = template_uuid
+                if docker_image:
+                    create_kwargs["template_config"] = {"image": docker_image}
                 new_bot = self._baas_service.create_bot(**create_kwargs)
 
             bot_uuid = new_bot.get("bot_uuid")
@@ -577,6 +580,7 @@ class BotBuildService:
         delivery: DeliveryArtifact = DeliveryArtifact(None),
         ext_info: Optional[Dict[str, Any]] = None,
         extra_envs: Optional[Dict[str, Any]] = None,
+        docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """异步发布 Bot 到 BaaS 层。
 
@@ -605,9 +609,17 @@ class BotBuildService:
         )
         # 使用 asyncio.to_thread 在线程池中执行同步方法
         return await asyncio.to_thread(
-            self.release, bot, user_id, migration_path, device_count, publish_stage, version,
-            delivery, ext_info,
-            extra_envs,
+            self.release,
+            bot=bot,
+            user_id=user_id,
+            migration_path=migration_path,
+            device_count=device_count,
+            publish_stage=publish_stage,
+            version=version,
+            delivery=delivery,
+            ext_info=ext_info,
+            extra_envs=extra_envs,
+            docker_image=docker_image,
         )
 
     def _sync_skill_links(
@@ -1065,6 +1077,7 @@ class BotBuildService:
             version: str = "1",
             delivery: DeliveryArtifact = DeliveryArtifact(None),
             extra_envs: Optional[Dict[str, Any]] = None,
+            docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """升级 Bot 到 BaaS 层（复用现有 Bot）。
 
@@ -1138,6 +1151,8 @@ class BotBuildService:
                 )
                 if template_uuid is not None:
                     upgrade_kwargs["template_uuid"] = template_uuid
+                if docker_image:
+                    upgrade_kwargs["template_config"] = {"image": docker_image}
                 upgrade_result = self._baas_service.upgrade_bot(**upgrade_kwargs)
 
             logger.info(
@@ -1555,6 +1570,7 @@ class BotBuildService:
         version: str = "1",
         delivery: DeliveryArtifact = DeliveryArtifact(None),
         extra_envs: Optional[Dict[str, Any]] = None,
+        docker_image: str | None = None,
     ) -> Dict[str, Any]:
         """异步升级 Bot 到 BaaS 层。
 
@@ -1567,7 +1583,15 @@ class BotBuildService:
 
         # 使用 asyncio.to_thread 在线程池中执行同步方法
         return await asyncio.to_thread(
-            self.upgrade, bot_uuid, bot, user_id, migration_path, device_count, publish_stage, version,
-            delivery,
-            extra_envs,
+            self.upgrade,
+            bot_uuid=bot_uuid,
+            bot=bot,
+            user_id=user_id,
+            migration_path=migration_path,
+            device_count=device_count,
+            publish_stage=publish_stage,
+            version=version,
+            delivery=delivery,
+            extra_envs=extra_envs,
+            docker_image=docker_image,
         )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -23,6 +23,9 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
     PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    copy_image_pin_to_ext,
+)
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
@@ -206,6 +209,12 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 raise PublishAlreadyExistsError(
                     f"Publish record already exists: {publish_bot_id}, owner={owner_id}, v{version}"
                 )
+
+        source_bot = self._bot_repo.get_by_id_and_owner(source_bot_id, owner_id)
+        source_bot_ext = (
+            source_bot.get("ext") if isinstance(source_bot, dict) else None
+        )
+        ext = copy_image_pin_to_ext(source_bot_ext, ext)
 
         record = self._repo.insert({
             "source_bot_pk": source_bot_pk,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -10,6 +10,9 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -68,6 +71,7 @@ class EvalPublishMixin:
         # config_artifact read above is only the build-artifact presence guard. Eval
         # does not persist, so the applied overrides are discarded.
         delivery, _ = self._ext_state.compose_live(publish_record, publish_stage)
+        image_pin = resolve_publish_image_pin(publish_record)
 
         ext_info = {}
         if biz_id:
@@ -95,6 +99,7 @@ class EvalPublishMixin:
                 version=str(publish_record.version or 1),
                 delivery=delivery,
                 ext_info=ext_info,
+                docker_image=image_pin.docker_image,
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -26,6 +26,9 @@ from agentclaw.community.core.service_bot.repository.models import (
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
+)
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.publish_flow.ext_state import (
     PublishExtState,
@@ -164,6 +167,7 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        image_pin = resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -187,6 +191,7 @@ class ReleaseStageRunner:
                 # provider seam in a follow-up; tracked separately.
                 delivery=delivery,
                 extra_envs=skills_env,
+                docker_image=image_pin.docker_image,
             )
             if spec.first_release_passes_version:
                 release_kwargs["version"] = f"{publish_record.version}"
@@ -262,6 +267,7 @@ class ReleaseStageRunner:
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        image_pin = resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -284,6 +290,7 @@ class ReleaseStageRunner:
                 version=version,
                 delivery=delivery,
                 extra_envs=skills_env,
+                docker_image=image_pin.docker_image,
             )
 
         try:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -9,6 +9,9 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
     service_skills_env_from_ext,
 )
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -240,6 +243,7 @@ class RestartMixin:
         # so restarting a non-latest stage never delivers another stage's channels.
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        image_pin = resolve_publish_image_pin(publish_record)
 
         # A prior recreate that crashed between its ext write and its
         # complete_operation left a dangling op. That crashed leg IS this restart
@@ -321,6 +325,7 @@ class RestartMixin:
                     version=version,
                     delivery=delivery,
                     skills_env=skills_env,
+                    docker_image=image_pin.docker_image,
                     operator=operator,
                 )
 
@@ -335,6 +340,7 @@ class RestartMixin:
                 version=version,
                 delivery=delivery,
                 extra_envs=skills_env,
+                docker_image=image_pin.docker_image,
             )
         # NOTE: transient errors out of the atom are NOT caught + failed here. A
         # genuine crash leaves the op non-terminal so the durable task retry
@@ -386,6 +392,7 @@ class RestartMixin:
                 version=version,
                 delivery=delivery,
                 skills_env=skills_env,
+                docker_image=image_pin.docker_image,
                 operator=operator,
             )
         restart_publish_id = op.baas_publish_id
@@ -477,6 +484,7 @@ class RestartMixin:
         version: str,
         delivery,
         skills_env: dict[str, str] | None,
+        docker_image: str | None,
         operator: str,
     ) -> dict:
         """Recreate a restart's gone target bot — crash-safe (closes the former
@@ -511,6 +519,7 @@ class RestartMixin:
                 version=version,
                 delivery=delivery,
                 extra_envs=skills_env,
+                docker_image=docker_image,
             )
 
         op = await acquire_deploy_workflow(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -9,6 +9,9 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
+)
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
@@ -113,6 +116,7 @@ class RollbackOpsMixin:
         version = f"{target_record.version}"
         delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
         skills_env = service_skills_env_from_ext(target_ext, bot)
+        image_pin = resolve_publish_image_pin(target_record)
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
         # adopt-by-query on resume, never a second rollback deploy).
@@ -135,6 +139,7 @@ class RollbackOpsMixin:
                 version=version,
                 delivery=delivery,
                 extra_envs=skills_env,
+                docker_image=image_pin.docker_image,
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)
@@ -333,4 +338,3 @@ class RollbackOpsMixin:
                 f"[PublishFlowService._destroy_bot_by_stage] "
                 f"Failed to destroy bot: binding_id={binding_id}, stage={stage.value}, error={e}"
             )
-

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
@@ -8,10 +8,12 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishOperationKind,
     PublishStatus,
 )
-from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
     PublishStatusInvalidError,
+)
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    resolve_publish_image_pin,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
@@ -91,6 +93,13 @@ class ScaleMixin:
 
         bot_uuid = binding.device_id
         target_count = self._resolve_scale_target_count(publish_record)
+        image_pin = resolve_publish_image_pin(publish_record)
+        pinned_image = image_pin.docker_image
+        scale_config = (
+            {"deploy_config": {"docker_image": pinned_image}}
+            if pinned_image
+            else None
+        )
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
         # adopt-by-query on resume, never a second scale). The op's deterministic
@@ -104,12 +113,17 @@ class ScaleMixin:
         )
 
         async def _issue():
+            scale_kwargs = {
+                "bot_uuid": bot_uuid,
+                "owner_id": operator,
+                "request_id": op.request_id,
+                "target_count": target_count,
+                "auto_approve_publish": True,
+            }
+            if scale_config is not None:
+                scale_kwargs["config"] = scale_config
             return self._baas_service.scale_bot(
-                bot_uuid=bot_uuid,
-                owner_id=operator,
-                request_id=op.request_id,
-                target_count=target_count,
-                auto_approve_publish=True,
+                **scale_kwargs,
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)
@@ -230,4 +244,3 @@ class ScaleMixin:
             )
             return None
         return count
-

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -71,6 +71,7 @@ from agentclaw.community.core.bot_management.services.teclaw_publish_task_handle
 )
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.cron.services.aicoding.cron_auto_setup import CronAutoSetupService
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
 from agentclaw.community.core.devices.repository.protocol import (
     DeviceBindingRepository,
@@ -270,6 +271,7 @@ class BotManagementModule(Module):
         system_config_service: SystemConfigService,
         drm_reader: DRMReaderPlugin,
         task_queue_service: TaskQueueService,
+        common_config_service: CommonConfigService,
         injector: Injector,
     ) -> BotService:
         # Explicit provider: ``BotService.__init__`` types several
@@ -307,6 +309,7 @@ class BotManagementModule(Module):
             # Lazy (cycle-safe): baas bot 原地重启走 BaaSService.restart_bot。
             baas_service_provider=lambda: injector.get(BaasService),
             task_queue_service=task_queue_service,
+            common_config_service=common_config_service,
         )
 
     @singleton

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -57,6 +57,7 @@ def _make_service(*, current_bots: int = 0) -> BotService:
     teclaw_provision = MagicMock()
     teclaw_provision.is_teclaw.return_value = False
     svc._teclaw_provision_provider = lambda: teclaw_provision
+    svc._common_config_service = None
     svc._policy_service = None
     # DRM reader: default unset (None) ⇒ _is_new_bot_use_nas() is False (OSS).
     # BCN-register tests patch BotService._is_claude_code_bcn_register_enabled.
@@ -152,6 +153,42 @@ class TestCreateBotBcnRegister:
             name="cc-svc-bot",
             summary="service desc",
         )
+
+    def test_service_bot_create_persists_and_uses_current_pinned_image(self):
+        svc = _make_service()
+        device_service = _attach_device_service(svc)
+        common_config = MagicMock()
+        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        svc._common_config_service = common_config
+        template_config = {
+            "image": "registry/arka:v1",
+            "envs": {"A": "1"},
+        }
+
+        svc.create_bot(
+            user_id="u1",
+            nick_name="nick",
+            bot_name="pinned-service-bot",
+            bot_id="service-pin-1",
+            engine_type="openclaw",
+            bot_type="service",
+            template_type="service",
+            template_config=template_config,
+            ext={"service_bot_config": {"device_count": 3}},
+        )
+
+        inserted_ext = svc._repository.insert.call_args.args[0]["ext"]
+        assert inserted_ext == {
+            "service_bot_config": {"device_count": 3},
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        }
+        apply_kwargs = device_service.apply_device.call_args.kwargs
+        assert apply_kwargs["template_config"] == {
+            "image": "registry/arka:v2",
+            "envs": {"A": "1"},
+        }
+        assert template_config["image"] == "registry/arka:v1"
 
     def test_claude_code_application_coding_does_not_trigger_bcn_register(self):
         """claude_code + applicationCoding 创建时不应触发 BCN 注册。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
     BAAS_RESTART_PUBLISH_POLL_TASK,
@@ -65,6 +67,9 @@ def _make_service(
         "status": "ACTIVE",
     }
     svc._bot_publish_provider = lambda: MagicMock()
+    svc._teclaw_provision_provider = lambda: SimpleNamespace(
+        is_teclaw=lambda engine: engine == "teclaw"
+    )
     svc._oss_record_repo = MagicMock()
     svc._skill_set_factory = MagicMock()
     svc._device_binding_repo = MagicMock()
@@ -118,6 +123,122 @@ def _make_bot(
 # ===========================================================================
 # extra_envs / template_config 透传
 # ===========================================================================
+
+
+class TestRestartBaasImagePin:
+    def test_restart_uses_pinned_image_without_mutating_template_snapshot(self):
+        template_config = {"image": "registry/arka:v1", "envs": {"A": "1"}}
+        svc, baas, _ = _make_service(
+            template_config=template_config,
+            bot_type="service",
+            active_engine="openclaw",
+        )
+        bot = {
+            **_make_bot(bot_type="service", active_engine="openclaw"),
+            "ext": {
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            },
+        }
+
+        svc._restart_bot_baas(
+            bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+        )
+
+        assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
+            "image": "registry/arka:v2",
+            "envs": {"A": "1"},
+        }
+        assert template_config["image"] == "registry/arka:v1"
+
+    def test_restart_failure_does_not_persist_resolved_pin(self):
+        svc, baas, _ = _make_service(
+            template_config={},
+            bot_type="service",
+            active_engine="openclaw",
+        )
+        baas.upgrade_bot.side_effect = RuntimeError("baas rejected")
+        bot = {
+            **_make_bot(bot_type="service", active_engine="openclaw"),
+            "ext": {
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            },
+        }
+
+        with pytest.raises(RuntimeError, match="baas rejected"):
+            svc._restart_bot_baas(
+                bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+            )
+
+        svc._repository.update_by_owner.assert_not_called()
+        svc._bot_publish_repo.update_status_with_ext.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("bot_type", "active_engine"),
+        [("personal", "openclaw"), ("service", "teclaw")],
+    )
+    def test_pin_persistence_skips_non_arka_service_bot(
+        self,
+        bot_type: str,
+        active_engine: str,
+    ):
+        svc, _, _ = _make_service(
+            template_config={},
+            bot_type=bot_type,
+            active_engine=active_engine,
+        )
+        bot = {
+            **_make_bot(bot_type=bot_type, active_engine=active_engine),
+            "ext": {
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            },
+        }
+
+        svc._persist_service_bot_arka_image_pin(bot, user_id="user001")
+
+        svc._repository.update_by_owner.assert_not_called()
+        svc._bot_publish_repo.get_draft_by_publish_bot_id.assert_not_called()
+        svc._bot_publish_repo.update_status_with_ext.assert_not_called()
+
+    def test_restart_success_persists_bot_and_current_draft_pin(self):
+        svc, _, _ = _make_service(
+            template_config={},
+            bot_type="service",
+            active_engine="openclaw",
+        )
+        svc._bot_publish_repo.get_draft_by_publish_bot_id.return_value = SimpleNamespace(
+            id=6643,
+            status="draft",
+            ext={"migration_path": "/old"},
+        )
+        bot = {
+            **_make_bot(bot_type="service", active_engine="openclaw"),
+            "ext": {
+                "service_bot_config": {"device_count": 1},
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            },
+        }
+
+        svc._restart_bot_baas(
+            bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+        )
+
+        svc._repository.update_by_owner.assert_any_call(
+            "bot001", "user001", {"ext": bot["ext"]}
+        )
+        svc._bot_publish_repo.update_status_with_ext.assert_called_once_with(
+            publish_id=6643,
+            target_status="draft",
+            ext={
+                "migration_path": "/old",
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            },
+            source_status="draft",
+        )
 
 
 class TestRestartBaasEnvInjection:

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -143,6 +143,7 @@ def _make_service(
     bot_publish_repo: MagicMock | None = None,
     baas_template_resolver: MagicMock | None = None,
     task_queue_service: MagicMock | None = None,
+    common_config_service: MagicMock | None = None,
 ) -> BotService:
     if lock_repo is None:
         lock_repo = FakeRestartLockRepo()
@@ -159,6 +160,10 @@ def _make_service(
     svc._bot_publish_repo = bot_publish_repo if bot_publish_repo is not None else MagicMock()
     svc._baas_template_resolver = baas_template_resolver
     svc._task_queue_service = task_queue_service
+    svc._common_config_service = common_config_service
+    svc._teclaw_provision_provider = lambda: SimpleNamespace(
+        is_teclaw=lambda active_engine: active_engine == "teclaw"
+    )
     svc._drm_reader = MagicMock()
     svc._drm_reader.read.return_value = None
     svc._bcn_service = MagicMock()
@@ -768,6 +773,47 @@ class TestRestartGuardOrchestration:
         stop.assert_not_called()
         start.assert_not_called()
         assert result == bot
+
+    def test_restart_baas_service_refreshes_pin_before_upgrade(self):
+        """草稿态重启读取当前开关，并仅刷新 Pin 字段后透传镜像。"""
+        repo = FakeRestartLockRepo()
+        common_config = MagicMock()
+        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        bot = {
+            **_make_bot(status="ACTIVE", binding_id=42, bot_type="service"),
+            "ext": {"service_bot_config": {"device_count": 3}},
+        }
+        bot_repository, state = _stateful_bot_repository(bot)
+        svc = _make_service(
+            repo,
+            bot_repository=bot_repository,
+            common_config_service=common_config,
+        )
+        svc._template_service.get_template_config.return_value = {
+            "image": "registry/arka:v1",
+            "envs": {"A": "1"},
+        }
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="baas", device_id="BOT-uuid-9",
+        )
+        svc._device_service_provider = lambda: device_service
+        baas = MagicMock()
+        baas.upgrade_bot.return_value = {"publish_id": 101}
+        svc._baas_service_provider = lambda: baas
+
+        with patch.object(svc, "stop_bot"), patch.object(svc, "start_bot"):
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        common_config.get_value.assert_called_once()
+        assert state["ext"]["service_bot_config"] == {"device_count": 3}
+        assert state["ext"]["sbot_pin_image"] is True
+        assert state["ext"]["sbot_docker_image"] == "registry/arka:v2"
+        upgrade_kwargs = baas.upgrade_bot.call_args.kwargs
+        assert upgrade_kwargs["template_config"] == {
+            "image": "registry/arka:v2",
+            "envs": {"A": "1"},
+        }
 
     def test_restart_baas_service_ignores_existing_publish_migration_path(self):
         """普通 restart 只重启当前 bot；历史发布记录里的 migration_path 不参与。"""

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -270,7 +270,14 @@ class TestCreateContainer:
         _wire_binding_repo(binding_repo)
         bot_build_service.release_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 888})
 
-        await svc._create_container(BOT_ID, OWNER_ID, USER_ID, migration_path="/nas/path", version=2)
+        await svc._create_container(
+            BOT_ID,
+            OWNER_ID,
+            USER_ID,
+            migration_path="/nas/path",
+            version=2,
+            docker_image="registry/arka:v2",
+        )
 
         bot_build_service.release_async.assert_called_once()
         call_kwargs = bot_build_service.release_async.call_args[1]
@@ -280,6 +287,7 @@ class TestCreateContainer:
         assert call_kwargs["device_count"] == 1
         assert call_kwargs["publish_stage"] == PublishStage.ONLINE
         assert call_kwargs["version"] == "2"
+        assert call_kwargs["docker_image"] == "registry/arka:v2"
 
 
 class TestUpgradeContainer:
@@ -335,7 +343,14 @@ class TestUpgradeContainer:
         _wire_bot_repo(bot_repo, bot_info)
         bot_build_service.upgrade_async = AsyncMock(return_value={"bot_uuid": BOT_UUID, "publish_id": 999})
 
-        await svc._upgrade_container(BOT_UUID, BOT_ID, OWNER_ID, migration_path="/nas/path", version=3)
+        await svc._upgrade_container(
+            BOT_UUID,
+            BOT_ID,
+            OWNER_ID,
+            migration_path="/nas/path",
+            version=3,
+            docker_image="registry/arka:v2",
+        )
 
         bot_build_service.upgrade_async.assert_called_once()
         call_kwargs = bot_build_service.upgrade_async.call_args[1]
@@ -346,6 +361,7 @@ class TestUpgradeContainer:
         assert call_kwargs["device_count"] == 1
         assert call_kwargs["publish_stage"] == PublishStage.ONLINE
         assert call_kwargs["version"] == "3"
+        assert call_kwargs["docker_image"] == "registry/arka:v2"
 
 
 class TestBuildConnection:

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+from datetime import datetime
+
+from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    apply_image_pin_to_ext,
+    copy_image_pin_to_ext,
+    overlay_image_pin_on_template_config,
+    resolve_current_arka_image,
+    resolve_publish_image_pin,
+)
+
+
+def test_resolve_current_image_uses_enabled_common_config():
+    service = MagicMock()
+    service.get_value.return_value = {"image": " registry.example/arka:v2 "}
+
+    assert resolve_current_arka_image(service, env="pre") == "registry.example/arka:v2"
+    service.get_value.assert_called_once_with(
+        business_code="service_bot",
+        param_code="sbot_pin_image",
+        env="pre",
+        default=None,
+        only_enabled=True,
+    )
+
+
+def test_apply_pin_preserves_service_bot_config_and_clears_stale_pin():
+    ext = {
+        "service_bot_config": {"device_count": 3},
+        "sbot_pin_image": True,
+        "sbot_docker_image": "old:v1",
+    }
+
+    assert apply_image_pin_to_ext(ext, None) == {
+        "service_bot_config": {"device_count": 3}
+    }
+    assert apply_image_pin_to_ext(ext, "new:v2") == {
+        "service_bot_config": {"device_count": 3},
+        "sbot_pin_image": True,
+        "sbot_docker_image": "new:v2",
+    }
+
+
+def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
+    source = {
+        "service_bot_config": {"device_count": 3},
+        "sbot_pin_image": True,
+        "sbot_docker_image": "arka:v2",
+    }
+    target = {"config_artifact": {"schema_version": 4}}
+    template = {"image": "template:v1", "envs": {"A": "1"}}
+
+    assert copy_image_pin_to_ext(source, target) == {
+        "config_artifact": {"schema_version": 4},
+        "sbot_pin_image": True,
+        "sbot_docker_image": "arka:v2",
+    }
+    assert overlay_image_pin_on_template_config(template, source) == {
+        "image": "arka:v2",
+        "envs": {"A": "1"},
+    }
+    assert template["image"] == "template:v1"
+
+
+def test_resolve_publish_image_pin_reads_only_publish_ext():
+    record = BotPublishRecord(
+        id=1,
+        source_bot_pk=1,
+        source_bot_id="bot-1",
+        publish_bot_id="bot-1",
+        name="bot",
+        owner_id="u1",
+        status="success",
+        version=2,
+        env="pre",
+        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v2"},
+        permission_owner="owner",
+        gmt_create=datetime.now(),
+        gmt_modified=datetime.now(),
+    )
+
+    resolved = resolve_publish_image_pin(record)
+
+    assert resolved.enabled is True
+    assert resolved.docker_image == "arka:v2"

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_scale_bot.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_scale_bot.py
@@ -66,6 +66,26 @@ class TestBaasServiceScaleBot:
             "auto_approve_publish": False,
         }
 
+    def test_scale_bot_sends_optional_image_config(self):
+        service, http = _make_service()
+        http.set_response("post", _resp({"bot_uuid": "BOT-1", "publish_id": 9}))
+
+        service.scale_bot(
+            bot_uuid="BOT-1",
+            owner_id="op",
+            request_id="req-1",
+            target_count=3,
+            config={
+                "deploy_config": {"docker_image": "registry/arka:v2"},
+            },
+        )
+
+        assert http.calls_to("post")[0].kwargs["json"]["config"] == {
+            "deploy_config": {
+                "docker_image": "registry/arka:v2",
+            },
+        }
+
     @pytest.mark.parametrize(
         ("bot_uuid", "owner_id", "request_id", "target_count", "match"),
         [

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -94,6 +94,23 @@ def test_release_routes_arca_to_create_bot_unchanged():
 
 
 @pytest.mark.unit
+def test_release_routes_arca_pinned_image_to_template_config():
+    svc, baas = _svc("baas")
+
+    svc.release(
+        _BOT,
+        user_id="u1",
+        migration_path="/m/1",
+        publish_stage=PublishStage.VERIFY,
+        docker_image="registry/arka:v2",
+    )
+
+    assert baas.create_bot.call_args.kwargs["template_config"] == {
+        "image": "registry/arka:v2"
+    }
+
+
+@pytest.mark.unit
 def test_release_routes_arca_with_template_uuid_from_system_config():
     resolver = _template_resolver()
     svc, baas = _svc("baas", baas_template_resolver=resolver)
@@ -157,6 +174,41 @@ def test_upgrade_routes_teclaw_to_update_teclaw_bot():
     svc._passport_plugin.query_token.assert_not_called()
     baas.update_teclaw_outbound_rule_by_bot_uuid.assert_not_called()
     baas.upgrade_bot.assert_not_called()
+
+
+@pytest.mark.unit
+def test_upgrade_routes_arca_pinned_image_to_template_config():
+    svc, baas = _svc("baas")
+
+    svc.upgrade(
+        "BOT-a",
+        _BOT,
+        user_id="u1",
+        migration_path="/m/1",
+        publish_stage=PublishStage.ONLINE,
+        docker_image="registry/arka:v2",
+    )
+
+    assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
+        "image": "registry/arka:v2"
+    }
+
+
+@pytest.mark.unit
+def test_teclaw_ignores_arka_docker_image():
+    svc, baas = _svc("teclaw")
+
+    svc.release(
+        _BOT,
+        user_id="u1",
+        migration_path="",
+        publish_stage=PublishStage.VERIFY,
+        delivery=DeliveryArtifact(_ARTIFACT),
+        docker_image="registry/arka:v2",
+    )
+
+    baas.create_teclaw_bot.assert_called_once()
+    assert "template_config" not in baas.create_teclaw_bot.call_args.kwargs
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -167,6 +167,41 @@ class TestUpgradePublish:
         assert "binding" not in inserted_ext
         assert "publish" not in inserted_ext
 
+    def test_upgrade_publish_snapshots_only_image_pin_from_current_bot(self):
+        mock_repo = Mock()
+        original_record = _create_mock_record(
+            record_id=1,
+            status=PublishStatus.SUCCESS,
+            version=1,
+            ext={"binding": {"online": 99}},
+        )
+        mock_repo.get_by_id.return_value = original_record
+        mock_repo.get_by_last_pub_id.return_value = None
+        mock_repo.get_by_publish_bot_id_and_version.return_value = None
+        mock_repo.get_by_publish_bot_id.return_value = original_record
+        mock_repo.insert.return_value = _create_mock_record(
+            record_id=2,
+            status=PublishStatus.DRAFT,
+            version=2,
+            last_pub_id=1,
+        )
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "ext": {
+                "service_bot_config": {"device_count": 3},
+                "sbot_pin_image": True,
+                "sbot_docker_image": "registry/arka:v2",
+            }
+        }
+
+        service = _make_service(mock_repo, bot_repo=bot_repo)
+        service.upgrade_publish(publish_id=1, owner_id="user_001")
+
+        assert mock_repo.insert.call_args.args[0]["ext"] == {
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        }
+
     def test_upgrade_publish_not_found(self):
         """发布单不存在时抛出 PublishNotFoundError。"""
         mock_repo = Mock()

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -988,7 +988,12 @@ async def test_restart_sets_restarting_flag_in_ext():
 
     record = _make_publish_record(
         status=PublishStatus.SUCCESS.value,
-        ext={"binding": {"online": 1}, "migration_path": "/path/to/artifact"},
+        ext={
+            "binding": {"online": 1},
+            "migration_path": "/path/to/artifact",
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        },
     )
     _setup_restart(svc, record)
 
@@ -1051,13 +1056,19 @@ async def test_restart_recreate_threads_config_artifact():
     artifact = {"schema_version": 2, "skills": []}
     record = _make_publish_record(
         status=PublishStatus.SUCCESS.value,
-        ext={"binding": {"online": 1}, "config_artifact": artifact},
+        ext={
+            "binding": {"online": 1},
+            "config_artifact": artifact,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        },
     )
     _setup_restart(svc, record)
 
     result = await svc.execute_restart(publish_id=1, stage="online", operator="op")
     assert result["success"] is True
     assert build_service.release_async.await_args.kwargs["delivery"].config_artifact == artifact
+    assert build_service.release_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
     # The recreate minted a fresh binding for the new bot.
     assert publish_service.create_device_binding.call_args.kwargs["device_id"] == "BOT-recreated"
     # BOT_NOT_FOUND = the record is already gone → nothing to retire.
@@ -1142,7 +1153,12 @@ async def test_restart_baas_not_live_target_upgrades_in_place():
     svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
     record = _make_publish_record(
         status=PublishStatus.SUCCESS.value,
-        ext={"binding": {"online": 1}, "migration_path": "/m/1"},
+        ext={
+            "binding": {"online": 1},
+            "migration_path": "/m/1",
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        },
     )
     _setup_restart(svc, record, bot_uuid="BOT-old")
 
@@ -1150,6 +1166,7 @@ async def test_restart_baas_not_live_target_upgrades_in_place():
 
     assert result["success"] is True
     build_service.upgrade_async.assert_awaited_once()
+    assert build_service.upgrade_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
     build_service.release_async.assert_not_awaited()
     build_service.retire_superseded_bot.assert_not_called()
 
@@ -1586,7 +1603,12 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
     svc.approve_baas_publish = Mock()
 
     record = _make_publish_record(
-        status=PublishStatus.BUILT.value, ext=_artifact_ext("draft")
+        status=PublishStatus.BUILT.value,
+        ext={
+            **_artifact_ext("draft"),
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        },
     )
     await svc._execute_verify_first_release(
         publish_record=record,
@@ -1600,6 +1622,7 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
     # identity keys stable across the promotion
     assert delivered["engine_ext"]["bot_id"] == "b2"
     assert delivered["engine_ext"]["owner_id"] == "u1"
+    assert build_service.release_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
 
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "canary"
@@ -1623,7 +1646,12 @@ async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
     svc.refresh_publish_handle = Mock()
 
     record = _make_publish_record(
-        status=PublishStatus.BUILT.value, ext=_artifact_ext("draft")
+        status=PublishStatus.BUILT.value,
+        ext={
+            **_artifact_ext("draft"),
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        },
     )
     await svc._execute_verify_upgrade(
         publish_record=record,
@@ -1636,6 +1664,7 @@ async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
 
     delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "canary"
+    assert build_service.upgrade_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "canary"
 
@@ -2168,6 +2197,10 @@ async def test_execute_rollback_uses_fixed_device_count_one():
         status=PublishStatus.DRAFT.value,
         version=3,
         source_bot_id="bot-123",
+        ext={
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry.example.com/arka/openclaw:v3",
+        },
     )
 
     # Target version (v2, SUCCESS) - has a build artifact and binding
@@ -2178,6 +2211,8 @@ async def test_execute_rollback_uses_fixed_device_count_one():
         ext={
             "migration_path": "/tmp/build/v2",
             "binding": {"online": 100},  # binding_id
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry.example.com/arka/openclaw:v2",
             "skills_manifest": {
                 "schema_version": 1,
                 "engine": "openclaw",
@@ -2216,6 +2251,10 @@ async def test_execute_rollback_uses_fixed_device_count_one():
     # Verify upgrade_async uses the fixed device_count
     upgrade_call = build_service.upgrade_async.call_args
     assert upgrade_call.kwargs["device_count"] == 1
+    assert (
+        upgrade_call.kwargs["docker_image"]
+        == "registry.example.com/arka/openclaw:v2"
+    )
     assert upgrade_call.kwargs["extra_envs"] == {
         "AGENTCLAW_SKILLS_LAYOUT": "pool",
         "AGENTCLAW_SKILLS_LAYOUT_CONTRACT_VERSION": "skills-pool-p3-v1",
@@ -2368,6 +2407,7 @@ async def test_execute_rollback_with_config_artifact():
     upgrade_call = build_service.upgrade_async.call_args
     assert upgrade_call.kwargs["delivery"].config_artifact == artifact
     assert upgrade_call.kwargs["migration_path"] is None
+    assert upgrade_call.kwargs["docker_image"] is None
 
     assert result.publish_id == 2
     assert result.status == PublishStatus.ONLINE_PUB
@@ -2488,6 +2528,8 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
         ext={
             "binding": {"online": 123},
             "skills_manifest": frozen_skills,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
         },
     )
     binding = Mock()
@@ -2510,6 +2552,9 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
     assert kwargs["owner_id"] == "u1"
     assert kwargs["target_count"] == 3
     assert kwargs["auto_approve_publish"] is True
+    assert kwargs["config"] == {
+        "deploy_config": {"docker_image": "registry/arka:v2"}
+    }
     # (#197) request_id is now the runner's deterministic op id (wall-clock id gone).
     assert kwargs["request_id"] == operation_request_id(10, "scale", "online", 1)
     publish_service.update_publish_ext.assert_called_once_with(
@@ -2517,6 +2562,8 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
         ext={
             "binding": {"online": 123},
             "skills_manifest": frozen_skills,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
             "scale": {"publish_id": 888},
         },
     )


### PR DESCRIPTION
## Problem

ARKA service Bot instances currently inherit the image selected by the runtime template. After the configured image changes, create, restart, publish, caller, scale, and rollback operations can resolve different images for the same service Bot version. In particular, a historical rollback could combine an old build artifact with the current image, making the deployment non-reproducible.

The rollout also needs an environment-level switch so image Pin can be enabled independently without rewriting existing Bots or historical publish records.

## Solution

- Reuse the existing Common Config capability as the environment-level switch and current ARKA image source.
- Resolve the current configured image for new ARKA service Bots and draft restarts, then persist the accepted snapshot to the Bot and current Draft publish metadata.
- Copy only the image Pin fields into publish metadata, preserving unrelated service configuration, bindings, and build artifacts.
- Resolve published lifecycle operations from the target publish record instead of the current Common Config:
  - Verify and Online release
  - Eval publish
  - Published restart and fallback recreate
  - Caller containers
  - Scale Up
  - Historical rollback
- Thread an optional `docker_image` through `BotBuildService` into the existing BaaS create, upgrade, and scale payload construction.
- Keep TeClaw on its existing artifact delivery path and ignore the ARKA image Pin field.
- Preserve historical behavior when a Bot or publish record has no valid image snapshot by passing no custom image.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/core/service_bot/services/test_arka_image_pin.py tests/community/core/service_bot/services/test_publish_flow_service.py -q` — 174 passed
- `DEPLOY_PROFILE=test uv run pytest tests/community/core/service_bot/services/test_publish_flow_service.py -k 'execute_rollback' -v` — 6 passed
- `uv run ruff check src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py tests/community/core/service_bot/services/test_publish_flow_service.py` — passed
- `git diff --check` — passed

## Compatibility and risk

- No database schema migration is required; the implementation uses existing configuration and metadata storage.
- Existing Bots and historical publish records are not batch-updated or restarted.
- Old publish records without Pin metadata continue using the existing template/default image behavior and never fall back to the latest Common Config during published operations.
- Changing or disabling Common Config affects only subsequent Bot creation and draft restart; published restart, scale, Eval, Caller, and rollback remain bound to their target publish snapshot.
- A configured image pull or startup failure is surfaced by BaaS/ARKA rather than silently falling back to another image.
