### PR TITLE
fix(backend): release rolled-back rollout batches

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/operations.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/operations.py
@@ -694,7 +694,8 @@ class SkillsPoolRolloutOperations:
         for state in self._layouts.list_states(env=env, engine=engine):
             evidence = state.rollout_evidence
             if (
-                evidence is not None
+                self._claimed(state.active_layout, state.target_layout)
+                and evidence is not None
                 and evidence.engine_type == engine
                 and evidence.batch_id is not None
                 and evidence.batch_id not in accepted

--- a/src/backend/tests/community/core/skills_pool/test_operations.py
+++ b/src/backend/tests/community/core/skills_pool/test_operations.py
@@ -572,7 +572,27 @@ def test_only_one_unaccepted_batch_can_be_open_per_engine() -> None:
         )
 
 
-def test_claimed_batch_stays_open_after_whitelist_removal() -> None:
+@pytest.mark.parametrize(
+    ("active_layout", "target_layout", "phase"),
+    [
+        (
+            SkillLayout.LEGACY,
+            SkillLayout.POOL,
+            SkillLayoutPhase.POOL_PREPARING,
+        ),
+        (
+            SkillLayout.POOL,
+            SkillLayout.LEGACY,
+            SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+        ),
+    ],
+    ids=["pool-claim", "rollback-in-progress"],
+)
+def test_claimed_batch_stays_open_after_whitelist_removal(
+    active_layout: SkillLayout,
+    target_layout: SkillLayout,
+    phase: SkillLayoutPhase,
+) -> None:
     operations, _, _, layouts = build_operations(
         config=rollout_config(
             promoted_engines=["openclaw"],
@@ -587,8 +607,9 @@ def test_claimed_batch_stays_open_after_whitelist_removal() -> None:
     )
     layouts.state = replace(
         layouts.state,
-        target_layout=SkillLayout.POOL,
-        phase=SkillLayoutPhase.POOL_PREPARING,
+        active_layout=active_layout,
+        target_layout=target_layout,
+        phase=phase,
         migration_generation="generation-1",
         persisted=True,
         rollout_evidence=RolloutEvidence(
@@ -621,6 +642,38 @@ def test_claimed_batch_stays_open_after_whitelist_removal() -> None:
             operator="freddie",
             reason="must not bypass claimed batch",
         )
+
+
+def test_fully_rolled_back_batch_releases_open_batch_ownership() -> None:
+    operations, _, _, layouts = build_operations(
+        config=rollout_config(promoted_engines=["openclaw"])
+    )
+    layouts.state = replace(
+        layouts.state,
+        persisted=True,
+        rollout_evidence=RolloutEvidence(
+            env=ENV,
+            config_id=7,
+            config_version="config-1",
+            batch_id="batch-1",
+            engine_type="openclaw",
+            decision_reason="exact_bot_whitelist",
+        ),
+    )
+
+    result = operations.add_bot(
+        env=ENV,
+        owner_id=OWNER,
+        bot_id=BOT_ID,
+        batch_id="batch-2",
+        acceptance_batch_id=None,
+        operator="freddie",
+        reason="retry after complete rollback",
+    )
+
+    assert result.snapshot.whitelist[0].batch_id == "batch-2"
+    assert layouts.state.rollout_evidence is not None
+    assert layouts.state.rollout_evidence.batch_id == "batch-1"
 
 
 def test_other_engine_can_promote_while_existing_engine_batch_is_open() -> None:


### PR DESCRIPTION
## Problem

After an exact rollout Bot is fully rolled back to Legacy and removed from the whitelist, its retained `rollout_evidence` still makes the batch appear open. The batch cannot be accepted because it is no longer promotion-ready, while a new batch for the same engine is rejected with `the current engine batch must be accepted before expansion`.

## Solution

Count persisted rollout evidence as open-batch ownership only while the Bot remains claimed (`active_layout=pool` or `target_layout=pool`). A completed rollback (`active_layout=legacy`, `target_layout=None`) releases ownership without deleting historical evidence. Pool preparation and rollback-in-progress states continue to fail closed.

## Validation

- Red/green regression for a completed rollback followed by a new batch.
- Claimed Pool preparation and rollback-in-progress cases remain blocked.
- `278 passed` for the Skills Pool core plus rollout HTTP/endpoint suites.
- Ruff passed for both changed files.
- Backend local SAST passed.
- `git diff --check` passed.

## Compatibility and risk

No API, schema, configuration, Engine, Desktop, or runtime contract changes. Historical rollout evidence remains persisted for audit. The behavior changes only for states that have already completed rollback to Legacy.
