### PR TITLE
fix(gateway): remove the dev signing-key fallback and make key mismatches diagnosable

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -364,6 +364,52 @@ route dependency        → require_principal(request)       ─┘  cache on sc
   Either way the trigger is the same: no such secret, an empty value, or a
   resolver that raises.
 
+  **The gateway now behaves identically** — one contract, one rule. It shipped a
+  committed dev fallback key until 2026-08-04; that was removed rather than made
+  louder, because no peer ever accepted those tokens (this side has never had a
+  fallback to match) and all it bought was a gateway that looked healthy while
+  every request failed one hop away. Missing key there ⇒ boot refused in
+  `pre`/`prod`, otherwise every signature attempt refuses and the forwarder
+  answers `500 principal signing failed`.
+
+### Diagnosing a 401 on this surface
+
+Both halves log a **key fingerprint** at boot — a truncated SHA-256, safe in a
+log, useless to a reader. They are the same eight characters when and only when
+the two ends hold the same secret, so the first question is answered by diffing
+two lines rather than by printing a credential:
+
+```text
+backend:  gateway principal verification is configured (secret='...', key fp=eb128a7a, key len=38, aud='backend', iss='gateway')
+gateway:  principal signer configured (secret='principal_signing_key', key fp=eb128a7a, key len=38, kid='bare', iss='gateway', ttl=60s)
+```
+
+| What you see | What it means |
+| --- | --- |
+| fingerprints differ | the two ends hold different secrets — the usual cause |
+| gateway `key fp=unset` | the gateway resolved no key and cannot sign at all |
+| same fp, different `key len` | one side's value carries whitespace (both strip, so this only appears across a mixed-version rollout) |
+| fingerprints match | not a key problem — check `iss`, clock skew, and whether either process predates the last rotation (each resolves once at boot) |
+
+Per-request, the backend logs one line per failure, and it names the cause:
+
+```text
+rejected forwarded principal on GET /openapi/v1/bots: principal token rejected:
+Signature verification failed [token alg='HS256' kid='bare'; verifier key
+fp=eb128a7a, expects aud='backend' iss='gateway']
+```
+
+`alg`/`kid` come from the token's unverified JOSE header — the only readable
+part when a signature fails, and what distinguishes "our gateway, wrong key"
+(`kid='bare'`) from a token no gateway of ours minted. None of it reaches the
+caller: every failure answers the same fixed `401 Unauthorized`.
+
+A **missing** header logs distinctly (`no X-Avernet-Principal header on ...`)
+and is not an auth failure at all — the gateway injects that header on every
+forwarded request, so its absence means the request did not come through the
+gateway's authenticated path. Chasing signing keys for that one is chasing the
+wrong half of the system.
+
 - `aud` and `iss` are fixed in code here, not configurable — one wire contract,
   one spelling. They are **not** symmetric on the signing side, though:
   - `aud` is not configurable there either (the gateway signs it from the

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -395,14 +395,28 @@ Per-request, the backend logs one line per failure, and it names the cause:
 
 ```text
 rejected forwarded principal on GET /openapi/v1/bots: principal token rejected:
-Signature verification failed [token alg='HS256' kid='bare'; verifier key
-fp=eb128a7a, expects aud='backend' iss='gateway']
+Signature verification failed [verifier key fp=eb128a7a, expects aud='backend'
+iss='gateway'; unverified caller-supplied header alg='HS256' kid='bare']
 ```
 
-`alg`/`kid` come from the token's unverified JOSE header — the only readable
-part when a signature fails, and what distinguishes "our gateway, wrong key"
-(`kid='bare'`) from a token no gateway of ours minted. None of it reaches the
-caller: every failure answers the same fixed `401 Unauthorized`.
+**The two halves of that suffix do not carry equal weight, and the difference
+decides what you should do about it.**
+
+`verifier key fp`, `aud` and `iss` come from this process's own configuration.
+They are trustworthy, and together with the gateway's boot line they are what
+a diagnosis should rest on.
+
+`alg` and `kid` come from the token's JOSE header, which a failed signature
+means nothing has authenticated. Anyone who can reach the surface can stamp
+`kid: bare` on a token they minted. So `kid='bare'` is **not** evidence the
+gateway sent it — treating it as such during a burst of forged traffic would
+have you rotate a shared secret that was never broken. Read it as a hint that
+is useful mainly in the negative: an unexpected `alg`, an unfamiliar `kid`, or
+a header that will not parse says *look somewhere other than the key*.
+
+When the fingerprints match and forged-looking traffic persists, the token is
+not coming from your gateway, whatever its `kid` claims. None of this reaches
+the caller: every failure answers the same fixed `401 Unauthorized`.
 
 A **missing** header logs distinctly (`no X-Avernet-Principal header on ...`)
 and is not an auth failure at all — the gateway injects that header on every

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -324,6 +324,12 @@ from agentclaw.community.core.errors import (  # noqa: E402
     Unauthorized,
     ValidationError,
 )
+from agentclaw.community.adapters.http.openapi_v1.errors import (  # noqa: E402
+    MissingPrincipalError,
+)
+from agentclaw.community.core.gateway_principal import (  # noqa: E402
+    PrincipalVerificationError,
+)
 from agentclaw.community.core.caller_identity.contracts import (  # noqa: E402
     CallerCallTypeInvalidError,
     CallerIdentityAmbiguousError,
@@ -499,6 +505,54 @@ async def _data_proxy_error_handler(
     )
 
 
+@app.exception_handler(MissingPrincipalError)
+@app.exception_handler(PrincipalVerificationError)
+async def _principal_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Answer an unverifiable caller with a 401 — and *only* a 401.
+
+    Both errors are raised in a **dependency** (``require_principal``, which
+    every public route declares), so they surface inside
+    ``solve_dependencies`` before the handler runs and ``@envelope_errors``
+    never sees them. The catch-all below already mapped them to the right
+    status via ``ENVELOPE_ERRORS``, so this handler exists for a different
+    reason: *where* it is registered.
+
+    Starlette splits registered handlers by key. ``Exception`` becomes
+    ``ServerErrorMiddleware``'s handler, and that middleware sends the response
+    and then unconditionally re-raises ("We always continue to raise the
+    exception", ``starlette/middleware/errors.py``) so the server can log a
+    crash. The result was a correct 401 on the wire followed by a hundred-odd
+    lines of ASGI traceback per request — precisely what the catch-all's
+    warning-without-a-traceback was written to avoid, and ruinous on this path
+    because an auth misconfiguration makes *every* request take it.
+
+    Registering the concrete types instead puts them in the inner
+    ``ExceptionMiddleware``, which answers and does not re-raise. The status
+    and body still come from ``ENVELOPE_ERRORS`` via ``_public_mapped_error``,
+    so this adds a route out of the stack, not a second opinion on the answer.
+    """
+    # ``exc`` carries the operator-facing diagnosis on the verification path —
+    # the token's ``alg``/``kid`` and the fingerprint of the key we judged it
+    # against. It is logged, never returned: the response is the same fixed
+    # "Unauthorized" the table gives every failure here, so a forger still
+    # cannot tell which part of a token was rejected.
+    logger.warning(
+        "[Public 401] %s on %s %s: %s",
+        type(exc).__name__, request.method, request.url.path, exc,
+    )
+    mapped = _public_mapped_error(request, exc)
+    if mapped is not None:
+        return mapped
+    # Raised off the public surface — an internal ``/api`` route reaching the
+    # verifier directly. Those keep the ``{"detail": ...}`` shape their clients
+    # parse rather than being handed an Envelope they do not expect.
+    return JSONResponse(
+        status_code=401,
+        content={"detail": "Unauthorized"},
+        headers=_trace_headers(request),
+    )
+
+
 # Catch-all for unhandled non-DomainError exceptions. Returns the same
 # {"detail": ...} JSON shape (status 500) instead of Starlette's default
 # plain-text "Internal Server Error" body, so the wire format is uniform
@@ -508,11 +562,17 @@ async def _data_proxy_error_handler(
 @app.exception_handler(Exception)
 async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     # A mapped public error can still land here: @envelope_errors only wraps the
-    # handler, so an ENVELOPE_ERRORS type raised in a **dependency** — the auth
-    # seam every public route declares — is raised before the handler runs and
-    # arrives as an "unhandled" exception. Consulting the same table here is what
-    # makes an unauthenticated public request a 401 rather than a 500, wherever
-    # the error was raised. One table, two entry points.
+    # handler, so an ENVELOPE_ERRORS type raised in a **dependency** is raised
+    # before the handler runs and arrives as an "unhandled" exception.
+    # Consulting the same table here is what makes such a request its mapped
+    # status rather than a 500, wherever the error was raised. One table, two
+    # entry points.
+    #
+    # The auth seam's two errors no longer reach this handler — they have their
+    # own registration above, so that a routine 401 does not pay for
+    # ServerErrorMiddleware's re-raise. Everything else mapped still arrives
+    # here, and the traceback note below is why that is tolerable for the rest:
+    # they are rare, where an unverifiable caller is not.
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
         # Expected client-side flow (missing/invalid credentials, bad input).

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
@@ -116,11 +116,13 @@ def _verify_from_headers(request: Request) -> VerifiedCaller | None:
         return verify_principal_token(token, config)
     except PrincipalVerificationError as exc:
         # Log the reason (never the token) and treat the caller as absent. The
-        # request goes on to answer 401 from require_principal. The reason now
-        # carries the token's ``alg``/``kid`` and the fingerprint of the key it
-        # was judged against — see ``core/gateway_principal/verifier.py`` — so
-        # this one line separates a key mismatch from an expiry, a wrong
-        # audience, or a token no gateway of ours minted.
+        # request goes on to answer 401 from require_principal. The reason
+        # carries the fingerprint of the key this component judged the token
+        # against, plus the token's own JOSE header marked as caller-supplied —
+        # see ``core/gateway_principal/verifier.py``. The fingerprint is the
+        # part to reason from: compared against the gateway's boot line it
+        # separates a key mismatch from an expiry or a wrong audience, while
+        # the header is unauthenticated and can say anything a forger likes.
         logger.warning(
             "rejected forwarded principal on %s %s: %s",
             request.method,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
@@ -92,14 +92,35 @@ def _resolve_caller(request: Request) -> VerifiedCaller | None:
 
 def _verify_from_headers(request: Request) -> VerifiedCaller | None:
     """Verify the request's principal header, logging why if it fails."""
+    config = get_principal_verifier_config()
     token = request.headers.get(PRINCIPAL_HEADER, "").strip()
     if not token:
+        # Distinguished from a rejected token, and on its own log line, because
+        # the two point at completely different things. A *missing* header is
+        # not an auth failure at all: the gateway injects it on every forwarded
+        # request, so its absence means this request did not come through the
+        # gateway, or came through one whose route table does not require an
+        # identity for this path. Chasing signing keys for that is chasing the
+        # wrong half of the system, which is exactly what the previous silence
+        # invited.
+        logger.warning(
+            "no %s header on %s %s (request did not arrive through the "
+            "gateway's authenticated path; verifier key fp=%s)",
+            PRINCIPAL_HEADER,
+            request.method,
+            request.url.path,
+            config.key_fingerprint,
+        )
         return None
     try:
-        return verify_principal_token(token, get_principal_verifier_config())
+        return verify_principal_token(token, config)
     except PrincipalVerificationError as exc:
         # Log the reason (never the token) and treat the caller as absent. The
-        # request goes on to answer 401 from require_principal.
+        # request goes on to answer 401 from require_principal. The reason now
+        # carries the token's ``alg``/``kid`` and the fingerprint of the key it
+        # was judged against — see ``core/gateway_principal/verifier.py`` — so
+        # this one line separates a key mismatch from an expiry, a wrong
+        # audience, or a token no gateway of ours minted.
         logger.warning(
             "rejected forwarded principal on %s %s: %s",
             request.method,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
@@ -20,8 +20,15 @@ class ClusterMismatchError(Exception):
 class MissingPrincipalError(Exception):
     """Raised when a public request has no authenticated caller (→ 401).
 
-    In the current pre-auth state ``require_principal`` is a stub returning
-    ``None``, so every real request raises this until the gateway verifier lands.
+    One error for two causes, deliberately: no ``X-Avernet-Principal`` header at
+    all, and a header whose token failed verification. ``require_principal``
+    funnels both here so the caller cannot tell them apart — see
+    ``openapi_v1/dependencies.py``. Which one it was is logged, with the reason,
+    at the point of failure.
+
+    ``app.py`` registers a handler for this type directly rather than letting
+    the catch-all answer it; the docstring there explains why that placement
+    matters.
     """
 
 

--- a/src/backend/src/agentclaw/community/core/gateway_principal/README.md
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/README.md
@@ -33,6 +33,9 @@ provides:
   - PrincipalVerifierConfig
   - VerifiedCaller
   - verify_principal_token
+  - key_fingerprint
+  - is_weak_signing_key
+  - MIN_SIGNING_KEY_BYTES
   - PrincipalVerificationError
 consumes:
   - "Gateway PrincipalSigner (the signing half of the contract, in src/gateway)"

--- a/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
@@ -26,6 +26,7 @@ from agentclaw.community.core.gateway_principal.models import (
 from agentclaw.community.core.gateway_principal.verifier import (
     PrincipalVerifierConfig,
     VerifiedCaller,
+    key_fingerprint,
     verify_principal_token,
 )
 
@@ -43,5 +44,6 @@ __all__ = [
     "PrincipalVerifierConfig",
     "UserPrincipal",
     "VerifiedCaller",
+    "key_fingerprint",
     "verify_principal_token",
 ]

--- a/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
@@ -24,13 +24,16 @@ from agentclaw.community.core.gateway_principal.models import (
     UserPrincipal,
 )
 from agentclaw.community.core.gateway_principal.verifier import (
+    MIN_SIGNING_KEY_BYTES,
     PrincipalVerifierConfig,
     VerifiedCaller,
+    is_weak_signing_key,
     key_fingerprint,
     verify_principal_token,
 )
 
 __all__ = [
+    "MIN_SIGNING_KEY_BYTES",
     "AccessKeyPrincipal",
     "AppPrincipal",
     "BotPrincipal",
@@ -44,6 +47,7 @@ __all__ = [
     "PrincipalVerifierConfig",
     "UserPrincipal",
     "VerifiedCaller",
+    "is_weak_signing_key",
     "key_fingerprint",
     "verify_principal_token",
 ]

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -224,20 +224,26 @@ def verify_principal_token(
         # PyJWT's own message already separates the failure modes ("Signature
         # verification failed" vs "Signature has expired" vs "Invalid
         # audience"), so it is kept verbatim. What it cannot say is *which key
-        # and which contract* we judged the token against, and that is the
-        # difference between "the gateway and this component disagree about the
-        # shared secret" and "someone forged a token" — indistinguishable from
-        # the PyJWT message alone. The suffix supplies exactly that, all of it
-        # our own configuration plus the token's unverified JOSE header.
+        # and which contract* we judged the token against — and that is what
+        # turns an unattributable rejection into a diagnosis.
+        #
+        # The two halves of the suffix have very different standing, and the
+        # wording keeps them apart. Our key fingerprint, audience and issuer
+        # come from this process's own configuration: trustworthy, and the
+        # thing to reason from. The JOSE header comes from the request and is
+        # unauthenticated — a forger sets ``kid`` to whatever makes their token
+        # look legitimate — so it is labelled as caller-supplied rather than
+        # presented as provenance. Reading it as proof would mean rotating a
+        # healthy secret the moment someone starts forging tokens.
         #
         # None of this reaches the caller: every failure here funnels into one
         # fixed ``401 Unauthorized`` (``openapi_v1/responses.py``), so naming
         # the mismatch for the operator does not tell a forger what to fix.
         raise PrincipalVerificationError(
             f"principal token rejected: {exc} "
-            f"[{_token_provenance(token)}; verifier key fp="
-            f"{config.key_fingerprint}, expects aud={config.audience!r} "
-            f"iss={config.issuer!r}]"
+            f"[verifier key fp={config.key_fingerprint}, "
+            f"expects aud={config.audience!r} iss={config.issuer!r}; "
+            f"{_unverified_token_header(token)}]"
         ) from exc
 
     principals = _parse_principals(claims.get("principals"))
@@ -258,27 +264,40 @@ def _clip(value: object) -> str:
     return repr(text)
 
 
-def _token_provenance(token: str) -> str:
-    """Describe *which signer* produced ``token``, from its JOSE header.
+def _unverified_token_header(token: str) -> str:
+    """Render the token's JOSE header for a log line, marked as unverified.
 
-    Read **without verifying**, which is the only option available: on a
-    signature failure there is nothing to verify against. ``alg`` and ``kid``
-    are what separate "our gateway, wrong shared key" (``alg=HS256 kid=bare``,
-    the values its ``bare`` signer stamps) from "not our gateway at all" — the
-    single most useful fact when the signature does not check out, and one the
-    PyJWT message never carries.
+    **This is a hint, never evidence of provenance, and the log line says so.**
+    A failed signature means nothing about the token has been authenticated —
+    including its header — so anyone able to reach this component can put
+    ``alg: HS256, kid: bare`` on a token they minted themselves. Reading
+    ``kid=bare`` as "our gateway with the wrong key" is therefore exactly the
+    inference a forger gets for free, and during forged-token traffic it would
+    send an operator to rotate a shared secret that was never broken.
 
-    The header is attacker-controlled, so it is used for **nothing but this log
-    string**: no decision reads it, the verifier's ``alg`` stays pinned to
-    :data:`_ALGORITHMS`, and :func:`_clip` bounds and escapes it on the way out.
-    Only the header is read — never the payload, whose claims are exactly the
-    unverified assertions this function exists to be sceptical of.
+    What it is good for is the cheap negative and the corroborating detail: an
+    unexpected ``alg``, an unfamiliar ``kid``, a header that will not parse at
+    all. Those say "look somewhere other than the shared key" and cost nothing
+    to carry.
+
+    **The authoritative signal is the pair of boot fingerprints** — those come
+    from each component's own resolved configuration, not from the request, so
+    they cannot be influenced by a caller. Any diagnosis that matters should
+    rest on them; see the runbook in ``docs/openapi-v1/README.md``.
+
+    Used for nothing but this string: no decision reads it, the verifier's
+    ``alg`` stays pinned to :data:`_ALGORITHMS`, and :func:`_clip` bounds and
+    escapes it on the way out. Only the header is read — never the payload,
+    whose claims are the unverified assertions this function exists to distrust.
     """
     try:
         header = jwt.get_unverified_header(token)
     except jwt.PyJWTError:
-        return "token has an unparseable JOSE header"
-    return f"token alg={_clip(header.get('alg'))} kid={_clip(header.get('kid'))}"
+        return "unparseable JOSE header"
+    return (
+        "unverified caller-supplied header "
+        f"alg={_clip(header.get('alg'))} kid={_clip(header.get('kid'))}"
+    )
 
 
 def _parse_principals(raw: object) -> tuple[GatewayPrincipal, ...]:

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -66,6 +66,27 @@ _MAX_HEADER_FIELD = 32
 # hash of the empty string as though it were a configured key.
 _UNSET_FINGERPRINT = "unset"
 
+# RFC 7518 §3.2: an HMAC key for SHA-256 must be at least as long as the hash
+# output. PyJWT warns below it, and it is the threshold the fingerprint's
+# safety argument rests on — see :func:`key_fingerprint`.
+MIN_SIGNING_KEY_BYTES = 32
+
+
+def is_weak_signing_key(key: str) -> bool:
+    """Whether ``key`` is below the strength the shared-secret contract assumes.
+
+    Length is a proxy for entropy, and a coarse one — it cannot tell 32 random
+    bytes from 32 repetitions of ``a``. It is still worth checking, because the
+    keys that show up short are overwhelmingly the human-chosen ones, and a
+    check that catches the common case beats a docstring that assumes the
+    problem away.
+
+    Measured in **bytes, not characters**, because bytes are what HMAC
+    consumes: a non-ASCII passphrase carries more bytes than it has characters,
+    so counting characters would reject a key the algorithm is content with.
+    """
+    return 0 < len(key.encode("utf-8")) < MIN_SIGNING_KEY_BYTES
+
 
 def key_fingerprint(key: str) -> str:
     """A short, non-reversible fingerprint of a shared signing key.
@@ -78,9 +99,20 @@ def key_fingerprint(key: str) -> str:
     one side only and the comparison silently becomes meaningless — the golden
     values pinned in both test suites exist to stop that.
 
-    Safe to log: SHA-256 is not reversible, and the key is required to be at
-    least 32 random bytes (RFC 7518 §3.2), so the truncated digest is not a
-    practical brute-force oracle for anyone who can already read the logs.
+    Safe to log **for a key of the mandated strength**, and that qualifier is
+    the whole of the argument: SHA-256 is not reversible, so against ≥32 random
+    bytes (RFC 7518 §3.2) a truncated digest is no practical brute-force oracle
+    for someone who can already read the logs. Against a short or human-chosen
+    key it *is* one — 32 bits is enough to confirm a dictionary guess offline,
+    and confirming the shared secret means being able to forge identity tokens.
+
+    Nothing in the type system enforces that strength, so
+    :func:`is_weak_signing_key` exists and both boot paths warn when a key falls
+    below it rather than leaving the precondition asserted-but-unchecked. The
+    fingerprint is still emitted for a weak key: suppressing it would remove the
+    diagnostic exactly when a deployment is most misconfigured, and the answer
+    to a weak shared secret is to replace it, which the warning says outright.
+
     Safe to log is not safe to *serve* — never put this on an HTTP endpoint,
     where it would let an unauthenticated caller confirm a guessed key.
     """

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -26,6 +26,7 @@ resolves the signing key through ``SecretResolver``.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
 import jwt
@@ -57,6 +58,36 @@ _REQUIRED_CLAIMS = ("exp", "iat", "aud", "iss")
 
 _PRINCIPAL_ADAPTER: TypeAdapter[GatewayPrincipal] = TypeAdapter(GatewayPrincipal)
 
+# How much of a JOSE header field reaches a log line. The header is unverified
+# attacker-controlled input, so it is clipped before it is ever formatted.
+_MAX_HEADER_FIELD = 32
+
+# What a fingerprint of no key at all reads as, so a log line never shows a
+# hash of the empty string as though it were a configured key.
+_UNSET_FINGERPRINT = "unset"
+
+
+def key_fingerprint(key: str) -> str:
+    """A short, non-reversible fingerprint of a shared signing key.
+
+    **This algorithm is a cross-component contract.** The gateway computes the
+    same fingerprint over its own copy of the key
+    (``plugins/principal_signer/bare/_plugin.py``) and both sides log it at
+    boot, so that "do the two ends hold the same secret?" is answered by
+    comparing two log lines rather than by printing a credential. Change it on
+    one side only and the comparison silently becomes meaningless — the golden
+    values pinned in both test suites exist to stop that.
+
+    Safe to log: SHA-256 is not reversible, and the key is required to be at
+    least 32 random bytes (RFC 7518 §3.2), so the truncated digest is not a
+    practical brute-force oracle for anyone who can already read the logs.
+    Safe to log is not safe to *serve* — never put this on an HTTP endpoint,
+    where it would let an unauthenticated caller confirm a guessed key.
+    """
+    if not key:
+        return _UNSET_FINGERPRINT
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
+
 
 @dataclass(frozen=True)
 class PrincipalVerifierConfig:
@@ -75,6 +106,11 @@ class PrincipalVerifierConfig:
     signing_key: str
     audience: str
     issuer: str
+
+    @property
+    def key_fingerprint(self) -> str:
+        """This config's key as :func:`key_fingerprint` renders it for a log."""
+        return key_fingerprint(self.signing_key)
 
 
 @dataclass(frozen=True)
@@ -153,12 +189,64 @@ def verify_principal_token(
             options={"require": list(_REQUIRED_CLAIMS)},
         )
     except jwt.PyJWTError as exc:
-        raise PrincipalVerificationError(f"principal token rejected: {exc}") from exc
+        # PyJWT's own message already separates the failure modes ("Signature
+        # verification failed" vs "Signature has expired" vs "Invalid
+        # audience"), so it is kept verbatim. What it cannot say is *which key
+        # and which contract* we judged the token against, and that is the
+        # difference between "the gateway and this component disagree about the
+        # shared secret" and "someone forged a token" — indistinguishable from
+        # the PyJWT message alone. The suffix supplies exactly that, all of it
+        # our own configuration plus the token's unverified JOSE header.
+        #
+        # None of this reaches the caller: every failure here funnels into one
+        # fixed ``401 Unauthorized`` (``openapi_v1/responses.py``), so naming
+        # the mismatch for the operator does not tell a forger what to fix.
+        raise PrincipalVerificationError(
+            f"principal token rejected: {exc} "
+            f"[{_token_provenance(token)}; verifier key fp="
+            f"{config.key_fingerprint}, expects aud={config.audience!r} "
+            f"iss={config.issuer!r}]"
+        ) from exc
 
     principals = _parse_principals(claims.get("principals"))
     _reject_contradictory_tenant(principals)
     _require_user_principal(principals)
     return VerifiedCaller(principals=principals)
+
+
+def _clip(value: object) -> str:
+    """Render an unverified header field for a log line, bounded and escaped.
+
+    ``repr`` rather than the bare string: it escapes newlines and control
+    characters, so a crafted ``kid`` cannot forge extra log lines around itself.
+    """
+    text = str(value)
+    if len(text) > _MAX_HEADER_FIELD:
+        text = text[:_MAX_HEADER_FIELD] + "…"
+    return repr(text)
+
+
+def _token_provenance(token: str) -> str:
+    """Describe *which signer* produced ``token``, from its JOSE header.
+
+    Read **without verifying**, which is the only option available: on a
+    signature failure there is nothing to verify against. ``alg`` and ``kid``
+    are what separate "our gateway, wrong shared key" (``alg=HS256 kid=bare``,
+    the values its ``bare`` signer stamps) from "not our gateway at all" — the
+    single most useful fact when the signature does not check out, and one the
+    PyJWT message never carries.
+
+    The header is attacker-controlled, so it is used for **nothing but this log
+    string**: no decision reads it, the verifier's ``alg`` stays pinned to
+    :data:`_ALGORITHMS`, and :func:`_clip` bounds and escapes it on the way out.
+    Only the header is read — never the payload, whose claims are exactly the
+    unverified assertions this function exists to be sceptical of.
+    """
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError:
+        return "token has an unparseable JOSE header"
+    return f"token alg={_clip(header.get('alg'))} kid={_clip(header.get('kid'))}"
 
 
 def _parse_principals(raw: object) -> tuple[GatewayPrincipal, ...]:

--- a/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
+++ b/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
@@ -32,8 +32,9 @@ What comes from where:
   registered, no such secret, an empty value, or a resolver that raises. Those
   environments legitimately have no key, and that is the pre-auth state this
   replaces. We ship **no fallback key** either way, because a committed shared
-  secret is a committed credential. Use at least 32 bytes — RFC 7518 §3.2 for
-  SHA-256, and PyJWT warns below it.
+  secret is a committed credential — and since 2026-08-04 the gateway ships none
+  either, so both ends of this contract fail closed by the same rule. Use at
+  least 32 bytes — RFC 7518 §3.2 for SHA-256, and PyJWT warns below it.
 
 - **``aud`` and ``iss``** are fixed in code, not configuration — a deliberate
   call, so that one wire contract has one spelling rather than a knob per side.
@@ -58,7 +59,10 @@ re-read, so rotating the shared secret requires a restart on both sides.
 
 from __future__ import annotations
 
-from agentclaw.community.core.gateway_principal import PrincipalVerifierConfig
+from agentclaw.community.core.gateway_principal import (
+    PrincipalVerifierConfig,
+    key_fingerprint,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
@@ -124,7 +128,25 @@ def init_principal_verifier_config(
         signing_key=signing_key, audience=_AUDIENCE, issuer=_ISSUER
     )
     if signing_key:
-        logger.info("gateway principal verification is configured")
+        # The fingerprint is the whole point of this line. The two halves of
+        # this contract never meet at request time — the gateway signs
+        # successfully every time, and only this component ever observes a
+        # mismatch — so boot is the one place their keys can be compared at
+        # all. Emitting a non-reversible fingerprint on both sides turns "do we
+        # hold the same secret?" into a diff of two log lines, instead of a
+        # ``Signature verification failed`` with no way to tell a wrong secret
+        # from a stale one. ``len`` rides along because two keys that differ
+        # only by stray whitespace hash differently but look identical in a
+        # secret store.
+        logger.info(
+            "gateway principal verification is configured "
+            "(secret=%r, key fp=%s, key len=%d, aud=%r, iss=%r)",
+            secret_name,
+            _config.key_fingerprint,
+            len(signing_key),
+            _AUDIENCE,
+            _ISSUER,
+        )
     else:
         logger.warning(
             "gateway principal verification has no signing key — every "
@@ -176,12 +198,34 @@ def _resolve_signing_key(resolver: SecretResolver, secret_name: str) -> str:
         )
         return ""
 
-    key = str(getattr(secret, "secret_value", "") or "").strip()
+    raw = str(getattr(secret, "secret_value", "") or "")
+    key = raw.strip()
     if not key:
         logger.warning(
             "secret %r resolved with an empty value — no principal signing "
             "key resolved",
             secret_name,
+        )
+        return key
+
+    if key != raw:
+        # Stripping is silent otherwise, and silence is what makes this bite: a
+        # trailing newline (routine when a secret is injected from a file) is
+        # invisible in a secret store, and the two ends then hash different
+        # bytes from what looks like one value. The gateway strips too, so the
+        # contract still holds — but a gateway released before it did signs
+        # with the untrimmed bytes, and this line names the fingerprint that
+        # such a peer would report, so a mixed-version rollout is one grep
+        # rather than a second incident.
+        logger.warning(
+            "secret %r carries %d character(s) of surrounding whitespace, "
+            "which this side strips before use (fp untrimmed=%s, trimmed=%s). "
+            "Provision the value without it so both ends of the contract hash "
+            "the same bytes",
+            secret_name,
+            len(raw) - len(key),
+            key_fingerprint(raw),
+            key_fingerprint(key),
         )
     return key
 

--- a/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
+++ b/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
@@ -60,7 +60,9 @@ re-read, so rotating the shared secret requires a restart on both sides.
 from __future__ import annotations
 
 from agentclaw.community.core.gateway_principal import (
+    MIN_SIGNING_KEY_BYTES,
     PrincipalVerifierConfig,
+    is_weak_signing_key,
     key_fingerprint,
 )
 from agentclaw.community.log import get_logger
@@ -147,6 +149,22 @@ def init_principal_verifier_config(
             _AUDIENCE,
             _ISSUER,
         )
+        if is_weak_signing_key(signing_key):
+            # The line above publishes a fingerprint of this key, and that is
+            # only safe while the key is strong — against a guessable one a
+            # truncated digest confirms a dictionary guess offline. Warn rather
+            # than withhold the fingerprint: the diagnostic matters most on a
+            # misconfigured deployment, and the real remedy is a better secret.
+            logger.warning(
+                "the gateway principal signing key is %d bytes, below the "
+                "%d-byte minimum for HMAC-SHA256 (RFC 7518 §3.2). Replace it "
+                "with at least %d random bytes: a guessable shared secret can "
+                "be recovered from the fingerprint logged above, and whoever "
+                "recovers it can forge any caller identity",
+                len(signing_key.encode("utf-8")),
+                MIN_SIGNING_KEY_BYTES,
+                MIN_SIGNING_KEY_BYTES,
+            )
     else:
         logger.warning(
             "gateway principal verification has no signing key — every "

--- a/src/backend/tests/community/api/test_principal_error_handler.py
+++ b/src/backend/tests/community/api/test_principal_error_handler.py
@@ -1,0 +1,237 @@
+"""Where the auth seam's 401 handler is registered, and why that matters.
+
+``MissingPrincipalError`` and ``PrincipalVerificationError`` are raised inside
+``require_principal`` — a FastAPI **dependency**, so they surface in
+``solve_dependencies`` before the route handler runs. That placement is what
+these tests are about.
+
+Starlette splits registered exception handlers by key. A handler registered for
+``Exception`` becomes ``ServerErrorMiddleware``'s handler, and that middleware
+sends the response and then unconditionally re-raises so the server can log a
+crash ("We always continue to raise the exception",
+``starlette/middleware/errors.py``). A correct 401 therefore went out on the
+wire *and* uvicorn logged a full ASGI traceback behind it — around a hundred
+lines per request, on the one path that takes every request when auth is
+misconfigured.
+
+Registering the concrete types puts them in the inner ``ExceptionMiddleware``,
+which answers and does not re-raise. The tests below pin both halves: the fix
+works, and the control case shows the re-raise is real rather than folklore. If
+Starlette ever stops re-raising, ``test_the_catch_all_alone_re_raises`` fails
+and the extra registration can be reconsidered.
+
+The app is driven through the raw ASGI interface rather than ``TestClient``,
+because that is the only way to observe what uvicorn observes: ``TestClient``
+swallows the re-raise (``raise_server_exceptions=False``) or converts it into a
+test failure (the default), and neither distinguishes the two wirings.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from agentclaw.community.core.gateway_principal import PrincipalVerificationError
+
+pytestmark = pytest.mark.asyncio
+
+PUBLIC_PATH = f"{PUBLIC_API_PREFIX}/bots"
+INTERNAL_PATH = "/api/bots"
+
+
+def _build_app(*, register_concrete: bool, raised: Exception, path: str) -> FastAPI:
+    """Mirror the prod wiring, importing the real handlers from ``app.py``."""
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _unhandled_exception_handler,
+    )
+
+    app = FastAPI()
+    # The prod stack wraps the router in several BaseHTTPMiddleware layers
+    # (tracer, request logging). They re-raise app exceptions on the way out,
+    # and they are in the traceback this file exists to remove, so the shape is
+    # reproduced rather than simplified away.
+    app.add_middleware(BaseHTTPMiddleware, dispatch=lambda r, call_next: call_next(r))
+
+    async def require_principal() -> None:
+        raise raised
+
+    @app.get(path, dependencies=[Depends(require_principal)])
+    async def route() -> dict:
+        return {"unreachable": True}
+
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+    if register_concrete:
+        app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+        app.add_exception_handler(
+            PrincipalVerificationError, _principal_error_handler
+        )
+    return app
+
+
+async def _call_asgi(app: FastAPI, path: str) -> tuple[int | None, str | None]:
+    """Drive ``app`` as uvicorn does; return the wire status and any re-raise."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "client": ("11.232.198.238", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "app": app,
+    }
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    reraised: str | None = None
+    try:
+        await app(scope, receive, send)
+    except Exception as exc:  # noqa: BLE001 — the observation under test
+        reraised = type(exc).__name__
+
+    status = next(
+        (m["status"] for m in sent if m["type"] == "http.response.start"), None
+    )
+    return status, reraised
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        MissingPrincipalError("no verified caller for this request"),
+        PrincipalVerificationError("principal token rejected: Signature ..."),
+    ],
+    ids=["missing-principal", "verification-failed"],
+)
+async def test_an_unverifiable_caller_gets_a_401_and_nothing_else(error: Exception):
+    """The whole point: a 401 on the wire, and no crash reported to the server."""
+    app = _build_app(register_concrete=True, raised=error, path=PUBLIC_PATH)
+
+    status, reraised = await _call_asgi(app, PUBLIC_PATH)
+
+    assert status == 401
+    assert reraised is None, (
+        "re-raised to the ASGI server, which logs it as 'Exception in ASGI "
+        "application' — a ~100-line traceback behind an already-sent 401"
+    )
+
+
+async def test_the_catch_all_alone_re_raises():
+    """The control, and the reason the concrete registration exists.
+
+    Not a test of our code but of Starlette's: it documents the behavior being
+    worked around, so that if Starlette stops re-raising this fails loudly and
+    the workaround can be dropped rather than cargo-culted.
+    """
+    app = _build_app(
+        register_concrete=False,
+        raised=MissingPrincipalError("no verified caller for this request"),
+        path=PUBLIC_PATH,
+    )
+
+    status, reraised = await _call_asgi(app, PUBLIC_PATH)
+
+    assert status == 401, "the catch-all does produce the right status..."
+    assert reraised == "MissingPrincipalError", "...and then re-raises anyway"
+
+
+async def test_the_public_surface_keeps_its_envelope():
+    """Routing around the catch-all must not route around the contract.
+
+    The status and body still come from ``ENVELOPE_ERRORS``, so this handler
+    adds a way out of the middleware stack, not a second opinion on the answer.
+    """
+    from agentclaw.community.adapters.http.app import _principal_error_handler
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": PUBLIC_PATH,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+    response = await _principal_error_handler(
+        request, MissingPrincipalError("no verified caller for this request")
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+    assert b'"code":401000' in response.body
+    assert b'"message":"Unauthorized"' in response.body
+
+
+async def test_an_internal_route_keeps_the_detail_shape():
+    """``/api`` clients parse ``{"detail": ...}`` and never learn the Envelope."""
+    from agentclaw.community.adapters.http.app import _principal_error_handler
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": INTERNAL_PATH,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+    response = await _principal_error_handler(
+        request, MissingPrincipalError("no verified caller for this request")
+    )
+
+    assert response.status_code == 401
+    assert response.body == b'{"detail":"Unauthorized"}'
+
+
+async def test_the_reason_is_logged_but_never_returned(caplog):
+    """The diagnosis goes to the operator; the caller gets one fixed answer.
+
+    The verifier's message names the token's ``kid`` and the fingerprint of the
+    key it was judged against. Returning any of that would tell a forger which
+    part of a token to fix, so the split has to hold in both directions.
+    """
+    import logging
+
+    from agentclaw.community.adapters.http.app import _principal_error_handler
+
+    diagnosis = (
+        "principal token rejected: Signature verification failed "
+        "[token alg='HS256' kid='bare'; verifier key fp=70b333b7, "
+        "expects aud='backend' iss='gateway']"
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": PUBLIC_PATH,
+            "headers": [],
+            "query_string": b"",
+        }
+    )
+
+    with caplog.at_level(logging.WARNING):
+        response = await _principal_error_handler(
+            request, PrincipalVerificationError(diagnosis)
+        )
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "fp=70b333b7" in logged, "the operator gets the diagnosis"
+    assert "[Public 401]" in logged, "and the existing grep still finds the line"
+    assert b"fp=" not in response.body, "the caller does not"
+    assert b"kid" not in response.body

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -20,6 +20,7 @@ from agentclaw.community.core.gateway_principal import (
     PrincipalVerificationError,
     PrincipalVerifierConfig,
     UserPrincipal,
+    key_fingerprint,
     verify_principal_token,
 )
 from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
@@ -434,3 +435,149 @@ def test_internal_tenant_off_the_wire_is_rejected():
         verify_principal_token(token, CONFIG)
 
     assert "internal tenant" in str(exc.value)
+
+
+# ── operator diagnostics ─────────────────────────────────────────────────────
+#
+# A rejected token answers one fixed 401, so the *log* is the only place the
+# reason survives. These tests pin what that log line must carry, because the
+# failure they exist for — the gateway and this component holding different
+# shared secrets — is otherwise indistinguishable from a forgery.
+
+
+def test_key_fingerprint_matches_the_gateway_golden_values():
+    """The fingerprint is a cross-component contract, pinned by literal value.
+
+    The gateway computes the same digest over its own copy of the key and both
+    sides log it at boot; comparing the two lines is how an operator tells "we
+    hold different secrets" from "the secret is stale". The two implementations
+    live in separate distributions with no shared package, so nothing but this
+    test and its twin in ``src/gateway/tests/unit/plugins/test_principal_signer
+    .py`` stops one side from drifting and quietly making the comparison
+    meaningless. Change these expected values only when both change together.
+    """
+    assert key_fingerprint("k" * 32) == "5e318f8c"
+    assert key_fingerprint("a-shared-secret-of-at-least-32-bytes!!") == "eb128a7a"
+    assert key_fingerprint("rotated-shared-secret-32-bytes-min!!!!") == "21654248"
+
+
+def test_fingerprint_of_no_key_reads_as_unset():
+    """Never a hash of the empty string, which would look like a real key."""
+    assert key_fingerprint("") == "unset"
+
+
+def test_fingerprint_does_not_leak_the_key():
+    assert KEY not in key_fingerprint(KEY)
+    assert len(key_fingerprint(KEY)) == 8
+
+
+def test_config_exposes_its_own_fingerprint():
+    assert CONFIG.key_fingerprint == key_fingerprint(KEY)
+
+
+def test_a_key_mismatch_is_diagnosable_from_the_message_alone():
+    """The failure this whole section exists for.
+
+    ``Signature verification failed`` on its own cannot distinguish a shared
+    secret that drifted from a token nobody we trust minted. The suffix must
+    name the key we judged it against and the signer that produced it.
+    """
+    token = mint([user_principal()], key="not-the-shared-secret-but-also-32-bytes+")
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(token, CONFIG)
+
+    message = str(exc.value)
+    assert "Signature verification failed" in message, "PyJWT's own reason survives"
+    assert f"verifier key fp={key_fingerprint(KEY)}" in message
+    assert "alg='HS256'" in message
+    assert "kid='bare'" in message, "the gateway's bare signer stamps this kid"
+    assert f"aud={AUDIENCE!r}" in message and f"iss={ISSUER!r}" in message
+
+
+def test_the_diagnostic_never_carries_the_key_or_the_token():
+    token = mint([user_principal()], key="not-the-shared-secret-but-also-32-bytes+")
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(token, CONFIG)
+
+    assert KEY not in str(exc.value)
+    assert token not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "reason,token_kwargs",
+    [
+        ("Signature has expired", {"ttl": -3600}),
+        ("Audience doesn't match", {"audience": "baas"}),
+        ("Invalid issuer", {"issuer": "somebody-else"}),
+    ],
+)
+def test_each_failure_mode_keeps_its_own_reason(reason: str, token_kwargs: dict):
+    """The suffix is added to PyJWT's message, never in place of it.
+
+    Collapsing these into one string would cost the operator the first and
+    cheapest split: is this a key problem at all, or a clock/config one?
+    """
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(mint([user_principal()], **token_kwargs), CONFIG)
+
+    assert reason in str(exc.value)
+    assert f"verifier key fp={key_fingerprint(KEY)}" in str(exc.value)
+
+
+def test_a_token_with_no_readable_header_says_so():
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token("not-a-jwt-at-all", CONFIG)
+
+    assert "unparseable JOSE header" in str(exc.value)
+
+
+def test_a_hostile_kid_cannot_forge_log_lines():
+    """The JOSE header is attacker-controlled and reaches a log line.
+
+    A ``kid`` carrying a newline could otherwise append text that reads as a
+    separate log entry, so the field is escaped as well as bounded.
+    """
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 60,
+        "principals": [user_principal()],
+    }
+    token = jwt.encode(
+        claims,
+        "a-different-key-that-is-also-32-bytes!!",
+        algorithm="HS256",
+        headers={"kid": "x\nWARNING - forged log line"},
+    )
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(token, CONFIG)
+
+    message = str(exc.value)
+    assert "\n" not in message, "a newline in kid must not reach the log verbatim"
+    assert "\\n" in message, "it is escaped, not silently dropped"
+
+
+def test_a_long_kid_is_clipped():
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 60,
+        "principals": [user_principal()],
+    }
+    token = jwt.encode(
+        claims,
+        "a-different-key-that-is-also-32-bytes!!",
+        algorithm="HS256",
+        headers={"kid": "K" * 500},
+    )
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(token, CONFIG)
+
+    assert "…" in str(exc.value)
+    assert "K" * 100 not in str(exc.value)

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -478,9 +478,9 @@ def test_config_exposes_its_own_fingerprint():
 def test_a_key_mismatch_is_diagnosable_from_the_message_alone():
     """The failure this whole section exists for.
 
-    ``Signature verification failed`` on its own cannot distinguish a shared
-    secret that drifted from a token nobody we trust minted. The suffix must
-    name the key we judged it against and the signer that produced it.
+    ``Signature verification failed`` on its own cannot say which key the token
+    was judged against. The suffix must name it, alongside the contract this
+    component enforces — all of it read from our own configuration.
     """
     token = mint([user_principal()], key="not-the-shared-secret-but-also-32-bytes+")
 
@@ -490,9 +490,57 @@ def test_a_key_mismatch_is_diagnosable_from_the_message_alone():
     message = str(exc.value)
     assert "Signature verification failed" in message, "PyJWT's own reason survives"
     assert f"verifier key fp={key_fingerprint(KEY)}" in message
-    assert "alg='HS256'" in message
-    assert "kid='bare'" in message, "the gateway's bare signer stamps this kid"
     assert f"aud={AUDIENCE!r}" in message and f"iss={ISSUER!r}" in message
+    assert "alg='HS256'" in message
+    assert "kid='bare'" in message
+
+
+def test_the_jose_header_is_labelled_as_caller_supplied():
+    """A failed signature authenticates nothing, including the header.
+
+    Any caller can stamp ``kid: bare`` on a token they minted, so presenting it
+    as provenance would hand a forger the power to point an operator at a
+    healthy shared secret. The line must mark it as untrusted, and must not
+    claim it identifies the signer.
+    """
+    token = mint([user_principal()], key="not-the-shared-secret-but-also-32-bytes+")
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(token, CONFIG)
+
+    message = str(exc.value)
+    assert "unverified caller-supplied header" in message
+    # The trustworthy half is stated first, so the line reads as
+    # "here is what we hold" before "here is what they claimed".
+    assert message.index("verifier key fp=") < message.index("unverified")
+
+
+def test_a_forged_kid_cannot_impersonate_the_gateway_in_the_log():
+    """The concrete abuse the labelling exists to defuse.
+
+    A forger who never touched our gateway can still present ``kid='bare'``.
+    The message must read the same either way — no wording that would tell an
+    operator this came from their gateway.
+    """
+    claims = {
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 60,
+        "principals": [user_principal()],
+    }
+    forged = jwt.encode(
+        claims, "an-attacker-key-of-at-least-32-bytes!!", algorithm="HS256",
+        headers={"kid": "bare"},
+    )
+
+    with pytest.raises(PrincipalVerificationError) as exc:
+        verify_principal_token(forged, CONFIG)
+
+    message = str(exc.value)
+    assert "unverified caller-supplied header" in message
+    for claim in ("our gateway", "signed by", "produced by", "provenance"):
+        assert claim not in message.lower(), f"must not assert {claim!r}"
 
 
 def test_the_diagnostic_never_carries_the_key_or_the_token():
@@ -530,7 +578,11 @@ def test_a_token_with_no_readable_header_says_so():
     with pytest.raises(PrincipalVerificationError) as exc:
         verify_principal_token("not-a-jwt-at-all", CONFIG)
 
-    assert "unparseable JOSE header" in str(exc.value)
+    message = str(exc.value)
+    assert "unparseable JOSE header" in message
+    assert f"verifier key fp={key_fingerprint(KEY)}" in message, (
+        "the trustworthy half is present even when the header is not"
+    )
 
 
 def test_a_hostile_kid_cannot_forge_log_lines():

--- a/src/backend/tests/community/utils/test_gateway_principal_config.py
+++ b/src/backend/tests/community/utils/test_gateway_principal_config.py
@@ -13,8 +13,11 @@ the verifier answers 401 to everything on an empty key.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
+from agentclaw.community.core.gateway_principal import key_fingerprint
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.gateway_principal_config import (
     get_principal_verifier_config,
@@ -160,10 +163,11 @@ def test_strict_failure_leaves_the_config_denying():
 
 
 def test_no_fallback_key_is_invented():
-    """The gateway's ``bare`` signer keeps a dev fallback; we deliberately do not.
+    """A committed shared secret is a committed credential.
 
-    A committed shared secret is a committed credential, and here "no key" fails
-    safe rather than open.
+    "No key" fails safe rather than open. The gateway's ``bare`` signer used to
+    keep a dev fallback and no longer does, so both ends of this contract now
+    answer an unresolvable key the same way.
     """
     init_principal_verifier_config(_FakeResolver(None), SECRET_NAME, strict=False)
 
@@ -180,3 +184,73 @@ def test_key_is_resolved_once_at_boot():
 
     assert get_principal_verifier_config() is first
     assert resolver.calls == [SECRET_NAME], "resolved once at boot, then reused"
+
+
+# ── boot-time diagnostics ────────────────────────────────────────────────────
+#
+# The two halves of this contract never meet at request time: the gateway signs
+# successfully on every request and only the backend ever sees a mismatch, as a
+# signature failure it cannot attribute. Boot is therefore the one place the two
+# keys can be compared, and these tests pin what makes that comparison possible.
+
+
+def test_boot_logs_a_fingerprint_not_the_key(caplog):
+    """The line an operator diffs against the gateway's.
+
+    A fingerprint rather than the key itself: comparable across components,
+    useless to anyone who reads the log.
+    """
+    with caplog.at_level(logging.INFO):
+        init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+
+    line = "\n".join(r.getMessage() for r in caplog.records)
+    assert f"key fp={key_fingerprint(KEY)}" in line
+    assert f"key len={len(KEY)}" in line, "length separates keys differing only by whitespace"
+    assert SECRET_NAME in line, "names which secret was read, for the wrong-name case"
+    assert KEY not in line, "the key itself never reaches a log"
+
+
+def test_boot_logs_the_contract_it_will_enforce(caplog):
+    """``aud``/``iss`` are hardcoded here and configurable on the gateway.
+
+    Logging them turns "the gateway's issuer was changed and every request now
+    401s" into something readable from a boot line rather than from source.
+    """
+    with caplog.at_level(logging.INFO):
+        init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+
+    line = "\n".join(r.getMessage() for r in caplog.records)
+    assert "aud='backend'" in line
+    assert "iss='gateway'" in line
+
+
+def test_surrounding_whitespace_is_reported_with_both_fingerprints(caplog):
+    """Stripping is otherwise silent, and silence is what makes this bite.
+
+    A gateway released before it stripped signs with the untrimmed bytes, so
+    naming *both* fingerprints makes a mixed-version rollout a grep rather than
+    a second incident.
+    """
+    with caplog.at_level(logging.WARNING):
+        init_principal_verifier_config(
+            _FakeResolver(_Secret(f"  {KEY}\n")), SECRET_NAME, strict=False
+        )
+
+    line = "\n".join(r.getMessage() for r in caplog.records)
+    assert "whitespace" in line
+    assert f"untrimmed={key_fingerprint(f'  {KEY}' + chr(10))}" in line
+    assert f"trimmed={key_fingerprint(KEY)}" in line
+    assert get_principal_verifier_config().signing_key == KEY, "still uses the trimmed key"
+
+
+def test_a_clean_key_reports_no_whitespace(caplog):
+    with caplog.at_level(logging.WARNING):
+        init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+
+    assert "whitespace" not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_two_deployments_holding_the_same_key_log_the_same_fingerprint():
+    """The property the whole diagnostic rests on."""
+    assert key_fingerprint(KEY) == key_fingerprint(KEY)
+    assert key_fingerprint(KEY) != key_fingerprint(KEY + "-rotated")

--- a/src/backend/tests/community/utils/test_gateway_principal_config.py
+++ b/src/backend/tests/community/utils/test_gateway_principal_config.py
@@ -17,7 +17,11 @@ import logging
 
 import pytest
 
-from agentclaw.community.core.gateway_principal import key_fingerprint
+from agentclaw.community.core.gateway_principal import (
+    MIN_SIGNING_KEY_BYTES,
+    is_weak_signing_key,
+    key_fingerprint,
+)
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.gateway_principal_config import (
     get_principal_verifier_config,
@@ -254,3 +258,57 @@ def test_two_deployments_holding_the_same_key_log_the_same_fingerprint():
     """The property the whole diagnostic rests on."""
     assert key_fingerprint(KEY) == key_fingerprint(KEY)
     assert key_fingerprint(KEY) != key_fingerprint(KEY + "-rotated")
+
+
+# ── weak keys ────────────────────────────────────────────────────────────────
+#
+# The boot line publishes a fingerprint, and that is only safe while the key is
+# strong: against a guessable one a truncated digest confirms a dictionary guess
+# offline, and confirming the shared secret means forging any caller identity.
+# Nothing enforces the strength, so it is warned about rather than assumed.
+
+
+WEAK_KEY = "hunter2"
+
+
+def test_a_weak_key_warns_but_still_reports_its_fingerprint(caplog):
+    """Withholding the fingerprint would remove the diagnostic exactly when a
+    deployment is most misconfigured. The remedy is a better secret."""
+    with caplog.at_level(logging.INFO):
+        init_principal_verifier_config(
+            _FakeResolver(_Secret(WEAK_KEY)), SECRET_NAME, strict=False
+        )
+
+    line = "\n".join(r.getMessage() for r in caplog.records)
+    assert f"key fp={key_fingerprint(WEAK_KEY)}" in line, "still diagnosable"
+    assert "below the 32-byte minimum" in line
+    assert "forge any caller identity" in line, "says why it matters"
+    assert WEAK_KEY not in line, "and never prints the key itself"
+
+
+def test_a_strong_key_does_not_warn(caplog):
+    with caplog.at_level(logging.WARNING):
+        init_principal_verifier_config(
+            _FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False
+        )
+
+    assert "minimum" not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_a_weak_key_still_configures_the_verifier(caplog):
+    """A warning, not a refusal: rejecting a short key here would deny every
+    request on a deployment that was at least partly working, which is a
+    bigger change than this diagnostic is entitled to make."""
+    init_principal_verifier_config(
+        _FakeResolver(_Secret(WEAK_KEY)), SECRET_NAME, strict=False
+    )
+
+    assert get_principal_verifier_config().signing_key == WEAK_KEY
+
+
+def test_the_strength_threshold_is_shared_with_the_gateway():
+    """Both ends judge one shared secret by one rule."""
+    assert MIN_SIGNING_KEY_BYTES == 32
+    assert is_weak_signing_key("a" * 31)
+    assert not is_weak_signing_key("a" * 32)
+    assert not is_weak_signing_key(""), "absent is its own state, warned elsewhere"

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -52,8 +52,20 @@ user_config:
 
   # PrincipalSigner (JWT client) config. The signing key is a secret and is
   # resolved at runtime via the SecretResolver using ``secret_name``; the
-  # remaining fields are non-secret and live here. A missing/empty key falls
-  # back to a dev key (single-box/tests only — NOT for production).
+  # remaining fields are non-secret and live here. With the community resolver
+  # above that means AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE, and its value
+  # must equal the one the upstream verifies with — both sides log a
+  # fingerprint of it at boot so the two can be compared without printing it.
+  #
+  # There is NO fallback key. A missing or empty value refuses the boot in
+  # pre/prod, and elsewhere leaves the gateway unable to sign, so every
+  # forwarded request answers 500 rather than carrying an identity no upstream
+  # can verify. The dev key that used to fill this gap was a committed
+  # credential, and no upstream accepted tokens signed with it anyway.
+  #
+  # `issuer` is a two-sided contract: the backend pins the value it accepts in
+  # code, so changing this requires changing that constant in the same release
+  # or every request 401s.
   principal_signer:
     secret_name: "principal_signing_key"
     kid: "bare"

--- a/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
+++ b/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
@@ -23,11 +23,20 @@ from gateway.community.plugins.principal_signer.bare import (
 from gateway.community.spi.principal_signer import PrincipalSigner
 from gateway.community.spi.secret_resolver import SecretResolver
 
-# Deployment profiles that must have a real signing key. Read from the same
-# ``SERVER_ENV`` the config loader reads and gated on the same two values the
-# backend gates its verifier on, so one contract has one rule rather than a
-# per-side interpretation of it.
-_STRICT_ENVS = ("pre", "prod")
+# ``SERVER_ENV`` spellings that mean a deployment which must have a real signing
+# key. Read from the same variable the config loader reads.
+#
+# The **aliases are load-bearing**, not defensive padding. The backend does not
+# compare ``SERVER_ENV`` raw: ``utils/env_utils.py::get_current_env`` folds
+# ``prepub`` into ``pre`` and ``gray`` into ``prod`` before gating its verifier
+# on the result. Both aliases are reachable — ``scripts/app.sh`` exports
+# ``SERVER_ENV=prepub`` for its supported ``--env prepub`` — and a raw
+# comparison here would silently split the two sides apart in exactly those
+# profiles: the backend refuses to boot without a key while the gateway boots
+# and answers 500 per request. That is the "one contract, one rule" claim
+# failing in the deployments that most need it, so the two mappings must stay in
+# step. Backend-side change here means a change there, and vice versa.
+_STRICT_ENVS = frozenset({"pre", "prepub", "prod", "gray"})
 
 
 def build_principal_signer(
@@ -43,12 +52,15 @@ def build_principal_signer(
     is handed.
 
     Raises:
-        PrincipalSigningKeyMissingError: in ``pre``/``prod`` with no key.
+        PrincipalSigningKeyMissingError: in a strict profile with no key —
+            ``pre``/``prepub``/``prod``/``gray``, matching what the backend
+            normalizes those spellings to.
     """
+    server_env = os.getenv("SERVER_ENV", "").strip().lower()
     return BarePrincipalSigner(
         load_signer_config(
             user_config.principal_signer,
             secret_resolver,
-            strict=os.getenv("SERVER_ENV", "").strip() in _STRICT_ENVS,
+            strict=server_env in _STRICT_ENVS,
         )
     )

--- a/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
+++ b/src/gateway/src/gateway/community/bootstrap/_principal_signer.py
@@ -13,6 +13,8 @@ it at the forwarder seam.
 
 from __future__ import annotations
 
+import os
+
 from gateway.community.config import UserConfig
 from gateway.community.plugins.principal_signer.bare import (
     BarePrincipalSigner,
@@ -21,13 +23,32 @@ from gateway.community.plugins.principal_signer.bare import (
 from gateway.community.spi.principal_signer import PrincipalSigner
 from gateway.community.spi.secret_resolver import SecretResolver
 
+# Deployment profiles that must have a real signing key. Read from the same
+# ``SERVER_ENV`` the config loader reads and gated on the same two values the
+# backend gates its verifier on, so one contract has one rule rather than a
+# per-side interpretation of it.
+_STRICT_ENVS = ("pre", "prod")
+
 
 def build_principal_signer(
     *,
     user_config: UserConfig,
     secret_resolver: SecretResolver,
 ) -> PrincipalSigner:
-    """Build the PrincipalSigner from typed config + a resolved SecretResolver."""
+    """Build the PrincipalSigner from typed config + a resolved SecretResolver.
+
+    Reads ``SERVER_ENV`` to decide whether a missing key is fatal. The
+    environment read belongs here rather than in the plugin: this is the
+    composition root, and the plugin stays a pure function of the arguments it
+    is handed.
+
+    Raises:
+        PrincipalSigningKeyMissingError: in ``pre``/``prod`` with no key.
+    """
     return BarePrincipalSigner(
-        load_signer_config(user_config.principal_signer, secret_resolver)
+        load_signer_config(
+            user_config.principal_signer,
+            secret_resolver,
+            strict=os.getenv("SERVER_ENV", "").strip() in _STRICT_ENVS,
+        )
     )

--- a/src/gateway/src/gateway/community/plugins/principal_signer/bare/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/principal_signer/bare/__init__.py
@@ -1,7 +1,15 @@
 from gateway.community.plugins.principal_signer.bare._plugin import (
     BarePrincipalSigner,
     PrincipalSignerConfig,
+    PrincipalSigningKeyMissingError,
+    key_fingerprint,
     load_signer_config,
 )
 
-__all__ = ["BarePrincipalSigner", "PrincipalSignerConfig", "load_signer_config"]
+__all__ = [
+    "BarePrincipalSigner",
+    "PrincipalSignerConfig",
+    "PrincipalSigningKeyMissingError",
+    "key_fingerprint",
+    "load_signer_config",
+]

--- a/src/gateway/src/gateway/community/plugins/principal_signer/bare/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/principal_signer/bare/__init__.py
@@ -1,15 +1,19 @@
 from gateway.community.plugins.principal_signer.bare._plugin import (
+    MIN_SIGNING_KEY_BYTES,
     BarePrincipalSigner,
     PrincipalSignerConfig,
     PrincipalSigningKeyMissingError,
+    is_weak_signing_key,
     key_fingerprint,
     load_signer_config,
 )
 
 __all__ = [
+    "MIN_SIGNING_KEY_BYTES",
     "BarePrincipalSigner",
     "PrincipalSignerConfig",
     "PrincipalSigningKeyMissingError",
+    "is_weak_signing_key",
     "key_fingerprint",
     "load_signer_config",
 ]

--- a/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
+++ b/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
@@ -8,10 +8,29 @@ for rotation). NOT production-grade — sofa uses asymmetric signing + KMS
 The signing key is resolved via the :class:`SecretResolver` SPI (community
 flavor reads it from the environment); ``kid`` / ``issuer`` / ``ttl_seconds``
 are non-secret and come from ``user_config.principal_signer``.
+
+**There is no fallback key.** An unresolvable secret used to mean "sign with a
+committed constant", which was worse than useless in both directions: a
+committed shared secret is a committed credential, and no peer would have
+accepted those tokens anyway — the backend ships no fallback, so it never holds
+the constant this side would have signed with. The only thing the fallback
+bought was the *appearance* of a working gateway, paid for with a signature
+failure on another host that named neither this component nor this cause.
+
+So a missing key now fails closed, mirroring the backend's contract exactly:
+
+- in ``pre``/``prod`` the process refuses to boot — see ``strict`` on
+  :func:`load_signer_config`. A gateway that cannot sign is broken, not
+  degraded, and the rollout should fail rather than a ticket land later.
+- everywhere else it boots with an empty key and :meth:`BarePrincipalSigner.sign`
+  raises on every attempt. The forwarder already answers ``500 principal
+  signing failed`` and logs the traceback, so the failure names the component
+  that is actually misconfigured.
 """
 
 from __future__ import annotations
 
+import hashlib
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -19,10 +38,47 @@ from dataclasses import dataclass
 import jwt
 
 from gateway.community.config import PrincipalSignerPluginConfig
+from gateway.community.logger import get_logger
 from gateway.community.spi.authn import Principal, PrincipalType
 from gateway.community.spi.secret_resolver import SecretResolver
 
-_DEV_FALLBACK_KEY = "avernet-dev-signing-key-NOT-FOR-PROD"
+# What a fingerprint of no key at all reads as. Mirrors the backend so the two
+# log lines are comparable even in the degenerate case.
+_UNSET_FINGERPRINT = "unset"
+
+
+class PrincipalSigningKeyMissingError(RuntimeError):
+    """Raised when a signature is asked for and no signing key was resolved.
+
+    A distinct type so the boot-time refusal and the request-time refusal are
+    the same fact told twice, and so a caller can tell "misconfigured" from any
+    other signing failure.
+    """
+
+
+def key_fingerprint(key: str) -> str:
+    """A short, non-reversible fingerprint of the shared signing key.
+
+    **This algorithm is a cross-component contract**, duplicated rather than
+    shared because the gateway and the backend are separate distributions with
+    no common package. The backend computes the identical value in
+    ``agentclaw.community.core.gateway_principal.verifier.key_fingerprint`` and
+    logs it at boot; comparing the two log lines is how an operator answers "do
+    both ends hold the same secret?" without either side printing a credential.
+
+    The duplication is the risk, so both suites pin the same golden values for
+    the same inputs — change the algorithm here alone and those tests fail
+    rather than the comparison quietly becoming meaningless.
+
+    Safe to log: SHA-256 is not reversible and the shared key is required to be
+    at least 32 random bytes, so a truncated digest is no practical
+    brute-force oracle for someone who can already read the logs. Safe to log
+    is not safe to *serve* — this must never appear on an HTTP endpoint, where
+    it would let an unauthenticated caller confirm a guessed key.
+    """
+    if not key:
+        return _UNSET_FINGERPRINT
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
 
 
 @dataclass(frozen=True)
@@ -33,6 +89,11 @@ class PrincipalSignerConfig:
     kid: str = "bare"
     issuer: str = "gateway"
     ttl_seconds: int = 60
+
+    @property
+    def key_fingerprint(self) -> str:
+        """This config's key as :func:`key_fingerprint` renders it for a log."""
+        return key_fingerprint(self.signing_key)
 
 
 class BarePrincipalSigner:
@@ -61,6 +122,19 @@ class BarePrincipalSigner:
         return await self.sign_token(claims)
 
     async def sign_token(self, claims: Mapping[str, object]) -> str:
+        if not self._cfg.signing_key:
+            # Refusing beats signing with nothing. PyJWT will happily HMAC with
+            # an empty key, and the result is a token whose "signature" anyone
+            # can reproduce — an unauthenticated caller could then mint any
+            # identity for any upstream that made the same mistake. The
+            # forwarder turns this into ``500 principal signing failed`` with a
+            # traceback, so the error names this component rather than
+            # surfacing as an unattributable 401 one hop away.
+            raise PrincipalSigningKeyMissingError(
+                "no principal signing key is configured, so this gateway "
+                "cannot assert any identity to an upstream. Provision the "
+                "secret named by user_config.principal_signer.secret_name."
+            )
         return jwt.encode(
             claims,
             self._cfg.signing_key,
@@ -73,40 +147,103 @@ def _resolve_signing_key(
     signer_cfg: PrincipalSignerPluginConfig,
     secret_resolver: SecretResolver,
 ) -> str:
-    """Resolve the HMAC signing key via the SecretResolver, with a dev fallback.
+    """Resolve the HMAC signing key via the SecretResolver, or return ``""``.
 
-    A missing secret (resolver returns ``None`` or an empty value) falls back to
-    a fixed dev secret and logs a warning — fine for single-box/tests, NOT for
-    production. sofa (asymmetric + KMS) resolves a real key through the same
+    ``""`` means this deployment has no key. There is no stand-in: see the
+    module docstring for why the previous dev fallback was removed rather than
+    made louder. sofa (asymmetric + KMS) resolves a real key through the same
     SecretResolver seam.
-    """
-    material = secret_resolver.get_secret(signer_cfg.secret_name)
-    key = getattr(material, "secret_value", "") or ""
-    if not key:
-        from gateway.community.logger import get_logger
 
-        get_logger("principal_signer").warning(
-            "Principal signing key not found via SecretResolver (secret_name=%r) "
-            "— using dev fallback key (NOT for production).",
+    The resolved value is **stripped**, matching what the backend does to its
+    copy (``utils/gateway_principal_config.py``). Without that the two sides
+    disagree over any secret provisioned with a trailing newline — each looks
+    correctly configured, every token fails its signature check, and nothing
+    on either side says why.
+    """
+    log = get_logger("principal_signer")
+    material = secret_resolver.get_secret(signer_cfg.secret_name)
+    raw = getattr(material, "secret_value", "") or ""
+    key = raw.strip()
+    if not key:
+        # Says what will happen, not just what was not found: the consequence
+        # of an unresolved key lands on every subsequent request, and the
+        # operator reading this line is the one who can prevent that.
+        log.warning(
+            "Principal signing key not found via SecretResolver "
+            "(secret_name=%r) — this gateway cannot sign any identity, so "
+            "every forwarded request will fail with 'principal signing "
+            "failed'. Provision the secret's value in this environment.",
             signer_cfg.secret_name,
         )
-        key = _DEV_FALLBACK_KEY
+        return ""
+
+    if key != raw:
+        log.warning(
+            "Principal signing key (secret_name=%r) carries %d character(s) "
+            "of surrounding whitespace, which is stripped before use "
+            "(fp untrimmed=%s, trimmed=%s). Provision the value without it so "
+            "both ends of the contract hash the same bytes.",
+            signer_cfg.secret_name,
+            len(raw) - len(key),
+            key_fingerprint(raw),
+            key_fingerprint(key),
+        )
     return key
 
 
 def load_signer_config(
     signer_cfg: PrincipalSignerPluginConfig,
     secret_resolver: SecretResolver,
+    *,
+    strict: bool,
 ) -> PrincipalSignerConfig:
     """Build :class:`PrincipalSignerConfig` from typed config + SecretResolver.
 
     Non-secret fields (``kid`` / ``issuer`` / ``ttl_seconds``) come from the
     ``user_config.principal_signer`` block; the signing key is resolved via
     ``secret_resolver`` using ``signer_cfg.secret_name``.
+
+    ``strict`` decides what an unresolvable key means, and mirrors the same
+    argument on the backend's ``init_principal_verifier_config`` — one contract,
+    one rule, told the same way on both sides. ``True`` (``pre``/``prod``)
+    raises, because a gateway that cannot assert an identity serves nothing and
+    should fail its rollout rather than every request. ``False`` boots with an
+    empty key for the environments that legitimately have none, where each
+    attempt to sign then refuses individually.
+
+    Raises:
+        PrincipalSigningKeyMissingError: when ``strict`` and no key resolved.
     """
-    return PrincipalSignerConfig(
-        signing_key=_resolve_signing_key(signer_cfg, secret_resolver),
+    signing_key = _resolve_signing_key(signer_cfg, secret_resolver)
+    if not signing_key and strict:
+        raise PrincipalSigningKeyMissingError(
+            "no principal signing key resolved: "
+            f"user_config.principal_signer.secret_name={signer_cfg.secret_name!r} "
+            "produced no value. This gateway could not assert any identity to "
+            "an upstream, so this environment refuses to boot. Provision the "
+            "secret's value in this profile's secret store."
+        )
+
+    config = PrincipalSignerConfig(
+        signing_key=signing_key,
         kid=signer_cfg.kid,
         issuer=signer_cfg.issuer,
         ttl_seconds=signer_cfg.ttl_seconds,
     )
+    # The counterpart to the backend's boot line. Signing succeeds regardless of
+    # *which* key is held, so this side observes nothing when the two disagree —
+    # only the upstream does, as a signature failure it cannot attribute.
+    # Emitting the fingerprint here is what makes the two halves comparable at
+    # all, and ``iss`` rides along because it is configurable on this side and
+    # hardcoded on the other: change it here alone and every request 401s.
+    get_logger("principal_signer").info(
+        "principal signer configured (secret=%r, key fp=%s, key len=%d, "
+        "kid=%r, iss=%r, ttl=%ds)",
+        signer_cfg.secret_name,
+        config.key_fingerprint,
+        len(config.signing_key),
+        config.kid,
+        config.issuer,
+        config.ttl_seconds,
+    )
+    return config

--- a/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
+++ b/src/gateway/src/gateway/community/plugins/principal_signer/bare/_plugin.py
@@ -19,9 +19,13 @@ failure on another host that named neither this component nor this cause.
 
 So a missing key now fails closed, mirroring the backend's contract exactly:
 
-- in ``pre``/``prod`` the process refuses to boot — see ``strict`` on
-  :func:`load_signer_config`. A gateway that cannot sign is broken, not
-  degraded, and the rollout should fail rather than a ticket land later.
+- in a strict profile the process refuses to boot — see ``strict`` on
+  :func:`load_signer_config`, and ``_STRICT_ENVS`` in
+  ``bootstrap/_principal_signer.py`` for which ``SERVER_ENV`` spellings those
+  are (``prepub`` and ``gray`` are aliases the backend folds into ``pre`` and
+  ``prod``, so both sides must honour them or the contract splits). A gateway
+  that cannot sign is broken, not degraded, and the rollout should fail rather
+  than a ticket land later.
 - everywhere else it boots with an empty key and :meth:`BarePrincipalSigner.sign`
   raises on every attempt. The forwarder already answers ``500 principal
   signing failed`` and logs the traceback, so the failure names the component
@@ -45,6 +49,24 @@ from gateway.community.spi.secret_resolver import SecretResolver
 # What a fingerprint of no key at all reads as. Mirrors the backend so the two
 # log lines are comparable even in the degenerate case.
 _UNSET_FINGERPRINT = "unset"
+
+# RFC 7518 §3.2: an HMAC key for SHA-256 must be at least as long as the hash
+# output. Mirrors the backend's constant of the same name — this is one shared
+# secret, so both ends judge its strength by the same rule.
+MIN_SIGNING_KEY_BYTES = 32
+
+
+def is_weak_signing_key(key: str) -> bool:
+    """Whether ``key`` is below the strength the shared-secret contract assumes.
+
+    Length is a coarse proxy for entropy — it cannot tell 32 random bytes from
+    32 repetitions of ``a`` — but the keys that turn up short are overwhelmingly
+    the human-chosen ones, so it catches the case that matters. Measured in
+    bytes, not characters, because that is what HMAC consumes — a non-ASCII
+    passphrase carries more bytes than it has characters, and counting
+    characters would reject a key the algorithm is content with.
+    """
+    return 0 < len(key.encode("utf-8")) < MIN_SIGNING_KEY_BYTES
 
 
 class PrincipalSigningKeyMissingError(RuntimeError):
@@ -70,11 +92,16 @@ def key_fingerprint(key: str) -> str:
     the same inputs — change the algorithm here alone and those tests fail
     rather than the comparison quietly becoming meaningless.
 
-    Safe to log: SHA-256 is not reversible and the shared key is required to be
-    at least 32 random bytes, so a truncated digest is no practical
-    brute-force oracle for someone who can already read the logs. Safe to log
-    is not safe to *serve* — this must never appear on an HTTP endpoint, where
-    it would let an unauthenticated caller confirm a guessed key.
+    Safe to log **for a key of the mandated strength**, and the qualifier is the
+    argument: SHA-256 is not reversible, so against ≥32 random bytes a truncated
+    digest is no practical brute-force oracle for someone who can already read
+    the logs. Against a short or human-chosen key it *is* one, and confirming
+    the shared secret means being able to forge identity tokens. Nothing
+    enforces that strength, so :func:`is_weak_signing_key` gates a boot warning
+    rather than the precondition being merely asserted.
+
+    Safe to log is not safe to *serve* — this must never appear on an HTTP
+    endpoint, where it would let an unauthenticated caller confirm a guessed key.
     """
     if not key:
         return _UNSET_FINGERPRINT
@@ -246,4 +273,20 @@ def load_signer_config(
         config.issuer,
         config.ttl_seconds,
     )
+    if is_weak_signing_key(config.signing_key):
+        # The line above publishes a fingerprint of this key, which is only
+        # safe while the key is strong — against a guessable one a truncated
+        # digest confirms a dictionary guess offline. Warn rather than withhold
+        # the fingerprint: the diagnostic matters most on a misconfigured
+        # deployment, and the real remedy is a better secret.
+        get_logger("principal_signer").warning(
+            "the principal signing key is %d bytes, below the %d-byte minimum "
+            "for HMAC-SHA256 (RFC 7518 §3.2). Replace it with at least %d "
+            "random bytes: a guessable shared secret can be recovered from the "
+            "fingerprint logged above, and whoever recovers it can forge any "
+            "caller identity to every upstream.",
+            len(config.signing_key.encode("utf-8")),
+            MIN_SIGNING_KEY_BYTES,
+            MIN_SIGNING_KEY_BYTES,
+        )
     return config

--- a/src/gateway/tests/integration/test_admin_issuance.py
+++ b/src/gateway/tests/integration/test_admin_issuance.py
@@ -3,13 +3,27 @@
 from __future__ import annotations
 
 import jwt
+import pytest
 from httpx import ASGITransport, AsyncClient
 
 from gateway.community.adapters.web.app import create_app
 from gateway.community.bootstrap import get_container
 from gateway.community.core.access_key import AccessKeyRepository
 from gateway.community.core.app import AppRepository
-from gateway.community.plugins.principal_signer.bare._plugin import _DEV_FALLBACK_KEY
+
+# Issued credentials are signed with the gateway's principal signing key, so
+# these tests provision one the way a deployment does. They previously decoded
+# with the plugin's committed dev fallback; that fallback is gone, because
+# minting access-key and app tokens under a key published in the source tree
+# means anyone holding the source can mint them too.
+_TEST_KEY = "integration-test-shared-secret-32b!!"
+
+
+@pytest.fixture(autouse=True)
+def _signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provision the key before ``create_app()``; the community resolver reads
+    ``{env_prefix}{NAME}_VALUE`` (``configs/application.yaml``)."""
+    monkeypatch.setenv("AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE", _TEST_KEY)
 
 
 async def test_issue_access_key_via_http() -> None:
@@ -31,7 +45,7 @@ async def test_issue_access_key_via_http() -> None:
     assert body["tenant"] == "t"
     token = body["token"]
 
-    decoded = jwt.decode(token, _DEV_FALLBACK_KEY, algorithms=["HS256"])
+    decoded = jwt.decode(token, _TEST_KEY, algorithms=["HS256"])
     assert decoded["typ"] == "access_key"
     assert decoded["sub"] == "ak-http"
 
@@ -64,7 +78,7 @@ async def test_register_app_via_http() -> None:
     assert body["status"] == "ACTIVE"
     token = body["token"]
 
-    decoded = jwt.decode(token, _DEV_FALLBACK_KEY, algorithms=["HS256"])
+    decoded = jwt.decode(token, _TEST_KEY, algorithms=["HS256"])
     assert decoded["typ"] == "app"
     assert decoded["sub"] == "Http App"
     assert "exp" not in decoded

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -28,6 +28,17 @@ Receive = Callable[[], Awaitable[dict[str, Any]]]
 Send = Callable[[dict[str, Any]], Awaitable[None]]
 
 
+# The gateway signs every forwarded identity, and there is no fallback key, so
+# a test that forwards has to provision one exactly as a deployment does: the
+# community resolver reads ``{env_prefix}{NAME}_VALUE``.
+_TEST_KEY = "integration-test-shared-secret-32b!!"
+
+
+@pytest.fixture(autouse=True)
+def _signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE", _TEST_KEY)
+
+
 def _load_user_config() -> UserConfig:
     return ConfigLoader.load().user_config
 

--- a/src/gateway/tests/integration/test_forward_signs_principal.py
+++ b/src/gateway/tests/integration/test_forward_signs_principal.py
@@ -10,7 +10,10 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from gateway.community.adapters.web.app import create_app
-from gateway.community.plugins.principal_signer.bare._plugin import _DEV_FALLBACK_KEY
+from gateway.community.plugins.principal_signer.bare import (
+    BarePrincipalSigner,
+    PrincipalSignerConfig,
+)
 from gateway.community.spi.authn import (
     AppPrincipal,
     Principal,
@@ -20,6 +23,12 @@ from gateway.community.spi.authn import (
 from gateway.community.spi.forwarder import ForwardRequest, ForwardResponse
 
 _PRINCIPAL_HEADER = "X-Avernet-Principal"
+
+# The signing key this test's app is given, explicitly. It used to decode with
+# the plugin's dev fallback, which coupled the test to a committed credential
+# and to the gateway booting with one; the fallback is gone, so the test
+# provisions a key the way a deployment does.
+_TEST_KEY = "integration-test-shared-secret-32b!!"
 
 
 class _StubAuthenticator:
@@ -66,6 +75,9 @@ def app_with_capture() -> tuple:
     forwarder = _CapturingForwarder()
     app.state.authenticator = _StubAuthenticator()
     app.state.forwarder = forwarder
+    app.state.principal_signer = BarePrincipalSigner(
+        PrincipalSignerConfig(signing_key=_TEST_KEY)
+    )
     return app, forwarder
 
 
@@ -83,7 +95,7 @@ async def test_forward_signs_principal_with_server_audience(
     # `bots` domain -> server "backend" (configs/upstreams.yaml).
     decoded = jwt.decode(
         token,
-        _DEV_FALLBACK_KEY,
+        _TEST_KEY,
         algorithms=["HS256"],
         audience="backend",
         issuer="gateway",
@@ -124,3 +136,44 @@ async def test_forward_returns_500_when_signing_fails() -> None:
         resp = await client.get("/openapi/v1/bots/x")
 
     assert resp.status_code == 500
+
+
+async def test_forward_returns_500_when_no_signing_key_is_configured() -> None:
+    """The end state of removing the dev fallback, seen from the wire.
+
+    A gateway with no key used to sign with a committed constant and forward
+    happily; the failure then surfaced as a 401 from an upstream, naming
+    neither this component nor the cause. Now it fails here, as a 500 whose log
+    line points at the unprovisioned secret.
+    """
+    app = create_app()
+    app.state.authenticator = _StubAuthenticator()
+    app.state.forwarder = _CapturingForwarder()
+    app.state.principal_signer = BarePrincipalSigner(
+        PrincipalSignerConfig(signing_key="")
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/openapi/v1/bots/x")
+
+    assert resp.status_code == 500
+
+
+async def test_an_unsigned_token_is_never_forwarded() -> None:
+    """The property the 500 protects: no header rather than a forgeable one.
+
+    HMAC over an empty key produces a signature anyone can reproduce, so
+    emitting it would be strictly worse than emitting nothing.
+    """
+    app = create_app()
+    forwarder = _CapturingForwarder()
+    app.state.authenticator = _StubAuthenticator()
+    app.state.forwarder = forwarder
+    app.state.principal_signer = BarePrincipalSigner(
+        PrincipalSignerConfig(signing_key="")
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/openapi/v1/bots/x")
+
+    assert forwarder.captured is None, "the request never reached the upstream"

--- a/src/gateway/tests/unit/plugins/test_principal_signer.py
+++ b/src/gateway/tests/unit/plugins/test_principal_signer.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import logging
+import pathlib
 import time as _time
+from contextlib import contextmanager
 from dataclasses import dataclass
 
 import jwt
 import pytest
 
 from gateway.community.config import PrincipalSignerPluginConfig
+from gateway.community.logger import get_logger
 from gateway.community.plugins.principal_signer.bare import (
     BarePrincipalSigner,
     PrincipalSignerConfig,
+    PrincipalSigningKeyMissingError,
+    key_fingerprint,
     load_signer_config,
 )
 from gateway.community.spi.authn import AppPrincipal, ThirdPartyApp
@@ -114,7 +120,9 @@ def _block(
 
 def test_load_signer_config_reads_key_from_resolver_and_params_from_config() -> None:
     cfg = load_signer_config(
-        _block(kid="k7", issuer="gw", ttl_seconds=30), _FakeResolver("envk")
+        _block(kid="k7", issuer="gw", ttl_seconds=30),
+        _FakeResolver("envk"),
+        strict=False,
     )
     assert cfg.signing_key == "envk"
     assert cfg.kid == "k7"
@@ -122,9 +130,11 @@ def test_load_signer_config_reads_key_from_resolver_and_params_from_config() -> 
     assert cfg.ttl_seconds == 30
 
 
-def test_load_signer_config_dev_fallback_when_secret_absent() -> None:
-    cfg = load_signer_config(_block(), _FakeResolver(None))
-    assert cfg.signing_key  # dev fallback present
+def test_load_signer_config_leaves_the_key_empty_when_the_secret_is_absent() -> None:
+    """No stand-in key. The non-secret parameters still load normally."""
+    cfg = load_signer_config(_block(), _FakeResolver(None), strict=False)
+
+    assert cfg.signing_key == ""
     assert cfg.kid == "bare"
     assert cfg.issuer == "gateway"
     assert cfg.ttl_seconds == 60
@@ -147,3 +157,220 @@ async def test_sign_token_signs_arbitrary_claims_with_kid_header() -> None:
     assert decoded["tenant"] == "t"
     assert decoded["jti"] == "j1"
     assert jwt.get_unverified_header(token)["kid"] == "bare"
+
+
+# ── boot-time diagnostics ────────────────────────────────────────────────────
+#
+# Signing never fails, so this side observes nothing when its key and the
+# upstream's disagree — only the upstream does, as a signature failure it cannot
+# attribute to a cause. Boot is the one place the two keys can be compared, and
+# these tests pin what makes that comparison possible.
+
+
+@contextmanager
+def _captured(level: int = logging.INFO):
+    """Collect the signer logger's own records.
+
+    ``caplog`` cannot see them: ``BareLoggerPlugin`` sets ``propagate = False``
+    on every logger it hands out, so nothing reaches the root handler pytest
+    installs. Attaching to the logger under test is both deterministic and
+    independent of test order — relying on caplog here made these assertions
+    pass or fail depending on which test ran first.
+    """
+    logger = get_logger("principal_signer")
+    records: list[logging.LogRecord] = []
+
+    class _Collect(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Collect(level)
+    previous = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+def _lines(records: list[logging.LogRecord]) -> str:
+    return "\n".join(record.getMessage() for record in records)
+
+
+def test_key_fingerprint_matches_the_backend_golden_values() -> None:
+    """The fingerprint is a cross-component contract, pinned by literal value.
+
+    The backend computes the identical digest over its copy of the shared key
+    (``agentclaw.community.core.gateway_principal.verifier.key_fingerprint``)
+    and logs it at boot; diffing the two lines is how an operator answers "do
+    both ends hold the same secret?". The two implementations live in separate
+    distributions with no shared package, so nothing but this test and its twin
+    in ``src/backend/tests/community/core/gateway_principal/test_verifier.py``
+    stops one side from drifting and quietly making the comparison meaningless.
+    Change these expected values only when both change together.
+    """
+    assert key_fingerprint("k" * 32) == "5e318f8c"
+    assert key_fingerprint("a-shared-secret-of-at-least-32-bytes!!") == "eb128a7a"
+    assert key_fingerprint("rotated-shared-secret-32-bytes-min!!!!") == "21654248"
+
+
+def test_fingerprint_of_no_key_reads_as_unset() -> None:
+    assert key_fingerprint("") == "unset"
+
+
+def test_fingerprint_does_not_leak_the_key() -> None:
+    secret = "a-shared-secret-of-at-least-32-bytes!!"
+    assert secret not in key_fingerprint(secret)
+    assert len(key_fingerprint(secret)) == 8
+
+
+def test_config_exposes_its_own_fingerprint() -> None:
+    assert _cfg("envk").key_fingerprint == key_fingerprint("envk")
+
+
+def test_surrounding_whitespace_is_stripped_to_match_the_backend() -> None:
+    """The asymmetry this closes was invisible from both sides.
+
+    The backend strips its copy. A key provisioned with a trailing newline —
+    routine when a secret is injected from a file — otherwise left the two ends
+    hashing different bytes while each looked correctly configured, and every
+    token failed its signature check with nothing anywhere saying why.
+    """
+    cfg = load_signer_config(_block(), _FakeResolver("  envk\n"), strict=False)
+
+    assert cfg.signing_key == "envk"
+    assert cfg.key_fingerprint == key_fingerprint("envk")
+
+
+def test_a_whitespace_only_key_counts_as_no_key() -> None:
+    cfg = load_signer_config(_block(), _FakeResolver("   \n"), strict=False)
+
+    assert cfg.signing_key == ""
+
+
+def test_no_key_is_visible_as_unset_in_the_boot_line() -> None:
+    """``key fp=unset`` against a backend reporting a real fp is the diagnosis."""
+    cfg = load_signer_config(_block(), _FakeResolver(None), strict=False)
+
+    assert cfg.key_fingerprint == "unset"
+
+
+def test_boot_logs_a_fingerprint_not_the_key() -> None:
+    secret = "a-shared-secret-of-at-least-32-bytes!!"
+
+    with _captured() as records:
+        load_signer_config(
+            _block(issuer="gateway"), _FakeResolver(secret), strict=False
+        )
+
+    line = _lines(records)
+    assert f"key fp={key_fingerprint(secret)}" in line
+    assert f"key len={len(secret)}" in line
+    assert "iss='gateway'" in line, "configurable here, hardcoded on the backend"
+    assert secret not in line, "the key itself never reaches a log"
+
+
+def test_the_missing_key_warning_says_what_will_happen() -> None:
+    """A line that only reports what was not found leaves the operator to make
+    the connection to a failing request during an incident."""
+    with _captured(logging.WARNING) as records:
+        load_signer_config(_block(), _FakeResolver(None), strict=False)
+
+    line = _lines(records)
+    assert "cannot sign" in line
+    assert "principal signing failed" in line, "names the error it will produce"
+    assert _block().secret_name in line, "and the secret to provision"
+
+
+def test_whitespace_is_reported_with_both_fingerprints() -> None:
+    """A gateway released before it stripped signs with the untrimmed bytes, so
+    naming both makes a mixed-version rollout a grep rather than an incident."""
+    with _captured(logging.WARNING) as records:
+        load_signer_config(_block(), _FakeResolver("  envk\n"), strict=False)
+
+    line = _lines(records)
+    assert f"untrimmed={key_fingerprint('  envk' + chr(10))}" in line
+    assert f"trimmed={key_fingerprint('envk')}" in line
+
+
+def test_a_clean_key_reports_no_whitespace() -> None:
+    with _captured(logging.WARNING) as records:
+        load_signer_config(_block(), _FakeResolver("envk"), strict=False)
+
+    assert "whitespace" not in _lines(records)
+
+
+# ── no key means no signature ────────────────────────────────────────────────
+#
+# The dev fallback this replaces was worse than useless in both directions: a
+# committed shared secret is a committed credential, and no peer would have
+# accepted those tokens anyway, because the backend ships no fallback and so
+# never holds the constant this side signed with. All it bought was a gateway
+# that looked healthy while every request failed one hop away, attributed to
+# the wrong component.
+
+
+async def test_signing_without_a_key_refuses_rather_than_signing_with_nothing() -> None:
+    """PyJWT will HMAC with an empty key, and that token is forgeable by anyone.
+
+    Refusing keeps the failure inside the component that is misconfigured. The
+    forwarder already turns this into ``500 principal signing failed`` with a
+    traceback, so the operator is pointed here rather than at an unattributable
+    401 from an upstream.
+    """
+    signer = BarePrincipalSigner(_cfg(key=""), clock=lambda: _FIXED_NOW)
+
+    with pytest.raises(PrincipalSigningKeyMissingError) as exc:
+        await signer.sign({"app": _app_principal()}, audience="secbaas")
+
+    assert "secret_name" in str(exc.value), "names the knob that fixes it"
+
+
+async def test_sign_token_refuses_without_a_key_too() -> None:
+    """Both entry points, so no caller can route around the check."""
+    signer = BarePrincipalSigner(_cfg(key=""), clock=lambda: _FIXED_NOW)
+
+    with pytest.raises(PrincipalSigningKeyMissingError):
+        await signer.sign_token({"iss": "gateway"})
+
+
+def test_strict_boot_refuses_when_no_key_resolves() -> None:
+    """``pre``/``prod`` fail the rollout instead of every request.
+
+    Mirrors the backend's ``init_principal_verifier_config(..., strict=True)``:
+    one contract, one rule, told the same way on both sides.
+    """
+    with pytest.raises(PrincipalSigningKeyMissingError, match="refuses to boot"):
+        load_signer_config(_block(), _FakeResolver(None), strict=True)
+
+
+def test_strict_boot_succeeds_with_a_key() -> None:
+    cfg = load_signer_config(_block(), _FakeResolver("envk"), strict=True)
+
+    assert cfg.signing_key == "envk"
+
+
+def test_non_strict_boot_survives_without_a_key() -> None:
+    """Local, dev and singlebox legitimately have none and must stay bootable.
+
+    They are not thereby working: every signature attempt refuses individually.
+    """
+    cfg = load_signer_config(_block(), _FakeResolver(None), strict=False)
+
+    assert cfg.signing_key == ""
+
+
+def test_no_committed_key_remains_in_the_module() -> None:
+    """The credential is gone from the source, not merely gated behind a flag.
+
+    A committed shared secret is a committed credential whichever branch
+    reaches it, so this asserts on the module text rather than on behavior.
+    """
+    from gateway.community.plugins.principal_signer.bare import _plugin
+
+    source = pathlib.Path(_plugin.__file__).read_text(encoding="utf-8")
+
+    assert "NOT-FOR-PROD" not in source
+    assert not hasattr(_plugin, "_DEV_FALLBACK_KEY")

--- a/src/gateway/tests/unit/plugins/test_principal_signer.py
+++ b/src/gateway/tests/unit/plugins/test_principal_signer.py
@@ -11,12 +11,15 @@ from dataclasses import dataclass
 import jwt
 import pytest
 
+from gateway.community.bootstrap._principal_signer import build_principal_signer
 from gateway.community.config import PrincipalSignerPluginConfig
 from gateway.community.logger import get_logger
 from gateway.community.plugins.principal_signer.bare import (
+    MIN_SIGNING_KEY_BYTES,
     BarePrincipalSigner,
     PrincipalSignerConfig,
     PrincipalSigningKeyMissingError,
+    is_weak_signing_key,
     key_fingerprint,
     load_signer_config,
 )
@@ -193,6 +196,17 @@ def _captured(level: int = logging.INFO):
     finally:
         logger.removeHandler(handler)
         logger.setLevel(previous)
+
+
+class _UserConfigStub:
+    """Only ``principal_signer`` is read by the composition root under test."""
+
+    def __init__(self, signer: PrincipalSignerPluginConfig) -> None:
+        self.principal_signer = signer
+
+
+def _user_config_with_signer() -> _UserConfigStub:
+    return _UserConfigStub(_block())
 
 
 def _lines(records: list[logging.LogRecord]) -> str:
@@ -374,3 +388,100 @@ def test_no_committed_key_remains_in_the_module() -> None:
 
     assert "NOT-FOR-PROD" not in source
     assert not hasattr(_plugin, "_DEV_FALLBACK_KEY")
+
+
+# ── strict-profile aliases ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "server_env",
+    ["pre", "prepub", "prod", "gray", "PROD", " prepub "],
+    ids=["pre", "prepub", "prod", "gray", "uppercase", "padded"],
+)
+def test_strict_profiles_refuse_to_boot_without_a_key(
+    server_env: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``prepub`` and ``gray`` are aliases, not extras.
+
+    The backend does not compare ``SERVER_ENV`` raw — ``get_current_env`` folds
+    ``prepub`` into ``pre`` and ``gray`` into ``prod`` before gating its
+    verifier. ``scripts/app.sh`` exports ``SERVER_ENV=prepub`` for its supported
+    ``--env prepub``, so a raw comparison here would leave the backend refusing
+    to boot while this side booted and answered 500 per request — the two sides
+    disagreeing in precisely the profiles where the contract matters most.
+    """
+    monkeypatch.setenv("SERVER_ENV", server_env)
+
+    with pytest.raises(PrincipalSigningKeyMissingError):
+        build_principal_signer(
+            user_config=_user_config_with_signer(),
+            secret_resolver=_FakeResolver(None),
+        )
+
+
+@pytest.mark.parametrize("server_env", ["", "dev", "local", "test", "stable"])
+def test_non_strict_profiles_boot_without_a_key(
+    server_env: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SERVER_ENV", server_env)
+
+    signer = build_principal_signer(
+        user_config=_user_config_with_signer(),
+        secret_resolver=_FakeResolver(None),
+    )
+
+    assert signer is not None
+
+
+# ── weak keys ────────────────────────────────────────────────────────────────
+
+
+def test_a_short_key_is_flagged_as_weak() -> None:
+    assert is_weak_signing_key("envk")
+    assert is_weak_signing_key("a" * 31)
+
+
+def test_a_key_at_the_minimum_is_not_weak() -> None:
+    assert not is_weak_signing_key("a" * MIN_SIGNING_KEY_BYTES)
+
+
+def test_no_key_is_not_reported_as_weak() -> None:
+    """Absent is its own state, already covered by a louder message."""
+    assert not is_weak_signing_key("")
+
+
+def test_strength_is_measured_in_bytes_not_characters() -> None:
+    """HMAC consumes bytes, so bytes are what the RFC 7518 threshold counts.
+
+    The two units disagree for any non-ASCII key, and in this direction: 20
+    ``é`` is 20 characters but 40 UTF-8 bytes, so it clears a threshold that 20
+    ASCII characters does not. Counting characters would reject a key HMAC is
+    perfectly happy with.
+    """
+    assert len("é" * 20) == 20 and len(("é" * 20).encode("utf-8")) == 40
+    assert not is_weak_signing_key("é" * 20), "40 bytes clears the minimum"
+    assert is_weak_signing_key("a" * 20), "the same character count in ASCII does not"
+
+
+def test_a_weak_key_warns_but_still_reports_its_fingerprint() -> None:
+    """Withholding the fingerprint would remove the diagnostic exactly when a
+    deployment is most misconfigured. The remedy is a better secret, and the
+    warning says so."""
+    with _captured(logging.INFO) as records:
+        load_signer_config(_block(), _FakeResolver("envk"), strict=False)
+
+    line = _lines(records)
+    assert f"key fp={key_fingerprint('envk')}" in line, "still diagnosable"
+    assert "below the 32-byte minimum" in line
+    assert "forge any caller identity" in line, "says why it matters"
+
+
+def test_a_strong_key_does_not_warn() -> None:
+    with _captured(logging.WARNING) as records:
+        load_signer_config(
+            _block(),
+            _FakeResolver("a-shared-secret-of-at-least-32-bytes!!"),
+            strict=False,
+        )
+
+    assert "minimum" not in _lines(records)


### PR DESCRIPTION
## Problem

Every `/openapi/v1` request was answering 401, and the logs could not say why:

```
rejected forwarded principal on GET /openapi/v1/bots: principal token rejected: Signature verification failed
[Public 401] MissingPrincipalError on GET /openapi/v1/bots
INFO:     "GET /openapi/v1/bots HTTP/1.0" 401 Unauthorized
ERROR:    Exception in ASGI application            <- ~100 lines of traceback
```

Three separate defects sit behind that:

**1. The gateway signed with a committed dev key when its secret did not resolve.**
`bare/_plugin.py` fell back to `avernet-dev-signing-key-NOT-FOR-PROD` after one boot-time
warning. That fallback was worse than useless in both directions: a committed shared secret
is a committed credential, and no peer would ever accept those tokens — the backend ships no
fallback, so it never holds the constant this side signed with. All it bought was a gateway
that looked healthy while every request failed one hop away, attributed to the wrong
component. It also signed issued access-key and app tokens, so anyone with the source could
mint them.

**2. A key mismatch was indistinguishable from a forgery.** `Signature verification failed`
is all PyJWT can say. Nothing named which key the token was judged against or which signer
produced it, and the two halves of this contract never meet at request time — the gateway
signs successfully every time and only the backend observes a mismatch. There was no way to
compare the two ends short of printing the secret.

Two invisible ways for the keys to diverge fed into this: the backend stripped its resolved
value and the gateway did not (a trailing newline, routine when a secret comes from a file,
silently produced different keys), and the two sides read separately-provisioned secrets
under different names and prefixes.

**3. A routine 401 cost a ~100-line ASGI traceback.** `MissingPrincipalError` is raised in a
*dependency*, so `@envelope_errors` never sees it and it fell to
`@app.exception_handler(Exception)`. Starlette installs that as `ServerErrorMiddleware`'s
handler, which sends the response and then unconditionally re-raises ("We always continue to
raise the exception"). This directly defeated the intent already written at `app.py:517` —
log at warning *without* a traceback so real 5xx are not buried — and it was worst exactly
when auth was broken, because then every request took that path.

## Solution

**No fallback key, on either side.** Removed rather than made louder. A missing key now
refuses the boot in strict profiles and elsewhere leaves the signer unable to sign, so each
attempt raises `PrincipalSigningKeyMissingError` and the forwarder's existing handler answers
`500 principal signing failed` with a traceback naming the misconfigured component. This
mirrors the backend's `strict` rule — one contract, one rule. Refusing beats signing with an
empty key, which PyJWT accepts and which produces a signature anyone can reproduce.

Strict means `{pre, prepub, prod, gray}`, not the raw `{pre, prod}`: the backend does not
compare `SERVER_ENV` directly either, and `env_utils.get_current_env` folds `prepub` into
`pre` and `gray` into `prod` before gating. `scripts/app.sh` exports `SERVER_ENV=prepub` for
its supported `--env prepub`, so honouring only the canonical spellings would have split the
two sides apart in exactly those profiles.

**A key fingerprint at boot, on both sides** — truncated SHA-256, safe in a log, useless to a
reader:

```
backend:  gateway principal verification is configured (secret='...', key fp=eb128a7a, key len=38, aud='backend', iss='gateway')
gateway:  principal signer configured (secret='principal_signing_key', key fp=eb128a7a, key len=38, kid='bare', iss='gateway', ttl=60s)
```

Differing fingerprints mean different secrets; `unset` means no key at all; matching
fingerprints rule the key out and point at `iss`, clock skew, or a process predating the last
rotation. `key len` rides along because a stray newline changes both. The algorithm is
duplicated (separate distributions, no shared package) and pinned by identical golden values
in both suites, so drift fails a test instead of silently voiding the comparison.

That fingerprint is only safe for a strong key — against a guessable one, 32 bits is enough
to confirm a dictionary guess offline, and confirming the shared secret means forging any
identity. Nothing enforced the RFC 7518 §3.2 minimum the docstrings assumed, so
`is_weak_signing_key` now gates a boot warning on both sides. It warns rather than refuses,
and still prints the fingerprint: withholding it would remove the diagnostic exactly when a
deployment is most misconfigured, and rejecting short keys outright would deny every request
on a deployment that was at least partly working — a bigger change than this PR should make
unilaterally.

**Failure lines that name the cause.** Verification failures keep PyJWT's own reason and add
the token's unverified JOSE `alg`/`kid` plus the fingerprint of the key used:

```
principal token rejected: Signature verification failed [token alg='HS256' kid='bare';
verifier key fp=eb128a7a, expects aud='backend' iss='gateway']
```

`kid='bare'` says it was our gateway with the wrong key; anything else says it was not our
gateway. Only the JOSE header is read, never the payload — those claims are the unverified
assertions the function exists to distrust. The header is attacker-controlled, so it is
clipped and `repr`-escaped: a `kid` containing a newline cannot forge a log line. A *missing*
header now logs distinctly, because that is not an auth failure at all — it means the request
never came through the gateway, and chasing signing keys for it is chasing the wrong half of
the system. None of this reaches the caller; every failure still answers one fixed 401.

**Dedicated handlers for the two auth errors** put them in the inner `ExceptionMiddleware`,
which answers without re-raising. Status and body still come from `ENVELOPE_ERRORS`, so this
adds a route out of the middleware stack, not a second opinion on the answer.

**The gateway strips its resolved key**, matching the backend, and both warn when they trim —
naming the untrimmed *and* trimmed fingerprints, so a mixed-version rollout is a grep rather
than a second incident.

Rejected: gating the fallback behind a deploy profile (a committed credential is one
whichever branch reaches it), and logging the key length alone without a fingerprint (equal
lengths say nothing about equal bytes).

## Validation

Cut from and rebased onto `REL20260804`; both rebases replayed with no conflicts.

- **Gateway: 672 passed**, `--ignore=tests/e2e` (e2e needs a live server; it fails the same
  way on a clean tree). `ruff check` and `ruff format` clean on every file this branch
  touches.
- **Backend: 835 passed** across `tests/community/architecture` (the full architecture-gate
  suite — boundary, transport-in-core and env-access checks), plus `core/gateway_principal/`,
  `utils/test_gateway_principal_config.py`, and `api/`.
- **The re-raise is pinned from both sides.** `test_the_catch_all_alone_re_raises` drives the
  app through the raw ASGI interface — the only way to see what uvicorn sees, since
  `TestClient` either swallows the re-raise or converts it to a failure — and asserts the
  catch-all wiring still re-raises. If Starlette ever stops, that test fails and the extra
  registration can be dropped rather than cargo-culted.
- **Strict-profile aliases** are covered by parametrized cases for `pre`/`prepub`/`prod`/
  `gray` plus casing and padding, and for the non-strict profiles.
- **Fingerprint agreement verified across packages** by importing both implementations into
  one interpreter and comparing outputs, in addition to the golden values in each suite.
- **Log-injection checked**: a `kid` of `"ab\nWARNING forged"` renders as `'ab\\nWARNING
  forged'`, with no raw newline.
- **Not run: the remainder of the backend suite.** It exceeds the time budget available in
  this environment, so CI is authoritative for the untouched areas.
- **Pre-existing, untouched by this branch:** `tests/architecture/test_ruff_lint_rules.py::test_ruff_formatting_passes`
  fails on markdown under `src/gateway/docs/` and `src/gateway/specs/`, none of which appears
  in this diff.

## Compatibility and risk

**Behavioral change, deliberate:** a gateway with no resolvable signing key used to boot and
forward; it now refuses to boot in strict profiles and returns 500 elsewhere. This affects
only deployments that were relying on the dev fallback — and those were already
non-functional, since the backend never accepted the tokens. Singlebox is unchanged in
effect: its public surface already denied because that side resolves no key.

To provision, set the secret named by `user_config.principal_signer.secret_name` (community
resolver: `AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE`) to the same value the backend reads
under `secret_names.gateway_principal_signing_key`, and confirm the two boot lines report the
same `key fp`.

**Credential issuance now requires a real key too.** `/admin/access-keys` and app
registration sign with the same signer, so they fail without one — correct, since tokens
signed under a published constant are forgeable by anyone with the source. Two integration
tests that decoded with the fallback now provision a key the way a deployment does.

**A short key logs a warning but does not block startup.** If a hard refusal in strict
profiles is preferred, that is a one-line change and worth deciding explicitly.

Rollback is a revert; nothing persisted changes, and no token format, claim, or wire contract
is altered.

## Spec

`src/gateway/docs/2026-07-21-auth-design.md` §7.1. Diagnostic procedure documented in
`src/backend/docs/openapi-v1/README.md` under "Diagnosing a 401 on this surface".