### PR TITLE
feat(bcs): group_context_delivery option for driver GROUP CONTEXT on session create

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
@@ -182,6 +182,7 @@ pub async fn post_invocation(
                                 reason,
                                 session_input,
                                 task_ledger: None,
+                                driver_delivery: None,
                             },
                             &sid,
                             &session_participants,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -13,7 +13,7 @@ use axum::{
 use serde::Deserialize;
 use serde_json::Value;
 
-use bcs_domain::{ActorKind, SystemMessageEvent};
+use bcs_domain::{ActorKind, DeliveryType, SystemMessageEvent};
 use bcs_service_api::{
     AuthenticatedHumanCaller, GroupChatCommand, StartStateMachineRunCommand,
     StartStateMachineRunOutcome,
@@ -180,6 +180,12 @@ pub struct CreateSessionRequest {
     pub created_by: Option<String>,
     #[serde(default)]
     pub caller_role: Option<String>,
+    /// Optional delivery override for the driver bot's `[GROUP CONTEXT]`
+    /// message: `"send"` (default, driver is asked to respond) or
+    /// `"inject"` (driver observes silently). Other participants always
+    /// receive the context via `chat.inject`.
+    #[serde(default)]
+    pub group_context_delivery: Option<DeliveryType>,
 }
 
 pub async fn create_session_for_group(
@@ -590,6 +596,7 @@ pub async fn create_session_for_group(
                 let sid = sess.id.clone();
                 let session_input = sess.input.clone();
                 let session_participants = sess.participants.clone();
+                let driver_delivery = body.group_context_delivery;
                 let reason = group
                     .label
                     .clone()
@@ -604,6 +611,7 @@ pub async fn create_session_for_group(
                                 reason,
                                 session_input,
                                 task_ledger: None,
+                                driver_delivery,
                             },
                             &sid,
                             &session_participants,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_create_request_dto.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_create_request_dto.rs
@@ -1,0 +1,34 @@
+//! Contract tests for the `group_context_delivery` field of
+//! `CreateSessionRequest` (`POST /groups/{id}/sessions`).
+//!
+//! The field chooses whether the driver bot's `[GROUP CONTEXT]` message is
+//! actively sent (`"send"`, default, asks the driver to respond) or silently
+//! injected (`"inject"`). Other participants always receive `chat.inject`.
+
+use bcs_domain::DeliveryType;
+use bcs_http::routes::sessions::CreateSessionRequest;
+
+#[test]
+fn group_context_delivery_defaults_to_none() {
+    let req: CreateSessionRequest = serde_json::from_str(r#"{"input":"task"}"#).unwrap();
+    assert_eq!(req.group_context_delivery, None);
+}
+
+#[test]
+fn group_context_delivery_accepts_send_and_inject() {
+    let req: CreateSessionRequest =
+        serde_json::from_str(r#"{"group_context_delivery":"send"}"#).unwrap();
+    assert_eq!(req.group_context_delivery, Some(DeliveryType::Send));
+
+    let req: CreateSessionRequest =
+        serde_json::from_str(r#"{"group_context_delivery":"inject"}"#).unwrap();
+    assert_eq!(req.group_context_delivery, Some(DeliveryType::Inject));
+}
+
+#[test]
+fn group_context_delivery_rejects_unknown_value() {
+    assert!(serde_json::from_str::<CreateSessionRequest>(
+        r#"{"group_context_delivery":"bogus"}"#
+    )
+    .is_err());
+}

--- a/src/bcs/crates/contracts/bcs-domain/src/message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/message.rs
@@ -105,7 +105,8 @@ pub enum GroupMessageType {
 /// Determines how the message should be delivered to the bot:
 /// - Send: Bot should respond (mentioned or coordinator for non-@ messages)
 /// - Inject: Bot should observe silently
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DeliveryType {
     /// Bot should respond to this message.
     Send,

--- a/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
@@ -29,6 +29,12 @@ pub enum SystemMessageEvent {
         session_input: Option<serde_json::Value>,
         #[serde(default)]
         task_ledger: Option<crate::LedgerSummary>,
+        /// Delivery override for the driver bot's `[GROUP CONTEXT]` message.
+        /// `None` keeps the default `DeliveryType::Send`; `Some(Inject)`
+        /// delivers the context silently. Only applies to the driver;
+        /// other participants always receive `DeliveryType::Inject`.
+        #[serde(default)]
+        driver_delivery: Option<DeliveryType>,
     },
     HumanJoined {
         group_id: String,

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -364,6 +364,7 @@ impl BcsChannelService {
                         reason,
                         session_input: session.input.clone(),
                         task_ledger: None,
+                        driver_delivery: None,
                     },
                     &session.id,
                     &session.participants,
@@ -3846,6 +3847,7 @@ mod tests {
             reason,
             session_input,
             task_ledger,
+            ..
         } = &notification.event
         else {
             return Err("expected session context notification".into());

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -1132,6 +1132,7 @@ impl GroupManagementService for GroupManagement {
                                 reason,
                                 session_input: None,
                                 task_ledger: None,
+                                driver_delivery: None,
                             },
                             &sid,
                             &session_participants,

--- a/src/bcs/crates/services/bcs-proposal/src/application/proposal.rs
+++ b/src/bcs/crates/services/bcs-proposal/src/application/proposal.rs
@@ -333,6 +333,7 @@ impl GroupProposalService for GroupProposalUseCases {
                     reason: proposal.reason.clone(),
                     session_input: None,
                     task_ledger: None,
+                    driver_delivery: None,
                 },
                 &session.id,
                 &session.participants,

--- a/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
+++ b/src/bcs/crates/services/bcs-proposal/tests/use_cases.rs
@@ -357,6 +357,7 @@ async fn confirm_proposal_creates_initial_session_and_dispatches_session_context
             reason,
             session_input,
             task_ledger,
+            ..
         } => {
             assert_eq!(group_id, &confirmed.group_id);
             assert_eq!(session_id, &format!("{}:initial", confirmed.group_id));

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -432,6 +432,7 @@ async fn dispatch_session_context_preserves_manager_worker_group_type() {
         reason: "性能审计".to_string(),
         session_input: Some(serde_json::json!("执行数据库慢查询审计")),
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());
@@ -482,6 +483,7 @@ async fn dispatch_manager_worker_session_context_persists_worker_private_context
         reason: "性能审计".to_string(),
         session_input: Some(serde_json::json!("执行数据库慢查询审计")),
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());
@@ -547,6 +549,7 @@ async fn dispatch_manager_worker_session_context_persists_each_worker_private_co
         reason: "性能审计".to_string(),
         session_input: Some(serde_json::json!("执行数据库慢查询审计")),
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());
@@ -604,6 +607,7 @@ async fn dispatch_non_manager_worker_session_context_persists_per_recipient_reco
         reason: "普通协作".to_string(),
         session_input: None,
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());
@@ -655,6 +659,7 @@ async fn dispatch_manager_worker_session_context_does_not_make_worker_context_pu
         reason: "性能审计".to_string(),
         session_input: None,
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());
@@ -1211,6 +1216,7 @@ async fn dispatch_session_context_with_provider_registry(
         reason: reason.to_string(),
         session_input: None,
         task_ledger: None,
+        driver_delivery: None,
     };
     let registry = Arc::new(ProviderTargetRegistry::default());
     let delivery = Arc::new(MockDeliveryPort::default());

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -3,7 +3,10 @@
 //! When a session is created this producer generates the initial
 //! `[GROUP CONTEXT]` or `[SERVICE GROUP CONTEXT]` message delivered
 //! to all bot participants, with `chat.send` for the driver/manager
-//! and `chat.inject` for other participants.
+//! and `chat.inject` for other participants. The driver's delivery
+//! can be overridden to `chat.inject` via the event's
+//! `driver_delivery` field (except in ManagerWorker groups, which
+//! always deliver to the manager via `chat.send`).
 
 use std::collections::HashMap;
 
@@ -36,6 +39,7 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
             reason,
             session_input,
             task_ledger,
+            driver_delivery,
             ..
         } = event
         else {
@@ -64,13 +68,22 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
         let mut messages = Vec::new();
         for participant in bot_participants {
             let is_driver = is_lead_participant(&render_group, participant);
+            let is_manager_worker = render_group.group_strategy == GroupStrategy::ManagerWorker;
             let delivery_type = if is_driver {
-                DeliveryType::Send
+                // ManagerWorker groups intentionally ignore the
+                // `driver_delivery` (group_context_delivery) override: the
+                // manager is expected to actively pick up and dispatch the
+                // task, so its context is always delivered via `chat.send`.
+                if is_manager_worker {
+                    DeliveryType::Send
+                } else {
+                    driver_delivery.unwrap_or(DeliveryType::Send)
+                }
             } else {
                 DeliveryType::Inject
             };
 
-            let context_message = if render_group.group_strategy == GroupStrategy::ManagerWorker {
+            let context_message = if is_manager_worker {
                 let coordination_surface = registry
                     .resolve_coordination_surface(&participant.bot_uuid)
                     .await

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -261,6 +261,7 @@ async fn manager_worker_session_context_messages_with_ledger(
         reason: "协作任务".to_string(),
         session_input: None,
         task_ledger,
+        driver_delivery: None,
     };
 
     let (messages, _) = SessionContextMessageProducer
@@ -366,6 +367,7 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
         reason: "协作任务".to_string(),
         session_input: None,
         task_ledger: None,
+        driver_delivery: None,
     };
 
     let (messages, _) = SessionContextMessageProducer
@@ -453,6 +455,7 @@ async fn session_context_produces_no_user_message() {
         reason: "普通协作".to_string(),
         session_input: Some(serde_json::json!("任务X")),
         task_ledger: None,
+        driver_delivery: None,
     };
     let (chat_messages, chat_user_message) = SessionContextMessageProducer
         .produce(&chat_event, &chat_group, &NamedRegistry::new(&[]), &chat_group.participants)
@@ -480,10 +483,123 @@ async fn session_context_produces_no_user_message() {
             failed: Vec::new(),
             timed_out: Vec::new(),
         }),
+        driver_delivery: None,
     };
     let (mw_messages, mw_user_message) = SessionContextMessageProducer
         .produce(&mw_event, &mw_group, &NamedRegistry::new(&[]), &mw_group.participants)
         .await;
     assert!(!mw_messages.is_empty(), "MW bot context messages still produced");
     assert!(mw_user_message.is_none(), "MW SessionContext user_message must be None");
+}
+
+#[tokio::test]
+async fn driver_delivery_defaults_to_send_for_driver() {
+    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
+    driver.bot_name = Some("Driver".to_string());
+    let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
+    peer.bot_name = Some("Peer".to_string());
+    let mut group = Group::new("group-chat-default", "bot-driver", vec![driver, peer]);
+    group.group_strategy = GroupStrategy::Chat;
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "普通协作".to_string(),
+        session_input: None,
+        task_ledger: None,
+        driver_delivery: None,
+    };
+    let (messages, _) = SessionContextMessageProducer
+        .produce(&event, &group, &NamedRegistry::new(&[]), &group.participants)
+        .await;
+
+    let driver_message = messages
+        .iter()
+        .find(|m| m.recipients == vec!["bot-driver".to_string()])
+        .expect("driver receives context");
+    assert_eq!(driver_message.delivery_type, DeliveryType::Send);
+
+    let peer_message = messages
+        .iter()
+        .find(|m| m.recipients == vec!["bot-peer".to_string()])
+        .expect("peer receives context");
+    assert_eq!(peer_message.delivery_type, DeliveryType::Inject);
+}
+
+#[tokio::test]
+async fn driver_delivery_override_injects_to_driver_in_chat_group() {
+    let mut driver = Participant::bot("bot-driver", ParticipantRole::Driver);
+    driver.bot_name = Some("Driver".to_string());
+    let mut peer = Participant::bot("bot-peer", ParticipantRole::Consultant);
+    peer.bot_name = Some("Peer".to_string());
+    let mut group = Group::new("group-chat-override", "bot-driver", vec![driver, peer]);
+    group.group_strategy = GroupStrategy::Chat;
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "普通协作".to_string(),
+        session_input: None,
+        task_ledger: None,
+        driver_delivery: Some(DeliveryType::Inject),
+    };
+    let (messages, _) = SessionContextMessageProducer
+        .produce(&event, &group, &NamedRegistry::new(&[]), &group.participants)
+        .await;
+
+    let driver_message = messages
+        .iter()
+        .find(|m| m.recipients == vec!["bot-driver".to_string()])
+        .expect("driver receives context");
+    assert_eq!(
+        driver_message.delivery_type,
+        DeliveryType::Inject,
+        "driver_delivery=inject must override the driver's default chat.send"
+    );
+
+    let peer_message = messages
+        .iter()
+        .find(|m| m.recipients == vec!["bot-peer".to_string()])
+        .expect("peer receives context");
+    assert_eq!(peer_message.delivery_type, DeliveryType::Inject);
+}
+
+#[tokio::test]
+async fn manager_worker_ignores_driver_delivery_override() {
+    // ManagerWorker groups intentionally ignore driver_delivery: the manager
+    // must actively pick up and dispatch the task, so its context is always
+    // delivered via chat.send even when the override asks for inject.
+    let manager_id = "20260416_a5clr6ig:12345678";
+    let worker_id = "20260528_vobmrqo6:12345678";
+    let mut manager = Participant::bot(manager_id, ParticipantRole::Manager);
+    manager.bot_name = Some(manager_id.to_string());
+    let mut worker = Participant::bot(worker_id, ParticipantRole::Worker);
+    worker.bot_name = Some(worker_id.to_string());
+    let mut group = Group::new("group-mw-override", manager_id, vec![manager, worker]);
+    group.group_strategy = GroupStrategy::ManagerWorker;
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: format!("{}:7c18e4be", group.id),
+        reason: "协作任务".to_string(),
+        session_input: Some(serde_json::json!("执行慢查询审计")),
+        task_ledger: None,
+        driver_delivery: Some(DeliveryType::Inject),
+    };
+    let (messages, _) = SessionContextMessageProducer
+        .produce(&event, &group, &NamedRegistry::new(&[]), &group.participants)
+        .await;
+
+    let manager_message = messages
+        .iter()
+        .find(|m| m.recipients == vec![manager_id.to_string()])
+        .expect("manager receives context");
+    assert_eq!(
+        manager_message.delivery_type,
+        DeliveryType::Send,
+        "ManagerWorker manager always receives chat.send regardless of driver_delivery"
+    );
+
+    let worker_message = messages
+        .iter()
+        .find(|m| m.recipients == vec![worker_id.to_string()])
+        .expect("worker receives context");
+    assert_eq!(worker_message.delivery_type, DeliveryType::Inject);
 }


### PR DESCRIPTION
## Problem

Session creation (`POST /groups/{id}/sessions`) always delivers the initial `[GROUP CONTEXT]` message to the driver bot via `chat.send`, i.e. the driver is actively asked to respond. Callers have no way to create a session where the driver only observes the context silently (e.g. workbench/driven flows that will @mention or steer the driver later).

## Solution

Add an optional `group_context_delivery` field (`"send"` | `"inject"`) to the create-session request:

- Absent or `"send"`: unchanged behavior — driver receives `chat.send`.
- `"inject"`: driver receives the context via `chat.inject` (silent). Other participants always receive `chat.inject` regardless, as before.
- ManagerWorker groups intentionally ignore the override: the manager must actively pick up and dispatch the task, so its context is always `chat.send` (documented in the producer).

The choice is creation-time only, so it is threaded through a new optional `driver_delivery` field on `SystemMessageEvent::SessionContext` rather than persisted; the four other event construction sites (service invocation, proposal confirm, group management, channel) pass `None` and are unchanged. `DeliveryType` gains serde (`"send"`/`"inject"`) so it can be used in HTTP DTOs.

Rejected alternative: persisting the preference on the session (`meta` or a new column) — unnecessary because `SessionContext` is only emitted at session creation, never on reactivation.

## Validation

- `cargo check --workspace --all-targets` — clean.
- New producer unit tests in `session_context_test.rs`: driver defaults to `Send`, `driver_delivery: Some(Inject)` injects the driver in Chat groups, ManagerWorker ignores the override (manager stays `Send`).
- New DTO contract tests `session_create_request_dto.rs`: field defaults to `None`, accepts `send`/`inject`, rejects unknown values (400 via serde).
- Full test runs of `bcs-domain`, `bcs-system-message`, `bcs-http` (all test targets), `bcs-channel`, `bcs-proposal`, `bcs-group` — all green.
- Pre-existing `cargo clippy` findings in `bcs-domain` are identical on the clean tree (26 error lines before and after); no new lint introduced.

## Compatibility and risk

Fully backward compatible: omitting the field preserves today's behavior. No schema migration (no persistence). Unknown enum values are rejected at deserialization with 400, consistent with other enum request fields.