### PR TITLE
fix(backend): publish direct skills in Pool mappings

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -1015,10 +1015,13 @@ async def activate_skill(
             engine_type=effective_engine,
             entity_type=effective_entity_type,
         )
-        symlinks = skill_set_service.get_symlink_mappings(
-            user_id=ctx.user_id,
-            bolt_id=effective_bot_id
-        )
+        mapping_kwargs: dict[str, Any] = {
+            "user_id": ctx.user_id,
+            "bolt_id": effective_bot_id,
+        }
+        if service.runtime_uses_pool_paths:
+            mapping_kwargs["additional_skill_paths"] = [actual_skill_id]
+        symlinks = skill_set_service.get_symlink_mappings(**mapping_kwargs)
         symlinks_dict = [sm.to_dict() for sm in symlinks]
         sync_result = device_sync.sync_symlinks(symlinks_dict)
         logger.info(f"[skills.activate_skill] Device sync result: {sync_result}")
@@ -1101,7 +1104,7 @@ async def deactivate_skill(
         )
         symlinks = skill_set_service.get_symlink_mappings(
             user_id=ctx.user_id,
-            bolt_id=effective_bot_id
+            bolt_id=effective_bot_id,
         )
         symlinks_dict = [sm.to_dict() for sm in symlinks]
         sync_result = device_sync.sync_symlinks(symlinks_dict)
@@ -1592,10 +1595,15 @@ async def activate_skills_batch(
             engine_type=effective_engine,
             entity_type=effective_entity_type,
         )
-        symlinks = skill_set_service.get_symlink_mappings(
-            user_id=ctx.user_id,
-            bolt_id=effective_bot_id
-        )
+        mapping_kwargs: dict[str, Any] = {
+            "user_id": ctx.user_id,
+            "bolt_id": effective_bot_id,
+        }
+        if service.runtime_uses_pool_paths:
+            mapping_kwargs["additional_skill_paths"] = [
+                item["path"] for item in results["success"]
+            ]
+        symlinks = skill_set_service.get_symlink_mappings(**mapping_kwargs)
         symlinks_dict = [sm.to_dict() for sm in symlinks]
         sync_result = device_sync.sync_symlinks(symlinks_dict)
         logger.info(f"[skills.activate_skills_batch] Device sync result: {sync_result}")

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -604,7 +604,10 @@ class SkillService:
             source_relative = source.resolve()
             logger.debug(f"[SkillService.activate_skill] Using absolute path (relative calculation failed): {target_link} -> {source_relative}")
 
-        if target_link.exists() or target_link.is_symlink():
+        if (
+            not self.runtime_uses_pool_paths
+            and (target_link.exists() or target_link.is_symlink())
+        ):
             # Phase 4: engine-view path — 让 engine 在 VM 内删，不要宿主机 shutil.rmtree
             success = await self._delete_active_entry(device_fs, target_link)
             if not success:
@@ -612,6 +615,12 @@ class SkillService:
                     f"[SkillService.activate_skill] Failed to remove existing link at {target_link}"
                 )
                 return False
+
+        # Pool bindpath validates every source before replacing targets. Keep an
+        # existing runtime link in place until that single authoritative publish
+        # succeeds; eagerly deleting it here would create a gap and would violate
+        # fail-before-mutation when the requested mapping conflicts with an active
+        # SkillSet mapping.
 
         # R2 修复: 不再 pathlib 本地写软链。
         # 软链建立由 device_sync (调 adapter bindpath) 单方面负责,跟线上 Arca 行为对齐。

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1176,7 +1176,8 @@ class SkillSetService:
     def get_symlink_mappings(
         self,
         user_id: str | None = None,
-        bolt_id: str | None = None
+        bolt_id: str | None = None,
+        additional_skill_paths: list[str] | None = None,
     ) -> list[SynlinkMappingInfo]:
         """生成技能激活软链配置（支持多能力集激活）
 
@@ -1186,11 +1187,39 @@ class SkillSetService:
         Args:
             user_id: 用户 ID
             bolt_id: Bot ID，默认使用 self.bot_id
+            additional_skill_paths: 当前请求直接激活、但尚未属于 active
+                SkillSet 的 Skill locator。它们与 SkillSet 快照使用同一套
+                Engine/Planner 路径规则生成一次完整 publish。
 
         Returns:
             List[SynlinkMappingInfo]: 软链配置列表（已去重）
         """
         unique_skills = self.get_active_skills(user_id=user_id, bolt_id=bolt_id)
+
+        # Direct Skill CRUD is intentionally orthogonal to SkillSet membership.
+        # The device boundary accepts a complete mapping publish, so the current
+        # request must be merged into the active-SkillSet snapshot explicitly;
+        # otherwise bindpath can report success while never seeing the requested
+        # Skill. Keep the locator as the identity and let the common mapping code
+        # below select Legacy/Pool roots for every filesystem engine.
+        seen_paths = {
+            str(skill.get("git_path", ""))
+            for skill in unique_skills
+            if skill.get("git_path")
+        }
+        requested_paths = additional_skill_paths or []
+        for skill_path in requested_paths:
+            if not isinstance(skill_path, str) or not skill_path.startswith(
+                ("git://", "local://")
+            ):
+                raise ValueError(
+                    f"Unsupported direct Skill locator: {skill_path!r}"
+                )
+            if skill_path in seen_paths:
+                continue
+            unique_skills.append({"name": "", "git_path": skill_path})
+            seen_paths.add(skill_path)
+
         if not unique_skills:
             return []
 
@@ -1303,11 +1332,31 @@ class SkillSetService:
                 target = str(base_skills_dir / skill_name)
                 symlinks.append(SynlinkMappingInfo(source=source, target=target))
 
-        logger.info(f"[get_symlink_mappings] 生成软链配置完成: symlinks_count={len(symlinks)}")
-        for sm in symlinks:
+        resolved_mappings = symlinks
+        if requested_paths:
+            # A single runtime link name cannot safely resolve to two corpora.
+            # Reject collisions before calling the device boundary; identical
+            # mappings are harmless duplicates and collapse in insertion order.
+            resolved_mappings = []
+            mappings_by_target: dict[str, SynlinkMappingInfo] = {}
+            for mapping in symlinks:
+                existing = mappings_by_target.get(mapping.target)
+                if existing is None:
+                    mappings_by_target[mapping.target] = mapping
+                    resolved_mappings.append(mapping)
+                    continue
+                if existing.source != mapping.source:
+                    raise ValueError(
+                        "Conflicting Skill mappings for runtime target "
+                        f"{mapping.target!r}: {existing.source!r} != "
+                        f"{mapping.source!r}"
+                    )
+
+        logger.info(f"[get_symlink_mappings] 生成软链配置完成: symlinks_count={len(resolved_mappings)}")
+        for sm in resolved_mappings:
             logger.info(f"[get_symlink_mappings] symlink: source={sm.source}, target={sm.target}")
 
-        return symlinks
+        return resolved_mappings
 
     # ====== MCP Server Management in SkillSet ======
 

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -54,7 +54,12 @@ def _skill_service_di_app(
     mock_skill_service.activate_skill = AsyncMock(return_value=True)
     mock_skill_service.deactivate_skill = AsyncMock(return_value=True)
     mock_skill_service.activate_skills_batch = AsyncMock(
-        return_value={"success": ["a"], "failed": []}
+        return_value={
+            "success": [
+                {"id": "a", "link_name": "a", "path": "git://path/a"}
+            ],
+            "failed": [],
+        }
     )
     mock_skill_service.get_link_name = MagicMock(return_value="link_name")
     mock_skill_service.runtime_uses_pool_paths = runtime_uses_pool_paths
@@ -135,7 +140,7 @@ def _skill_service_di_app(
     injector = Injector([_TestModule()])
     attach_injector(app, injector)
     client = TestClient(app, raise_server_exceptions=False)
-    yield client, mock_skill_service
+    yield client, mock_skill_service, mock_skill_set_service
 
 
 @contextmanager
@@ -532,7 +537,7 @@ class TestActivateSkillAsyncAwait:
     """
 
     def test_activate_skill_awaits_service_method(self, mock_ctx):
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post(
                 "/api/skills/my-skill-id/activate",
                 json={"source_path": "git://some/path"},
@@ -554,7 +559,7 @@ class TestActivateSkillAsyncAwait:
         the device_fs router. The fix uses kwargs to make the contract
         explicit and unambiguous.
         """
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post(
                 "/api/skills/my-skill-id/activate",
                 json={"source_path": "git://some/path"},
@@ -579,12 +584,51 @@ class TestActivateSkillAsyncAwait:
                 f"got {call.kwargs['user_id']!r}"
             )
 
+    def test_pool_activate_merges_requested_locator_into_mapping_publish(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(
+            mock_ctx, runtime_uses_pool_paths=True
+        ) as (client, _, mock_set_svc):
+            response = client.post(
+                "/api/skills/1120709/activate",
+                json={
+                    "source_path": "local:///pool/direct-local",
+                    "relative_path": "local:///pool/direct-local",
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            assert mock_set_svc.get_symlink_mappings.call_args.kwargs == {
+                "user_id": mock_ctx.user_id,
+                "bolt_id": mock_ctx.bot_id,
+                "additional_skill_paths": ["local:///pool/direct-local"],
+            }
+
+    def test_legacy_activate_keeps_existing_mapping_publish_contract(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(mock_ctx) as (client, _, mock_set_svc):
+            response = client.post(
+                "/api/skills/1120709/activate",
+                json={
+                    "source_path": "local:///legacy/direct-local",
+                    "relative_path": "local:///legacy/direct-local",
+                },
+            )
+
+            assert response.status_code == 200, response.text
+            assert mock_set_svc.get_symlink_mappings.call_args.kwargs == {
+                "user_id": mock_ctx.user_id,
+                "bolt_id": mock_ctx.bot_id,
+            }
+
     def test_activate_skill_fails_when_runtime_mapping_sync_fails(self, mock_ctx):
         with _skill_service_di_app(
             mock_ctx,
             device_sync_result={"success": False, "message": "source missing"},
             runtime_uses_pool_paths=True,
-        ) as (client, mock_svc):
+        ) as (client, mock_svc, _):
             response = client.post(
                 "/api/skills/my-skill-id/activate",
                 json={"source_path": "local://skills-local/my-skill"},
@@ -610,7 +654,7 @@ class TestDeactivateSkillAsyncAwait:
     """
 
     def test_deactivate_skill_awaits_service_method(self, mock_ctx):
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post("/api/skills/my-skill-id/deactivate")
             # If the bug exists: mock await_count == 0 (missing await)
             # After fix: mock await_count == 1
@@ -621,7 +665,7 @@ class TestDeactivateSkillAsyncAwait:
 
     def test_deactivate_skill_passes_correct_skill_id(self, mock_ctx):
         """user_id/bolt_id must be passed as kwargs (not positional)."""
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post("/api/skills/my-skill-id/deactivate")
             mock_svc.deactivate_skill.assert_called_once()
             call = mock_svc.deactivate_skill.call_args
@@ -643,7 +687,7 @@ class TestDeactivateSkillAsyncAwait:
             mock_ctx,
             device_sync_result={"success": False, "message": "runtime unavailable"},
             runtime_uses_pool_paths=True,
-        ) as (client, mock_svc):
+        ) as (client, mock_svc, _):
             response = client.post("/api/skills/my-skill-id/deactivate")
 
             assert response.status_code == 502
@@ -666,7 +710,7 @@ class TestActivateSkillsBatchAsyncAwait:
     """
 
     def test_activate_skills_batch_awaits_service_method(self, mock_ctx):
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post(
                 "/api/skills/market/activate-batch",
                 json={"skill_paths": ["git://path/a", "git://path/b"]},
@@ -680,7 +724,7 @@ class TestActivateSkillsBatchAsyncAwait:
 
     def test_activate_skills_batch_passes_correct_skill_paths(self, mock_ctx):
         """skill_paths must propagate; user_id/bolt_id must be kwargs."""
-        with _skill_service_di_app(mock_ctx) as (client, mock_svc):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
             client.post(
                 "/api/skills/market/activate-batch",
                 json={"skill_paths": ["git://path/a", "git://path/b"]},
@@ -701,6 +745,35 @@ class TestActivateSkillsBatchAsyncAwait:
             )
             assert call.kwargs["user_id"] == mock_ctx.user_id
 
+    def test_pool_batch_merges_only_successful_locators_into_mapping_publish(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(
+            mock_ctx, runtime_uses_pool_paths=True
+        ) as (client, mock_svc, mock_set_svc):
+            mock_svc.activate_skills_batch.return_value = {
+                "success": [
+                    {
+                        "id": "a",
+                        "link_name": "a",
+                        "path": "git://path/a",
+                    }
+                ],
+                "failed": [
+                    {"path": "git://path/b", "error": "source missing"}
+                ],
+            }
+
+            response = client.post(
+                "/api/skills/market/activate-batch",
+                json={"skill_paths": ["git://path/a", "git://path/b"]},
+            )
+
+            assert response.status_code == 200, response.text
+            assert mock_set_svc.get_symlink_mappings.call_args.kwargs[
+                "additional_skill_paths"
+            ] == ["git://path/a"]
+
     def test_activate_skills_batch_fails_when_runtime_mapping_sync_fails(
         self, mock_ctx
     ):
@@ -708,7 +781,7 @@ class TestActivateSkillsBatchAsyncAwait:
             mock_ctx,
             device_sync_result={"success": False, "message": "source missing"},
             runtime_uses_pool_paths=True,
-        ) as (client, mock_svc):
+        ) as (client, mock_svc, _):
             response = client.post(
                 "/api/skills/market/activate-batch",
                 json={"skill_paths": ["git://path/a"]},

--- a/src/backend/tests/community/services/test_skill_service_async.py
+++ b/src/backend/tests/community/services/test_skill_service_async.py
@@ -228,6 +228,25 @@ class TestSkillServiceAsyncRouting:
         device_fs.exists.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_pool_activate_keeps_existing_link_until_bindpath_publish(
+        self, tmp_path
+    ):
+        service, device_fs, _ = self._service(tmp_path)
+        service.runtime_uses_pool_paths = True
+        existing = service.active_dir / "direct-skill"
+        existing.symlink_to("skills-repo/business/direct-skill")
+
+        activated = await service.activate_skill(
+            "git://business/direct-skill",
+            user_id="user1",
+            bolt_id="bot1",
+        )
+
+        assert activated is True
+        device_fs.delete_tree.assert_not_awaited()
+        assert existing.is_symlink()
+
+    @pytest.mark.asyncio
     async def test_upload_does_not_overwrite_global_local_skill(
         self, tmp_path
     ):

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -269,6 +269,100 @@ class TestGetSymlinkMappings:
             ),
         ]
 
+    @pytest.mark.parametrize(
+        ("engine", "active_dir", "pool_dir"),
+        [
+            (
+                "openclaw",
+                "/home/admin/.openclaw/workspace/skills",
+                "/home/admin/.openclaw/workspace/skills-pool",
+            ),
+            (
+                "claude_code",
+                "/home/admin/.claude/skills",
+                "/home/admin/.claude_code/workspace/skills-pool",
+            ),
+            (
+                "hermes",
+                "/home/admin/.hermes/skills",
+                "/home/admin/.hermes/workspace/skills-pool",
+            ),
+        ],
+    )
+    def test_direct_local_activation_uses_pool_mapping_for_filesystem_engines(
+        self,
+        skill_set_service,
+        mock_skill_set_repo,
+        engine,
+        active_dir,
+        pool_dir,
+    ):
+        skill_set_service.engine_type = engine
+        skill_set_service.entity_id = "100015"
+        skill_set_service.is_desktop = True
+        skill_set_service._pool_layout_paths = lambda *_: (
+            active_dir,
+            f"{pool_dir}/skills-local",
+            f"{pool_dir}/skills-repo",
+        )
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = []
+
+        mappings = skill_set_service.get_symlink_mappings(
+            user_id="100015",
+            bolt_id="desktop-bot",
+            additional_skill_paths=[
+                f"local://{pool_dir}/skills-local/direct-local"
+            ],
+        )
+
+        assert [mapping.to_dict() for mapping in mappings] == [
+            {
+                "source": f"{pool_dir}/skills-local/direct-local",
+                "target": f"{active_dir}/direct-local",
+                "skill_uuid": None,
+                "version": None,
+            }
+        ]
+
+    def test_direct_activation_deduplicates_existing_identical_mapping(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Active", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "same",
+                "git_path": "git://business/same",
+            }
+        ]
+
+        mappings = skill_set_service.get_symlink_mappings(
+            additional_skill_paths=["git://business/same"]
+        )
+
+        assert len(mappings) == 1
+
+    def test_direct_activation_rejects_runtime_target_collision(
+        self, skill_set_service, mock_skill_set_repo
+    ):
+        mock_skill_set_repo.get_all_active_skill_sets.return_value = [
+            {"id": "1", "name": "Active", "is_default": False}
+        ]
+        mock_skill_set_repo.get_skills_in_set.return_value = [
+            {
+                "id": "1",
+                "name": "same",
+                "git_path": "git://business/one/same",
+            }
+        ]
+
+        with pytest.raises(ValueError, match="Conflicting Skill mappings"):
+            skill_set_service.get_symlink_mappings(
+                additional_skill_paths=["git://business/two/same"]
+            )
+
     def test_pool_active_repo_only_skill_uses_canonical_pool_source(
         self, skill_set_service, mock_skill_set_repo
     ):


### PR DESCRIPTION
## Summary
- merge a Pool-active direct Skill locator into the same full mapping publish as active SkillSets
- keep Legacy and non-Pool mapping calls unchanged
- reject conflicting runtime targets before device mutation and keep an existing Pool link until authoritative bindpath succeeds
- cover OpenClaw, Claude Code, and Hermes Pool roots plus direct batch activation

## Problem
A real pre Desktop OpenClaw acceptance for #455 uploaded local Skill \`1120709 / sp455-r2-oc-probe\`. The activate API returned success twice, but the runtime link was absent. Backend traces showed the requested Pool local mapping was computed by the direct activation path but \`get_symlink_mappings()\` published only the six active-SkillSet mappings, so BaaS/Engine never received the requested Skill.

## Scope / compatibility
- only callers whose request-scoped SkillService reports \`runtime_uses_pool_paths=true\` add direct locators
- rollout-disabled/unclaimed Desktop, Legacy, and non-Desktop callers keep the existing mapping publish contract
- no new state table, lock, Desktop state machine, or alternate probe contract

## Verification
- Backend focused and Skills Pool suite: 981 passed
- Engine bindpath / Claude adapter focused suite: 248 passed
- focused Pool direct-activation regressions: 7 passed
- Ruff, local Python SAST, and git diff check passed

Relates to #455.
