### PR TITLE
feat(session-files): support large attachment reupload

### DIFF
--- a/src/engine/src/engine/community/api/resource_materialization/router.py
+++ b/src/engine/src/engine/community/api/resource_materialization/router.py
@@ -1,4 +1,5 @@
 """Thin HTTP adapter for Backend-triggered materialization."""
+
 from __future__ import annotations
 
 import asyncio
@@ -6,26 +7,27 @@ import hashlib
 import logging
 from collections.abc import AsyncIterator
 
-from engine.community.core.resource_materialization.models import (
-    MaterializationRequest,
-)
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi.responses import StreamingResponse
+
+from engine.community.core.resource_materialization.models import MaterializationRequest
 from engine.community.core.resource_materialization.service import (
     ResourceMaterializationService,
     ResourceNotMaterializedError,
 )
 from engine.community.di import Injected
-from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
-from fastapi.responses import StreamingResponse
 
 log = logging.getLogger("engine.resource_materialization.api")
-router = APIRouter(prefix="/api/resource-materializations", tags=["resource-materializations"])
+router = APIRouter(
+    prefix="/api/resource-materializations", tags=["resource-materializations"]
+)
 
 
 @router.post("")
 async def create_resource_materialization(
     request: MaterializationRequest,
     background_tasks: BackgroundTasks,
-    service: ResourceMaterializationService = Injected(ResourceMaterializationService),
+    service: ResourceMaterializationService = Injected(ResourceMaterializationService),  # noqa: B008
 ) -> dict:
     """Accept a Backend task after BaaS proxypass authenticates the route.
 
@@ -52,7 +54,7 @@ async def create_resource_materialization(
 async def stream_resource_content(
     resource_id: str,
     disposition: str = Query("inline", pattern="^(inline|attachment)$"),
-    service: ResourceMaterializationService = Injected(ResourceMaterializationService),
+    service: ResourceMaterializationService = Injected(ResourceMaterializationService),  # noqa: B008
 ) -> StreamingResponse:
     """Stream manifest-controlled content over the Backend-only route."""
     try:
@@ -63,7 +65,9 @@ async def stream_resource_content(
         )
     except ResourceNotMaterializedError as exc:
         log.info("engine.resource_content.missing resource_id=%s", resource_id)
-        raise HTTPException(status_code=409, detail="resource_not_materialized") from exc
+        raise HTTPException(
+            status_code=409, detail="resource_not_materialized"
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/engine/src/engine/community/api/session_files/router.py
+++ b/src/engine/src/engine/community/api/session_files/router.py
@@ -1,18 +1,25 @@
 """Direct, session-scoped file access through a trusted Bot proxypass."""
+
 from __future__ import annotations
 
 import asyncio
 import logging
 from collections.abc import AsyncIterator
 
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from engine.community.core.session_files.export_service import (
+    EXPORT_POLL_SECONDS,
+    SessionFileExportService,
+)
 from engine.community.core.session_files.models import SessionFileError
 from engine.community.core.session_files.service import SessionFileService
 from engine.community.di import Injected
-from fastapi import APIRouter, HTTPException, Query
-from fastapi.responses import StreamingResponse
 
 log = logging.getLogger("engine.session_files.api")
 router = APIRouter(prefix="/api/session-files", tags=["session-files"])
+_MAX_DIRECT_CONTENT_BYTES = 30 * 1024 * 1024
 
 
 def _error(exc: SessionFileError) -> HTTPException:
@@ -39,17 +46,66 @@ async def list_session_files(
     return {"files": [item.as_dict() for item in files]}
 
 
-@router.get("/{resource_id}/content")
+@router.get("/{resource_id}/content", response_model=None)
 async def stream_session_file_content(
     resource_id: str,
     session_key: str = Query(alias="sessionKey", min_length=1, max_length=2048),
     disposition: str = Query("inline", pattern="^(inline|attachment)$"),
     service: SessionFileService = Injected(SessionFileService),  # noqa: B008
-) -> StreamingResponse:
+    export_service: SessionFileExportService = Injected(SessionFileExportService),  # noqa: B008
+) -> Response:
     log.info(
         "engine.session_files.proxypass_access operation=content resource_id=%s",
         resource_id,
     )
+    if disposition == "attachment":
+        try:
+            source = await asyncio.to_thread(
+                service.prepare_export_source,
+                session_key=session_key,
+                resource_id=resource_id,
+            )
+        except SessionFileError as exc:
+            raise _error(exc) from exc
+        if source.size_bytes > _MAX_DIRECT_CONTENT_BYTES:
+            result = await export_service.request_download(
+                source=source,
+                session_key=session_key,
+            )
+            if result.state == "preparing":
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "status": "preparing_download",
+                        "retry_after_seconds": EXPORT_POLL_SECONDS,
+                    },
+                    headers={
+                        "Retry-After": str(EXPORT_POLL_SECONDS),
+                        "Cache-Control": "no-store",
+                    },
+                )
+            if result.state == "failed":
+                if result.error_code in {"resource_missing", "resource_changed"}:
+                    raise _error(SessionFileError(result.error_code))
+                status_code = {
+                    "file_export_unavailable": 503,
+                    "file_export_timeout": 504,
+                }.get(result.error_code, 502)
+                raise HTTPException(status_code=status_code, detail=result.error_code)
+            if result.download is None:
+                raise HTTPException(status_code=502, detail="file_export_failed")
+            return JSONResponse(
+                content={
+                    "status": "ready",
+                    "delivery": "external_url",
+                    "download_url": result.download.download_url,
+                    "expires_at": result.download.expires_at,
+                    "filename": result.download.filename,
+                    "size_bytes": result.download.size_bytes,
+                },
+                headers={"Cache-Control": "no-store"},
+            )
+
     try:
         content = await asyncio.to_thread(
             service.open_content,
@@ -59,6 +115,8 @@ async def stream_session_file_content(
         )
     except SessionFileError as exc:
         raise _error(exc) from exc
+    if content.size_bytes > _MAX_DIRECT_CONTENT_BYTES:
+        raise HTTPException(status_code=413, detail="resource_preview_too_large")
 
     async def body() -> AsyncIterator[bytes]:
         stream = await asyncio.to_thread(content.path.open, "rb")

--- a/src/engine/src/engine/community/api/session_files/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_files/tests/test_router.py
@@ -2,20 +2,26 @@ from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime
+import time
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, InstanceProvider, Module, singleton
+
 from engine.community.api.session_files.router import router
 from engine.community.core.resource_materialization.models import (
     ManifestEntry,
     hash_identifier,
 )
 from engine.community.core.resource_materialization.service import ManifestStore
+from engine.community.core.session_files.export_service import SessionFileExportService
+from engine.community.core.session_files.models import (
+    BaasFileExportShareLink,
+)
 from engine.community.core.session_files.service import SessionFileService
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-from fastapi_injector import attach_injector
-from injector import Injector, InstanceProvider, Module, singleton
 
 
 def _write_ready_file(root: Path, session_key: str, content: bytes = b"report") -> Path:
@@ -42,6 +48,7 @@ def _write_ready_file(root: Path, session_key: str, content: bytes = b"report") 
             observed_mtime_ns=observed.st_mtime_ns,
             observed_inode=observed.st_ino,
             uploaded_at=datetime(2026, 8, 3, 10, 20, 30, tzinfo=UTC),
+            baas_tenant="team_claw",
         )
     )
     return target
@@ -51,9 +58,38 @@ def _write_ready_file(root: Path, session_key: str, content: bytes = b"report") 
 def client(tmp_path: Path):
     service = SessionFileService(workspace_root_provider=lambda: tmp_path)
 
+    class _ExportClient:
+        async def create_share_link(self, request, *, expire_seconds):
+            assert expire_seconds == 7200
+            return BaasFileExportShareLink(
+                download_url="https://oss.example/file?redacted",
+                expires_at="2099-08-02T12:00:00Z",
+            )
+
+        async def create_upload_grant(self, request, *, filename, size_bytes):
+            raise AssertionError("unchanged router fixture must not upload")
+
+        async def upload_file(self, grant, source_path, *, resource_id):
+            raise AssertionError("unchanged router fixture must not upload")
+
+        async def complete_upload(self, request):
+            raise AssertionError("unchanged router fixture must not upload")
+
+    export_service = SessionFileExportService(
+        session_file_service=service,
+        export_client=_ExportClient(),
+    )
+
     class _Module(Module):
         def configure(self, binder) -> None:
-            binder.bind(SessionFileService, to=InstanceProvider(service), scope=singleton)
+            binder.bind(
+                SessionFileService, to=InstanceProvider(service), scope=singleton
+            )
+            binder.bind(
+                SessionFileExportService,
+                to=InstanceProvider(export_service),
+                scope=singleton,
+            )
 
     app = FastAPI()
     attach_injector(app, Injector([_Module()]))
@@ -81,7 +117,7 @@ def test_list_and_content_are_scoped_to_manifest_session(client):
     )
     content = test_client.get(
         "/api/session-files/sr_001/content",
-        params={"sessionKey": "session-a", "disposition": "attachment"},
+        params={"sessionKey": "session-a", "disposition": "inline"},
     )
     cross_session = test_client.get(
         "/api/session-files/sr_001/content",
@@ -102,7 +138,7 @@ def test_list_and_content_are_scoped_to_manifest_session(client):
     }
     assert content.status_code == 200
     assert content.content == b"report"
-    assert content.headers["content-disposition"].startswith("attachment;")
+    assert content.headers["content-disposition"].startswith("inline;")
     assert cross_session.status_code == 404
 
 
@@ -154,6 +190,47 @@ def test_changed_and_missing_files_are_not_streamed(client):
     assert listed.json()["files"][0]["uploaded_at"] == "2026-08-03T10:20:30Z"
     assert missing.status_code == 409
     assert missing.json()["detail"] == "resource_missing"
+
+
+def test_small_attachment_streams_without_baas(client):
+    test_client, root = client
+    _write_ready_file(root, "session-a")
+    params = {"sessionKey": "session-a", "disposition": "attachment"}
+
+    response = test_client.get("/api/session-files/sr_001/content", params=params)
+
+    assert response.status_code == 200
+    assert response.content == b"report"
+    assert response.headers["content-disposition"].startswith("attachment;")
+
+
+def test_large_attachment_returns_preparing_then_external_url(client):
+    test_client, root = client
+    _write_ready_file(root, "session-a", b"x" * (30 * 1024 * 1024 + 1))
+    params = {"sessionKey": "session-a", "disposition": "attachment"}
+
+    preparing = test_client.get("/api/session-files/sr_001/content", params=params)
+    time.sleep(0.05)
+    ready = test_client.get("/api/session-files/sr_001/content", params=params)
+
+    assert preparing.status_code == 202
+    assert preparing.headers["retry-after"] == "2"
+    assert ready.status_code == 200
+    assert ready.json()["delivery"] == "external_url"
+    assert ready.headers["cache-control"] == "no-store"
+
+
+def test_inline_rejects_large_files_without_starting_export(client):
+    test_client, root = client
+    _write_ready_file(root, "session-a", b"x" * (30 * 1024 * 1024 + 1))
+
+    response = test_client.get(
+        "/api/session-files/sr_001/content",
+        params={"sessionKey": "session-a", "disposition": "inline"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "resource_preview_too_large"
 
 
 def test_delete_removes_only_manifest_entry_and_local_file(client):

--- a/src/engine/src/engine/community/core/resource_materialization/models.py
+++ b/src/engine/src/engine/community/core/resource_materialization/models.py
@@ -1,4 +1,5 @@
 """Transport-neutral value types for resource materialization."""
+
 from __future__ import annotations
 
 import hashlib
@@ -38,8 +39,14 @@ class MaterializationRequest(BaseModel):
 
     def model_post_init(self, __context, /) -> None:
         if self.transfer_api_version == "session_v2":
-            if not self.tenant or not self.session_id or not self.workspace_relative_path:
-                raise ValueError("session_v2 requires tenant, session_id, and workspace_relative_path")
+            if (
+                not self.tenant
+                or not self.session_id
+                or not self.workspace_relative_path
+            ):
+                raise ValueError(
+                    "session_v2 requires tenant, session_id, and workspace_relative_path"
+                )
         elif not self.device_path:
             raise ValueError("bot_device_v1 requires device_path")
 
@@ -74,6 +81,7 @@ class ManifestEntry(BaseModel):
     observed_mtime_ns: int | None = None
     observed_inode: int | None = None
     uploaded_at: datetime | None = None
+    baas_tenant: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/engine/src/engine/community/core/resource_materialization/service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/service.py
@@ -1,4 +1,5 @@
 """Materialize BaaS transfers into the controlled Bot workspace."""
+
 from __future__ import annotations
 
 import asyncio
@@ -98,6 +99,49 @@ class ManifestStore:
             self._write_locked(payload)
             return ManifestEntry.model_validate(value)
 
+    def replace_export_source(
+        self,
+        *,
+        resource_id: str,
+        scope_key_hash: str,
+        session_key_hash: str,
+        transfer_id: str,
+        size_bytes: int,
+        content_hash: str,
+        observed_size: int,
+        observed_mtime_ns: int,
+        observed_inode: int | None,
+        baas_tenant: str,
+    ) -> ManifestEntry | None:
+        """Atomically replace the BaaS source after a verified Engine re-upload."""
+        with self._lock_for(self.path):
+            payload = self._read_locked()
+            value = payload["resources"].get(resource_id)
+            if value is None:
+                return None
+            entry = ManifestEntry.model_validate(value)
+            if (
+                entry.status != "ready"
+                or entry.scope_key_hash != scope_key_hash
+                or entry.session_key_hash != session_key_hash
+            ):
+                return None
+            updated = entry.model_copy(
+                update={
+                    "transfer_id": transfer_id,
+                    "size_bytes": size_bytes,
+                    "content_hash": content_hash,
+                    "observed_size": observed_size,
+                    "observed_mtime_ns": observed_mtime_ns,
+                    "observed_inode": observed_inode,
+                    "baas_tenant": baas_tenant,
+                }
+            )
+            payload["resources"][resource_id] = updated.model_dump(mode="json")
+            payload["version"] = 1
+            self._write_locked(payload)
+            return updated
+
     def _write_locked(self, payload: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_name(f".manifest-{uuid.uuid4().hex}.tmp")
@@ -162,7 +206,9 @@ class ResourceMaterializationService:
                 raise ResourceNotMaterializedError("resource_not_materialized")
         except (OSError, MaterializationSecurityError) as exc:
             raise ResourceNotMaterializedError("resource_not_materialized") from exc
-        media_type = mimetypes.guess_type(entry.filename)[0] or "application/octet-stream"
+        media_type = (
+            mimetypes.guess_type(entry.filename)[0] or "application/octet-stream"
+        )
         content_disposition = "{}; filename*=UTF-8''{}".format(
             disposition,
             quote(entry.filename, safe=""),
@@ -279,6 +325,7 @@ class ResourceMaterializationService:
                 observed_mtime_ns=observed.st_mtime_ns,
                 observed_inode=getattr(observed, "st_ino", None),
                 uploaded_at=request.uploaded_at,
+                baas_tenant=request.tenant,
             )
             store.upsert(entry)
             log.info(
@@ -320,7 +367,9 @@ class ResourceMaterializationService:
         try:
             filename_bytes = request.filename.encode("utf-8")
         except UnicodeEncodeError as exc:
-            raise MaterializationSecurityError("invalid controlled path segment") from exc
+            raise MaterializationSecurityError(
+                "invalid controlled path segment"
+            ) from exc
         if (
             not request.filename
             or Path(request.filename).name != request.filename
@@ -349,9 +398,13 @@ class ResourceMaterializationService:
         )
         if request.transfer_api_version == "session_v2":
             if tuple(supplied.parts) != expected_suffix:
-                raise MaterializationSecurityError("workspace path does not match resource scope")
-        elif tuple(supplied.parts[-len(expected_suffix):]) != expected_suffix:
-            raise MaterializationSecurityError("device_path does not match resource scope")
+                raise MaterializationSecurityError(
+                    "workspace path does not match resource scope"
+                )
+        elif tuple(supplied.parts[-len(expected_suffix) :]) != expected_suffix:
+            raise MaterializationSecurityError(
+                "device_path does not match resource scope"
+            )
         relative = Path(*expected_suffix)
         target = root / relative
         self._assert_contained(root, target)
@@ -363,7 +416,10 @@ class ResourceMaterializationService:
         # string-prefix checks are insufficient for sibling-prefix and symlink escapes.
         resolved_root = root.resolve(strict=True)
         resolved_target = target.resolve(strict=False)
-        if resolved_target != resolved_root and resolved_root not in resolved_target.parents:
+        if (
+            resolved_target != resolved_root
+            and resolved_root not in resolved_target.parents
+        ):
             raise MaterializationSecurityError("workspace path escapes Bot root")
 
     async def _entry_file_is_valid(self, root: Path, entry: ManifestEntry) -> bool:

--- a/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
+++ b/src/engine/src/engine/community/core/resource_materialization/tests/test_service.py
@@ -54,8 +54,7 @@ def _request(content: bytes, **overrides) -> MaterializationRequest:
         "scope_key_hash": "scope_abc",
         "session_key_hash": "session_abc",
         "device_path": (
-            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
-            "sr_001/report.txt"
+            "workspace/.teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
         ),
         "filename": "report.txt",
         "size_bytes": len(content),
@@ -80,8 +79,7 @@ async def test_materialize_writes_atomic_file_manifest_and_callback(tmp_path: Pa
     result = await service.materialize(_request(content))
 
     expected = (
-        tmp_path
-        / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
     ).resolve()
     assert result.ready is True
     assert Path(result.canonical_bot_absolute_path) == expected
@@ -111,17 +109,14 @@ async def test_materialize_supports_filename_near_filesystem_segment_limit(
         content,
         filename=filename,
         device_path=(
-            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
-            f"sr_001/{filename}"
+            f"workspace/.teamclaw/session-files/scope_abc/session_abc/sr_001/{filename}"
         ),
     )
 
     result = await service.materialize(request)
 
     target = (
-        tmp_path
-        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
-        / filename
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001" / filename
     )
     assert result.ready is True
     assert target.read_bytes() == content
@@ -141,17 +136,14 @@ async def test_materialize_supports_unicode_filename(tmp_path: Path):
         content,
         filename=filename,
         device_path=(
-            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
-            f"sr_001/{filename}"
+            f"workspace/.teamclaw/session-files/scope_abc/session_abc/sr_001/{filename}"
         ),
     )
 
     result = await service.materialize(request)
 
     target = (
-        tmp_path
-        / ".teamclaw/session-files/scope_abc/session_abc/sr_001"
-        / filename
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001" / filename
     )
     assert result.ready is True
     assert target.read_bytes() == content
@@ -160,7 +152,14 @@ async def test_materialize_supports_unicode_filename(tmp_path: Path):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "filename",
-    [".", "..", "folder/report.txt", r"folder\report.txt", "report?.txt", "report\n.txt"],
+    [
+        ".",
+        "..",
+        "folder/report.txt",
+        r"folder\report.txt",
+        "report?.txt",
+        "report\n.txt",
+    ],
 )
 async def test_materialize_rejects_unsafe_filename_characters(
     tmp_path: Path,
@@ -177,8 +176,7 @@ async def test_materialize_rejects_unsafe_filename_characters(
         content,
         filename=filename,
         device_path=(
-            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
-            f"sr_001/{filename}"
+            f"workspace/.teamclaw/session-files/scope_abc/session_abc/sr_001/{filename}"
         ),
     )
 
@@ -190,7 +188,9 @@ async def test_materialize_rejects_unsafe_filename_characters(
 
 
 @pytest.mark.asyncio
-async def test_materialize_rejects_filename_exceeding_utf8_segment_limit(tmp_path: Path):
+async def test_materialize_rejects_filename_exceeding_utf8_segment_limit(
+    tmp_path: Path,
+):
     content = b"too long unicode filename"
     filename = f"{'\u4e2d' * 86}.txt"
     callback = _CallbackClient()
@@ -203,8 +203,7 @@ async def test_materialize_rejects_filename_exceeding_utf8_segment_limit(tmp_pat
         content,
         filename=filename,
         device_path=(
-            "workspace/.teamclaw/session-files/scope_abc/session_abc/"
-            f"sr_001/{filename}"
+            f"workspace/.teamclaw/session-files/scope_abc/session_abc/sr_001/{filename}"
         ),
     )
 
@@ -241,6 +240,9 @@ async def test_session_v2_materialization_never_persists_raw_session_id(tmp_path
     assert pull.requests[0].session_id == "session/raw-value"
     manifest_text = (tmp_path / ".teamclaw/session-files/.manifest.json").read_text()
     assert "session/raw-value" not in manifest_text
+    entry = service.manifest_store.get("sr_001")
+    assert entry is not None
+    assert entry.baas_tenant == "tenant-1"
 
 
 @pytest.mark.asyncio
@@ -299,7 +301,9 @@ async def test_hash_mismatch_removes_partial_file_and_reports_failure(tmp_path: 
 
     result = await service.materialize(_request(b"expected"))
 
-    target = tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    target = (
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    )
     assert result.ready is False
     assert result.error_code == "hash_mismatch"
     assert not target.exists()
@@ -334,9 +338,7 @@ async def test_materialize_rejects_untrusted_device_path_escape(tmp_path: Path, 
 async def test_materialize_rejects_symlink_escape(tmp_path: Path):
     outside = tmp_path.parent / "outside-resource-target"
     outside.mkdir()
-    controlled_parent = (
-        tmp_path / ".teamclaw/session-files/scope_abc/session_abc"
-    )
+    controlled_parent = tmp_path / ".teamclaw/session-files/scope_abc/session_abc"
     controlled_parent.mkdir(parents=True)
     (controlled_parent / "sr_001").symlink_to(outside, target_is_directory=True)
     pull = _PullClient(b"x")
@@ -422,7 +424,9 @@ async def test_open_content_rejects_same_size_hash_changed_file(tmp_path: Path):
         workspace_root_provider=lambda: tmp_path,
     )
     await service.materialize(_request(content))
-    target = tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    target = (
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    )
     target.write_bytes(b"changed bytes")
 
     with pytest.raises(ResourceNotMaterializedError, match="resource_not_materialized"):
@@ -438,7 +442,9 @@ async def test_open_content_rejects_file_replaced_by_outside_symlink(tmp_path: P
         workspace_root_provider=lambda: tmp_path,
     )
     await service.materialize(_request(content))
-    target = tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    target = (
+        tmp_path / ".teamclaw/session-files/scope_abc/session_abc/sr_001/report.txt"
+    )
     outside = tmp_path.parent / "outside-content.txt"
     outside.write_bytes(content)
     target.unlink()

--- a/src/engine/src/engine/community/core/session_files/export_service.py
+++ b/src/engine/src/engine/community/core/session_files/export_service.py
@@ -1,0 +1,231 @@
+"""In-memory coordinator for large Session File attachment downloads."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from engine.community.core.session_files.models import (
+    SessionFileError,
+    SessionFileExportSource,
+    SessionFileExternalDownload,
+    SessionFileTransferRequest,
+)
+from engine.community.core.session_files.service import SessionFileService
+from engine.community.plugin_api.session_file_export import (
+    BaasFileExportError,
+    BaasSessionFileClient,
+)
+
+log = logging.getLogger("engine.session_file_export")
+EXPORT_POLL_SECONDS = 2
+EXPORT_SHARE_LINK_TTL_SECONDS = 7200
+EXPORT_ERROR_CACHE_SECONDS = 2
+
+
+@dataclass
+class _ExportJob:
+    task: asyncio.Task[None]
+    download: SessionFileExternalDownload | None = None
+    expires_monotonic: float = 0.0
+    error_code: str | None = None
+    error_expires_monotonic: float = 0.0
+
+
+@dataclass(frozen=True)
+class ExportRequestResult:
+    state: str
+    download: SessionFileExternalDownload | None = None
+    error_code: str | None = None
+
+
+class SessionFileExportService:
+    """Keep large file bytes out of proxypass while preserving Engine authority."""
+
+    def __init__(
+        self,
+        *,
+        session_file_service: SessionFileService,
+        export_client: BaasSessionFileClient,
+        share_link_ttl_seconds: int = EXPORT_SHARE_LINK_TTL_SECONDS,
+    ) -> None:
+        self._session_file_service = session_file_service
+        self._export_client = export_client
+        self._share_link_ttl_seconds = share_link_ttl_seconds
+        self._lock = asyncio.Lock()
+        self._jobs: dict[tuple[str, str, str], _ExportJob] = {}
+
+    async def request_download(
+        self,
+        *,
+        source: SessionFileExportSource,
+        session_key: str,
+    ) -> ExportRequestResult:
+        key = (source.resource_id, source.content_hash, source.transfer_id)
+        now = time.monotonic()
+        async with self._lock:
+            job = self._jobs.get(key)
+            if job is not None:
+                if job.download is not None and now < job.expires_monotonic:
+                    return ExportRequestResult(state="ready", download=job.download)
+                if job.error_code is not None and now < job.error_expires_monotonic:
+                    return ExportRequestResult(
+                        state="failed", error_code=job.error_code
+                    )
+                if not job.task.done():
+                    return ExportRequestResult(state="preparing")
+                self._jobs.pop(key, None)
+            task = asyncio.create_task(self._export(key, source, session_key))
+            self._jobs[key] = _ExportJob(task=task)
+        log.info(
+            "engine.session_file_export.queued resource_id=%s requires_upload=%s",
+            source.resource_id,
+            source.requires_upload,
+        )
+        return ExportRequestResult(state="preparing")
+
+    async def _export(
+        self,
+        key: tuple[str, str, str],
+        source: SessionFileExportSource,
+        session_key: str,
+    ) -> None:
+        error_code: str | None = None
+        download: SessionFileExternalDownload | None = None
+        try:
+            active_source = source
+            if active_source.requires_upload:
+                active_source = await self._reupload(active_source, session_key)
+            try:
+                share_link = await self._create_share_link(active_source, session_key)
+            except BaasFileExportError as exc:
+                if exc.code != "file_export_source_missing":
+                    raise
+                active_source = await self._reupload(active_source, session_key)
+                share_link = await self._create_share_link(active_source, session_key)
+            await asyncio.to_thread(
+                self._session_file_service.revalidate_export_source, active_source
+            )
+            download = SessionFileExternalDownload(
+                download_url=share_link.download_url,
+                expires_at=share_link.expires_at,
+                filename=active_source.filename,
+                size_bytes=active_source.size_bytes,
+            )
+            cache_ttl_seconds = self._cache_ttl_seconds(share_link.expires_at)
+            log.info(
+                "engine.session_file_export.ready resource_id=%s size_bytes=%s",
+                active_source.resource_id,
+                active_source.size_bytes,
+            )
+        except SessionFileError as exc:
+            error_code = str(exc)
+            log.info(
+                "engine.session_file_export.changed resource_id=%s error_code=%s",
+                source.resource_id,
+                error_code,
+            )
+        except BaasFileExportError as exc:
+            error_code = exc.code
+            log.warning(
+                "engine.session_file_export.failed resource_id=%s error_code=%s",
+                source.resource_id,
+                error_code,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            error_code = "file_export_failed"
+            log.warning(
+                "engine.session_file_export.failed resource_id=%s error_type=%s",
+                source.resource_id,
+                type(exc).__name__,
+            )
+        async with self._lock:
+            job = self._jobs.get(key)
+            if job is None:
+                return
+            if download is not None:
+                job.download = download
+                job.expires_monotonic = time.monotonic() + cache_ttl_seconds
+                return
+            if error_code == "resource_changed":
+                self._jobs.pop(key, None)
+                return
+            job.error_code = error_code or "file_export_failed"
+            job.error_expires_monotonic = time.monotonic() + EXPORT_ERROR_CACHE_SECONDS
+
+    async def _reupload(
+        self,
+        source: SessionFileExportSource,
+        session_key: str,
+    ) -> SessionFileExportSource:
+        snapshot = await asyncio.to_thread(
+            self._session_file_service.create_export_snapshot, source
+        )
+        try:
+            request = self._request(source, session_key)
+            grant = await self._export_client.create_upload_grant(
+                request,
+                filename=source.filename,
+                size_bytes=source.size_bytes,
+            )
+            await self._export_client.upload_file(
+                grant,
+                str(snapshot),
+                resource_id=source.resource_id,
+            )
+            await self._export_client.complete_upload(
+                self._request(source, session_key, transfer_id=grant.transfer_id)
+            )
+            promoted = await asyncio.to_thread(
+                self._session_file_service.promote_export_source,
+                source,
+                transfer_id=grant.transfer_id,
+            )
+            log.info(
+                "engine.session_file_export.reupload.done resource_id=%s size_bytes=%s",
+                source.resource_id,
+                source.size_bytes,
+            )
+            return promoted
+        finally:
+            await asyncio.to_thread(Path(snapshot).unlink, missing_ok=True)
+
+    async def _create_share_link(
+        self,
+        source: SessionFileExportSource,
+        session_key: str,
+    ):
+        return await self._export_client.create_share_link(
+            self._request(source, session_key),
+            expire_seconds=self._share_link_ttl_seconds,
+        )
+
+    @staticmethod
+    def _request(
+        source: SessionFileExportSource,
+        session_key: str,
+        *,
+        transfer_id: str | None = None,
+    ) -> SessionFileTransferRequest:
+        return SessionFileTransferRequest(
+            resource_id=source.resource_id,
+            tenant=source.tenant,
+            session_key=session_key,
+            transfer_id=transfer_id or source.transfer_id,
+        )
+
+    def _cache_ttl_seconds(self, expires_at: str) -> float:
+        try:
+            expiry = datetime.fromisoformat(expires_at)
+        except ValueError as exc:
+            raise BaasFileExportError("file_export_failed") from exc
+        if expiry.tzinfo is None:
+            raise BaasFileExportError("file_export_failed")
+        seconds = (expiry.astimezone(UTC) - datetime.now(UTC)).total_seconds()
+        if seconds <= 0:
+            raise BaasFileExportError("file_export_failed")
+        return min(seconds, float(self._share_link_ttl_seconds))

--- a/src/engine/src/engine/community/core/session_files/models.py
+++ b/src/engine/src/engine/community/core/session_files/models.py
@@ -1,7 +1,9 @@
 """Value types for the Engine-owned session file data plane."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 
 class SessionFileError(ValueError):
@@ -24,3 +26,51 @@ class SessionFileView:
             "availability": self.availability,
             "uploaded_at": self.uploaded_at,
         }
+
+
+@dataclass(frozen=True)
+class SessionFileExportSource:
+    """A manifest-controlled file prepared for an external download."""
+
+    resource_id: str
+    session_key_hash: str
+    filename: str
+    size_bytes: int
+    content_hash: str
+    canonical_path: Path
+    tenant: str
+    transfer_id: str
+    requires_upload: bool
+
+
+@dataclass(frozen=True)
+class SessionFileTransferRequest:
+    resource_id: str
+    tenant: str
+    session_key: str
+    transfer_id: str
+
+
+@dataclass(frozen=True)
+class SessionFileUploadGrant:
+    transfer_id: str
+    upload_type: str
+    upload_url: str | None = None
+    http_method: str = "PUT"
+    part_size: int | None = None
+    part_count: int | None = None
+    parts: list[dict] | None = None
+
+
+@dataclass(frozen=True)
+class BaasFileExportShareLink:
+    download_url: str
+    expires_at: str
+
+
+@dataclass(frozen=True)
+class SessionFileExternalDownload:
+    download_url: str
+    expires_at: str
+    filename: str
+    size_bytes: int

--- a/src/engine/src/engine/community/core/session_files/service.py
+++ b/src/engine/src/engine/community/core/session_files/service.py
@@ -1,9 +1,11 @@
 """Serve ready session files directly from the controlled Engine workspace."""
+
 from __future__ import annotations
 
 import hashlib
 import logging
 import mimetypes
+import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,7 +17,11 @@ from engine.community.core.resource_materialization.models import (
     hash_identifier,
 )
 from engine.community.core.resource_materialization.service import ManifestStore
-from engine.community.core.session_files.models import SessionFileError, SessionFileView
+from engine.community.core.session_files.models import (
+    SessionFileError,
+    SessionFileExportSource,
+    SessionFileView,
+)
 from engine.community.plugin_api.workspace_root import workspace_root_strict
 
 log = logging.getLogger("engine.session_files")
@@ -28,8 +34,10 @@ class SessionFileService:
         self,
         *,
         workspace_root_provider: Callable[[], Path | None] = workspace_root_strict,
+        default_baas_tenant: str | None = None,
     ) -> None:
         self._workspace_root_provider = workspace_root_provider
+        self._default_baas_tenant = default_baas_tenant
 
     def list_files(self, *, session_key: str) -> list[SessionFileView]:
         root = self._workspace_root()
@@ -78,7 +86,9 @@ class SessionFileService:
         availability, canonical = self._inspect(root, entry, force_hash=True)
         if availability != "ready" or canonical is None:
             raise SessionFileError(f"resource_{availability}")
-        media_type = mimetypes.guess_type(entry.filename)[0] or "application/octet-stream"
+        media_type = (
+            mimetypes.guess_type(entry.filename)[0] or "application/octet-stream"
+        )
         content_disposition = "{}; filename*=UTF-8''{}".format(
             disposition,
             quote(entry.filename, safe=""),
@@ -109,6 +119,135 @@ class SessionFileService:
             hash_identifier(session_key)[:16],
         )
 
+    def prepare_export_source(
+        self,
+        *,
+        session_key: str,
+        resource_id: str,
+    ) -> SessionFileExportSource:
+        """Resolve the current controlled file for a large attachment request."""
+        root, entry = self._entry_for_session(session_key, resource_id)
+        availability, canonical, size_bytes, content_hash = self._current_file(
+            root, entry
+        )
+        if availability != "ready" or canonical is None:
+            raise SessionFileError(f"resource_{availability}")
+        requires_upload = (
+            size_bytes != entry.size_bytes or content_hash != entry.content_hash
+        )
+        log.info(
+            "engine.session_files.export.source resource_id=%s size_bytes=%s requires_upload=%s",
+            resource_id,
+            size_bytes,
+            requires_upload,
+        )
+        tenant = entry.baas_tenant or self._default_baas_tenant
+        if not tenant:
+            raise SessionFileError("resource_export_tenant_unavailable")
+        return SessionFileExportSource(
+            resource_id=entry.resource_id,
+            session_key_hash=entry.session_key_hash,
+            filename=entry.filename,
+            size_bytes=size_bytes,
+            content_hash=content_hash,
+            canonical_path=canonical,
+            tenant=tenant,
+            transfer_id=entry.transfer_id,
+            requires_upload=requires_upload,
+        )
+
+    def revalidate_export_source(
+        self,
+        source: SessionFileExportSource,
+    ) -> None:
+        """Ensure an asynchronous export did not race a file or manifest change."""
+        root = self._workspace_root()
+        try:
+            entry = ManifestStore(root).get(source.resource_id)
+        except RuntimeError as exc:
+            raise SessionFileError("manifest_unavailable") from exc
+        if entry is None or entry.status != "ready":
+            raise SessionFileError("resource_missing")
+        if entry.session_key_hash != source.session_key_hash:
+            raise SessionFileError("resource_changed")
+        availability, canonical, size_bytes, content_hash = self._current_file(
+            root, entry
+        )
+        if (
+            availability != "ready"
+            or canonical != source.canonical_path
+            or size_bytes != source.size_bytes
+            or content_hash != source.content_hash
+        ):
+            raise SessionFileError(f"resource_{availability}")
+
+    def create_export_snapshot(self, source: SessionFileExportSource) -> Path:
+        """Copy a verified current file before an Engine-originated upload."""
+        self.revalidate_export_source(source)
+        root = self._workspace_root()
+        directory = root / ".teamclaw/session-files/.exports"
+        directory.mkdir(parents=True, exist_ok=True)
+        snapshot = directory / f".export-{uuid.uuid4().hex}.part"
+        digest = hashlib.sha256()
+        total = 0
+        try:
+            with (
+                source.canonical_path.open("rb") as source_stream,
+                snapshot.open("xb") as target,
+            ):
+                for chunk in iter(lambda: source_stream.read(1024 * 1024), b""):
+                    total += len(chunk)
+                    digest.update(chunk)
+                    target.write(chunk)
+            if total != source.size_bytes or digest.hexdigest() != source.content_hash:
+                raise SessionFileError("resource_changed")
+            self.revalidate_export_source(source)
+            return snapshot
+        except (OSError, SessionFileError):
+            snapshot.unlink(missing_ok=True)
+            raise
+
+    def promote_export_source(
+        self,
+        source: SessionFileExportSource,
+        *,
+        transfer_id: str,
+    ) -> SessionFileExportSource:
+        """Atomically make a verified re-upload the manifest's current source."""
+        self.revalidate_export_source(source)
+        root, entry = self._entry_for_session_hash(
+            source.resource_id, source.session_key_hash
+        )
+        observed = source.canonical_path.stat()
+        updated = ManifestStore(root).replace_export_source(
+            resource_id=source.resource_id,
+            scope_key_hash=entry.scope_key_hash,
+            session_key_hash=source.session_key_hash,
+            transfer_id=transfer_id,
+            size_bytes=source.size_bytes,
+            content_hash=source.content_hash,
+            observed_size=observed.st_size,
+            observed_mtime_ns=observed.st_mtime_ns,
+            observed_inode=getattr(observed, "st_ino", None),
+            baas_tenant=source.tenant,
+        )
+        if updated is None:
+            raise SessionFileError("resource_changed")
+        tenant = updated.baas_tenant or self._default_baas_tenant
+        if not tenant:
+            raise SessionFileError("resource_export_tenant_unavailable")
+        return SessionFileExportSource(
+            resource_id=updated.resource_id,
+            session_key_hash=updated.session_key_hash,
+            filename=updated.filename,
+            size_bytes=updated.size_bytes,
+            content_hash=updated.content_hash,
+            canonical_path=source.canonical_path,
+            tenant=tenant,
+            transfer_id=updated.transfer_id,
+            requires_upload=False,
+        )
+
     def _entry_for_session(
         self,
         session_key: str,
@@ -123,6 +262,24 @@ class SessionFileService:
             raise SessionFileError("resource_not_found")
         if entry.session_key_hash != hash_identifier(session_key):
             raise SessionFileError("resource_not_found")
+        return root, entry
+
+    def _entry_for_session_hash(
+        self,
+        resource_id: str,
+        session_key_hash: str,
+    ) -> tuple[Path, ManifestEntry]:
+        root = self._workspace_root()
+        try:
+            entry = ManifestStore(root).get(resource_id)
+        except RuntimeError as exc:
+            raise SessionFileError("manifest_unavailable") from exc
+        if (
+            entry is None
+            or entry.status != "ready"
+            or entry.session_key_hash != session_key_hash
+        ):
+            raise SessionFileError("resource_changed")
         return root, entry
 
     def _inspect(
@@ -147,9 +304,26 @@ class SessionFileService:
             and entry.observed_mtime_ns == stat.st_mtime_ns
             and entry.observed_inode == getattr(stat, "st_ino", None)
         )
-        if (force_hash or not observed_matches) and self._sha256(canonical) != entry.content_hash:
+        if (force_hash or not observed_matches) and self._sha256(
+            canonical
+        ) != entry.content_hash:
             return "changed", None
         return "ready", canonical
+
+    def _current_file(
+        self,
+        root: Path,
+        entry: ManifestEntry,
+    ) -> tuple[str, Path | None, int, str]:
+        try:
+            target = self._target(root, entry)
+            canonical = target.resolve(strict=True)
+            if not self._is_contained(root, canonical) or not canonical.is_file():
+                return "missing", None, 0, ""
+            stat = canonical.stat()
+            return "ready", canonical, stat.st_size, self._sha256(canonical)
+        except OSError:
+            return "missing", None, 0, ""
 
     def _remove_local_file(self, root: Path, entry: ManifestEntry) -> None:
         try:

--- a/src/engine/src/engine/community/core/session_files/tests/test_export_service.py
+++ b/src/engine/src/engine/community/core/session_files/tests/test_export_service.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from engine.community.core.resource_materialization.models import (
+    ManifestEntry,
+    hash_identifier,
+)
+from engine.community.core.resource_materialization.service import ManifestStore
+from engine.community.core.session_files.export_service import SessionFileExportService
+from engine.community.core.session_files.models import (
+    BaasFileExportShareLink,
+    SessionFileError,
+)
+from engine.community.core.session_files.service import SessionFileService
+from engine.community.plugin_api.session_file_export import BaasFileExportError
+
+
+def _write_file(
+    root: Path, content: bytes = b"downloadable report"
+) -> tuple[SessionFileService, str, Path]:
+    session_key = "session-a"
+    relative = f".teamclaw/session-files/scope_a/{hash_identifier(session_key)}/sr_001/report.txt"
+    path = root / relative
+    path.parent.mkdir(parents=True)
+    path.write_bytes(content)
+    stat = path.stat()
+    ManifestStore(root).upsert(
+        ManifestEntry(
+            resource_id="sr_001",
+            transfer_id="source-transfer",
+            task_id="task-001",
+            task_version=1,
+            scope_key_hash="scope_a",
+            session_key_hash=hash_identifier(session_key),
+            filename="report.txt",
+            relative_path=relative,
+            canonical_bot_absolute_path=str(path.resolve()),
+            size_bytes=len(content),
+            content_hash=hashlib.sha256(content).hexdigest(),
+            status="ready",
+            observed_size=stat.st_size,
+            observed_mtime_ns=stat.st_mtime_ns,
+            observed_inode=stat.st_ino,
+            baas_tenant="team_claw",
+        )
+    )
+    return SessionFileService(workspace_root_provider=lambda: root), session_key, path
+
+
+class _SessionFileClient:
+    def __init__(self) -> None:
+        self.share_calls = []
+        self.grant_calls = []
+        self.upload_calls = []
+        self.complete_calls = []
+        self.release: asyncio.Event | None = None
+        self.source_missing = False
+        self.fail = False
+
+    async def create_share_link(self, request, *, expire_seconds):
+        self.share_calls.append((request, expire_seconds))
+        if self.release is not None:
+            await self.release.wait()
+        if self.source_missing and len(self.share_calls) == 1:
+            raise BaasFileExportError("file_export_source_missing")
+        if self.fail:
+            raise BaasFileExportError("file_export_unavailable")
+        return BaasFileExportShareLink(
+            download_url="https://oss.example/download?redacted",
+            expires_at="2099-08-02T12:00:00Z",
+        )
+
+    async def create_upload_grant(self, request, *, filename, size_bytes):
+        self.grant_calls.append((request, filename, size_bytes))
+        return type(
+            "Grant",
+            (),
+            {
+                "transfer_id": "replacement-transfer",
+                "upload_type": "SINGLE",
+                "upload_url": "https://oss.example/upload?redacted",
+                "http_method": "PUT",
+                "part_size": None,
+                "part_count": None,
+                "parts": None,
+            },
+        )()
+
+    async def upload_file(self, grant, source_path, *, resource_id):
+        self.upload_calls.append((grant, Path(source_path).read_bytes(), resource_id))
+
+    async def complete_upload(self, request):
+        self.complete_calls.append(request)
+
+
+async def _ready_result(
+    exports: SessionFileExportService,
+    service: SessionFileService,
+    session_key: str,
+):
+    source = service.prepare_export_source(
+        session_key=session_key, resource_id="sr_001"
+    )
+    assert (
+        await exports.request_download(source=source, session_key=session_key)
+    ).state == "preparing"
+    await exports._jobs[
+        (source.resource_id, source.content_hash, source.transfer_id)
+    ].task
+    return await exports.request_download(source=source, session_key=session_key)
+
+
+@pytest.mark.asyncio
+async def test_original_transfer_is_shared_and_cached_without_upload(tmp_path: Path):
+    service, session_key, _ = _write_file(tmp_path)
+    client = _SessionFileClient()
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+
+    result = await _ready_result(exports, service, session_key)
+
+    assert result.state == "ready"
+    assert result.download is not None
+    assert result.download.filename == "report.txt"
+    assert len(client.share_calls) == 1
+    request, expires = client.share_calls[0]
+    assert request.tenant == "team_claw"
+    assert request.session_key == session_key
+    assert request.transfer_id == "source-transfer"
+    assert expires == 7200
+    assert client.grant_calls == []
+    assert client.upload_calls == []
+
+
+def test_missing_manifest_tenant_uses_injected_default_or_fails_closed(tmp_path: Path):
+    service, session_key, _ = _write_file(tmp_path)
+    entry = ManifestStore(tmp_path).get("sr_001")
+    assert entry is not None
+    ManifestStore(tmp_path).upsert(entry.model_copy(update={"baas_tenant": None}))
+
+    with pytest.raises(SessionFileError, match="resource_export_tenant_unavailable"):
+        service.prepare_export_source(session_key=session_key, resource_id="sr_001")
+
+    configured_service = SessionFileService(
+        workspace_root_provider=lambda: tmp_path,
+        default_baas_tenant="configured-tenant",
+    )
+    source = configured_service.prepare_export_source(
+        session_key=session_key,
+        resource_id="sr_001",
+    )
+
+    assert source.tenant == "configured-tenant"
+
+
+@pytest.mark.asyncio
+async def test_changed_file_is_reuploaded_and_promoted_only_in_manifest(tmp_path: Path):
+    service, session_key, path = _write_file(tmp_path)
+    path.write_bytes(b"changed report")
+    client = _SessionFileClient()
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+
+    result = await _ready_result(exports, service, session_key)
+    entry = ManifestStore(tmp_path).get("sr_001")
+
+    assert result.state == "ready"
+    assert entry is not None
+    assert entry.transfer_id == "replacement-transfer"
+    assert entry.content_hash == hashlib.sha256(b"changed report").hexdigest()
+    assert client.grant_calls[0][0].session_key == session_key
+    assert len(client.upload_calls) == 1
+    assert client.upload_calls[0][1:] == (b"changed report", "sr_001")
+    assert client.complete_calls[0].transfer_id == "replacement-transfer"
+    assert client.share_calls[0][0].transfer_id == "replacement-transfer"
+
+
+@pytest.mark.asyncio
+async def test_missing_original_transfer_reuploads_current_file(tmp_path: Path):
+    service, session_key, _ = _write_file(tmp_path)
+    client = _SessionFileClient()
+    client.source_missing = True
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+
+    result = await _ready_result(exports, service, session_key)
+
+    assert result.state == "ready"
+    assert len(client.share_calls) == 2
+    assert client.share_calls[0][0].transfer_id == "source-transfer"
+    assert client.share_calls[1][0].transfer_id == "replacement-transfer"
+    assert len(client.grant_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_source_joins_one_inflight_share_request(tmp_path: Path):
+    service, session_key, _ = _write_file(tmp_path)
+    client = _SessionFileClient()
+    client.release = asyncio.Event()
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+    source = service.prepare_export_source(
+        session_key=session_key, resource_id="sr_001"
+    )
+
+    assert (
+        await exports.request_download(source=source, session_key=session_key)
+    ).state == "preparing"
+    await asyncio.sleep(0)
+    assert (
+        await exports.request_download(source=source, session_key=session_key)
+    ).state == "preparing"
+    assert len(client.share_calls) == 1
+    client.release.set()
+    await exports._jobs[
+        (source.resource_id, source.content_hash, source.transfer_id)
+    ].task
+
+    assert (
+        await exports.request_download(source=source, session_key=session_key)
+    ).state == "ready"
+
+
+@pytest.mark.asyncio
+async def test_change_during_export_is_retried_as_a_fresh_job(tmp_path: Path):
+    service, session_key, path = _write_file(tmp_path, b"old")
+    path.write_bytes(b"first change")
+    client = _SessionFileClient()
+    client.release = asyncio.Event()
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+    source = service.prepare_export_source(
+        session_key=session_key, resource_id="sr_001"
+    )
+
+    assert (
+        await exports.request_download(source=source, session_key=session_key)
+    ).state == "preparing"
+    await asyncio.sleep(0)
+    path.write_bytes(b"second change")
+    client.release.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    fresh = service.prepare_export_source(session_key=session_key, resource_id="sr_001")
+    assert fresh.requires_upload is True
+    assert (
+        await exports.request_download(source=fresh, session_key=session_key)
+    ).state == "preparing"
+
+
+@pytest.mark.asyncio
+async def test_baas_failure_is_short_lived_and_safe_to_expose(tmp_path: Path):
+    service, session_key, _ = _write_file(tmp_path)
+    client = _SessionFileClient()
+    client.fail = True
+    exports = SessionFileExportService(
+        session_file_service=service, export_client=client
+    )
+
+    result = await _ready_result(exports, service, session_key)
+
+    assert result.state == "failed"
+    assert result.error_code == "file_export_unavailable"

--- a/src/engine/src/engine/community/di/modules/resource_materialization_module.py
+++ b/src/engine/src/engine/community/di/modules/resource_materialization_module.py
@@ -1,19 +1,26 @@
 """DI bindings for shared resource materialization."""
+
 from __future__ import annotations
+
+from injector import Binder, Module, inject, provider, singleton
 
 from engine.community.core.resource_materialization.service import (
     ResourceMaterializationService,
 )
+from engine.community.core.session_files.export_service import SessionFileExportService
 from engine.community.core.session_files.service import SessionFileService
 from engine.community.plugin_api.resource_materialization import (
     BaasMaterializationClient,
     BackendMaterializationCallbackClient,
 )
+from engine.community.plugin_api.session_file_export import BaasSessionFileClient
 from engine.community.plugins.resource_materialization import (
     NotConfiguredBaasMaterializationClient,
     NotConfiguredBackendMaterializationCallbackClient,
 )
-from injector import Binder, Module, inject, provider, singleton
+from engine.community.plugins.session_file_export import (
+    NotConfiguredBaasSessionFileClient,
+)
 
 
 class ResourceMaterializationModule(Module):
@@ -26,10 +33,16 @@ class ResourceMaterializationModule(Module):
             scope=singleton,
         )
         binder.bind(
+            BaasSessionFileClient,
+            to=NotConfiguredBaasSessionFileClient,
+            scope=singleton,
+        )
+        binder.bind(
             BackendMaterializationCallbackClient,
             to=NotConfiguredBackendMaterializationCallbackClient,
             scope=singleton,
         )
+
     @singleton
     @provider
     @inject
@@ -47,3 +60,16 @@ class ResourceMaterializationModule(Module):
     @provider
     def session_file_service(self) -> SessionFileService:
         return SessionFileService()
+
+    @singleton
+    @provider
+    @inject
+    def session_file_export_service(
+        self,
+        session_file_service: SessionFileService,
+        export_client: BaasSessionFileClient,
+    ) -> SessionFileExportService:
+        return SessionFileExportService(
+            session_file_service=session_file_service,
+            export_client=export_client,
+        )

--- a/src/engine/src/engine/community/plugin_api/session_file_export.py
+++ b/src/engine/src/engine/community/plugin_api/session_file_export.py
@@ -1,0 +1,50 @@
+"""Contracts for Session File share-link downloads and controlled re-uploads."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from engine.community.core.session_files.models import (
+    BaasFileExportShareLink,
+    SessionFileTransferRequest,
+    SessionFileUploadGrant,
+)
+
+
+class BaasFileExportError(RuntimeError):
+    """A normalized BaaS export failure that is safe to expose as an error code."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@runtime_checkable
+class BaasSessionFileClient(Protocol):
+    async def create_share_link(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        expire_seconds: int,
+    ) -> BaasFileExportShareLink: ...
+
+    async def create_upload_grant(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        filename: str,
+        size_bytes: int,
+    ) -> SessionFileUploadGrant: ...
+
+    async def upload_file(
+        self,
+        grant: SessionFileUploadGrant,
+        source_path: str,
+        *,
+        resource_id: str,
+    ) -> None: ...
+
+    async def complete_upload(
+        self,
+        request: SessionFileTransferRequest,
+    ) -> None: ...

--- a/src/engine/src/engine/community/plugins/session_file_export.py
+++ b/src/engine/src/engine/community/plugins/session_file_export.py
@@ -1,0 +1,383 @@
+"""HTTP Session File client for large attachment share links and re-uploads."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Mapping
+from urllib.parse import quote, urlsplit
+
+import httpx
+
+from engine.community.core.session_files.models import (
+    BaasFileExportShareLink,
+    SessionFileTransferRequest,
+    SessionFileUploadGrant,
+)
+from engine.community.plugin_api.session_file_export import BaasFileExportError
+
+log = logging.getLogger("engine.session_file_export")
+
+
+class NotConfiguredBaasSessionFileClient:
+    async def create_share_link(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        expire_seconds: int,
+    ) -> BaasFileExportShareLink:
+        raise BaasFileExportError("file_export_unavailable")
+
+    async def create_upload_grant(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        filename: str,
+        size_bytes: int,
+    ) -> SessionFileUploadGrant:
+        raise BaasFileExportError("file_export_unavailable")
+
+    async def upload_file(
+        self,
+        grant: SessionFileUploadGrant,
+        source_path: str,
+        *,
+        resource_id: str,
+    ) -> None:
+        raise BaasFileExportError("file_export_unavailable")
+
+    async def complete_upload(self, request: SessionFileTransferRequest) -> None:
+        raise BaasFileExportError("file_export_unavailable")
+
+
+class BaasSessionFileClient:
+    """Use Session File APIs without a Bot UUID or caller-supplied path."""
+
+    def __init__(
+        self,
+        *,
+        baas_base_url: str,
+        control_headers: Mapping[str, str],
+        allowed_share_hosts: frozenset[str],
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        parsed = urlsplit(baas_base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("invalid BaaS base URL")
+        if not allowed_share_hosts:
+            raise ValueError("allowed_share_hosts is required")
+        self._baas_base_url = baas_base_url.rstrip("/")
+        self._control_headers = dict(control_headers)
+        self._allowed_share_hosts = {host.lower() for host in allowed_share_hosts}
+        self._transport = transport
+
+    async def create_share_link(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        expire_seconds: int,
+    ) -> BaasFileExportShareLink:
+        data = await self._request(
+            "POST",
+            self._path(
+                request,
+                "files/transfers/{}/share-link".format(
+                    quote(request.transfer_id, safe="")
+                ),
+            ),
+            json={
+                "expire_seconds": expire_seconds,
+                "show": False,
+                "operator": "engine",
+            },
+            resource_id=request.resource_id,
+        )
+        url = data.get("share_url") or data.get("download_url")
+        expires_at = data.get("expires_at")
+        if not isinstance(url, str) or not isinstance(expires_at, str):
+            raise BaasFileExportError("file_export_failed")
+        self._validate_share_url(url)
+        return BaasFileExportShareLink(download_url=url, expires_at=expires_at)
+
+    async def create_upload_grant(
+        self,
+        request: SessionFileTransferRequest,
+        *,
+        filename: str,
+        size_bytes: int,
+    ) -> SessionFileUploadGrant:
+        data = await self._request(
+            "POST",
+            self._path(request, "files/upload-url"),
+            json={
+                "filename": filename,
+                "file_size": size_bytes,
+                "operator": "engine",
+                "expire_seconds": 3600,
+            },
+            resource_id=request.resource_id,
+        )
+        return SessionFileUploadGrant(
+            transfer_id=self._required_string(data, "transfer_id"),
+            upload_type=self._required_string(data, "type").upper(),
+            upload_url=self._optional_string(data, "upload_url"),
+            http_method=self._optional_string(data, "http_method") or "PUT",
+            part_size=self._optional_int(data, "part_size"),
+            part_count=self._optional_int(data, "part_count"),
+            parts=self._optional_parts(data),
+        )
+
+    async def upload_file(
+        self,
+        grant: SessionFileUploadGrant,
+        source_path: str,
+        *,
+        resource_id: str,
+    ) -> None:
+        from pathlib import Path
+
+        source = Path(source_path)
+        try:
+            size_bytes = source.stat().st_size
+        except OSError as exc:
+            raise BaasFileExportError("file_export_failed") from exc
+        if grant.upload_type == "SINGLE":
+            if not grant.upload_url:
+                raise BaasFileExportError("file_export_failed")
+            await self._put_file(
+                grant.upload_url,
+                grant.http_method,
+                source,
+                0,
+                size_bytes,
+                resource_id=resource_id,
+            )
+            return
+        if (
+            grant.upload_type != "MULTIPART"
+            or grant.part_size is None
+            or grant.part_count is None
+            or grant.parts is None
+            or grant.part_count != len(grant.parts)
+        ):
+            raise BaasFileExportError("file_export_failed")
+        offset = 0
+        for index, part in enumerate(grant.parts):
+            length = min(grant.part_size, size_bytes - offset)
+            if length <= 0:
+                raise BaasFileExportError("file_export_failed")
+            await self._put_file(
+                self._part_url(part),
+                self._part_method(part, grant.http_method),
+                source,
+                offset,
+                length,
+                resource_id=resource_id,
+                headers=self._part_headers(part),
+            )
+            offset += length
+            if (
+                not isinstance(part.get("part_number"), int)
+                or part["part_number"] != index + 1
+            ):
+                raise BaasFileExportError("file_export_failed")
+        if offset != size_bytes:
+            raise BaasFileExportError("file_export_failed")
+
+    async def complete_upload(self, request: SessionFileTransferRequest) -> None:
+        data = await self._request(
+            "POST",
+            self._path(
+                request,
+                "files/upload-url/{}/complete".format(
+                    quote(request.transfer_id, safe="")
+                ),
+            ),
+            resource_id=request.resource_id,
+        )
+        if self._required_string(data, "status").upper() != "DONE":
+            raise BaasFileExportError("file_export_failed")
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        resource_id: str,
+        json: dict | None = None,
+    ) -> dict:
+        timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
+        try:
+            async with httpx.AsyncClient(
+                base_url=self._baas_base_url,
+                headers=self._control_headers,
+                timeout=timeout,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = await client.request(method, path, json=json)
+        except httpx.HTTPError as exc:
+            log.warning(
+                "engine.session_file_export.transport_fail resource_id=%s error_type=%s",
+                resource_id,
+                type(exc).__name__,
+            )
+            raise BaasFileExportError("file_export_failed") from exc
+        if response.status_code in {404, 410}:
+            raise BaasFileExportError("file_export_source_missing")
+        if response.status_code == 503:
+            raise BaasFileExportError("file_export_unavailable")
+        if response.status_code == 504:
+            raise BaasFileExportError("file_export_timeout")
+        if response.is_error:
+            log.warning(
+                "engine.session_file_export.http_fail resource_id=%s status_code=%s",
+                resource_id,
+                response.status_code,
+            )
+            raise BaasFileExportError("file_export_failed")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise BaasFileExportError("file_export_failed") from exc
+        if (
+            not isinstance(payload, dict)
+            or payload.get("code") not in {None, 0}
+            or not isinstance(payload.get("data"), dict)
+        ):
+            raise BaasFileExportError("file_export_failed")
+        return payload["data"]
+
+    @staticmethod
+    def _path(request: SessionFileTransferRequest, operation: str) -> str:
+        return "/api/v1/sessions/{}/{}/{}".format(
+            quote(request.tenant, safe=""),
+            quote(request.session_key, safe=""),
+            operation,
+        )
+
+    @staticmethod
+    def _required_string(data: dict, key: str) -> str:
+        value = data.get(key)
+        if not isinstance(value, str) or not value:
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    @staticmethod
+    def _optional_string(data: dict, key: str) -> str | None:
+        value = data.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value:
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    @staticmethod
+    def _optional_int(data: dict, key: str) -> int | None:
+        value = data.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    @staticmethod
+    def _optional_parts(data: dict) -> list[dict] | None:
+        value = data.get("parts")
+        if value is None:
+            return None
+        if not isinstance(value, list) or not all(
+            isinstance(part, dict) for part in value
+        ):
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    def _validate_share_url(self, share_url: str) -> None:
+        parsed = urlsplit(share_url)
+        host = parsed.hostname.lower() if parsed.hostname else ""
+        if (
+            parsed.scheme != "https"
+            or not host
+            or host not in self._allowed_share_hosts
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise BaasFileExportError("file_export_failed")
+
+    async def _put_file(
+        self,
+        upload_url: str,
+        method: str,
+        source_path,
+        offset: int,
+        length: int,
+        *,
+        resource_id: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self._validate_share_url(upload_url)
+        if method.upper() not in {"PUT", "POST"}:
+            raise BaasFileExportError("file_export_failed")
+
+        async def body():
+            stream = await asyncio.to_thread(source_path.open, "rb")
+            try:
+                await asyncio.to_thread(stream.seek, offset)
+                remaining = length
+                while remaining:
+                    chunk = await asyncio.to_thread(
+                        stream.read, min(1024 * 1024, remaining)
+                    )
+                    if not chunk:
+                        raise BaasFileExportError("file_export_failed")
+                    remaining -= len(chunk)
+                    yield chunk
+            finally:
+                await asyncio.to_thread(stream.close)
+
+        request_headers = {"Content-Length": str(length)}
+        if headers:
+            request_headers.update(headers)
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(connect=10.0, read=60.0, write=600.0, pool=30.0),
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = await client.request(
+                    method.upper(), upload_url, content=body(), headers=request_headers
+                )
+            response.raise_for_status()
+        except (httpx.HTTPError, OSError) as exc:
+            log.warning(
+                "engine.session_file_export.upload_fail resource_id=%s error_type=%s",
+                resource_id,
+                type(exc).__name__,
+            )
+            raise BaasFileExportError("file_export_failed") from exc
+
+    @staticmethod
+    def _part_url(part: dict) -> str:
+        value = part.get("upload_url") or part.get("url")
+        if not isinstance(value, str) or not value:
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    @staticmethod
+    def _part_method(part: dict, default: str) -> str:
+        value = part.get("http_method") or part.get("method") or default
+        if not isinstance(value, str) or not value:
+            raise BaasFileExportError("file_export_failed")
+        return value
+
+    @staticmethod
+    def _part_headers(part: dict) -> Mapping[str, str] | None:
+        value = part.get("headers")
+        if value is None:
+            return None
+        if not isinstance(value, dict) or not all(
+            isinstance(key, str) and isinstance(item, str)
+            for key, item in value.items()
+        ):
+            raise BaasFileExportError("file_export_failed")
+        return value

--- a/src/engine/src/engine/community/plugins/tests/test_session_file_export.py
+++ b/src/engine/src/engine/community/plugins/tests/test_session_file_export.py
@@ -6,9 +6,15 @@ from pathlib import Path
 import httpx
 import pytest
 
-from engine.community.core.session_files.models import SessionFileTransferRequest
+from engine.community.core.session_files.models import (
+    SessionFileTransferRequest,
+    SessionFileUploadGrant,
+)
 from engine.community.plugin_api.session_file_export import BaasFileExportError
-from engine.community.plugins.session_file_export import BaasSessionFileClient
+from engine.community.plugins.session_file_export import (
+    BaasSessionFileClient,
+    NotConfiguredBaasSessionFileClient,
+)
 
 
 def _request(transfer_id: str = "source-001") -> SessionFileTransferRequest:
@@ -183,3 +189,62 @@ async def test_share_link_source_missing_and_untrusted_host_are_rejected():
     )
     with pytest.raises(BaasFileExportError, match="file_export_failed"):
         await untrusted.create_share_link(_request(), expire_seconds=7200)
+
+
+@pytest.mark.asyncio
+async def test_not_configured_client_fails_closed_for_every_operation():
+    client = NotConfiguredBaasSessionFileClient()
+    grant = SessionFileUploadGrant(
+        transfer_id="replacement-001",
+        upload_type="SINGLE",
+    )
+
+    with pytest.raises(BaasFileExportError, match="file_export_unavailable"):
+        await client.create_share_link(_request(), expire_seconds=7200)
+    with pytest.raises(BaasFileExportError, match="file_export_unavailable"):
+        await client.create_upload_grant(
+            _request(), filename="report.txt", size_bytes=7
+        )
+    with pytest.raises(BaasFileExportError, match="file_export_unavailable"):
+        await client.upload_file(grant, "report.txt", resource_id="sr_001")
+    with pytest.raises(BaasFileExportError, match="file_export_unavailable"):
+        await client.complete_upload(_request())
+
+
+@pytest.mark.parametrize(
+    ("base_url", "allowed_hosts", "message"),
+    [
+        ("not-a-url", frozenset({"oss.example"}), "invalid BaaS base URL"),
+        ("https://baas.example", frozenset(), "allowed_share_hosts is required"),
+    ],
+)
+def test_client_rejects_invalid_configuration(base_url, allowed_hosts, message):
+    with pytest.raises(ValueError, match=message):
+        BaasSessionFileClient(
+            baas_base_url=base_url,
+            control_headers={},
+            allowed_share_hosts=allowed_hosts,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "error_code"),
+    [
+        (httpx.Response(503), "file_export_unavailable"),
+        (httpx.Response(504), "file_export_timeout"),
+        (httpx.Response(500), "file_export_failed"),
+        (httpx.Response(200, text="not-json"), "file_export_failed"),
+        (httpx.Response(200, json={"code": 1, "data": {}}), "file_export_failed"),
+    ],
+)
+async def test_share_link_normalizes_control_plane_failures(response, error_code):
+    client = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(lambda request: response),
+    )
+
+    with pytest.raises(BaasFileExportError, match=error_code):
+        await client.create_share_link(_request(), expire_seconds=7200)

--- a/src/engine/src/engine/community/plugins/tests/test_session_file_export.py
+++ b/src/engine/src/engine/community/plugins/tests/test_session_file_export.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from engine.community.core.session_files.models import SessionFileTransferRequest
+from engine.community.plugin_api.session_file_export import BaasFileExportError
+from engine.community.plugins.session_file_export import BaasSessionFileClient
+
+
+def _request(transfer_id: str = "source-001") -> SessionFileTransferRequest:
+    return SessionFileTransferRequest(
+        resource_id="sr_001",
+        tenant="team_claw",
+        session_key="session/a",
+        transfer_id=transfer_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_link_uses_session_route_without_bot_uuid():
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.headers["x-control-token"] == "control-secret"
+        assert request.url.raw_path.decode() == (
+            "/api/v1/sessions/team_claw/session%2Fa/files/transfers/source-001/share-link"
+        )
+        assert json.loads(request.content) == {
+            "expire_seconds": 7200,
+            "show": False,
+            "operator": "engine",
+        }
+        return httpx.Response(
+            200,
+            json={
+                "code": 0,
+                "data": {
+                    "share_url": "https://oss.example/object?signature=redacted",
+                    "expires_at": "2099-08-02T12:00:00Z",
+                },
+            },
+        )
+
+    client = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={"x-control-token": "control-secret"},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(handler),
+    )
+
+    link = await client.create_share_link(_request(), expire_seconds=7200)
+
+    assert link.expires_at == "2099-08-02T12:00:00Z"
+    assert [item.method for item in requests] == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_single_upload_streams_only_file_bytes_to_oss(tmp_path: Path):
+    source = tmp_path / "report.txt"
+    source.write_bytes(b"payload")
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.host == "baas.example" and request.url.path.endswith(
+            "upload-url"
+        ):
+            assert request.headers["x-control-token"] == "control-secret"
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "data": {
+                        "transfer_id": "replacement-001",
+                        "type": "SINGLE",
+                        "upload_url": "https://oss.example/upload?signature=redacted",
+                        "http_method": "PUT",
+                    },
+                },
+            )
+        if request.url.host == "oss.example":
+            assert "x-control-token" not in request.headers
+            assert request.content == b"payload"
+            return httpx.Response(200)
+        assert request.url.path.endswith("upload-url/replacement-001/complete")
+        return httpx.Response(200, json={"code": 0, "data": {"status": "DONE"}})
+
+    client = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={"x-control-token": "control-secret"},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(handler),
+    )
+    grant = await client.create_upload_grant(
+        _request(), filename="report.txt", size_bytes=source.stat().st_size
+    )
+    await client.upload_file(grant, str(source), resource_id="sr_001")
+    await client.complete_upload(_request(grant.transfer_id))
+
+    assert [item.method for item in requests] == ["POST", "PUT", "POST"]
+    assert "/api/v1/bots/" not in "\n".join(str(item.url) for item in requests)
+
+
+@pytest.mark.asyncio
+async def test_multipart_upload_uses_each_presigned_part(tmp_path: Path):
+    source = tmp_path / "report.txt"
+    source.write_bytes(b"abcde")
+    uploaded: list[bytes] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "baas.example":
+            return httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "data": {
+                        "transfer_id": "replacement-002",
+                        "type": "MULTIPART",
+                        "part_size": 3,
+                        "part_count": 2,
+                        "parts": [
+                            {
+                                "part_number": 1,
+                                "upload_url": "https://oss.example/part-1",
+                            },
+                            {
+                                "part_number": 2,
+                                "upload_url": "https://oss.example/part-2",
+                            },
+                        ],
+                    },
+                },
+            )
+        uploaded.append(request.content)
+        return httpx.Response(200)
+
+    client = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(handler),
+    )
+    grant = await client.create_upload_grant(
+        _request(), filename="report.txt", size_bytes=source.stat().st_size
+    )
+    await client.upload_file(grant, str(source), resource_id="sr_001")
+
+    assert uploaded == [b"abc", b"de"]
+
+
+@pytest.mark.asyncio
+async def test_share_link_source_missing_and_untrusted_host_are_rejected():
+    source_missing = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(lambda request: httpx.Response(404)),
+    )
+    with pytest.raises(BaasFileExportError, match="file_export_source_missing"):
+        await source_missing.create_share_link(_request(), expire_seconds=7200)
+
+    untrusted = BaasSessionFileClient(
+        baas_base_url="https://baas.example",
+        control_headers={},
+        allowed_share_hosts=frozenset({"oss.example"}),
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                json={
+                    "code": 0,
+                    "data": {
+                        "share_url": "http://blocked.example/object",
+                        "expires_at": "2099-08-02T12:00:00Z",
+                    },
+                },
+            )
+        ),
+    )
+    with pytest.raises(BaasFileExportError, match="file_export_failed"):
+        await untrusted.create_share_link(_request(), expire_seconds=7200)


### PR DESCRIPTION
## Problem

Bot proxypass limits make direct responses unsuitable for session-file attachments larger than 30 MiB. The Engine also needs a controlled way to refresh a download when the workspace file changed or the original Session File transfer expired, without introducing Bot File Transfer identity or leaking workspace paths.

## Solution

- Keep inline previews and attachments up to 30 MiB as direct Engine streams.
- For larger attachments, asynchronously create or reuse a Session File transfer, expose `202 preparing_download` while work is in progress, and return a two-hour share link when ready.
- Re-upload a manifest-controlled snapshot through SINGLE or MULTIPART grants when the local file changed or the source transfer is unavailable, then atomically promote the new transfer only after integrity revalidation.
- Keep BaaS control credentials off OSS requests, validate allowed share hosts, and use tenant plus session key without `bot_uuid` or caller-provided paths.
- Cover unavailable configuration, invalid configuration, BaaS status mapping, malformed responses, direct small-file streaming, single-flight export, source expiry, and changed-file re-upload.

## Validation

- `src/engine/scripts/ci_test.sh --base origin/dev --head HEAD`: 2234/2234 tests passed; case pass rate 100%; total line coverage 92.68%; changed-line coverage 90.24% (675/748).
- `scripts/ci/python_sast_local.sh src/engine 1 --base origin/dev --head HEAD`: passed.
- Ruff `F,E9` checks on changed Python files: passed.
- `git diff --check origin/dev...HEAD`: passed.

## Compatibility and risk

Small attachments remain binary responses. Large attachment requests use the asynchronous JSON polling contract and depend on the Session File API and its temporary share-link lifecycle. Download URLs and transfer coordination remain in memory and are not persisted to Backend audit records.
