### PR TITLE
fix(engine): reject active repo bridges after cutover

### DIFF
--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -732,10 +732,7 @@ def inspect_runtime_layout(
             )
         if active_marker["activation_state"] == "active":
             retired_bridges = [("local", layout.local_bridge)]
-            if engine in {"openclaw", "claude_code"} and not (
-                engine == "openclaw"
-                and effective_repo_delivery is RepoDelivery.DOWNLOAD
-            ):
+            if layout.repo_bridge.is_relative_to(layout.active_root):
                 retired_bridges.append(("repo", layout.repo_bridge))
             for bridge_name, bridge_path in retired_bridges:
                 if bridge_path.exists() or bridge_path.is_symlink():

--- a/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_desktop_layout_activation.py
@@ -46,6 +46,7 @@ ROLLBACK = {
     "aicoding": rollback_aicoding_pool,
     "hermes": rollback_hermes_pool,
 }
+ACTIVE_ROOT_REPO_BRIDGE_ENGINES = ("openclaw", "claude_code")
 
 
 def _target(path: Path) -> Path:
@@ -178,3 +179,47 @@ def test_desktop_download_layout_uses_public_cutover_and_rollback(
     )
     assert legacy_ready.status is RuntimeLayoutInspectionStatus.READY
     assert legacy_ready.preparation_id == prepared.preparation_id
+
+
+@pytest.mark.parametrize("engine", ACTIVE_ROOT_REPO_BRIDGE_ENGINES)
+def test_active_probe_rejects_recreated_repo_bridge_inside_active_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    engine: str,
+) -> None:
+    monkeypatch.setenv("MAC_CONTAINER", "true")
+    home = tmp_path / "home/admin"
+    layout, repo_source = _legacy_runtime(home, engine)
+    prepared = prepare_desktop_pool(
+        engine=engine,
+        repo_source=repo_source,
+        home=home,
+    )
+    assert prepared.status is DesktopPreparationStatus.PREPARED
+
+    activated = ACTIVATE[engine](
+        migration_generation="G1",
+        preparation_id=str(prepared.preparation_id),
+        registered_local_names=["handmade"],
+        mappings=[
+            SkillMapping(
+                source=str(layout.pool_local / "handmade"),
+                target=str(layout.active_root / "handmade"),
+            )
+        ],
+        home=home,
+    )
+    assert activated.status is PoolActivationStatus.COMMITTED
+    assert layout.repo_bridge.is_relative_to(layout.active_root)
+    assert not layout.repo_bridge.exists()
+    assert not layout.repo_bridge.is_symlink()
+
+    layout.repo_bridge.symlink_to(layout.pool_repo, target_is_directory=True)
+
+    inspection = inspect_runtime_layout(
+        engine=engine,
+        home=home,
+        repo_delivery=RepoDelivery.DOWNLOAD,
+    )
+    assert inspection.status is RuntimeLayoutInspectionStatus.INVALID
+    assert inspection.evidence["reason"] == "retired_repo_bridge_present"


### PR DESCRIPTION
## Problem

After a Desktop DOWNLOAD cutover, an active-root repo bridge is retired so the runtime cannot recursively expose the complete Skill corpus. The runtime probe retained an obsolete OpenClaw DOWNLOAD exception and could report READY if that bridge was recreated.

## Solution

- Derive repo-bridge retirement from the Planner layout topology: any repo bridge located inside the active root must remain absent after activation.
- Remove the engine/delivery special case.
- Add a public-seam regression through prepare, activate, bridge recreation, and inspect_runtime_layout for OpenClaw and Claude Code.

## Validation

- Regression demonstrated RED for OpenClaw and existing correct behavior for Claude Code, then GREEN for both.
- 171 focused Engine tests passed across Desktop preparation/activation/rollback, probe evidence, and OpenClaw/Claude Code/AICoding/Hermes Pool adapters.
- Changed-line coverage: 100% (18/18; gate 90%).
- Ruff, local Python SAST, and diff-check passed.

## Compatibility and risk

- Only active Pool layouts whose Planner repo bridge is inside the active scan root are tightened.
- Claude Code keeps its prior behavior; AICoding and Hermes stable repo bridges remain valid because they are outside the active root.
- Legacy, preparation, cutover publication, and rollback behavior are unchanged.

Follow-up hardening for #455.