### PR TITLE
fix(backend): guard local skill bot ownership

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -604,6 +604,7 @@ class SkillSetService:
             target_bot_id = skill_set.get("bolt_id") or self.bot_id
             if (
                 skill_git_path.startswith("local://")
+                and skill.get("bolt_id") is not None
                 and skill.get("bolt_id") != target_bot_id
             ):
                 results["failed"].append(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -596,6 +596,33 @@ class SkillSetService:
                     results["failed"].append({"skill_id": skill_id, "error": "Skill not found"})
                     continue
 
+            # Local skills are stored in a per-Bot workspace and must never be
+            # associated with another Bot's skill set. Numeric skill IDs are
+            # globally resolvable, so a stale caller bot_id could otherwise
+            # create a cross-Bot association here.
+            skill_git_path = skill.get("git_path", "")
+            target_bot_id = skill_set.get("bolt_id") or self.bot_id
+            if (
+                skill_git_path.startswith("local://")
+                and skill.get("bolt_id") != target_bot_id
+            ):
+                results["failed"].append(
+                    {
+                        "skill_id": skill_id,
+                        "error": "Skill belongs to another bot",
+                    }
+                )
+                logger.warning(
+                    "[add_skills_to_set] Rejected cross-Bot local skill: "
+                    "skill_id=%s, skill_bot_id=%s, skill_set_id=%s, "
+                    "skill_set_bot_id=%s",
+                    skill_id,
+                    skill.get("bolt_id"),
+                    skill_set_id,
+                    target_bot_id,
+                )
+                continue
+
             # Check if already associated in the same skill set
             existing_skills = self.skill_set_repo.get_skills_in_set(skill_set_id)
             already_exists = any(s.get('id') == skill.get('id') for s in existing_skills)

--- a/src/backend/tests/community/services/test_skill_set_service_bot_ownership.py
+++ b/src/backend/tests/community/services/test_skill_set_service_bot_ownership.py
@@ -1,0 +1,65 @@
+"""Regression coverage for per-Bot skill-set ownership."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def skill_set_service(tmp_path):
+    from agentclaw.community.core.skill_center.services.skill_set_service import (
+        SkillSetService,
+    )
+
+    skill_repo = MagicMock()
+    skill_set_repo = MagicMock()
+    return SkillSetService(
+        skill_repo=skill_repo,
+        skill_set_repo=skill_set_repo,
+        mcp_center=MagicMock(),
+        mcp_config_service=MagicMock(),
+        skill_service=MagicMock(),
+        bot_repo=MagicMock(),
+        skills_dir=tmp_path / "skills",
+        repo_dir=tmp_path / "skills-repo",
+        local_dir=tmp_path / "skills-local",
+        bot_id="target-bot",
+        entity_id="owner",
+        engine_type="openclaw",
+        path_factory=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_skills_to_set_rejects_skill_owned_by_another_bot(skill_set_service):
+    """A local skill may only be associated with its owning Bot's skill set."""
+    skill_set_service.skill_set_repo.get_by_id.return_value = {
+        "id": "10",
+        "bolt_id": "target-bot",
+        "is_default": False,
+        "is_active": False,
+    }
+    skill_set_service.skill_set_repo.get_skills_in_set.return_value = []
+    skill_set_service.skill_set_repo.list_all.return_value = []
+    skill_set_service.skill_repo.get_by_id.return_value = {
+        "id": "20",
+        "name": "local-skill",
+        "bolt_id": "other-bot",
+        "git_path": "local:///skills-local/local-skill",
+    }
+
+    with patch(
+        "agentclaw.community.core.skill_center.services.skill_set_service"
+        ".SkillSetMetadataWriter.write_metadata"
+    ):
+        result = await skill_set_service.add_skills_to_set(
+            "10", ["20"], user_id="owner"
+        )
+
+    assert result["success"] == []
+    assert result["failed"] == [
+        {
+            "skill_id": "20",
+            "error": "Skill belongs to another bot",
+        }
+    ]
+    skill_set_service.skill_set_repo.add_skill_to_set.assert_not_called()


### PR DESCRIPTION
## 背景

防止前端携带错误 Bot 上下文时，将 local skill 关联到其他 Bot 的技能集。

## 变更

- 为 `local://` 技能新增技能归属 Bot 与目标技能集 Bot 一致性校验
- 不匹配时拒绝写入关联并记录告警
- 新增回归测试覆盖跨 Bot 关联拒绝

## 验证

- `uv run pytest tests/community/services/test_skill_set_service_bot_ownership.py -q`（1 passed）