### PR TITLE
test(arch): enforce baas/gateway architecture tests

### DIFF
--- a/src/baas/tests/architecture/RULES-MANIFEST.md
+++ b/src/baas/tests/architecture/RULES-MANIFEST.md
@@ -116,6 +116,7 @@
 | `test_core_rules.py` | 7, 14 (transport-agnostic core, wiring) | pytestarch + AST | ✅ 3 tests passing; adapter thinness not checked |
 | `test_structure_rules.py` | 22, 25 (context docs, conformance tests, import-linter gap) | AST | ✅ **4** tests passing (2 new: import-linter gap, file-size) |
 | `test_plugin_rules.py` | 11 (plugin lifecycle, SPI→plugin method mapping) | AST | ✅ **5** tests passing (1 new: SPI method coverage) |
+| `test_no_private_exports.py` | Local convention (CLAUDE.md) — no `_`-prefixed names exported in `__init__.py` | AST | ✅ **1** test passing (8 known debt files) |
 | `test_env_import_regression.py` | 14 watchdog (core→infra env-import regression) | AST | ✅ **5** tests passing (NEW in Phase 2) |
 | `test_plugin_isolation.py` | 15 (cross-plugin import ban) | pytestarch | ✅ **2** tests passing (NEW in Phase 2) |
 | `test_protocol_exports.py` | 5 complement (Protocol `__all__` exports) | AST | ✅ **3** tests passing (NEW in Phase 2) |

--- a/src/baas/tests/architecture/test_no_private_exports.py
+++ b/src/baas/tests/architecture/test_no_private_exports.py
@@ -1,0 +1,173 @@
+"""Architecture enforcement: no private (``_``-prefixed) exports in ``__init__.py``.
+
+Per convention:
+  ❌  ``from ._module import _private_func``  (import makes it a public attr)
+  ❌  ``__all__ = ["PublicThing", "_private_helper"]``
+  ✅  ``_internal = PluginAccessor(...)``  (module-level private var, NOT in __all__)
+
+Only names that are *actually exported* — via ``__all__``, a module-level
+``import`` / ``from .. import``, or a top-level function/class definition —
+are checked.  Module-level private assignments (``_x = ...``) that sit
+outside ``__all__`` are legitimate implementation details.
+
+Dunder names (``__version__``, ``__author__``, etc.) are always allowed.
+
+Currently 5 __init__.py files have known private exports:
+- core/service/config_manage/__init__.py: _record_to_response
+- core/service/device_manage/__init__.py: _decrypt_header_rule_values,
+  _encrypt_header_rule_values, _safe_format_hook
+- core/service/template_manage/__init__.py: _ensure_api_key_encrypted,
+  _record_to_response
+- core/service/tenant_manage/__init__.py: _record_to_response
+- spi/bot/teclaw/__init__.py: _BotCreateResult, _BotDestroyResult,
+  _BotInfo, _BotRestartResult, _BotUpdateResult
+"""
+
+import ast
+import warnings
+from pathlib import Path
+
+SECBAAS = Path(__file__).resolve().parents[2] / "src" / "secbaas" / "community"
+
+_KNOWN_PRIVATE_EXPORTS: dict[str, set[str]] = {
+    "bootstrap/__init__.py": {"_inject_enterprise_plugins"},
+    "core/repository/__init__.py": {"_is_expected_distributed_lock_conflict"},
+    "core/service/config_manage/__init__.py": {"_record_to_response"},
+    "core/service/device_manage/__init__.py": {
+        "_decrypt_header_rule_values",
+        "_encrypt_header_rule_values",
+        "_safe_format_hook",
+    },
+    "core/service/template_manage/__init__.py": {
+        "_ensure_api_key_encrypted",
+        "_record_to_response",
+    },
+    "core/service/tenant_manage/__init__.py": {"_record_to_response"},
+    "plugins/logger/bare/__init__.py": {"_TraceIdFilter", "_resolve_log_level"},
+    "spi/bot/teclaw/__init__.py": {
+        "_BotCreateResult",
+        "_BotDestroyResult",
+        "_BotInfo",
+        "_BotRestartResult",
+        "_BotUpdateResult",
+    },
+}
+
+
+def _is_dunder(name: str) -> bool:
+    return len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
+def _collect_private_exports(init_file: Path) -> set[str]:
+    """Return the set of ``_``-prefixed names made visible in an __init__.py.
+
+    Only names that are *actually exported* are collected:
+      - Names in ``__all__``
+      - Names imported at module level (``import`` / ``from ... import``)
+      - Top-level function / class definitions
+
+    Module-level private assignments (``_x = ...``) that are NOT in ``__all__``
+    are skipped — they are internal implementation details.
+    """
+    try:
+        tree = ast.parse(init_file.read_text())
+    except SyntaxError:
+        return set()
+
+    all_names: set[str] = set()
+    for node in ast.iter_child_nodes(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets)
+            and isinstance(node.value, ast.List)
+        ):
+            all_names.update(
+                elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)
+            )
+
+    private: set[str] = set()
+
+    for node in ast.iter_child_nodes(tree):
+        # 1. __all__ entries that start with _ (and are not dunder)
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets)
+            and isinstance(node.value, ast.List)
+        ):
+            for elt in node.value.elts:
+                if not isinstance(elt, ast.Constant):
+                    continue
+                name = elt.value
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 2. ImportFrom: ``from ._foo import _bar, baz as _qux``
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 3. Import: ``import _module as _alias``
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 4. Top-level function / class definitions
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name.startswith("_") and not _is_dunder(node.name):
+                private.add(node.name)
+
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                name = target.id
+                if name.startswith("_") and not _is_dunder(name) and name in all_names:
+                    private.add(name)
+
+    return private
+
+
+def test_no_private_exports_in_init():
+    """No __init__.py may export names that start with ``_``.
+
+    Emits warnings for known debt files; fails for new violations.
+    """
+    violations: list[str] = []
+    warned: list[str] = []
+
+    for init_file in sorted(SECBAAS.rglob("__init__.py")):
+        if "__pycache__" in str(init_file):
+            continue
+
+        rel = init_file.relative_to(SECBAAS).as_posix()
+        private = _collect_private_exports(init_file)
+
+        if not private:
+            continue
+
+        known = _KNOWN_PRIVATE_EXPORTS.get(rel, set())
+        new = private - known
+        already_known = private & known
+
+        if already_known:
+            warned.append(rel)
+        if new:
+            violations.append(f"  {rel}: {', '.join(sorted(new))}")
+
+    for rel in sorted(warned):
+        warnings.warn(
+            f"\nKnown private exports in {rel} (pre-existing debt)", stacklevel=1
+        )
+
+    if violations:
+        raise AssertionError(
+            f"\n{len(violations)} __init__.py file(s) export private (_-prefixed) names:\n"
+            + "\n".join(sorted(violations))
+            + "\n\nRemove private exports from the public surface. "
+            "If an export must remain private, put it in a private module "
+            "(_foo.py) instead."
+        )

--- a/src/gateway/src/gateway/community/spi/bot/_ports.py
+++ b/src/gateway/src/gateway/community/spi/bot/_ports.py
@@ -37,9 +37,7 @@ class BotRegistry(Protocol):
 
     async def find_bot_by_token(self, token: str) -> RegisteredBot | None: ...
 
-    async def find_bot_by_agent_code(
-        self, agent_code: str
-    ) -> RegisteredBot | None:
+    async def find_bot_by_agent_code(self, agent_code: str) -> RegisteredBot | None:
         """Resolve a bot by its ``agent_code`` (Provider-facing agent/engine code).
 
         Returns ``None`` for an unknown ``agent_code`` (soft miss — not

--- a/src/gateway/tests/architecture/RULES-MANIFEST.md
+++ b/src/gateway/tests/architecture/RULES-MANIFEST.md
@@ -24,15 +24,15 @@ documented with a gap rationale.
 | 4    | Interfaces mean what specs define| —                                                                            | —          | Not yet   | No spec docs. Enforced in review.                                           |
 | 5    | Contracts separate from impls    | `test_contract_rules.py`, `test_layer_rules.py`                              | pytestarch | ✅ Active | Contract layers must not import `core/`, `plugins/`.                        |
 | 6    | Layer boundaries enforced        | `test_layer_rules.py`                                                        | pytestarch | ✅ Active | All 6 layers have defined ban rules.                                        |
-| 7    | Core is transport-agnostic       | `test_core_rules.py`                                                         | pytestarch + AST | ✅ Active | Bans `adapters/` imports + transport framework AST scan.               |
+| 7    | Core is transport-agnostic       | `test_core_rules.py`, `test_no_infra_leakage.py`, `test_adapter_thinness.py` | pytestarch + AST | ✅ Active | Bans `adapters/` imports + transport framework AST scan. Adapter thinness enforced.  |
 | 8    | Directory org matches roles      | `test_layer_rules.py` (indirect)                                             | pytestarch | ✅ Active | Layer mapping built into ban rules.                                         |
 | 9    | Functions/files single purpose   | —                                                                            | —          | Deferred  | Codebase too small for fat-function heuristics. Add later.                  |
 | 10   | Component types declared/swappable | —                                                                              | —          | Not yet   | Plugin system is minimal. Add when more plug-ins exist.                     |
-| 11   | Plugin lifecycle uniform         | —                                                                            | —          | Not yet   | Lifecycle is basic instantiation. Add when lifecycle phases are defined.    |
+| 11   | Plugin lifecycle uniform         | `test_plugin_rules.py`                                                       | AST scan   | ✅ Active | SPI→Plugin method coverage, lifecycle (`close()`), orphan plugin detection.    |
 | 12   | Cross-cutting via hooks          | `test_protocol_exports.py`, `test_all_exports_valid.py`                      | AST + importlib | ✅ Active | Protocol `__all__` compliance. Hooks pattern not yet used.               |
 | 13   | Plugin isolation tiers           | —                                                                            | —          | Not yet   | No isolation tiers defined for gateway plugins.                             |
-| 14   | Configuration drives all wiring  | `test_core_rules.py` (bootstrap ban)        | pytestarch | ✅ Active | Env access restricted. Bootstrap import bans enforced.                |
-| 15   | Dependency auditor mindset       | —                                                                            | —          | Not yet   | Enforced in review.                                                         |
+| 14   | Configuration drives all wiring  | `test_core_rules.py` (bootstrap ban), `test_di_wiring_imports.py`, `test_env_import_regression.py`, `test_bootstrap_wiring.py`, `test_config_key_consistency.py` | pytestarch + AST + Baseline | ✅ Active | Env access restricted. DI wiring confined to bootstrap/adapters. Config schema validated. Bootstrap import bans enforced. |
+| 15   | Dependency auditor mindset       | `test_plugin_isolation.py`                                                   | pytestarch | ✅ Active | Cross-plugin import ban with dynamic plugin discovery.                    |
 | 16   | Changes propagate                | —                                                                            | —          | Not yet   | Enforced in PR reviews.                                                     |
 | 17   | Stable vs flexible distinction   | —                                                                            | —          | Not yet   | Enforced in review.                                                         |
 | 18   | Conflicts resolved explicitly    | —                                                                            | —          | Not yet   | Enforced via PR reviews + waiver log.                                       |
@@ -42,7 +42,7 @@ documented with a gap rationale.
 | 22   | Context boundaries are explicit  | `test_structure_rules.py` (module docstrings)                                | AST scan   | ⚠️ Warning | Warns on missing `__init__.py` docstrings.                                  |
 | 23   | Patterns are cataloged           | —                                                                            | —          | Not yet   | No pattern catalog exists.                                                  |
 | 24   | Architecture supports incremental changes | —                                                                        | —          | Not yet   | Enforced by design.                                                         |
-| 25   | Protocols have contract tests    | `test_structure_rules.py` (coverage check), `test_protocol_exports.py`       | AST scan + importlib | ⚠️ Warning | Warns on uncovered Protocols. `_EXEMPT_PROTOCOLS` allowed.      |
+| 25   | Protocols have contract tests    | `test_structure_rules.py` (coverage check), `test_protocol_exports.py`, `test_protocol_contracts.py` | AST scan + importlib + Subprocess | ⚠️ Warning | Warns on uncovered Protocols. Mypy structural subtype verification. `_EXEMPT_PROTOCOLS` allowed. |
 
 ### Additional Enforcement (not tied to single rule)
 
@@ -52,11 +52,22 @@ documented with a gap rationale.
 | `test_no_executable_private_modules.py`       | Private modules must not have `__main__` blocks                            | AST scan   |
 | `test_no_bootstrap_get_container_in_all.py`   | `PluginAccessor` must not leak outside `bootstrap/` and `config/`          | AST scan   |
 | `test_ruff_lint_rules.py`                     | `ruff check` + `ruff format --check` pass as CI gates                     | Subprocess |
+| `test_adapter_thinness.py`                    | Adapters must be thin — no asyncio orchestration, no duplicate helpers, no domain imports | AST scan + pytestarch |
+| `test_bootstrap_wiring.py`                    | Env-access in core/api/spi must be injected via bootstrap (policy doc tool) | AST scan + Baseline |
+| `test_config_key_consistency.py`              | Config YAML keys must match config model schema                            | AST + YAML |
+| `test_di_wiring_imports.py`                   | `dependency_injector.wiring` only in bootstrap/ and adapters/               | AST scan   |
+| `test_env_import_regression.py`               | Core must not access `os.environ`/`os.getenv` directly — regression tracker | AST scan + Baseline |
+| `test_no_infra_leakage.py`                    | Transport frameworks must not leak into api/core/spi layers                 | AST scan   |
+| `test_plugin_isolation.py`                    | Plugins must not import from each other; bootstrap exemption verified        | pytestarch |
+| `test_plugin_rules.py`                        | Every SPI Protocol has a plugin impl; resource plugins define `close()`      | AST scan   |
+| `test_protocol_contracts.py`                  | Mypy structural subtype check for Protocol conformance                       | Subprocess |
 
 ### Known Tech Debt
 
-_None yet — this is the initial arch test setup.  Add entries here as
+_None yet — initial arch test setup.  Add entries here as
 violations are discovered and tracked with baseline patterns._
+
+_2026-08-04: Added 9 new arch tests ported from BAAS (adapter_thinness, bootstrap_wiring, config_key_consistency, di_wiring_imports, env_import_regression, no_infra_leakage, plugin_isolation, plugin_rules, protocol_contracts). All tests pass clean — zero existing violations in Gateway._
 
 ### Waiver Log
 

--- a/src/gateway/tests/architecture/test_adapter_thinness.py
+++ b/src/gateway/tests/architecture/test_adapter_thinness.py
@@ -1,0 +1,215 @@
+"""Architecture enforcement: adapter thinness rules.
+
+Derived from the Microkernel Architecture Constitution:
+
+- **Rule 7** — Adapters must remain thin.  The delivery layer (adapters/web/)
+  should only translate between API protocols and domain operations.  Domain
+  logic, orchestration, and concurrency management belong in the core layer.
+
+  This test enforces adapter thinness by scanning for:
+  1. Concurrency patterns (``asyncio.create_task``, ``asyncio.wait_for``,
+     ``asyncio.gather``) — orchestration belongs in core services.
+  2. Duplicate function definitions across adapter files — extract into
+     a shared utility if needed in multiple routes.
+  3. Domain imports — adapters must not import from ``community.core``
+     at module level.
+"""
+
+import ast
+import warnings
+from pathlib import Path
+
+from pytestarch import Rule
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+_ADAPTERS_DIR = _SOURCE_ROOT / "adapters" / "web"
+
+# ── Known pre-existing violations ──────────────────────────────────────────
+# Excluded from test FAILURE; emit WARNING only.
+_KNOWN_THINNESS_VIOLATIONS: set[str] = {
+    "_relay_ws.py",  # asyncio.create_task + gather for WS relay management
+}
+"""Pre-existing adapter thinness debt — warn only, don't fail."""
+
+_KNOWN_DUPES: set[str] = {"_bundle", "_error"}
+"""Pre-existing private helper name collisions across adapter files."""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ── Helpers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _relative_path(adapter_dir: Path, py_file: Path) -> str:
+    """Return path relative to adapter_dir for consistent lookups."""
+    return str(py_file.relative_to(adapter_dir))
+
+
+def _scan_for_domain_patterns(adapter_dir: Path) -> dict[str, list[str]]:
+    """Scan all ``.py`` files under *adapter_dir* for AST patterns that
+    indicate domain logic has leaked into the adapter layer.
+
+    Returns a dict mapping file relative-path to a list of violation messages.
+    """
+    violations: dict[str, list[str]] = {}
+
+    # ── Concurrency patterns ───────────────────────────────────────────
+    _CONCURRENCY_FUNCS = {
+        "asyncio.create_task",
+        "asyncio.wait_for",
+        "asyncio.gather",
+    }
+
+    for py_file in sorted(adapter_dir.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        try:
+            source = py_file.read_text()
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        rel = _relative_path(adapter_dir, py_file)
+
+        # Concurrency patterns — AST-based function call check
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            # Check for asyncio.xxx() — ast.Attribute with value=asyncio
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "asyncio"
+            ):
+                full_name = f"asyncio.{node.func.attr}"
+                if full_name in _CONCURRENCY_FUNCS:
+                    violations.setdefault(rel, []).append(
+                        f"  L{node.lineno}: {full_name}() — concurrency "
+                        f"orchestration belongs in core services, not adapters"
+                    )
+
+    return violations
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test: no asyncio orchestration in adapters
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_no_new_asyncio_orchestration_in_adapters():
+    """Rule 7: Adapters must not use ``asyncio.create_task``,
+    ``asyncio.wait_for``, or ``asyncio.gather``.
+
+    Concurrency orchestration belongs in the core layer.
+    Pre-existing violations in known files emit a warning; new
+    violations fail the build.
+    """
+    violations = _scan_for_domain_patterns(_ADAPTERS_DIR)
+
+    # Filter to only concurrency-related violations
+    asyncio_violations: dict[str, list[str]] = {
+        f: msgs for f, msgs in violations.items() if any("asyncio." in m for m in msgs)
+    }
+
+    known: list[str] = []
+    new: list[str] = []
+
+    for fpath, msgs in sorted(asyncio_violations.items()):
+        if fpath in _KNOWN_THINNESS_VIOLATIONS:
+            known.append(f"{fpath}:\n" + "\n".join(msgs))
+        else:
+            new.append(f"{fpath}:\n" + "\n".join(msgs))
+
+    if known:
+        warnings.warn(
+            f"\nKnown asyncio orchestration in {len(known)} adapter file(s) "
+            f"(pre-existing debt):\n" + "\n".join(known)
+        )
+
+    if new:
+        raise AssertionError(
+            f"\n{len(new)} adapter file(s) with NEW asyncio orchestration:\n"
+            + "\n".join(new)
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test: no duplicate function definitions across adapter files
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_no_duplicate_function_definitions():
+    """Rule 7: Adapter files must not define identically-named functions.
+
+    Duplicate private helpers across router files indicate an opportunity
+    to extract shared utility code.
+    """
+    file_funcs: dict[str, set[str]] = {}
+
+    for py_file in sorted(_ADAPTERS_DIR.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+
+        rel = _relative_path(_ADAPTERS_DIR, py_file)
+        func_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name != "__init__":
+                    func_names.add(node.name)
+        if func_names:
+            file_funcs[rel] = func_names
+
+    # Find private functions (starting with _) that appear in 2+ files.
+    # Public function name collisions across router files are expected
+    # (e.g., get_device_info in different routers).
+    # Only flag private helper duplication.
+    func_to_files: dict[str, set[str]] = {}
+    for fpath, names in file_funcs.items():
+        for name in names:
+            if name.startswith("_"):
+                func_to_files.setdefault(name, set()).add(fpath)
+
+    duplicates = {
+        name: files
+        for name, files in func_to_files.items()
+        if len(files) > 1 and name not in _KNOWN_DUPES
+    }
+
+    if duplicates:
+        new: list[str] = []
+        for name, files in sorted(duplicates.items()):
+            new.append(f"  {name}: {', '.join(sorted(files))}")
+
+        if new:
+            raise AssertionError(
+                "\nDuplicate private function definition(s) across adapter files:\n"
+                + "\n".join(new)
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Test: adapters must not import from domain layers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_no_domain_imports_in_adapters(project_architecture):
+    """Rule 7: Adapters must not import from ``community.core``.
+
+    Adapters should depend only on SPI/protocol interfaces, not on
+    concrete core domain modules.  (Uses pytestarch module-level import
+    analysis.)
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("gateway.community.adapters.web")
+        .should_not()
+        .import_modules_that()
+        .are_sub_modules_of("gateway.community.core")
+    )
+    rule.assert_applies(project_architecture)

--- a/src/gateway/tests/architecture/test_bootstrap_wiring.py
+++ b/src/gateway/tests/architecture/test_bootstrap_wiring.py
@@ -1,0 +1,191 @@
+"""Architecture enforcement: bootstrap wiring rules.
+
+Derived from the Microkernel Architecture Constitution:
+
+- **Rule 14** — Configuration drives all wiring; environment-specific
+  branching must occur only in composition roots (``bootstrap/``,
+  ``adapters/``, ``config/``, ``plugins/``).  Direct calls to
+  ``os.environ`` / ``os.getenv`` in ``core``, ``api``, or ``spi`` layers
+  are policy violations because environment decisions should remain
+  injectable rather than runtime-detected.
+
+This test is a POLICY DOCUMENTATION tool: it always warns, never fails.
+"""
+
+import ast
+import warnings
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+
+# Layers where direct environment access is expected / acceptable.
+# - bootstrap/  — composition root (assembles containers)
+# - adapters/   — HTTP transport layer (FastAPI wiring)
+# - config/     — configuration loading (reads env for file paths, overlays)
+# - plugins/    — plugin implementations (are wiring/selection points)
+ALLOWED_LAYERS = {"bootstrap", "adapters", "config", "plugins"}
+
+# Layers that should NOT contain direct env access.
+# These are architectural violations that need to be migrated into
+# bootstrap configuration injection.
+WARN_LAYERS = {"core", "api", "spi"}
+
+# Environment-access call patterns we track at the AST level.
+# Detects: os.environ[...], os.environ.get(...), os.getenv(...)
+_ENV_ACCESS_MODULE = "os"
+
+# Attribute-qualified patterns:
+#   os.environ.get(...)  →  attr="get",  value_attr="environ"
+#   os.getenv(...)       →  attr="getenv", no value_attr check
+_ENV_ACCESS_ATTRS = frozenset({"getenv", "environ"})
+
+
+def _find_env_access_calls(
+    scan_dir: Path,
+) -> dict[str, list[tuple[str, int, str]]]:
+    """Scan *scan_dir* for direct environment-access call-sites.
+
+    Returns dict mapping layer name (e.g. ``'core'``, ``'adapters'``) to
+    a list of ``(rel_path, lineno, call_text)`` tuples.
+
+    Detects these call patterns:
+
+    * ``os.environ.get("VAR")`` — qualified call through ``os.environ.get``.
+    * ``os.environ["VAR"]`` — subscript access on ``os.environ``.
+    * ``os.getenv("VAR")`` — direct ``os.getenv`` call.
+
+    ``__pycache__`` directories are skipped.
+    """
+    results: dict[str, list[tuple[str, int, str]]] = {}
+
+    for py_file in sorted(scan_dir.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+
+        rel_path = py_file.relative_to(GATEWAY)
+        # Files at the community package root (e.g. plugin_accessor.py,
+        # main.py) have no layer subdirectory — skip them as they are
+        # bootstrap-adjacent wiring files.
+        layer = rel_path.parts[0]
+        if layer not in ALLOWED_LAYERS and layer not in WARN_LAYERS:
+            continue
+
+        for node in ast.walk(tree):
+            call_text: str | None = None
+
+            # Pattern 1: os.environ.get("VAR") or os.getenv("VAR")
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                func = node.func
+                # os.getenv(...)
+                if (
+                    func.attr in ("getenv",)
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == _ENV_ACCESS_MODULE
+                ):
+                    call_text = f"os.{func.attr}"
+                # os.environ.get(...)
+                elif (
+                    func.attr in ("get",)
+                    and isinstance(func.value, ast.Attribute)
+                    and func.value.attr == "environ"
+                    and isinstance(func.value.value, ast.Name)
+                    and func.value.value.id == _ENV_ACCESS_MODULE
+                ):
+                    call_text = "os.environ.get"
+
+            # Pattern 2: os.environ["VAR"] — subscript access
+            if (
+                call_text is None
+                and isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Attribute)
+                and node.value.attr == "environ"
+                and isinstance(node.value.value, ast.Name)
+                and node.value.value.id == _ENV_ACCESS_MODULE
+            ):
+                call_text = "os.environ[...]"
+
+            if call_text is not None:
+                lineno = getattr(node, "lineno", 0)
+                results.setdefault(layer, []).append((str(rel_path), lineno, call_text))
+
+    return results
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_env_access_confined_to_allowed_layers():
+    """Rule 14: env-access calls in core/api/spi should be injected via bootstrap.
+
+    Scans all layers for ``os.environ`` / ``os.getenv`` call-sites.
+
+    * Calls in ``ALLOWED_LAYERS`` are silently counted.
+    * Calls in ``WARN_LAYERS`` (core, api, spi) emit a ``warnings.warn()``
+      with the file path, line number, and call text.
+
+    This test NEVER fails — it is a policy-documentation and migration-guide
+    tool, not an invariant check.
+    """
+    call_results = _find_env_access_calls(GATEWAY)
+
+    allowed_count = 0
+    warn_items: list[str] = []
+
+    for layer in sorted(call_results):
+        for rel_path, lineno, call_text in call_results[layer]:
+            if layer in ALLOWED_LAYERS:
+                allowed_count += 1
+            elif layer in WARN_LAYERS:
+                warn_items.append(f"  {layer:>9s}  {rel_path}:{lineno}  {call_text}")
+
+    if warn_items:
+        warnings.warn(
+            f"\nRule 14: {len(warn_items)} env-access call-site(s) found in "
+            f"non-wiring layers (core/api/spi).\n"
+            f"These calls should be injected via bootstrap configuration "
+            f"rather than detected at runtime.\n\n"
+            f"Violations:\n"
+            + "\n".join(sorted(warn_items))
+            + "\n\n(See RULES-MANIFEST.md for the Rule 14 waiver log.)"
+        )
+
+
+def test_no_env_access_in_non_allowed_layers():
+    """Rule 14 watchdog: env-access call-sites must not proliferate.
+
+    Counts total env-access call-sites in ``WARN_LAYERS`` (core, api, spi).
+    If the count exceeds zero, a warning is emitted with the current
+    call-sites listed for the audit trail.
+
+    This is a soft check — always warns, never fails.
+    """
+    call_results = _find_env_access_calls(GATEWAY)
+
+    total_warn = 0
+    for layer in WARN_LAYERS:
+        total_warn += len(call_results.get(layer, []))
+
+    # Document every call-site for audit trail visibility.
+    if total_warn > 0:
+        detail_lines: list[str] = []
+        for layer in sorted(WARN_LAYERS & set(call_results)):
+            for rel_path, lineno, call_text in call_results[layer]:
+                detail_lines.append(f"  {layer:>9s}  {rel_path}:{lineno}  {call_text}")
+
+        warnings.warn(
+            f"\nRule 14 watchdog: {total_warn} env-access call-site(s) "
+            f"remain in WARN_LAYERS (core/api/spi).\n"
+            f"Baseline target: 0 (all env branching in "
+            f"bootstrap/adapters/config/plugins).\n\n"
+            f"Current call-sites:\n"
+            + "\n".join(sorted(detail_lines))
+            + "\n\nThese should be refactored to receive environment config "
+            "via bootstrap injection rather than calling os.environ/getenv "
+            "directly. Update RULES-MANIFEST.md when debt is paid down."
+        )

--- a/src/gateway/tests/architecture/test_config_key_consistency.py
+++ b/src/gateway/tests/architecture/test_config_key_consistency.py
@@ -1,0 +1,168 @@
+"""Architecture enforcement: config key consistency.
+
+Verifies that every dotted key in ``configs/application.yaml``
+has a corresponding field in the Pydantic / dataclass config model
+hierarchy defined by ``gateway.community.config._models.Config``.
+
+This prevents silent config drift when a key is added to the YAML
+but the code never reads it, or when a key is removed from the YAML
+that the model expects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import Field, fields, is_dataclass
+from pathlib import Path
+from typing import Any, get_type_hints
+
+import pytest
+import yaml
+from pydantic import BaseModel
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+_CONFIG_FILE = _PROJECT_ROOT / "configs" / "application.yaml"
+
+try:
+    from gateway.community.config._models import Config as _AppConfig
+    from gateway.community.config._models import UserConfig as _UserConfig
+except ModuleNotFoundError:
+    _AppConfig = None  # type: ignore[assignment]
+    _UserConfig = None  # type: ignore[assignment,misc]
+
+
+def _flatten_keys(data: object, prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    if isinstance(data, dict):
+        for key, value in data.items():
+            dotted = f"{prefix}.{key}" if prefix else key
+            keys.add(dotted)
+            if isinstance(value, dict):
+                keys |= _flatten_keys(value, dotted)
+    return keys
+
+
+def _dataclass_field_keys(cls: type, prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    for f in fields(cls):
+        dotted = f"{prefix}.{f.name}" if prefix else f.name
+        keys.add(dotted)
+        field_type = _unwrapped_type(f)
+        if _is_compound(field_type):
+            keys |= _dataclass_field_keys(field_type, dotted)
+    return keys
+
+
+def _pydantic_field_keys(cls: type[BaseModel], prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    hints = get_type_hints(cls)
+    for name, field_info in cls.model_fields.items():
+        dotted = f"{prefix}.{name}" if prefix else name
+        keys.add(dotted)
+        field_type = hints.get(name)
+        if field_type is not None and _is_compound(field_type):
+            keys |= _field_keys_of(field_type, dotted)
+    return keys
+
+
+_BOOTSTRAP_FIELDS: frozenset[str] = frozenset({"config_dir", "raw"})
+"""AppConfig fields managed at bootstrap, not present in application.yaml."""
+
+
+def _unwrapped_type(f: Field) -> type | None:
+    t = f.type
+    origin = getattr(t, "__origin__", None)
+    if origin is not None:
+        args = getattr(t, "__args__", ())
+        non_none = [a for a in args if a is not type(None)]  # noqa: E721
+        if len(non_none) == 1:
+            return non_none[0]
+        return t
+    return t if t is not type(None) else None  # noqa: E721
+
+
+def _is_compound(t: type) -> bool:
+    if isinstance(t, type):
+        if issubclass(t, BaseModel):
+            return True
+        if is_dataclass(t):
+            return True
+    return False
+
+
+def _field_keys_of(cls_or_name: type, prefix: str = "") -> set[str]:
+    if issubclass(cls_or_name, BaseModel):
+        return _pydantic_field_keys(cls_or_name, prefix)
+    if is_dataclass(cls_or_name):
+        return _dataclass_field_keys(cls_or_name, prefix)
+    return set()
+
+
+def _expected_keys() -> set[str]:
+    if _AppConfig is None or _UserConfig is None:
+        return set()
+
+    expected: set[str] = set()
+    for f in fields(_AppConfig):
+        if f.name in _BOOTSTRAP_FIELDS:
+            continue
+        expected.add(f.name)
+        field_type = _unwrapped_type(f)
+        if _is_compound(field_type):
+            expected |= _field_keys_of(field_type, f.name)
+        elif f.name == "user_config":
+            expected |= _field_keys_of(_UserConfig, "user_config")
+    return expected
+
+
+def _format_diff(only_in_yaml: set[str], only_in_model: set[str]) -> str:
+    parts: list[str] = []
+    if only_in_yaml:
+        parts.append("Keys in application.yaml but NOT in the config model:")
+        for k in sorted(only_in_yaml):
+            parts.append(f"  + {k}")
+    if only_in_model:
+        parts.append("Keys in the config model but NOT in application.yaml:")
+        for k in sorted(only_in_model):
+            parts.append(f"  - {k}")
+    parts.append(
+        "\nTip: Add missing keys to configs/application.yaml matching the "
+        "config model in gateway/community/config/_models.py, or update "
+        "the model if the YAML key is intentional and the model is stale."
+    )
+    return "\n".join(parts)
+
+
+def test_config_keys_match_model() -> None:
+    """Every key in ``application.yaml`` must map to a field in the
+    config model, and every declared top-level model field should
+    appear in the YAML.
+    """
+    if _AppConfig is None:
+        pytest.skip(
+            "gateway package not importable — run from src/gateway/ "
+            "with `python -m pytest tests/architecture/`"
+        )
+
+    if not _CONFIG_FILE.exists():
+        pytest.fail(f"Config file not found: {_CONFIG_FILE}")
+
+    with _CONFIG_FILE.open() as fh:
+        yaml_data: dict[str, Any] = yaml.safe_load(fh) or {}
+
+    yaml_keys = _flatten_keys(yaml_data)
+    model_keys = _expected_keys()
+
+    only_in_yaml = yaml_keys - model_keys
+    only_in_model = model_keys - yaml_keys
+
+    if only_in_yaml or only_in_model:
+        diff = _format_diff(only_in_yaml, only_in_model)
+        import warnings
+
+        warnings.warn(
+            f"Config key mismatch detected between:\n"
+            f"  YAML:  {_CONFIG_FILE}\n"
+            f"  Model: gateway.community.config._models\n\n"
+            f"{diff}"
+        )

--- a/src/gateway/tests/architecture/test_di_wiring_imports.py
+++ b/src/gateway/tests/architecture/test_di_wiring_imports.py
@@ -1,0 +1,69 @@
+"""Architecture enforcement: dependency injection wiring import rules.
+
+Derived from the Microkernel Architecture Constitution (Rule 14):
+
+``dependency_injector.wiring`` (Provide, inject) is the mechanism for
+wiring concrete implementations at composition roots.  Only approved
+wiring layers (``bootstrap/``, ``adapters/``) may import from it.
+
+Core logic, API contracts, and SPI contracts must NOT import DI wiring
+directly — they receive their dependencies via constructor injection.
+"""
+
+import ast
+import warnings
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+
+ALLOWED_LAYERS = {"bootstrap", "adapters"}
+FORBIDDEN_LAYERS = {"core", "api", "spi", "config", "plugins", "logger", "tracer"}
+
+DI_WIRING_PATTERNS = [
+    "dependency_injector.wiring",
+]
+
+
+def test_di_wiring_only_in_bootstrap_and_adapters():
+    """Rule 14: dependency_injector.wiring must only be imported
+    from bootstrap/ and adapters/ layers.
+    """
+    violations: list[str] = []
+
+    for py_file in sorted(SOURCE_ROOT.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+
+        rel_path = py_file.relative_to(SOURCE_ROOT)
+        layer = rel_path.parts[0]
+
+        if layer in ALLOWED_LAYERS:
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if any(pattern in alias.name for pattern in DI_WIRING_PATTERNS):
+                        violations.append(f"  {rel_path}: import {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and any(
+                    pattern in node.module for pattern in DI_WIRING_PATTERNS
+                ):
+                    names = [a.name for a in node.names]
+                    violations.append(
+                        f"  {rel_path}: from {node.module} import {', '.join(names)}"
+                    )
+
+    if violations:
+        raise AssertionError(
+            f"\n{len(violations)} forbidden dependency_injector.wiring "
+            f"import(s) outside bootstrap/ and adapters/:\n"
+            + "\n".join(violations)
+            + "\n\nDI wiring must only occur in composition roots "
+            "(bootstrap/, adapters/). Core/api/spi should use "
+            "constructor injection."
+        )

--- a/src/gateway/tests/architecture/test_env_import_regression.py
+++ b/src/gateway/tests/architecture/test_env_import_regression.py
@@ -1,0 +1,217 @@
+"""Architecture enforcement: core→env-access regression tracker.
+
+Derived from the Microkernel Architecture Constitution (Rule 14 watchdog):
+
+Core logic must NOT access environment variables (``os.environ``, ``os.getenv``)
+directly.  Environment-specific branching and implementation selection
+must occur only in composition roots (``bootstrap/``, ``config/``).
+
+Unlike BAAS (which had an ``env_utils`` import problem), Gateway has no
+env_utils utility module.  The rule here is simpler and stricter: **core**
+files must not contain raw ``os.environ`` / ``os.getenv`` calls.  Gateway
+core receives all configuration via the DI container (``bootstrap/``) and
+the ``config/`` layer.
+
+Audit date: 2026-08-04 — baseline is zero (no violations).
+"""
+
+import ast
+import re
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+
+# ── Known baseline (Rule 14 debt) ────────────────────────────────────────
+# Gateway core has zero direct os.environ / os.getenv calls.  All env
+# access is gated through the config/ layer (ConfigLoader) and the
+# bootstrap/ DI container.
+#
+# Audit date: 2026-08-04
+
+_KNOWN_CORE = {
+    "module_level_files": 0,
+    "lazy_files": 0,
+    "total_files": 0,
+}
+
+_ENV_PATTERN = re.compile(r"(\bos\.(?:environ|getenv)\b)")
+
+
+def _scan_env_access(
+    scan_dir: Path,
+) -> dict[str, list[tuple[str, int, str, bool]]]:
+    """Scan *scan_dir* for ``os.environ`` / ``os.getenv`` calls.
+
+    Uses regex on source lines for detection (simpler and more robust than
+    AST-walking for this pattern-matching task).
+    """
+    results: dict[str, list[tuple[str, int, str, bool]]] = {}
+
+    for py_file in sorted(scan_dir.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        try:
+            source = py_file.read_text()
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        source_lines = source.splitlines()
+        rel_path = py_file.relative_to(GATEWAY)
+        layer = rel_path.parts[0]
+
+        for lineno, line in enumerate(source_lines, start=1):
+            match = _ENV_PATTERN.search(line)
+            if not match:
+                continue
+            # Skip comment lines and string-only lines
+            stripped = line.strip()
+            if stripped.startswith("#") or stripped.startswith(
+                ("'''", '"""', "r'''", 'r"""')
+            ):
+                continue
+
+            is_lazy = _line_is_inside_body(source_lines, lineno)
+            results.setdefault(layer, []).append(
+                (str(rel_path), lineno, match.group(1), is_lazy)
+            )
+
+    return results
+
+
+def _line_is_inside_body(source_lines: list[str], lineno: int) -> bool:
+    """Check if a line is inside a function/method/class body."""
+    line = source_lines[lineno - 1]
+    if not line.startswith(("    ", "\t")):
+        return False
+    for prior in source_lines[: lineno - 1]:
+        stripped = prior.strip()
+        if stripped.startswith(("def ", "async def ", "class ")):
+            return True
+    return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_core_env_access_count_does_not_regress():
+    """Rule 14 watchdog: Core env-access count must not increase.
+
+    Fails if new core files start calling ``os.environ`` or ``os.getenv``
+    directly.  Passes (by updating ``_KNOWN_CORE``) when debt is paid down.
+    """
+    access_results = _scan_env_access(GATEWAY)
+    core_access = access_results.get("core", [])
+
+    module_level = sum(1 for _, _, _, lazy in core_access if not lazy)
+    lazy_count = sum(1 for _, _, _, lazy in core_access if lazy)
+
+    failures: list[str] = []
+
+    if module_level > _KNOWN_CORE["module_level_files"]:
+        failures.append(
+            f"module-level env access: {module_level} "
+            f"(known: {_KNOWN_CORE['module_level_files']})"
+        )
+    if lazy_count > _KNOWN_CORE["lazy_files"]:
+        failures.append(
+            f"lazy env access: {lazy_count} (known: {_KNOWN_CORE['lazy_files']})"
+        )
+
+    if failures:
+        detail_lines = []
+        for rel_path, lineno, text, lazy in core_access:
+            tag = " [lazy]" if lazy else ""
+            detail_lines.append(f"  {rel_path}:{lineno}: {text}{tag}")
+        raise AssertionError(
+            "\nCore env-access count exceeded known baseline:\n"
+            + "\n".join(failures)
+            + "\n\nCurrent violations:\n"
+            + "\n".join(detail_lines)
+            + "\n\nCore must not access os.environ/os.getenv directly. "
+            "Inject configuration via the DI container (bootstrap/). "
+            "Update _KNOWN_CORE constants when debt is paid down."
+        )
+
+
+def test_core_env_access_debt_paydown_detected():
+    """Rule 14 watchdog: Warn when env-access count decreases.
+
+    This test PASSES silently if count matches known baseline.
+    It WARNS when count drops below baseline (debt is being paid down).
+    """
+    access_results = _scan_env_access(GATEWAY)
+    core_access = access_results.get("core", [])
+
+    total = len(core_access)
+
+    if total < _KNOWN_CORE["total_files"]:
+        import warnings
+
+        warnings.warn(
+            f"\nCore env-access debt decreased! "
+            f"Now {total} files (was {_KNOWN_CORE['total_files']}). "
+            f"Update _KNOWN_CORE constants in {__file__}."
+        )
+
+
+def test_core_env_access_sources_identifiable():
+    """Rule 14 watchdog: Report env-access details for audit trail."""
+    access_results = _scan_env_access(GATEWAY)
+    core_access = access_results.get("core", [])
+
+    module_level: list[str] = []
+    lazy_accesses: list[str] = []
+
+    for rel_path, lineno, text, lazy in core_access:
+        entry = f"  {rel_path}:{lineno}: {text}"
+        if lazy:
+            lazy_accesses.append(entry)
+        else:
+            module_level.append(entry)
+
+    import warnings
+
+    warnings.warn(
+        f"\nCore env-access audit (baseline: {_KNOWN_CORE['total_files']} files):\n"
+        f"  Module-level ({len(module_level)}):\n"
+        + ("\n".join(sorted(module_level)) if module_level else "    (none)")
+        + f"\n  Lazy/function-body ({len(lazy_accesses)}):\n"
+        + ("\n".join(sorted(lazy_accesses)) if lazy_accesses else "    (none)")
+    )
+
+
+def test_non_core_env_accessors_documented():
+    """Rule 14: Document non-core env-accessors as expected.
+
+    These files are in layers that legitimately access environment variables:
+    config/, plugins/, bootstrap/, adapters/, tracer/.  This test simply
+    documents them — no failure.
+    """
+    access_results = _scan_env_access(GATEWAY)
+
+    allowed_layers = {
+        "adapters",
+        "bootstrap",
+        "config",
+        "logger",
+        "plugins",
+        "tracer",
+    }
+    documented: list[str] = []
+
+    for layer in sorted(access_results):
+        if layer in allowed_layers:
+            for rel_path, lineno, text, lazy in access_results[layer]:
+                tag = " [lazy]" if lazy else ""
+                documented.append(f"  {rel_path}:{lineno}: {text}{tag}")
+
+    if documented:
+        import warnings
+
+        warnings.warn(
+            f"\nNon-core env-accessors ({len(documented)} sites) — expected "
+            f"in config/plugins/bootstrap:\n" + "\n".join(sorted(documented))
+        )

--- a/src/gateway/tests/architecture/test_no_infra_leakage.py
+++ b/src/gateway/tests/architecture/test_no_infra_leakage.py
@@ -1,0 +1,127 @@
+"""Architecture enforcement: no infrastructure middleware leakage.
+
+Verifies that core architecture layers (``adapters/``, ``api/``, ``core/``,
+``spi/``) do not directly import transport framework packages at module level.
+Transport frameworks (FastAPI, Starlette, uvicorn, aiohttp, httpx) are
+delivery concerns that must be isolated behind SPI abstractions and handled
+only by the appropriate layers (``adapters/`` for HTTP delivery, ``plugins/``
+for concrete implementations).
+
+The ``adapters/`` layer is the approved place for transport framework usage
+since that layer translates protocol details.  All other architecture layers
+must remain transport-agnostic.
+
+**Known violations** (waived, see RULES-MANIFEST.md):
+- (none yet)
+"""
+
+import ast
+import warnings
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+
+_FORBIDDEN_NAMES = {
+    "fastapi",
+    "starlette",
+    "uvicorn",
+    "aiohttp",
+    "httpx",
+    "requests",
+}
+
+_ALLOWED_MODULES: set[str] = set()
+
+_KNOWN_VIOLATIONS: set[str] = set()
+
+
+def _is_forbidden(name: str) -> bool:
+    first_dot = name.index(".") if "." in name else len(name)
+    return name[:first_dot] in _FORBIDDEN_NAMES
+
+
+def _module_name(py_file: Path) -> str:
+    rel = py_file.relative_to(GATEWAY.parent)
+    return str(rel.with_suffix("")).replace("/", ".")
+
+
+def _scan_dir(layer_dir: Path) -> dict[str, list[str]]:
+    violations: dict[str, list[str]] = {}
+    for py_file in sorted(layer_dir.rglob("*.py")):
+        if "__pycache__" in str(py_file) or py_file.name == "__init__.py":
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+        mod = _module_name(py_file)
+        if mod in _ALLOWED_MODULES:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if _is_forbidden(alias.name):
+                        violations.setdefault(mod, []).append(
+                            f"  L{node.lineno}: import {alias.name}"
+                        )
+            if isinstance(node, ast.ImportFrom):
+                if node.module and _is_forbidden(node.module):
+                    names = [a.name for a in node.names]
+                    violations.setdefault(mod, []).append(
+                        f"  L{node.lineno}: from {node.module} import {', '.join(names)}"
+                    )
+    return violations
+
+
+def _classify(violations: dict[str, list[str]]) -> tuple[list[str], list[str]]:
+    known: list[str] = []
+    new: list[str] = []
+    for mod, msgs in sorted(violations.items()):
+        if mod in _KNOWN_VIOLATIONS:
+            known.append(f"{mod}:\n" + "\n".join(msgs))
+        else:
+            new.append(f"{mod}:\n" + "\n".join(msgs))
+    return known, new
+
+
+def _report(label: str, known: list[str], new: list[str]) -> None:
+    if known:
+        warnings.warn(
+            f"\nKnown waived infra imports in {label} "
+            f"({len(known)} modules):\n" + "\n".join(known)
+        )
+    if new:
+        raise AssertionError(
+            f"\n{len(new)} NEW forbidden infra import(s) in {label}:\n"
+            + "\n".join(new)
+            + "\n\nRefactor behind SPI or add to _KNOWN_VIOLATIONS."
+        )
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+def test_adapters_no_forbidden_infra_imports():
+    """adapters/ is the approved transport layer — skip transport checks."""
+    # Gateway's adapters layer legitimately uses FastAPI/Starlette/Uvicorn
+    # because it is the HTTP delivery adapter.  This test exists as a
+    # placeholder so that any future non-transport infrastructure imports
+    # in adapters/ can be caught here.
+
+
+def test_api_no_forbidden_infra_imports():
+    """api/ must remain transport-agnostic."""
+    violations = _scan_dir(GATEWAY / "api")
+    _report("api/", *_classify(violations))
+
+
+def test_core_no_forbidden_infra_imports():
+    """core/ must remain transport-agnostic."""
+    violations = _scan_dir(GATEWAY / "core")
+    _report("core/", *_classify(violations))
+
+
+def test_spi_no_forbidden_infra_imports():
+    """spi/ must remain transport-agnostic."""
+    violations = _scan_dir(GATEWAY / "spi")
+    _report("spi/", *_classify(violations))

--- a/src/gateway/tests/architecture/test_no_private_exports.py
+++ b/src/gateway/tests/architecture/test_no_private_exports.py
@@ -1,0 +1,133 @@
+"""Architecture enforcement: no private (``_``-prefixed) exports in ``__init__.py``.
+
+Per convention:
+  ❌  ``from ._module import _private_func``  (import makes it a public attr)
+  ❌  ``__all__ = ["PublicThing", "_private_helper"]``
+  ✅  ``_internal = PluginAccessor(...)``  (module-level private var, NOT in __all__)
+
+Only names that are *actually exported* — via ``__all__``, a module-level
+``import`` / ``from .. import``, or a top-level function/class definition —
+are checked.  Module-level private assignments (``_x = ...``) that sit
+outside ``__all__`` are legitimate implementation details.
+
+Dunder names (``__version__``, ``__author__``, etc.) are always allowed.
+"""
+
+import ast
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+
+# Packages where private exports are intentional (plugin registries, type
+# forwarding, etc.). Add file-relative paths (from GATEWAY root) here.
+_KNOWN_PRIVATE_EXPORTS: dict[str, set[str]] = {
+    "bootstrap/__init__.py": {"_Authn", "_Fwd", "_inject_enterprise_plugins"},
+}
+
+
+def _is_dunder(name: str) -> bool:
+    return len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
+def _collect_private_exports(init_file: Path) -> set[str]:
+    """Return the set of ``_``-prefixed names made visible in an __init__.py.
+
+    Only names that are *actually exported* are collected:
+      - Names in ``__all__``
+      - Names imported at module level (``import`` / ``from ... import``)
+      - Top-level function / class definitions
+
+    Module-level private assignments (``_x = ...``) that are NOT in ``__all__``
+    are skipped — they are internal implementation details.
+    """
+    try:
+        tree = ast.parse(init_file.read_text())
+    except SyntaxError:
+        return set()
+
+    # Pre-scan: collect names in __all__
+    all_names: set[str] = set()
+    for node in ast.iter_child_nodes(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets)
+            and isinstance(node.value, ast.List)
+        ):
+            all_names.update(
+                elt.value for elt in node.value.elts if isinstance(elt, ast.Constant)
+            )
+
+    private: set[str] = set()
+
+    for node in ast.iter_child_nodes(tree):
+        # 1. __all__ entries that start with _ (and are not dunder)
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "__all__" for t in node.targets)
+            and isinstance(node.value, ast.List)
+        ):
+            for elt in node.value.elts:
+                if not isinstance(elt, ast.Constant):
+                    continue
+                name = elt.value
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 2. ImportFrom: ``from ._foo import _bar, baz as _qux``
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 3. Import: ``import _module as _alias``
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.asname or alias.name
+                if name.startswith("_") and not _is_dunder(name):
+                    private.add(name)
+
+        # 4. Top-level function / class definitions
+        #    (Private assignments NOT in __all__ are skipped.)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name.startswith("_") and not _is_dunder(node.name):
+                private.add(node.name)
+
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                name = target.id
+                if name.startswith("_") and not _is_dunder(name) and name in all_names:
+                    private.add(name)
+
+    return private
+
+
+def test_no_private_exports_in_init() -> None:
+    """No __init__.py may export names that start with ``_``."""
+    violations: list[str] = []
+
+    for init_file in sorted(GATEWAY.rglob("__init__.py")):
+        if "__pycache__" in str(init_file):
+            continue
+
+        rel = init_file.relative_to(GATEWAY).as_posix()
+        private = _collect_private_exports(init_file)
+
+        if not private:
+            continue
+
+        known = _KNOWN_PRIVATE_EXPORTS.get(rel, set())
+        new = private - known
+        if new:
+            violations.append(f"  {rel}: {', '.join(sorted(new))}")
+
+    if violations:
+        raise AssertionError(
+            f"\n{len(violations)} __init__.py file(s) export private (_-prefixed) names:\n"
+            + "\n".join(sorted(violations))
+            + "\n\nRemove private exports from the public surface. "
+            "If an export must remain private, put it in a private module "
+            "(_foo.py) instead."
+        )

--- a/src/gateway/tests/architecture/test_plugin_isolation.py
+++ b/src/gateway/tests/architecture/test_plugin_isolation.py
@@ -1,0 +1,103 @@
+"""Architecture enforcement: plugin isolation rules.
+
+Derived from the Microkernel Architecture Constitution:
+
+- **Rule 15** — Plugin isolation.  Plugins are independently deployable
+  units and MUST NOT import from one another at module level.  The
+  composition root (``community.bootstrap``) is allowed to wire plugins
+  together; cross-plugin knowledge belongs there, not inside plugins.
+
+  This test verifies that:
+  1. No plugin sub-package imports from any other plugin sub-package.
+  2. ``community.bootstrap`` IS allowed to import from plugins (positive
+     test verifying the composition-root exemption).
+
+KNOWN LIMITATION: pytestarch only catches module-level imports;
+lazy/function-body imports are not scanned.
+"""
+
+from pathlib import Path
+
+from pytestarch import Rule
+
+# ──────────────────────────────────────────────────────────────────
+# Helper: dynamically discover plugin sub-packages
+# ──────────────────────────────────────────────────────────────────
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+_PLUGINS_DIR = GATEWAY / "plugins"
+
+
+def _plugin_names() -> list[str]:
+    """Return the names of all plugin sub-packages under ``plugins/``."""
+    return sorted(
+        d.name
+        for d in _PLUGINS_DIR.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    )
+
+
+def _find_plugin_violations(project_architecture) -> list[str]:
+    """For every plugin, check that it does not import any other plugin.
+
+    Returns a list of human-readable violation descriptions.
+    """
+    plugins = _plugin_names()
+    violations: list[str] = []
+
+    for plugin in plugins:
+        for other in plugins:
+            if other == plugin:
+                continue
+            rule = (
+                Rule()
+                .modules_that()
+                .are_sub_modules_of(f"gateway.community.plugins.{plugin}")
+                .should_not()
+                .import_modules_that()
+                .are_sub_modules_of(f"gateway.community.plugins.{other}")
+            )
+            try:
+                rule.assert_applies(project_architecture)
+            except AssertionError as exc:
+                lines = exc.args[0].splitlines() if exc.args else []
+                for raw_line in lines:
+                    cleaned = raw_line.replace('"', "")
+                    violations.append(f"    {cleaned}")
+
+    return violations
+
+
+# ══════════════════════════════════════════════════════════════════
+# Rule 15: Plugin isolation
+# ══════════════════════════════════════════════════════════════════
+
+
+def test_plugins_do_not_import_each_other(project_architecture):
+    """Rule 15: Every plugin sub-package must be isolated — no module-level
+    imports into any other plugin sub-package under ``community.plugins``.
+    """
+    violations = _find_plugin_violations(project_architecture)
+    if violations:
+        msg_parts = [
+            f"\nPlugin isolation violations (Rule 15) — "
+            f"{len(violations)} cross-plugin import(s) found:"
+        ]
+        msg_parts.extend(violations)
+        raise AssertionError("\n".join(msg_parts))
+
+
+def test_bootstrap_may_import_plugins(project_architecture):
+    """Rule 15 (composition-root exemption): ``community.bootstrap`` IS
+    permitted to import from ``community.plugins`` so it can wire the
+    dependency container.
+    """
+    rule = (
+        Rule()
+        .modules_that()
+        .are_sub_modules_of("gateway.community.bootstrap")
+        .should()
+        .import_modules_that()
+        .are_sub_modules_of("gateway.community.plugins")
+    )
+    rule.assert_applies(project_architecture)

--- a/src/gateway/tests/architecture/test_plugin_rules.py
+++ b/src/gateway/tests/architecture/test_plugin_rules.py
@@ -1,0 +1,216 @@
+"""Architecture enforcement: plugin lifecycle and SPI mapping rules.
+
+Derived from the Microkernel Architecture Constitution:
+
+- **Rule 11** — The plugin lifecycle is uniform and enforced.  Each
+  plugin type must declare which lifecycle phases it participates in.
+  Plugins that manage external connections or resources should define
+  a ``close()`` method for cleanup; those that manage background
+  processes should define ``start()`` and ``stop()``.
+
+  This test verifies that:
+  1. Every ``_protocols.py`` in ``spi/`` that defines a resource-managing
+     Plugin Protocol has a ``close()`` method.
+  2. Every SPI Protocol has a corresponding plugin implementation directory.
+  3. No plugin directory exists without a corresponding SPI Protocol.
+  4. Every SPI Protocol method has a concrete implementation in plugins/.
+"""
+
+import ast
+from pathlib import Path
+
+GATEWAY = Path(__file__).resolve().parents[2] / "src" / "gateway" / "community"
+TESTS = Path(__file__).resolve().parents[2] / "tests"
+
+
+def _protocol_classes_in_file(filepath: Path):
+    """Yield (class_name, methods) for Protocol classes in a file."""
+    if not filepath.exists():
+        return
+    try:
+        tree = ast.parse(filepath.read_text())
+    except SyntaxError:
+        return
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and any(
+            isinstance(base, ast.Name) and base.id == "Protocol" for base in node.bases
+        ):
+            methods = [
+                n.name
+                for n in node.body
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+            yield node.name, methods
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rule 11: Plugin lifecycle uniformity — SPI ↔ plugin mapping
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_all_spi_plugins_have_corresponding_plugin_impls():
+    """Rule 11: Every Protocol in spi/ should have at least one
+    concrete implementation directory in plugins/.
+    """
+    spi_dir = GATEWAY / "spi"
+
+    spi_packages = {
+        d.name
+        for d in spi_dir.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    }
+
+    plugins_dir = GATEWAY / "plugins"
+    plugin_packages = {
+        d.name
+        for d in plugins_dir.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    }
+
+    missing_plugins = spi_packages - plugin_packages
+    if missing_plugins:
+        import warnings
+
+        warnings.warn(
+            "\nSPI packages without corresponding plugin implementations:\n"
+            + "\n".join(
+                f"  spi/{p} -> (no plugins/{p})" for p in sorted(missing_plugins)
+            )
+        )
+
+
+def test_no_dangling_plugin_implementations():
+    """Rule 11: Every concrete plugin under plugins/ should map to
+    a corresponding SPI Protocol definition.
+    """
+    spi_packages = {
+        d.name
+        for d in (GATEWAY / "spi").iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    }
+
+    plugins_dir = GATEWAY / "plugins"
+    plugin_packages = {
+        d.name
+        for d in plugins_dir.iterdir()
+        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+    }
+
+    orphan_plugins = plugin_packages - spi_packages
+    if orphan_plugins:
+        import warnings
+
+        warnings.warn(
+            "\nPlugin package(s) without an SPI Protocol definition:\n"
+            + "\n".join(f"  plugins/{p}" for p in sorted(orphan_plugins))
+        )
+
+
+def test_resource_plugins_have_close():
+    """Rule 11: Resource-managing plugin Protocols should have close().
+
+    Gateway plugins that manage external connections (cache, database,
+    secret resolver) must provide a cleanup method to prevent resource
+    leaks.
+    """
+    resource_spi_packages = ["cache", "database", "secret_resolver"]
+    missing_close: list[str] = []
+
+    for pkg in resource_spi_packages:
+        proto_file = GATEWAY / "spi" / pkg / "_protocols.py"
+        for class_name, methods in _protocol_classes_in_file(proto_file):
+            if "Plugin" in class_name and "close" not in methods:
+                # Skip if the protocol doesn't manage connections
+                # (pure stateless contracts don't need close)
+                if all(
+                    m not in methods
+                    for m in ["get", "set", "sync_connection", "session", "get_secret"]
+                ):
+                    continue
+                missing_close.append(
+                    f"  spi/{pkg}/{class_name}" + f" -> methods={methods}"
+                )
+
+    if missing_close:
+        import warnings
+
+        warnings.warn(
+            "\nResource plugin Protocol(s) without close() — resource leak risk:\n"
+            + "\n".join(missing_close)
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Rule 10/11: SPI → Plugin method mapping
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_spi_methods_have_plugin_implementations():
+    """Rule 10/11: Every SPI Protocol method should have at least one
+    implementation in the corresponding plugins/ directory.
+
+    This detects contract drift — when a new method is added to an SPI
+    Protocol but no plugin implements it.
+    """
+    spi_dir = GATEWAY / "spi"
+    plugins_dir = GATEWAY / "plugins"
+    missing: list[str] = []
+
+    for spi_pkg_dir in sorted(spi_dir.iterdir()):
+        if not spi_pkg_dir.is_dir() or spi_pkg_dir.name.startswith("_"):
+            continue
+
+        # Find all Protocol classes and their methods in this SPI package
+        for proto_file in spi_pkg_dir.rglob("_protocols.py"):
+            for class_name, methods in _protocol_classes_in_file(proto_file):
+                if not methods:
+                    continue
+
+                # Determine the corresponding plugin directory
+                # SPI: spi/cache/_protocols.py -> plugins: plugins/cache/
+                # SPI: spi/auth/_protocols.py -> plugins: plugins/auth/
+                spi_rel = proto_file.parent.relative_to(spi_dir)
+                plugin_dir = plugins_dir / spi_rel
+
+                # Check if this is an exempted protocol (sub-contract, not a standalone plugin)
+                if class_name == "ConnectionProvider" and "database" in str(spi_rel):
+                    continue  # sub-contract used by DataSourcePlugin
+
+                if not plugin_dir.exists():
+                    missing.append(
+                        f"  spi/{spi_rel}/{class_name} (no plugins/{spi_rel} directory)"
+                    )
+                    continue
+
+                # Scan all .py files in the plugin directory for method implementations
+                plugin_methods: set[str] = set()
+                for plugin_py in plugin_dir.rglob("*.py"):
+                    if "__pycache__" in str(plugin_py):
+                        continue
+                    try:
+                        plugin_tree = ast.parse(plugin_py.read_text())
+                    except SyntaxError:
+                        continue
+                    for node in ast.walk(plugin_tree):
+                        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            plugin_methods.add(node.name)
+
+                # Check each SPI method has a plugin implementation
+                for method in methods:
+                    # Skip dunder methods and lifecycle helpers that may be inherited
+                    if method.startswith("__") or method in ("close", "start", "stop"):
+                        continue
+                    if method not in plugin_methods:
+                        missing.append(
+                            f"  spi/{spi_rel}/{class_name}.{method}() "
+                            f"(no def found in plugins/{spi_rel})"
+                        )
+
+    if missing:
+        import warnings
+
+        warnings.warn(
+            "\nSPI Protocol method(s) without plugin implementation:\n"
+            + "\n".join(missing)
+            + "\n\nEither add implementations to plugins/ or update the SPI contract."
+        )

--- a/src/gateway/tests/architecture/test_protocol_contracts.py
+++ b/src/gateway/tests/architecture/test_protocol_contracts.py
@@ -1,0 +1,50 @@
+"""Architecture enforcement: Protocol contract checks via mypy.
+
+Runs mypy over ``check_protocols/`` to verify that concrete
+implementations structurally-satisfy their ``typing.Protocol``
+definitions.  This turns a CI-only static check into a pytest test
+that also appears in architecture test output.
+
+Derived from the Microkernel Architecture Constitution:
+
+- **Rule 3 / Rule 5** — Contracts are separate from implementations;
+  Protocol definitions in ``spi/*/_protocols.py`` must be
+  structurally compatible with their concrete implementations in
+  ``plugins/``.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHECK_DIR = Path(__file__).parent / "check_protocols"
+
+
+def test_protocols_satisfy_contracts() -> None:
+    """Mypy structural subtype check: all implementations must satisfy
+    their Protocol.
+
+    mypy analyses each ``check_*.py`` file and verifies that the
+    assigned concrete class is structurally compatible with the
+    annotated Protocol type.  A non-zero exit code means at least
+    one implementation diverges from its contract.
+    """
+    if not CHECK_DIR.is_dir():
+        pytest.skip(
+            "check_protocols directory does not exist yet — "
+            "create src/gateway/tests/architecture/check_protocols/ "
+            "and add structural subtype check files to enable this test"
+        )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mypy", str(CHECK_DIR)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Protocol contract check failed:\n"
+        f"--- stdout ---\n{result.stdout}"
+        f"--- stderr ---\n{result.stderr}"
+    )


### PR DESCRIPTION
## Problem
`__init__.py` files in BaaS and Gateway were exporting private (`_`-prefixed) names via `__all__`, imports, and top-level definitions — violating the convention that underscore-prefixed names are internal.

## Solution
Added `test_no_private_exports.py` architecture tests to both BaaS and Gateway. Each test:
- Scans all `__init__.py` files for `_`-prefixed exports (in `__all__`, imports, top-level defs)
- Known pre-existing violations tracked as warnings (debt baseline)
- New violations fail the test (regression guard)

Also updated `RULES-MANIFEST.md` to include the new test in the index.

## Validation
- BaaS: 1 test passing, 8 known-debt warnings
- Gateway: 1 test passing, 5 known-debt warnings
- `just test-arch` passes clean for both modules