### PR TITLE
fix(bot): apply first passport to first personal bot

### DIFF
--- a/src/backend/src/agentclaw/community/api/bot_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_service.py
@@ -38,10 +38,13 @@ class BotServiceProtocol(Protocol):
 
     def check_create_bot_preflight(self, *args: Any, **kwargs: Any) -> Any: ...
 
-    # Whether the owner has no bots yet. ``create_flow`` calls this on the
-    # injected service to choose the first-bot passport application, so it is
-    # part of the surface adapters depend on — not an internal helper.
+    # Whether the owner has no Bots yet. ``create_flow`` keeps this separate
+    # from Passport selection so the response can preserve its first-Bot field.
     def is_first_bot(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    # Passport onboarding is based on the first live personal Bot, independently
+    # from whether the owner already has service Bots.
+    def is_first_personal_bot(self, *args: Any, **kwargs: Any) -> Any: ...
 
     # The ceiling creation actually enforces (per-user policy, falling back to
     # the configured allocation limit). Exposed so a surface that *reports* the

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -336,11 +336,11 @@ def create_bot_with_authorization(
     # Validate the name up front so an invalid one never reaches Passport or
     # create. An unset name stays unset — create_bot applies default naming.
     bot_name = validate_bot_name(spec.bot_name) if spec.bot_name is not None else None
-    # Keep the response contract tied to the owner's first Bot of any type, but
-    # choose Passport onboarding independently: a converted/existing service Bot
-    # must not consume the owner's first-personal-Bot entitlement.
+    # Preserve the existing first-Bot Passport path for every Bot type. When the
+    # owner already has service Bots, the first live personal Bot also uses that
+    # path; service and soft-deleted personal Bots do not consume this eligibility.
     is_first_bot = bot_service.is_first_bot(user_id)
-    use_first_passport = (
+    use_first_passport = is_first_bot or (
         spec.bot_type == "personal"
         and bot_service.is_first_personal_bot(user_id)
     )

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -197,7 +197,7 @@ def _apply_passport(
     spec: BotCreateSpec,
     mcp_codes: list[str],
     cli_items: list[Any],
-    is_first_bot: bool,
+    use_first_passport: bool,
 ) -> dict[str, Any] | None:
     """Apply for the bot's Passport, normalizing non-Passport failures.
 
@@ -205,10 +205,14 @@ def _apply_passport(
     any other apply failure becomes a ``BotServiceError`` so it keeps the
     "Passport apply failed" mapping rather than falling into a generic bucket.
     """
-    # 默认租户:首 bot → applyFirst(跳过审批),非首 → applyAgent(走审批)。
+    # 默认租户:首个个人 Bot → applyFirst(跳过审批),否则 → applyAgent(走审批)。
+    # 服务 Bot 不占用“首个个人 Bot”资格；软删除过滤由仓储查询保证。
     # 其他租户(openapi / 外部):一律 applyFirst —— 审批流不适用于外部租户,
-    # 且 applyFirst 对重复调用幂等,故不依赖 is_first_bot。见 #556 的根因修复。
-    if get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT and not is_first_bot:
+    # 且 applyFirst 对重复调用幂等,故不依赖首个个人 Bot 判断。见 #556。
+    if (
+        get_current_avernet_tenant() == DEFAULT_AVERNET_TENANT
+        and not use_first_passport
+    ):
         apply = passport_plugin.apply_agent_passport
     else:
         apply = passport_plugin.apply_first_agent_passport
@@ -332,7 +336,14 @@ def create_bot_with_authorization(
     # Validate the name up front so an invalid one never reaches Passport or
     # create. An unset name stays unset — create_bot applies default naming.
     bot_name = validate_bot_name(spec.bot_name) if spec.bot_name is not None else None
+    # Keep the response contract tied to the owner's first Bot of any type, but
+    # choose Passport onboarding independently: a converted/existing service Bot
+    # must not consume the owner's first-personal-Bot entitlement.
     is_first_bot = bot_service.is_first_bot(user_id)
+    use_first_passport = (
+        spec.bot_type == "personal"
+        and bot_service.is_first_personal_bot(user_id)
+    )
 
     # Pre-flight before Passport, so quota, name, and reserved-bot engine
     # violations are reported before an external Passport identity is minted.
@@ -356,7 +367,7 @@ def create_bot_with_authorization(
         cli_items=get_default_cli_items(
             spec.engine_type, spec.template_type
         ),
-        is_first_bot=is_first_bot,
+        use_first_passport=use_first_passport,
     )
 
     passport_token = passport_result.get("token") if passport_result else None

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
@@ -184,6 +184,10 @@ class BotRepository(Protocol):
         """Check if a bot with specific bot_id exists for the owner."""
         ...
 
+    def exists_by_owner_and_bot_type(self, owner_id: str, bot_type: str) -> bool:
+        """Check if the owner has a live Bot of the requested type."""
+        ...
+
     def exists_by_bot_name(self, bot_name: str) -> bool:
         """Check if a bot with specific bot_name exists globally."""
         ...

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -947,6 +947,12 @@ class BotService:
         """First bot iff the owner has zero bots (current env; tenant enforced by guard)."""
         return self._repository.count_by_owner(user_id) == 0
 
+    def is_first_personal_bot(self, user_id: str) -> bool:
+        """Return whether the owner has no live personal Bot in the current scope."""
+        return not self._repository.exists_by_owner_and_bot_type(
+            user_id, "personal"
+        )
+
     def _check_bot_count_limit(self, owner_id: str) -> None:
         """Enforce the per-owner bot count limit.
 

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -546,6 +546,22 @@ class BotRepository:
                 > 0
             )
 
+    def exists_by_owner_and_bot_type(
+        self, owner_id: str, bot_type: str
+    ) -> bool:
+        with self._db.orm_session() as db:
+            return (
+                db.query(self.Model)
+                .filter(
+                    self.Model.is_delete == 0,
+                    self.Model.owner_id == owner_id,
+                    self.Model.bot_type == bot_type,
+                    self._env(),
+                )
+                .count()
+                > 0
+            )
+
     def exists_by_bot_name(self, bot_name: str) -> bool:
         with self._db.orm_session() as db:
             return (

--- a/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
@@ -1,17 +1,4 @@
-"""Which Passport apply the create flow calls is a data question, not a string one.
-
-``create_bot_with_authorization`` picks between ``apply_first_agent_passport``
-and ``apply_agent_passport``. It used to decide with ``bot_id == "default"``, a
-proxy that held only while every owner's first bot was ``"default"``.
-
-``generate_bot_id`` now confines that shortcut to the default tenant (issue
-#556), so in any other tenant a genuinely first bot carries a generated id. Under
-the old proxy that owner would be sent to ``apply_agent_passport`` — the
-non-first-bot branch — despite never having had a Passport.
-
-The flow therefore asks the repository. These tests pin both directions, since
-the two branches hit different tcauthmng facade methods.
-"""
+"""Passport selection is based on the owner's first live personal Bot."""
 
 from __future__ import annotations
 
@@ -22,76 +9,101 @@ import pytest
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_management.create_flow import (
     BotCreateSpec,
+    Created,
     create_bot_with_authorization,
 )
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 pytestmark = pytest.mark.unit
 
-_SPEC = BotCreateSpec(
-    entity_id="85020",
-    engine_type="openclaw",
-    bot_type="personal",
-    bot_name="Bot",
-)
+
+def _spec(bot_type: str = "personal") -> BotCreateSpec:
+    return BotCreateSpec(
+        entity_id="85020",
+        engine_type="openclaw",
+        bot_type=bot_type,
+        bot_name="Bot",
+    )
 
 
-def _run(*, bot_id: str, is_first_bot: bool):
+def _run(
+    *,
+    bot_type: str = "personal",
+    is_first_bot: bool,
+    is_first_personal_bot: bool,
+):
     passport = MagicMock()
     passport.apply_first_agent_passport.return_value = {"token": "tok"}
     passport.apply_agent_passport.return_value = {"token": "tok"}
 
-    # Spec'd to the *protocol*, not the concrete class: both routers inject
-    # BotServiceProtocol, so anything create_flow calls on it has to be declared
-    # there. A bare MagicMock would happily answer an undeclared method and hide
-    # the AttributeError a conforming implementation would raise at runtime.
     bot_service = MagicMock(spec=BotServiceProtocol)
     bot_service.is_first_bot.return_value = is_first_bot
+    bot_service.is_first_personal_bot.return_value = is_first_personal_bot
+    bot_service.create_bot.return_value = {"bot_id": "20260805_ab12cd34"}
 
     skill_set_factory = MagicMock()
     skill_set_factory.create.return_value.get_bot_mcp_codes.return_value = []
 
-    create_bot_with_authorization(
+    outcome = create_bot_with_authorization(
         user_id="85020",
         nick_name="Alice",
-        bot_id=bot_id,
-        spec=_SPEC,
+        bot_id="20260805_ab12cd34",
+        spec=_spec(bot_type),
         bot_service=bot_service,
         passport_plugin=passport,
         auth_rel_plugin=MagicMock(),
         skill_set_factory=skill_set_factory,
     )
-    return passport, bot_service
+    return passport, bot_service, outcome
 
 
-def test_generated_id_still_takes_the_first_bot_branch():
-    """The case the id proxy got wrong: first bot, non-"default" id."""
-    passport, bot_service = _run(bot_id="20260730_ab12cd34", is_first_bot=True)
-
-    passport.apply_first_agent_passport.assert_called_once()
-    passport.apply_agent_passport.assert_not_called()
-    bot_service.is_first_bot.assert_called_once_with("85020")
-
-
-def test_default_id_takes_the_first_bot_branch():
-    """Unchanged for the default tenant, where a first bot is still "default"."""
-    passport, _ = _run(bot_id="default", is_first_bot=True)
+def test_first_bot_and_first_personal_bot_uses_first_passport():
+    passport, bot_service, outcome = _run(
+        is_first_bot=True, is_first_personal_bot=True
+    )
 
     passport.apply_first_agent_passport.assert_called_once()
     passport.apply_agent_passport.assert_not_called()
+    bot_service.is_first_personal_bot.assert_called_once_with("85020")
+    assert isinstance(outcome, Created)
+    assert outcome.is_first_bot is True
 
 
-def test_owner_with_existing_bots_takes_the_non_first_branch():
-    passport, _ = _run(bot_id="20260730_ab12cd34", is_first_bot=False)
+def test_service_bot_exists_but_first_personal_bot_uses_first_passport():
+    passport, _, outcome = _run(
+        is_first_bot=False, is_first_personal_bot=True
+    )
+
+    passport.apply_first_agent_passport.assert_called_once()
+    passport.apply_agent_passport.assert_not_called()
+    assert isinstance(outcome, Created)
+    assert outcome.is_first_bot is False
+
+
+def test_existing_personal_bot_uses_regular_passport():
+    passport, _, _ = _run(
+        is_first_bot=False, is_first_personal_bot=False
+    )
 
     passport.apply_agent_passport.assert_called_once()
     passport.apply_first_agent_passport.assert_not_called()
 
 
-def test_branch_is_not_inferred_from_the_id_in_another_tenant():
-    """A non-default tenant never mints "default", so the id must not decide."""
+def test_creating_service_bot_does_not_use_first_personal_passport():
+    passport, bot_service, _ = _run(
+        bot_type="service", is_first_bot=True, is_first_personal_bot=True
+    )
+
+    passport.apply_agent_passport.assert_called_once()
+    passport.apply_first_agent_passport.assert_not_called()
+    bot_service.is_first_personal_bot.assert_not_called()
+
+
+def test_non_default_tenant_keeps_apply_first_behavior():
     with avernet_tenant_scope("acme"):
-        passport, _ = _run(bot_id="20260730_ab12cd34", is_first_bot=True)
+        passport, _, _ = _run(
+            is_first_bot=False, is_first_personal_bot=False
+        )
 
     passport.apply_first_agent_passport.assert_called_once()
     passport.apply_agent_passport.assert_not_called()

--- a/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_first_bot.py
@@ -64,7 +64,7 @@ def test_first_bot_and_first_personal_bot_uses_first_passport():
 
     passport.apply_first_agent_passport.assert_called_once()
     passport.apply_agent_passport.assert_not_called()
-    bot_service.is_first_personal_bot.assert_called_once_with("85020")
+    bot_service.is_first_personal_bot.assert_not_called()
     assert isinstance(outcome, Created)
     assert outcome.is_first_bot is True
 
@@ -89,9 +89,19 @@ def test_existing_personal_bot_uses_regular_passport():
     passport.apply_first_agent_passport.assert_not_called()
 
 
-def test_creating_service_bot_does_not_use_first_personal_passport():
+def test_first_service_bot_preserves_first_passport_behavior():
     passport, bot_service, _ = _run(
         bot_type="service", is_first_bot=True, is_first_personal_bot=True
+    )
+
+    passport.apply_first_agent_passport.assert_called_once()
+    passport.apply_agent_passport.assert_not_called()
+    bot_service.is_first_personal_bot.assert_not_called()
+
+
+def test_non_first_service_bot_uses_regular_passport():
+    passport, bot_service, _ = _run(
+        bot_type="service", is_first_bot=False, is_first_personal_bot=True
     )
 
     passport.apply_agent_passport.assert_called_once()

--- a/src/backend/tests/community/core/bot_management/test_create_flow_is_first.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_is_first.py
@@ -28,11 +28,30 @@ class TestIsFirstBot:
         assert _svc_with_count(5).is_first_bot("user001") is False
 
 
+class TestIsFirstPersonalBot:
+    def test_no_live_personal_bot_is_first_personal(self):
+        svc = BotService.__new__(BotService)
+        svc._repository = MagicMock()
+        svc._repository.exists_by_owner_and_bot_type.return_value = False
+
+        assert svc.is_first_personal_bot("user001") is True
+        svc._repository.exists_by_owner_and_bot_type.assert_called_once_with(
+            "user001", "personal"
+        )
+
+    def test_existing_live_personal_bot_is_not_first_personal(self):
+        svc = BotService.__new__(BotService)
+        svc._repository = MagicMock()
+        svc._repository.exists_by_owner_and_bot_type.return_value = True
+
+        assert svc.is_first_personal_bot("user001") is False
+
+
 class TestApplyRpcTenantBranch:
-    """发证 RPC 按租户分流:默认租户按 is_first 分,其他租户一律 applyFirst。"""
+    """发证 RPC 按租户分流:默认租户按首个个人 Bot 分,其他租户一律 applyFirst。"""
 
     @pytest.mark.parametrize(
-        "tenant,is_first,expect_first_rpc",
+        "tenant,use_first_passport,expect_first_rpc",
         [
             ("teamclaw", True, True),    # 默认租户首 bot → applyFirst
             ("teamclaw", False, False),  # 默认租户非首 → applyAgent
@@ -40,7 +59,9 @@ class TestApplyRpcTenantBranch:
             ("tenantB", False, True),    # 其他租户非首 → 仍 applyFirst
         ],
     )
-    def test_rpc_selection(self, tenant, is_first, expect_first_rpc, monkeypatch):
+    def test_rpc_selection(
+        self, tenant, use_first_passport, expect_first_rpc, monkeypatch
+    ):
         from agentclaw.community.core.bot_management import create_flow
         from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
 
@@ -62,7 +83,7 @@ class TestApplyRpcTenantBranch:
             spec=MagicMock(),
             mcp_codes=[],
             cli_items=[],
-            is_first_bot=is_first,
+            use_first_passport=use_first_passport,
         )
 
         if expect_first_rpc:

--- a/src/backend/tests/community/core/bot_management/test_create_flow_pending.py
+++ b/src/backend/tests/community/core/bot_management/test_create_flow_pending.py
@@ -35,6 +35,8 @@ def _run(apply_result):
     passport = MagicMock()
     passport.apply_first_agent_passport.return_value = apply_result
     bot_service = MagicMock()
+    bot_service.is_first_bot.return_value = True
+    bot_service.is_first_personal_bot.return_value = True
     skill_set_factory = MagicMock()
     skill_set_factory.create.return_value.get_bot_mcp_codes.return_value = []
     return create_bot_with_authorization(

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -186,6 +186,7 @@ def test_get_env_scoped(repo, db):
     assert repo.get_by_id_and_owner("bot-1", "emp1") is None
     assert repo.count_by_owner("emp1") == 0
     assert repo.exists_by_owner_and_bot_id("emp1", "bot-1") is False
+    assert repo.exists_by_owner_and_bot_type("emp1", "personal") is False
 
 
 def test_explicit_env_default_bot_read_and_ext_update_are_isolated(repo, db):
@@ -287,6 +288,19 @@ def test_count_by_owner_excludes_desktop(repo):
     repo.insert(_data(bot_id="b3", bot_type="desktop"))
     assert repo.count_by_owner("emp1") == 3
     assert repo.count_by_owner("emp1", exclude_bot_type="desktop") == 1
+
+
+def test_exists_by_owner_and_bot_type_only_matches_live_requested_type(repo):
+    repo.insert(_data(bot_id="service", bot_type="service"))
+    repo.insert(_data(bot_id="deleted-personal", bot_type="personal", is_delete=1))
+
+    assert repo.exists_by_owner_and_bot_type("emp1", "personal") is False
+    assert repo.exists_by_owner_and_bot_type("emp1", "service") is True
+
+    repo.insert(_data(bot_id="live-personal", bot_type="personal"))
+
+    assert repo.exists_by_owner_and_bot_type("emp1", "personal") is True
+    assert repo.exists_by_owner_and_bot_type("other-owner", "personal") is False
 
 
 # ── update_by_owner allowlist (adopt prod) ──────────────────────────


### PR DESCRIPTION
用户已有服务 Bot、但没有有效个人 Bot 时，创建个人 Bot 会被误判为“非首个 Bot”，从而调用普通 Passport 授权流程 `apply_agent_passport`，导致创建接口出现未授权异常。

  典型场景：

  - 用户原来的 Default 个人 Bot 已转换为服务 Bot
  - 用户当前没有未删除的个人 Bot
  - 再次创建个人 Bot 时，仍应视为“首个个人 Bot”