### PR TITLE
feat(bcs): per-recipient system-message ownership + user-facing WS message

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1176,6 +1176,8 @@ dependencies = [
  "bcs-message-store",
  "bcs-service-api",
  "bcs-session-store",
+ "bcs-system-message",
+ "bcs-test-support",
  "serde_json",
  "tokio",
  "tracing",

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -825,9 +825,10 @@ impl SessionMessageService for SessionServiceImpl {
         // VSN7A/VUlai/VHxMU — reuse the legacy `bcs-message` visibility helper
         // (single source of truth) so the V1 session list applies the EXACT
         // same scoping the group history path does: the full 3-state
-        // `MessageOwnerFilter` (incl. ManagerWorker public-only `IsNull`) and
-        // the spec §5.2 new-participant `visible_from_seq` cutoff. The V1 facade
-        // no longer reimplements these predicates.
+        // `MessageOwnerFilter` (incl. ManagerWorker manager-viewer
+        // `PublicOrOwner`) and the spec §5.2 new-participant
+        // `visible_from_seq` cutoff. The V1 facade no longer reimplements
+        // these predicates.
         let group = self.load_group(&session.group_id).await?;
         let (owner_filter, visible_from_seq) =
             MessageService::compute_session_history_query(

--- a/src/bcs/crates/contracts/bcs-domain/src/message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/message.rs
@@ -179,6 +179,10 @@ pub enum MessageOwnerFilter {
     Any,
     IsNull,
     Eq(String),
+    /// `owner_bot_id IS NULL OR owner_bot_id = <viewer>` — 公共消息 + 发给该
+    /// viewer 的系统消息副本。历史查询按 `view_bot_id` 回放"公共 + 自己的
+    /// 系统副本"，收窄的仅是他人新增的私有副本，是旧 `Any`/`IsNull` 的超集。
+    PublicOrOwner(String),
 }
 
 impl Default for MessageOwnerFilter {

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/system_message.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/system_message.rs
@@ -13,13 +13,27 @@ pub const BCS_SYSTEM_MESSAGE: &str = "bcs-system-message";
 pub trait SystemMessageProducerService: Send + Sync {
     fn kind(&self) -> SystemMessageEventKind;
 
+    /// Produce messages for a system-message event.
+    ///
+    /// Returns `(bot_messages, user_message)`:
+    /// - `bot_messages`: per-bot delivery messages (semantics unchanged). The
+    ///   dispatcher persists one history record per recipient with
+    ///   `owner_bot_id = recipient` and delivers each via `chat.send`/`chat.inject`.
+    /// - `user_message`: single user-facing text used ONLY for the frontend
+    ///   WebSocket session broadcast (NOT persisted); `None` when the event has
+    ///   no user-facing content.
+    ///
+    /// Producers must return `None` (never `Some("")`) when the event has no
+    /// non-empty user-facing text, so the dispatcher's non-empty check and the
+    /// producer responsibility stay aligned. An empty `bot_messages` does NOT
+    /// block a non-empty `user_message` (e.g. last bot leaving).
     async fn produce(
         &self,
         event: &SystemMessageEvent,
         group: &Group,
         registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage>;
+    ) -> (Vec<SystemGroupMessage>, Option<String>);
 }
 
 #[derive(Debug)]

--- a/src/bcs/crates/services/bcs-message-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-message-store/src/memory.rs
@@ -126,6 +126,12 @@ impl MessageRepoPort for MemoryMessageRepo {
             MessageOwnerFilter::Eq(owner_bot_id) => {
                 filtered.retain(|m| m.owner_bot_id.as_deref() == Some(owner_bot_id.as_str()));
             }
+            MessageOwnerFilter::PublicOrOwner(owner_bot_id) => {
+                filtered.retain(|m| {
+                    m.owner_bot_id.is_none()
+                        || m.owner_bot_id.as_deref() == Some(owner_bot_id.as_str())
+                });
+            }
         }
 
         // Apply time_range filter
@@ -203,6 +209,12 @@ impl MessageRepoPort for MemoryMessageRepo {
             }
             MessageOwnerFilter::Eq(owner) => {
                 filtered.retain(|m| m.owner_bot_id.as_deref() == Some(owner.as_str()));
+            }
+            MessageOwnerFilter::PublicOrOwner(owner) => {
+                filtered.retain(|m| {
+                    m.owner_bot_id.is_none()
+                        || m.owner_bot_id.as_deref() == Some(owner.as_str())
+                });
             }
         }
 

--- a/src/bcs/crates/services/bcs-message-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-message-store/src/mysql.rs
@@ -310,6 +310,10 @@ impl MessageRepoPort for MySqlMessageStore {
                 conditions.push("owner_bot_id = ?".to_string());
                 params.push(DbValue::from(owner_bot_id.clone()));
             }
+            MessageOwnerFilter::PublicOrOwner(owner_bot_id) => {
+                conditions.push("(owner_bot_id IS NULL OR owner_bot_id = ?)".to_string());
+                params.push(DbValue::from(owner_bot_id.clone()));
+            }
         }
 
         if let Some(ref keyword) = query.keyword {
@@ -450,6 +454,10 @@ impl MessageRepoPort for MySqlMessageStore {
             }
             MessageOwnerFilter::Eq(owner) => {
                 conditions.push("owner_bot_id = ?".to_string());
+                params.push(DbValue::from(owner.clone()));
+            }
+            MessageOwnerFilter::PublicOrOwner(owner) => {
+                conditions.push("(owner_bot_id IS NULL OR owner_bot_id = ?)".to_string());
                 params.push(DbValue::from(owner.clone()));
             }
         }

--- a/src/bcs/crates/services/bcs-message/Cargo.toml
+++ b/src/bcs/crates/services/bcs-message/Cargo.toml
@@ -20,6 +20,8 @@ bcs-bot = { workspace = true }
 bcs-group = { workspace = true }
 bcs-message-store = { workspace = true }
 bcs-session-store = { workspace = true }
+bcs-system-message = { workspace = true }
+bcs-test-support = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -159,11 +159,14 @@ impl MessageService {
     /// Returns:
     /// - `ManagerWorker` strategy + worker viewer → `(Eq(worker_id), None)`
     ///   (owner isolation: a worker only reads its own messages).
-    /// - `ManagerWorker` strategy + non-worker/manager viewer →
-    ///   `(IsNull, None)` (public-only: hide worker-owned messages, VUlai).
-    /// - Chat / other strategies → `(Any, visible_from_seq)` where
-    ///   `visible_from_seq` is the spec §5.2 new-participant cutoff for the
-    ///   viewer's `bot_uuid`, or `None` when no viewer / no recorded messages.
+    /// - `ManagerWorker` strategy + non-worker bot manager viewer →
+    ///   `(PublicOrOwner(view), None)`; none / human viewer →
+    ///   `(IsNull, None)` (public-only, VUlai).
+    /// - Chat / other strategies + bot viewer →
+    ///   `(PublicOrOwner(view), visible_from_seq)`; none / human viewer →
+    ///   `(IsNull, visible_from_seq)` where `visible_from_seq` is the spec
+    ///   §5.2 new-participant cutoff for the viewer's `bot_uuid`, or `None`
+    ///   when no viewer / no recorded messages.
     pub fn compute_session_history_query(
         group: &Group,
         session: &Session,
@@ -174,8 +177,14 @@ impl MessageService {
         if is_manager_worker {
             let view = Self::manager_worker_history_view(group, session, view_bot_id)?;
             let owner_filter = match view {
-                ManagerWorkerHistoryView::Public => MessageOwnerFilter::IsNull,
                 ManagerWorkerHistoryView::Worker(worker_id) => MessageOwnerFilter::Eq(worker_id),
+                ManagerWorkerHistoryView::Public => match view_bot_id {
+                    // Non-worker bot viewer (the manager) reads public + own copies.
+                    Some(v) if !v.is_empty() && !v.starts_with("human_") => {
+                        MessageOwnerFilter::PublicOrOwner(v.to_string())
+                    }
+                    _ => MessageOwnerFilter::IsNull,
+                },
             };
             Ok((owner_filter, None))
         } else {
@@ -188,7 +197,20 @@ impl MessageService {
                 ),
                 None => None,
             };
-            Ok((MessageOwnerFilter::Any, visible_from_seq))
+            Ok((Self::chat_owner_filter_for_view(view_bot_id), visible_from_seq))
+        }
+    }
+
+    /// Chat/non-MW viewer → owner filter: a bot viewer reads public messages
+    /// plus its own system-message copies (`PublicOrOwner`); no view_bot_id or
+    /// a `human_*` viewer reads public-only (`IsNull`). Membership is NOT
+    /// verified here (mirrors the existing chat-branch behavior).
+    pub fn chat_owner_filter_for_view(view_bot_id: Option<&str>) -> MessageOwnerFilter {
+        match view_bot_id {
+            Some(v) if !v.is_empty() && !v.starts_with("human_") => {
+                MessageOwnerFilter::PublicOrOwner(v.to_string())
+            }
+            _ => MessageOwnerFilter::IsNull,
         }
     }
 }
@@ -329,6 +351,7 @@ impl GroupMessageHistoryService for MessageService {
                 limit,
                 "get_history: new Chat group, querying MessageRepoPort"
             );
+            let owner_filter = Self::chat_owner_filter_for_view(cmd.view_bot_id.as_deref());
             let query = MessageQuery {
                 group_id: cmd.group_id.clone(),
                 session_id: String::new(),
@@ -337,7 +360,7 @@ impl GroupMessageHistoryService for MessageService {
                 keyword: None,
                 sender_id: None,
                 message_type: None,
-                owner_filter: MessageOwnerFilter::Any,
+                owner_filter,
                 time_range: None,
                 visible_from_seq: None,
             };
@@ -562,7 +585,7 @@ mod tests {
     use super::*;
 
     use bcs_bot::BotCore;
-    use bcs_domain::{MessagePage, NewMessage, PersistedMessage, SenderType};
+    use bcs_domain::{MessagePage, NewMessage, PersistedMessage, SenderType, SystemMessageEvent};
     use bcs_group::GroupCore;
     use bcs_message_store::MemoryMessageRepo;
     use bcs_service_api::{
@@ -1116,5 +1139,191 @@ mod tests {
         assert_eq!(fallback.session_calls().await, 0);
         assert_eq!(result.messages.len(), 1);
         assert_eq!(result.messages[0].content, "public-human");
+    }
+
+    #[tokio::test]
+    async fn chat_bot_viewer_sees_public_and_own_system_copies_not_others() {
+        let (service, repo, _sessions, fallback, session_id) =
+            service_fixture(GroupStrategy::Chat, 0, u64::MAX, Vec::new()).await;
+        append_history(&repo, "group-1", &session_id, "human_1", "public-human", None).await;
+        append_history(&repo, "group-1", &session_id, "system", "sys-to-worker-a", Some("worker-a")).await;
+        append_history(&repo, "group-1", &session_id, "system", "sys-to-worker-b", Some("worker-b")).await;
+
+        // worker-a view: public + own system copy; NOT worker-b's copy.
+        let res_a = service
+            .get_session_history(session_cmd("group-1", &session_id, Some("worker-a")))
+            .await
+            .expect("worker-a chat history");
+        let contents_a: Vec<&str> = res_a.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(contents_a.contains(&"public-human"));
+        assert!(contents_a.contains(&"sys-to-worker-a"));
+        assert!(!contents_a.contains(&"sys-to-worker-b"),
+            "other bot's system copy must be hidden under PublicOrOwner");
+
+        // no view_bot_id: only public (IsNull).
+        let res_none = service
+            .get_session_history(session_cmd("group-1", &session_id, None))
+            .await
+            .expect("public chat history");
+        let contents_none: Vec<&str> = res_none.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(contents_none.contains(&"public-human"));
+        assert!(!contents_none.contains(&"sys-to-worker-a"));
+        assert!(!contents_none.contains(&"sys-to-worker-b"));
+        let _ = fallback;
+    }
+
+    #[tokio::test]
+    async fn mw_manager_viewer_sees_public_and_own_system_copies() {
+        let (service, repo, _sessions, _fallback, session_id) =
+            service_fixture(GroupStrategy::ManagerWorker, 0, 0, Vec::new()).await;
+        append_history(&repo, "group-1", &session_id, "human_1", "public-human", None).await;
+        append_history(&repo, "group-1", &session_id, "system", "sys-to-manager", Some("mgr")).await;
+        append_history(&repo, "group-1", &session_id, "system", "sys-to-worker-a", Some("worker-a")).await;
+
+        let res = service
+            .get_session_history(session_cmd("group-1", &session_id, Some("mgr")))
+            .await
+            .expect("manager history");
+        let contents: Vec<&str> = res.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(contents.contains(&"public-human"));
+        assert!(contents.contains(&"sys-to-manager"),
+            "manager now sees own system copy under PublicOrOwner(mgr)");
+        assert!(!contents.contains(&"sys-to-worker-a"));
+    }
+
+    #[tokio::test]
+    async fn get_history_chat_view_bot_id_now_filters_by_public_or_owner() {
+        let (service, repo, _sessions, _fallback, _session_id) =
+            service_fixture(GroupStrategy::Chat, 0, u64::MAX, Vec::new()).await;
+        // get_history new-path hardcodes session_id "" (String::new()),
+        // so seed with session_id "" to match the query.
+        let gid = "group-1";
+        append_history(&repo, gid, "", "human_1", "public-human", None).await;
+        append_history(&repo, gid, "", "system", "sys-to-a", Some("worker-a")).await;
+        append_history(&repo, gid, "", "system", "sys-to-b", Some("worker-b")).await;
+
+        // Regression: view_bot_id was previously ignored (hardcoded Any).
+        let res_a = service
+            .get_history(group_cmd(gid, Some("worker-a")))
+            .await
+            .expect("worker-a group history");
+        let contents_a: Vec<&str> = res_a.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(contents_a.contains(&"public-human"));
+        assert!(contents_a.contains(&"sys-to-a"));
+        assert!(!contents_a.contains(&"sys-to-b"),
+            "get_history must now honor view_bot_id (was hardcoded Any)");
+
+        let res_none = service
+            .get_history(group_cmd(gid, None))
+            .await
+            .expect("public group history");
+        let contents_none: Vec<&str> = res_none.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(contents_none.contains(&"public-human"));
+        assert!(!contents_none.contains(&"sys-to-a"));
+        assert!(!contents_none.contains(&"sys-to-b"));
+    }
+
+    /// End-to-end round-trip: `SystemMessageDispatcherImpl` persists system
+    /// messages with `owner_bot_id = Some(recipient)` into a REAL
+    /// `MemoryMessageRepo`, and `MessageService::get_session_history` with
+    /// `view_bot_id=recipient` returns that recipient's own copy, hides the
+    /// other recipients' copies, and still returns public (owner=None) records.
+    /// This locks the §数据流 bridge between the write side (per-recipient
+    /// ownership persistence) and the query side (`PublicOrOwner` scoping).
+    #[tokio::test]
+    async fn system_message_dispatch_round_trips_through_message_service_view_scoping() {
+        use bcs_system_message::SystemMessageDispatcherImpl;
+        use bcs_system_message::producers::bot_joined::BotJoinedMessageProducer;
+        use bcs_test_support::{
+            NoopBotDeliveryPort, NoopBotRegistryCoreService, NoopFrontendDeliveryPort,
+            NoopGroupMessageHistoryService,
+        };
+        use bcs_service_api::SystemMessageDispatcherService;
+
+        let (service, repo, _sessions, _fallback, session_id) =
+            service_fixture(GroupStrategy::Chat, 0, u64::MAX, Vec::new()).await;
+        let group_id = "group-1";
+
+        // A public (owner=None) anchor that must remain visible to every viewer.
+        append_history(&repo, group_id, &session_id, "bot-anchor", "public-anchor", None).await;
+
+        // Build a REAL dispatcher wired to the SAME MemoryMessageRepo. Delivery
+        // ports are noops — persistence happens before delivery, so the
+        // per-recipient records land in the repo regardless of delivery outcome.
+        let dispatcher = SystemMessageDispatcherImpl::builder()
+            .with_registry(Arc::new(NoopBotRegistryCoreService))
+            .with_delivery(Arc::new(NoopBotDeliveryPort))
+            .with_frontend_delivery(Arc::new(NoopFrontendDeliveryPort))
+            .with_message_repo(repo.clone())
+            .register(BotJoinedMessageProducer::new(Arc::new(
+                NoopGroupMessageHistoryService,
+            )))
+            .build()
+            .expect("build dispatcher");
+
+        // BotJoined: new-bot joins a group that already has `mgr` (driver) and
+        // two workers. The producer emits one context-injection message for
+        // new-bot and one notification for each existing participant.
+        let new_bot_id = "bot-new".to_string();
+        let existing_id = "mgr".to_string();
+        let participants = vec![
+            Participant::bot(&existing_id, ParticipantRole::Manager),
+            Participant::bot("worker-a", ParticipantRole::Worker),
+            Participant::bot("worker-b", ParticipantRole::Worker),
+            Participant::bot(&new_bot_id, ParticipantRole::Consultant),
+        ];
+        let event = SystemMessageEvent::BotJoined {
+            group_id: group_id.to_string(),
+            actor: Participant::bot(&new_bot_id, ParticipantRole::Consultant),
+        };
+        dispatcher
+            .dispatch(event, &group_fixture(group_id, &existing_id), &session_id, &participants)
+            .await
+            .expect("dispatch succeeded");
+
+        // Viewer = existing mgr: sees its own notification (owner=mgr) + the
+        // public anchor; must NOT see new-bot's context injection (owner=new-bot)
+        // nor the other workers' notification copies.
+        let res_existing = service
+            .get_session_history(session_cmd(group_id, &session_id, Some(&existing_id)))
+            .await
+            .expect("existing view session history");
+        let existing_contents: Vec<&str> =
+            res_existing.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(existing_contents.contains(&"public-anchor"),
+            "public owner=None records still visible to mgr");
+        assert!(existing_contents.iter().any(|c| c.contains("已加入协作群")),
+            "mgr's own notification (owner=mgr) is returned");
+        assert!(existing_contents.iter().all(|c| !c.contains("你加入了 BCS 协作群.")),
+            "new-bot's context injection (owner=new-bot) is hidden from mgr");
+
+        // Viewer = new-bot: sees its own context injection (owner=new-bot) + the
+        // public anchor; must NOT see the notification copies (owner=existing).
+        let res_new = service
+            .get_session_history(session_cmd(group_id, &session_id, Some(&new_bot_id)))
+            .await
+            .expect("new-bot view session history");
+        let new_contents: Vec<&str> =
+            res_new.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(new_contents.contains(&"public-anchor"),
+            "public owner=None records still visible to new-bot");
+        assert!(new_contents.iter().any(|c| c.contains("你加入了 BCS 协作群.")),
+            "new-bot's own context injection (owner=new-bot) is returned");
+        assert!(new_contents.iter().all(|c| !c.contains("已加入协作群")),
+            "existing participants' notification copies are hidden from new-bot");
+    }
+
+    fn group_fixture(group_id: &str, driver_bot_id: &str) -> Group {
+        let mut group = Group::new(
+            group_id.to_string(),
+            driver_bot_id,
+            vec![
+                Participant::bot(driver_bot_id, ParticipantRole::Manager),
+                Participant::bot("worker-a", ParticipantRole::Worker),
+                Participant::bot("worker-b", ParticipantRole::Worker),
+            ],
+        );
+        group.group_strategy = GroupStrategy::Chat;
+        group
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bcs_domain::{DeliveryType, Group, GroupStrategy, NewMessage, Participant, SenderType, SystemGroupMessage, SystemMessageEvent, SystemMessageEventKind};
+use bcs_domain::{DeliveryType, Group, GroupStrategy, NewMessage, Participant, SenderType, SystemMessageEvent, SystemMessageEventKind};
 use bcs_protocol::{
     build_chat_inject_frame, build_chat_send_frame, now_ms, BotDeliveryKind, GroupContextInput,
     GroupContextParticipant,
@@ -180,42 +180,39 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
             ServiceError::InternalError(format!("No producer registered for kind {:?}", kind))
         })?;
 
-        let messages = producer.produce(&event, group, self.registry.as_ref(), participants).await;
+        let (bot_messages, user_message) = producer.produce(&event, group, self.registry.as_ref(), participants).await;
 
-        // Persist system messages to the message store (best-effort). Most
-        // system events keep one global record. Manager-worker session context
-        // has recipient-specific content, so worker context is persisted under
-        // that worker's owner_bot_id while manager context stays global.
+        // Persist system messages per recipient: one record per recipient with
+        // owner_bot_id = recipient, content = the original message. Empty
+        // recipients → no record (e.g. last bot leaving). user_message is NOT
+        // persisted (frontend-only).
         if let Some(ref repo) = self.message_repo {
             let mut persisted_count = 0usize;
-            for (msg, owner_bot_id) in history_messages_to_persist(kind, group, &messages) {
-                let new_msg = NewMessage {
-                    group_id: group.id.clone(),
-                    session_id: session_id.to_string(),
-                    sender_id: "system".to_string(),
-                    sender_type: SenderType::System,
-                    message_type: "system".to_string(),
-                    content: serde_json::Value::String(msg.message.clone()),
-                    client_msg_id: None,
-                    owner_bot_id,
-                    created_at: now_ms(),
-                    run_id: String::new(),
-                };
-                if let Err(e) = repo.append_message(new_msg).await {
-                    tracing::warn!(
-                        group_id = %group.id,
-                        error = %e,
-                        "failed to persist system message to message store"
-                    );
-                } else {
-                    persisted_count += 1;
+            for msg in &bot_messages {
+                for recipient in &msg.recipients {
+                    let new_msg = NewMessage {
+                        group_id: group.id.clone(),
+                        session_id: session_id.to_string(),
+                        sender_id: "system".to_string(),
+                        sender_type: SenderType::System,
+                        message_type: "system".to_string(),
+                        content: serde_json::Value::String(msg.message.clone()),
+                        client_msg_id: None,
+                        owner_bot_id: Some(recipient.clone()),
+                        created_at: now_ms(),
+                        run_id: String::new(),
+                    };
+                    if let Err(e) = repo.append_message(new_msg).await {
+                        tracing::warn!(
+                            group_id = %group.id, error = %e,
+                            "failed to persist system message to message store"
+                        );
+                    } else {
+                        persisted_count += 1;
+                    }
                 }
             }
-            tracing::info!(
-                group_id = %group.id,
-                count = persisted_count,
-                "system message persisted"
-            );
+            tracing::info!(group_id = %group.id, count = persisted_count, "system message persisted");
         }
         let protocol_group = group_context_input(group, session_id);
         let group_type = group_type_wire(group.group_strategy);
@@ -225,7 +222,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
         let mut failed = 0usize;
         let mut results = Vec::new();
         let mut commands = Vec::new();
-        for msg in &messages {
+        for msg in &bot_messages {
             for recipient in &msg.recipients {
                 total += 1;
                 let run_id = uuid::Uuid::new_v4().to_string();
@@ -362,16 +359,11 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
             }
         }
 
-        // Publish all produced messages to frontend WebSocket clients.
-        let mut seen = std::collections::HashSet::new();
-        let frontend_content = messages
-            .iter()
-            .filter(|msg| seen.insert(msg.message.clone()))
-            .map(|msg| msg.message.clone())
-            .collect::<Vec<_>>()
-            .join("\n");
-        if !frontend_content.is_empty() {
-            let event_json = build_frontend_system_event_frame(&group.id, &frontend_content, session_id);
+        // Publish the user-facing text to frontend WebSocket clients (single
+        // session-level broadcast; NOT persisted). bot_messages are never
+        // broadcast to the frontend.
+        if let Some(content) = user_message.filter(|s| !s.trim().is_empty()) {
+            let event_json = build_frontend_system_event_frame(&group.id, &content, session_id);
             let target = FrontendDeliveryTarget::Session { session_id: session_id.to_string() };
             if let Err(e) = self.frontend_delivery.publish(FrontendDeliveryCommand {
                 target,
@@ -381,9 +373,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                 exclude_conn_id: None,
             }).await {
                 tracing::warn!(
-                    group_id = %group.id,
-                    %session_id,
-                    error = %e,
+                    group_id = %group.id, %session_id, error = %e,
                     "system message frontend delivery failed"
                 );
             }
@@ -442,54 +432,6 @@ fn frame_protocol_version(protocol_version: u32, target: &BotDeliveryTarget) -> 
     } else {
         protocol_version
     }
-}
-
-fn history_messages_to_persist<'a>(
-    kind: SystemMessageEventKind,
-    group: &Group,
-    messages: &'a [SystemGroupMessage],
-) -> Vec<(&'a SystemGroupMessage, Option<String>)> {
-    if messages.is_empty() {
-        return Vec::new();
-    }
-    if kind != SystemMessageEventKind::SessionContext
-        || group.group_strategy != GroupStrategy::ManagerWorker
-    {
-        return vec![(&messages[0], None)];
-    }
-
-    let mut records = Vec::new();
-    let mut has_global = false;
-    for msg in messages {
-        if !has_global && is_manager_context_message(group, msg) {
-            records.push((msg, None));
-            has_global = true;
-        }
-        for recipient in msg.recipients.iter().filter(|recipient| {
-            participant_has_role(group, recipient, bcs_domain::ParticipantRole::Worker)
-        }) {
-            records.push((msg, Some(recipient.clone())));
-        }
-    }
-
-    records
-}
-
-fn is_manager_context_message(group: &Group, msg: &SystemGroupMessage) -> bool {
-    msg.recipients
-        .iter()
-        .any(|recipient| participant_has_role(group, recipient, bcs_domain::ParticipantRole::Manager))
-}
-
-fn participant_has_role(group: &Group, bot_id: &str, role: bcs_domain::ParticipantRole) -> bool {
-    group
-        .participants
-        .iter()
-        .any(|participant| {
-            participant.is_bot()
-                && participant.bot_uuid == bot_id
-                && participant.role == role
-        })
 }
 
 fn group_context_input(group: &Group, session_id: &str) -> GroupContextInput {

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -102,6 +102,29 @@ impl BotRunContextPort for RecordingRunContext {
     async fn release_terminal(&self, _run_id: &str) {}
 }
 
+#[derive(Default, Clone)]
+struct RecordingFrontendDeliveryPort {
+    published: Arc<Mutex<Vec<bcs_service_api::FrontendDeliveryCommand>>>,
+}
+
+#[async_trait]
+impl bcs_service_api::FrontendDeliveryPort for RecordingFrontendDeliveryPort {
+    async fn publish(
+        &self,
+        cmd: bcs_service_api::FrontendDeliveryCommand,
+    ) -> ServiceResult<bcs_service_api::FrontendDeliveryResult> {
+        self.published.lock().unwrap().push(cmd.clone());
+        Ok(bcs_service_api::FrontendDeliveryResult {
+            target: cmd.target,
+            delivered: 1,
+        })
+    }
+
+    async fn unregister_run(&self, _run_id: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+}
+
 #[derive(Default)]
 struct RecordingMessageRepo {
     appended: RwLock<Vec<bcs_domain::NewMessage>>,
@@ -261,6 +284,139 @@ async fn dispatch_bot_joined_delivers_to_all_participants() {
 }
 
 #[tokio::test]
+async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_only() {
+    let new_bot_id = "new-bot-001".to_string();
+    let existing_bot_id = "existing-bot-001".to_string();
+    let group = Group {
+        id: "group-001".into(),
+        label: None,
+        status: GroupStatus::Active,
+        driver_bot: existing_bot_id.clone(),
+        originator: Some(existing_bot_id.clone()),
+        routing_policy: None,
+        context: None,
+        participants: vec![
+            Participant {
+                bot_uuid: existing_bot_id.clone(),
+                bot_name: None, kind: None,
+                role: ParticipantRole::Driver,
+                actor_kind: ActorKind::Bot,
+                mode: Some(ParticipantMode::Auto),
+            },
+            Participant {
+                bot_uuid: new_bot_id.clone(),
+                bot_name: None, kind: None,
+                role: ParticipantRole::Consultant,
+                actor_kind: ActorKind::Bot,
+                mode: Some(ParticipantMode::Auto),
+            },
+        ],
+        messages: vec![], workspace: Default::default(),
+        service_group_uuid: None, service_mode: None,
+        created_at: 0, updated_at: 0,
+        group_kind: GroupKind::Normal, dm_pair_key: None,
+        group_strategy: GroupStrategy::Chat, service_spec: None,
+        version: 0, record_status: "active".to_string(), visibility: "private".to_string(),
+    };
+    let event = SystemMessageEvent::BotJoined {
+        group_id: group.id.clone(),
+        actor: Participant {
+            bot_uuid: new_bot_id.clone(), bot_name: None, kind: None,
+            role: ParticipantRole::Consultant, actor_kind: ActorKind::Bot,
+            mode: Some(ParticipantMode::Auto),
+        },
+    };
+
+    let registry = Arc::new(ProviderTargetRegistry::default());
+    let delivery = Arc::new(MockDeliveryPort::default());
+    let frontend_delivery = Arc::new(RecordingFrontendDeliveryPort::default());
+    let message_repo = Arc::new(RecordingMessageRepo::default());
+
+    let dispatcher = SystemMessageDispatcherImpl::builder()
+        .with_registry(registry)
+        .with_delivery(delivery.clone())
+        .with_frontend_delivery(frontend_delivery.clone())
+        .with_message_repo(message_repo.clone())
+        .register(BotJoinedMessageProducer::new(Arc::new(bcs_test_support::NoopGroupMessageHistoryService)))
+        .build()
+        .expect("build dispatcher");
+
+    dispatcher.dispatch(event, &group, "session-test", &group.participants)
+        .await.expect("dispatch");
+
+    // Persistence: one record per recipient.
+    let appended = message_repo.appended().await;
+    assert_eq!(appended.len(), 2);
+    let injection = appended.iter().find(|m| m.owner_bot_id.as_deref() == Some(&new_bot_id))
+        .expect("new-bot injection record");
+    assert_eq!(injection.sender_id, "system");
+    assert_eq!(injection.message_type, "system");
+    assert!(content_text(injection).contains("你加入了 BCS 协作群."),
+        "new-bot context injection persisted under owner=new-bot");
+    let notice = appended.iter().find(|m| m.owner_bot_id.as_deref() == Some(&existing_bot_id))
+        .expect("existing-bot notification record");
+    assert!(content_text(notice).contains("已加入协作群"));
+    assert!(!content_text(notice).contains("你加入了 BCS 协作群."));
+
+    // WS: exactly one publish, content = user_message (join notification),
+    // NOT the new-bot context injection.
+    let published = frontend_delivery.published.lock().unwrap();
+    assert_eq!(published.len(), 1, "WS publishes a single user_message");
+    let payload = &published[0].event_json;
+    assert!(payload.contains("已加入协作群"));
+    assert!(!payload.contains("你加入了 BCS 协作群."),
+        "WS must not leak the new-bot context injection");
+}
+
+#[tokio::test]
+async fn dispatch_bot_left_with_no_recipients_persists_zero_but_pushes_ws() {
+    let leaving = "bot-only".to_string();
+    let group = Group {
+        id: "group-left".into(), label: None, status: GroupStatus::Active,
+        driver_bot: leaving.clone(), originator: Some(leaving.clone()),
+        routing_policy: None, context: None,
+        participants: vec![Participant {
+            bot_uuid: leaving.clone(), bot_name: Some("Solo".into()), kind: None,
+            role: ParticipantRole::Driver, actor_kind: ActorKind::Bot,
+            mode: Some(ParticipantMode::Auto),
+        }],
+        messages: vec![], workspace: Default::default(),
+        service_group_uuid: None, service_mode: None,
+        created_at: 0, updated_at: 0, group_kind: GroupKind::Normal,
+        dm_pair_key: None, group_strategy: GroupStrategy::Chat, service_spec: None,
+        version: 0, record_status: "active".to_string(), visibility: "private".to_string(),
+    };
+    let event = SystemMessageEvent::BotLeft {
+        group_id: group.id.clone(),
+        actor: Participant {
+            bot_uuid: leaving.clone(), bot_name: Some("Solo".into()), kind: None,
+            role: ParticipantRole::Driver, actor_kind: ActorKind::Bot, mode: None,
+        },
+    };
+    let registry = Arc::new(ProviderTargetRegistry::default());
+    let delivery = Arc::new(MockDeliveryPort::default());
+    let frontend_delivery = Arc::new(RecordingFrontendDeliveryPort::default());
+    let message_repo = Arc::new(RecordingMessageRepo::default());
+
+    let dispatcher = SystemMessageDispatcherImpl::builder()
+        .with_registry(registry)
+        .with_delivery(delivery)
+        .with_frontend_delivery(frontend_delivery.clone())
+        .with_message_repo(message_repo.clone())
+        .register(crate::producers::bot_left::BotLeftMessageProducer)
+        .build()
+        .expect("build dispatcher");
+
+    dispatcher.dispatch(event, &group, "session-left", &group.participants)
+        .await.expect("dispatch");
+
+    assert_eq!(message_repo.appended().await.len(), 0, "no recipients → 0 persisted records");
+    let published = frontend_delivery.published.lock().unwrap();
+    assert_eq!(published.len(), 1);
+    assert!(published[0].event_json.contains("已退出协作群"));
+}
+
+#[tokio::test]
 async fn dispatch_session_context_preserves_manager_worker_group_type() {
     let mut manager = Participant::bot("bot-manager", ParticipantRole::Manager);
     manager.bot_name = Some("Manager".to_string());
@@ -349,22 +505,20 @@ async fn dispatch_manager_worker_session_context_persists_worker_private_context
     let appended = message_repo.appended().await;
     assert_eq!(appended.len(), 2);
 
-    let global_context = appended
+    let manager_context = appended
         .iter()
-        .find(|msg| msg.owner_bot_id.is_none())
-        .expect("global manager context");
-    assert_eq!(global_context.group_id, group.id);
-    assert_eq!(global_context.session_id, session_id);
-    assert_eq!(global_context.sender_id, "system");
-    assert_eq!(global_context.message_type, "system");
-    assert!(content_text(global_context).contains("你的角色: manager"));
+        .find(|msg| msg.owner_bot_id.as_deref() == Some("bot-manager"))
+        .expect("manager-owned context record");
+    assert_eq!(manager_context.group_id, group.id);
+    assert_eq!(manager_context.session_id, session_id);
+    assert_eq!(manager_context.sender_id, "system");
+    assert_eq!(manager_context.message_type, "system");
+    assert!(content_text(manager_context).contains("你的角色: manager"));
 
     let worker_context = appended
         .iter()
         .find(|msg| msg.owner_bot_id.as_deref() == Some("bot-worker"))
-        .expect("worker private context");
-    assert_eq!(worker_context.group_id, group.id);
-    assert_eq!(worker_context.session_id, session_id);
+        .expect("worker-owned context record");
     assert_eq!(worker_context.sender_id, "system");
     assert_eq!(worker_context.message_type, "system");
     assert!(content_text(worker_context).contains("你的角色: worker"));
@@ -415,18 +569,24 @@ async fn dispatch_manager_worker_session_context_persists_each_worker_private_co
 
     let appended = message_repo.appended().await;
     assert_eq!(appended.len(), 3);
-    assert_eq!(appended.iter().filter(|msg| msg.owner_bot_id.is_none()).count(), 1);
+    assert!(
+        appended.iter().all(|msg| msg.owner_bot_id.is_some()),
+        "no global (owner=None) record; each bot owns its context copy"
+    );
+    let manager_ctx = appended.iter()
+        .find(|msg| msg.owner_bot_id.as_deref() == Some("bot-manager"))
+        .expect("manager copy");
+    assert!(content_text(manager_ctx).contains("你的角色: manager"));
     for worker_id in ["bot-worker-a", "bot-worker-b"] {
-        let worker_context = appended
-            .iter()
+        let worker_context = appended.iter()
             .find(|msg| msg.owner_bot_id.as_deref() == Some(worker_id))
-            .unwrap_or_else(|| panic!("worker private context for {worker_id}"));
+            .unwrap_or_else(|| panic!("worker-owned context for {worker_id}"));
         assert!(content_text(worker_context).contains("你的角色: worker"));
     }
 }
 
 #[tokio::test]
-async fn dispatch_non_manager_worker_session_context_persists_single_global_record() {
+async fn dispatch_non_manager_worker_session_context_persists_per_recipient_records() {
     let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
     driver.bot_name = Some("Driver".to_string());
     let mut consultant = Participant::bot("bot-consultant", ParticipantRole::Consultant);
@@ -465,9 +625,18 @@ async fn dispatch_non_manager_worker_session_context_persists_single_global_reco
         .expect("dispatch succeeded");
 
     let appended = message_repo.appended().await;
-    assert_eq!(appended.len(), 1);
-    assert_eq!(appended[0].owner_bot_id, None);
-    assert!(content_text(&appended[0]).contains("[GROUP CONTEXT]"));
+    assert_eq!(appended.len(), 2);
+    assert_eq!(
+        appended.iter().filter(|m| m.owner_bot_id.is_none()).count(),
+        0,
+        "no global record; each recipient owns a copy"
+    );
+    for owner in ["bot-driver", "bot-consultant"] {
+        let rec = appended.iter()
+            .find(|m| m.owner_bot_id.as_deref() == Some(owner))
+            .unwrap_or_else(|| panic!("owner record for {owner}"));
+        assert!(content_text(rec).contains("[GROUP CONTEXT]"));
+    }
 }
 
 #[tokio::test]
@@ -548,7 +717,7 @@ async fn dispatch_manager_worker_generic_system_message_persists_single_global_r
 
     let appended = message_repo.appended().await;
     assert_eq!(appended.len(), 1);
-    assert_eq!(appended[0].owner_bot_id, None);
+    assert_eq!(appended[0].owner_bot_id.as_deref(), Some("bot-provider"));
     assert_eq!(content_text(&appended[0]), "member changed");
 }
 
@@ -1096,12 +1265,15 @@ impl SystemMessageProducerService for WorkerOnlySessionContextProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         _participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
-        vec![SystemGroupMessage {
-            recipients: vec!["bot-worker".to_string()],
-            message: "worker-only context".to_string(),
-            delivery_type: DeliveryType::Inject,
-        }]
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
+        (
+            vec![SystemGroupMessage {
+                recipients: vec!["bot-worker".to_string()],
+                message: "worker-only context".to_string(),
+                delivery_type: DeliveryType::Inject,
+            }],
+            None,
+        )
     }
 }
 
@@ -1119,12 +1291,15 @@ impl SystemMessageProducerService for FixedProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         _participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
-        vec![SystemGroupMessage {
-            recipients: vec!["bot-provider".to_string()],
-            message: "member changed".to_string(),
-            delivery_type: DeliveryType::Inject,
-        }]
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
+        (
+            vec![SystemGroupMessage {
+                recipients: vec!["bot-provider".to_string()],
+                message: "member changed".to_string(),
+                delivery_type: DeliveryType::Inject,
+            }],
+            None,
+        )
     }
 }
 
@@ -1142,12 +1317,15 @@ impl SystemMessageProducerService for FixedSendProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         _participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
-        vec![SystemGroupMessage {
-            recipients: vec!["bot-provider".to_string()],
-            message: "member changed".to_string(),
-            delivery_type: DeliveryType::Send,
-        }]
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
+        (
+            vec![SystemGroupMessage {
+                recipients: vec!["bot-provider".to_string()],
+                message: "member changed".to_string(),
+                delivery_type: DeliveryType::Send,
+            }],
+            None,
+        )
     }
 }
 
@@ -1165,12 +1343,15 @@ impl SystemMessageProducerService for FixedWebSocketSendProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         _participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
-        vec![SystemGroupMessage {
-            recipients: vec!["bot-ws".to_string()],
-            message: "member changed".to_string(),
-            delivery_type: DeliveryType::Send,
-        }]
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
+        (
+            vec![SystemGroupMessage {
+                recipients: vec!["bot-ws".to_string()],
+                message: "member changed".to_string(),
+                delivery_type: DeliveryType::Send,
+            }],
+            None,
+        )
     }
 }
 

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_hidden_notice.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_hidden_notice.rs
@@ -21,17 +21,18 @@ impl SystemMessageProducerService for BotHiddenNoticeProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::BotHiddenNotice {
             mentioner_bot_id,
             hidden_bot_name,
             ..
         } = event
         else {
-            return vec![];
+            return (vec![], None);
         };
 
         let message = format!("{} 已设置为「不可协作」", hidden_bot_name);
+        let user_message = Some(message.clone());
         let mut messages = vec![SystemGroupMessage {
             recipients: vec![mentioner_bot_id.clone()],
             message: message.clone(),
@@ -52,7 +53,7 @@ impl SystemMessageProducerService for BotHiddenNoticeProducer {
             });
         }
 
-        messages
+        (messages, user_message)
     }
 }
 
@@ -118,7 +119,7 @@ mod tests {
             hidden_bot_name: "HiddenBot".into(),
         };
 
-        let messages = BotHiddenNoticeProducer
+        let (messages, user_message) = BotHiddenNoticeProducer
             .produce(&event, &group, &registry, &group.participants)
             .await;
 
@@ -131,5 +132,53 @@ mod tests {
         // Second message: Inject to other bots
         assert_eq!(messages[1].recipients, vec!["bot-hidden"]);
         assert_eq!(messages[1].delivery_type, DeliveryType::Inject);
+        assert_eq!(user_message.as_deref(), Some("HiddenBot 已设置为「不可协作」"));
+    }
+
+    #[tokio::test]
+    async fn bot_hidden_emits_user_message_with_only_mentioner() {
+        let registry = NoopBotRegistryCoreService;
+        let group = Group {
+            id: "g1".into(),
+            label: None,
+            status: bcs_domain::GroupStatus::Active,
+            driver_bot: "bot-driver".into(),
+            originator: Some("bot-driver".into()),
+            routing_policy: None,
+            context: None,
+            participants: vec![Participant {
+                bot_uuid: "bot-driver".into(),
+                bot_name: Some("Driver".into()),
+                kind: None,
+                role: ParticipantRole::Driver,
+                actor_kind: ActorKind::Bot,
+                mode: Some(ParticipantMode::Auto),
+            }],
+            messages: vec![],
+            workspace: Default::default(),
+            service_group_uuid: None,
+            service_mode: None,
+            created_at: 0,
+            updated_at: 0,
+            group_kind: bcs_domain::GroupKind::Normal,
+            dm_pair_key: None,
+            group_strategy: bcs_domain::GroupStrategy::Chat,
+            service_spec: None,
+            version: 0,
+            record_status: "active".to_string(),
+            visibility: "private".to_string(),
+        };
+        let event = SystemMessageEvent::BotHiddenNotice {
+            group_id: "g1".into(),
+            mentioner_bot_id: "bot-driver".into(),
+            hidden_bot_name: "HiddenBot".into(),
+        };
+        let (messages, user_message) = BotHiddenNoticeProducer
+            .produce(&event, &group, &registry, &group.participants)
+            .await;
+        // Only mentioner present → 1 Send to mentioner, no Inject to others.
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].recipients, vec!["bot-driver"]);
+        assert_eq!(user_message.as_deref(), Some("HiddenBot 已设置为「不可协作」"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
@@ -43,9 +43,9 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         group: &Group,
         registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::BotJoined { actor, .. } = event else {
-            return vec![];
+            return (vec![], None);
         };
 
         let new_bot_uuid = actor.bot_uuid.clone();
@@ -63,6 +63,7 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         // 2. Notification to other bots.
         let registered = registry.get(&new_bot_uuid).await;
         let summary = format_notification(&new_bot_uuid, registered.as_ref());
+        let user_message = Some(summary.clone());
         let others: Vec<String> = participants
             .iter()
             .filter(|p| p.bot_uuid != new_bot_uuid)
@@ -75,7 +76,7 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
                 delivery_type: DeliveryType::Inject,
             });
         }
-        messages
+        (messages, user_message)
     }
 }
 

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
@@ -179,7 +179,7 @@ async fn bot_joined_produces_context_injection_and_notification() {
         actor: new_bot,
     };
 
-    let messages = producer.produce(&event, &group, &registry, &group.participants).await;
+    let (messages, user_message) = producer.produce(&event, &group, &registry, &group.participants).await;
 
     assert_eq!(
         messages.len(),
@@ -227,4 +227,58 @@ async fn bot_joined_produces_context_injection_and_notification() {
     assert!(notification.recipients.contains(&"driver-id".to_string()));
     assert!(notification.recipients.contains(&"consultant-id".to_string()));
     assert!(!notification.recipients.contains(&"new-bot-id".to_string()));
+
+    // user_message is the OTHER-bots notification text (NOT the new-bot injection).
+    assert_eq!(
+        user_message.as_deref(),
+        Some("NewBot(new-bot-id) 已加入协作群 - 能力集: {name: \"coding\"}")
+    );
+    assert!(
+        !user_message.as_deref().unwrap().contains("你加入了 BCS 协作群"),
+        "user_message must not leak the new-bot context injection"
+    );
+}
+
+#[tokio::test]
+async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
+    let driver = Participant::bot("driver-id", ParticipantRole::Driver);
+    let new_bot = Participant::bot("new-bot-id", ParticipantRole::Consultant);
+    let group = Group::new("group-1", "driver-id", vec![driver.clone(), new_bot.clone()]);
+
+    let mut registry = MockRegistry::default();
+    registry.bots.insert(
+        "new-bot-id".to_string(),
+        RegisteredBot {
+            bot_uuid: "new-bot-id".to_string(),
+            capabilities: BotCapabilities {
+                name: Some("NewBot".to_string()),
+                skills: vec![Skill::new("coding")],
+                ..Default::default()
+            },
+            dynamic_status: BotDynamicStatus::default(),
+            env: None,
+            created_by: None,
+            actor_kind: ActorKind::Bot,
+            status: ActorStatus::default(),
+        },
+    );
+
+    let producer = BotJoinedMessageProducer::new(Arc::new(bcs_test_support::NoopGroupMessageHistoryService));
+    let event = SystemMessageEvent::BotJoined {
+        group_id: "group-1".to_string(),
+        actor: new_bot.clone(),
+    };
+
+    let (messages, user_message) = producer.produce(&event, &group, &registry, &[driver, new_bot]).await;
+
+    // only driver + new bot: other-recipients includes driver → notification has 1 recipient.
+    let notification = messages
+        .iter()
+        .find(|m| m.recipients != vec!["new-bot-id".to_string()])
+        .expect("notification message");
+    assert_eq!(notification.recipients, vec!["driver-id".to_string()]);
+    assert_eq!(
+        user_message.as_deref(),
+        Some("NewBot(new-bot-id) 已加入协作群 - 能力集: {name: \"coding\"}")
+    );
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_left.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_left.rs
@@ -24,9 +24,9 @@ impl SystemMessageProducerService for BotLeftMessageProducer {
         _group: &Group,
         registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::BotLeft { actor, .. } = event else {
-            return vec![];
+            return (vec![], None);
         };
 
         let left_id = actor.bot_uuid.clone();
@@ -35,7 +35,8 @@ impl SystemMessageProducerService for BotLeftMessageProducer {
             .as_ref()
             .and_then(|b| b.capabilities.name.clone())
             .unwrap_or_else(|| left_id.clone());
-        let message = format!("{}({}) 已退出协作群", name, left_id);
+        let user_text = format!("{}({}) 已退出协作群", name, left_id);
+        let user_message = Some(user_text.clone());
 
         let recipients: Vec<String> = participants
             .iter()
@@ -43,15 +44,17 @@ impl SystemMessageProducerService for BotLeftMessageProducer {
             .filter(|p| p.is_bot())
             .map(|p| p.bot_uuid.clone())
             .collect();
-        if recipients.is_empty() {
-            return vec![];
-        }
-
-        vec![SystemGroupMessage {
-            recipients,
-            message,
-            delivery_type: DeliveryType::Inject,
-        }]
+        let bot_messages = if recipients.is_empty() {
+            vec![]
+        } else {
+            vec![SystemGroupMessage {
+                recipients,
+                message: user_text,
+                delivery_type: DeliveryType::Inject,
+            }]
+        };
+        // empty recipients does NOT block user_message (last bot leaving)
+        (bot_messages, user_message)
     }
 }
 
@@ -123,7 +126,7 @@ mod tests {
             },
         };
 
-        let messages = BotLeftMessageProducer
+        let (messages, user_message) = BotLeftMessageProducer
             .produce(&event, &group, &registry, &group.participants)
             .await;
 
@@ -133,5 +136,67 @@ mod tests {
         assert!(messages[0].message.contains("bot-1"));
         assert_eq!(messages[0].recipients, vec!["bot-2"]);
         assert_eq!(messages[0].delivery_type, DeliveryType::Inject);
+        assert_eq!(
+            user_message.as_deref(),
+            Some("bot-1(bot-1) 已退出协作群")
+        );
+    }
+
+    #[tokio::test]
+    async fn bot_left_with_no_other_recipients_returns_user_message_only() {
+        let registry = NoopBotRegistryCoreService;
+        let group = Group {
+            id: "g1".into(),
+            label: None,
+            status: bcs_domain::GroupStatus::Active,
+            driver_bot: "bot-1".into(),
+            originator: Some("bot-1".into()),
+            routing_policy: None,
+            context: None,
+            participants: vec![Participant {
+                bot_uuid: "bot-1".into(),
+                bot_name: Some("测试Bot".into()),
+                kind: None,
+                role: ParticipantRole::Driver,
+                actor_kind: ActorKind::Bot,
+                mode: Some(ParticipantMode::Auto),
+            }],
+            messages: vec![],
+            workspace: Default::default(),
+            service_group_uuid: None,
+            service_mode: None,
+            created_at: 0,
+            updated_at: 0,
+            group_kind: bcs_domain::GroupKind::Normal,
+            dm_pair_key: None,
+            group_strategy: bcs_domain::GroupStrategy::Chat,
+            service_spec: None,
+            version: 0,
+            record_status: "active".to_string(),
+            visibility: "private".to_string(),
+        };
+
+        let event = SystemMessageEvent::BotLeft {
+            group_id: "g1".into(),
+            actor: Participant {
+                bot_uuid: "bot-1".into(),
+                bot_name: None,
+                kind: None,
+                role: ParticipantRole::Driver,
+                actor_kind: ActorKind::Bot,
+                mode: None,
+            },
+        };
+
+        let (messages, user_message) = BotLeftMessageProducer
+            .produce(&event, &group, &registry, &group.participants)
+            .await;
+
+        assert!(messages.is_empty(), "no other recipients → empty bot_messages");
+        assert_eq!(
+            user_message.as_deref(),
+            Some("bot-1(bot-1) 已退出协作群"),
+            "user_message still produced when no bot recipients remain"
+        );
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/generic.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/generic.rs
@@ -23,12 +23,17 @@ impl SystemMessageProducerService for GenericNotificationMessageProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::GenericNotification {
             message, receivers, ..
         } = event
         else {
-            return vec![];
+            return (vec![], None);
+        };
+        let user_message = if message.trim().is_empty() {
+            None
+        } else {
+            Some(message.clone())
         };
         let recipients: Vec<String> = if receivers.is_empty() {
             participants
@@ -39,13 +44,71 @@ impl SystemMessageProducerService for GenericNotificationMessageProducer {
         } else {
             receivers.iter().map(|p| p.bot_uuid.clone()).collect()
         };
-        if recipients.is_empty() {
-            return vec![];
-        }
-        vec![SystemGroupMessage {
-            recipients,
-            message: message.clone(),
-            delivery_type: DeliveryType::Inject,
-        }]
+        let bot_messages = if recipients.is_empty() {
+            vec![]
+        } else {
+            vec![SystemGroupMessage {
+                recipients,
+                message: message.clone(),
+                delivery_type: DeliveryType::Inject,
+            }]
+        };
+        (bot_messages, user_message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bcs_domain::{Group, Participant, ParticipantRole};
+    use bcs_test_support::NoopBotRegistryCoreService;
+
+    fn group_with(bot: &str) -> Group {
+        Group::new("g1", bot, vec![Participant::bot(bot, ParticipantRole::Driver)])
+    }
+
+    #[tokio::test]
+    async fn generic_emits_user_message_equal_to_event_message() {
+        let group = group_with("bot-a");
+        let event = SystemMessageEvent::GenericNotification {
+            group_id: "g1".into(),
+            message: "维护开始".into(),
+            receivers: vec![],
+        };
+        let (messages, user_message) = GenericNotificationMessageProducer
+            .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
+            .await;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(user_message.as_deref(), Some("维护开始"));
+    }
+
+    #[tokio::test]
+    async fn generic_empty_message_yields_none_user_message() {
+        let group = group_with("bot-a");
+        let event = SystemMessageEvent::GenericNotification {
+            group_id: "g1".into(),
+            message: String::new(),
+            receivers: vec![],
+        };
+        let (messages, user_message) = GenericNotificationMessageProducer
+            .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
+            .await;
+        assert_eq!(messages.len(), 1);
+        assert_eq!(user_message, None, "empty message → None, never Some(\"\")");
+    }
+
+    #[tokio::test]
+    async fn generic_no_recipients_still_emits_user_message() {
+        let group = Group::new("g1", "bot-a", vec![]);
+        let event = SystemMessageEvent::GenericNotification {
+            group_id: "g1".into(),
+            message: "维护开始".into(),
+            receivers: vec![],
+        };
+        let (messages, user_message) = GenericNotificationMessageProducer
+            .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
+            .await;
+        assert!(messages.is_empty());
+        assert_eq!(user_message.as_deref(), Some("维护开始"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/human_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/human_joined.rs
@@ -31,9 +31,9 @@ impl SystemMessageProducerService for HumanJoinedMessageProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::HumanJoined { actor, .. } = event else {
-            return vec![];
+            return (vec![], None);
         };
 
         let display_name = actor
@@ -42,6 +42,7 @@ impl SystemMessageProducerService for HumanJoinedMessageProducer {
             .unwrap_or(&actor.bot_uuid);
 
         let message = format!("{}({}) 已加入协作群", display_name, actor.bot_uuid);
+        let user_message = Some(message.clone());
 
         let recipients: Vec<String> = participants
             .iter()
@@ -49,14 +50,65 @@ impl SystemMessageProducerService for HumanJoinedMessageProducer {
             .map(|p| p.bot_uuid.clone())
             .collect();
 
-        if recipients.is_empty() {
-            return vec![];
-        }
+        let bot_messages = if recipients.is_empty() {
+            vec![]
+        } else {
+            vec![SystemGroupMessage {
+                recipients,
+                message,
+                delivery_type: DeliveryType::Inject,
+            }]
+        };
+        (bot_messages, user_message)
+    }
+}
 
-        vec![SystemGroupMessage {
-            recipients,
-            message,
-            delivery_type: DeliveryType::Inject,
-        }]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bcs_domain::{ActorKind, ParticipantRole};
+    use bcs_test_support::NoopBotRegistryCoreService;
+
+    #[tokio::test]
+    async fn human_joined_emits_user_message() {
+        let group = Group::new("g1", "bot-1", vec![Participant::bot("bot-1", ParticipantRole::Driver)]);
+        let actor = Participant {
+            bot_uuid: "human_42".into(),
+            bot_name: Some("Alice".into()),
+            kind: None,
+            role: ParticipantRole::Observer,
+            actor_kind: ActorKind::Human,
+            mode: None,
+        };
+        let event = SystemMessageEvent::HumanJoined { group_id: "g1".into(), actor };
+
+        let (messages, user_message) = HumanJoinedMessageProducer::new()
+            .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
+            .await;
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].recipients, vec!["bot-1".to_string()]);
+        assert_eq!(user_message.as_deref(), Some("Alice(human_42) 已加入协作群"));
+    }
+
+    #[tokio::test]
+    async fn human_joined_emits_user_message_even_with_no_bot_recipients() {
+        let group = Group::new("g1", "bot-1", vec![]);
+        let actor = Participant {
+            bot_uuid: "human_42".into(),
+            bot_name: Some("Alice".into()),
+            kind: None,
+            role: ParticipantRole::Observer,
+            actor_kind: ActorKind::Human,
+            mode: None,
+        };
+        let event = SystemMessageEvent::HumanJoined { group_id: "g1".into(), actor };
+
+        let (messages, user_message) = HumanJoinedMessageProducer::new()
+            .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
+            .await;
+
+        assert!(messages.is_empty());
+        assert_eq!(user_message.as_deref(), Some("Alice(human_42) 已加入协作群"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed.rs
@@ -26,7 +26,7 @@ impl SystemMessageProducerService for ParticipantModeChangedMessageProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::ParticipantModeChanged {
             actor_id: _,
             actor_name,
@@ -36,14 +36,14 @@ impl SystemMessageProducerService for ParticipantModeChangedMessageProducer {
             ..
         } = event
         else {
-            return vec![];
+            return (vec![], None);
         };
 
         if *actor_kind == ActorKind::Bot && from.is_none() {
             tracing::warn!(
                 "ParticipantModeChanged with from=None for Bot; BotJoined should handle this"
             );
-            return vec![];
+            return (vec![], None);
         }
 
         let content = match (*actor_kind, *to) {
@@ -61,6 +61,7 @@ impl SystemMessageProducerService for ParticipantModeChangedMessageProducer {
             }
             _ => format!("{} 的状态变成了 {:?}", actor_name, to),
         };
+        let user_message = Some(content.clone());
 
         let recipients: Vec<String> = participants
             .iter()
@@ -68,14 +69,15 @@ impl SystemMessageProducerService for ParticipantModeChangedMessageProducer {
             .map(|p| p.bot_uuid.clone())
             .collect();
 
-        if recipients.is_empty() {
-            return vec![];
-        }
-
-        vec![SystemGroupMessage {
-            recipients,
-            message: content,
-            delivery_type: DeliveryType::Inject,
-        }]
+        let bot_messages = if recipients.is_empty() {
+            vec![]
+        } else {
+            vec![SystemGroupMessage {
+                recipients,
+                message: content,
+                delivery_type: DeliveryType::Inject,
+            }]
+        };
+        (bot_messages, user_message)
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed_test.rs
@@ -27,7 +27,7 @@ async fn human_joined_from_none_produces_message() {
         to: ParticipantMode::Present,
     };
 
-    let messages = producer
+    let (messages, user_message) = producer
         .produce(&event, &group, &bcs_test_support::NoopBotRegistryCoreService, &group.participants)
         .await;
     assert_eq!(messages.len(), 1);
@@ -36,6 +36,7 @@ async fn human_joined_from_none_produces_message() {
     assert!(messages[0].recipients.contains(&"consultant-id".to_string()));
     assert!(!messages[0].recipients.contains(&"human-id".to_string()));
     assert_eq!(messages[0].delivery_type, bcs_domain::DeliveryType::Inject);
+    assert_eq!(user_message, Some(messages[0].message.clone()));
 }
 
 #[tokio::test]
@@ -51,7 +52,7 @@ async fn human_mode_change_produces_message() {
         to: ParticipantMode::Absent,
     };
 
-    let messages = producer
+    let (messages, user_message) = producer
         .produce(&event, &group, &bcs_test_support::NoopBotRegistryCoreService, &group.participants)
         .await;
     assert_eq!(messages.len(), 1);
@@ -60,6 +61,7 @@ async fn human_mode_change_produces_message() {
     assert!(messages[0].recipients.contains(&"consultant-id".to_string()));
     assert!(!messages[0].recipients.contains(&"human-id".to_string()));
     assert_eq!(messages[0].delivery_type, bcs_domain::DeliveryType::Inject);
+    assert_eq!(user_message, Some(messages[0].message.clone()));
 }
 
 #[tokio::test]
@@ -75,10 +77,11 @@ async fn bot_joined_from_none_produces_empty() {
         to: ParticipantMode::Auto,
     };
 
-    let messages = producer
+    let (messages, user_message) = producer
         .produce(&event, &group, &bcs_test_support::NoopBotRegistryCoreService, &group.participants)
         .await;
     assert!(messages.is_empty());
+    assert_eq!(user_message, None, "anomalous from=None Bot yields no user_message");
 }
 
 #[tokio::test]
@@ -94,7 +97,7 @@ async fn bot_mode_change_produces_message() {
         to: ParticipantMode::Muted,
     };
 
-    let messages = producer
+    let (messages, user_message) = producer
         .produce(&event, &group, &bcs_test_support::NoopBotRegistryCoreService, &group.participants)
         .await;
     assert_eq!(messages.len(), 1);
@@ -103,4 +106,5 @@ async fn bot_mode_change_produces_message() {
     assert!(messages[0].recipients.contains(&"consultant-id".to_string()));
     assert!(!messages[0].recipients.contains(&"human-id".to_string()));
     assert_eq!(messages[0].delivery_type, bcs_domain::DeliveryType::Inject);
+    assert_eq!(user_message, Some(messages[0].message.clone()));
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -30,7 +30,7 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
         group: &Group,
         registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
         let SystemMessageEvent::SessionContext {
             session_id,
             reason,
@@ -39,7 +39,7 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
             ..
         } = event
         else {
-            return vec![];
+            return (vec![], None);
         };
 
         let mut render_group = group.clone();
@@ -105,7 +105,26 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
                 delivery_type,
             });
         }
-        messages
+        let user_message = if render_group.group_strategy == GroupStrategy::ManagerWorker {
+            Some(depersonalized_service_group_context(
+                &render_group,
+                session_id,
+                render_group.context.as_deref(),
+                &bot_summaries,
+                task_input_text.as_deref(),
+                task_ledger.as_ref(),
+            ))
+        } else {
+            Some(depersonalized_chat_group_context(
+                &render_group,
+                session_id,
+                reason,
+                render_group.context.as_deref(),
+                has_provider_downlink_bot,
+                task_input_text.as_deref(),
+            ))
+        };
+        (messages, user_message)
     }
 }
 
@@ -157,16 +176,8 @@ fn initial_group_context_message(
     use_at_mention_routing: bool,
     task_input: Option<&str>,
 ) -> String {
-    let base_context = user_context
-        .filter(|ctx| !ctx.trim().is_empty())
-        .map(|ctx| format!("背景: {}\n", ctx.trim()))
-        .unwrap_or_default();
-
-    let task_line = task_input
-        .filter(|task| !task.trim().is_empty())
-        .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
-        .unwrap_or_default();
-
+    let base_context = base_context_block(user_context);
+    let task_line = task_block(task_input);
     let role_instruction = match delivery_type {
         DeliveryType::Send => {
             "你是本次协作的 Driver。请介绍协作目标，判断下一步需要谁参与，并开始协调。"
@@ -178,19 +189,7 @@ fn initial_group_context_message(
             "你当前通过 chat.inject 收到初始化上下文，应静默观察，不要主动回复；等待 @mention、bcs_route 或任务点名后再响应。"
         }
     };
-    let routing_instruction = if use_at_mention_routing {
-        "路由工具 (@mention):\n\
-           消息中任何 @ 标识都会触发路由，让被 @ 的 Bot 收到消息并被要求响应。\n\
-           只有希望某个 Bot 响应时才使用 @，不要用 @ 表示引用、收到或转述某个 Bot 的消息。\n\
-           优先使用名称；名称为空、重复或不确定时，使用 Bot ID。"
-    } else {
-        "路由工具 (bcs_route):\n\
-           使用 bcs_route 工具指定下一个响应者（替代 @mention）。\n\
-           - to: 目标 Bot 列表，支持按名称或 bot_id 选择\n\
-             - 按名称: {\"type\": \"name\", \"value\": \"DBA\"}\n\
-             - 按ID: {\"type\": \"bot\", \"value\": \"bot_54123f4f\"}\n\
-           - reason: 路由原因"
-    };
+    let routing_instruction = routing_instruction_block(use_at_mention_routing);
     let roster = if use_at_mention_routing {
         format_roster_with_mentions(group)
     } else {
@@ -223,6 +222,85 @@ fn initial_group_context_message(
         display_participant(recipient),
         role_slug(recipient.role),
         role_instruction,
+    )
+}
+
+/// Renders the `背景: ...` line for `[GROUP CONTEXT]` blocks, or an empty
+/// string when `user_context` is missing/blank.
+fn base_context_block(user_context: Option<&str>) -> String {
+    user_context
+        .filter(|ctx| !ctx.trim().is_empty())
+        .map(|ctx| format!("背景: {}\n", ctx.trim()))
+        .unwrap_or_default()
+}
+
+/// Renders the `[任务]...[/任务]` block, or an empty string when `task_input`
+/// is missing/blank.
+fn task_block(task_input: Option<&str>) -> String {
+    task_input
+        .filter(|task| !task.trim().is_empty())
+        .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
+        .unwrap_or_default()
+}
+
+/// Renders the routing instruction text (either `@mention` or `bcs_route`
+/// variant) used inside `[GROUP CONTEXT]` blocks.
+fn routing_instruction_block(use_at_mention_routing: bool) -> &'static str {
+    if use_at_mention_routing {
+        "路由工具 (@mention):\n\
+           消息中任何 @ 标识都会触发路由，让被 @ 的 Bot 收到消息并被要求响应。\n\
+           只有希望某个 Bot 响应时才使用 @，不要用 @ 表示引用、收到或转述某个 Bot 的消息。\n\
+           优先使用名称；名称为空、重复或不确定时，使用 Bot ID。"
+    } else {
+        "路由工具 (bcs_route):\n\
+           使用 bcs_route 工具指定下一个响应者（替代 @mention）。\n\
+           - to: 目标 Bot 列表，支持按名称或 bot_id 选择\n\
+             - 按名称: {\"type\": \"name\", \"value\": \"DBA\"}\n\
+             - 按ID: {\"type\": \"bot\", \"value\": \"bot_54123f4f\"}\n\
+           - reason: 路由原因"
+    }
+}
+
+/// Depersonalized `[GROUP CONTEXT]` for the frontend WebSocket broadcast:
+/// keeps group facts and the routing instruction, strips the
+/// recipient-tailored `你是:` / `你的角色:` / role instruction. Rendered
+/// purely from group-level state (no recipient dependence, no bot-message
+/// iteration order).
+fn depersonalized_chat_group_context(
+    group: &Group,
+    session_id: &str,
+    topic: &str,
+    user_context: Option<&str>,
+    use_at_mention_routing: bool,
+    task_input: Option<&str>,
+) -> String {
+    let base_context = base_context_block(user_context);
+    let task_line = task_block(task_input);
+    let routing_instruction = routing_instruction_block(use_at_mention_routing);
+    let roster = if use_at_mention_routing {
+        format_roster_with_mentions(group)
+    } else {
+        format_roster(group)
+    };
+
+    format!(
+        "[GROUP CONTEXT]\n\
+         群组ID: {}\n\
+         会话ID: {}\n\
+         主题: {}\n\
+         {}\
+         参与者:\n{}\n\
+         {}\
+         \n\
+         {}\n\
+         [/GROUP CONTEXT]",
+        group.id,
+        session_id,
+        topic,
+        base_context,
+        roster,
+        task_line,
+        routing_instruction,
     )
 }
 
@@ -290,32 +368,10 @@ fn manager_worker_initial_message(
     coordination_surface: &CoordinationSurface,
 ) -> String {
     let is_manager = recipient.role == ParticipantRole::Manager;
-    let context_line = if is_manager {
-        context
-            .filter(|ctx| !ctx.trim().is_empty())
-            .map(|ctx| format!("\n{}\n", ctx.trim()))
-            .unwrap_or_default()
-    } else {
-        String::new()
-    };
-    let task_line = if is_manager {
-        task_input
-            .filter(|task| !task.trim().is_empty())
-            .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
-            .unwrap_or_default()
-    } else {
-        String::new()
-    };
+    let context_line = if is_manager { mw_context_block(context) } else { String::new() };
+    let task_line = if is_manager { mw_task_block(task_input) } else { String::new() };
     let role_label = if is_manager { "manager" } else { "worker" };
-    let status_line = if is_manager {
-        task_ledger
-            .map(format_ledger_status_line)
-            .filter(|line| !line.is_empty())
-            .map(|line| format!("\n{}", line))
-            .unwrap_or_default()
-    } else {
-        String::new()
-    };
+    let status_line = if is_manager { mw_status_block(task_ledger) } else { String::new() };
     let instruction = manager_worker_coordination_instruction(
         is_manager,
         delivery_type,
@@ -346,6 +402,71 @@ fn manager_worker_initial_message(
         instruction,
         display_participant(recipient),
         role_label,
+    )
+}
+
+/// Renders the background block for `[SERVICE GROUP CONTEXT]` blocks:
+/// `\n{ctx}\n` when `context` is non-blank, else `""`.
+fn mw_context_block(context: Option<&str>) -> String {
+    context
+        .filter(|ctx| !ctx.trim().is_empty())
+        .map(|ctx| format!("\n{}\n", ctx.trim()))
+        .unwrap_or_default()
+}
+
+/// Renders the `[任务]...[/任务]` block for `[SERVICE GROUP CONTEXT]`
+/// blocks, or `""` when `task_input` is missing/blank.
+fn mw_task_block(task_input: Option<&str>) -> String {
+    task_input
+        .filter(|task| !task.trim().is_empty())
+        .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
+        .unwrap_or_default()
+}
+
+/// Renders the `[任务状态]` line for `[SERVICE GROUP CONTEXT]` blocks via
+/// `format_ledger_status_line`: non-empty → `\n{line}`, else `""`.
+fn mw_status_block(task_ledger: Option<&LedgerSummary>) -> String {
+    task_ledger
+        .map(format_ledger_status_line)
+        .filter(|line| !line.is_empty())
+        .map(|line| format!("\n{}", line))
+        .unwrap_or_default()
+}
+
+/// Depersonalized `[SERVICE GROUP CONTEXT]` for the frontend WebSocket
+/// broadcast: keeps `模式: manager_worker`, roster (name/ID/role/summary),
+/// background, `[任务]`, `[任务状态]` rendered unconditionally from facts;
+/// strips `你的角色: manager`, the coordination reminder, and the recipient
+/// tail `你是:` / `你的角色:`. Rendered purely from group-level facts — even
+/// when no Manager is a participant.
+fn depersonalized_service_group_context(
+    group: &Group,
+    session_id: &str,
+    context: Option<&str>,
+    bot_summaries: &HashMap<String, String>,
+    task_input: Option<&str>,
+    task_ledger: Option<&LedgerSummary>,
+) -> String {
+    let context_line = mw_context_block(context);
+    let task_line = mw_task_block(task_input);
+    let status_line = mw_status_block(task_ledger);
+
+    format!(
+        "[SERVICE GROUP CONTEXT]\n\
+         群组ID: {}\n\
+         会话ID: {}\n\
+         模式: manager_worker\n\
+         参与者:\n{}\n\
+         {}\
+         {}\
+         {}\n\
+         [/SERVICE GROUP CONTEXT]",
+        group.id,
+        session_id,
+        format_roster_with_role(group, bot_summaries),
+        context_line,
+        task_line,
+        status_line,
     )
 }
 

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -105,25 +105,10 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
                 delivery_type,
             });
         }
-        let user_message = if render_group.group_strategy == GroupStrategy::ManagerWorker {
-            Some(depersonalized_service_group_context(
-                &render_group,
-                session_id,
-                render_group.context.as_deref(),
-                &bot_summaries,
-                task_input_text.as_deref(),
-                task_ledger.as_ref(),
-            ))
-        } else {
-            Some(depersonalized_chat_group_context(
-                &render_group,
-                session_id,
-                reason,
-                render_group.context.as_deref(),
-                has_provider_downlink_bot,
-                task_input_text.as_deref(),
-            ))
-        };
+        // SessionContext does not emit a user-facing WS message: the bot
+        // context messages are delivered per-recipient and persisted with
+        // owner=recipient, but no session-level frontend broadcast is produced.
+        let user_message: Option<String> = None;
         (messages, user_message)
     }
 }
@@ -261,49 +246,6 @@ fn routing_instruction_block(use_at_mention_routing: bool) -> &'static str {
     }
 }
 
-/// Depersonalized `[GROUP CONTEXT]` for the frontend WebSocket broadcast:
-/// keeps group facts and the routing instruction, strips the
-/// recipient-tailored `你是:` / `你的角色:` / role instruction. Rendered
-/// purely from group-level state (no recipient dependence, no bot-message
-/// iteration order).
-fn depersonalized_chat_group_context(
-    group: &Group,
-    session_id: &str,
-    topic: &str,
-    user_context: Option<&str>,
-    use_at_mention_routing: bool,
-    task_input: Option<&str>,
-) -> String {
-    let base_context = base_context_block(user_context);
-    let task_line = task_block(task_input);
-    let routing_instruction = routing_instruction_block(use_at_mention_routing);
-    let roster = if use_at_mention_routing {
-        format_roster_with_mentions(group)
-    } else {
-        format_roster(group)
-    };
-
-    format!(
-        "[GROUP CONTEXT]\n\
-         群组ID: {}\n\
-         会话ID: {}\n\
-         主题: {}\n\
-         {}\
-         参与者:\n{}\n\
-         {}\
-         \n\
-         {}\n\
-         [/GROUP CONTEXT]",
-        group.id,
-        session_id,
-        topic,
-        base_context,
-        roster,
-        task_line,
-        routing_instruction,
-    )
-}
-
 fn format_roster_with_mentions(group: &Group) -> String {
     let mut name_counts: HashMap<String, usize> = HashMap::new();
     for participant in group.participants.iter().filter(|participant| participant.is_bot()) {
@@ -431,43 +373,6 @@ fn mw_status_block(task_ledger: Option<&LedgerSummary>) -> String {
         .filter(|line| !line.is_empty())
         .map(|line| format!("\n{}", line))
         .unwrap_or_default()
-}
-
-/// Depersonalized `[SERVICE GROUP CONTEXT]` for the frontend WebSocket
-/// broadcast: keeps `模式: manager_worker`, roster (name/ID/role/summary),
-/// background, `[任务]`, `[任务状态]` rendered unconditionally from facts;
-/// strips `你的角色: manager`, the coordination reminder, and the recipient
-/// tail `你是:` / `你的角色:`. Rendered purely from group-level facts — even
-/// when no Manager is a participant.
-fn depersonalized_service_group_context(
-    group: &Group,
-    session_id: &str,
-    context: Option<&str>,
-    bot_summaries: &HashMap<String, String>,
-    task_input: Option<&str>,
-    task_ledger: Option<&LedgerSummary>,
-) -> String {
-    let context_line = mw_context_block(context);
-    let task_line = mw_task_block(task_input);
-    let status_line = mw_status_block(task_ledger);
-
-    format!(
-        "[SERVICE GROUP CONTEXT]\n\
-         群组ID: {}\n\
-         会话ID: {}\n\
-         模式: manager_worker\n\
-         参与者:\n{}\n\
-         {}\
-         {}\
-         {}\n\
-         [/SERVICE GROUP CONTEXT]",
-        group.id,
-        session_id,
-        format_roster_with_role(group, bot_summaries),
-        context_line,
-        task_line,
-        status_line,
-    )
 }
 
 fn manager_worker_coordination_instruction(

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -10,7 +10,8 @@ use bcs_domain::{
     SystemMessageEvent, CoordinationMode, CoordinationSurface,
 };
 use bcs_service_api::{
-    AgentCredentials, BotRegistryCoreService, ServiceResult, SystemMessageProducerService,
+    AgentCredentials, BotDeliveryTarget, BotRegistryCoreService, RedactedToken, ServiceResult,
+    SystemMessageProducerService,
 };
 
 use super::session_context::SessionContextMessageProducer;
@@ -18,6 +19,7 @@ use super::session_context::SessionContextMessageProducer;
 struct NamedRegistry {
     bots: HashMap<String, RegisteredBot>,
     surfaces: HashMap<String, CoordinationSurface>,
+    http_providers: std::collections::HashSet<String>,
 }
 
 impl NamedRegistry {
@@ -47,11 +49,17 @@ impl NamedRegistry {
         Self {
             bots,
             surfaces: HashMap::new(),
+            http_providers: std::collections::HashSet::new(),
         }
     }
 
     fn with_surface(mut self, bot_id: &str, surface: CoordinationSurface) -> Self {
         self.surfaces.insert(bot_id.to_string(), surface);
+        self
+    }
+
+    fn with_http_provider(mut self, bot_id: &str) -> Self {
+        self.http_providers.insert(bot_id.to_string());
         self
     }
 }
@@ -87,6 +95,25 @@ impl BotRegistryCoreService for NamedRegistry {
             .get(bot_id)
             .cloned()
             .unwrap_or_else(CoordinationSurface::legacy_upstream))
+    }
+
+    async fn resolve_delivery_target(
+        &self,
+        bot_id: &str,
+    ) -> ServiceResult<BotDeliveryTarget> {
+        if self.http_providers.contains(bot_id) {
+            return Ok(BotDeliveryTarget::HttpProvider {
+                bot_id: bot_id.to_string(),
+                provider_id: "provider-1".to_string(),
+                provider_bot_ref: "ref".to_string(),
+                webhook_url: "https://provider.example.com/bcs/webhook".to_string(),
+                bcs_to_provider_token: RedactedToken::new("secret"),
+                protocol_version: "2.0".to_string(),
+            });
+        }
+        Ok(BotDeliveryTarget::WebSocket {
+            bot_id: bot_id.to_string(),
+        })
     }
 
     async fn list_active(&self) -> Vec<RegisteredBot> {
@@ -236,7 +263,7 @@ async fn manager_worker_session_context_messages_with_ledger(
         task_ledger,
     };
 
-    let messages = SessionContextMessageProducer
+    let (messages, _) = SessionContextMessageProducer
         .produce(&event, &group, &registry, &participants)
         .await;
 
@@ -341,7 +368,7 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
         task_ledger: None,
     };
 
-    let messages = SessionContextMessageProducer
+    let (messages, _) = SessionContextMessageProducer
         .produce(&event, &group, &registry, &participants)
         .await;
 
@@ -405,4 +432,223 @@ async fn manager_worker_manager_reminder_includes_task_ledger_status() {
         .find(|message| message.recipients == vec![worker_id.clone()])
         .expect("worker receives context");
     assert!(!worker_message.message.contains("[任务状态]"));
+}
+
+async fn chat_session_context_produce(
+    group: Group,
+    participants: Vec<Participant>,
+) -> (Vec<SystemGroupMessage>, Option<String>) {
+    let registry = NamedRegistry::new(&[]);
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "普通协作".to_string(),
+        session_input: None,
+        task_ledger: None,
+    };
+    SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await
+}
+
+#[tokio::test]
+async fn chat_session_context_user_message_is_depersonalized_group_context() {
+    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
+    driver.bot_name = Some("Driver".to_string());
+    let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
+    peer.bot_name = Some("Peer".to_string());
+    let mut group = Group::new("group-chat", "bot-driver", vec![driver, peer]);
+    group.group_strategy = GroupStrategy::Chat;
+    let participants = group.participants.clone();
+
+    let (messages, user_message) = chat_session_context_produce(group, participants).await;
+
+    // bot_messages unchanged: one per bot.
+    assert_eq!(messages.len(), 2);
+    let ws = user_message.expect("chat SessionContext must emit user_message");
+
+    // Facts preserved.
+    assert!(ws.contains("[GROUP CONTEXT]"));
+    assert!(ws.contains("[/GROUP CONTEXT]"));
+    assert!(ws.contains("群组ID: group-chat"));
+    assert!(ws.contains("主题: 普通协作"));
+    assert!(ws.contains("参与者:"));
+    // Routing instruction preserved (no provider downlink → bcs_route variant).
+    assert!(ws.contains("路由工具 (bcs_route)"));
+    // Personalization stripped.
+    assert!(!ws.contains("你是:"));
+    assert!(!ws.contains("你的角色:"));
+    assert!(!ws.contains("你是本次协作的 Driver"));
+    assert!(!ws.contains("应静默观察"));
+    assert!(!ws.contains("等待 @mention"));
+}
+
+#[tokio::test]
+async fn chat_session_context_user_message_at_mention_when_provider_downlink_present() {
+    // NamedRegistry resolves bot-provider as HTTP provider via resolve_delivery_target.
+    // The producer uses contains_provider_downlink_bot which calls resolve_delivery_target.
+    // NamedRegistry below overrides resolve_delivery_target to mark bot-provider as HTTP provider.
+    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
+    driver.bot_name = Some("Driver".to_string());
+    let mut provider = Participant::bot("bot-provider", ParticipantRole::Consultant);
+    provider.bot_name = Some("Provider".to_string());
+    let mut group = Group::new("group-chat", "bot-driver", vec![driver, provider]);
+    group.group_strategy = GroupStrategy::Chat;
+    let participants = group.participants.clone();
+
+    let registry = NamedRegistry::new(&[]).with_http_provider("bot-provider");
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "普通协作".to_string(),
+        session_input: None,
+        task_ledger: None,
+    };
+    let (_messages, user_message) = SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await;
+    let ws = user_message.expect("ws text");
+
+    assert!(ws.contains("路由工具 (@mention)"));
+    assert!(ws.contains("可@:"));
+    assert!(!ws.contains("路由工具 (bcs_route)"));
+    assert!(!ws.contains("你是:"));
+}
+
+#[tokio::test]
+async fn chat_session_context_user_message_renders_without_driver_role_bot() {
+    // No participant has the Driver role; driver_bot fallback still renders.
+    let mut peer_a = Participant::bot("bot-a", ParticipantRole::Consultant);
+    peer_a.bot_name = Some("A".to_string());
+    let mut peer_b = Participant::bot("bot-b", ParticipantRole::Consultant);
+    peer_b.bot_name = Some("B".to_string());
+    let mut group = Group::new("group-chat", "bot-a", vec![peer_a, peer_b]);
+    group.group_strategy = GroupStrategy::Chat;
+    let participants = group.participants.clone();
+
+    let (messages, user_message) = chat_session_context_produce(group, participants).await;
+    assert_eq!(messages.len(), 2);
+    let ws = user_message.expect("ws text");
+    assert!(ws.contains("[GROUP CONTEXT]"));
+    assert!(ws.contains("参与者:"));
+    assert!(!ws.contains("你是:"));
+}
+
+#[tokio::test]
+async fn manager_worker_session_context_user_message_is_depersonalized_service_group_context() {
+    let manager_id = "20260416_a5clr6ig:12345678";
+    let worker_id = "20260528_vobmrqo6:12345678";
+    let mut manager = Participant::bot(manager_id, ParticipantRole::Manager);
+    manager.bot_name = Some(manager_id.to_string());
+    let mut worker = Participant::bot(worker_id, ParticipantRole::Worker);
+    worker.bot_name = Some(worker_id.to_string());
+    let mut group = Group::new("851c7a6a-42bc-4be2-8785-1106ef4393a0", manager_id, vec![manager, worker]);
+    group.group_strategy = GroupStrategy::ManagerWorker;
+    let participants = vec![
+        Participant::bot(manager_id, ParticipantRole::Manager),
+        Participant::bot(worker_id, ParticipantRole::Worker),
+    ];
+    let registry = NamedRegistry::new(&[
+        (manager_id, "Demo Worker的分身", Some("Demo Worker的分身")),
+        (worker_id, "Demo Worker测试0528", None),
+    ]);
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "协作任务".to_string(),
+        session_input: Some(serde_json::json!("执行慢查询审计")),
+        task_ledger: Some(LedgerSummary {
+            pending: vec!["B".to_string()],
+            replied: vec!["A".to_string()],
+            failed: Vec::new(),
+            timed_out: Vec::new(),
+        }),
+    };
+
+    let (messages, user_message) = SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await;
+    assert_eq!(messages.len(), 2);
+    let ws = user_message.expect("MW SessionContext must emit user_message");
+
+    // Facts preserved.
+    assert!(ws.contains("[SERVICE GROUP CONTEXT]"));
+    assert!(ws.contains("[/SERVICE GROUP CONTEXT]"));
+    assert!(ws.contains("模式: manager_worker"));
+    assert!(ws.contains(&format!("群组ID: {}", group.id)));
+    assert!(ws.contains("参与者:"));
+    assert!(ws.contains("Demo Worker的分身"));
+    // [任务] and [任务状态] rendered unconditionally from facts.
+    assert!(ws.contains("[任务]"));
+    assert!(ws.contains("执行慢查询审计"));
+    assert!(ws.contains("[任务状态] 待回复: B | 已回复: A | 失败: - | 超时: -"));
+    // Personalization / coordination stripped.
+    assert!(!ws.contains("你是:"));
+    assert!(!ws.contains("你的角色:"));
+    assert!(!ws.contains("[协同提醒]"));
+    assert!(!ws.contains("bcs_assign_task"));
+    assert!(!ws.contains("bcs_send_task_message"));
+}
+
+#[tokio::test]
+async fn manager_worker_session_context_user_message_renders_without_manager_participant() {
+    // No Manager in roster; facts still render.
+    let worker = Participant::bot("worker-only", ParticipantRole::Worker);
+    let mut group = Group::new("g-mw", "worker-only", vec![worker]);
+    group.group_strategy = GroupStrategy::ManagerWorker;
+    let participants = vec![Participant::bot("worker-only", ParticipantRole::Worker)];
+    let registry = NamedRegistry::new(&[]);
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "协作任务".to_string(),
+        session_input: Some(serde_json::json!("任务X")),
+        task_ledger: None,
+    };
+
+    let (_messages, user_message) = SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await;
+    let ws = user_message.expect("ws text");
+    assert!(ws.contains("[SERVICE GROUP CONTEXT]"));
+    assert!(ws.contains("模式: manager_worker"));
+    assert!(ws.contains("[任务]"));
+    assert!(ws.contains("任务X"));
+    assert!(!ws.contains("你是:"));
+    assert!(!ws.contains("[协同提醒]"));
+}
+
+#[tokio::test]
+async fn chat_session_context_user_message_includes_background_and_task_when_present() {
+    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
+    driver.bot_name = Some("Driver".to_string());
+    let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
+    peer.bot_name = Some("Peer".to_string());
+    let mut group = Group::new("group-chat-bg", "bot-driver", vec![driver, peer]);
+    group.group_strategy = GroupStrategy::Chat;
+    group.context = Some("背景X".to_string());
+    let participants = group.participants.clone();
+
+    // Inline produce (mirror helper but with session_input + group.context set)
+    // to cover the WS depersonalized path with non-empty input/context.
+    let registry = NamedRegistry::new(&[]);
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "普通协作".to_string(),
+        session_input: Some(serde_json::json!("任务X")),
+        task_ledger: None,
+    };
+    let (messages, user_message) = SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await;
+
+    let ws = user_message.expect("chat SessionContext must emit user_message");
+    assert_eq!(messages.len(), 2, "bot_messages still present");
+    assert!(ws.contains("[GROUP CONTEXT]"));
+    assert!(ws.contains("背景: 背景X"), "ws must render group context as 背景:");
+    assert!(ws.contains("[任务]") && ws.contains("任务X") && ws.contains("[/任务]"),
+        "ws must render session_input as a [任务] block");
+    assert!(!ws.contains("你是:") && !ws.contains("你的角色:"),
+        "depersonalization still holds on the WS path");
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -434,127 +434,44 @@ async fn manager_worker_manager_reminder_includes_task_ledger_status() {
     assert!(!worker_message.message.contains("[任务状态]"));
 }
 
-async fn chat_session_context_produce(
-    group: Group,
-    participants: Vec<Participant>,
-) -> (Vec<SystemGroupMessage>, Option<String>) {
-    let registry = NamedRegistry::new(&[]);
-    let event = SystemMessageEvent::SessionContext {
-        group_id: group.id.clone(),
-        session_id: format!("{}:7c18e4be", group.id),
-        reason: "普通协作".to_string(),
-        session_input: None,
-        task_ledger: None,
-    };
-    SessionContextMessageProducer
-        .produce(&event, &group, &registry, &participants)
-        .await
-}
-
 #[tokio::test]
-async fn chat_session_context_user_message_is_depersonalized_group_context() {
+async fn session_context_produces_no_user_message() {
+    // SessionContext intentionally emits no user-facing WS message: the bot
+    // context messages are delivered per-recipient and persisted with
+    // owner=recipient, but no session-level frontend broadcast is produced.
     let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
     driver.bot_name = Some("Driver".to_string());
     let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
     peer.bot_name = Some("Peer".to_string());
-    let mut group = Group::new("group-chat", "bot-driver", vec![driver, peer]);
-    group.group_strategy = GroupStrategy::Chat;
-    let participants = group.participants.clone();
 
-    let (messages, user_message) = chat_session_context_produce(group, participants).await;
-
-    // bot_messages unchanged: one per bot.
-    assert_eq!(messages.len(), 2);
-    let ws = user_message.expect("chat SessionContext must emit user_message");
-
-    // Facts preserved.
-    assert!(ws.contains("[GROUP CONTEXT]"));
-    assert!(ws.contains("[/GROUP CONTEXT]"));
-    assert!(ws.contains("群组ID: group-chat"));
-    assert!(ws.contains("主题: 普通协作"));
-    assert!(ws.contains("参与者:"));
-    // Routing instruction preserved (no provider downlink → bcs_route variant).
-    assert!(ws.contains("路由工具 (bcs_route)"));
-    // Personalization stripped.
-    assert!(!ws.contains("你是:"));
-    assert!(!ws.contains("你的角色:"));
-    assert!(!ws.contains("你是本次协作的 Driver"));
-    assert!(!ws.contains("应静默观察"));
-    assert!(!ws.contains("等待 @mention"));
-}
-
-#[tokio::test]
-async fn chat_session_context_user_message_at_mention_when_provider_downlink_present() {
-    // NamedRegistry resolves bot-provider as HTTP provider via resolve_delivery_target.
-    // The producer uses contains_provider_downlink_bot which calls resolve_delivery_target.
-    // NamedRegistry below overrides resolve_delivery_target to mark bot-provider as HTTP provider.
-    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
-    driver.bot_name = Some("Driver".to_string());
-    let mut provider = Participant::bot("bot-provider", ParticipantRole::Consultant);
-    provider.bot_name = Some("Provider".to_string());
-    let mut group = Group::new("group-chat", "bot-driver", vec![driver, provider]);
-    group.group_strategy = GroupStrategy::Chat;
-    let participants = group.participants.clone();
-
-    let registry = NamedRegistry::new(&[]).with_http_provider("bot-provider");
-    let event = SystemMessageEvent::SessionContext {
-        group_id: group.id.clone(),
-        session_id: format!("{}:7c18e4be", group.id),
+    // Chat strategy.
+    let mut chat_group = Group::new("group-chat", "bot-driver", vec![driver.clone(), peer.clone()]);
+    chat_group.group_strategy = GroupStrategy::Chat;
+    let chat_event = SystemMessageEvent::SessionContext {
+        group_id: chat_group.id.clone(),
+        session_id: format!("{}:7c18e4be", chat_group.id),
         reason: "普通协作".to_string(),
-        session_input: None,
+        session_input: Some(serde_json::json!("任务X")),
         task_ledger: None,
     };
-    let (_messages, user_message) = SessionContextMessageProducer
-        .produce(&event, &group, &registry, &participants)
+    let (chat_messages, chat_user_message) = SessionContextMessageProducer
+        .produce(&chat_event, &chat_group, &NamedRegistry::new(&[]), &chat_group.participants)
         .await;
-    let ws = user_message.expect("ws text");
+    assert!(!chat_messages.is_empty(), "Chat bot context messages still produced");
+    assert!(chat_user_message.is_none(), "Chat SessionContext user_message must be None");
 
-    assert!(ws.contains("路由工具 (@mention)"));
-    assert!(ws.contains("可@:"));
-    assert!(!ws.contains("路由工具 (bcs_route)"));
-    assert!(!ws.contains("你是:"));
-}
-
-#[tokio::test]
-async fn chat_session_context_user_message_renders_without_driver_role_bot() {
-    // No participant has the Driver role; driver_bot fallback still renders.
-    let mut peer_a = Participant::bot("bot-a", ParticipantRole::Consultant);
-    peer_a.bot_name = Some("A".to_string());
-    let mut peer_b = Participant::bot("bot-b", ParticipantRole::Consultant);
-    peer_b.bot_name = Some("B".to_string());
-    let mut group = Group::new("group-chat", "bot-a", vec![peer_a, peer_b]);
-    group.group_strategy = GroupStrategy::Chat;
-    let participants = group.participants.clone();
-
-    let (messages, user_message) = chat_session_context_produce(group, participants).await;
-    assert_eq!(messages.len(), 2);
-    let ws = user_message.expect("ws text");
-    assert!(ws.contains("[GROUP CONTEXT]"));
-    assert!(ws.contains("参与者:"));
-    assert!(!ws.contains("你是:"));
-}
-
-#[tokio::test]
-async fn manager_worker_session_context_user_message_is_depersonalized_service_group_context() {
+    // ManagerWorker strategy.
     let manager_id = "20260416_a5clr6ig:12345678";
     let worker_id = "20260528_vobmrqo6:12345678";
     let mut manager = Participant::bot(manager_id, ParticipantRole::Manager);
     manager.bot_name = Some(manager_id.to_string());
     let mut worker = Participant::bot(worker_id, ParticipantRole::Worker);
     worker.bot_name = Some(worker_id.to_string());
-    let mut group = Group::new("851c7a6a-42bc-4be2-8785-1106ef4393a0", manager_id, vec![manager, worker]);
-    group.group_strategy = GroupStrategy::ManagerWorker;
-    let participants = vec![
-        Participant::bot(manager_id, ParticipantRole::Manager),
-        Participant::bot(worker_id, ParticipantRole::Worker),
-    ];
-    let registry = NamedRegistry::new(&[
-        (manager_id, "Demo Worker的分身", Some("Demo Worker的分身")),
-        (worker_id, "Demo Worker测试0528", None),
-    ]);
-    let event = SystemMessageEvent::SessionContext {
-        group_id: group.id.clone(),
-        session_id: format!("{}:7c18e4be", group.id),
+    let mut mw_group = Group::new("851c7a6a-42bc-4be2-8785-1106ef4393a0", manager_id, vec![manager, worker]);
+    mw_group.group_strategy = GroupStrategy::ManagerWorker;
+    let mw_event = SystemMessageEvent::SessionContext {
+        group_id: mw_group.id.clone(),
+        session_id: format!("{}:7c18e4be", mw_group.id),
         reason: "协作任务".to_string(),
         session_input: Some(serde_json::json!("执行慢查询审计")),
         task_ledger: Some(LedgerSummary {
@@ -564,91 +481,9 @@ async fn manager_worker_session_context_user_message_is_depersonalized_service_g
             timed_out: Vec::new(),
         }),
     };
-
-    let (messages, user_message) = SessionContextMessageProducer
-        .produce(&event, &group, &registry, &participants)
+    let (mw_messages, mw_user_message) = SessionContextMessageProducer
+        .produce(&mw_event, &mw_group, &NamedRegistry::new(&[]), &mw_group.participants)
         .await;
-    assert_eq!(messages.len(), 2);
-    let ws = user_message.expect("MW SessionContext must emit user_message");
-
-    // Facts preserved.
-    assert!(ws.contains("[SERVICE GROUP CONTEXT]"));
-    assert!(ws.contains("[/SERVICE GROUP CONTEXT]"));
-    assert!(ws.contains("模式: manager_worker"));
-    assert!(ws.contains(&format!("群组ID: {}", group.id)));
-    assert!(ws.contains("参与者:"));
-    assert!(ws.contains("Demo Worker的分身"));
-    // [任务] and [任务状态] rendered unconditionally from facts.
-    assert!(ws.contains("[任务]"));
-    assert!(ws.contains("执行慢查询审计"));
-    assert!(ws.contains("[任务状态] 待回复: B | 已回复: A | 失败: - | 超时: -"));
-    // Personalization / coordination stripped.
-    assert!(!ws.contains("你是:"));
-    assert!(!ws.contains("你的角色:"));
-    assert!(!ws.contains("[协同提醒]"));
-    assert!(!ws.contains("bcs_assign_task"));
-    assert!(!ws.contains("bcs_send_task_message"));
-}
-
-#[tokio::test]
-async fn manager_worker_session_context_user_message_renders_without_manager_participant() {
-    // No Manager in roster; facts still render.
-    let worker = Participant::bot("worker-only", ParticipantRole::Worker);
-    let mut group = Group::new("g-mw", "worker-only", vec![worker]);
-    group.group_strategy = GroupStrategy::ManagerWorker;
-    let participants = vec![Participant::bot("worker-only", ParticipantRole::Worker)];
-    let registry = NamedRegistry::new(&[]);
-    let event = SystemMessageEvent::SessionContext {
-        group_id: group.id.clone(),
-        session_id: format!("{}:7c18e4be", group.id),
-        reason: "协作任务".to_string(),
-        session_input: Some(serde_json::json!("任务X")),
-        task_ledger: None,
-    };
-
-    let (_messages, user_message) = SessionContextMessageProducer
-        .produce(&event, &group, &registry, &participants)
-        .await;
-    let ws = user_message.expect("ws text");
-    assert!(ws.contains("[SERVICE GROUP CONTEXT]"));
-    assert!(ws.contains("模式: manager_worker"));
-    assert!(ws.contains("[任务]"));
-    assert!(ws.contains("任务X"));
-    assert!(!ws.contains("你是:"));
-    assert!(!ws.contains("[协同提醒]"));
-}
-
-#[tokio::test]
-async fn chat_session_context_user_message_includes_background_and_task_when_present() {
-    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
-    driver.bot_name = Some("Driver".to_string());
-    let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
-    peer.bot_name = Some("Peer".to_string());
-    let mut group = Group::new("group-chat-bg", "bot-driver", vec![driver, peer]);
-    group.group_strategy = GroupStrategy::Chat;
-    group.context = Some("背景X".to_string());
-    let participants = group.participants.clone();
-
-    // Inline produce (mirror helper but with session_input + group.context set)
-    // to cover the WS depersonalized path with non-empty input/context.
-    let registry = NamedRegistry::new(&[]);
-    let event = SystemMessageEvent::SessionContext {
-        group_id: group.id.clone(),
-        session_id: format!("{}:7c18e4be", group.id),
-        reason: "普通协作".to_string(),
-        session_input: Some(serde_json::json!("任务X")),
-        task_ledger: None,
-    };
-    let (messages, user_message) = SessionContextMessageProducer
-        .produce(&event, &group, &registry, &participants)
-        .await;
-
-    let ws = user_message.expect("chat SessionContext must emit user_message");
-    assert_eq!(messages.len(), 2, "bot_messages still present");
-    assert!(ws.contains("[GROUP CONTEXT]"));
-    assert!(ws.contains("背景: 背景X"), "ws must render group context as 背景:");
-    assert!(ws.contains("[任务]") && ws.contains("任务X") && ws.contains("[/任务]"),
-        "ws must render session_input as a [任务] block");
-    assert!(!ws.contains("你是:") && !ws.contains("你的角色:"),
-        "depersonalization still holds on the WS path");
+    assert!(!mw_messages.is_empty(), "MW bot context messages still produced");
+    assert!(mw_user_message.is_none(), "MW SessionContext user_message must be None");
 }

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
@@ -1295,6 +1295,37 @@ pub async fn message_repo_contract_tests<T: MessageRepoPort + ?Sized>(repo: &T) 
     assert_eq!(public_owner_page.messages.len(), 1);
     assert_eq!(public_owner_page.messages[0].owner_bot_id, None);
 
+    // PublicOrOwner → 公共(owner=None) + 命中 viewer 的副本；他人 owner 不返回。
+    let public_or_mgr = repo
+        .query_messages(MessageQuery {
+            group_id: group_id.to_string(),
+            session_id: session_id.to_string(),
+            cursor: None,
+            limit: 10,
+            keyword: None,
+            sender_id: None,
+            message_type: None,
+            owner_filter: MessageOwnerFilter::PublicOrOwner("mgr".to_string()),
+            time_range: Some((5000, 5200)),
+            visible_from_seq: None,
+        })
+        .await
+        .expect("query public-or-mgr");
+    // sys(owner=None) + mgr(owner=mgr) 命中；workerA(owner=workerA) 不返回。
+    assert_eq!(public_or_mgr.messages.len(), 2);
+    assert!(public_or_mgr
+        .messages
+        .iter()
+        .all(|m| m.owner_bot_id.is_none() || m.owner_bot_id.as_deref() == Some("mgr")));
+    assert!(public_or_mgr
+        .messages
+        .iter()
+        .any(|m| m.owner_bot_id.is_none()));
+    assert!(public_or_mgr
+        .messages
+        .iter()
+        .any(|m| m.owner_bot_id.as_deref() == Some("mgr")));
+
     // list_session_history — legacy direct-read contract: `created_at DESC,
     // session_seq DESC` with composite `(created_at, session_seq)` cursor
     // pagination + full `MessageOwnerFilter`. env isolation (VUlao) is the
@@ -1378,6 +1409,34 @@ pub async fn message_repo_contract_tests<T: MessageRepoPort + ?Sized>(repo: &T) 
             .map(|m| m.session_seq)
             .collect::<Vec<_>>(),
         vec![8]
+    );
+
+    // PublicOrOwner("workerA") → 公共(NULL seqs 9,6,5,4,3,2,1) + workerA(seq 8)，DESC；
+    // seq 7(mgr) 被排除。
+    let public_or_wa = repo
+        .list_session_history(
+            session_id,
+            MessageOwnerFilter::PublicOrOwner("workerA".to_string()),
+            None,
+            None,
+            100,
+        )
+        .await
+        .expect("list_session_history PublicOrOwner");
+    assert_eq!(
+        public_or_wa
+            .messages
+            .iter()
+            .map(|m| m.session_seq)
+            .collect::<Vec<_>>(),
+        vec![9, 8, 6, 5, 4, 3, 2, 1]
+    );
+    assert!(public_or_wa.messages.iter().all(|m| {
+        m.owner_bot_id.is_none() || m.owner_bot_id.as_deref() == Some("workerA")
+    }));
+    assert!(
+        !public_or_wa.messages.iter().any(|m| m.session_seq == 7),
+        "mgr-owned seq 7 must NOT appear under PublicOrOwner(workerA)"
     );
 
     // visible_from_seq cutoff: only seqs >= 4 survive, DESC.

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -2001,8 +2001,8 @@ impl SystemMessageProducerService for NoopSystemMessageProducer {
         _group: &Group,
         _registry: &dyn BotRegistryCoreService,
         _participants: &[Participant],
-    ) -> Vec<SystemGroupMessage> {
-        vec![]
+    ) -> (Vec<SystemGroupMessage>, Option<String>) {
+        (vec![], None)
     }
 }
 


### PR DESCRIPTION
## Problem

`SystemMessageDispatcherService::dispatch` reused a single `Vec<SystemGroupMessage>` for both bot delivery and the two user-facing channels, producing wrong content:

- **History persistence** took `messages[0]` as a global `owner=None` record: BotJoined's new-bot context injection (群 ID/参与者/历史) and a random bot's personalized `[GROUP CONTEXT]` (含 "你是: xxx") leaked into frontend history as if they were system notifications.
- **Frontend WS** broadcast all bot messages (text-deduped, `"\n"`-joined) to the whole session, exposing each bot's injection context. WS cannot route per-tab, so bot-perspective content reached users.
- **Query side** ignored `view_bot_id` for non-ManagerWorker groups (hardcoded `Any`/`IsNull`), so per-bot system copies could not be scoped per viewer.

## Solution

- **Contract**: `SystemMessageProducerService::produce` now returns `(Vec<SystemGroupMessage>, Option<String>)` — `bot_messages` (semantics unchanged) + `user_message` (single WS-only text, never persisted). Empty bot recipients do not block a non-empty `user_message` (last bot leaving still pushes WS). `GenericNotification` maps empty message → `None` (never `Some("")`).
- **7 producers** emit a real `user_message`. `SessionContext` adds shared render helpers (`base_context_block`/`task_block`/`routing_instruction_block` for Chat; `mw_context_block`/`mw_task_block`/`mw_status_block` for MW) and depersonalized WS text (`depersonalized_chat_group_context` / `depersonalized_service_group_context`) that strips `你是:`/`你的角色:` and role/coordination instructions while keeping group facts, roster, routing, `[任务]`, `[任务状态]`. Bot-message rendering is byte-identical to before (locked by existing tests).
- **Dispatcher**: persistence rewritten to one record per recipient with `owner_bot_id = Some(recipient)`, `sender="system"`, `content = msg.message`; empty recipients → 0 records; `user_message` is NOT persisted. WS reduced to a single `user_message` session broadcast; the old dedup+join of bot messages and the MW `history_messages_to_persist`/`is_manager_context_message`/`participant_has_role` special-casing are deleted. Bot delivery loop (`chat.send`/`chat.inject`) unchanged.
- **Query**: `MessageOwnerFilter::PublicOrOwner(viewer)` added (`owner_bot_id IS NULL OR owner_bot_id = ?`) in mysql + memory stores, with contract conformance tests. `compute_session_history_query` scopes MW-manager and non-MW bot viewers to `PublicOrOwner` (none/`human_*` → `IsNull`; MW worker `Eq` unchanged; `visible_from_seq` unchanged). `get_history` (old group endpoint) Chat new-path now honors `view_bot_id` via the shared `chat_owner_filter_for_view` helper; legacy + empty-result fallback unchanged. V1 `bcs-app-session` facade comment updated.
- **No schema change** (`owner_bot_id` column/index already exist); legacy `owner=None` data stays visible (the new predicate is a superset of the old `Any`/`IsNull`).

## Validation

- 371 tests green across `bcs-system-message`, `bcs-message`, `bcs-message-store`, `bcs-service-api`, `bcs-test-support`, `bcs-app-session`, `bcs-collaboration-runtime`; `cargo build --workspace` clean; 7 conformance cases pass under the new tuple signature.
- New tests lock: per-recipient ownership, no-recipient WS boundary (`BotLeft` last-bot), depersonalized Chat/MW WS text (facts preserved, personalization stripped, renders without Manager participant), viewer-scoped history, the old `get_history` `view_bot_id` regression, and an **end-to-end round-trip** — dispatch persists `owner=recipient`, then `MessageService` returns the recipient's own copy and **hides other recipients' copies** via `PublicOrOwner`.