### PR TITLE
fix(bcs): allow direct self chat

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/e2e_ws_messaging.rs
@@ -582,25 +582,28 @@ async fn test_1to1_chat_http_to_ws() {
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    // Connect Bot B (receiver) via WebSocket
-    let mut ws_b = connect_bot(addr, None).await;
-    let resp_b = send_frame(&mut ws_b, json!({
-        "type": "req", "id": "1", "method": "bot.connect", "params": {}
-    })).await.unwrap();
-    let bot_b_id = resp_b["payload"]["bot_uuid"].as_str().unwrap().to_string();
-    let bot_b_token = resp_b["payload"]["token"].as_str().unwrap().to_string();
+    let (_sender_ws, sender_bot_id, sender_client) =
+        connect_and_onboard_public_bot(addr, "SenderBot").await;
+    let (mut receiver_ws, receiver_bot_id, _receiver_client) =
+        connect_and_onboard_public_bot(addr, "ReceiverBot").await;
 
-    // Onboard Bot B
-    let client = create_client(addr, &bot_b_token);
-    client.onboard("ReceiverBot", None, None, None, None, None).await.ok();
+    let chat_task = tokio::spawn(async move {
+        sender_client
+            .chat(
+                &receiver_bot_id,
+                "Hello from Bot A",
+                Some(&sender_bot_id),
+                Some(200),
+            )
+            .await
+    });
 
-    // Bot A sends 1:1 message to Bot B via HTTP API
-    // Note: This requires Bot A to be connected via WS with a token
-    let result = client.chat(&bot_b_id, "Hello from Bot A", Some("bot_a"), None);
-    // The chat might fail if bot_a is not in registry, but we test the flow
-    let _ = result.await;
+    let frame = recv_chat_send_frame(&mut receiver_ws)
+        .await
+        .expect("Receiver bot should receive chat.send");
+    assert_eq!(frame["method"], "chat.send");
 
-    // The test verifies the infrastructure works
+    let _ = chat_task.await.expect("chat task should join");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -1079,6 +1079,10 @@ impl A2aChat {
             .await
             .ok_or_else(|| ServiceError::BotNotFound(target_bot_id.to_string()))?;
 
+        if from_bot_id == target_bot_id {
+            return Ok(target);
+        }
+
         match target.capabilities.visibility.as_str() {
             "public" => Ok(target),
             "protected" if self.friend.are_friends(from_bot_id, target_bot_id).await => Ok(target),

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
@@ -1111,6 +1111,19 @@ async fn protected_target_requires_friendship_in_a2a_service() {
 }
 
 #[tokio::test]
+async fn protected_target_allows_self_chat_without_friendship() {
+    let (service, delivery, _) = build_service(
+        vec![("bot-source", "protected", Some("owner-1"))],
+        vec![],
+    )
+    .await;
+
+    service.chat(chat_command("bot-source")).await.unwrap();
+
+    assert_eq!(delivery.frames().await.len(), 1);
+}
+
+#[tokio::test]
 async fn protected_friend_and_public_target_are_delivered_by_a2a_service() {
     let (service, delivery, _) = build_service(
         vec![


### PR DESCRIPTION
## Problem
`bcs-cli chat` routes through the A2A direct chat service. When a Bot chats with itself and its visibility is protected, the service currently applies the protected-target friendship check and rejects the request as `NotFriends`, even though self-chat is not cross-Bot collaboration.

## Solution
Allow direct self-chat after the target Bot is resolved, before visibility-based friendship checks run. This keeps the exception scoped to direct chat reachability and does not make the friendship model self-referential. Added a contract test proving protected self-chat works without a friendship while the existing protected non-friend rejection still holds. Also updated the HTTP-to-WS 1:1 chat e2e to use a real Sender Bot -> Receiver Bot flow, so it no longer relies on self-chat being rejected to finish quickly.

## Validation
- `cargo test --offline -p bcs-message-flow --test contract_a2a_chat protected_target`
- `cargo test -p bcs --test e2e_ws_messaging test_1to1_chat_http_to_ws -- --nocapture`
- `git diff --check`

Committed and pushed with `--no-verify` per Avernet publishing workflow; explicit validation above passed.

## Compatibility and risk
Low risk. The runtime change only affects direct chat where caller Bot ID equals target Bot ID. Protected/private cross-Bot reachability and friend request semantics are unchanged.