### PR TITLE
feat(backend): add hello world endpoint to the public API

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -551,6 +551,22 @@ as reference).
 All responses use the `Envelope[T]` / `Page[T]` shapes from
 `openapi_v1/contracts.py` unless noted (binary streams bypass the envelope).
 
+### ✅ shared — hello (1 endpoint) · `openapi_v1/hello/router.py` — **IMPLEMENTED**
+Not a Track B category and not owned by a slice: a no-input smoke-test endpoint
+for integrators and for our own testing. It reads nothing and calls no service,
+so a failure on it is the transport or the caller's credentials — never the
+domain. It is **not** exempt from the surface-wide auth: like every other route
+it requires a verified principal, which is most of what a smoke test is for.
+
+| Method | Path | Purpose | Success |
+|---|---|---|---|
+| GET | `/openapi/v1/bots/hello` | Fixed greeting; no path/query/body input | `Envelope[Hello]` — `data.message` is always `"Hello, World!"` |
+
+_Nested under `/openapi/v1/bots/` like the other groups, deliberately: the
+gateway picks the upstream from the first segment after `/openapi/v1`, so a
+top-level `/openapi/v1/hello` would need a new domain and a new `route_security`
+rule to be reachable at all._
+
 ### ✅ totalfrank · P1 — bots (13 endpoints) · `openapi_v1/bots/router.py` — **IMPLEMENTED (PR #494)**
 All 13 wired to the internal bot services. Kept here as the reference shape for
 the other six: this is what "done" looks like per category.
@@ -1017,3 +1033,17 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   cross-repo test pins that contract, so a rename on either side leaves both
   suites green and 401s production. Full suite 10204 passed / 3 skipped. SDD:
   `src/backend/specs/2026-08-02-public-api-user-only-principal/`.
+- **2026-08-04** — **`GET /openapi/v1/bots/hello` added** — a no-input smoke-test
+  endpoint that answers a fixed `Hello, World!` in the standard envelope. New
+  `openapi_v1/hello/` group, mounted in `_SUBGROUPS` ahead of the bots router so
+  the literal path is not read as a bot whose id is `hello`. Three decisions
+  worth knowing: it is **nested under `/openapi/v1/bots/`** because the gateway
+  selects the upstream from the first segment after `/openapi/v1`, so a
+  top-level `/openapi/v1/hello` would need a new domain plus a `route_security`
+  rule before it could be reached at all; it **requires a principal** like every
+  other route on this surface (the surface-wide dependency in
+  `build_public_router()` gives it no way to opt out, and an unauthenticated
+  smoke test would prove less anyway); and it carries **no `@envelope_errors`**
+  because it raises no domain error — its only failure is the dependency's 401,
+  which the app-level handler already envelopes. Board unmoved: this is not a
+  Track B category and no track's definition of done changes.

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -483,6 +483,20 @@ AvernetTenantMiddleware → resolve_avernet_tenant(request)  ─┐
 除注明外，所有响应都使用 `openapi_v1/contracts.py` 里的 `Envelope[T]` / `Page[T]` 结构
 （二进制流不走信封）。
 
+### ✅ 公共 —— hello（1 个端点）· `openapi_v1/hello/router.py` —— **已实现**
+它不属于 Track B 的任何类别，也不归某个切片所有：这是一个不接受任何输入的冒烟测试端点，
+供集成方以及我们自己做联调用。它不读取任何数据、不调用任何服务，所以它一旦失败，问题
+只会出在链路或调用方的凭据上，绝不会在业务域里。它**不豁免**面级认证：和其余路由一样
+需要通过验证的 principal —— 而这恰恰是冒烟测试最想验证的那一段。
+
+| 方法 | 路径 | 用途 | 成功响应 |
+|---|---|---|---|
+| GET | `/openapi/v1/bots/hello` | 固定问候语；无 path/query/body 输入 | `Envelope[Hello]` —— `data.message` 恒为 `"Hello, World!"` |
+
+_和其余组一样嵌套在 `/openapi/v1/bots/` 之下，这是刻意的：网关按 `/openapi/v1` 之后的
+第一段选择上游，所以顶层的 `/openapi/v1/hello` 需要新增一个 domain 和一条
+`route_security` 规则才能被路由到。_
+
 ### ✅ totalfrank · P1 —— bots（13 个端点）· `openapi_v1/bots/router.py` —— **已实现（PR #494）**
 13 个端点已全部接到内部 bot 服务上。这里保留下来，是作为其余六个类别的参照形态：
 一个类别"做完了"长什么样。
@@ -872,3 +886,13 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   **新记为待办：** 没有任何跨仓测试钉住这份契约，任一侧改字段名都会让两边测试保持绿色
   而线上全 401。整套测试 10204 通过 / 3 跳过。SDD：
   `src/backend/specs/2026-08-02-public-api-user-only-principal/`。
+- **2026-08-04** —— **新增 `GET /openapi/v1/bots/hello`** —— 一个不接受任何输入的冒烟
+  测试端点，用标准信封返回固定的 `Hello, World!`。新增 `openapi_v1/hello/` 组，挂在
+  `_SUBGROUPS` 里、位于 bots 路由之前，这样字面路径不会被当成 id 为 `hello` 的 Agent。
+  三点值得知道的决定：它**嵌套在 `/openapi/v1/bots/` 之下**，因为网关按 `/openapi/v1`
+  之后的第一段选择上游，顶层的 `/openapi/v1/hello` 需要新增 domain 和 `route_security`
+  规则才可能被路由到；它和本面上其余路由一样**需要 principal**（`build_public_router()`
+  的面级依赖让它没有豁免的余地，而且免认证的冒烟测试能验证的东西更少）；它**没有加
+  `@envelope_errors`**，因为它不会抛出任何业务域错误 —— 它唯一的失败是依赖抛出的 401，
+  而那已经由应用级处理器包成信封了。看板未动：它不是 Track B 的类别，也不改变任何
+  track 的完成定义。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -5,7 +5,8 @@ only; handlers are stubs). The gateway forwards ``/openapi/v1/bots/...`` here
 verbatim and generates its served doc from this surface. This is distinct from —
 and does not reuse — the legacy ``/api/...`` routers.
 
-The sub-resource groups (channels, identity, mcp, resources, routines, skills)
+The sub-resource groups (channels, hello, identity, mcp, resources, routines,
+skills)
 are mounted **before** the bots group so their literal path segments
 (``/openapi/v1/bots/channels`` …) resolve ahead of the agent-CRUD wildcard
 ``/openapi/v1/bots/{bot_id}``.
@@ -24,6 +25,7 @@ from .engine_runtime.engine import router as engine_engine_router
 from .engine_runtime.models import router as engine_models_router
 from .engine_runtime.sessions import router as engine_sessions_router
 from .channels import router as channels_router
+from .hello import router as hello_router
 from .identity import router as identity_router
 from .mcp import router as mcp_router
 from .resources import router as resources_router
@@ -38,6 +40,7 @@ PUBLIC_API_PREFIX = "/openapi/v1"
 # Order matters: literal sub-groups first, the `{bot_id}` wildcard group last.
 _SUBGROUPS = [
     channels_router,
+    hello_router,
     identity_router,
     mcp_router,
     resources_router,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/__init__.py
@@ -1,0 +1,5 @@
+"""hello public API group."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/router.py
@@ -1,0 +1,52 @@
+"""Hello group — ``GET /openapi/v1/bots/hello``, the surface's smoke test.
+
+One endpoint that takes no input and answers a fixed greeting. It exists so a
+caller can prove the whole path works — gateway forwarding, the principal
+header, the response envelope — before wiring a call that also depends on a bot,
+a device or a downstream service. It reads nothing and touches no service, which
+is the point: a failure here is the transport or the caller's credentials, never
+the domain.
+
+The path sits under ``/openapi/v1/bots/`` like every other non-bots group, so
+the gateway's existing ``bots`` domain forwards it to this service with no
+routing or ``route_security`` change. Like the rest of the surface it requires
+an authenticated user principal — "no input" is about the request, not about the
+credentials.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import envelope
+
+from .schemas import Hello
+
+router = APIRouter(prefix="/openapi/v1/bots/hello", tags=["hello"])
+
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+
+# Fixed, and exported so a test asserts against the same constant the handler
+# returns rather than a second copy of the string.
+HELLO_MESSAGE = "Hello, World!"
+
+
+@router.get("", response_model=Envelope[Hello])
+async def hello(principal: PrincipalDep, request: Request) -> Envelope[Hello]:
+    """Return a fixed greeting.
+
+    No path, query or body parameters. ``request`` is not an input either — the
+    envelope builder reads the trace id off it for ``request_id``.
+    """
+    # No ``@envelope_errors``: the decorator maps domain errors raised *inside* a
+    # handler, and this one raises none. The only failure this route can produce
+    # is the 401 from the auth dependency, which the app-level handler already
+    # answers in the envelope.
+    return envelope(Hello(message=HELLO_MESSAGE), request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/hello/schemas.py
@@ -1,0 +1,11 @@
+"""Response model for the hello group."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class Hello(BaseModel):
+    """The greeting payload; its value is fixed, so a caller can assert on it."""
+
+    message: str = Field(description='Fixed greeting — always "Hello, World!".')

--- a/src/backend/tests/community/adapters/http/openapi_v1/hello/test_hello_endpoint.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/hello/test_hello_endpoint.py
@@ -1,0 +1,111 @@
+"""Endpoint tests for ``GET /openapi/v1/bots/hello``.
+
+The route is a smoke test for integrators, so the properties worth pinning are
+the ones an integrator would rely on: a fixed payload in the standard envelope,
+no request input of any kind, the literal path resolving ahead of the
+``{bot_id}`` wildcard, and a caller-less request answering 401 rather than a
+greeting.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from agentclaw.community.adapters.http.openapi_v1.contracts import CODE_OK
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.hello.router import (
+    HELLO_MESSAGE,
+    router,
+)
+
+PATH = "/openapi/v1/bots/hello"
+
+
+@pytest.fixture
+def client():
+    """The hello router alone, with a verified caller supplied."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "u1"}
+    return TestClient(app)
+
+
+def test_hello_returns_the_fixed_greeting(client):
+    response = client.get(PATH)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["code"] == CODE_OK
+    assert body["message"] == "OK"
+    assert body["data"] == {"message": HELLO_MESSAGE}
+    assert "request_id" in body
+
+
+def test_hello_takes_no_input(client):
+    """No path, query or body parameters — the contract, not just the handler."""
+    operation = client.app.openapi()["paths"][PATH]["get"]
+
+    assert operation.get("parameters", []) == []
+    assert "requestBody" not in operation
+
+
+def test_hello_ignores_query_and_body(client):
+    """Extra input changes nothing; the answer is the same fixed payload."""
+    response = client.request("GET", PATH, params={"name": "x"}, json={"name": "x"})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"] == {"message": HELLO_MESSAGE}
+
+
+def test_hello_resolves_ahead_of_the_bot_id_wildcard():
+    """``/bots/hello`` must not be read as a bot whose id is ``hello``.
+
+    ``build_public_router`` mounts the literal sub-groups before the bots group;
+    this asserts the resulting order rather than trusting the list stayed sorted.
+    """
+    paths = [route.path for route in _api_routes(build_public_router())]
+
+    assert PATH in paths
+    assert paths.index(PATH) < paths.index("/openapi/v1/bots/{bot_id}")
+
+
+def test_hello_requires_a_verified_caller():
+    """No principal, no greeting — the surface-wide auth covers this route too.
+
+    Uses the production catch-all from ``app.py`` (as the seam tests do) because
+    ``require_principal`` raises in a *dependency*: it is that handler, not
+    ``@envelope_errors``, that turns the failure into an enveloped 401.
+    """
+    from agentclaw.community.adapters.http.app import _unhandled_exception_handler
+
+    app = FastAPI()
+    app.include_router(build_public_router())
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+
+    response = TestClient(app, raise_server_exceptions=False).get(PATH)
+
+    assert response.status_code == 401
+    body = response.json()
+    assert body["message"] == "Unauthorized"
+    assert body["data"] is None
+
+
+def _api_routes(router) -> list:
+    """Every real route under ``router``, in mount order.
+
+    ``include_router`` stores a lazy wrapper rather than copying routes, so the
+    nesting ``build_public_router`` creates has to be walked (same helper as
+    ``test_principal_seam``) — reading ``app.routes`` finds only the docs routes.
+    """
+    found = []
+    for route in getattr(router, "routes", []):
+        if hasattr(route, "dependant"):
+            found.append(route)
+        elif hasattr(route, "original_router"):
+            found.extend(_api_routes(route.original_router))
+        else:
+            found.extend(_api_routes(route))
+    return found

--- a/src/backend/tests/community/framework/coverage_baseline.txt
+++ b/src/backend/tests/community/framework/coverage_baseline.txt
@@ -7,6 +7,15 @@
 # token, and the harness has no minter — so a case could assert nothing but a
 # 401. #651 covers the minter and the backfill for the whole surface.
 #
+# `GET /openapi/v1/bots/hello` is on that list too, and deliberately so despite
+# taking no input and calling no service: it is a route on the public surface,
+# so it needs the same gateway-signed token as its neighbours. Covering it here
+# would mean the harness forging one — which is exactly what the auth workstream
+# declined to do (see _GATEWAY_PRINCIPAL_EXEMPT_REASON in flow_coverage.py). Its
+# happy path is covered by unit tests in
+# tests/community/adapters/http/openapi_v1/hello/ meanwhile, and it drains with
+# the rest of the surface on #651.
+#
 # Comments survive hand edits; `python -m tests.community.framework.coverage_gate
 # --regen` rewrites the file and drops them.
 DELETE /api/bot-render-screens/{record_id}: missing [happy, error]
@@ -154,6 +163,7 @@ GET /openapi/v1/bots/ceiling: missing [happy, error]
 GET /openapi/v1/bots/channels/{channel_id}: missing [happy, error]
 GET /openapi/v1/bots/channels: missing [happy, error]
 GET /openapi/v1/bots/check-name: missing [happy, error]
+GET /openapi/v1/bots/hello: missing [happy, error]
 GET /openapi/v1/bots/identity/bot/{bot_id}/{file_type}: missing [happy, error]
 GET /openapi/v1/bots/identity/bot/{bot_id}: missing [happy, error]
 GET /openapi/v1/bots/mcp/servers/{server_code}/config: missing [happy, error]


### PR DESCRIPTION
## Problem

The `/openapi/v1` surface has no endpoint that can be called without also
depending on a bot, a device, or a downstream service. That makes the first
call an integrator (or one of our own test runs) makes a poor probe: when it
fails, the cause could be gateway forwarding, the principal header, the
response envelope, or the domain, and the answer does not say which.

## Solution

Add `GET /openapi/v1/bots/hello` — no path, query or body input — returning the
standard envelope with a fixed payload:

```json
{"code": 200000, "message": "OK", "data": {"message": "Hello, World!"}, "request_id": "…"}
```

New `openapi_v1/hello/` group (router + schema), mounted in `_SUBGROUPS` ahead
of the bots router. Three decisions worth flagging:

- **Nested under `/openapi/v1/bots/`**, like every other non-bots group. The
  gateway picks the upstream from the first path segment after `/openapi/v1`, so
  a top-level `/openapi/v1/hello` would need a new domain in `upstreams.domains`
  plus a `route_security` rule before it was reachable at all. Nesting it keeps
  this a backend-only change.
- **It requires a verified principal**, like the rest of the surface. The
  dependency is attached surface-wide in `build_public_router()`, so the route
  has no way to opt out and `test_public_routes_require_principal` would fail if
  it did — and an unauthenticated greeting would prove less than one that also
  exercises the auth seam. "No input" is about the request, not the credentials.
  In an environment with no signing key configured (local / singlebox) this
  answers 401, same as every other public route.
- **No `@envelope_errors`** — the decorator maps domain errors raised inside a
  handler and this one raises none. Its only failure is the dependency's 401,
  which the app-level handler already envelopes.

Docs: added the endpoint to the `openapi-v1` README status doc and a dated
changelog line, in both EN and zh-CN, as that file asks.

## Validation

Ran in `src/backend` (`uv sync --default-index https://pypi.org/simple`, since
the pinned mirror is blocked in this sandbox):

- `pytest tests/community/adapters` — **700 passed**. Includes the new
  `openapi_v1/hello/test_hello_endpoint.py` (5 tests: fixed greeting in the
  envelope; the published operation declares no parameters and no request body;
  stray query/body input changes nothing; the literal path is walked before the
  `/openapi/v1/bots/{bot_id}` wildcard; a caller-less request answers an
  enveloped 401 through the production catch-all) and the existing surface-wide
  gates — `test_public_routes_require_principal` and
  `test_every_public_operation_documents_the_error_envelope` — which now cover
  this route too.
- `pytest tests/community/contracts/gateway tests/community/architecture` —
  **214 passed**.
- `scripts/ci/python_sast_local.sh` block rules over the changed files — clean.
- Published-artifact check via `scripts/dump_openapi.py`: the route appears in
  the narrowed public document with `parameters: none`, no `requestBody`, a
  `Envelope_Hello_` 200, and the shared error statuses (400/401/404/409/422/500/502).

Not run: the singlebox coverage / E2E gate — it needs the full standalone stack,
and every `/openapi/v1` route answers 401 there (no signing key in singlebox), so
a flow could only assert 401s. No `core/` module was added, so no coverage
manifest or `SINGLEBOX_E2E_EXEMPT` entry changes.

## Compatibility and risk

Additive only: one new route, one new schema, no change to any existing
operation, no schema/config/DDL impact. The gateway's committed
`configs/schemas/bots.openapi.json` is a release-time artifact and is
deliberately left untouched; it picks the route up on the next dump. Rollback is
reverting the commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUgZnitSJv2HmoKCt7JsYB)_