### PR TITLE
feat(baas): support template override migration on bot restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.bot_management.capabilities import (
     has_declared_capabilities,
     is_template_factory_config,
 )
+from agentclaw.community.core.bot_management.engines.aicoding import CODING_TEMPLATE_TYPES
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
@@ -90,7 +91,11 @@ from agentclaw.community.core.devices.repository.protocol import (
     OssToNasRecordRepository,
 )
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
-from agentclaw.community.core.devices.services.device_service import DeviceService
+from agentclaw.community.core.devices.services.device_service import (
+    ARCA_DEVICE_PROVIDER,
+    BAAS_DEVICE_PROVIDER,
+    DeviceService,
+)
 from agentclaw.community.plugin_api.drm import DRMReaderPlugin
 from agentclaw.community.plugin_api.passport import PassportError
 from agentclaw.community.plugin_api.passport import PassportPlugin
@@ -666,6 +671,83 @@ class BotService:
             template.template_uuid,
         )
         return template.template_uuid
+
+    def _resolve_restart_target_provider(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        bot: dict[str, Any],
+        source_provider: str | None,
+    ) -> str | None:
+        """Resolve an opt-in provider migration for an existing ARCA bot.
+
+        The database-backed template override is a positive-match switch. Any
+        absent, invalid, unmatched, or unreadable configuration preserves the
+        source provider and therefore the pre-existing restart behavior.
+        """
+        if source_provider != ARCA_DEVICE_PROVIDER:
+            return source_provider
+
+        active_engine = (
+            str(bot.get("active_engine") or "")
+            .strip()
+            .lower()
+            .replace("-", "_")
+        )
+        template_type = bot.get("template_type")
+        if active_engine not in {"openclaw", "hermes", "claude_code"}:
+            return source_provider
+        if active_engine == "claude_code" and template_type in CODING_TEMPLATE_TYPES:
+            return source_provider
+
+        template_resolver = getattr(self, "_baas_template_resolver", None)
+        if template_resolver is None:
+            return source_provider
+
+        owner_id = str(bot.get("owner_id") or user_id)
+        try:
+            override_uuid = template_resolver.resolve_template_override(
+                env=get_current_env(),
+                user_id=owner_id,
+                bot_type=str(bot.get("bot_type") or "personal"),
+            )
+        except Exception as e:
+            logger.warning(
+                "[bot_service.restart_provider] template override lookup failed; "
+                "preserving source provider: bot_id=%s owner_id=%s "
+                "source_provider=%s error=%s",
+                bot_id,
+                owner_id,
+                source_provider,
+                e,
+            )
+            return source_provider
+
+        if override_uuid is None:
+            logger.info(
+                "[bot_service.restart_provider] no template override hit; "
+                "preserving source provider: bot_id=%s owner_id=%s "
+                "source_provider=%s",
+                bot_id,
+                owner_id,
+                source_provider,
+            )
+            return source_provider
+
+        logger.info(
+            "[bot_service.restart_provider] template override hit; migrating provider: "
+            "bot_id=%s owner_id=%s source_provider=%s target_provider=%s "
+            "template_uuid=%s active_engine=%s template_type=%s",
+            bot_id,
+            owner_id,
+            source_provider,
+            BAAS_DEVICE_PROVIDER,
+            override_uuid,
+            active_engine,
+            template_type,
+        )
+        return BAAS_DEVICE_PROVIDER
 
     def _get_device_binding_repo(self):
         """Get the DeviceBindingRepository (injected via __init__)."""
@@ -3830,11 +3912,11 @@ class BotService:
             # against the wrong scope.
             raise BotServiceError(f"Bot {bot_id} has no entity_id; cannot restart")
 
-        # Restart is a lifecycle operation, not a fresh create rollout. When a
-        # current binding exists, preserve its provider so an existing ARCA bot
-        # cannot be migrated to BaaS merely because the owner later entered the
-        # create whitelist. An ACTIVE bot without a binding retains the legacy
-        # fallback to normal allocation. FAILED bots require a trustworthy
+        # Restart normally preserves its provider. Existing ARCA bots opt in to
+        # BaaS only when the same database-backed template override used during
+        # creation positively matches their owner; every other outcome keeps the
+        # legacy provider behavior. An ACTIVE bot without a binding retains the
+        # legacy fallback to normal allocation. FAILED bots require a trustworthy
         # historical provider because their current binding may be lost.
         current_device_provider = None
         binding_id = bot.get("binding_id")
@@ -3911,6 +3993,13 @@ class BotService:
                 f"bot_id={bot_id}, user_id={user_id}"
             )
 
+        restart_target_provider = self._resolve_restart_target_provider(
+            bot_id=bot_id,
+            user_id=user_id,
+            bot=bot,
+            source_provider=current_device_provider,
+        )
+
         # Idempotency guard: acquire the per-bot restart lock. If a restart is
         # already in progress, suppress this duplicate and return the current
         # in-progress bot — the frontend is already polling on PENDING, so this
@@ -3957,7 +4046,7 @@ class BotService:
                 bot = self._resolve_service_bot_arka_image_pin(bot)
             if (
                 binding_id
-                and current_device_provider == "baas"
+                and current_device_provider == BAAS_DEVICE_PROVIDER
                 and self._baas_service_provider is not None
             ):
                 # BaaS 原地重启：不 destroy、不 release binding，bot_uuid/device_uuid 不变,
@@ -3994,7 +4083,7 @@ class BotService:
                 bot_id=bot_id,
                 user_id=user_id,
                 nick_name=nick_name,
-                device_provider=current_device_provider,
+                device_provider=restart_target_provider,
                 restart_lock_key=lock_key,
                 bot_ext_override=(
                     bot.get("ext")

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -41,6 +41,15 @@ class BaasTemplateResolveError(DeviceServiceError):
 
 
 class BaasTemplateResolverProtocol(Protocol):
+    def resolve_template_override(
+        self,
+        *,
+        env: str,
+        user_id: str | None,
+        bot_type: str,
+    ) -> str | None:
+        """命中现有工号映射时返回覆盖的 template_uuid。"""
+
     def resolve_template_uid(
         self,
         *,
@@ -223,26 +232,26 @@ class SystemConfigBaasTemplateResolver:
         template_config: dict | None,
     ) -> BaasTemplateResolution:
         """解析当前业务上下文最终使用的 BaaS template。"""
-        # 白名单覆盖检查：个人 Bot 创建者命中白名单时，直接返回测试模板 UUID。
-        # bot_type 统一归一化后比较，避免大小写不一致导致白名单被绕过。
-        normalized_bot_type = (bot_type or "").strip().lower()
-        if normalized_bot_type == "personal":
-            override_uuid = self._resolve_whitelist_override(env=env, user_id=user_id)
-            if override_uuid is not None:
-                logger.info(
-                    "[template.whitelist] whitelist override hit: "
-                    "env=%s config_key=%s user_id=%s template_uuid=%s bot_id=%s",
-                    env,
-                    PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
-                    user_id,
-                    override_uuid,
-                    bot_id,
-                )
-                return BaasTemplateResolution(
-                    template_uid="__whitelist_override__",
-                    template_uuid=override_uuid,
-                    source="whitelist",
-                )
+        override_uuid = self.resolve_template_override(
+            env=env,
+            user_id=user_id,
+            bot_type=bot_type,
+        )
+        if override_uuid is not None:
+            logger.info(
+                "[template.whitelist] whitelist override hit: "
+                "env=%s config_key=%s user_id=%s template_uuid=%s bot_id=%s",
+                env,
+                PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
+                user_id,
+                override_uuid,
+                bot_id,
+            )
+            return BaasTemplateResolution(
+                template_uid="__whitelist_override__",
+                template_uuid=override_uuid,
+                source="whitelist",
+            )
 
         uid_resolution = self.resolve_template_uid_context(
             bot_id=bot_id,
@@ -264,6 +273,23 @@ class SystemConfigBaasTemplateResolver:
             source=uid_resolution.source,
             config_version=uid_resolution.config_version,
         )
+
+    def resolve_template_override(
+        self,
+        *,
+        env: str,
+        user_id: str | None,
+        bot_type: str,
+    ) -> str | None:
+        """从现有数据库配置解析个人或服务 Bot 的模板覆盖。
+
+        只有配置有效且 owner 工号明确命中时才返回模板。调用方可将
+        ``None`` 视为保持原逻辑，包括配置缺失、读取失败和工号未命中。
+        """
+        normalized_bot_type = (bot_type or "").strip().lower()
+        if normalized_bot_type not in {"personal", "service"}:
+            return None
+        return self._resolve_whitelist_override(env=env, user_id=user_id)
 
     def select_template_uid(
         self,

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -679,6 +679,153 @@ class TestRestartGuardOrchestration:
         start.assert_called_once()
         assert start.call_args.kwargs["device_provider"] == "arca"
 
+    @pytest.mark.parametrize(
+        ("active_engine", "template_type", "bot_type"),
+        [
+            ("openclaw", None, "personal"),
+            ("hermes", None, "personal"),
+            ("claude_code", "normalCC", "personal"),
+            ("openclaw", None, "service"),
+        ],
+        ids=["openclaw", "hermes", "claude-code", "service"],
+    )
+    def test_restart_migrates_arca_to_baas_only_on_template_override_hit(
+        self,
+        active_engine,
+        template_type,
+        bot_type,
+    ):
+        """A positive hit in the existing DB config opts ARCA into BaaS."""
+        repo = FakeRestartLockRepo()
+        resolver = MagicMock()
+        resolver.resolve_template_override.return_value = "TEMPLATE-new"
+        svc = _make_service(repo, baas_template_resolver=resolver)
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            active_engine=active_engine,
+            template_type=template_type,
+            bot_type=bot_type,
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with patch.object(svc, "stop_bot", return_value=True) as stop, \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert result == bot
+        stop.assert_called_once()
+        start.assert_called_once()
+        assert start.call_args.kwargs["device_provider"] == "baas"
+        resolver.resolve_template_override.assert_called_once_with(
+            env="dev",
+            user_id="user001",
+            bot_type=bot_type,
+        )
+
+    @pytest.mark.parametrize(
+        "lookup_result",
+        [None, "raises"],
+        ids=["not-configured-or-not-matched", "read-error"],
+    )
+    def test_restart_preserves_arca_when_template_override_does_not_hit(
+        self,
+        lookup_result,
+    ):
+        """Missing, unmatched, or unreadable config keeps the old ARCA path."""
+        repo = FakeRestartLockRepo()
+        resolver = MagicMock()
+        if lookup_result == "raises":
+            resolver.resolve_template_override.side_effect = RuntimeError(
+                "config unavailable"
+            )
+        else:
+            resolver.resolve_template_override.return_value = lookup_result
+        svc = _make_service(repo, baas_template_resolver=resolver)
+        bot = _make_bot(status="ACTIVE", binding_id=42, active_engine="openclaw")
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with patch.object(svc, "stop_bot", return_value=True), \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert start.call_args.kwargs["device_provider"] == "arca"
+
+    def test_restart_preserves_arca_without_template_resolver(self):
+        """Deployments without the resolver retain the original ARCA path."""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo, baas_template_resolver=None)
+        bot = _make_bot(status="ACTIVE", binding_id=42, active_engine="openclaw")
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with patch.object(svc, "stop_bot", return_value=True), \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert start.call_args.kwargs["device_provider"] == "arca"
+
+    @pytest.mark.parametrize(
+        ("active_engine", "template_type"),
+        [
+            ("aicoding", "personalCoding"),
+            ("claude_code", "personalCoding"),
+            ("claude_code", "applicationCoding"),
+        ],
+        ids=["aicoding", "claude-personal-coding", "claude-application-coding"],
+    )
+    def test_restart_does_not_migrate_aicoding_paths(
+        self,
+        active_engine,
+        template_type,
+    ):
+        """AI Coding paths remain on their original provider."""
+        repo = FakeRestartLockRepo()
+        resolver = MagicMock()
+        resolver.resolve_template_override.return_value = "TEMPLATE-new"
+        svc = _make_service(repo, baas_template_resolver=resolver)
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            active_engine=active_engine,
+            template_type=template_type,
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="arca",
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with patch.object(svc, "stop_bot", return_value=True), \
+             patch.object(svc, "start_bot", return_value=bot) as start:
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert start.call_args.kwargs["device_provider"] == "arca"
+        resolver.resolve_template_override.assert_not_called()
+
     def test_restart_logs_preserved_provider_before_stop(self):
         """Regression evidence: pre-release provider preservation must be visible
         in logs so staging rollback checks do not rely on DB side evidence only."""

--- a/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentclaw.community.core.devices.services.baas_template_resolver import (
+    BAAS_TEMPLATE_MAPPING_CATEGORY,
     BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY,
     PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
     BaasTemplateResolveError,
@@ -879,14 +880,55 @@ def test_whitelist_config_read_error_does_not_block():
     assert result.source == "system_config"
 
 
-def test_whitelist_skipped_for_service_bot():
-    """Whitelist override is NOT applied for service bots."""
+def test_whitelist_override_hit_for_service_bot():
+    """Service bot owners in the whitelist use the configured override UUID."""
     mapping = {
         "selectors": [{"engine": "openclaw", "template_uid": "default_template"}],
         "templates": {"default_template": {"template_uuid": "TEMPLATE-default"}},
     }
+    whitelist_config = {
+        "staff_ids": ["405935"],
+        "template_uuid": "TEMPLATE-service-override",
+    }
     system_config = MagicMock()
-    system_config.get_config.return_value = mapping
+    system_config.get_config.side_effect = lambda *, category, config_key, env: (
+        mapping
+        if config_key == BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY
+        else whitelist_config
+    )
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template(
+        bot_id="bot001",
+        user_id="405935",
+        env="pre",
+        bot_type="service",
+        engine_type="openclaw",
+        template_type=None,
+        template_config=None,
+    )
+
+    assert result.template_uuid == "TEMPLATE-service-override"
+    assert result.template_uid == "__whitelist_override__"
+    assert result.source == "whitelist"
+
+
+def test_whitelist_override_miss_for_service_bot_falls_through():
+    """Service bot owners outside the whitelist keep normal template routing."""
+    mapping = {
+        "selectors": [{"engine": "openclaw", "template_uid": "default_template"}],
+        "templates": {"default_template": {"template_uuid": "TEMPLATE-default"}},
+    }
+    whitelist_config = {
+        "staff_ids": ["168944"],
+        "template_uuid": "TEMPLATE-service-override",
+    }
+    system_config = MagicMock()
+    system_config.get_config.side_effect = lambda *, category, config_key, env: (
+        mapping
+        if config_key == BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY
+        else whitelist_config
+    )
     resolver = SystemConfigBaasTemplateResolver(system_config)
 
     result = resolver.resolve_template(
@@ -901,6 +943,44 @@ def test_whitelist_skipped_for_service_bot():
 
     assert result.template_uuid == "TEMPLATE-default"
     assert result.source == "system_config"
+
+
+def test_resolve_template_override_reads_existing_database_config():
+    """Restart lookups reuse the same system_config record as creation."""
+    system_config = MagicMock()
+    system_config.get_config.return_value = {
+        "staff_ids": [405935],
+        "template_uuid": "TEMPLATE-shared-config",
+    }
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template_override(
+        env="pre",
+        user_id="405935",
+        bot_type="service",
+    )
+
+    assert result == "TEMPLATE-shared-config"
+    system_config.get_config.assert_called_once_with(
+        category=BAAS_TEMPLATE_MAPPING_CATEGORY,
+        config_key=PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
+        env="pre",
+    )
+
+
+def test_resolve_template_override_skips_unsupported_bot_type():
+    """Unsupported bot types preserve their original path without a DB read."""
+    system_config = MagicMock()
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template_override(
+        env="pre",
+        user_id="405935",
+        bot_type="desktop",
+    )
+
+    assert result is None
+    system_config.get_config.assert_not_called()
 
 
 def test_whitelist_staff_ids_type_coercion():


### PR DESCRIPTION
## Summary

- extend the existing database-backed template whitelist override to service bots
- migrate an existing ARCA bot to BaaS on restart only when its owner explicitly matches the configured template override
- support OpenClaw, Hermes, and regular Claude Code bots while excluding AI Coding paths

## Compatibility

This change reuses the existing `system/personal_bot_test_template_whitelist` configuration. When the configuration is absent, invalid, unreadable, or does not contain the bot owner, restart preserves the current provider and follows the original behavior.

Existing BaaS bots continue using the in-place restart path. Other providers and AI Coding templates are unchanged.

## Validation

- `102 passed`: template resolver and restart idempotency tests
- `736 passed`: bot management service and device routing regression tests
- `3 passed`: architecture boundary tests
- Ruff checks passed for all changed files
- changed-line coverage: `100% (36/36)`
