### PR TITLE
fix(bot_run): read errorMessage from payload on chat error state

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -736,14 +736,9 @@ class AsyncChatClient:
                         f"[chat] final: sessionKey={session_key}, state={chat_state}"
                     )
         elif chat_state == "error":
-            state.content = text
-            state.state = chat_state
-            state.chat_complete.set()
-            self._emit_stream_chunk(state, StreamChunk(type="error", content=text))
-            if self.verbose:
-                logger.info(
-                    f"[chat] error: sessionKey={session_key}, payload={payload}"
-                )
+            self._handle_terminal_error(
+                state, session_key, payload.get("errorMessage", ""), "chat"
+            )
         else:
             if self.verbose:
                 logger.info(

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -544,12 +544,11 @@ class TestOnChat:
             {
                 "sessionKey": _TEST_SESSION_KEY,
                 "state": "error",
-                "message": {"content": [{"text": "error message"}]},
+                "errorMessage": "LLM is trying to invoke a non-exist tool",
             }
         )
         await asyncio.sleep(0)
         assert state.state == "error"
-        assert state.content == "error message"
         assert state.chat_complete.is_set() is True
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -432,10 +432,11 @@ class TestOnChatAdditional:
             {
                 "sessionKey": "sk1",
                 "state": "error",
-                "message": {"content": [{"text": "err"}]},
+                "errorMessage": "some error",
             }
         )
         assert state.state == "error"
+        assert state.chat_complete.is_set() is True
 
     @pytest.mark.asyncio
     async def test_on_chat_verbose_ignored_state(self, mock_bot_ws):


### PR DESCRIPTION
```
fix(bot_run): read errorMessage from payload on chat error state

## Problem

When a chat event arrives with state="error", _on_chat was extracting
the error text from message.content[0].text. In error state that field
is typically empty — the actual error detail lives in payload["errorMessage"].
As a result, error chunks carried an empty string downstream and callers
could not see why the session failed (e.g. "LLM is trying to invoke a
non-exist tool").

## Solution

Replace the inline error handling in _on_chat with a call to
_handle_terminal_error, the same method _on_agent already uses. This
reads payload["errorMessage"], falls back to "chat error" when empty,
sets state to "error", emits a StreamChunk(type="error"), and logs a
warning — consistent with agent-side error handling.

## Validation

Ran 168 unit tests across test_async_chat_client.py,
test_async_chat_client_coverage.py, and test_async_chat_client_pool.py
— all passed. Updated two test cases to send errorMessage in the
payload instead of message.content text.
```