### PR TITLE
test(baas): add E2E tests for hook execution failure handling

### DIFF
--- a/src/baas/tests/e2e/asgi/mock_paas_failure/test_hook_execution_failure.py
+++ b/src/baas/tests/e2e/asgi/mock_paas_failure/test_hook_execution_failure.py
@@ -97,10 +97,15 @@ class TestRestartHookFailure:
     async def test_restart_with_hook_failure(
         self, api: APITestHelper, monkeypatch: pytest.MonkeyPatch, unique_id: str
     ) -> None:
-        _set_mock(monkeypatch)
+        # Enable PAAS_MOCK_MODE so the factory returns MockPaasService,
+        # but do NOT enable PAAS_MOCK_HOOK_FAILURE yet — otherwise the
+        # create hook also fails and the bot never reaches ACTIVE status.
+        monkeypatch.setenv("PAAS_MOCK_MODE", "true")
         bot = await create_and_activate_bot(
             api, f"restart-hook-fail-{unique_id}", device_count=1
         )
+        # Now enable hook failure for the restart phase.
+        monkeypatch.setenv("PAAS_MOCK_HOOK_FAILURE", "true")
         resp = await api.client.post(
             api.bot_url(bot["bot_uuid"]) + "/restart",
             params=api.params(),

--- a/src/baas/tests/e2e/asgi/mock_paas_failure/test_hook_execution_failure.py
+++ b/src/baas/tests/e2e/asgi/mock_paas_failure/test_hook_execution_failure.py
@@ -40,7 +40,7 @@ class TestCreateHookFailure:
         code = await approve_publish(api, publish_id)
         assert code == 200
         status = await wait_for_publish_status(
-            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=5.0
+            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=15.0
         )
         assert status == "FAILED", f"Expected publish FAILED, got {status}"
         devices = await get_devices_from_progress(api, publish_id)
@@ -50,7 +50,7 @@ class TestCreateHookFailure:
         # Bot status transition ACTIVE → FAILED is async: poll with backoff.
         bot_status = "ACTIVE"
         t0 = time.monotonic()
-        while time.monotonic() - t0 < 5.0:
+        while time.monotonic() - t0 < 15.0:
             resp = await api.client.get(
                 api.bot_url(bot["bot_uuid"]), params=api.params()
             )
@@ -87,7 +87,7 @@ class TestDestroyHookFailure:
         code = await approve_publish(api, publish_id)
         assert code == 200
         status = await wait_for_publish_status(
-            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=5.0
+            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=15.0
         )
         assert status in ("SUCCESS", "FAILED"), f"Expected terminal state, got {status}"
 
@@ -113,6 +113,19 @@ class TestRestartHookFailure:
         code = await approve_publish(api, publish_id)
         assert code == 200
         status = await wait_for_publish_status(
-            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=5.0
+            api, publish_id, {"SUCCESS", "FAILED"}, timeout_seconds=15.0
         )
         assert status == "FAILED", f"Expected FAILED, got {status}"
+        # Bot status transition ACTIVE → FAILED is async: poll with backoff.
+        bot_status = "ACTIVE"
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < 15.0:
+            resp = await api.client.get(
+                api.bot_url(bot["bot_uuid"]), params=api.params()
+            )
+            if resp.status_code == 200:
+                bot_status = resp.json()["data"]["status"]
+                if bot_status == "FAILED":
+                    break
+            await asyncio.sleep(0.1)
+        assert bot_status == "FAILED", f"Expected bot FAILED, got {bot_status}"


### PR DESCRIPTION
## Problem

The BaaS hook execution failure path lacked dedicated E2E coverage. When a PaaS hook fails during bot creation, destruction, or restart, the system must correctly propagate the failure through both the publish status and the bot status, but this behavior was only validated implicitly.

## Solution

Add a new E2E test file `test_hook_execution_failure.py` under the `mock_paas_failure` test suite. Three test classes exercise the failure path:

- **TestCreateHookFailure** -- publish a bot with a failing create hook; assert publish reaches FAILED and the bot asynchronously transitions ACTIVE -> FAILED (polled with 15s timeout).
- **TestDestroyHookFailure** -- destroy a bot with a failing destroy hook; assert publish reaches a terminal state (SUCCESS or FAILED), with a skip guard if no publish_id is returned.
- **TestRestartHookFailure** -- restart an active bot with a failing hook; assert publish and bot both reach FAILED status.

All tests use `PAAS_MOCK_MODE=true` and `PAAS_MOCK_HOOK_FAILURE=true` environment variables to simulate hook failures without external dependencies.

## Validation

- **E2E tests**: 9/9 passed, 0 failed, 0 skipped
- **Code review**: 0 blocking issues. One P2 (duplicate bot-status polling loop between TestCreateHookFailure and TestRestartHookFailure) and two P3 findings (test maintainability, polling backoff strategy) -- all non-blocking and suitable for future follow-up.
- **Privacy scan**: Passed. No internal identifiers or sensitive data introduced.