### PR TITLE
fix(engine): restore canonical repo bridge after Desktop rollback

### DIFF
--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -396,18 +396,15 @@ def _publish_structural_bridge(path: Path, target: Path) -> None:
 
 def _restore_legacy_repo_bridge(
     *,
-    engine: str,
     layout: _Layout,
 ) -> None:
     """Restore the descriptor's Legacy repo view after rollback."""
 
     repo_delivery = current_repo_delivery()
-    if repo_delivery is RepoDelivery.MOUNT or engine == "openclaw":
+    if repo_delivery is RepoDelivery.MOUNT or layout.repo_bridge == layout.legacy_repo:
         target = layout.pool_repo
-    elif layout.repo_bridge != layout.legacy_repo:
-        target = layout.legacy_repo
     else:
-        target = _lexical_target(layout.pool_repo)
+        target = layout.legacy_repo
     _publish_structural_bridge(layout.repo_bridge, target)
 
 
@@ -2007,7 +2004,7 @@ def _rollback_pool(
     copy_staging = layout.pool_root / (f".rollback-copy-{rollback_generation}")
 
     def finish_legacy_structure() -> PoolActivationResult | None:
-        _restore_legacy_repo_bridge(engine=engine, layout=layout)
+        _restore_legacy_repo_bridge(layout=layout)
         active_repo = layout.active_root / "skills-repo"
         if (
             engine == "aicoding"

--- a/src/engine/src/engine/community/plugins/skills_pool/tests/test_desktop_download_rollback.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/tests/test_desktop_download_rollback.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    resolve_filesystem_skill_layout,
+)
+from engine.community.plugins.skills_pool.desktop_preparation import (
+    DesktopPreparationStatus,
+    prepare_desktop_pool,
+)
+from engine.community.plugins.skills_pool.layout_activation import (
+    MappingSourceLayout,
+    PoolActivationResult,
+    PoolActivationStatus,
+    SkillMapping,
+    activate_aicoding_pool,
+    activate_claude_code_pool,
+    activate_hermes_pool,
+    activate_openclaw_pool,
+    publish_pool_mappings,
+    rollback_aicoding_pool,
+    rollback_claude_code_pool,
+    rollback_hermes_pool,
+    rollback_openclaw_pool,
+)
+from engine.community.plugins.skills_pool.layout_probe import (
+    RuntimeLayoutInspectionStatus,
+    inspect_runtime_layout,
+)
+
+Activate = Callable[..., PoolActivationResult]
+Rollback = Callable[..., PoolActivationResult]
+
+
+@pytest.mark.parametrize(
+    ("engine", "activate", "rollback"),
+    [
+        ("openclaw", activate_openclaw_pool, rollback_openclaw_pool),
+        ("claude_code", activate_claude_code_pool, rollback_claude_code_pool),
+        ("aicoding", activate_aicoding_pool, rollback_aicoding_pool),
+        ("hermes", activate_hermes_pool, rollback_hermes_pool),
+    ],
+)
+def test_desktop_download_rollback_is_ready_for_remigration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+    activate: Activate,
+    rollback: Rollback,
+) -> None:
+    monkeypatch.setenv("MAC_CONTAINER", "true")
+    home = tmp_path / "home" / "admin"
+    layout = resolve_filesystem_skill_layout(
+        LayoutIdentity(engine, LAYOUT_CONTRACT_VERSION),
+        RuntimeLayoutContext(home=home),
+    )
+    layout.active_root.mkdir(parents=True)
+    layout.legacy_local.mkdir(parents=True)
+    if layout.local_bridge != layout.legacy_local:
+        layout.local_bridge.symlink_to(
+            layout.legacy_local,
+            target_is_directory=True,
+        )
+    repo_source = layout.legacy_repo
+    (repo_source / "repo-skill").mkdir(parents=True)
+    (repo_source / "repo-skill" / "SKILL.md").write_text("repo")
+    if layout.repo_bridge != layout.legacy_repo:
+        layout.repo_bridge.parent.mkdir(parents=True, exist_ok=True)
+        layout.repo_bridge.symlink_to(
+            layout.legacy_repo,
+            target_is_directory=True,
+        )
+
+    prepared = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+
+    assert prepared.status is DesktopPreparationStatus.PREPARED
+    assert prepared.preparation_id is not None
+    mapping = SkillMapping(
+        source=str(layout.pool_repo / "repo-skill"),
+        target=str(layout.active_root / "repo-skill"),
+    )
+    activated = activate(
+        migration_generation="generation-1",
+        preparation_id=prepared.preparation_id,
+        registered_local_names=[],
+        mappings=[mapping],
+        home=home,
+    )
+    assert activated.status is PoolActivationStatus.COMMITTED
+
+    rolled_back = rollback(
+        rollback_generation="generation-1",
+        registered_local_names=[],
+        home=home,
+    )
+    assert rolled_back.status is PoolActivationStatus.COMMITTED
+    assert "reason" not in rolled_back.evidence
+    assert not layout.active_marker.exists()
+    assert layout.repo_bridge.is_symlink()
+    assert layout.repo_bridge.resolve() == layout.pool_repo.resolve()
+    if layout.local_bridge != layout.legacy_local:
+        assert layout.local_bridge.is_symlink()
+        assert layout.local_bridge.resolve() == layout.legacy_local.resolve()
+
+    legacy_mapping = SkillMapping(
+        source=str(layout.legacy_repo / "repo-skill"),
+        target=str(layout.active_root / "repo-skill"),
+    )
+    republished = publish_pool_mappings(
+        mappings=[legacy_mapping],
+        home=home,
+        engine=engine,
+        source_layout=MappingSourceLayout.LEGACY,
+    )
+    assert republished.published
+    ready = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+    )
+    assert ready.status is RuntimeLayoutInspectionStatus.READY
+    assert ready.preparation_id == prepared.preparation_id


### PR DESCRIPTION
## Problem

Desktop DOWNLOAD now stores the canonical Skills repo as a real `pool_repo` directory. During rollback, AICoding and Hermes still attempted to resolve that directory with `readlink()`, which returns `EINVAL`. The local corpus had already been restored, so the operation appeared committed while leaving the stable local bridge and Pool active marker behind; a later migration then failed its runtime probe.

## Solution

Restore the Legacy repo view from the Planner topology: layouts whose `repo_bridge` is the Legacy repo entry point bridge directly to canonical `pool_repo`; layouts with a separate active compatibility bridge continue to target `legacy_repo`. This removes the stale assumption that canonical `pool_repo` is itself a symlink and adds a four-engine Desktop lifecycle regression covering prepare, cutover, rollback, Legacy mapping publication, and readiness for remigration.

## Validation

- New four-engine Desktop DOWNLOAD rollback/remigration regression: 4 passed.
- Skills Pool, OpenClaw, Claude Code, AICoding, Hermes, Desktop preparation, activation, probe, and downloader suites: 264 passed.
- Focused Hermes/AICoding rerun after formatting: 29 passed.
- Ruff check and format check passed for changed files.
- `git diff --check` passed.
- Local Python SAST block scan passed for both changed files.

## Compatibility and risk

This is Engine-owned filesystem cleanup only. Backend state, rollout policy, mapping contracts, and layout descriptors are unchanged. Cloud MOUNT behavior is unchanged; Desktop DOWNLOAD behavior is covered for all four filesystem engines. Teclaw remains out of the filesystem layout protocol.

## Spec

Implements the canonical Pool repo and Engine-owned compatibility bridge rules in `docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md`.

## Related issues

Related to #455.
