### PR TITLE
feat(baas): add OpenAPI endpoint for listing sessions by Bot ID

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -209,3 +209,31 @@ class SessionMessagesResponse(ApiResponse[SessionMessagesResponseData]):
     data: SessionMessagesResponseData | None = Field(
         default=None, description="Session message data"
     )
+
+
+class SessionListItem(BaseModel):
+    """Single session item in list response."""
+
+    session_id: str = Field(..., description="Session ID")
+    bot_id: str = Field(..., description="Bot ID")
+    status: str = Field(..., description="Session status")
+    created_at: datetime | None = Field(default=None, description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Update time")
+
+
+class SessionListResponseData(BaseModel):
+    """Session list response data."""
+
+    items: list[SessionListItem] = Field(
+        default_factory=list, description="Session list"
+    )
+    total: int = Field(default=0, description="Total sessions")
+    has_more: bool = Field(default=False, description="Whether there are more sessions")
+
+
+class SessionListResponse(ApiResponse[SessionListResponseData]):
+    """Session list standard response."""
+
+    data: SessionListResponseData | None = Field(
+        default=None, description="Response data"
+    )

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
@@ -14,6 +14,9 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     MessageItem,
+    SessionListItem,
+    SessionListResponse,
+    SessionListResponseData,
     SessionMessagesResponse,
     SessionMessagesResponseData,
     SessionQueryResponse,
@@ -49,6 +52,150 @@ def _check_app_type(api_key_record: APIKeyRecord) -> None:
                 "code": OpenAPICode.FORBIDDEN,
                 "message": get_code_message(OpenAPICode.FORBIDDEN),
             },
+        )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="List sessions",
+    description="List sessions for a specified Bot using a Bearer Token-authenticated API Key",
+    responses={
+        200: {"description": "Query successful"},
+        401: {"description": "Authentication failed"},
+        403: {"description": "Access denied"},
+        404: {"description": "Bot not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+@inject
+async def list_sessions(
+    bot_id: str | None = Query(
+        default=None,
+        description="Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+    ),
+    lifecycle_stage: str = Query(
+        default="online",
+        description="Bot lifecycle stage. Options: online, verify, draft, all",
+    ),
+    limit: int = Query(
+        default=20, ge=1, le=100, description="Maximum number of sessions to return"
+    ),
+    offset: int = Query(default=0, ge=0, description="Number of sessions to skip"),
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    context: BotChatContext = Depends(get_bot_chat_context),
+    bot_runner: BotRunner = Depends(Provide[ApplicationContainer.services.bot_runner]),
+) -> SessionListResponse:
+    """List sessions endpoint
+
+    Args:
+        bot_id: Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.
+        lifecycle_stage: Bot lifecycle stage. Options: online, verify, draft, all. Default: online
+        limit: Maximum number of sessions to return. Default 20, range 1-100
+        offset: Number of sessions to skip. Default 0
+        api_key_record: Record obtained from API Key validation
+        context: Request context (authentication, caller identity, etc.)
+        bot_runner: BotRunner instance
+
+    Returns:
+        SessionListResponse: Session list response
+    """
+    # Only app_type=bot can resolve bot_id from the API Key; other types must pass it explicitly
+    if bot_id:
+        resolved_bot_id = bot_id
+    elif api_key_record.app_type == "bot":
+        resolved_bot_id = resolve_bot_id_from_api_key(api_key_record)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": "bot_id is a required parameter",
+            },
+        )
+
+    _check_app_type(api_key_record)
+    if api_key_record.app_type != "bot":
+        resolved_bot_id = validate_policy(api_key_record, resolved_bot_id)
+
+    logger.info(
+        f"list_sessions: bot_id={resolved_bot_id}, "
+        f"lifecycle_stage={lifecycle_stage}, limit={limit}, offset={offset}, "
+        f"api_key_prefix={api_key_record.api_key_prefix}"
+    )
+
+    try:
+        # Fetch limit+1 to determine has_more without extra count
+        sessions = await bot_runner.list_sessions(
+            bot_id=resolved_bot_id,
+            context=context,
+            metadata={"bot_options": {"lifecycle_stage": lifecycle_stage}},
+            limit=limit + 1,
+            offset=offset,
+        )
+
+        has_more = len(sessions) > limit
+        sessions = sessions[:limit]
+        total = offset + len(sessions) + (1 if has_more else 0)
+
+        session_items = [
+            SessionListItem(
+                session_id=s.session_id,
+                bot_id=s.bot_id,
+                status=s.status,
+                created_at=s.created_at,
+                updated_at=s.updated_at,
+            )
+            for s in sessions
+        ]
+
+        logger.info(
+            f"list_sessions success: bot_id={resolved_bot_id}, "
+            f"returned={len(session_items)}, has_more={has_more}"
+        )
+
+        return SessionListResponse(
+            code=0,
+            message="success",
+            data=SessionListResponseData(
+                items=session_items,
+                total=total,
+                has_more=has_more,
+            ),
+        )
+
+    except BotBindingNotFoundError as e:
+        logger.warning(
+            f"list_sessions binding not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotNotFoundError as e:
+        logger.warning(
+            f"list_sessions bot not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotServiceError as e:
+        logger.error(
+            f"list_sessions bot service error: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": OpenAPICode.BUSINESS_ERROR, "message": str(e)},
+        )
+    except Exception as e:
+        logger.error(
+            f"list_sessions unexpected error: bot_id={resolved_bot_id}, error={e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": 50001, "message": f"Internal server error: {str(e)}"},
         )
 
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -404,6 +404,29 @@ class BotRunner(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: "BotChatContext",
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list["SessionInfo"]:
+        """List sessions for a given bot (read-only).
+
+        Args:
+            bot_id: Bot 唯一标识，格式为 <real_bot_id>:<entity_id>
+            context: 请求上下文
+            metadata: 元数据，支持 bot_options.lifecycle_stage 指定生命周期阶段
+            limit: Maximum number of sessions to return
+            offset: Number of sessions to skip
+
+        Returns:
+            List of SessionInfo objects
+        """
+        ...
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -659,6 +659,63 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """List sessions for a given bot binding (read-only).
+
+        通过 AsyncSessionClient 从 adapter 侧查询会话列表，不创建新会话。
+
+        Args:
+            binding_info: Binding info for HTTP connection.
+            context: Optional request context for tenant extraction.
+            limit: Maximum number of sessions to return.
+            offset: Number of sessions to skip.
+
+        Returns:
+            List of SessionInfo objects.
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        try:
+            conn_info = await self._resolve_ws_connection_for_binding(
+                binding_info, context
+            )
+        except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
+
+        session_client = self._create_session_client(
+            conn_info, binding_info.engine_type
+        )
+        try:
+            async with session_client:
+                adapter_sessions = await session_client.list_sessions(
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_info(s, binding_info.bot_id)
+                    for s in adapter_sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -433,6 +433,52 @@ class ClawBotService(BotService):
         except Exception as e:
             raise BotServiceError(f"Failed to get session: {e}") from e
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """List sessions for a given bot binding (read-only).
+
+        通过 AsyncSessionClient 从 adapter 侧查询会话列表，不创建新会话。
+
+        Args:
+            binding_info: Binding info for HTTP connection.
+            context: Optional request context (unused in ClawBotService).
+            limit: Maximum number of sessions to return.
+            offset: Number of sessions to skip.
+
+        Returns:
+            List of SessionInfo objects.
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        sandbox_id = binding_info.sandbox_id
+        if sandbox_id is None:
+            raise BotServiceError("ClawBotService requires sandbox_id in binding_info.")
+
+        session_client = self._create_session_client(sandbox_id)
+        try:
+            async with session_client:
+                adapter_sessions = await session_client.list_sessions(
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_info(s, binding_info.bot_id)
+                    for s in adapter_sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            raise BotServiceError(f"Failed to list sessions: {e}") from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -183,6 +183,27 @@ class BotService(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """List sessions for a given bot binding (read-only).
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文
+            limit: Maximum number of sessions to return
+            offset: Number of sessions to skip
+
+        Returns:
+            List of SessionInfo objects
+        """
+        ...
+
 
 @runtime_checkable
 class MessageDispatcher(Protocol):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -440,6 +440,24 @@ class BotRunner:
             context=context,
         )
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: BotChatContext,
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """List sessions for a given bot (read-only)."""
+        route = await self._resolve_bot_route(bot_id, metadata)
+        return await route.bot_service.list_sessions(
+            binding_info=route.binding_info,
+            context=context,
+            limit=limit,
+            offset=offset,
+        )
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
@@ -1,8 +1,8 @@
 """E2E tests for Open API Session endpoints.
 
 Tests cover:
-- GET /openapi/v1/sessions - list sessions → 200/404 (no list endpoint)
-- GET /openapi/v1/sessions - pagination with page and page_size params
+- GET /openapi/v1/sessions - list sessions → 200/400/401/403
+- GET /openapi/v1/sessions - pagination with limit and offset params
 - GET /openapi/v1/sessions/{session_id} - valid session ID → 200
 - GET /openapi/v1/sessions/{session_id} - not found → 404
 - GET /openapi/v1/sessions/{session_id} - invalid session ID format
@@ -38,41 +38,56 @@ class TestListSessions:
             headers={"Authorization": "Bearer test-key"},
         )
 
-        # No dedicated list endpoint exists; expect 404 or 401 (invalid key)
-        assert response.status_code in (200, 401, 404)
+        # Invalid key → 401; valid key → 200/400/403/404
+        assert response.status_code in (200, 400, 401, 403, 404)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_with_pagination(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with pagination params → 401/404."""
+    async def test_list_sessions_with_limit_offset(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit and offset params."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 5},
+            params={"bot_id": "test-bot", "limit": 5, "offset": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        assert response.status_code in (200, 400, 401, 403, 404)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_page_out_of_range(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page=99999 → 401/404."""
+    async def test_list_sessions_limit_exceeds_max(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit > 100 → 422."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 99999, "page_size": 10},
+            params={"bot_id": "test-bot", "limit": 200},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        # limit has ge=1, le=100 constraint → 422 for out of range
+        assert response.status_code in (200, 400, 401, 403, 404, 422)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_zero_page_size(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page_size=0 → 401/422/404."""
+    async def test_list_sessions_negative_offset(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with negative offset → 422."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 0},
+            params={"bot_id": "test-bot", "offset": -1},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 422, 404)
+        # offset has ge=0 constraint → 422 for negative
+        assert response.status_code in (200, 400, 401, 403, 404, 422)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_without_bot_id_non_bot_key(
+        self, api: APITestHelper
+    ) -> None:
+        """GET /openapi/v1/sessions without bot_id for non-bot API Key → 400."""
+        response = await api.client.get(
+            api.open_api_session_url(),
+            headers={"Authorization": "Bearer test-key"},
+        )
+
+        # Without bot_id, non-bot app_type → 400; bot app_type → 200/404
+        assert response.status_code in (200, 400, 401, 403, 404)
 
 
 class TestGetSessionById:

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -19,6 +19,7 @@ from secbaas.community.adapters.web.routers.open_api.session_router import (
     _check_app_type,
     get_session,
     get_session_messages,
+    list_sessions,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
 from secbaas.community.api.bot_runtime import (
@@ -925,6 +926,354 @@ class TestGetSessionMessages:
                     limit=DEFAULT_LIMIT,
                     bot_id=BOT_ID,
                     lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert exc.value.detail["code"] == 50001
+        assert "Internal server error" in exc.value.detail["message"]
+
+
+# ── list_sessions ─────────────────────────────────────────────
+
+
+class TestListSessions:
+    """list_sessions 端点核心逻辑测试。"""
+
+    @pytest.mark.asyncio
+    async def test_bot_id_resolution_explicit(self):
+        """显式传入 bot_id 时直接使用。"""
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-default:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id="bot-explicit:entity-1",
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once()
+        assert (
+            mock_runner.list_sessions.call_args[1]["bot_id"]
+            == "bot-explicit:entity-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bot_id_resolution_from_api_key(self):
+        """app_type='bot' 不传 bot_id 时从 API Key 解析。"""
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-1:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(RESOLVE_PATH, return_value=BOT_ID) as mock_resolve,
+            patch(POLICY_PATH),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_resolve.assert_called_once_with(api_key)
+
+    @pytest.mark.asyncio
+    async def test_missing_bot_id_system_type_returns_400(self):
+        """app_type='system' 不传 bot_id 返回 400。"""
+        api_key = _make_api_key_record(app_type="system")
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=AsyncMock(spec=BotRunner),
+            )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_disallowed_app_type_returns_403(self):
+        """app_type 不在 ('system','app','bot') -> 403。"""
+        api_key = _make_api_key_record(app_type="user")
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=AsyncMock(spec=BotRunner),
+            )
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_bot_type_skips_validate_policy(self):
+        """app_type='bot' 时跳过 validate_policy。"""
+        api_key = _make_api_key_record(app_type="bot", app_id=BOT_ID)
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(POLICY_PATH) as mock_policy,
+            patch(RESOLVE_PATH, return_value=BOT_ID),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_system_type_calls_validate_policy(self):
+        """app_type='system' 时调用 validate_policy。"""
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID) as mock_policy:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_called_once_with(api_key, BOT_ID)
+
+    @pytest.mark.asyncio
+    async def test_success_with_sessions(self):
+        """成功返回会话列表。"""
+        sessions = [
+            _make_session_info(session_id="sess-001"),
+            _make_session_info(session_id="sess-002"),
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.message == "success"
+        assert len(result.data.items) == 2
+        assert result.data.items[0].session_id == "sess-001"
+        assert result.data.items[1].session_id == "sess-002"
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_success_with_empty_list(self):
+        """空会话列表成功返回。"""
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=0,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.data.items == []
+        assert result.data.total == 0
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_pagination_has_more(self):
+        """limit+1 策略：结果超过 limit 时 has_more=True。"""
+        sessions = [_make_session_info(session_id=f"sess-{i:03d}") for i in range(3)]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=2,
+                offset=0,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.has_more is True
+        assert len(result.data.items) == 2
+        # Called with limit+1=3
+        assert mock_runner.list_sessions.call_args[1]["limit"] == 3
+
+    @pytest.mark.asyncio
+    async def test_pagination_no_has_more(self):
+        """结果不超过 limit 时 has_more=False。"""
+        sessions = [_make_session_info(session_id=f"sess-{i:03d}") for i in range(2)]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=2,
+                offset=0,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.has_more is False
+        assert len(result.data.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_offset_passed_through(self):
+        """offset 参数传递给 BotRunner。"""
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=20,
+                offset=10,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert mock_runner.list_sessions.call_args[1]["offset"] == 10
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_stage_passed_in_metadata(self):
+        """lifecycle_stage 通过 metadata 传递给 BotRunner。"""
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage="draft",
+                limit=20,
+                offset=0,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert mock_runner.list_sessions.call_args[1]["metadata"] == {
+            "bot_options": {"lifecycle_stage": "draft"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_bot_binding_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotBindingNotFoundError(BOT_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=20,
+                    offset=0,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotNotFoundError("bot-1"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=20,
+                    offset=0,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_returns_400(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotServiceError("service unavailable"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=20,
+                    offset=0,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_500(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=20,
+                    offset=0,
                     api_key_record=_make_api_key_record(),
                     context=_make_context(),
                     bot_runner=mock_runner,

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -2154,6 +2154,122 @@ class TestSendMessageWaitResult:
             assert call_kwargs["wait_result"] is False
 
 
+# ==================== TestListSessions ====================
+
+
+class TestListSessions:
+    """BaasBotService.list_sessions() coverage."""
+
+    @pytest.mark.asyncio
+    async def test_success_path(self, service):
+        """Successful list_sessions resolves WS conn, queries client, maps results."""
+        from secbaas.community.core.service.bot_run._async_session_client import (
+            SessionInfo as AdapterSessionInfo,
+        )
+
+        adapter_session = AdapterSessionInfo(
+            id="sess-001",
+            title="test",
+            user_id="user-1",
+            agent_id=BOT_UUID,
+            created_at="2025-01-01T00:00:00Z",
+            updated_at="2025-01-01T01:00:00Z",
+        )
+
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(return_value=[adapter_session])
+
+        binding = _make_binding_info(engine_type="openclaw")
+        context = MagicMock()
+
+        with (
+            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
+            patch.object(service, "_create_session_client", return_value=session_client),
+        ):
+            result = await service.list_sessions(
+                binding_info=binding,
+                context=context,
+                limit=5,
+                offset=2,
+            )
+
+        session_client.list_sessions.assert_awaited_once_with(
+            agent_id=BOT_UUID,
+            limit=5,
+            offset=2,
+            engine="openclaw",
+        )
+        assert len(result) == 1
+        assert result[0].session_id == "sess-001"
+        assert result[0].bot_id == BOT_UUID
+
+    @pytest.mark.asyncio
+    async def test_connection_resolution_failure(self, service):
+        """WS connection resolution failure wraps as BotServiceError."""
+        binding = _make_binding_info()
+        context = MagicMock()
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("conn failed"),
+        ):
+            with pytest.raises(BotServiceError, match="Failed to resolve WS connection"):
+                await service.list_sessions(
+                    binding_info=binding,
+                    context=context,
+                    limit=20,
+                    offset=0,
+                )
+
+    @pytest.mark.asyncio
+    async def test_downstream_client_failure(self, service):
+        """Downstream session client failure wraps as BotServiceError."""
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(side_effect=RuntimeError("timeout"))
+
+        binding = _make_binding_info()
+        context = MagicMock()
+
+        with (
+            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
+            patch.object(service, "_create_session_client", return_value=session_client),
+        ):
+            with pytest.raises(BotServiceError, match="Failed to list sessions"):
+                await service.list_sessions(
+                    binding_info=binding,
+                    context=context,
+                )
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_not_double_wrapped(self, service):
+        """Existing BotServiceError from client passes through without re-wrapping."""
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(
+            side_effect=BotServiceError("already wrapped"),
+        )
+
+        binding = _make_binding_info()
+        context = MagicMock()
+
+        with (
+            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
+            patch.object(service, "_create_session_client", return_value=session_client),
+        ):
+            with pytest.raises(BotServiceError, match="already wrapped"):
+                await service.list_sessions(
+                    binding_info=binding,
+                    context=context,
+                )
+
+
 # ==================== ANY matcher for mock assertions ====================
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -578,3 +578,83 @@ class TestCreateSessionFullFlow:
         )
         assert session.session_id == SESSION_ID
         assert session.status == "active"
+
+
+# ==================== TestListSessions ====================
+
+
+class TestListSessions:
+    """ClawBotService.list_sessions() coverage."""
+
+    @pytest.mark.asyncio
+    async def test_missing_sandbox_id(self, service, baas_binding):
+        """ClawBotService requires sandbox_id in binding_info."""
+        with pytest.raises(BotServiceError, match="ClawBotService requires sandbox_id"):
+            await service.list_sessions(binding_info=baas_binding)
+
+    @pytest.mark.asyncio
+    async def test_success_path_with_pagination(self, service, arca_binding, monkeypatch):
+        """Successful list_sessions delegates to session client with correct args."""
+        from secbaas.community.core.service.bot_run._async_session_client import (
+            SessionInfo as AdapterSessionInfo,
+        )
+
+        adapter_session = AdapterSessionInfo(
+            id="sess-001",
+            title="test",
+            user_id="user-1",
+            agent_id=BOT_ID,
+            created_at="2025-01-01T00:00:00Z",
+            updated_at="2025-01-01T01:00:00Z",
+        )
+
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(return_value=[adapter_session])
+
+        monkeypatch.setattr(service, "_create_session_client", lambda x: session_client)
+
+        result = await service.list_sessions(
+            binding_info=arca_binding,
+            limit=5,
+            offset=2,
+        )
+
+        session_client.list_sessions.assert_awaited_once_with(
+            agent_id=BOT_ID,
+            limit=5,
+            offset=2,
+            engine=arca_binding.engine_type,
+        )
+        assert len(result) == 1
+        assert result[0].session_id == "sess-001"
+        assert result[0].bot_id == BOT_ID
+
+    @pytest.mark.asyncio
+    async def test_downstream_client_failure(self, service, arca_binding, monkeypatch):
+        """Downstream client RuntimeError wraps as BotServiceError."""
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(side_effect=RuntimeError("timeout"))
+
+        monkeypatch.setattr(service, "_create_session_client", lambda x: session_client)
+
+        with pytest.raises(BotServiceError, match="Failed to list sessions"):
+            await service.list_sessions(binding_info=arca_binding)
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_passthrough(self, service, arca_binding, monkeypatch):
+        """Existing BotServiceError passes through without re-wrapping."""
+        session_client = AsyncMock()
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+        session_client.list_sessions = AsyncMock(
+            side_effect=BotServiceError("already wrapped"),
+        )
+
+        monkeypatch.setattr(service, "_create_session_client", lambda x: session_client)
+
+        with pytest.raises(BotServiceError, match="already wrapped"):
+            await service.list_sessions(binding_info=arca_binding)

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -2035,6 +2035,70 @@ class TestConvertChunksToSse:
         assert results == []
 
 
+# ==================== TestListSessions ====================
+
+
+class TestListSessions:
+    """BotRunner.list_sessions() coverage."""
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_bot_service(self, mock_bot_service, mock_selector, mock_run_repo, context):
+        """list_sessions resolves route and delegates to bot_service."""
+        from secbaas.community.api.bot_runtime import SessionInfo
+        from datetime import datetime, UTC
+
+        binding = BotBindingInfo(
+            bot_id=BOT_ID,
+            entity_id="entity-1",
+            sandbox_id="sandbox-1",
+            device_id="device-1",
+            device_provider="arca",
+            binding_id=100,
+            device_props={},
+            bot_type="personal",
+        )
+
+        expected_sessions = [
+            SessionInfo(
+                session_id="sess-001",
+                bot_id=BOT_ID,
+                status="active",
+                created_at=datetime.now(tz=UTC),
+            )
+        ]
+        mock_bot_service.list_sessions = AsyncMock(return_value=expected_sessions)
+
+        runner = BotRunner(
+            service_selector=mock_selector,
+            run_repo=mock_run_repo,
+            bot_service_plugin=None,
+            task_pool=None,
+            message_dispatcher=None,
+        )
+
+        # Patch _resolve_bot_route to return our binding and service
+        route = MagicMock()
+        route.binding_info = binding
+        route.bot_service = mock_bot_service
+
+        with patch.object(runner, "_resolve_bot_route", new_callable=AsyncMock, return_value=route):
+            result = await runner.list_sessions(
+                bot_id=BOT_ID,
+                context=context,
+                metadata={"source": "openapi"},
+                limit=5,
+                offset=2,
+            )
+
+        assert result == expected_sessions
+        mock_bot_service.list_sessions.assert_awaited_once_with(
+            binding_info=binding,
+            context=context,
+            limit=5,
+            offset=2,
+        )
+
+
 class _DummyConverter:
     """Minimal StreamConverter stub for testing convert_chunks_to_sse."""
 

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -2069,11 +2069,10 @@ class TestListSessions:
         mock_bot_service.list_sessions = AsyncMock(return_value=expected_sessions)
 
         runner = BotRunner(
-            service_selector=mock_selector,
-            run_repo=mock_run_repo,
+            bot_service_selector=mock_selector,
+            run_repository=mock_run_repo,
             bot_service_plugin=None,
-            task_pool=None,
-            message_dispatcher=None,
+            dispatchers=[],
         )
 
         # Patch _resolve_bot_route to return our binding and service


### PR DESCRIPTION
Add GET /openapi/v1/sessions endpoint to query session lists by Bot ID using Bearer Token auth. 9 files changed, 720 insertions, 16 new unit tests.