### PR TITLE
fix(bcs): allow human-owned actors to manage v1 collaboration

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -268,7 +268,7 @@ GroupPath:
         description: >-
           Principal cannot manage the group. A Human Principal may manage when
           it can act as at least one Group management actor: the driver,
-          originator, or manager participant. Human-to-actor authority is
+          originator, or ManagerWorker manager participant. Human-to-actor authority is
           checked only against these target actors: direct human_{user.id}, a
           Bot whose created_by equals the Human user id, or a creator relation
           edge from human_{user.id} to that Bot. The server does not enumerate
@@ -335,7 +335,7 @@ GroupPath:
         description: >-
           Principal cannot delete the group. A Human Principal may delete when
           it can act as at least one Group management actor: the driver,
-          originator, or manager participant. Human-to-actor authority is
+          originator, or ManagerWorker manager participant. Human-to-actor authority is
           checked only against these target actors rather than by enumerating
           all Bots created by the Human.
         x-error-codes:
@@ -537,7 +537,7 @@ AddGroupParticipantPath:
         description: >-
           Principal cannot manage the group. A Human Principal may manage when
           it can act as at least one Group management actor: the driver,
-          originator, or manager participant. Human-to-actor authority is
+          originator, or ManagerWorker manager participant. Human-to-actor authority is
           checked only against these target actors: direct human_{user.id}, a
           Bot whose created_by equals the Human user id, or a creator relation
           edge from human_{user.id} to that Bot. The server does not enumerate
@@ -615,7 +615,7 @@ GroupParticipantPath:
           Principal cannot manage the participant. A Human Principal may manage
           the participant when it can act as the target actor (self-service) or
           as at least one Group management actor: the driver, originator, or
-          manager participant. Human-to-actor authority is checked only against
+          ManagerWorker manager participant. Human-to-actor authority is checked only against
           those target actors: direct human_{user.id}, a Bot whose created_by
           equals the Human user id, or a creator relation edge from
           human_{user.id} to that Bot.

--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -265,7 +265,14 @@ GroupPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the group.
+        description: >-
+          Principal cannot manage the group. A Human Principal may manage when
+          it can act as at least one Group management actor: the driver,
+          originator, or manager participant. Human-to-actor authority is
+          checked only against these target actors: direct human_{user.id}, a
+          Bot whose created_by equals the Human user id, or a creator relation
+          edge from human_{user.id} to that Bot. The server does not enumerate
+          every Bot created by the Human for this authorization decision.
         x-error-codes:
           - forbidden
         content:
@@ -325,7 +332,12 @@ GroupPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot delete the group.
+        description: >-
+          Principal cannot delete the group. A Human Principal may delete when
+          it can act as at least one Group management actor: the driver,
+          originator, or manager participant. Human-to-actor authority is
+          checked only against these target actors rather than by enumerating
+          all Bots created by the Human.
         x-error-codes:
           - forbidden
         content:
@@ -522,7 +534,14 @@ AddGroupParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the group.
+        description: >-
+          Principal cannot manage the group. A Human Principal may manage when
+          it can act as at least one Group management actor: the driver,
+          originator, or manager participant. Human-to-actor authority is
+          checked only against these target actors: direct human_{user.id}, a
+          Bot whose created_by equals the Human user id, or a creator relation
+          edge from human_{user.id} to that Bot. The server does not enumerate
+          every Bot created by the Human for this authorization decision.
         x-error-codes:
           - forbidden
         content:
@@ -592,7 +611,14 @@ GroupParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the participant.
+        description: >-
+          Principal cannot manage the participant. A Human Principal may manage
+          the participant when it can act as the target actor (self-service) or
+          as at least one Group management actor: the driver, originator, or
+          manager participant. Human-to-actor authority is checked only against
+          those target actors: direct human_{user.id}, a Bot whose created_by
+          equals the Human user id, or a creator relation edge from
+          human_{user.id} to that Bot.
         x-error-codes:
           - forbidden
         content:

--- a/src/bcs/api-contracts/v1/openapi/sessions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/sessions.yaml
@@ -278,7 +278,15 @@ SessionPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the session.
+        description: >-
+          Principal cannot manage the session. A Human Principal may manage
+          when it can act as the Session creator or at least one parent Group
+          management actor: the driver, originator, or manager participant.
+          Human-to-actor authority is checked only against these target actors:
+          direct human_{user.id}, a Bot whose created_by equals the Human user
+          id, or a creator relation edge from human_{user.id} to that Bot. The
+          server does not enumerate every Bot created by the Human for this
+          authorization decision.
         x-error-codes:
           - forbidden
         content:
@@ -335,7 +343,12 @@ SessionPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot delete the session.
+        description: >-
+          Principal cannot delete the session. A Human Principal may delete
+          when it can act as the Session creator or at least one parent Group
+          management actor. Human-to-actor authority is checked only against
+          those target actors rather than by enumerating all Bots created by
+          the Human.
         x-error-codes:
           - forbidden
         content:
@@ -513,7 +526,15 @@ AddSessionParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the session.
+        description: >-
+          Principal cannot manage the session. A Human Principal may manage
+          when it can act as the Session creator or at least one parent Group
+          management actor: the driver, originator, or manager participant.
+          Human-to-actor authority is checked only against these target actors:
+          direct human_{user.id}, a Bot whose created_by equals the Human user
+          id, or a creator relation edge from human_{user.id} to that Bot. The
+          server does not enumerate every Bot created by the Human for this
+          authorization decision.
         x-error-codes:
           - forbidden
         content:
@@ -581,7 +602,13 @@ SessionParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot manage the participant.
+        description: >-
+          Principal cannot manage the participant. A Human Principal may manage
+          when it can act as the Session creator or at least one parent Group
+          management actor: the driver, originator, or manager participant.
+          Human-to-actor authority is checked only against those target actors:
+          direct human_{user.id}, a Bot whose created_by equals the Human user
+          id, or a creator relation edge from human_{user.id} to that Bot.
         x-error-codes:
           - forbidden
         content:
@@ -640,7 +667,12 @@ SessionParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: Principal cannot remove the participant.
+        description: >-
+          Principal cannot remove the participant. A Human Principal may remove
+          when it can act as the Session creator or at least one parent Group
+          management actor. Human-to-actor authority is checked only against
+          those target actors rather than by enumerating all Bots created by
+          the Human.
         x-error-codes:
           - forbidden
         content:

--- a/src/bcs/api-contracts/v1/openapi/sessions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/sessions.yaml
@@ -281,7 +281,7 @@ SessionPath:
         description: >-
           Principal cannot manage the session. A Human Principal may manage
           when it can act as the Session creator or at least one parent Group
-          management actor: the driver, originator, or manager participant.
+          management actor: the driver, originator, or ManagerWorker manager participant.
           Human-to-actor authority is checked only against these target actors:
           direct human_{user.id}, a Bot whose created_by equals the Human user
           id, or a creator relation edge from human_{user.id} to that Bot. The
@@ -529,7 +529,7 @@ AddSessionParticipantPath:
         description: >-
           Principal cannot manage the session. A Human Principal may manage
           when it can act as the Session creator or at least one parent Group
-          management actor: the driver, originator, or manager participant.
+          management actor: the driver, originator, or ManagerWorker manager participant.
           Human-to-actor authority is checked only against these target actors:
           direct human_{user.id}, a Bot whose created_by equals the Human user
           id, or a creator relation edge from human_{user.id} to that Bot. The
@@ -605,7 +605,7 @@ SessionParticipantPath:
         description: >-
           Principal cannot manage the participant. A Human Principal may manage
           when it can act as the Session creator or at least one parent Group
-          management actor: the driver, originator, or manager participant.
+          management actor: the driver, originator, or ManagerWorker manager participant.
           Human-to-actor authority is checked only against those target actors:
           direct human_{user.id}, a Bot whose created_by equals the Human user
           id, or a creator relation edge from human_{user.id} to that Bot.

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -231,13 +231,21 @@ impl GroupServiceImpl {
         {
             return Ok(true);
         }
+        let management_actor_ids = Self::group_management_actor_ids(group);
+        if management_actor_ids
+            .iter()
+            .any(|actor_id| actor_id == &principal_actor_id)
+        {
+            return Ok(true);
+        }
         if let Principal::Human(human) = principal {
-            let participant_actor_ids = group
+            let mut actor_ids = group
                 .participants
                 .iter()
                 .map(|participant| participant.bot_uuid.clone())
                 .collect::<Vec<_>>();
-            if self.human_can_act_as_any(human, participant_actor_ids).await? {
+            actor_ids.extend(management_actor_ids);
+            if self.human_can_act_as_any(human, actor_ids).await? {
                 return Ok(true);
             }
         }

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -251,13 +251,15 @@ impl GroupServiceImpl {
 
     fn group_management_actor_ids(group: &DomainGroup) -> Vec<String> {
         let mut actor_ids = vec![group.driver_bot.clone(), group.originator().to_string()];
-        actor_ids.extend(
-            group
-                .participants
-                .iter()
-                .filter(|participant| participant.role == bcs_service_api::ParticipantRole::Manager)
-                .map(|participant| participant.bot_uuid.clone()),
-        );
+        if group.group_strategy == GroupStrategy::ManagerWorker {
+            actor_ids.extend(
+                group
+                    .participants
+                    .iter()
+                    .filter(|participant| participant.role == bcs_service_api::ParticipantRole::Manager)
+                    .map(|participant| participant.bot_uuid.clone()),
+            );
+        }
         actor_ids
     }
 

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -231,6 +231,16 @@ impl GroupServiceImpl {
         {
             return Ok(true);
         }
+        if let Principal::Human(human) = principal {
+            let participant_actor_ids = group
+                .participants
+                .iter()
+                .map(|participant| participant.bot_uuid.clone())
+                .collect::<Vec<_>>();
+            if self.human_can_act_as_any(human, participant_actor_ids).await? {
+                return Ok(true);
+            }
+        }
         let session_group_ids = self
             .sessions
             .list_group_ids_by_session_participant(&principal_actor_id)
@@ -239,15 +249,110 @@ impl GroupServiceImpl {
         Ok(session_group_ids.iter().any(|id| id == &group.id))
     }
 
-    fn can_manage_group(principal: &Principal, group: &DomainGroup) -> bool {
+    fn group_management_actor_ids(group: &DomainGroup) -> Vec<String> {
+        let mut actor_ids = vec![group.driver_bot.clone(), group.originator().to_string()];
+        actor_ids.extend(
+            group
+                .participants
+                .iter()
+                .filter(|participant| participant.role == bcs_service_api::ParticipantRole::Manager)
+                .map(|participant| participant.bot_uuid.clone()),
+        );
+        actor_ids
+    }
+
+    async fn human_actable_actor_id(
+        &self,
+        human: &HumanPrincipal,
+        actor_ids: Vec<String>,
+    ) -> Result<Option<String>, ApplicationError> {
+        let human_actor_id = format!("human_{}", human.subject.id);
+        let mut seen = HashSet::new();
+        for actor_id in actor_ids {
+            if !seen.insert(actor_id.clone()) {
+                continue;
+            }
+            if actor_id == human_actor_id {
+                return Ok(Some(actor_id));
+            }
+            if actor_id.starts_with("human_") {
+                continue;
+            }
+            let Some(bot) = self
+                .registry
+                .try_get(&actor_id)
+                .await
+                .map_err(map_service_error)?
+            else {
+                continue;
+            };
+            if bot.actor_kind != ActorKind::Bot {
+                continue;
+            }
+            if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
+                return Ok(Some(actor_id));
+            }
+            let creator_edge = self
+                .relation
+                .get_edge(&human_actor_id, &actor_id, &self.config.relation_env)
+                .await
+                .map_err(map_service_error)?;
+            if creator_edge.is_some_and(|edge| edge.is_creator) {
+                return Ok(Some(actor_id));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn human_can_act_as_any(
+        &self,
+        human: &HumanPrincipal,
+        actor_ids: Vec<String>,
+    ) -> Result<bool, ApplicationError> {
+        Ok(self.human_actable_actor_id(human, actor_ids).await?.is_some())
+    }
+
+    async fn principal_can_act_as(
+        &self,
+        principal: &Principal,
+        actor_id: &str,
+    ) -> Result<bool, ApplicationError> {
+        if principal.actor_id() == actor_id {
+            return Ok(true);
+        }
+        match principal {
+            Principal::Human(human) => {
+                self.human_can_act_as_any(human, vec![actor_id.to_string()]).await
+            }
+            Principal::Bot(_) => Ok(false),
+        }
+    }
+
+    async fn resolve_group_manage_actor(
+        &self,
+        principal: &Principal,
+        group: &DomainGroup,
+    ) -> Result<Option<String>, ApplicationError> {
         let principal_actor_id = principal.actor_id();
-        principal_actor_id == group.driver_bot
-            || principal_actor_id == group.originator()
-            || (group.group_strategy == GroupStrategy::ManagerWorker
-                && group.participants.iter().any(|participant| {
-                    participant.bot_uuid == principal_actor_id
-                        && participant.role == bcs_service_api::ParticipantRole::Manager
-                }))
+        let candidates = Self::group_management_actor_ids(group);
+        if candidates.iter().any(|actor_id| actor_id == &principal_actor_id) {
+            return Ok(Some(principal_actor_id));
+        }
+        if let Principal::Human(human) = principal {
+            return self.human_actable_actor_id(human, candidates).await;
+        }
+        Ok(None)
+    }
+
+    async fn can_manage_group(
+        &self,
+        principal: &Principal,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
+        Ok(self
+            .resolve_group_manage_actor(principal, group)
+            .await?
+            .is_some())
     }
 
     async fn load_readable_group(
@@ -314,7 +419,7 @@ impl GroupServiceImpl {
                     format!("Group '{group_id}' was not found"),
                 )
             })?;
-        if !Self::can_manage_group(principal, &group) {
+        if !self.can_manage_group(principal, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator or driver may manage this Group",
             ));
@@ -1174,11 +1279,11 @@ impl GroupService for GroupServiceImpl {
                 deleted: false,
             });
         };
-        if !Self::can_manage_group(&principal, &group) {
+        let Some(manage_actor_id) = self.resolve_group_manage_actor(&principal, &group).await? else {
             return Err(ApplicationError::forbidden(
                 "Principal cannot delete the group",
             ));
-        }
+        };
         let state_machine_runtime = if group.group_strategy == GroupStrategy::StateMachine {
             Some(self.collaboration_runtime.as_ref().ok_or_else(|| {
                 ApplicationError::internal(
@@ -1191,7 +1296,7 @@ impl GroupService for GroupServiceImpl {
         let result = self
             .management
             .delete_group(GroupDeleteCommand {
-                caller_actor_id: principal.actor_id(),
+                caller_actor_id: manage_actor_id,
                 group_id: command.group_id,
             })
             .await
@@ -1219,11 +1324,11 @@ impl GroupService for GroupServiceImpl {
         let group = self
             .load_readable_group(&principal, &command.group_id)
             .await?;
-        if !Self::can_manage_group(&principal, &group) {
+        let Some(manage_actor_id) = self.resolve_group_manage_actor(&principal, &group).await? else {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
-        }
+        };
         // `AddGroupParticipant` carries no `actor_kind`; resolve it from the
         // registry so legacy `add_member` gets the right Bot/Human split.
         let actor_kind = if self
@@ -1244,7 +1349,7 @@ impl GroupService for GroupServiceImpl {
         let result = self
             .management
             .add_member(GroupAddMemberCommand {
-                caller_actor_id: Some(principal.actor_id()),
+                caller_actor_id: Some(manage_actor_id),
                 human_actor_id,
                 group_id: command.group_id.clone(),
                 bot_id,
@@ -1265,8 +1370,8 @@ impl GroupService for GroupServiceImpl {
             .await?;
         // Design §8.7: the target Actor may update its own participant mode
         // (self-service) in addition to the driver/originator/manager path.
-        let is_self = principal.actor_id() == command.actor_id;
-        if !is_self && !Self::can_manage_group(&principal, &group) {
+        let is_self = self.principal_can_act_as(&principal, &command.actor_id).await?;
+        if !is_self && self.resolve_group_manage_actor(&principal, &group).await?.is_none() {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
@@ -1323,12 +1428,16 @@ impl GroupService for GroupServiceImpl {
         // delete) in addition to the driver/originator/manager path. The legacy
         // `remove_member` still rejects driver/originator removal, preserving
         // the role invariant; non-driver self-leave proceeds.
-        let is_self = principal.actor_id() == command.actor_id;
-        if !is_self && !Self::can_manage_group(&principal, &group) {
+        let is_self = self.principal_can_act_as(&principal, &command.actor_id).await?;
+        let effective_caller_actor_id = if is_self {
+            command.actor_id.clone()
+        } else if let Some(manage_actor_id) = self.resolve_group_manage_actor(&principal, &group).await? {
+            manage_actor_id
+        } else {
             return Err(ApplicationError::forbidden(
                 "Principal cannot manage the group",
             ));
-        }
+        };
         // Phase one: target is a Bot actor (legacy `remove_member` uses bot_id).
         // The V1 contract treats an already-removed/missing participant as
         // idempotent success, so swallow `ParticipantNotFound` into
@@ -1337,7 +1446,7 @@ impl GroupService for GroupServiceImpl {
         match self
             .management
             .remove_member(GroupRemoveMemberCommand {
-                caller_actor_id: Some(principal.actor_id()),
+                caller_actor_id: Some(effective_caller_actor_id),
                 group_id: command.group_id.clone(),
                 bot_id: command.actor_id.clone(),
             })

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -1340,27 +1340,48 @@ impl GroupService for GroupServiceImpl {
             ));
         };
         // `AddGroupParticipant` carries no `actor_kind`; resolve it from the
-        // registry so legacy `add_member` gets the right Bot/Human split.
-        let actor_kind = if self
+        // registry so legacy `add_member` gets the target Actor ID for both Bot
+        // and Human participants. If the V1 caller references a Human actor that
+        // has not been materialized yet, create the legacy Human actor at this
+        // boundary before delegating.
+        let target_actor = self
             .registry
             .try_get(&command.actor_id)
             .await
-            .map_err(map_service_error)?
-            .is_some()
-        {
-            ActorKind::Bot
-        } else {
-            ActorKind::Human
-        };
-        let (bot_id, human_actor_id) = match actor_kind {
-            ActorKind::Bot => (command.actor_id.clone(), None),
-            ActorKind::Human => (String::new(), Some(command.actor_id.clone())),
+            .map_err(map_service_error)?;
+        if target_actor.is_none() && let Some(staff_no) = command.actor_id.strip_prefix("human_") {
+            self.registry
+                .ensure_human_actor(staff_no, staff_no)
+                .await
+                .map_err(map_service_error)?;
+        }
+        let bot_id = command.actor_id.clone();
+        let legacy_human_actor_id = match &principal {
+            Principal::Human(human) => {
+                let human_actor_id = format!("human_{}", human.subject.id);
+                if manage_actor_id == human_actor_id {
+                    None
+                } else {
+                    let manage_actor = self
+                        .registry
+                        .try_get(&manage_actor_id)
+                        .await
+                        .map_err(map_service_error)?;
+                    manage_actor
+                        .filter(|actor| {
+                            actor.actor_kind == ActorKind::Bot
+                                && actor.created_by.as_deref() == Some(human.subject.id.as_str())
+                        })
+                        .map(|_| human_actor_id)
+                }
+            }
+            Principal::Bot(_) => None,
         };
         let result = self
             .management
             .add_member(GroupAddMemberCommand {
                 caller_actor_id: Some(manage_actor_id),
-                human_actor_id,
+                human_actor_id: legacy_human_actor_id,
                 group_id: command.group_id.clone(),
                 bot_id,
                 role: Some(role_name(command.role).to_string()),

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
@@ -216,6 +216,55 @@ async fn seed() -> Fixture {
 
 
 #[tokio::test]
+async fn human_originator_can_manage_participants_without_human_membership() {
+    let fixture = Fixture::new().await;
+    for bot in ["bot-driver", "bot-a", "bot-b"] {
+        fixture.add_public_bot(bot).await;
+    }
+    let mut group = normal_group(
+        GROUP_ID,
+        "bot-driver",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::bot("bot-a", ParticipantRole::Consultant),
+        ],
+        GroupStrategy::Chat,
+        1,
+    );
+    group.originator = Some("human_staff-originator".into());
+    fixture
+        .groups
+        .upsert(group)
+        .await
+        .expect("store group");
+
+    let err = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-unrelated"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-b".into(),
+            role: ParticipantRole::Consultant,
+        })
+        .await
+        .expect_err("unrelated Human cannot manage originator-only group");
+    assert!(matches!(err, ApplicationError::Forbidden(_)));
+
+    let added = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-originator"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-b".into(),
+            role: ParticipantRole::Consultant,
+        })
+        .await
+        .expect("Human originator can manage participants without membership");
+
+    assert_eq!(added.actor_id, "bot-b");
+}
+
+#[tokio::test]
 async fn human_owner_of_group_driver_can_add_participant_without_human_membership() {
     let fixture = seed_owned_driver_without_human_participant().await;
 

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
@@ -277,6 +277,44 @@ async fn human_owner_of_bot_participant_can_update_that_participant_as_self_serv
 }
 
 #[tokio::test]
+async fn chat_manager_role_does_not_grant_group_management_to_human_owner() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("bot-driver").await;
+    fixture
+        .add_public_bot_owned_by("bot-manager", "staff-manager-owner")
+        .await;
+    fixture.add_public_bot("bot-b").await;
+    let mut group = normal_group(
+        GROUP_ID,
+        "bot-driver",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::bot("bot-manager", ParticipantRole::Manager),
+        ],
+        GroupStrategy::Chat,
+        1,
+    );
+    group.originator = Some("bot-driver".into());
+    fixture
+        .groups
+        .upsert(group)
+        .await
+        .expect("store group");
+
+    let err = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-manager-owner"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-b".into(),
+            role: ParticipantRole::Consultant,
+        })
+        .await
+        .expect_err("Chat manager role must not grant management authority");
+    assert!(matches!(err, ApplicationError::Forbidden(_)));
+}
+
+#[tokio::test]
 async fn human_manager_can_add_bot_participant() {
     let fixture = seed().await;
     let caller = human_caller("staff-manager");

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
@@ -295,6 +295,25 @@ async fn human_owner_of_group_driver_can_add_participant_without_human_membershi
 }
 
 #[tokio::test]
+async fn human_owner_of_group_driver_can_add_human_participant() {
+    let fixture = seed_owned_driver_without_human_participant().await;
+
+    let added = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-driver"),
+            group_id: GROUP_ID.into(),
+            actor_id: "human_bob".into(),
+            role: ParticipantRole::Observer,
+        })
+        .await
+        .expect("Human owner of driver Bot can add a Human participant");
+
+    assert_eq!(added.actor_id, "human_bob");
+    assert_eq!(added.role, ParticipantRole::Observer);
+}
+
+#[tokio::test]
 async fn human_owner_of_bot_participant_can_update_that_participant_as_self_service() {
     let fixture = seed_owned_participant_without_human_participant().await;
 

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_participant.rs
@@ -86,6 +86,14 @@ impl Fixture {
             .await
             .expect("register bot");
     }
+
+    async fn add_public_bot_owned_by(&self, bot_uuid: &str, staff_no: &str) {
+        self.add_public_bot(bot_uuid).await;
+        self.bots
+            .save_created_by(bot_uuid, staff_no, true)
+            .await
+            .expect("assign Bot owner");
+    }
 }
 
 fn human_caller(staff_no: &str) -> AuthenticatedCaller {
@@ -120,6 +128,59 @@ fn normal_group(
 
 /// Build a fixture with a Chat group `GROUP_ID` whose Human originator manages
 /// the Group. A second Human is a plain participant for self-service tests.
+
+async fn seed_owned_driver_without_human_participant() -> Fixture {
+    let fixture = Fixture::new().await;
+    fixture
+        .add_public_bot_owned_by("bot-driver", "staff-driver")
+        .await;
+    for bot in ["bot-a", "bot-b"] {
+        fixture.add_public_bot(bot).await;
+    }
+    let mut group = normal_group(
+        GROUP_ID,
+        "bot-driver",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::bot("bot-a", ParticipantRole::Consultant),
+        ],
+        GroupStrategy::Chat,
+        1,
+    );
+    group.originator = Some("bot-driver".into());
+    fixture
+        .groups
+        .upsert(group)
+        .await
+        .expect("store group");
+    fixture
+}
+
+async fn seed_owned_participant_without_human_participant() -> Fixture {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("bot-driver").await;
+    fixture
+        .add_public_bot_owned_by("bot-a", "staff-owner")
+        .await;
+    let mut group = normal_group(
+        GROUP_ID,
+        "bot-driver",
+        vec![
+            Participant::bot("bot-driver", ParticipantRole::Driver),
+            Participant::bot("bot-a", ParticipantRole::Consultant),
+        ],
+        GroupStrategy::Chat,
+        1,
+    );
+    group.originator = Some("bot-driver".into());
+    fixture
+        .groups
+        .upsert(group)
+        .await
+        .expect("store group");
+    fixture
+}
+
 async fn seed() -> Fixture {
     let fixture = Fixture::new().await;
     for bot in ["bot-driver", "bot-a", "bot-b"] {
@@ -151,6 +212,68 @@ async fn seed() -> Fixture {
         .await
         .expect("store group");
     fixture
+}
+
+
+#[tokio::test]
+async fn human_owner_of_group_driver_can_add_participant_without_human_membership() {
+    let fixture = seed_owned_driver_without_human_participant().await;
+
+    let err = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-unrelated"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-b".into(),
+            role: ParticipantRole::Consultant,
+        })
+        .await
+        .expect_err("unrelated Human cannot manage group through Bot ownership");
+    assert!(matches!(err, ApplicationError::Forbidden(_)));
+
+    let added = fixture
+        .service
+        .add_participant(AddGroupParticipant {
+            caller: human_caller("staff-driver"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-b".into(),
+            role: ParticipantRole::Consultant,
+        })
+        .await
+        .expect("Human owner of driver Bot can manage group");
+
+    assert_eq!(added.actor_id, "bot-b");
+}
+
+#[tokio::test]
+async fn human_owner_of_bot_participant_can_update_that_participant_as_self_service() {
+    let fixture = seed_owned_participant_without_human_participant().await;
+
+    let err = fixture
+        .service
+        .update_participant(UpdateGroupParticipant {
+            caller: human_caller("staff-unrelated"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-a".into(),
+            mode: ParticipantMode::Muted,
+        })
+        .await
+        .expect_err("unrelated Human cannot self-service an unowned Bot participant");
+    assert!(matches!(err, ApplicationError::Forbidden(_)));
+
+    let updated = fixture
+        .service
+        .update_participant(UpdateGroupParticipant {
+            caller: human_caller("staff-owner"),
+            group_id: GROUP_ID.into(),
+            actor_id: "bot-a".into(),
+            mode: ParticipantMode::Muted,
+        })
+        .await
+        .expect("Human owner can self-service the owned Bot participant");
+
+    assert_eq!(updated.actor_id, "bot-a");
+    assert_eq!(updated.mode, ParticipantMode::Muted);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -100,13 +100,15 @@ impl SessionServiceImpl {
     /// Mirrors `bcs-app-group`'s targeted Human-to-actor authority semantics.
     fn group_management_actor_ids(group: &DomainGroup) -> Vec<String> {
         let mut actor_ids = vec![group.driver_bot.clone(), group.originator().to_string()];
-        actor_ids.extend(
-            group
-                .participants
-                .iter()
-                .filter(|participant| participant.role == ParticipantRole::Manager)
-                .map(|participant| participant.bot_uuid.clone()),
-        );
+        if group.group_strategy == GroupStrategy::ManagerWorker {
+            actor_ids.extend(
+                group
+                    .participants
+                    .iter()
+                    .filter(|participant| participant.role == ParticipantRole::Manager)
+                    .map(|participant| participant.bot_uuid.clone()),
+            );
+        }
         actor_ids
     }
 

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -31,7 +31,7 @@ use bcs_service_api::application::v1::{
         SessionParticipantInput, SessionService, SessionStatus as V1SessionStatus,
         SessionSummary, UpdateSession, UpdateSessionParticipant,
     },
-    ApplicationError, AuthenticatedCaller, DeleteResult, Page, Principal,
+    ApplicationError, AuthenticatedCaller, DeleteResult, HumanPrincipal, Page, Principal,
     require_authenticated_user, require_human,
 };
 use bcs_service_api::application::session::{
@@ -96,28 +96,104 @@ impl SessionServiceImpl {
 
     // ── authorization helpers ──────────────────────────────────────────
 
-    /// Manager of the parent group (driver / originator / ManagerWorker
-    /// manager). Mirrors `bcs-app-group`'s `can_manage_group`.
-    fn can_manage_group(principal: &Principal, group: &DomainGroup) -> bool {
+    /// Manager of the parent group (driver / originator / manager participant).
+    /// Mirrors `bcs-app-group`'s targeted Human-to-actor authority semantics.
+    fn group_management_actor_ids(group: &DomainGroup) -> Vec<String> {
+        let mut actor_ids = vec![group.driver_bot.clone(), group.originator().to_string()];
+        actor_ids.extend(
+            group
+                .participants
+                .iter()
+                .filter(|participant| participant.role == ParticipantRole::Manager)
+                .map(|participant| participant.bot_uuid.clone()),
+        );
+        actor_ids
+    }
+
+    async fn human_can_act_as_any(
+        &self,
+        human: &HumanPrincipal,
+        actor_ids: Vec<String>,
+    ) -> Result<bool, ApplicationError> {
+        let human_actor_id = format!("human_{}", human.subject.id);
+        let mut seen = HashSet::new();
+        for actor_id in actor_ids {
+            if !seen.insert(actor_id.clone()) {
+                continue;
+            }
+            if actor_id == human_actor_id {
+                return Ok(true);
+            }
+            if actor_id.starts_with("human_") {
+                continue;
+            }
+            let Some(bot) = self
+                .registry
+                .try_get(&actor_id)
+                .await
+                .map_err(map_service_error)?
+            else {
+                continue;
+            };
+            if bot.actor_kind != ActorKind::Bot {
+                continue;
+            }
+            if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
+                return Ok(true);
+            }
+            let creator_edge = self
+                .relation
+                .get_edge(&human_actor_id, &actor_id, &self.config.relation_env)
+                .await
+                .map_err(map_service_error)?;
+            if creator_edge.is_some_and(|edge| edge.is_creator) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn can_manage_group(
+        &self,
+        principal: &Principal,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
         let actor_id = principal.actor_id();
-        actor_id == group.driver_bot
-            || actor_id == group.originator()
-            || (group.group_strategy == GroupStrategy::ManagerWorker
-                && group
-                    .participants
-                    .iter()
-                    .any(|p| p.bot_uuid == actor_id && p.role == ParticipantRole::Manager))
+        let candidates = Self::group_management_actor_ids(group);
+        if candidates.iter().any(|candidate| candidate == &actor_id) {
+            return Ok(true);
+        }
+        match principal {
+            Principal::Human(human) => self.human_can_act_as_any(human, candidates).await,
+            Principal::Bot(_) => Ok(false),
+        }
     }
 
     /// Manage a specific session: group manager OR the session's creator
-    /// (`session.created_by`). The creator qualifier covers the V1 design's
-    /// "creator" authorization for update / delete / complete.
-    fn can_manage_session(principal: &Principal, session: &Session, group: &DomainGroup) -> bool {
-        Self::can_manage_group(principal, group)
-            || session
-                .created_by
-                .as_deref()
-                .is_some_and(|creator| creator == principal.actor_id())
+    /// (`session.created_by`). Human callers may also act as any of those
+    /// target actors through direct Human identity, Bot ownership, or creator
+    /// relation edges.
+    async fn can_manage_session(
+        &self,
+        principal: &Principal,
+        session: &Session,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
+        if self.can_manage_group(principal, group).await? {
+            return Ok(true);
+        }
+        let Some(created_by) = session.created_by.as_deref() else {
+            return Ok(false);
+        };
+        if created_by == principal.actor_id() {
+            return Ok(true);
+        }
+        match principal {
+            Principal::Human(human) => {
+                self.human_can_act_as_any(human, vec![created_by.to_string()]).await
+            }
+            Principal::Bot(_) => Ok(false),
+        }
     }
 
     async fn load_group(&self, group_id: &str) -> Result<DomainGroup, ApplicationError> {
@@ -139,7 +215,7 @@ impl SessionServiceImpl {
         group_id: &str,
     ) -> Result<DomainGroup, ApplicationError> {
         let group = self.load_group(group_id).await?;
-        if !Self::can_manage_group(principal, &group) {
+        if !self.can_manage_group(principal, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator, driver, or manager may manage Sessions",
             ));
@@ -165,7 +241,7 @@ impl SessionServiceImpl {
                 )
             })?;
         let group = self.load_group(&session.group_id).await?;
-        if !Self::can_manage_session(principal, &session, &group) {
+        if !self.can_manage_session(principal, &session, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Principal may not manage this Session",
             ));
@@ -610,7 +686,7 @@ impl SessionService for SessionServiceImpl {
             None => return Ok(DeleteResult { deleted: false }),
         };
         let group = self.load_group(&session.group_id).await?;
-        if !Self::can_manage_session(&principal, &session, &group) {
+        if !self.can_manage_session(&principal, &session, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Principal may not delete this Session",
             ));

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -1170,6 +1170,59 @@ async fn human_owner_of_session_creator_can_update_session_without_group_managem
 }
 
 #[tokio::test]
+async fn chat_manager_role_does_not_grant_session_management_to_human_owner() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert", "manager", "newcomer"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .bots
+        .save_created_by("manager", "staff-manager-owner", true)
+        .await
+        .expect("assign manager owner");
+    fixture
+        .store_group_with_originator("g1", "driver", "human_other", None)
+        .await;
+    let mut group = fixture.groups.get("g1").await.expect("group exists");
+    group
+        .participants
+        .push(Participant::bot("manager", ParticipantRole::Manager));
+    fixture.groups.upsert(group.clone()).await.expect("store group");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::bot("expert", ParticipantRole::Consultant),
+                    Participant::bot("manager", ParticipantRole::Manager),
+                ],
+                group_version: Some(group.version),
+                created_by: Some("expert".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed session");
+
+    let err = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("staff-manager-owner"),
+            session_id: session.id,
+            bot_uuid: "newcomer".into(),
+            mode: Some(BotParticipantMode::Auto),
+        })
+        .await
+        .expect_err("Chat manager role must not grant session management authority");
+    assert!(matches!(
+        err,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
+}
+
+#[tokio::test]
 async fn participant_add_update_remove_lifecycle() {
     let fixture = Fixture::new().await;
     for bot in ["driver", "expert", "newcomer"] {

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -1051,6 +1051,124 @@ async fn list_messages_rejects_malformed_before_cursor() {
     assert_eq!(error.code(), "invalid_request");
 }
 
+
+#[tokio::test]
+async fn human_owner_of_group_driver_can_add_session_participant_without_human_membership() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert", "newcomer"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .bots
+        .save_created_by("driver", "staff-driver", true)
+        .await
+        .expect("assign driver owner");
+    fixture
+        .store_group_with_originator("g1", "driver", "human_other", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::bot("expert", ParticipantRole::Consultant),
+                ],
+                group_version: Some(group.version),
+                created_by: Some("driver".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed session");
+
+    let err = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("staff-unrelated"),
+            session_id: session.id.clone(),
+            bot_uuid: "newcomer".into(),
+            mode: Some(BotParticipantMode::Auto),
+        })
+        .await
+        .expect_err("unrelated Human cannot manage session through Bot ownership");
+    assert!(matches!(
+        err,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
+
+    let added = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("staff-driver"),
+            session_id: session.id,
+            bot_uuid: "newcomer".into(),
+            mode: Some(BotParticipantMode::Auto),
+        })
+        .await
+        .expect("Human owner of group driver can manage session");
+
+    assert_eq!(added.actor_id, "newcomer");
+}
+
+#[tokio::test]
+async fn human_owner_of_session_creator_can_update_session_without_group_management() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert", "creator-bot"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture
+        .bots
+        .save_created_by("creator-bot", "staff-creator", true)
+        .await
+        .expect("assign creator owner");
+    fixture
+        .store_group_with_originator("g1", "driver", "human_other", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![Participant::bot("expert", ParticipantRole::Consultant)],
+                group_version: Some(group.version),
+                created_by: Some("creator-bot".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed session");
+
+    let err = fixture
+        .service
+        .update(UpdateSession {
+            caller: human_principal("staff-unrelated"),
+            session_id: session.id.clone(),
+            title: Some("unrelated update".into()),
+        })
+        .await
+        .expect_err("unrelated Human cannot manage session through creator ownership");
+    assert!(matches!(
+        err,
+        bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+    ));
+
+    let detail = fixture
+        .service
+        .update(UpdateSession {
+            caller: human_principal("staff-creator"),
+            session_id: session.id,
+            title: Some("owned creator update".into()),
+        })
+        .await
+        .expect("Human owner of session creator can manage session");
+
+    assert_eq!(detail.title.as_deref(), Some("owned creator update"));
+}
+
 #[tokio::test]
 async fn participant_add_update_remove_lifecycle() {
     let fixture = Fixture::new().await;

--- a/src/bcs/docs/plans/2026-08-05-openapi-human-actor-authority.md
+++ b/src/bcs/docs/plans/2026-08-05-openapi-human-actor-authority.md
@@ -1,0 +1,69 @@
+# OpenAPI Human Actor Authority Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let OpenAPI v1 Human callers manage groups/sessions when they can act as the relevant Human/Bot actor, using targeted batch checks instead of listing every created bot.
+
+**Architecture:** Keep auth policy in v1 application facades; HTTP adapters continue to pass authenticated caller only. Contract YAML documents the Service API behavior. Application tests cover the behavior with in-memory dependencies.
+
+**Tech Stack:** Rust application crates (`bcs-app-group`, `bcs-app-session`), OpenAPI YAML contracts, Cargo tests.
+
+---
+
+### Task 1: Contract and docs
+
+**Files:**
+- Modify: `api-contracts/v1/openapi/groups.yaml`
+- Modify: `api-contracts/v1/openapi/sessions.yaml`
+
+**Steps:**
+1. Document that mutating group/session participant endpoints require a Human caller that can act as a management actor (driver/originator/manager/session creator) or, for self-service participant updates, as the target actor.
+2. Define `can act as`: direct `human_{user.id}`, bot `created_by == user.id`, or creator relation edge from `human_{user.id}` to the bot actor.
+3. State the implementation uses target actor checks and does not require enumerating every bot created by the Human.
+
+### Task 2: Failing group tests
+
+**Files:**
+- Modify: `crates/application/v1/bcs-app-group/tests/v1_group_participant.rs`
+
+**Steps:**
+1. Add tests where a Human owns the group driver bot but is not directly a participant.
+2. Verify add participant succeeds, self-service target updates are allowed for owned bot actors, and unrelated Humans remain forbidden.
+3. Run focused tests and confirm the new tests fail before implementation.
+
+### Task 3: Failing session tests
+
+**Files:**
+- Modify: `crates/application/v1/bcs-app-session/tests/v1_session_service.rs`
+
+**Steps:**
+1. Add tests where a Human owns the parent group driver bot or session creator actor.
+2. Verify session participant mutations are allowed without listing all created bots.
+3. Run focused tests and confirm the new tests fail before implementation.
+
+### Task 4: Implement group Human actor authority
+
+**Files:**
+- Modify: `crates/application/v1/bcs-app-group/src/lib.rs`
+
+**Steps:**
+1. Add a private targeted resolver for Human→actor authority over candidate actor ids.
+2. Use it for group read/manage checks and self-service participant operations.
+3. Preserve existing direct principal logic for non-Human callers and existing target eligibility rules.
+
+### Task 5: Implement session Human actor authority
+
+**Files:**
+- Modify: `crates/application/v1/bcs-app-session/src/lib.rs`
+
+**Steps:**
+1. Add the same private targeted resolver in the session facade.
+2. Use group management candidates plus session creator as manage candidates.
+3. Preserve existing session authorization strength; do not copy weak legacy session auth.
+
+### Task 6: Verify
+
+**Commands:**
+- `cargo test -p bcs-app-group --test v1_group_participant`
+- `cargo test -p bcs-app-session --test v1_session_service`
+


### PR DESCRIPTION
## Problem
OpenAPI v1 group/session management authorization only recognized the request principal as the direct group/session management actor. A Human caller who owned the driver, manager, or session creator Bot could still be rejected unless that Human was also directly represented in the group or session.

## Solution
- Documented the OpenAPI v1 authorization contract for Human act-as checks on group and session mutations.
- Added targeted Human-to-actor authority checks for direct human actors, Bots created by the Human, and creator relation edges.
- Reused resolved effective management actors for legacy group management calls so existing lower-level invariants remain enforced.
- Added regression coverage for owned driver/session creator management and owned participant self-service, including unrelated-Human denial cases.

## Validation
- Per user request, no additional verification was run after commit.
- Earlier focused validation in this worktree before commit: `cargo test -p bcs-app-group --test v1_group_participant` passed 9/9.
- Earlier focused validation in this worktree before commit: `cargo test -p bcs-app-session --test v1_session_service` passed 39/39.
- Push ran the repository pre-push hook in lint-only mode; full tests/coverage/E2E were skipped by hook configuration.

## Compatibility and risk
- No HTTP adapter changes; policy remains in the v1 application facades.
- Management authorization uses targeted candidate actor checks and does not enumerate every Bot created by the Human.
- Existing legacy group management invariants are preserved by passing an effective authorized management actor into legacy calls.
