### PR TITLE
fix(engine): upgrade legacy Desktop repo bridge safely

### DIFF
--- a/src/engine/src/engine/community/core/skills/skills_repo_download.py
+++ b/src/engine/src/engine/community/core/skills/skills_repo_download.py
@@ -58,6 +58,7 @@ from engine.community.core.skills.layout_planner import (
 )
 from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.skills_pool.desktop_preparation import (
+    DesktopPreparationStatus,
     prepare_desktop_pool,
 )
 
@@ -556,11 +557,19 @@ def _download_and_save(url: str, etag: str | None) -> bool:
     return ok
 
 
-def prepare_pool_layout(*, home: Path | None = None) -> None:
-    """Best-effort Desktop Pool preparation over the existing repo delivery."""
+def _has_existing_repo_delivery() -> bool:
+    """Return whether a real or dangling Legacy/Pool repo entry already exists."""
+
+    return any(
+        path.exists() or path.is_symlink() for path in {TARGET_DIR, LEGACY_TARGET_DIR}
+    )
+
+
+def prepare_pool_layout(*, home: Path | None = None) -> bool:
+    """Prepare Desktop Pool and report whether existing delivery is safe to update."""
 
     if not _is_agentbox_env():
-        return
+        return False
     try:
         engine = normalize(load_engine_config().default_engine)
         repo_source = TARGET_DIR
@@ -584,10 +593,16 @@ def prepare_pool_layout(*, home: Path | None = None) -> None:
             result.preparation_id,
             result.reason,
         )
+        return result.status in {
+            DesktopPreparationStatus.PREPARED,
+            DesktopPreparationStatus.ALREADY_PREPARED,
+            DesktopPreparationStatus.ACTIVE_LAYOUT,
+        }
     except Exception:
         log.exception(
             "Desktop skills Pool preparation failed; preserving Legacy layout"
         )
+        return False
 
 
 def bootstrap_on_startup() -> None:
@@ -615,7 +630,13 @@ def bootstrap_on_startup() -> None:
     log.info("Skills-repo bootstrap starting...")
     # Upgrade old Desktop storage before the downloader decides which corpus
     # needs refreshing. Failure is non-fatal and leaves the old runtime intact.
-    prepare_pool_layout()
+    prepared = prepare_pool_layout()
+    if not prepared and _has_existing_repo_delivery():
+        log.error(
+            "Skills-repo bootstrap blocked: existing delivery could not be "
+            "prepared safely"
+        )
+        return
     url, etag = _get_download_info()
     if not url:
         log.info("No skills-repo URL available — skipping bootstrap download")
@@ -639,7 +660,12 @@ def bootstrap_on_startup() -> None:
 def _sync_once() -> None:
     """Run one periodic repo refresh and keep Pool preparation in sync."""
 
-    prepare_pool_layout()
+    prepared = prepare_pool_layout()
+    if not prepared and _has_existing_repo_delivery():
+        log.error(
+            "Background sync blocked: existing delivery could not be prepared safely"
+        )
+        return
     url, etag = _get_download_info()
     if not url:
         log.info("Background sync: no URL available, skipping")

--- a/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/desktop_preparation.py
@@ -112,8 +112,17 @@ def _canonicalize_downloaded_repo_locked(
         if not pool_repo.is_dir() or pool_repo.is_symlink():
             raise OSError(f"Canonical Pool repo is not a directory: {pool_repo}")
         return
+    legacy_forward_bridge_removed = False
     if pool_repo.is_symlink():
-        raise OSError(f"Canonical Pool repo must not be a symlink: {pool_repo}")
+        if _lexical_target(pool_repo) != repo_source:
+            raise OSError(f"Canonical Pool repo points elsewhere: {pool_repo}")
+        if repo_source.is_symlink() or not repo_source.is_dir():
+            raise OSError(f"Legacy repo source is not a directory: {repo_source}")
+        # The first Desktop rollout prepared ``Pool -> Legacy``. Remove only
+        # that exact bridge before atomically moving the same corpus in the
+        # canonical direction. Any other Pool symlink remains fail-closed.
+        pool_repo.unlink()
+        legacy_forward_bridge_removed = True
     if pool_repo.exists():
         if not pool_repo.is_dir():
             raise OSError(f"Canonical Pool repo is not a directory: {pool_repo}")
@@ -129,23 +138,34 @@ def _canonicalize_downloaded_repo_locked(
         raise OSError(f"Legacy repo source is not a directory: {repo_source}")
     moved_repo = False
     try:
-        os.replace(repo_source, pool_repo)
-        moved_repo = True
-    except OSError as error:
-        if pool_repo.is_dir() and not pool_repo.is_symlink():
-            if repo_source.is_symlink() and _lexical_target(repo_source) == pool_repo:
-                return
-            if isinstance(error, FileNotFoundError) and (
-                not repo_source.exists() and not repo_source.is_symlink()
-            ):
-                _publish_repo_delivery_bridge(repo_source, pool_repo)
-                return
-        raise
-    try:
+        try:
+            os.replace(repo_source, pool_repo)
+            moved_repo = True
+        except OSError as error:
+            if pool_repo.is_dir() and not pool_repo.is_symlink():
+                if (
+                    repo_source.is_symlink()
+                    and _lexical_target(repo_source) == pool_repo
+                ):
+                    return
+                if isinstance(error, FileNotFoundError) and (
+                    not repo_source.exists() and not repo_source.is_symlink()
+                ):
+                    _publish_repo_delivery_bridge(repo_source, pool_repo)
+                    return
+            raise
         _publish_repo_delivery_bridge(repo_source, pool_repo)
     except OSError:
         if moved_repo and not repo_source.exists() and not repo_source.is_symlink():
             os.replace(pool_repo, repo_source)
+        if (
+            legacy_forward_bridge_removed
+            and repo_source.is_dir()
+            and not repo_source.is_symlink()
+            and not pool_repo.exists()
+            and not pool_repo.is_symlink()
+        ):
+            _publish_repo_delivery_bridge(pool_repo, repo_source)
         raise
 
 

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_preparation.py
@@ -224,6 +224,69 @@ def test_preparation_reuses_downloaded_repo_and_preserves_legacy_layout(
     assert repeated.preparation_id == result.preparation_id
 
 
+@pytest.mark.parametrize("engine", FILESYSTEM_ENGINES)
+def test_preparation_upgrades_legacy_forward_repo_bridge(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    """Upgrade the layout emitted by the first Desktop Pool preparation."""
+
+    home = tmp_path / "home/admin"
+    layout, repo_source, managed, external = _legacy_runtime(home, engine)
+    managed_before = _target(managed)
+    external_before = _target(external)
+    layout.pool_root.mkdir(parents=True, exist_ok=True)
+    layout.pool_repo.symlink_to(repo_source, target_is_directory=True)
+    layout.ready_marker.write_text(
+        json.dumps(
+            {
+                "engine": engine,
+                "layout_contract_version": LAYOUT_CONTRACT_VERSION,
+                "preparation_id": "legacy-preparation",
+                "prepared_at": "2026-07-30T00:00:00Z",
+                "pool_local_root": str(layout.pool_local),
+                "pool_repo_root": str(layout.pool_repo),
+                "repo_delivery": "download",
+                "repo_delivery_source": str(repo_source),
+                "validation_summary": {
+                    "all_valid": True,
+                    "repo_delivery_bridge": {
+                        "path": str(layout.pool_repo),
+                        "target": str(repo_source),
+                        "valid": True,
+                    },
+                },
+            }
+        )
+    )
+
+    result = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.PREPARED
+    assert result.preparation_id not in {None, "legacy-preparation"}
+    assert layout.pool_repo.is_dir() and not layout.pool_repo.is_symlink()
+    assert (layout.pool_repo / "business/reviewer/SKILL.md").read_text() == "repo"
+    assert repo_source.is_symlink()
+    assert _target(repo_source) == layout.pool_repo
+    assert layout.legacy_repo.is_symlink()
+    assert _target(layout.legacy_repo) == layout.pool_repo
+    assert _target(managed) == managed_before
+    assert _target(external) == external_before
+    marker = json.loads(layout.ready_marker.read_text())
+    assert marker["repo_delivery_source"] == str(layout.pool_repo)
+    probe = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert probe.status is RuntimeLayoutInspectionStatus.READY
+    assert probe.preparation_id == result.preparation_id
+
+
 @pytest.mark.parametrize(
     ("engine", "activate"),
     [
@@ -448,6 +511,81 @@ def test_repo_move_loser_accepts_winner_published_reverse_bridge(
     assert (layout.pool_repo / "legacy.txt").read_text() == "legacy"
     assert repo_source.is_symlink()
     assert _target(repo_source) == layout.pool_repo
+
+
+@pytest.mark.parametrize("engine", FILESYSTEM_ENGINES)
+def test_concurrent_legacy_forward_bridge_upgrade_converges(
+    tmp_path: Path,
+    engine: str,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source, _managed, _external = _legacy_runtime(home, engine)
+    layout.pool_root.mkdir(parents=True, exist_ok=True)
+    layout.pool_repo.symlink_to(repo_source, target_is_directory=True)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda _: prepare_desktop_pool(
+                    engine=engine,
+                    repo_source=repo_source,
+                    home=home,
+                ),
+                range(2),
+            )
+        )
+
+    assert {result.status for result in results} <= {
+        DesktopPreparationStatus.PREPARED,
+        DesktopPreparationStatus.ALREADY_PREPARED,
+    }
+    assert layout.pool_repo.is_dir() and not layout.pool_repo.is_symlink()
+    assert repo_source.is_symlink()
+    assert _target(repo_source) == layout.pool_repo
+    assert (
+        inspect_runtime_layout(
+            engine=engine,
+            home=home,
+            repo_delivery=RepoDelivery.DOWNLOAD,
+        ).status
+        is RuntimeLayoutInspectionStatus.READY
+    )
+
+
+def test_forward_bridge_upgrade_failure_restores_legacy_layout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout, repo_source = _fresh_legacy_runtime(home, "openclaw")
+    (repo_source / "legacy.txt").write_text("legacy")
+    layout.pool_root.mkdir(parents=True, exist_ok=True)
+    layout.pool_repo.symlink_to(repo_source, target_is_directory=True)
+    original_publish = desktop_preparation._publish_repo_delivery_bridge
+
+    def fail_reverse_bridge_once(path: Path, source: Path) -> None:
+        if path == repo_source and source == layout.pool_repo:
+            raise OSError("injected reverse bridge publish failure")
+        original_publish(path, source)
+
+    monkeypatch.setattr(
+        desktop_preparation,
+        "_publish_repo_delivery_bridge",
+        fail_reverse_bridge_once,
+    )
+
+    result = prepare_desktop_pool(
+        engine="openclaw",
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert result.status is DesktopPreparationStatus.FAILED
+    assert repo_source.is_dir() and not repo_source.is_symlink()
+    assert (repo_source / "legacy.txt").read_text() == "legacy"
+    assert layout.pool_repo.is_symlink()
+    assert _target(layout.pool_repo) == repo_source
+    assert not layout.ready_marker.exists()
 
 
 def test_invalid_existing_claude_repo_bridge_never_publishes_ready_marker(

--- a/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_skills_repo_download.py
@@ -832,9 +832,10 @@ class TestPreparePoolLayout:
     def test_noop_when_not_agentbox(self, mod, tmp_root: Path):
         with patch.object(mod, "_is_agentbox_env", return_value=False):
             with patch.object(mod, "prepare_desktop_pool") as mock_prepare:
-                mod.prepare_pool_layout(home=tmp_root)
+                prepared = mod.prepare_pool_layout(home=tmp_root)
 
         mock_prepare.assert_not_called()
+        assert prepared is False
 
     def test_reuses_current_repo_for_configured_engine(
         self,
@@ -844,7 +845,7 @@ class TestPreparePoolLayout:
     ):
         target_dir.mkdir(parents=True)
         expected = SimpleNamespace(
-            status=SimpleNamespace(value="PREPARED"),
+            status=mod.DesktopPreparationStatus.PREPARED,
             preparation_id="P1",
             reason=None,
         )
@@ -859,13 +860,36 @@ class TestPreparePoolLayout:
                     "prepare_desktop_pool",
                     return_value=expected,
                 ) as mock_prepare:
-                    mod.prepare_pool_layout(home=tmp_root)
+                    prepared = mod.prepare_pool_layout(home=tmp_root)
 
         mock_prepare.assert_called_once_with(
             engine="hermes",
             repo_source=target_dir,
             home=tmp_root,
         )
+        assert prepared is True
+
+    def test_reports_failed_preparation(
+        self,
+        mod,
+        target_dir: Path,
+        tmp_root: Path,
+    ):
+        target_dir.mkdir(parents=True)
+        failed = SimpleNamespace(
+            status=mod.DesktopPreparationStatus.FAILED,
+            preparation_id=None,
+            reason="ambiguous repo delivery",
+        )
+        with patch.object(mod, "_is_agentbox_env", return_value=True):
+            with patch.object(
+                mod,
+                "prepare_desktop_pool",
+                return_value=failed,
+            ):
+                prepared = mod.prepare_pool_layout(home=tmp_root)
+
+        assert prepared is False
 
     def test_preparation_failure_is_non_fatal(
         self,
@@ -880,7 +904,9 @@ class TestPreparePoolLayout:
                 "load_engine_config",
                 side_effect=RuntimeError("broken config"),
             ):
-                mod.prepare_pool_layout(home=tmp_root)
+                prepared = mod.prepare_pool_layout(home=tmp_root)
+
+        assert prepared is False
 
 
 # ===================================================================
@@ -998,6 +1024,45 @@ class TestBootstrapOnStartup:
 
         assert (target_dir / "hello.txt").read_text() == "world"
 
+    def test_existing_repo_is_not_downloaded_after_preparation_failure(
+        self,
+        mod,
+        target_dir: Path,
+    ):
+        target_dir.mkdir(parents=True)
+        (target_dir / "keep.txt").write_text("existing")
+        with patch.object(mod, "_is_agentbox_env", return_value=True):
+            with patch.object(mod, "prepare_pool_layout", return_value=False):
+                with patch.object(mod, "_get_download_info") as mock_meta:
+                    with patch.object(mod, "_download_and_save") as mock_download:
+                        mod.bootstrap_on_startup()
+
+        mock_meta.assert_not_called()
+        mock_download.assert_not_called()
+        assert (target_dir / "keep.txt").read_text() == "existing"
+
+    def test_fresh_runtime_can_download_before_first_preparation(
+        self,
+        mod,
+        target_dir: Path,
+    ):
+        with patch.object(mod, "_is_agentbox_env", return_value=True):
+            with patch.object(mod, "prepare_pool_layout", return_value=False):
+                with patch.object(
+                    mod,
+                    "_get_download_info",
+                    return_value=("https://x.com/tar", '"e1"'),
+                ):
+                    with patch.object(mod, "_should_download", return_value=True):
+                        with patch.object(
+                            mod,
+                            "_download_and_save",
+                            return_value=True,
+                        ) as mock_download:
+                            mod.bootstrap_on_startup()
+
+        mock_download.assert_called_once_with("https://x.com/tar", '"e1"')
+
     def test_skips_download_when_should_download_false(self, mod):
         with patch.dict(os.environ, {"MAC_CONTAINER": "true"}):
             with patch.object(mod, "_is_agentbox_env", return_value=True):
@@ -1032,6 +1097,22 @@ class TestBootstrapOnStartup:
 
 
 class TestSyncOnce:
+    def test_existing_repo_is_not_refreshed_after_preparation_failure(
+        self,
+        mod,
+        target_dir: Path,
+    ):
+        target_dir.mkdir(parents=True)
+        (target_dir / "keep.txt").write_text("existing")
+        with patch.object(mod, "prepare_pool_layout", return_value=False):
+            with patch.object(mod, "_get_download_info") as mock_meta:
+                with patch.object(mod, "_download_and_save") as mock_download:
+                    mod._sync_once()
+
+        mock_meta.assert_not_called()
+        mock_download.assert_not_called()
+        assert (target_dir / "keep.txt").read_text() == "existing"
+
     def test_no_url_still_refreshes_preparation(self, mod):
         with patch.object(mod, "_get_download_info", return_value=(None, None)):
             with patch.object(mod, "prepare_pool_layout") as mock_prepare:


### PR DESCRIPTION
## Problem

Desktop Bots prepared by the first Skills Pool rollout can retain the historical forward bridge `Pool repo -> Legacy repo`. The canonical-repo image rejects that bridge during preparation, but the downloader then continues and publishes a second Pool corpus. The runtime stays Legacy, the readiness marker becomes stale, and probe/cutover are blocked.

## Solution

- recognize only the exact historical `Pool -> Legacy` bridge
- atomically move the existing corpus to canonical Pool storage and publish the reverse Legacy compatibility bridge
- restore the historical layout if reverse-bridge publication fails
- fail closed before bootstrap/background downloads when an existing repo delivery cannot be prepared safely
- preserve first download for genuinely fresh Desktop runtimes

## Validation

- Engine full suite: 2219 passed, 5 repository-defined skips
- Skills Pool focused suite: 193 passed
- bridge concurrency and failure-injection loop: 60/60 passed
- changed-line coverage: 96.24% (128/133)
- local Python SAST block scan and diff-check passed
- exact upgrade, retry, failure restoration, fresh Bot, OpenClaw, Claude Code, AICoding, and Hermes cases covered

Related: #455