### PR TITLE
fix: return not found for dormant activation

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
@@ -13,8 +13,11 @@ from agentclaw.community.adapters.http.bot_dormant.schemas import (
     WhitelistBatchResponse,
 )
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
-from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService, InvalidBotStateError
-from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
+from agentclaw.community.core.bot_dormant.activate_service import (
+    ActivateBotService,
+    BotNotFoundError,
+    InvalidBotStateError,
+)
 from agentclaw.community.core.bot_dormant.whitelist_service import WhitelistService
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger

--- a/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_dormant/router.py
@@ -14,6 +14,7 @@ from agentclaw.community.adapters.http.bot_dormant.schemas import (
 )
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
 from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService, InvalidBotStateError
+from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
 from agentclaw.community.core.bot_dormant.whitelist_service import WhitelistService
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
@@ -46,6 +47,8 @@ async def activate_bot(
             bot_id=bot_id, user_id=user_id, nick_name=ctx.nick_name
         )
         return ApiResponse(success=True, data=ActivateBotResponse(**result))
+    except BotNotFoundError:
+        return ApiResponse(success=False, message="Bot 不存在", error_code=404)
     except InvalidBotStateError as e:
         return ApiResponse(success=False, message=str(e), error_code=400)
     except Exception:

--- a/src/backend/src/agentclaw/community/adapters/http/common_config/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/common_config/router.py
@@ -193,7 +193,10 @@ async def enable_common_config(
     user: AuthenticatedUser = Depends(require_operator),
     service: CommonConfigServiceProtocol = Injected(CommonConfigServiceProtocol),
 ):
-    success = service.enable_config(config_id=req.id)
+    try:
+        success = service.enable_config(config_id=req.id)
+    except ValueError as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=40001, data=None)
     if not success:
         return ApiResponse(success=False, message="配置不存在", error_code=40401, data=None)
     return ApiResponse(success=True, message="配置已启用", error_code=200, data=None)
@@ -205,7 +208,10 @@ async def disable_common_config(
     user: AuthenticatedUser = Depends(require_operator),
     service: CommonConfigServiceProtocol = Injected(CommonConfigServiceProtocol),
 ):
-    success = service.disable_config(config_id=req.id)
+    try:
+        success = service.disable_config(config_id=req.id)
+    except ValueError as exc:
+        return ApiResponse(success=False, message=str(exc), error_code=40001, data=None)
     if not success:
         return ApiResponse(success=False, message="配置不存在", error_code=40401, data=None)
     return ApiResponse(success=True, message="配置已禁用", error_code=200, data=None)

--- a/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
@@ -28,6 +28,10 @@ class InvalidBotStateError(Exception):
     """Raised when activate is called on a bot that is not RECYCLED."""
 
 
+class BotNotFoundError(Exception):
+    """Raised when the requested bot does not exist for the owner."""
+
+
 class ActivateBotService:
     @inject
     def __init__(
@@ -42,7 +46,8 @@ class ActivateBotService:
         """Activate a RECYCLED bot.
 
         Returns a dict with keys ``status`` and ``message``.
-        Raises ``InvalidBotStateError`` if the bot is not RECYCLED (or REACTIVATING).
+        Raises ``BotNotFoundError`` if the bot does not exist and
+        ``InvalidBotStateError`` if it is not RECYCLED (or REACTIVATING).
         """
         bot = self._bot_service.get_bot(bot_id=bot_id, user_id=user_id)
         if not bot:
@@ -50,7 +55,7 @@ class ActivateBotService:
                 "[activate] bot not found bot_id=%s user_id=%s",
                 bot_id, user_id,
             )
-            raise InvalidBotStateError(f"bot not found: {bot_id}")
+            raise BotNotFoundError(f"bot not found: {bot_id}")
 
         status = bot.get("status")
         logger.info(

--- a/src/backend/src/agentclaw/community/core/bot_dormant/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/protocols.py
@@ -19,7 +19,7 @@ class BotServiceProtocol(Protocol):
     """Bot 服务接口 —— 供 dormant 模块查询 / 操作 Bot。
 
     实现类需提供这几个方法（签名宽松，便于跨实现复用）：
-      - get_bot(bot_id, user_id)        查询单个 bot
+      - get_bot(bot_id, user_id)        查询单个 bot；不存在时返回 None
       - update_status(bot_id, user_id, status)   修改 status 字段
       - stop_bot(bot_id, user_id, release_reason)  释放容器 + binding 置 PENDING
       - start_bot(bot_id, user_id, nick_name)      重新分配容器

--- a/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_dormant_module.py
@@ -15,6 +15,8 @@ BotServiceProtocol explicitly.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.bot_service import BotServiceProtocol as _ApiBotServiceProtocol
@@ -29,6 +31,9 @@ from agentclaw.community.core.bot_dormant.protocols import (
 from agentclaw.community.core.bot_dormant.scan_policy import DormantScanPolicyService
 from agentclaw.community.core.bot_dormant.service import DormantBotService
 from agentclaw.community.core.bot_dormant.whitelist_service import WhitelistService
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError as BotManagementNotFoundError,
+)
 from agentclaw.community.core.common_config import CommonWhiteListService
 from agentclaw.community.di.config import (
     DormantConfig,
@@ -58,6 +63,28 @@ logger = get_logger()
 # NOTE: this is intentionally a publicly-visible string — it only ever
 # gates singlebox/local where no real authority decision is at stake.
 _SINGLEBOX_FALLBACK_TOKEN = "singlebox-dormant-token-local"
+
+
+class _DormantBotServiceAdapter:
+    """Normalize BotService behavior to the dormant module's local contract."""
+
+    def __init__(self, bot_service: _ApiBotServiceProtocol) -> None:
+        self._bot_service = bot_service
+
+    def get_bot(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return self._bot_service.get_bot(*args, **kwargs)
+        except BotManagementNotFoundError:
+            return None
+
+    def update_status(self, *args: Any, **kwargs: Any) -> Any:
+        return self._bot_service.update_status(*args, **kwargs)
+
+    def stop_bot(self, *args: Any, **kwargs: Any) -> Any:
+        return self._bot_service.stop_bot(*args, **kwargs)
+
+    def start_bot(self, *args: Any, **kwargs: Any) -> Any:
+        return self._bot_service.start_bot(*args, **kwargs)
 
 
 class BotDormantModule(Module):
@@ -95,11 +122,8 @@ class BotDormantModule(Module):
         self,
         bot_service: _ApiBotServiceProtocol,
     ) -> _DormantBotServiceProtocol:
-        """Bridge the api-layer BotServiceProtocol to the dormant local
-        BotServiceProtocol. The same singleton instance backs both keys,
-        but core/bot_dormant code only refers to the local protocol so the
-        four-layer rule (core must not import api) holds."""
-        return bot_service
+        """Adapt the API service to the dormant module's local contract."""
+        return _DormantBotServiceAdapter(bot_service)
 
     @singleton
     @provider

--- a/src/backend/tests/community/adapters/http/common_config/test_router.py
+++ b/src/backend/tests/community/adapters/http/common_config/test_router.py
@@ -384,6 +384,26 @@ def test_enable_common_config_returns_404_when_missing():
     assert resp.data is None
 
 
+def test_enable_common_config_returns_business_error_when_protected():
+    service = MagicMock()
+    service.enable_config.side_effect = ValueError(
+        "skills_pool layout rollout must use its operator API"
+    )
+
+    resp = _run(
+        router.enable_common_config(
+            ToggleCommonConfigRequest(id=1),
+            user=_USER,
+            service=service,
+        )
+    )
+
+    assert resp.success is False
+    assert resp.message == "skills_pool layout rollout must use its operator API"
+    assert resp.error_code == 40001
+    assert resp.data is None
+
+
 def test_disable_common_config_returns_success():
     service = MagicMock()
     service.disable_config.return_value = True
@@ -418,4 +438,24 @@ def test_disable_common_config_returns_404_when_missing():
     assert resp.success is False
     assert resp.message == "配置不存在"
     assert resp.error_code == 40401
+    assert resp.data is None
+
+
+def test_disable_common_config_returns_business_error_when_protected():
+    service = MagicMock()
+    service.disable_config.side_effect = ValueError(
+        "skills_pool layout rollout must use its operator API"
+    )
+
+    resp = _run(
+        router.disable_common_config(
+            ToggleCommonConfigRequest(id=1),
+            user=_USER,
+            service=service,
+        )
+    )
+
+    assert resp.success is False
+    assert resp.message == "skills_pool layout rollout must use its operator API"
+    assert resp.error_code == 40001
     assert resp.data is None

--- a/src/backend/tests/community/core/bot_dormant/test_activate.py
+++ b/src/backend/tests/community/core/bot_dormant/test_activate.py
@@ -13,7 +13,21 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService, InvalidBotStateError
+from agentclaw.community.core.bot_dormant.activate_service import (
+    ActivateBotService,
+    BotNotFoundError,
+    InvalidBotStateError,
+)
+
+
+def test_activate_reports_missing_bot_through_dormant_contract():
+    """A protocol implementation returning no bot raises the stable service error."""
+    bot_service = MagicMock()
+    bot_service.get_bot.return_value = None
+    svc = ActivateBotService(bot_service, passport_plugin=MagicMock())
+
+    with pytest.raises(BotNotFoundError):
+        svc.activate(bot_id="missing", user_id="u1")
 
 
 def test_activate_rejects_active_bot():

--- a/src/backend/tests/community/core/bot_dormant/test_activate_endpoint.py
+++ b/src/backend/tests/community/core/bot_dormant/test_activate_endpoint.py
@@ -11,8 +11,10 @@ from injector import Injector, InstanceProvider, singleton
 
 from agentclaw.community.adapters.http.bot_dormant import router as dormant_router_module
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
-from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService
-from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
+from agentclaw.community.core.bot_dormant.activate_service import (
+    ActivateBotService,
+    BotNotFoundError,
+)
 
 
 def _build_app(activate_svc: ActivateBotService) -> TestClient:

--- a/src/backend/tests/community/core/bot_dormant/test_activate_endpoint.py
+++ b/src/backend/tests/community/core/bot_dormant/test_activate_endpoint.py
@@ -1,0 +1,51 @@
+"""Tests for the public dormant activation endpoint."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, InstanceProvider, singleton
+
+from agentclaw.community.adapters.http.bot_dormant import router as dormant_router_module
+from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
+from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService
+from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
+
+
+def _build_app(activate_svc: ActivateBotService) -> TestClient:
+    app = FastAPI()
+    app.include_router(dormant_router_module.router)
+    app.dependency_overrides[get_request_context] = (
+        lambda: RequestContext(user_id="462750", nick_name="tester")
+    )
+
+    injector = Injector()
+    injector.binder.bind(
+        ActivateBotService, InstanceProvider(activate_svc), scope=singleton
+    )
+    attach_injector(app, injector)
+
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_activate_returns_business_404_when_bot_not_found():
+    """Missing bot should be a clear not-found business error, not a generic 500."""
+    activate_svc = MagicMock(spec=ActivateBotService)
+    activate_svc.activate.side_effect = BotNotFoundError(
+        "Bot not found: 20260803_qt3u3s7n"
+    )
+
+    client = _build_app(activate_svc)
+    response = client.post("/api/bots/20260803_qt3u3s7n/activate", json={})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": False,
+        "data": None,
+        "message": "Bot 不存在",
+        "error_code": 404,
+    }

--- a/src/backend/tests/community/di/test_bot_dormant_module_wiring.py
+++ b/src/backend/tests/community/di/test_bot_dormant_module_wiring.py
@@ -1,0 +1,32 @@
+"""Wiring tests for the dormant bot module."""
+
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError as BotManagementNotFoundError,
+)
+from agentclaw.community.di.modules.bot_dormant_module import _DormantBotServiceAdapter
+
+
+def test_dormant_bot_service_adapter_normalizes_not_found_and_forwards_operations():
+    """The dormant subsystem receives its own stable BotService contract."""
+    bot_service = MagicMock()
+    adapter = _DormantBotServiceAdapter(bot_service)
+
+    bot_service.get_bot.side_effect = BotManagementNotFoundError("missing")
+    assert adapter.get_bot(bot_id="bot-1", user_id="user-1") is None
+
+    bot_service.get_bot.side_effect = None
+    bot_service.get_bot.return_value = {"bot_id": "bot-1"}
+    assert adapter.get_bot(bot_id="bot-1", user_id="user-1") == {"bot_id": "bot-1"}
+
+    bot_service.update_status.return_value = {"status": "RECYCLED"}
+    assert adapter.update_status(bot_id="bot-1", status="RECYCLED") == {
+        "status": "RECYCLED"
+    }
+
+    bot_service.stop_bot.return_value = {"status": "STOPPED"}
+    assert adapter.stop_bot(bot_id="bot-1") == {"status": "STOPPED"}
+
+    bot_service.start_bot.return_value = {"status": "RUNNING"}
+    assert adapter.start_bot(bot_id="bot-1") == {"status": "RUNNING"}


### PR DESCRIPTION
## Summary
- Map dormant bot activation missing-bot errors to a clear business 404 response instead of generic Internal server error.
- Add a public activate endpoint regression test for BotNotFoundError.

## Test Plan
- PYTHONPATH=src uv run pytest tests/community/core/bot_dormant/test_activate_endpoint.py tests/community/core/bot_dormant/test_activate.py tests/community/core/bot_dormant/test_internal_endpoints.py -q