### PR TITLE
fix(gateway): drop tenant from the user principal

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -442,6 +442,31 @@ wrong half of the system.
 - The gateway's tenant id **is** the `avernet_tenant` value — no mapping table.
   So a real external tenant reads an empty dataset until it has data; that is
   isolation working, not a bug.
+- **Only the machine principals carry a tenant.** _Changed 2026-08-05._ A
+  `user` principal has no `tenant` field: nothing in a user credential proves
+  which tenant a person acts for, and the gateway's google chain used to fill it
+  from a config default — which, left unset as it shipped, sent `null` and 401'd
+  every request. `app`, `bot` and `access_key` are each registered to a tenant,
+  and that registration is what their principal asserts.
+  - An identity set that asserts **no** tenant — a user and nothing else —
+    resolves to `DEFAULT_AVERNET_TENANT`. A first-party caller on our own
+    frontend *is* an internal caller, which is the scope `teamclaw` names, and
+    it is the same tenant every other path in this component resolves to.
+  - That fallback is **ours**, decided from the absence of a claim; it is not a
+    value the token supplied. So the `teamclaw` guard above keeps its teeth: a
+    token that *names* the internal tenant is still refused, and a `tenant`
+    smuggled onto a `user` entry is ignored (unknown fields are dropped, not
+    honoured) rather than becoming a scope.
+  - ⚠️ **Consequence for the public surface.** `route_security` declares
+    `user: required` and nothing else for every `/openapi/v1` path, so the
+    gateway resolves a user-only set and **every public request now scopes to
+    `teamclaw`** — the internal tenant. Nothing gates *which* Google account
+    that is (`AuthPlugin.is_allowed` exists in the gateway SPI but no authn
+    strategy calls it), so serving real data on this surface needs either that
+    whitelist wired up or a route requiring an identity that carries a
+    registered tenant. Until then the surface reads internal data for any
+    authenticated Google user, which is a widening of what the 401 used to
+    prevent by accident.
 
 **Two things you inherit if you own a Track B category:**
 
@@ -1172,3 +1197,42 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   owner-versus-collaborator semantics, offline reads, ready-Bot mutation gating,
   and compensation on runtime synchronization failure. Skill Center publication
   and reusable tenant-level Skills remain a later contract.
+- **2026-08-05** — **`tenant` removed from the `user` principal; a user-only
+  caller is an internal caller.** The public surface was answering `401` on every
+  request: the gateway declared `UserPrincipal.tenant` as `str | None` and filled
+  it from `authn.google.default_tenant`, a config key that appears nowhere in
+  `configs/application.yaml`, so it signed `tenant: null` — and this side
+  declared the field required, so the payload never parsed. The fix removes the
+  field on both halves rather than making it required, because the field was
+  asserting something no user credential proves.
+  1. **A tenant is a property of the calling program, not of a person.** `app`,
+     `bot` and `access_key` are each *registered* to a tenant, and their
+     principals assert that registration. A Google token proves a `sub` and an
+     email; the tenant that used to ride alongside it was a deployment default
+     dressed up as an authenticated fact.
+  2. **A set that asserts no tenant resolves to `DEFAULT_AVERNET_TENANT`.**
+     `VerifiedCaller.tenant` reads only the machine principals, so a user-only
+     caller — a first-party human on our own frontend — scopes to `teamclaw`,
+     the same tenant every non-public path in this component already resolves
+     to. `_reject_contradictory_tenant` likewise vets only what was claimed.
+  3. **The internal-tenant guard got sharper, not weaker.** The fallback is
+     decided *here*, from the absence of a claim; it is never a value the token
+     supplied. A token that names `teamclaw` is still refused, and a `tenant`
+     smuggled onto a `user` entry is dropped by the DTO rather than honoured —
+     both pinned by tests. Nobody can talk their way into the internal tenant.
+  4. ⚠️ **What this leaves open.** `route_security` declares `user: required`
+     and nothing else for the whole public surface, so *every* public request is
+     now a user-only set and scopes to `teamclaw`. Nothing gates which Google
+     account that is — `AuthPlugin.is_allowed` exists in the gateway SPI and no
+     authn strategy calls it. Before this surface serves real data, either wire
+     that whitelist up or have a route require an identity carrying a registered
+     tenant. Tests that meant to exercise external-tenant isolation now mint
+     `user` + `app` so they keep testing isolation instead of the internal
+     default.
+
+  Backend suite 10535 passed / 3 skipped; gateway suite green except the
+  pre-existing markdown-formatting and live-server failures. Gateway half:
+  `spi/authn/_models.py`, the `google` strategy (its `default_tenant` argument
+  and DI wiring are gone), and a dated amendment in
+  `src/gateway/docs/2026-07-21-auth-design.md` §4.6, whose original text made
+  `tenant` mandatory on every principal.

--- a/src/backend/src/agentclaw/community/core/gateway_principal/models.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/models.py
@@ -104,12 +104,31 @@ class GatewayAccessKey(BaseModel):
 
 
 class UserPrincipal(BaseModel):
-    """A first-party authenticated user."""
+    """A first-party authenticated user.
+
+    Alone among the four, this principal carries **no tenant** — the gateway
+    does not send one, because nothing in a user credential proves which tenant
+    a person acts for (gateway ``spi/authn/_models.py``). A tenant is asserted
+    by the *machine* identities: an app, a bot and an access key are each
+    registered to one.
+
+    So an identity set naming only a user asserts no tenant, and
+    ``VerifiedCaller.tenant`` resolves it to :data:`DEFAULT_AVERNET_TENANT` —
+    the internal tenant, which is the right scope for a first-party caller on
+    our own frontend. That fallback is **ours**, decided here from the absence
+    of a claim; it is not a value the token supplied. The distinction is what
+    keeps the guard in ``verifier.py`` meaningful: ``teamclaw`` is still refused
+    when a token *claims* it, and no caller can talk their way into the internal
+    tenant by asserting it.
+
+    ``subject.tenant_id`` still carries whatever the identity provider said
+    about the person. It is attribution, not an isolation key — nothing scopes
+    by it.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     type: Literal[PrincipalType.USER] = PrincipalType.USER
-    tenant: str
     subject: GatewayUser
 
 

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -10,8 +10,9 @@ about earning the right to believe it:
    not replayable here,
 3. ``iss`` must be the gateway and ``exp`` must not have passed,
 4. the ``principals`` payload must parse onto :mod:`.models`,
-5. every principal in the set must agree on one tenant, and that tenant must not
-   be the internal one,
+5. every principal that *asserts* a tenant must agree on one, and that tenant
+   must not be the internal one (a ``user`` principal asserts none — see
+   :func:`_asserted_tenants`),
 6. the set must name an end user — see :func:`_require_user_principal`.
 
 Any failure raises :class:`PrincipalVerificationError`. There is no partial
@@ -158,12 +159,25 @@ class VerifiedCaller:
 
     @property
     def tenant(self) -> str:
-        """The tenant every principal in the set agrees on.
+        """The tenant to scope this request by.
 
-        Verification rejects a set that disagrees, so reading the first is
-        reading all of them.
+        Every principal that asserts a tenant agrees on it — verification
+        rejects a set that disagrees — so reading any one of them reads all of
+        them.
+
+        A set that asserts **none** is the user-only case, and it resolves to
+        :data:`DEFAULT_AVERNET_TENANT`. That is not a guess standing in for a
+        missing claim: a caller who presents nothing but a first-party user
+        identity *is* an internal caller, which is exactly the scope
+        ``teamclaw`` names. Every other path through this component already
+        resolves to it (background work, the internal ``/api`` surface), so the
+        public surface agreeing is one rule rather than two.
+
+        Reached only through :func:`verify_principal_token`, which admits no set
+        without a user principal — so "asserts no tenant" always means "a user
+        and nothing else", never "an empty set".
         """
-        return self.principals[0].tenant
+        return next(iter(_asserted_tenants(self.principals)), DEFAULT_AVERNET_TENANT)
 
     @property
     def user_id(self) -> str:
@@ -318,9 +332,38 @@ def _parse_principals(raw: object) -> tuple[GatewayPrincipal, ...]:
         ) from exc
 
 
+def _asserted_tenants(principals: tuple[GatewayPrincipal, ...]) -> set[str]:
+    """The distinct tenants the identity set actually claims.
+
+    A ``user`` principal carries no tenant and so contributes nothing here: the
+    gateway authenticates a person, and nothing about a person proves which
+    tenant they act for (see :class:`~.models.UserPrincipal`). The other three
+    are each registered to a tenant, and that registration is what their
+    principal asserts.
+
+    Empty is therefore a real result, not a failure — it is the user-only
+    request, and :attr:`VerifiedCaller.tenant` answers it with the internal
+    default. Keeping "what was claimed" separate from "what we scope by" is the
+    point of this function: the guards below judge only claims, so a caller
+    cannot reach the internal tenant by naming it.
+    """
+    return {
+        principal.tenant
+        for principal in principals
+        if not isinstance(principal, UserPrincipal)
+    }
+
+
 def _reject_contradictory_tenant(principals: tuple[GatewayPrincipal, ...]) -> None:
-    """Require exactly one non-internal tenant across the whole identity set."""
-    tenants = {principal.tenant for principal in principals}
+    """Require at most one non-internal tenant across the whole identity set.
+
+    "At most" because a user-only set claims no tenant at all; there is then
+    nothing to contradict and nothing to vet, and
+    :attr:`VerifiedCaller.tenant` supplies the internal default locally.
+    """
+    tenants = _asserted_tenants(principals)
+    if not tenants:
+        return
     if len(tenants) > 1:
         # One request cannot belong to two tenants. Picking one would be
         # inventing an answer the gateway did not give us.

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
@@ -82,20 +82,40 @@ def signing_key():
     reset_principal_verifier_config_cache()
 
 
-def mint(*, tenant: str = TENANT, user_id: str = "u-1", **overrides) -> str:
+def mint(*, tenant: str | None = TENANT, user_id: str = "u-1", **overrides) -> str:
+    """A signed token for a caller, optionally belonging to a tenant.
+
+    ``tenant=None`` mints the **user-only** set: a first-party caller, which
+    asserts no tenant and so scopes to the internal default. Any other value
+    mints the user alongside an ``app`` principal registered to that tenant,
+    because a user principal cannot carry one — see ``gateway_principal/models``.
+    """
     now = int(time.time())
+    principals: list[dict] = [
+        {
+            "type": "user",
+            "subject": {"id": user_id, "username": "alice@example.com"},
+        }
+    ]
+    if tenant is not None:
+        principals.append(
+            {
+                "type": "app",
+                "tenant": tenant,
+                "app": {
+                    "app_id": 42,
+                    "app_name": "Partner App",
+                    "owners": "partner-org",
+                    "tenant": tenant,
+                },
+            }
+        )
     claims = {
         "iss": overrides.get("issuer", "gateway"),
         "aud": overrides.get("audience", "backend"),
         "iat": now,
         "exp": now + 60,
-        "principals": [
-            {
-                "type": "user",
-                "tenant": tenant,
-                "subject": {"id": user_id, "username": "alice@example.com"},
-            }
-        ],
+        "principals": principals,
     }
     return jwt.encode(claims, overrides.get("key", KEY), algorithm="HS256")
 
@@ -152,6 +172,25 @@ def test_verified_caller_scopes_owner_and_tenant(client):
 
     assert response.status_code == 200
     assert response.json()["data"] == {"owner_id": "u-1", "tenant": TENANT}
+
+
+def test_a_first_party_user_scopes_to_the_internal_tenant(client):
+    """A caller naming only a user asserts no tenant, so the internal one applies.
+
+    This is the shape the google chain produces, and the shape ``route_security``
+    asks for on the whole public surface today: ``user: required`` and nothing
+    else. Until an identity that carries a registered tenant is required
+    alongside it, every request through this seam lands here.
+    """
+    response = client.get(
+        "/openapi/v1/bots/_probe", headers={PRINCIPAL_HEADER: mint(tenant=None)}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "owner_id": "u-1",
+        "tenant": DEFAULT_AVERNET_TENANT,
+    }
 
 
 def test_each_caller_gets_their_own_tenant(client):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -266,6 +266,10 @@ def test_router_uses_verified_principal_and_real_tenant_guard(tmp_path):
     now = int(time.time())
 
     def token(tenant: str) -> str:
+        # The tenant rides on the ``app`` principal: a ``user`` principal carries
+        # none, because nothing in a user credential proves which tenant the
+        # person acts for. A user-only token would scope to the internal
+        # default and this pair of requests would stop testing isolation at all.
         return jwt.encode(
             {
                 "iss": "gateway",
@@ -275,9 +279,18 @@ def test_router_uses_verified_principal_and_real_tenant_guard(tmp_path):
                 "principals": [
                     {
                         "type": "user",
-                        "tenant": tenant,
                         "subject": {"id": "owner", "username": "owner@example.com"},
-                    }
+                    },
+                    {
+                        "type": "app",
+                        "tenant": tenant,
+                        "app": {
+                            "app_id": 1,
+                            "app_name": "Partner App",
+                            "owners": "partner-org",
+                            "tenant": tenant,
+                        },
+                    },
                 ],
             },
             key,

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -39,16 +39,21 @@ CONFIG = PrincipalVerifierConfig(signing_key=KEY, audience=AUDIENCE, issuer=ISSU
 # ── payload builders (mirroring the gateway's model_dump(mode="json")) ────────
 
 
-def user_principal(tenant: str = TENANT, user_id: str = "u-1") -> dict:
+def user_principal(user_id: str = "u-1", subject_tenant: str = TENANT) -> dict:
+    """A ``user`` principal as the gateway serializes it — with no tenant.
+
+    ``subject.tenant_id`` is the identity provider's claim about the person and
+    is carried for attribution only; nothing scopes by it. The principal itself
+    asserts no tenant, because nothing in a user credential proves one.
+    """
     return {
         "type": "user",
-        "tenant": tenant,
         "subject": {
             "id": user_id,
             "username": "alice@example.com",
             "display_name": "Alice",
             "full_name": None,
-            "tenant_id": tenant,
+            "tenant_id": subject_tenant,
         },
     }
 
@@ -122,10 +127,16 @@ def mint(
 # ── happy paths ──────────────────────────────────────────────────────────────
 
 
-def test_user_token_yields_tenant_and_owner():
+def test_user_only_token_yields_the_internal_tenant_and_the_owner():
+    """A caller presenting nothing but a first-party user identity is internal.
+
+    The user principal asserts no tenant, so there is nothing to scope by off
+    the wire and the internal default applies — the same tenant every non-public
+    path in this component resolves to.
+    """
     caller = verify_principal_token(mint([user_principal()]), CONFIG)
 
-    assert caller.tenant == TENANT
+    assert caller.tenant == DEFAULT_AVERNET_TENANT
     assert caller.user_id == "u-1"
     assert isinstance(caller.principals[0], UserPrincipal)
 
@@ -416,25 +427,66 @@ def test_renamed_contract_field_fails_closed():
 
 def test_contradictory_tenants_are_rejected():
     """One request cannot belong to two tenants; picking one would invent an answer."""
-    token = mint([user_principal(tenant="tenant-a"), app_principal(tenant="tenant-b")])
+    token = mint(
+        [
+            user_principal(),
+            app_principal(tenant="tenant-a"),
+            bot_principal(tenant="tenant-b"),
+        ]
+    )
 
     with pytest.raises(PrincipalVerificationError):
         verify_principal_token(token, CONFIG)
 
 
 def test_empty_tenant_is_rejected():
+    token = mint([user_principal(), app_principal(tenant="")])
+
     with pytest.raises(PrincipalVerificationError):
-        verify_principal_token(mint([user_principal(tenant="")]), CONFIG)
+        verify_principal_token(token, CONFIG)
 
 
 def test_internal_tenant_off_the_wire_is_rejected():
-    """``teamclaw`` owns every internal row and must not be reachable publicly."""
-    token = mint([user_principal(tenant=DEFAULT_AVERNET_TENANT)])
+    """``teamclaw`` owns every internal row and must not be *claimable* publicly.
+
+    The guard is about what a token asserts, not about what the request ends up
+    scoped to: a user-only caller resolves to ``teamclaw`` by our own decision
+    (see :func:`test_user_only_token_yields_the_internal_tenant_and_the_owner`),
+    while a token that names it is refused. Only the machine principals can
+    assert a tenant, so only they can trip this.
+    """
+    token = mint([user_principal(), app_principal(tenant=DEFAULT_AVERNET_TENANT)])
 
     with pytest.raises(PrincipalVerificationError) as exc:
         verify_principal_token(token, CONFIG)
 
     assert "internal tenant" in str(exc.value)
+
+
+def test_a_tenant_claimed_on_a_user_principal_is_ignored():
+    """An old-contract or forged token cannot scope itself by naming a tenant.
+
+    The DTO ignores unknown fields so the gateway can add one without breaking
+    us, which means a ``tenant`` on a ``user`` entry is dropped rather than
+    rejected. Dropping is the safe direction: the claim buys nothing, and the
+    caller lands on the internal default like any other user-only request.
+    """
+    payload = user_principal()
+    payload["tenant"] = "tenant-the-caller-would-like"
+
+    caller = verify_principal_token(mint([payload]), CONFIG)
+
+    assert caller.tenant == DEFAULT_AVERNET_TENANT
+
+
+def test_a_user_alongside_an_app_takes_the_apps_tenant():
+    """The machine identity is the one that carries a registered tenant."""
+    caller = verify_principal_token(
+        mint([user_principal(), app_principal(tenant="acme-partner")]), CONFIG
+    )
+
+    assert caller.tenant == "acme-partner"
+    assert caller.user_id == "u-1"
 
 
 # ── operator diagnostics ─────────────────────────────────────────────────────

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -67,6 +67,12 @@ def _package() -> bytes:
 
 
 def _principal() -> str:
+    """A caller in ``_TENANT`` — the tenant asserted by the ``app`` principal.
+
+    A ``user`` principal carries no tenant (nothing in a user credential proves
+    one), so a user-only token would scope to the internal default and this file
+    would seed one tenant while the request read another.
+    """
     now = int(time.time())
     return jwt.encode(
         {
@@ -77,9 +83,18 @@ def _principal() -> str:
             "principals": [
                 {
                     "type": "user",
-                    "tenant": _TENANT,
                     "subject": {"id": _OWNER, "username": "upload@example.test"},
-                }
+                },
+                {
+                    "type": "app",
+                    "tenant": _TENANT,
+                    "app": {
+                        "app_id": 1,
+                        "app_name": "Partner App",
+                        "owners": "partner-org",
+                        "tenant": _TENANT,
+                    },
+                },
             ],
         },
         _KEY,

--- a/src/gateway/docs/2026-07-21-auth-design.md
+++ b/src/gateway/docs/2026-07-21-auth-design.md
@@ -112,7 +112,7 @@ class PrincipalType(StrEnum):
 
 class UserPrincipal(BaseModel):
     type: Literal[PrincipalType.USER] = PrincipalType.USER
-    tenant: str                          # 必填；租户 **id**（稳定、非展示名），见 §4.6
+    tenant: str                          # 已于 2026-08-05 移除，见 §4.6 修订
     scopes: frozenset[str] = frozenset()
     subject: AuthenticatedUser           # 必填
 
@@ -132,6 +132,8 @@ Principal = Annotated[UserPrincipal | AppPrincipal, Field(discriminator="type")]
 **要点：**
 
 - `tenant` 在两个成员里都是**必填**——每个 Principal 一定归属某个租户（来源见 §4.6）。
+  **2026-08-05 修订：`UserPrincipal` 上的 `tenant` 已移除**，只有机器身份
+  （`app` / `bot` / `access_key`）断言租户；理由与后果见 §4.6 开头的修订说明。
 - pydantic 靠 `type` tag 干净地序列化/反序列化——正好用于网关签名内部头；下游按 `type` 做 `match` 投影。
 - `on_behalf_of_opaque` 是唯一保留的 `| None`，且其 `None` 是**契约上真的可缺省**（App 未代表任何具体用户），
   不是"取决于别的字段"的隐式互斥——符合仓库对 `T | None` 的要求。
@@ -169,6 +171,28 @@ class StrategyParams:
 ```
 
 ### 4.6 新增：`tenant` 字段与它的**来源**（本轮重点）
+
+> **修订 2026-08-05：`UserPrincipal` 不再带 `tenant`。** 本节原文要求"每个 Principal
+> 必填 `tenant`"，其中用户侧取 `subject.tenant_id or DEFAULT_TENANT`。实现走的是另一条
+> 路：`google` 策略直接填配置项 `authn.google.default_tenant`，而该项从未在
+> `configs/application.yaml` 里出现，于是网关签发的每个用户 Principal 都带 `tenant: null`，
+> 后端（要求 `str`）解析失败，公有面全量 401。
+>
+> 结论是把字段去掉，而不是把它补上：**租户是"调用程序"的属性，不是"人"的属性**。
+> `app` / `bot` / `access_key` 都在注册时归属某个租户，它们的 Principal 断言的就是这份注册记录；
+> 用户凭证证明不了任何租户归属，配置默认值只是把部署默认包装成"已认证事实"。
+> 因此下表的"我们的前端 / 人工"一行不再适用：**只带 `user` 的请求不断言租户**，由上游按
+> 自己的内部默认租户（后端为 `teamclaw`）来限定；真正属于某租户的用户请求，会同时带上
+> 断言该租户的机器身份（`user` + `app`），以那一个为准。
+>
+> 这条修订同时收紧了一处：由于用户 Principal 无法再断言租户，任何调用方都**无法通过声明
+> 内部租户名来进入内部数据**——后端对"令牌声明 `teamclaw`"的拒绝仍然生效，而 user-only
+> 的落库租户是上游本地决定的，不是令牌给的。
+>
+> ⚠️ **随之而来的问题（未在本轮解决）：** `route_security` 对 `/openapi/v1/**` 只声明
+> `user: required`，所以公有面每个请求都会落到 `teamclaw`；而 `AuthPlugin.is_allowed`
+> 这个白名单在 SPI 里有定义、却没有任何 authn 策略调用它。公有面要serve真实数据，必须先接上
+> 白名单，或让路由要求一个带注册租户的身份。
 
 `tenant` 在每个 `Principal` 上**必填**，值是**租户 id**（不是展示名），但**来源随调用方类型而定**——不是所有流量都从令牌来。
 关键约束：租户令牌是密钥，**不能下发给浏览器**，所以第一方前端不能用令牌。

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -67,9 +67,6 @@ class PluginContainer(containers.DeclarativeContainer):
         token_header=providers.Callable(
             _default, config.authn.google.token_header, "x-google-token"
         ),
-        default_tenant=providers.Callable(
-            _default, config.authn.google.default_tenant, None
-        ),
         userinfo_url=providers.Callable(
             _default,
             config.authn.google.userinfo_url,

--- a/src/gateway/src/gateway/community/plugins/authn/google_token/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/google_token/_strategy.py
@@ -48,12 +48,10 @@ class GoogleUserStrategy:
         self,
         *,
         token_header: str,
-        default_tenant: str | None = None,
         userinfo_url: str = GOOGLE_USERINFO_URL,
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._token_header = token_header
-        self._default_tenant = default_tenant
         self._userinfo_url = userinfo_url
         self._transport = transport
 
@@ -82,4 +80,10 @@ class GoogleUserStrategy:
             display_name=body.get("name"),
         )
         logger.debug("google token resolved: sub=%s", sub)
-        return UserPrincipal(tenant=self._default_tenant, subject=subject)
+        # No tenant: a Google token authenticates a person, and a person is not
+        # registered to a tenant the way an app or an access key is. The
+        # ``default_tenant`` this used to pass came from gateway config, so it
+        # asserted a deployment default as though the credential had proven it —
+        # and left unset (the shipped default) it asserted ``null``, which the
+        # backend rightly refused. See ``UserPrincipal`` for the full argument.
+        return UserPrincipal(subject=subject)

--- a/src/gateway/src/gateway/community/spi/authn/_models.py
+++ b/src/gateway/src/gateway/community/spi/authn/_models.py
@@ -65,16 +65,31 @@ class Bot(BaseModel):
 
 
 class UserPrincipal(BaseModel):
-    """A first-party authenticated user, produced by the gateway."""
+    """A first-party authenticated user, produced by the gateway.
+
+    Carries **no tenant**, and that is the design rather than an omission. A
+    tenant is a property of the calling *program*: an app, a bot and an access
+    key are each registered to one, and their principals assert the tenant that
+    registration recorded. No user credential says anything of the kind — the
+    google chain authenticates a person and learns their ``sub`` and email, never
+    which of our tenants they are acting for. The field this model used to carry
+    was filled from gateway configuration, which dressed a deployment default up
+    as an authenticated fact and made every unconfigured deploy send ``null``.
+
+    So a request naming only a user is a first-party call, and the upstream
+    scopes it to its own internal default — a decision the upstream makes
+    locally, never one the token asserts. A user request that genuinely belongs
+    to a tenant carries the machine identity that says so (``user`` alongside
+    ``app``), and *that* principal's tenant is the authoritative one.
+
+    ``subject.tenant_id`` is untouched by this: it is whatever the identity
+    provider said about the person, carried for attribution. It is not an
+    isolation key, and nothing downstream scopes by it.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     type: Literal[PrincipalType.USER] = PrincipalType.USER
-    tenant: str | None = Field(
-        default=None,
-        description="Tenant id the caller belongs to, if any; None when the "
-        "user has no tenant (the gateway does not fabricate a default).",
-    )
     subject: AuthenticatedUser = Field(description="The authenticated end user.")
 
 

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -92,7 +92,6 @@ class TestGoogleUserStrategy(AuthStrategyContract):
     def setup_method(self) -> None:
         self.strategy = GoogleUserStrategy(
             token_header="x-avernet-google-token",
-            default_tenant="t-default",
             transport=_userinfo_handler(_GOOGLE_BODY),
         )
         self.applicable_creds = CredentialBundle(

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -247,9 +247,7 @@ def _test_authenticator(db):
 
     return build_authenticator(
         strategies={
-            "google": GoogleUserStrategy(
-                token_header="x-avernet-google-token", default_tenant="default"
-            ),
+            "google": GoogleUserStrategy(token_header="x-avernet-google-token"),
             "bot_token": BotTokenStrategy(registry=BotRepository(db)),
             "app_token": AppTokenStrategy(registry=AppRepository(db)),
             "access_key_token": AccessKeyTokenStrategy(
@@ -283,7 +281,6 @@ def test_real_authenticator_admits_google_token_then_forwards() -> None:
         (
             GoogleUserStrategy(
                 token_header="x-avernet-google-token",
-                default_tenant="default",
                 transport=httpx.MockTransport(_userinfo_handler),
             ),
         ),

--- a/src/gateway/tests/integration/test_identity_pipeline.py
+++ b/src/gateway/tests/integration/test_identity_pipeline.py
@@ -74,9 +74,7 @@ def _db() -> DataSourcePlugin:
 
 def _strategy_pool(db: DataSourcePlugin):
     return {
-        "google": GoogleUserStrategy(
-            token_header="x-avernet-google-token", default_tenant="default"
-        ),
+        "google": GoogleUserStrategy(token_header="x-avernet-google-token"),
         "bot_token": BotTokenStrategy(registry=BotRepository(db)),
         "app_token": AppTokenStrategy(registry=AppRepository(db)),
         "access_key_token": AccessKeyTokenStrategy(registry=AccessKeyRepository(db)),
@@ -101,7 +99,6 @@ def _google_strategies() -> dict[PrincipalType, IdentityChain]:
         (
             GoogleUserStrategy(
                 token_header="x-avernet-google-token",
-                default_tenant="default",
                 transport=_userinfo_handler(_GOOGLE_BODY),
             ),
         ),

--- a/src/gateway/tests/integration/test_live_bcs_forwarding.py
+++ b/src/gateway/tests/integration/test_live_bcs_forwarding.py
@@ -52,7 +52,6 @@ class _ShippedRouteAuthenticator:
             return {}
         return {
             PrincipalType.USER: UserPrincipal(
-                tenant="gateway-live-test",
                 subject=AuthenticatedUser(
                     id=LIVE_USER_ID,
                     username=LIVE_USER_ID,

--- a/src/gateway/tests/test_auth_runner.py
+++ b/src/gateway/tests/test_auth_runner.py
@@ -21,7 +21,7 @@ _CREDS = CredentialBundle(headers={}, cookies={}, query={})
 
 
 def _user_p() -> UserPrincipal:
-    return UserPrincipal(tenant="t", subject=AuthenticatedUser(id="u", username="a"))
+    return UserPrincipal(subject=AuthenticatedUser(id="u", username="a"))
 
 
 def _app_p() -> AppPrincipal:

--- a/src/gateway/tests/test_authn_models.py
+++ b/src/gateway/tests/test_authn_models.py
@@ -30,36 +30,51 @@ def _subject() -> AuthenticatedUser:
 
 
 def test_user_principal_defaults() -> None:
-    p = UserPrincipal(tenant="t-1", subject=_subject())
+    p = UserPrincipal(subject=_subject())
     assert p.type is PrincipalType.USER
     assert p.type == "user"
-    assert p.tenant == "t-1"
     assert p.subject.id == "u1"
 
 
-def test_user_principal_tenant_defaults_to_none() -> None:
-    """Tenant is optional — a user with no tenant is None, not a fabricated default."""
-    p = UserPrincipal(subject=_subject())
-    assert p.tenant is None
+def test_user_principal_has_no_tenant_field() -> None:
+    """A person is not registered to a tenant; only machine callers assert one.
+
+    Asserted against the model's fields rather than an instance attribute so the
+    check fails if the field is reintroduced with a default — the shape sent over
+    the wire is the contract, and a defaulted field is still sent.
+    """
+    assert "tenant" not in UserPrincipal.model_fields
+    assert "tenant" not in UserPrincipal(subject=_subject()).model_dump()
+
+
+def test_user_principal_does_not_carry_a_tenant_it_is_handed() -> None:
+    """A caller still on the old contract cannot smuggle a tenant onto the wire.
+
+    The model ignores unknown fields (pydantic's default), so this does not
+    raise — it drops. What matters is that the dropped value never reaches
+    ``model_dump``, which is what the signer serializes into the token.
+    """
+    p = UserPrincipal(subject=_subject(), tenant="t-1")  # type: ignore[call-arg]
+    assert not hasattr(p, "tenant")
+    assert "tenant" not in p.model_dump()
 
 
 def test_user_principal_requires_subject() -> None:
     with pytest.raises(ValidationError):
-        UserPrincipal(tenant="t-1")  # type: ignore[call-arg]
+        UserPrincipal()  # type: ignore[call-arg]
 
 
 def test_user_principal_serialization_tags_type() -> None:
-    p = UserPrincipal(tenant="t-1", subject=_subject())
+    p = UserPrincipal(subject=_subject())
     dumped = p.model_dump()
     assert dumped["type"] == "user"
-    assert dumped["tenant"] == "t-1"
     assert dumped["subject"]["id"] == "u1"
 
 
 def test_user_principal_is_immutable() -> None:
-    p = UserPrincipal(tenant="t-1", subject=_subject())
+    p = UserPrincipal(subject=_subject())
     with pytest.raises(ValidationError):
-        p.tenant = "t-2"  # type: ignore[misc]
+        p.subject = _subject()  # type: ignore[misc]
 
 
 def test_principal_union_includes_all_members() -> None:

--- a/src/gateway/tests/unit/plugins/test_google_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_google_strategy.py
@@ -37,19 +37,22 @@ async def test_applicable_token_resolves_user_principal() -> None:
     transport = _userinfo_handler(_GOOGLE_BODY)
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=transport,
     )
     result = await strat.build(_creds("google-access-token"))
     assert isinstance(result, UserPrincipal)
-    assert result.tenant == "t-default"
     assert result.subject.id == "g-123"
     assert result.subject.username == "alice@example.com"
     assert result.subject.display_name == "Alice"
 
 
-async def test_no_default_tenant_leaves_tenant_none() -> None:
-    """With no default_tenant configured, a user principal carries tenant=None."""
+async def test_resolved_principal_asserts_no_tenant() -> None:
+    """Userinfo says who the person is, never which tenant they act for.
+
+    The strategy used to fill this from a ``default_tenant`` config value, which
+    made a deployment default look like something the credential proved — and
+    left unset, as it shipped, sent ``null`` and 401'd every request downstream.
+    """
     transport = _userinfo_handler(_GOOGLE_BODY)
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
@@ -57,13 +60,12 @@ async def test_no_default_tenant_leaves_tenant_none() -> None:
     )
     result = await strat.build(_creds("google-access-token"))
     assert isinstance(result, UserPrincipal)
-    assert result.tenant is None
+    assert "tenant" not in result.model_dump()
 
 
 async def test_absent_token_returns_none() -> None:
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=_userinfo_handler(_GOOGLE_BODY),
     )
     assert await strat.build(_creds(None)) is None
@@ -72,7 +74,6 @@ async def test_absent_token_returns_none() -> None:
 async def test_non_200_raises_auth_error() -> None:
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=_userinfo_handler({}, status=401),
     )
     with pytest.raises(AuthError):
@@ -87,7 +88,6 @@ async def test_malformed_json_raises_auth_error() -> None:
 
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=httpx.MockTransport(_handler),
     )
     with pytest.raises(AuthError):
@@ -97,7 +97,6 @@ async def test_malformed_json_raises_auth_error() -> None:
 async def test_missing_sub_raises_auth_error() -> None:
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=_userinfo_handler({"email": "no-sub@example.com"}),
     )
     with pytest.raises(AuthError):
@@ -113,7 +112,6 @@ async def test_request_to_userinfo_carries_bearer_authorization() -> None:
 
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=httpx.MockTransport(_handler),
     )
     await strat.build(_creds("google-access-token"))
@@ -123,7 +121,6 @@ async def test_request_to_userinfo_carries_bearer_authorization() -> None:
 async def test_email_falls_back_to_sub_when_missing() -> None:
     strat = GoogleUserStrategy(
         token_header="x-avernet-google-token",
-        default_tenant="t-default",
         transport=_userinfo_handler({"sub": "g-9"}),
     )
     result = await strat.build(_creds("tok"))

--- a/src/gateway/tests/unit/plugins/test_strategy_chains.py
+++ b/src/gateway/tests/unit/plugins/test_strategy_chains.py
@@ -20,9 +20,7 @@ from gateway.community.spi.authn import PrincipalType
 
 def _pool():
     return {
-        "google": GoogleUserStrategy(
-            token_header="x-google-token", default_tenant="default"
-        ),
+        "google": GoogleUserStrategy(token_header="x-google-token"),
         "bot_token": BotTokenStrategy(registry=None),
         "app_token": AppTokenStrategy(registry=None),
         "access_key_token": AccessKeyTokenStrategy(registry=None),


### PR DESCRIPTION
## Problem

The public API answers `401` on every request:

```
rejected forwarded principal on GET /openapi/v1/bots: principal payload does not
match the expected contract: 1 validation error for tagged-union[...]
user.tenant
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

The two halves disagree about one field:

- Gateway — `UserPrincipal.tenant: str | None = None` (`spi/authn/_models.py`), filled by the google strategy from `authn.google.default_tenant`.
- Backend — `UserPrincipal.tenant: str`, required (`core/gateway_principal/models.py`).

`authn.google.default_tenant` appears nowhere in `configs/application.yaml`, so the DI default of `None` wins and the gateway signs `tenant: null`. The backend refuses to parse it, and the request fails closed — correctly, but for a reason no config change was going to fix cleanly.

## Solution

Remove the field on both halves rather than making it required, because the field was asserting something no user credential proves.

**A tenant is a property of the calling program, not of a person.** `app`, `bot` and `access_key` are each *registered* to a tenant, and their principals assert that registration. A Google token proves a `sub` and an email; the tenant that used to ride alongside it was a deployment default dressed up as an authenticated fact.

- `VerifiedCaller.tenant` now reads only the principals that assert one. A set that asserts none — a user and nothing else — resolves to `DEFAULT_AVERNET_TENANT`. A first-party human on our own frontend *is* an internal caller, which is the scope `teamclaw` names and the one every non-public path in the backend already resolves to.
- `_reject_contradictory_tenant` likewise vets only what was claimed, via a new `_asserted_tenants` helper, and returns early when nothing was.
- The google strategy's `default_tenant` argument and its DI wiring are gone; nothing else read it.

**The internal-tenant guard gets sharper, not weaker.** The fallback is decided in the backend, from the *absence* of a claim; it is never a value the token supplied. A token that names `teamclaw` is still refused, and a `tenant` smuggled onto a `user` entry is dropped by the DTO rather than honoured — both pinned by tests.

Rejected alternatives: making the gateway field required and adding the config key would have kept a tenant on the principal that no credential backs, and moved the failure to boot time rather than removing it.

## Validation

Based on `REL20260806`.

- Backend full suite: **10535 passed, 3 skipped**.
- Gateway suite (`-m "not integration"`): **714 passed, 1 skipped**. The 12 failures are identical on an unmodified tree — pre-existing markdown formatting in `docs/`/`specs/`, plus e2e tests needing a live server and a script test needing network.
- `ruff check` and `ruff format` clean on the gateway (its lint gate); the backend declares no ruff config.
- `mypy`: no new errors on either side (gateway 71 before and after, all pre-existing and elsewhere; the backend's `gateway_principal` module is clean).
- Tests that meant to exercise external-tenant isolation now mint `user` + `app`, so they keep testing isolation rather than the internal default: `test_skills_endpoints.py`, `test_openapi_skill_upload.py`, `test_principal_seam.py`.

Not run: the gateway's integration tests (need live BCS/upstream) and the full pre-push CI gate — the environment could not install from the pinned aliyun index, so the suites above ran in a locally built venv from PyPI.

> Note for anyone comparing against an earlier CI run: the first push was cut from `dev` and its Backend job failed on four `test_openapi_skill_state.py` cases. That file arrived on `dev` in #467898e with the same now-stale `user`-principal-carries-a-tenant payload, and it does not exist on `REL20260806`. If it reaches this release branch it needs the same `user` + `app` treatment as the three files above.

## Compatibility and risk

⚠️ **`route_security` declares `user: required` and nothing else for the whole `/openapi/v1` surface**, so every public request is now a user-only set and scopes to `teamclaw` — the internal tenant. Nothing gates *which* Google account that is: `AuthPlugin.is_allowed` exists in the gateway SPI and no authn strategy calls it. Before this surface serves real data, either wire that whitelist up or have a route require an identity carrying a registered tenant. Called out in both docs rather than fixed here.

Wire contract change, so **both halves must ship together** — a gateway that still sends `tenant` on a `user` entry is fine (the field is ignored), but a backend still requiring it keeps 401-ing. Rollback is reverting the commit on both.

## Spec

- `src/gateway/docs/2026-07-21-auth-design.md` §4.6 — original text made `tenant` mandatory on every principal; amended in place with a dated revision note explaining the change and its consequence.
- `src/backend/docs/openapi-v1/README.md` — the auth-seam section and a dated changelog entry.