### PR TITLE
fix(backend): distinguish default and legacy ARKA image policy

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -69,10 +69,9 @@ from agentclaw.community.core.workspace.path_factory import (
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    apply_image_pin_to_ext,
-    copy_image_pin_to_ext,
+    apply_default_image_to_ext,
+    copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
-    resolve_current_arka_image,
 )
 from agentclaw.community.utils.avernet_tenant import (
     bind_current_avernet_tenant,
@@ -370,40 +369,33 @@ class BotService:
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
 
-    def _resolve_service_bot_arka_image_pin(
+    def _mark_service_bot_default_image(
         self,
         bot: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Resolve draft ARKA Pin in memory without changing persistent state."""
+        """Mark a draft ARKA bot to follow the provider default image."""
         if bot.get("bot_type") != "service" or self.is_teclaw_bot(
             bot.get("active_engine")
         ):
             return bot
-        image = resolve_current_arka_image(
-            getattr(self, "_common_config_service", None),
-            env=get_current_env(),
-        )
-        updated_ext = apply_image_pin_to_ext(bot.get("ext"), image)
-        if updated_ext == (bot.get("ext") or {}):
-            return bot
         updated_bot = dict(bot)
-        updated_bot["ext"] = updated_ext
+        updated_bot["ext"] = apply_default_image_to_ext(bot.get("ext"))
         return updated_bot
 
-    def _persist_service_bot_arka_image_pin(
+    def _persist_service_bot_default_image(
         self,
         bot: Dict[str, Any],
         *,
         user_id: str,
     ) -> None:
-        """Persist an accepted draft restart's Pin snapshot to Bot and Draft."""
+        """Persist an accepted draft restart's default policy to Bot and Draft."""
         if bot.get("bot_type") != "service" or self.is_teclaw_bot(
             bot.get("active_engine")
         ):
             return
 
         bot_id = str(bot["bot_id"])
-        updated_ext = dict(bot.get("ext") or {})
+        updated_ext = apply_default_image_to_ext(bot.get("ext"))
         self._repository.update_by_owner(bot_id, user_id, {"ext": updated_ext})
 
         draft = self._bot_publish_repo.get_draft_by_publish_bot_id(
@@ -412,7 +404,7 @@ class BotService:
         )
         if draft is None:
             return
-        draft_ext = copy_image_pin_to_ext(updated_ext, draft.ext) or {}
+        draft_ext = copy_image_policy_to_ext(updated_ext, draft.ext) or {}
         updated_draft = self._bot_publish_repo.update_status_with_ext(
             publish_id=draft.id,
             target_status=draft.status,
@@ -421,7 +413,7 @@ class BotService:
         )
         if updated_draft is None:
             raise BotServiceError(
-                f"Draft publish {draft.id} image Pin persistence conflicted"
+                f"Draft publish {draft.id} default-image persistence conflicted"
             )
 
     def _build_engine_extra_envs(
@@ -1317,13 +1309,10 @@ class BotService:
         if resolved_bot_type == "service" and not self.is_teclaw_bot(
             resolved_active_engine
         ):
-            ext = apply_image_pin_to_ext(
-                ext,
-                resolve_current_arka_image(
-                    getattr(self, "_common_config_service", None),
-                    env=get_current_env(),
-                ),
-            ) or None
+            # New ARKA service bots intentionally follow the provider default.
+            # Persist an explicit marker so their future publish records are not
+            # mistaken for legacy records that require Pin compatibility.
+            ext = apply_default_image_to_ext(ext)
 
         # Resolve bot name according to naming rules
         resolved_bot_name = self._resolve_bot_name(bot_name, bot_id, user_id, nick_name)
@@ -1872,7 +1861,7 @@ class BotService:
                     logger.error(f"[bot_service._allocate_device_async] Failed to update bot {bot_id} for user {user_id}: bot not found or not owner")
                     return
                 if bot_ext_override is not None:
-                    self._persist_service_bot_arka_image_pin(
+                    self._persist_service_bot_default_image(
                         {**(bot_record or {}), "bot_id": bot_id, "ext": bot_ext_override},
                         user_id=user_id,
                     )
@@ -4043,7 +4032,7 @@ class BotService:
             if bot.get("bot_type") == "service" and not self.is_teclaw_bot(
                 bot.get("active_engine")
             ):
-                bot = self._resolve_service_bot_arka_image_pin(bot)
+                bot = self._mark_service_bot_default_image(bot)
             if (
                 binding_id
                 and current_device_provider == BAAS_DEVICE_PROVIDER
@@ -4243,7 +4232,7 @@ class BotService:
         if template_uuid is not None:
             upgrade_kwargs["template_uuid"] = template_uuid
         result = self._baas_service_provider().upgrade_bot(**upgrade_kwargs)
-        self._persist_service_bot_arka_image_pin(bot, user_id=user_id)
+        self._persist_service_bot_default_image(bot, user_id=user_id)
 
         # 取 publish_id；置 bot/binding 双 PENDING；通过 durable queue 持久化轮询。
         # publish_id 缺失 / enqueue 异常仅 log，不影响重启返回（前端轮 status 自然

--- a/src/backend/src/agentclaw/community/core/expert_chat/README.md
+++ b/src/backend/src/agentclaw/community/core/expert_chat/README.md
@@ -13,12 +13,14 @@ consumes:
   - "BotRepository"
   - "DeviceService + DeviceContextResolver"
   - "ServiceBot repo + BaasService"
+  - "CommonConfigService (legacy ARKA image policy resolution)"
   - "SkillSync guard"
   - "CollaboratorService (chat 权限校验)"
 internal_dependencies:
   - agentclaw.community.core.bot_collaborator
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.caller_identity
+  - agentclaw.community.core.common_config
   - agentclaw.community.core.devices
   - agentclaw.community.core.service_bot
   - agentclaw.community.core.skill_center

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, Optional
 from injector import inject
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.caller_identity.contracts import CallerIdentityStage
 from agentclaw.community.core.caller_identity.protocols import (
     CallerIdentityTokenExchangeProtocol,
@@ -57,7 +58,14 @@ from agentclaw.community.core.service_bot.services.baas_service import (
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    IMAGE_POLICY_KEYS,
+    ImagePolicyState,
+    ServiceBotImagePin,
+    has_explicit_image_policy,
     resolve_publish_image_pin,
+)
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
@@ -91,6 +99,7 @@ class ExpertChatInstanceService:
         caller_identity: CallerIdentityTokenExchangeProtocol,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
+        common_config_service: CommonConfigService,
     ) -> None:
         self._instance_repo = instance_repo
         self._baas = baas_service
@@ -101,6 +110,57 @@ class ExpertChatInstanceService:
         self._caller_identity = caller_identity
         self._token_provider = token_provider
         self._runtime_updater = runtime_updater
+        self._common_config_service = common_config_service
+
+    def _resolve_publish_image_pin(
+        self,
+        publish_record,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ):
+        """Resolve a caller container from its SUCCESS publish snapshot."""
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if (
+            isinstance(bot, dict)
+            and self._baas.resolve_container_provider(bot)
+            == TECLAW_DEVICE_PROVIDER
+        ):
+            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+        was_legacy = not has_explicit_image_policy(publish_record.ext)
+
+        def _persist(snapshot: dict) -> None:
+            latest = self._publish_repo.get_by_id(publish_record.id)
+            if latest is None or has_explicit_image_policy(latest.ext):
+                return
+            latest_ext = dict(latest.ext or {})
+            for key in IMAGE_POLICY_KEYS:
+                if key in snapshot:
+                    latest_ext[key] = snapshot[key]
+            updated = self._publish_repo.update_status_with_ext(
+                publish_id=latest.id,
+                target_status=latest.status,
+                ext=latest_ext,
+                source_status=latest.status,
+            )
+            if updated is None:
+                raise ConnectionError(
+                    f"Publish image policy changed concurrently: publish_id={latest.id}"
+                )
+
+        resolved = resolve_publish_image_pin(
+            publish_record,
+            common_config_service=self._common_config_service,
+            env=get_current_env(),
+            persist_ext=_persist,
+        )
+        if was_legacy and resolved.enabled:
+            latest = self._publish_repo.get_by_id(publish_record.id)
+            if latest is not None:
+                publish_record.ext = latest.ext
+                return resolve_publish_image_pin(latest)
+        return resolved
 
     # ------------------------------------------------------------------
     # Public entry
@@ -140,7 +200,11 @@ class ExpertChatInstanceService:
             bot_id, owner_id
         )
         version = publish_record.version or 1
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self._resolve_publish_image_pin(
+            publish_record,
+            bot_id=bot_id,
+            owner_id=owner_id,
+        )
 
         # --- Step 1: look up / create instance row ---
         instance = self._instance_repo.get_instance(user_id, bot_id, owner_id)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
@@ -1,13 +1,15 @@
-"""ARKA service-bot image pin policy helpers.
+"""ARKA service-bot image policy helpers.
 
-The environment switch lives in ``ac_common_config``.  Bot and publish ``ext``
-only carry the resolved snapshot so later operations (notably scale-up) do not
-silently move to a newer image.
+New bots and successful draft restarts explicitly opt into the BaaS/ARKA
+default image. Published operations are reproducible: they read only the target
+publish record. Records created before the policy existed are lazily protected
+by the environment common-config and snapshot the configured image once.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from enum import Enum
+from typing import Any, Callable
 
 from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
@@ -17,16 +19,40 @@ logger = get_logger()
 
 IMAGE_PIN_BUSINESS_CODE = "service_bot"
 IMAGE_PIN_PARAM_CODE = "sbot_pin_image"
+IMAGE_DEFAULT_KEY = "sbot_use_default_image"
 IMAGE_PIN_ENABLED_KEY = "sbot_pin_image"
 IMAGE_PIN_VALUE_KEY = "sbot_docker_image"
+IMAGE_POLICY_KEYS = (
+    IMAGE_DEFAULT_KEY,
+    IMAGE_PIN_ENABLED_KEY,
+    IMAGE_PIN_VALUE_KEY,
+)
+
+
+class ImagePolicyState(str, Enum):
+    DEFAULT = "default"
+    PINNED = "pinned"
+    LEGACY = "legacy"
+
+
+class ImagePinConfigError(ValueError):
+    """Enabled image-pin configuration or snapshot is malformed."""
 
 
 @dataclass(frozen=True)
 class ServiceBotImagePin:
-    """Immutable ARKA image snapshot resolved from one publish record."""
+    """Resolved image policy for one publish record."""
 
-    enabled: bool
+    state: ImagePolicyState
     docker_image: str | None
+
+    @property
+    def enabled(self) -> bool:
+        """Backward-compatible pinned predicate."""
+        return self.state == ImagePolicyState.PINNED
+
+
+PublishExtWriter = Callable[[dict[str, Any]], None]
 
 
 def resolve_current_arka_image(
@@ -34,7 +60,12 @@ def resolve_current_arka_image(
     *,
     env: str,
 ) -> str | None:
-    """Return the enabled ARKA image, or ``None`` for disabled/invalid config."""
+    """Return the enabled legacy-protection image.
+
+    Missing/disabled configuration returns ``None``. An enabled but malformed
+    value fails closed so a historical bot is not silently moved to the current
+    default image.
+    """
     if common_config_service is None:
         return None
     value = common_config_service.get_value(
@@ -44,24 +75,36 @@ def resolve_current_arka_image(
         default=None,
         only_enabled=True,
     )
+    if value is None:
+        return None
     image = value.get("image") if isinstance(value, dict) else None
     if isinstance(image, str) and image.strip():
         return image.strip()
-    if value is not None:
-        logger.warning(
-            "[arka_image_pin] ignore invalid enabled config: env=%s value=%r",
-            env,
-            value,
-        )
-    return None
+    raise ImagePinConfigError(
+        f"Enabled {IMAGE_PIN_PARAM_CODE} config has no valid image: env={env}"
+    )
+
+
+def has_explicit_image_policy(ext: dict[str, Any] | None) -> bool:
+    return isinstance(ext, dict) and any(key in ext for key in IMAGE_POLICY_KEYS)
+
+
+def apply_default_image_to_ext(ext: dict[str, Any] | None) -> dict[str, Any]:
+    """Mark default-image behavior while preserving unrelated ext fields."""
+    updated = dict(ext or {})
+    updated.pop(IMAGE_PIN_ENABLED_KEY, None)
+    updated.pop(IMAGE_PIN_VALUE_KEY, None)
+    updated[IMAGE_DEFAULT_KEY] = True
+    return updated
 
 
 def apply_image_pin_to_ext(
     ext: dict[str, Any] | None,
     image: str | None,
 ) -> dict[str, Any]:
-    """Update only image-pin-owned keys while preserving unrelated Bot ext."""
+    """Set/clear a Pin snapshot while preserving unrelated ext fields."""
     updated = dict(ext or {})
+    updated.pop(IMAGE_DEFAULT_KEY, None)
     updated.pop(IMAGE_PIN_ENABLED_KEY, None)
     updated.pop(IMAGE_PIN_VALUE_KEY, None)
     if image:
@@ -71,39 +114,87 @@ def apply_image_pin_to_ext(
 
 
 def read_image_pin_from_ext(ext: dict[str, Any] | None) -> str | None:
-    """Read a valid immutable image snapshot from Bot/publish ext."""
     if not isinstance(ext, dict) or ext.get(IMAGE_PIN_ENABLED_KEY) is not True:
         return None
     image = ext.get(IMAGE_PIN_VALUE_KEY)
     return image.strip() if isinstance(image, str) and image.strip() else None
 
 
-def resolve_publish_image_pin(
-    publish_record: BotPublishRecord,
-) -> ServiceBotImagePin:
-    """Resolve the ARKA image snapshot owned by ``publish_record``.
-
-    Published lifecycle operations must be reproducible, so this resolver never
-    falls back to the environment's current common-config value.
-    """
-    image = read_image_pin_from_ext(publish_record.ext)
-    return ServiceBotImagePin(enabled=image is not None, docker_image=image)
-
-
-def copy_image_pin_to_ext(
+def copy_image_policy_to_ext(
     source_ext: dict[str, Any] | None,
     target_ext: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Whitelist-copy the Bot image snapshot into a publish ext."""
-    target = apply_image_pin_to_ext(target_ext, read_image_pin_from_ext(source_ext))
+    """Whitelist-copy an explicit default/Pin policy into a publish ext."""
+    target = dict(target_ext or {})
+    for key in IMAGE_POLICY_KEYS:
+        target.pop(key, None)
+    if isinstance(source_ext, dict) and source_ext.get(IMAGE_DEFAULT_KEY) is True:
+        target[IMAGE_DEFAULT_KEY] = True
+    else:
+        image = read_image_pin_from_ext(source_ext)
+        if image:
+            target[IMAGE_PIN_ENABLED_KEY] = True
+            target[IMAGE_PIN_VALUE_KEY] = image
     return target or None
+
+
+def resolve_publish_image_pin(
+    publish_record: BotPublishRecord,
+    *,
+    common_config_service: CommonConfigService | None = None,
+    env: str | None = None,
+    persist_ext: PublishExtWriter | None = None,
+) -> ServiceBotImagePin:
+    """Resolve default/pinned/legacy policy from the target publish record.
+
+    Explicit publish snapshots never consult common-config. A legacy record
+    consults it once; when enabled, the selected image is appended to ``ext``
+    through ``persist_ext`` before being used. Disabled/missing config leaves the
+    record legacy and uses the provider default for this operation.
+    """
+    ext = dict(publish_record.ext or {})
+    if ext.get(IMAGE_DEFAULT_KEY) is True:
+        return ServiceBotImagePin(ImagePolicyState.DEFAULT, None)
+
+    pin_enabled = ext.get(IMAGE_PIN_ENABLED_KEY) is True
+    image = read_image_pin_from_ext(ext)
+    if pin_enabled:
+        if image is None:
+            raise ImagePinConfigError(
+                f"Publish {publish_record.id} enables image Pin without a valid image"
+            )
+        return ServiceBotImagePin(ImagePolicyState.PINNED, image)
+
+    # Any dangling image-policy field is malformed rather than legacy.
+    if has_explicit_image_policy(ext):
+        raise ImagePinConfigError(
+            f"Publish {publish_record.id} has an inconsistent image policy snapshot"
+        )
+
+    image = resolve_current_arka_image(
+        common_config_service,
+        env=env or publish_record.env,
+    )
+    if image is None:
+        return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+    pinned_ext = apply_image_pin_to_ext(ext, image)
+    if persist_ext is not None:
+        persist_ext(pinned_ext)
+    publish_record.ext = pinned_ext
+    logger.info(
+        "[arka_image_pin] snapshotted legacy publish image: publish_id=%s env=%s image=%s",
+        publish_record.id,
+        env or publish_record.env,
+        image,
+    )
+    return ServiceBotImagePin(ImagePolicyState.PINNED, image)
 
 
 def overlay_image_pin_on_template_config(
     template_config: dict[str, Any] | None,
     bot_ext: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Overlay a pinned image for one ARKA operation without mutating templates."""
     image = read_image_pin_from_ext(bot_ext)
     if not image:
         return template_config

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -8,6 +8,7 @@ from agentclaw.community.core.service_bot.repository.publish_operation_repositor
     PublishOperationRepository,
 )
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
@@ -25,7 +26,10 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
 )
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    copy_image_pin_to_ext,
+    apply_image_pin_to_ext,
+    copy_image_policy_to_ext,
+    has_explicit_image_policy,
+    resolve_current_arka_image,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -57,6 +61,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         publish_operation_repo: PublishOperationRepository,
         task_queue_service: TaskQueueService,
         bot_process_registry: BotProcessRegistry,
+        common_config_service: CommonConfigService,
     ):
         self._repo = bot_publish_repo
         self._bot_repo = bot_repo
@@ -69,6 +74,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         self._publish_operation_repo = publish_operation_repo
         self._task_queue_service = task_queue_service
         self._bot_process_registry = bot_process_registry
+        self._common_config_service = common_config_service
         self._env = get_current_env()
 
     def create_device_binding(
@@ -217,7 +223,24 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         source_bot_ext = (
             source_bot.get("ext") if isinstance(source_bot, dict) else None
         )
-        ext = copy_image_pin_to_ext(source_bot_ext, ext)
+        ext = copy_image_policy_to_ext(source_bot_ext, ext)
+
+        # A new/default Bot carries an explicit marker and never consumes the
+        # legacy Pin switch. A pre-feature ARKA Bot has no policy marker; when
+        # protection is enabled, freeze the configured image on the new publish
+        # record so all published operations remain reproducible.
+        is_legacy_arka_service = (
+            isinstance(source_bot, dict)
+            and source_bot.get("bot_type") == "service"
+            and not self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
+            and not has_explicit_image_policy(source_bot_ext)
+        )
+        if is_legacy_arka_service:
+            legacy_image = resolve_current_arka_image(
+                self._common_config_service, env=self._env
+            )
+            if legacy_image:
+                ext = apply_image_pin_to_ext(ext, legacy_image)
 
         record = self._repo.insert({
             "source_bot_pk": source_bot_pk,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -10,9 +10,6 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    resolve_publish_image_pin,
-)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -71,7 +68,7 @@ class EvalPublishMixin:
         # config_artifact read above is only the build-artifact presence guard. Eval
         # does not persist, so the applied overrides are discarded.
         delivery, _ = self._ext_state.compose_live(publish_record, publish_stage)
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(publish_record, bot)
 
         ext_info = {}
         if biz_id:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
@@ -1,0 +1,62 @@
+"""Publish-record ARKA image-policy resolution."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    IMAGE_POLICY_KEYS,
+    ImagePolicyState,
+    ServiceBotImagePin,
+    has_explicit_image_policy,
+    resolve_publish_image_pin as resolve_publish_image_pin_policy,
+)
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class PublishImagePolicyMixin:
+    """Resolve and persist image policy for publish-record operations."""
+
+    def resolve_publish_image_pin(
+        self,
+        publish_record: BotPublishRecord,
+        bot: dict,
+    ) -> ServiceBotImagePin:
+        """Resolve and, for legacy rows, atomically append the Pin snapshot."""
+        if (
+            self._baas_service.resolve_container_provider(bot)
+            == TECLAW_DEVICE_PROVIDER
+        ):
+            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+        was_legacy = not has_explicit_image_policy(publish_record.ext)
+
+        def _persist(snapshot: dict) -> None:
+            def _mutate(latest_ext: dict) -> None:
+                # Another concurrent operation may have already fixed the policy.
+                # Never replace an explicit decision; otherwise append only our
+                # owned fields to the latest ext snapshot.
+                if has_explicit_image_policy(latest_ext):
+                    return
+                for key in IMAGE_POLICY_KEYS:
+                    latest_ext.pop(key, None)
+                for key in IMAGE_POLICY_KEYS:
+                    if key in snapshot:
+                        latest_ext[key] = snapshot[key]
+
+            self._mutate_and_update_ext(publish_record.id, _mutate)
+
+        resolved = resolve_publish_image_pin_policy(
+            publish_record,
+            common_config_service=self._common_config_service,
+            env=get_current_env(),
+            persist_ext=_persist,
+        )
+        if was_legacy and resolved.enabled:
+            latest = self._publish_service.get_publish_by_id(publish_record.id)
+            if latest is not None:
+                publish_record.ext = latest.ext
+                return resolve_publish_image_pin_policy(latest)
+        return resolved

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -27,7 +27,7 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    resolve_publish_image_pin,
+    ServiceBotImagePin,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.publish_flow.ext_state import (
@@ -82,6 +82,13 @@ class ReleaseRecordOps(Protocol):
     def release_binding(
         self, binding_id: int, *, destroy_publish_id: int | None
     ) -> None: ...
+
+    def resolve_publish_image_pin(
+        self,
+        publish_record: BotPublishRecord,
+        bot: dict,
+    ) -> ServiceBotImagePin: ...
+
 
 
 @dataclass(frozen=True)
@@ -167,7 +174,7 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self._ops.resolve_publish_image_pin(publish_record, bot)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -267,7 +274,7 @@ class ReleaseStageRunner:
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self._ops.resolve_publish_image_pin(publish_record, bot)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -9,9 +9,6 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
     service_skills_env_from_ext,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    resolve_publish_image_pin,
-)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -306,7 +303,7 @@ class RestartMixin:
         # so restarting a non-latest stage never delivers another stage's channels.
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(publish_record, bot)
 
         # A prior recreate that crashed between its ext write and its
         # complete_operation left a dangling op. That crashed leg IS this restart

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -9,9 +9,6 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    resolve_publish_image_pin,
-)
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
@@ -116,7 +113,7 @@ class RollbackOpsMixin:
         version = f"{target_record.version}"
         delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
         skills_env = service_skills_env_from_ext(target_ext, bot)
-        image_pin = resolve_publish_image_pin(target_record)
+        image_pin = self.resolve_publish_image_pin(target_record, bot)
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
         # adopt-by-query on resume, never a second rollback deploy).

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
@@ -12,9 +12,6 @@ from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
     PublishStatusInvalidError,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    resolve_publish_image_pin,
-)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -93,7 +90,7 @@ class ScaleMixin:
 
         bot_uuid = binding.device_id
         target_count = self._resolve_scale_target_count(publish_record)
-        image_pin = resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(publish_record, bot)
         pinned_image = image_pin.docker_image
         scale_config = (
             {"deploy_config": {"docker_image": pinned_image}}

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -36,6 +36,13 @@ from agentclaw.community.core.service_bot.types import (
     PublishStage,
 )
 from agentclaw.community.core.common_config.service import CommonConfigService
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    IMAGE_POLICY_KEYS,
+    ImagePolicyState,
+    ServiceBotImagePin,
+    has_explicit_image_policy,
+    resolve_publish_image_pin as resolve_publish_image_pin_policy,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -103,6 +110,7 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
 
 
 if TYPE_CHECKING:
@@ -855,6 +863,48 @@ class PublishFlowService(
             if op.state not in terminal:
                 self._publish_operation_repo.abandon(op.id, reason)
 
+    def resolve_publish_image_pin(
+        self,
+        publish_record: BotPublishRecord,
+        bot: dict,
+    ) -> ServiceBotImagePin:
+        """Resolve and, for legacy rows, atomically append the Pin snapshot."""
+        if (
+            self._baas_service.resolve_container_provider(bot)
+            == TECLAW_DEVICE_PROVIDER
+        ):
+            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+        was_legacy = not has_explicit_image_policy(publish_record.ext)
+
+        def _persist(snapshot: dict) -> None:
+            def _mutate(latest_ext: dict) -> None:
+                # Another concurrent operation may have already fixed the policy.
+                # Never replace an explicit decision; otherwise append only our
+                # owned fields to the latest ext snapshot.
+                if has_explicit_image_policy(latest_ext):
+                    return
+                for key in IMAGE_POLICY_KEYS:
+                    latest_ext.pop(key, None)
+                for key in IMAGE_POLICY_KEYS:
+                    if key in snapshot:
+                        latest_ext[key] = snapshot[key]
+
+            self._mutate_and_update_ext(publish_record.id, _mutate)
+
+        resolved = resolve_publish_image_pin_policy(
+            publish_record,
+            common_config_service=self._common_config_service,
+            env=get_current_env(),
+            persist_ext=_persist,
+        )
+        if was_legacy and resolved.enabled:
+            latest = self._publish_service.get_publish_by_id(publish_record.id)
+            if latest is not None:
+                publish_record.ext = latest.ext
+                return resolve_publish_image_pin_policy(latest)
+        return resolved
+
     def _get_owner_id(self, publish_record: BotPublishRecord) -> str:
         return self._ext_state.owner_id(publish_record)
 
@@ -985,4 +1035,3 @@ class PublishFlowService(
             ):
                 return True
         return False
-

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -36,18 +36,14 @@ from agentclaw.community.core.service_bot.types import (
     PublishStage,
 )
 from agentclaw.community.core.common_config.service import CommonConfigService
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    IMAGE_POLICY_KEYS,
-    ImagePolicyState,
-    ServiceBotImagePin,
-    has_explicit_image_policy,
-    resolve_publish_image_pin as resolve_publish_image_pin_policy,
-)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.ext_state import (
     PublishExtState,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.image_policy_mixin import (
+    PublishImagePolicyMixin,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
     DefaultProviderBehavior,
@@ -110,7 +106,6 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
 from agentclaw.community.log import get_logger
-from agentclaw.community.utils.env_utils import get_current_env
 
 
 if TYPE_CHECKING:
@@ -170,6 +165,7 @@ class PublishFlowService(
     UpgradeResolutionMixin,
     RetryOpsMixin,
     DraftRestoreOpsMixin,
+    PublishImagePolicyMixin,
 ):
     """Bot publish flow processing service.
 
@@ -862,48 +858,6 @@ class PublishFlowService(
         for op in self._publish_operation_repo.list_by_publish_id(publish_id):
             if op.state not in terminal:
                 self._publish_operation_repo.abandon(op.id, reason)
-
-    def resolve_publish_image_pin(
-        self,
-        publish_record: BotPublishRecord,
-        bot: dict,
-    ) -> ServiceBotImagePin:
-        """Resolve and, for legacy rows, atomically append the Pin snapshot."""
-        if (
-            self._baas_service.resolve_container_provider(bot)
-            == TECLAW_DEVICE_PROVIDER
-        ):
-            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
-        was_legacy = not has_explicit_image_policy(publish_record.ext)
-
-        def _persist(snapshot: dict) -> None:
-            def _mutate(latest_ext: dict) -> None:
-                # Another concurrent operation may have already fixed the policy.
-                # Never replace an explicit decision; otherwise append only our
-                # owned fields to the latest ext snapshot.
-                if has_explicit_image_policy(latest_ext):
-                    return
-                for key in IMAGE_POLICY_KEYS:
-                    latest_ext.pop(key, None)
-                for key in IMAGE_POLICY_KEYS:
-                    if key in snapshot:
-                        latest_ext[key] = snapshot[key]
-
-            self._mutate_and_update_ext(publish_record.id, _mutate)
-
-        resolved = resolve_publish_image_pin_policy(
-            publish_record,
-            common_config_service=self._common_config_service,
-            env=get_current_env(),
-            persist_ext=_persist,
-        )
-        if was_legacy and resolved.enabled:
-            latest = self._publish_service.get_publish_by_id(publish_record.id)
-            if latest is not None:
-                publish_record.ext = latest.ext
-                return resolve_publish_image_pin_policy(latest)
-        return resolved
 
     def _get_owner_id(self, publish_record: BotPublishRecord) -> str:
         return self._ext_state.owner_id(publish_record)

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -293,6 +293,7 @@ class ServiceBotModule(Module):
         publish_operation_repo: PublishOperationRepository,
         task_queue_service: TaskQueueService,
         bot_process_registry: BotProcessRegistry,
+        common_config_service: CommonConfigService,
     ) -> BotPublishService:
         """Construct ``BotPublishService``.
 
@@ -312,6 +313,7 @@ class ServiceBotModule(Module):
             publish_operation_repo=publish_operation_repo,
             task_queue_service=task_queue_service,
             bot_process_registry=bot_process_registry,
+            common_config_service=common_config_service,
             publish_flow_service_provider=lambda: injector.get(PublishFlowService),
         )
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -154,7 +154,7 @@ class TestCreateBotBcnRegister:
             summary="service desc",
         )
 
-    def test_service_bot_create_persists_and_uses_current_pinned_image(self):
+    def test_service_bot_create_uses_default_image_and_persists_marker(self):
         svc = _make_service()
         device_service = _attach_device_service(svc)
         common_config = MagicMock()
@@ -180,15 +180,15 @@ class TestCreateBotBcnRegister:
         inserted_ext = svc._repository.insert.call_args.args[0]["ext"]
         assert inserted_ext == {
             "service_bot_config": {"device_count": 3},
-            "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_use_default_image": True,
         }
         apply_kwargs = device_service.apply_device.call_args.kwargs
         assert apply_kwargs["template_config"] == {
-            "image": "registry/arka:v2",
+            "image": "registry/arka:v1",
             "envs": {"A": "1"},
         }
         assert template_config["image"] == "registry/arka:v1"
+        common_config.get_value.assert_not_called()
 
     def test_claude_code_application_coding_does_not_trigger_bcn_register(self):
         """claude_code + applicationCoding 创建时不应触发 BCN 注册。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -125,8 +125,8 @@ def _make_bot(
 # ===========================================================================
 
 
-class TestRestartBaasImagePin:
-    def test_restart_uses_pinned_image_without_mutating_template_snapshot(self):
+class TestRestartBaasImagePolicy:
+    def test_low_level_restart_uses_explicit_pin_without_mutating_template_snapshot(self):
         template_config = {"image": "registry/arka:v1", "envs": {"A": "1"}}
         svc, baas, _ = _make_service(
             template_config=template_config,
@@ -151,7 +151,7 @@ class TestRestartBaasImagePin:
         }
         assert template_config["image"] == "registry/arka:v1"
 
-    def test_restart_failure_does_not_persist_resolved_pin(self):
+    def test_restart_failure_does_not_persist_default_marker(self):
         svc, baas, _ = _make_service(
             template_config={},
             bot_type="service",
@@ -178,7 +178,7 @@ class TestRestartBaasImagePin:
         ("bot_type", "active_engine"),
         [("personal", "openclaw"), ("service", "teclaw")],
     )
-    def test_pin_persistence_skips_non_arka_service_bot(
+    def test_default_persistence_skips_non_arka_service_bot(
         self,
         bot_type: str,
         active_engine: str,
@@ -196,13 +196,13 @@ class TestRestartBaasImagePin:
             },
         }
 
-        svc._persist_service_bot_arka_image_pin(bot, user_id="user001")
+        svc._persist_service_bot_default_image(bot, user_id="user001")
 
         svc._repository.update_by_owner.assert_not_called()
         svc._bot_publish_repo.get_draft_by_publish_bot_id.assert_not_called()
         svc._bot_publish_repo.update_status_with_ext.assert_not_called()
 
-    def test_restart_success_persists_bot_and_current_draft_pin(self):
+    def test_restart_success_persists_bot_and_current_draft_default_marker(self):
         svc, _, _ = _make_service(
             template_config={},
             bot_type="service",
@@ -227,15 +227,21 @@ class TestRestartBaasImagePin:
         )
 
         svc._repository.update_by_owner.assert_any_call(
-            "bot001", "user001", {"ext": bot["ext"]}
+            "bot001",
+            "user001",
+            {
+                "ext": {
+                    "service_bot_config": {"device_count": 1},
+                    "sbot_use_default_image": True,
+                }
+            },
         )
         svc._bot_publish_repo.update_status_with_ext.assert_called_once_with(
             publish_id=6643,
             target_status="draft",
             ext={
                 "migration_path": "/old",
-                "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_use_default_image": True,
             },
             source_status="draft",
         )

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -921,8 +921,8 @@ class TestRestartGuardOrchestration:
         start.assert_not_called()
         assert result == bot
 
-    def test_restart_baas_service_refreshes_pin_before_upgrade(self):
-        """草稿态重启读取当前开关，并仅刷新 Pin 字段后透传镜像。"""
+    def test_restart_baas_service_uses_default_image_and_persists_marker(self):
+        """草稿态重启不读开关、不覆盖模板镜像，并持久化默认镜像标记。"""
         repo = FakeRestartLockRepo()
         common_config = MagicMock()
         common_config.get_value.return_value = {"image": "registry/arka:v2"}
@@ -952,13 +952,14 @@ class TestRestartGuardOrchestration:
         with patch.object(svc, "stop_bot"), patch.object(svc, "start_bot"):
             svc.restart_bot(bot_id="bot001", user_id="user001")
 
-        common_config.get_value.assert_called_once()
+        common_config.get_value.assert_not_called()
         assert state["ext"]["service_bot_config"] == {"device_count": 3}
-        assert state["ext"]["sbot_pin_image"] is True
-        assert state["ext"]["sbot_docker_image"] == "registry/arka:v2"
+        assert state["ext"]["sbot_use_default_image"] is True
+        assert "sbot_pin_image" not in state["ext"]
+        assert "sbot_docker_image" not in state["ext"]
         upgrade_kwargs = baas.upgrade_bot.call_args.kwargs
         assert upgrade_kwargs["template_config"] == {
-            "image": "registry/arka:v2",
+            "image": "registry/arka:v1",
             "envs": {"A": "1"},
         }
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -1580,6 +1580,53 @@ class TestAsyncReleasesLock:
         device_service.apply_device.assert_called_once()
         assert device_service.apply_device.call_args.kwargs["device_provider"] == "baas"
 
+    def test_allocator_persists_default_image_after_successful_recreate(self):
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        bot = _make_bot(status="PENDING", bot_type="service")
+        bot["ext"] = {"service_bot_config": {"device_count": 2}}
+        svc._repository.get_by_id_and_owner.return_value = bot
+        svc._repository.update_by_owner.return_value = bot
+
+        device_service = MagicMock()
+        device_service.apply_device.return_value = SimpleNamespace(
+            id=7,
+            device_id="device-7",
+            device_provider="arca",
+            status="PENDING",
+        )
+        svc._device_service_provider = lambda: device_service
+        svc._skill_set_factory.create.return_value.get_symlink_mappings.return_value = []
+        svc._template_service.get_template_config.return_value = None
+        svc._query_admin_worknos = MagicMock(return_value=[])
+        default_ext = {
+            "service_bot_config": {"device_count": 2},
+            "sbot_use_default_image": True,
+        }
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.threading.Thread",
+            _SyncThread,
+        ), patch.object(
+            svc, "_persist_service_bot_default_image"
+        ) as persist_default:
+            svc._allocate_device_async(
+                bot_id="bot001",
+                user_id="user001",
+                nick_name="u1",
+                entity_id="staff_user001",
+                entity_type="staff",
+                engine_types=["openclaw"],
+                active_engine="openclaw",
+                device_provider="arca",
+                bot_ext_override=default_ext,
+            )
+
+        persist_default.assert_called_once_with(
+            {**bot, "bot_id": "bot001", "ext": default_ext},
+            user_id="user001",
+        )
+
     def test_allocator_logs_explicit_provider_before_apply_device(self):
         repo = FakeRestartLockRepo()
         svc = _make_service(repo)

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -76,6 +76,7 @@ def _make_service(
     caller_identity=None,
     token_provider=None,
     runtime_updater=None,
+    common_config_service=None,
 ):
     """Construct ExpertChatInstanceService with mocks."""
     instance_repo = instance_repo or MagicMock()
@@ -87,6 +88,8 @@ def _make_service(
     caller_identity = caller_identity or MagicMock()
     token_provider = token_provider or MagicMock()
     runtime_updater = runtime_updater or MagicMock()
+    common_config_service = common_config_service or MagicMock()
+    common_config_service.get_value.return_value = None
 
     svc = ExpertChatInstanceService(
         instance_repo=instance_repo,
@@ -98,6 +101,7 @@ def _make_service(
         caller_identity=caller_identity,
         token_provider=token_provider,
         runtime_updater=runtime_updater,
+        common_config_service=common_config_service,
     )
     return svc, instance_repo, baas, publish_repo, bot_repo, binding_repo, bot_build_service, caller_identity, token_provider, runtime_updater
 

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -22,6 +22,9 @@ from agentclaw.community.core.service_bot.services.baas_service import (
     BaasServiceError,
     BotWsConnectionInfoResponse,
 )
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePolicyState,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 
 
@@ -42,6 +45,7 @@ class MockPublishRecord:
     id: int = 123
     name: str = "Test Bot"
     owner_id: str = OWNER_ID
+    status: str = "success"
     version: int = 1
     ext: dict = None
 
@@ -136,6 +140,101 @@ def _wire_bot_build_service_async(bot_build_service, create_result=None, upgrade
         bot_build_service.release_async = AsyncMock(return_value=create_result)
     if upgrade_result is not None:
         bot_build_service.upgrade_async = AsyncMock(return_value=upgrade_result)
+
+
+class TestResolvePublishImagePin:
+    def test_teclaw_skips_arka_policy_resolution(self):
+        svc, _, baas, _, bot_repo, *_ = _make_service()
+        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
+        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "teclaw"}
+        baas.resolve_container_provider.return_value = "teclaw"
+
+        resolved = svc._resolve_publish_image_pin(
+            record,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+        )
+
+        assert resolved.state == ImagePolicyState.LEGACY
+        assert resolved.docker_image is None
+        svc._common_config_service.get_value.assert_not_called()
+
+    def test_legacy_publish_persists_pin_and_refreshes_record(self):
+        common_config = MagicMock()
+        svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
+            common_config_service=common_config
+        )
+        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
+        latest = MockPublishRecord(
+            ext={"migration_path": "/nas/path", "unrelated": "preserved"}
+        )
+        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
+        baas.resolve_container_provider.return_value = "baas"
+        publish_repo.get_by_id.return_value = latest
+
+        def update_status_with_ext(**kwargs):
+            latest.ext = kwargs["ext"]
+            return latest
+
+        publish_repo.update_status_with_ext.side_effect = update_status_with_ext
+
+        resolved = svc._resolve_publish_image_pin(
+            record,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+        )
+
+        assert resolved.state == ImagePolicyState.PINNED
+        assert resolved.docker_image == "registry/arka:v2"
+        assert latest.ext["unrelated"] == "preserved"
+        assert latest.ext["sbot_pin_image"] is True
+        assert latest.ext["sbot_docker_image"] == "registry/arka:v2"
+        assert record.ext == latest.ext
+
+    def test_concurrent_explicit_policy_is_not_overwritten(self):
+        common_config = MagicMock()
+        svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
+            common_config_service=common_config
+        )
+        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
+        latest = MockPublishRecord(
+            ext={"migration_path": "/nas/path", "sbot_use_default_image": True}
+        )
+        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
+        baas.resolve_container_provider.return_value = "baas"
+        publish_repo.get_by_id.return_value = latest
+
+        resolved = svc._resolve_publish_image_pin(
+            record,
+            bot_id=BOT_ID,
+            owner_id=OWNER_ID,
+        )
+
+        assert resolved.state == ImagePolicyState.DEFAULT
+        publish_repo.update_status_with_ext.assert_not_called()
+        assert record.ext == latest.ext
+
+    def test_failed_policy_persistence_raises_connection_error(self):
+        common_config = MagicMock()
+        svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
+            common_config_service=common_config
+        )
+        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
+        latest = MockPublishRecord(ext={"migration_path": "/nas/path"})
+        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
+        baas.resolve_container_provider.return_value = "baas"
+        publish_repo.get_by_id.return_value = latest
+        publish_repo.update_status_with_ext.return_value = None
+
+        with pytest.raises(ConnectionError, match="changed concurrently"):
+            svc._resolve_publish_image_pin(
+                record,
+                bot_id=BOT_ID,
+                owner_id=OWNER_ID,
+            )
 
 
 class TestResolveBuildArtifact:

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -197,3 +197,8 @@ def test_resolve_legacy_publish_snapshots_pin_before_use():
 def test_resolve_rejects_pin_without_image():
     with pytest.raises(ImagePinConfigError, match="without a valid image"):
         resolve_publish_image_pin(_record({"sbot_pin_image": True}))
+
+
+def test_resolve_rejects_dangling_image_policy_field():
+    with pytest.raises(ImagePinConfigError, match="inconsistent image policy"):
+        resolve_publish_image_pin(_record({"sbot_docker_image": "arka:v2"}))

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -1,14 +1,37 @@
-from unittest.mock import MagicMock
 from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePinConfigError,
+    ImagePolicyState,
+    apply_default_image_to_ext,
     apply_image_pin_to_ext,
-    copy_image_pin_to_ext,
+    copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
     resolve_current_arka_image,
     resolve_publish_image_pin,
 )
+
+
+def _record(ext=None) -> BotPublishRecord:
+    return BotPublishRecord(
+        id=1,
+        source_bot_pk=1,
+        source_bot_id="bot-1",
+        publish_bot_id="bot-1",
+        name="bot",
+        owner_id="u1",
+        status="success",
+        version=2,
+        env="pre",
+        ext=ext,
+        permission_owner="owner",
+        gmt_create=datetime.now(),
+        gmt_modified=datetime.now(),
+    )
 
 
 def test_resolve_current_image_uses_enabled_common_config():
@@ -23,6 +46,22 @@ def test_resolve_current_image_uses_enabled_common_config():
         default=None,
         only_enabled=True,
     )
+
+
+def test_resolve_current_image_returns_none_for_disabled_or_missing_config():
+    service = MagicMock()
+    service.get_value.return_value = None
+
+    assert resolve_current_arka_image(service, env="pre") is None
+
+
+@pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arka:v2"])
+def test_resolve_current_image_rejects_enabled_malformed_config(value):
+    service = MagicMock()
+    service.get_value.return_value = value
+
+    with pytest.raises(ImagePinConfigError, match="has no valid image"):
+        resolve_current_arka_image(service, env="pre")
 
 
 def test_apply_pin_preserves_service_bot_config_and_clears_stale_pin():
@@ -42,6 +81,18 @@ def test_apply_pin_preserves_service_bot_config_and_clears_stale_pin():
     }
 
 
+def test_apply_default_preserves_unrelated_fields_and_clears_stale_pin():
+    assert apply_default_image_to_ext(
+        {
+            "service_bot_config": {"device_count": 3},
+            "sbot_pin_image": True,
+            "sbot_docker_image": "old:v1",
+        }
+    ) == {
+        "service_bot_config": {"device_count": 3},
+        "sbot_use_default_image": True,
+    }
+
 def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     source = {
         "service_bot_config": {"device_count": 3},
@@ -51,7 +102,7 @@ def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     target = {"config_artifact": {"schema_version": 4}}
     template = {"image": "template:v1", "envs": {"A": "1"}}
 
-    assert copy_image_pin_to_ext(source, target) == {
+    assert copy_image_policy_to_ext(source, target) == {
         "config_artifact": {"schema_version": 4},
         "sbot_pin_image": True,
         "sbot_docker_image": "arka:v2",
@@ -63,24 +114,86 @@ def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     assert template["image"] == "template:v1"
 
 
+def test_publish_copy_supports_default_and_clears_stale_target_policy():
+    source = {"sbot_use_default_image": True, "unrelated": "not-copied"}
+    target = {
+        "config_artifact": {"schema_version": 4},
+        "sbot_pin_image": True,
+        "sbot_docker_image": "old:v1",
+    }
+
+    assert copy_image_policy_to_ext(source, target) == {
+        "config_artifact": {"schema_version": 4},
+        "sbot_use_default_image": True,
+    }
+
+
 def test_resolve_publish_image_pin_reads_only_publish_ext():
-    record = BotPublishRecord(
-        id=1,
-        source_bot_pk=1,
-        source_bot_id="bot-1",
-        publish_bot_id="bot-1",
-        name="bot",
-        owner_id="u1",
-        status="success",
-        version=2,
-        env="pre",
-        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v2"},
-        permission_owner="owner",
-        gmt_create=datetime.now(),
-        gmt_modified=datetime.now(),
+    record = _record({"sbot_pin_image": True, "sbot_docker_image": "arka:v2"})
+    common_config = MagicMock()
+
+    resolved = resolve_publish_image_pin(
+        record, common_config_service=common_config
     )
 
-    resolved = resolve_publish_image_pin(record)
-
     assert resolved.enabled is True
+    assert resolved.state == ImagePolicyState.PINNED
     assert resolved.docker_image == "arka:v2"
+    common_config.get_value.assert_not_called()
+
+
+def test_resolve_default_publish_does_not_read_common_config():
+    common_config = MagicMock()
+
+    resolved = resolve_publish_image_pin(
+        _record({"sbot_use_default_image": True, "other": 1}),
+        common_config_service=common_config,
+    )
+
+    assert resolved.state == ImagePolicyState.DEFAULT
+    assert resolved.docker_image is None
+    common_config.get_value.assert_not_called()
+
+
+def test_resolve_legacy_publish_with_disabled_config_stays_legacy():
+    common_config = MagicMock()
+    common_config.get_value.return_value = None
+    persist = MagicMock()
+
+    resolved = resolve_publish_image_pin(
+        _record({"migration_path": "/build/v1"}),
+        common_config_service=common_config,
+        persist_ext=persist,
+    )
+
+    assert resolved.state == ImagePolicyState.LEGACY
+    assert resolved.docker_image is None
+    persist.assert_not_called()
+
+
+def test_resolve_legacy_publish_snapshots_pin_before_use():
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    persist = MagicMock()
+    record = _record({"migration_path": "/build/v1"})
+
+    resolved = resolve_publish_image_pin(
+        record,
+        common_config_service=common_config,
+        persist_ext=persist,
+    )
+
+    expected_ext = {
+        "migration_path": "/build/v1",
+        "sbot_pin_image": True,
+        "sbot_docker_image": "registry/arka:v2",
+    }
+    assert resolved.state == ImagePolicyState.PINNED
+    assert resolved.docker_image == "registry/arka:v2"
+    persist.assert_called_once_with(expected_ext)
+    assert record.ext == expected_ext
+
+
+def test_resolve_rejects_pin_without_image():
+    with pytest.raises(ImagePinConfigError, match="without a valid image"):
+        resolve_publish_image_pin(_record({"sbot_pin_image": True}))

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -39,6 +39,7 @@ def _make_service(
     publish_operation_repo=None,
     task_queue_service=None,
     bot_process_registry=None,
+    common_config_service=None,
 ) -> BotPublishService:
     """Build a ``BotPublishService`` with MagicMock fallbacks for unused deps.
 
@@ -55,6 +56,10 @@ def _make_service(
     if bot_process_registry is None:
         process_registry.get.return_value.get_active_runtime_engine_type.return_value = ""
 
+    common_config = common_config_service or MagicMock()
+    if common_config_service is None:
+        common_config.get_value.return_value = None
+
     return BotPublishService(
         bot_publish_repo=bot_publish_repo,
         bot_repo=bot_repo or MagicMock(),
@@ -66,6 +71,7 @@ def _make_service(
         publish_operation_repo=operation_repo,
         task_queue_service=task_queue_service or MagicMock(),
         bot_process_registry=process_registry,
+        common_config_service=common_config,
     )
 
 
@@ -92,6 +98,99 @@ def _create_mock_record(
         permission_owner="owner",
         ext=ext,
     )
+
+
+class TestCreatePublishImagePolicy:
+    def _create(self, *, source_bot, common_config_value=None, is_teclaw=False):
+        publish_repo = Mock()
+        publish_repo.get_by_publish_bot_id_and_version.return_value = None
+        publish_repo.insert.return_value = _create_mock_record(
+            record_id=10,
+            status=PublishStatus.DRAFT,
+        )
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = source_bot
+        bot_service = Mock()
+        bot_service.is_teclaw_bot.return_value = is_teclaw
+        common_config = Mock()
+        common_config.get_value.return_value = common_config_value
+        service = _make_service(
+            publish_repo,
+            bot_repo=bot_repo,
+            bot_service=bot_service,
+            common_config_service=common_config,
+        )
+
+        service.create_publish(
+            source_bot_pk=1,
+            source_bot_id="bot_001",
+            publish_bot_id="bot_001_pub",
+            name="bot",
+            owner_id="user_001",
+            permission_owner="owner",
+            ext={"migration_path": "/build/v1"},
+        )
+        return publish_repo.insert.call_args.args[0]["ext"], common_config
+
+    def test_default_bot_copies_marker_without_reading_common_config(self):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "openclaw",
+                "ext": {"sbot_use_default_image": True},
+            },
+            common_config_value={"image": "registry/arka:v2"},
+        )
+
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_use_default_image": True,
+        }
+        common_config.get_value.assert_not_called()
+
+    def test_legacy_arka_bot_snapshots_enabled_common_config_image(self):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "openclaw",
+                "ext": {"service_bot_config": {"device_count": 2}},
+            },
+            common_config_value={"image": "registry/arka:v2"},
+        )
+
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        }
+        common_config.get_value.assert_called_once()
+
+    def test_legacy_arka_bot_stays_policyless_when_switch_disabled(self):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "openclaw",
+                "ext": {"service_bot_config": {"device_count": 2}},
+            },
+            common_config_value=None,
+        )
+
+        assert ext == {"migration_path": "/build/v1"}
+        common_config.get_value.assert_called_once()
+
+    def test_teclaw_publish_does_not_consume_arka_common_config(self):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "teclaw",
+                "ext": None,
+            },
+            common_config_value={"image": "registry/arka:v2"},
+            is_teclaw=True,
+        )
+
+        assert ext == {"migration_path": "/build/v1"}
+        common_config.get_value.assert_not_called()
 
 
 class TestUpgradePublish:

--- a/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
@@ -141,13 +141,15 @@ def _arca_router(build_service):
 def _flow(*, ledger, baas, build_service, publish_service=None):
     reader = Mock()
     reader.overrides_for_stage.return_value = {}
+    common_config_service = Mock()
+    common_config_service.get_value.return_value = None
     svc = PublishFlowService(
         publish_service or Mock(),
         build_service,
         baas,
         Mock(),  # bot_service
         _arca_router(build_service),
-        Mock(),  # common_config_service
+        common_config_service,
         resolver=Mock(),
         device_fs_dispatcher=Mock(),
         teclaw_file_promotion=Mock(),

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -102,7 +102,10 @@ def _real_ledger():
 def _pf(*args, **kw):
     """Construct PublishFlowService for tests, defaulting the DI-required teclaw
     promotion deps to Mocks (the arca/verify flow tests don't exercise them)."""
-    kw.setdefault("common_config_service", Mock())
+    if "common_config_service" not in kw:
+        common_config = Mock()
+        common_config.get_value.return_value = None
+        kw["common_config_service"] = common_config
     kw.setdefault("task_queue_service", Mock())
     kw.setdefault("resolver", Mock())
     kw.setdefault("device_fs_dispatcher", Mock())
@@ -1659,7 +1662,9 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
     # identity keys stable across the promotion
     assert delivered["engine_ext"]["bot_id"] == "b2"
     assert delivered["engine_ext"]["owner_id"] == "u1"
-    assert build_service.release_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
+    # TeClaw does not consume ARKA image Pin fields even if a historical row
+    # happens to contain them.
+    assert build_service.release_async.await_args.kwargs["docker_image"] is None
 
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "canary"
@@ -1701,7 +1706,7 @@ async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
 
     delivered = build_service.upgrade_async.await_args.kwargs["delivery"].config_artifact
     assert delivered["engine_ext"]["stage"] == "canary"
-    assert build_service.upgrade_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
+    assert build_service.upgrade_async.await_args.kwargs["docker_image"] is None
     persisted = svc._ext_state.update_status.call_args.kwargs["ext"]["config_artifact"]
     assert persisted["engine_ext"]["stage"] == "canary"
 
@@ -2635,13 +2640,19 @@ async def test_scale_bot_falls_back_to_common_config_default_device_count():
     publish_service.get_publish_by_id = Mock(return_value=record)
     publish_service.get_device_binding_by_id = Mock(return_value=binding)
     bot_service.get_bot = Mock(return_value={"bot_id": "bot-source", "ext": {}})
-    common_config_service.get_value = Mock(return_value=2)
+    common_config_service.get_value = Mock(
+        side_effect=lambda **kwargs: (
+            2
+            if kwargs["business_code"] == "service_bot_device_count"
+            else None
+        )
+    )
     baas_service.scale_bot = Mock(return_value={"publish_id": 999, "target_count": 2})
 
     result = await svc.scale_bot(publish_id=13, operator="u1")
 
     assert result["target_count"] == 2
-    common_config_service.get_value.assert_called_once()
+    assert common_config_service.get_value.call_count == 2
     _, kwargs = baas_service.scale_bot.call_args
     assert kwargs["bot_uuid"] == "BOT-UUID-2"
     assert kwargs["owner_id"] == "u1"

--- a/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePolicyState,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.image_policy_mixin import (
+    PublishImagePolicyMixin,
+)
+
+
+def _record(ext=None) -> BotPublishRecord:
+    return BotPublishRecord(
+        id=1,
+        source_bot_pk=1,
+        source_bot_id="bot-1",
+        publish_bot_id="bot-1",
+        name="bot",
+        owner_id="u1",
+        status="success",
+        version=2,
+        env="pre",
+        ext=ext,
+        permission_owner="owner",
+        gmt_create=datetime.now(),
+        gmt_modified=datetime.now(),
+    )
+
+
+class _ImagePolicyHarness(PublishImagePolicyMixin):
+    def __init__(self, *, latest=None, image=None):
+        self._baas_service = MagicMock()
+        self._baas_service.resolve_container_provider.return_value = "baas"
+        self._common_config_service = MagicMock()
+        self._common_config_service.get_value.return_value = (
+            {"image": image} if image else None
+        )
+        self._publish_service = MagicMock()
+        self._publish_service.get_publish_by_id.return_value = latest
+        self.mutated_ext = None
+
+    def _mutate_and_update_ext(self, publish_id, mutator):
+        latest = self._publish_service.get_publish_by_id(publish_id)
+        if latest is None:
+            return None
+        latest_ext = dict(latest.ext or {})
+        mutator(latest_ext)
+        latest.ext = latest_ext
+        self.mutated_ext = latest_ext
+        return latest_ext
+
+
+def test_resolve_publish_image_pin_skips_teclaw():
+    record = _record({"migration_path": "/build/v1"})
+    svc = _ImagePolicyHarness(image="registry/arka:v2")
+    svc._baas_service.resolve_container_provider.return_value = "teclaw"
+
+    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "teclaw"})
+
+    assert resolved.state == ImagePolicyState.LEGACY
+    assert resolved.docker_image is None
+    svc._common_config_service.get_value.assert_not_called()
+
+
+def test_resolve_publish_image_pin_persists_legacy_snapshot_and_refreshes_record():
+    record = _record({"migration_path": "/build/v1"})
+    latest = _record({"migration_path": "/build/v1", "unrelated": "preserved"})
+    svc = _ImagePolicyHarness(latest=latest, image="registry/arka:v2")
+
+    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
+
+    assert resolved.state == ImagePolicyState.PINNED
+    assert resolved.docker_image == "registry/arka:v2"
+    assert svc.mutated_ext == {
+        "migration_path": "/build/v1",
+        "unrelated": "preserved",
+        "sbot_pin_image": True,
+        "sbot_docker_image": "registry/arka:v2",
+    }
+    assert record.ext == latest.ext
+
+
+def test_resolve_publish_image_pin_does_not_replace_concurrent_explicit_policy():
+    record = _record({"migration_path": "/build/v1"})
+    latest = _record(
+        {
+            "migration_path": "/build/v1",
+            "sbot_use_default_image": True,
+        }
+    )
+    svc = _ImagePolicyHarness(latest=latest, image="registry/arka:v2")
+
+    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
+
+    assert resolved.state == ImagePolicyState.DEFAULT
+    assert resolved.docker_image is None
+    assert latest.ext == {
+        "migration_path": "/build/v1",
+        "sbot_use_default_image": True,
+    }
+    assert record.ext == latest.ext
+
+
+def test_resolve_publish_image_pin_returns_initial_resolution_when_reread_missing():
+    record = _record({"migration_path": "/build/v1"})
+    svc = _ImagePolicyHarness(latest=None, image="registry/arka:v2")
+
+    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
+
+    assert resolved.state == ImagePolicyState.PINNED
+    assert resolved.docker_image == "registry/arka:v2"


### PR DESCRIPTION
## Problem

PR #766 applied the Common Config image snapshot to new ARKA service Bots and draft restarts. The clarified rollout policy is different: new Bots and successful draft restarts must follow the BaaS/ARKA default image, while only historical Bots and publish records without an explicit policy should use Common Config Pin protection.

Without an explicit default marker, new records are indistinguishable from historical unresolved records and may be incorrectly pinned. Published operations also need one consistent resolution path so restart, release, Eval, Caller, Scale, and rollback do not resolve different images.

## Solution

- Add an explicit default-image policy for new ARKA service Bots and successful draft restarts.
- Persist the draft-restart policy to the Bot and current Draft publish metadata only; historical Verify/Online/SUCCESS rows are not rewritten.
- Preserve two explicit publish policies and one compatibility state:
  - Default: follow the provider default image.
  - Pinned: use the image snapshot from the target publish record.
  - Legacy/unresolved: consult Common Config and lazily snapshot a valid Pin image.
- Copy only image-policy-owned fields when creating or updating publish metadata, preserving unrelated metadata.
- Centralize target-publish image resolution for Release, Upgrade, Eval, published Restart, Caller containers, Scale, and Rollback.
- Keep TeClaw outside the ARKA Common Config and image Pin path.
- Fail explicitly when an enabled Common Config or publish Pin snapshot has no valid image.
- Pass the Scale Pin image through the existing nested deploy configuration.

## Validation

- Extended service Bot regression suite: 940 passed
- Ruff on all modified production files and related tests: passed
- Expert Chat test Ruff with only the file's pre-existing F841 ignored: passed
- PR diff whitespace check: passed

## Compatibility and risk

- No database schema migration is required; the policy uses existing Bot and publish metadata.
- Existing explicit Pin snapshots remain immutable and do not follow later Common Config changes.
- Legacy records with disabled or missing Common Config use the provider default for the current operation and remain unresolved so the rollout switch can be enabled later.
- Legacy records are updated only when an enabled valid Pin image is selected, using latest-metadata field-level merge semantics.

## Related issues

- Follow-up correction to #766
