### PR TITLE
fix(backend): reject teclaw bot restart for others

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -40,6 +40,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
     BotInvalidLifecycleStateError,
     BotNotFoundError,
+    BotOperationNotAllowedError,
     BotPermissionError,
     DeviceAllocationError,
     BotNameExistsError,
@@ -369,19 +370,6 @@ async def restart_bot_for_others(
         target_user_id = target_user_id.strip()
         target_bot_id = target_bot_id.strip()
 
-        bot = bot_service.get_bot(target_bot_id, target_user_id)
-        if bot.get("active_engine") == "teclaw":
-            logger.warning(
-                "[bot_router.restart_bot_for_others] Restart is not supported for teclaw bot: "
-                f"bot_id={target_bot_id}, user_id={target_user_id}"
-            )
-            return ApiResponse(
-                success=False,
-                message="teclaw 类型的 Bot 不支持重启",
-                error_code=400,
-                data=None,
-            )
-
         # Call service to restart bot
         result = bot_service.restart_bot(
             bot_id=target_bot_id,
@@ -421,6 +409,14 @@ async def restart_bot_for_others(
             success=False,
             message=f"当前状态不允许重启Bot: {str(e)}",
             error_code=409,
+            data=None,
+        )
+    except BotOperationNotAllowedError as e:
+        logger.warning(f"[bot_router.restart_bot_for_others] Operation not allowed: {e}")
+        return ApiResponse(
+            success=False,
+            message=str(e),
+            error_code=400,
             data=None,
         )
     except BotServiceError as e:
@@ -500,6 +496,14 @@ async def restart_scheduler(
             success=False,
             message=f"当前状态不允许重启Bot: {str(e)}",
             error_code=409,
+            data=None,
+        )
+    except BotOperationNotAllowedError as e:
+        logger.warning(f"[bot_router.restart_scheduler] Operation not allowed: {e}")
+        return ApiResponse(
+            success=False,
+            message=str(e),
+            error_code=400,
             data=None,
         )
     except BotServiceError as e:
@@ -2676,6 +2680,14 @@ async def restart_bot(
             success=False,
             message=f"当前状态不允许重启Bot: {str(e)}",
             error_code=409,
+            data=None,
+        )
+    except BotOperationNotAllowedError as e:
+        logger.warning(f"[bot_router.restart_bot] Operation not allowed: {e}")
+        return ApiResponse(
+            success=False,
+            message=str(e),
+            error_code=400,
             data=None,
         )
     except BotServiceError as e:

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -369,6 +369,19 @@ async def restart_bot_for_others(
         target_user_id = target_user_id.strip()
         target_bot_id = target_bot_id.strip()
 
+        bot = bot_service.get_bot(target_bot_id, target_user_id)
+        if bot.get("active_engine") == "teclaw":
+            logger.warning(
+                "[bot_router.restart_bot_for_others] Restart is not supported for teclaw bot: "
+                f"bot_id={target_bot_id}, user_id={target_user_id}"
+            )
+            return ApiResponse(
+                success=False,
+                message="teclaw 类型的 Bot 不支持重启",
+                error_code=400,
+                data=None,
+            )
+
         # Call service to restart bot
         result = bot_service.restart_bot(
             bot_id=target_bot_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3870,6 +3870,15 @@ class BotService:
         if not bot:
             raise BotNotFoundError(f"Bot not found: {bot_id}")
 
+        if self.is_teclaw_bot(bot.get("active_engine")):
+            logger.warning(
+                "[bot_service.restart_bot] reject restart for teclaw bot: "
+                "bot_id=%s user_id=%s",
+                bot_id,
+                user_id,
+            )
+            raise BotOperationNotAllowedError("teclaw 类型的 Bot 不支持重启")
+
         if bot.get("bot_type") == "desktop":
             raise BotServiceError(
                 f"Desktop bot {bot_id} cannot be stopped via BotService.stop_bot, "

--- a/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.mcp.services.passport_scope import (
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.core.bot_management.services.bot_service import (
+    BotOperationNotAllowedError,
     generate_bot_id,
 )
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
@@ -294,11 +295,14 @@ class CreateBotForOthersService:
                 "runtime": {"restart_required": True},
             }
 
-        result = self._bot_service.restart_bot(
-            bot_id=bot_id,
-            user_id=target_user_id,
-            nick_name=target_nick_name,
-        )
+        try:
+            result = self._bot_service.restart_bot(
+                bot_id=bot_id,
+                user_id=target_user_id,
+                nick_name=target_nick_name,
+            )
+        except BotOperationNotAllowedError as exc:
+            raise CreateBotForOthersError(str(exc), error_code=400) from exc
         return {
             **base_result,
             "action": "restarted",

--- a/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
@@ -238,6 +238,11 @@ class CreateBotForOthersService:
                 error_code=500,
             )
         engine_type = str(bot.get("active_engine") or DEFAULT_ENGINE_TYPE)
+        if self._bot_service.is_teclaw_bot(engine_type):
+            raise CreateBotForOthersError(
+                "teclaw 类型的 Bot 不支持重启",
+                error_code=400,
+            )
         existing_ext = self._mapping_copy(bot.get("ext"))
         readiness = self._ensure_passport(
             bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py
@@ -238,11 +238,7 @@ class CreateBotForOthersService:
                 error_code=500,
             )
         engine_type = str(bot.get("active_engine") or DEFAULT_ENGINE_TYPE)
-        if self._bot_service.is_teclaw_bot(engine_type):
-            raise CreateBotForOthersError(
-                "teclaw 类型的 Bot 不支持重启",
-                error_code=400,
-            )
+        is_teclaw_bot = self._bot_service.is_teclaw_bot(engine_type)
         existing_ext = self._mapping_copy(bot.get("ext"))
         readiness = self._ensure_passport(
             bot_id=bot_id,
@@ -286,11 +282,18 @@ class CreateBotForOthersService:
             return {
                 **base_result,
                 "action": "repaired" if identity_repaired else "skipped",
-                "runtime": {"restart_required": identity_repaired},
+                "runtime": {
+                    "restart_required": identity_repaired and not is_teclaw_bot
+                },
             }
 
         wait = self._restart_wait(bot.get("gmt_modified"))
         if wait is not None:
+            if is_teclaw_bot:
+                raise CreateBotForOthersError(
+                    "teclaw 类型的 Bot 不支持重启",
+                    error_code=400,
+                )
             minutes_since_modified, minutes_remaining = wait
             return {
                 **base_result,

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -1008,6 +1008,18 @@ class TestRestartForOthers:
         resp = tc.post("/api/bots/restart-for-others", json={"target_user_id": "u1", "target_bot_id": "default"})
         assert resp.json()["success"] is True
 
+    def test_rejects_teclaw_bot(self, admin_client):
+        tc, svc, _, _ = admin_client
+        svc.get_bot.return_value = {**BOT_SAMPLE, "active_engine": "teclaw"}
+
+        resp = tc.post("/api/bots/restart-for-others", json={"target_user_id": "u1", "target_bot_id": "default"})
+
+        data = resp.json()
+        assert data["success"] is False
+        assert data["error_code"] == 400
+        assert data["message"] == "teclaw 类型的 Bot 不支持重启"
+        svc.restart_bot.assert_not_called()
+
     def test_missing_target_user(self, admin_client):
         tc, svc, _, _ = admin_client
         resp = tc.post("/api/bots/restart-for-others", json={"target_bot_id": "default"})

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -835,6 +835,22 @@ class TestRestartBot:
         assert resp.json()["success"] is False
         assert resp.json()["error_code"] == 409
 
+    def test_rejects_teclaw_bot(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.side_effect = BotOperationNotAllowedError(
+            "teclaw 类型的 Bot 不支持重启"
+        )
+
+        resp = tc.post("/api/bots/default/restart")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "success": False,
+            "message": "teclaw 类型的 Bot 不支持重启",
+            "error_code": 400,
+            "data": None,
+        }
+
     def test_activation_in_progress_returns_accepted(self, client):
         tc, svc, _ = client
         svc.restart_bot.return_value = {
@@ -938,6 +954,25 @@ class TestRestartScheduler:
 
         assert resp.status_code == 409
         assert resp.json()["error_code"] == 409
+
+    def test_rejects_teclaw_bot(self, client):
+        tc, svc, _ = client
+        svc.restart_bot.side_effect = BotOperationNotAllowedError(
+            "teclaw 类型的 Bot 不支持重启"
+        )
+
+        resp = tc.post(
+            "/api/bots/restart-scheduler",
+            json={"user_id": "test_user", "bot_id": "default"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "success": False,
+            "message": "teclaw 类型的 Bot 不支持重启",
+            "error_code": 400,
+            "data": None,
+        }
 
     def test_activation_in_progress_returns_accepted(self, client):
         tc, svc, _ = client

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
     BotInvalidLifecycleStateError,
     BotNotFoundError,
+    BotOperationNotAllowedError,
     BotPermissionError,
     DeviceAllocationError,
     BotNameExistsError,
@@ -1010,7 +1011,7 @@ class TestRestartForOthers:
 
     def test_rejects_teclaw_bot(self, admin_client):
         tc, svc, _, _ = admin_client
-        svc.get_bot.return_value = {**BOT_SAMPLE, "active_engine": "teclaw"}
+        svc.restart_bot.side_effect = BotOperationNotAllowedError("teclaw 类型的 Bot 不支持重启")
 
         resp = tc.post("/api/bots/restart-for-others", json={"target_user_id": "u1", "target_bot_id": "default"})
 
@@ -1018,7 +1019,7 @@ class TestRestartForOthers:
         assert data["success"] is False
         assert data["error_code"] == 400
         assert data["message"] == "teclaw 类型的 Bot 不支持重启"
-        svc.restart_bot.assert_not_called()
+        svc.restart_bot.assert_called_once()
 
     def test_missing_target_user(self, admin_client):
         tc, svc, _, _ = admin_client

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     RESTART_LOCK_TTL_SECONDS,
     BotInvalidLifecycleStateError,
     BotNotFoundError,
+    BotOperationNotAllowedError,
     BotService,
     BotServiceError,
 )
@@ -191,6 +192,22 @@ def _stateful_bot_repository(bot: dict) -> tuple[MagicMock, dict]:
 
 
 class TestRestartGuardOrchestration:
+
+    def test_teclaw_bot_restart_is_rejected_before_lock_or_device_work(self):
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        bot = _make_bot(active_engine="teclaw")
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start:
+            with pytest.raises(BotOperationNotAllowedError, match="teclaw 类型的 Bot 不支持重启"):
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+
     def test_restart_during_reactivation_is_idempotent(self):
         """Dormant reactivation owns the lifecycle while it is running."""
         repo = FakeRestartLockRepo()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -57,6 +57,9 @@ def _make_service() -> BotService:
     # the resolved DeviceService.
     svc._bot_publish_provider = lambda: MagicMock()
     svc._device_service_provider = lambda: MagicMock()
+    teclaw_provision = MagicMock()
+    teclaw_provision.is_teclaw.side_effect = lambda engine: engine == "teclaw"
+    svc._teclaw_provision_provider = lambda: teclaw_provision
     # Restart idempotency lock repo. Default: acquire() returns a truthy mock
     # so restart_bot treats the lock as acquired and proceeds to stop+start.
     svc._restart_lock_repo = MagicMock()

--- a/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
@@ -46,7 +46,7 @@ def _freeze_restart_wait_clock(monkeypatch):
     return service_module, FrozenDateTime
 
 
-def _bot(*, status="ACTIVE", ext=None, gmt_modified=None):
+def _bot(*, status="ACTIVE", ext=None, gmt_modified=None, active_engine="openclaw"):
     return {
         "bot_id": EXISTING_BOT_ID,
         "owner_id": TARGET_USER,
@@ -55,7 +55,7 @@ def _bot(*, status="ACTIVE", ext=None, gmt_modified=None):
         "bot_name": "Default Bot",
         "bot_desc": "default vault",
         "status": status,
-        "active_engine": "openclaw",
+        "active_engine": active_engine,
         "template_type": None,
         "ext": ext or {},
         "gmt_modified": gmt_modified,
@@ -84,6 +84,7 @@ def _service(*, existing_bot=None):
         "bot_id": "default",
         "status": "PENDING",
     }
+    bot_service.is_teclaw_bot.return_value = False
 
     passport = MagicMock()
     passport.apply_first_agent_passport.return_value = {
@@ -409,6 +410,28 @@ def test_active_bot_with_complete_identity_is_verified_without_restart():
     relationship.create_relationship.assert_not_called()
     repository.update_by_owner.assert_not_called()
     bot_service.create_bot.assert_not_called()
+    bot_service.restart_bot.assert_not_called()
+
+
+def test_teclaw_bot_rejects_create_for_others_before_repair_or_restart():
+    from agentclaw.community.core.bot_management.errors import (
+        CreateBotForOthersError,
+    )
+
+    stored = _bot(active_engine="teclaw")
+    service, _, bot_service, passport, relationship, _ = _service(
+        existing_bot=stored
+    )
+    bot_service.is_teclaw_bot.return_value = True
+
+    with pytest.raises(CreateBotForOthersError) as exc_info:
+        _execute(service)
+
+    assert exc_info.value.error_code == 400
+    assert str(exc_info.value) == "teclaw 类型的 Bot 不支持重启"
+    bot_service.is_teclaw_bot.assert_called_once_with("teclaw")
+    passport.apply_first_agent_passport.assert_not_called()
+    relationship.create_relationship.assert_not_called()
     bot_service.restart_bot.assert_not_called()
 
 

--- a/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
@@ -413,22 +413,23 @@ def test_active_bot_with_complete_identity_is_verified_without_restart():
     bot_service.restart_bot.assert_not_called()
 
 
-def test_teclaw_bot_rejects_create_for_others_before_repair_or_restart():
-    from agentclaw.community.core.bot_management.errors import (
-        CreateBotForOthersError,
+def test_active_teclaw_bot_is_verified_without_requesting_restart():
+    stored = _bot(
+        active_engine="teclaw",
+        ext={"passport": {"agent_code": AGENT_CODE}},
     )
-
-    stored = _bot(active_engine="teclaw")
     service, _, bot_service, passport, relationship, _ = _service(
         existing_bot=stored
     )
     bot_service.is_teclaw_bot.return_value = True
+    relationship.query_relationships.return_value = [
+        {"auth_id": 42, "work_no": TARGET_USER, "agent_code": AGENT_CODE},
+    ]
 
-    with pytest.raises(CreateBotForOthersError) as exc_info:
-        _execute(service)
+    result = _execute(service)
 
-    assert exc_info.value.error_code == 400
-    assert str(exc_info.value) == "teclaw 类型的 Bot 不支持重启"
+    assert result["action"] == "skipped"
+    assert result["runtime"]["restart_required"] is False
     bot_service.is_teclaw_bot.assert_called_once_with("teclaw")
     passport.apply_first_agent_passport.assert_not_called()
     relationship.create_relationship.assert_not_called()

--- a/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_create_bot_for_others_service.py
@@ -514,6 +514,36 @@ def test_failed_bot_is_repaired_before_restart_after_wait_period():
     )
 
 
+def test_failed_teclaw_bot_restart_rejection_is_client_error_after_wait_period():
+    from agentclaw.community.core.bot_management.errors import (
+        CreateBotForOthersError,
+    )
+    from agentclaw.community.core.bot_management.services.bot_service import (
+        BotOperationNotAllowedError,
+    )
+
+    stored = _bot(
+        status="FAILED",
+        ext={"passport": {"agent_code": AGENT_CODE}},
+        gmt_modified=datetime.now(timezone.utc) - timedelta(minutes=31),
+    )
+    service, _, bot_service, _, _, _ = _service(existing_bot=stored)
+    bot_service.restart_bot.side_effect = BotOperationNotAllowedError(
+        "teclaw 类型的 Bot 不支持重启"
+    )
+
+    with pytest.raises(CreateBotForOthersError) as exc_info:
+        _execute(service)
+
+    assert exc_info.value.error_code == 400
+    assert str(exc_info.value) == "teclaw 类型的 Bot 不支持重启"
+    bot_service.restart_bot.assert_called_once_with(
+        bot_id=EXISTING_BOT_ID,
+        user_id=TARGET_USER,
+        nick_name="Alice",
+    )
+
+
 def test_recent_failed_bot_is_repaired_but_still_observes_restart_wait():
     stored = _bot(
         status="FAILED",


### PR DESCRIPTION
## 变更说明
- restart-for-others 在执行重启前读取目标 Bot 的 active_engine。
- 当引擎为 teclaw 时返回 400，避免发起不支持的重启。
- 补充 teclaw 拦截回归测试。

## 验证
- `uv run pytest tests/community/api/bot_management/test_router.py`（147 passed）