### PR TITLE
feat(baas): enable template override during bot update

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/management_router.py
@@ -76,6 +76,12 @@ class UpdateBotRequest(BaseModel):
 
     name: str | None = Field(default=None, max_length=128)
     description: str | None = Field(default=None, max_length=512)
+    template_uuid: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=64,
+        description="Optional device template UUID for the UPDATE publish",
+    )
     operator: str = Field(default="", max_length=64)
     request_id: str | None = Field(
         default=None,
@@ -404,6 +410,7 @@ async def update_bot(
         bot_desc=request.description,
         bot_config=request.config,
         request_id=request.request_id,
+        template_uuid=request.template_uuid,
     )
     return ApiResponse(data=bot)
 

--- a/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_manage/_protocols.py
@@ -163,6 +163,7 @@ class BotManageService(Protocol):
         bot_desc: str | None = None,
         bot_config: BotConfig | None = None,
         request_id: str | None = None,
+        template_uuid: str | None = None,
     ) -> UpdateBotResponse:
         """Update Bot metadata and config."""
         ...

--- a/src/baas/src/secbaas/community/api/publish_manage/_models.py
+++ b/src/baas/src/secbaas/community/api/publish_manage/_models.py
@@ -119,6 +119,9 @@ class PublishConfig(BaseModel):
     # Deploy config (passed through for device provisioning)
     deploy_config: DeployConfig | None = None
 
+    # UPDATE-specific: optional device template for the target Bot record
+    template_uuid: str | None = None
+
     # UPDATE-specific: ID of the new PENDING bot record created during create_publish
     target_bot_id: int | None = None
 

--- a/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
@@ -353,6 +353,7 @@ class OrmBotRepository(OrmConnectionMixin, BotRepository):
         status: str,
         extra_config: dict[str, Any] | None = None,
         name: str | None = None,
+        template_uuid: str | None = None,
         modifier: str = "system",
     ) -> int:
         log.info(
@@ -398,7 +399,9 @@ class OrmBotRepository(OrmConnectionMixin, BotRepository):
             status=status,
             name=name if name is not None else source.name,
             description=source.description,
-            template_uuid=source.template_uuid,
+            template_uuid=(
+                template_uuid if template_uuid is not None else source.template_uuid
+            ),
             replica_desired=source.replica_desired,
             replica_minimum=source.replica_minimum,
             replica_maximum=source.replica_maximum,

--- a/src/baas/src/secbaas/community/core/repository/bot/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/bot/_protocol.py
@@ -126,12 +126,13 @@ class BotRepository(Protocol):
         status: str,
         extra_config: dict[str, Any] | None = None,
         name: str | None = None,
+        template_uuid: str | None = None,
         modifier: str = "system",
     ) -> int:
         """Clone an existing bot record with a new status.
 
         Copies all fields from the source bot record, overriding status
-        and optionally extra_config/name. Returns the new record ID.
+        and optionally extra_config/name/template_uuid. Returns the new record ID.
         Used by UPDATE publish to create a PENDING bot record.
         """
         ...

--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
@@ -875,6 +875,7 @@ class DefaultBotManagementService(BotManageService):
         bot_desc: str | None = None,
         bot_config: BotConfig | None = None,
         request_id: str | None = None,
+        template_uuid: str | None = None,
     ) -> UpdateBotResponse:
         """Update Bot metadata and config.
 
@@ -890,6 +891,7 @@ class DefaultBotManagementService(BotManageService):
             bot_desc: New bot description
             bot_config: Bot configuration update (triggers UPDATE publish)
             request_id: Request ID for publish correlation (required if bot_config provided)
+            template_uuid: Optional template UUID for the target UPDATE record
 
         Returns:
             UpdateBotResponse with publish_id if UPDATE publish was created
@@ -911,7 +913,8 @@ class DefaultBotManagementService(BotManageService):
         bot_repo = self._bot_repo
         logger.info(
             f"[update_bot] bot_uuid={bot_uuid} bot_id={bot_id} bot_status={record.status} "
-            f"has_config={bot_config is not None} has_name={bot_name is not None}"
+            f"has_config={bot_config is not None} has_name={bot_name is not None} "
+            f"has_template={template_uuid is not None}"
         )
 
         # Check if bot is being destroyed - only allow name/description updates
@@ -919,6 +922,11 @@ class DefaultBotManagementService(BotManageService):
             if bot_config is not None:
                 raise ValueError(
                     "Cannot update bot config while bot is in DESTROYING status. "
+                    "Only name and description updates are allowed."
+                )
+            if template_uuid is not None:
+                raise ValueError(
+                    "Cannot update bot template while bot is in DESTROYING status. "
                     "Only name and description updates are allowed."
                 )
 
@@ -932,12 +940,18 @@ class DefaultBotManagementService(BotManageService):
         if len(update_kwargs) > 1:  # More than just modifier
             bot_repo.update_bot(bot_id=bot_id, tenant=tenant, env=env, **update_kwargs)
 
-        # Config change: create UPDATE publish
+        # Config or template change: create UPDATE publish
         publish_id: int | None = None
-        if bot_config is not None:
+        if bot_config is not None or template_uuid is not None:
             if not request_id:
+                if bot_config is not None:
+                    raise ValueError(
+                        "request_id is required when updating bot_config "
+                        "(triggers UPDATE publish)"
+                    )
                 raise ValueError(
-                    "request_id is required when updating bot_config (triggers UPDATE publish)"
+                    "request_id is required when updating template_uuid "
+                    "(triggers UPDATE publish)"
                 )
 
             # Merge config with existing
@@ -946,25 +960,26 @@ class DefaultBotManagementService(BotManageService):
                 if record and record.extra_config
                 else BotConfig()
             )
-            if bot_config.share_policy is not None:
-                stored_config.share_policy = bot_config.share_policy
-            if bot_config.deploy_config is not None:
-                stored_config.deploy_config = merge_deploy_config(
-                    stored_config.deploy_config,
-                    bot_config.deploy_config,
-                )
-            if bot_config.entity_id:
-                stored_config.entity_id = bot_config.entity_id
-            if bot_config.entity_type:
-                stored_config.entity_type = bot_config.entity_type
-            if bot_config.sla_grade:
-                stored_config.sla_grade = bot_config.sla_grade
-            if bot_config.auto_approve_publish is not None:
-                stored_config.auto_approve_publish = bot_config.auto_approve_publish
-            if bot_config.callback_timeout_seconds is not None:
-                stored_config.callback_timeout_seconds = (
-                    bot_config.callback_timeout_seconds
-                )
+            if bot_config is not None:
+                if bot_config.share_policy is not None:
+                    stored_config.share_policy = bot_config.share_policy
+                if bot_config.deploy_config is not None:
+                    stored_config.deploy_config = merge_deploy_config(
+                        stored_config.deploy_config,
+                        bot_config.deploy_config,
+                    )
+                if bot_config.entity_id:
+                    stored_config.entity_id = bot_config.entity_id
+                if bot_config.entity_type:
+                    stored_config.entity_type = bot_config.entity_type
+                if bot_config.sla_grade:
+                    stored_config.sla_grade = bot_config.sla_grade
+                if bot_config.auto_approve_publish is not None:
+                    stored_config.auto_approve_publish = bot_config.auto_approve_publish
+                if bot_config.callback_timeout_seconds is not None:
+                    stored_config.callback_timeout_seconds = (
+                        bot_config.callback_timeout_seconds
+                    )
 
             # Also update name on the current bot if provided
             update_kwargs_name: dict[str, Any] = {"modifier": operator}
@@ -992,6 +1007,7 @@ class DefaultBotManagementService(BotManageService):
                     stored_config.callback_timeout_seconds, self._system_config_repo
                 ),
                 auto_approve=stored_config.auto_approve_publish,
+                template_uuid=template_uuid,
             )
 
             publish = await self._publish_service.create_publish(

--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_service.py
@@ -117,6 +117,7 @@ class DefaultBotCrudService(BotCrudService):
         source_bot_id: int,
         new_config: BotConfig | None = None,
         new_name: str | None = None,
+        new_template_uuid: str | None = None,
         operator: str = "system",
     ) -> BotResponse:
         """Create a new bot record by cloning an existing one with PENDING status.
@@ -130,6 +131,7 @@ class DefaultBotCrudService(BotCrudService):
             source_bot_id: The existing bot record to clone
             new_config: Optional new BotConfig for the cloned record
             new_name: Optional new name for the cloned record
+            new_template_uuid: Optional template UUID for the cloned record
             operator: User performing the operation
 
         Returns:
@@ -156,6 +158,7 @@ class DefaultBotCrudService(BotCrudService):
             status=BotStatus.PENDING.value,
             extra_config=extra_config,
             name=new_name,
+            template_uuid=new_template_uuid,
             modifier=operator,
         )
 

--- a/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
+++ b/src/baas/src/secbaas/community/core/service/publish_manage/_publish_service.py
@@ -306,6 +306,19 @@ class DefaultPublishService(PublishService):
             )
             raise BotNotFoundError(str(bot_id))
 
+        if publish_type == PublishType.UPDATE and config and config.template_uuid:
+            # COSEC: Resolve the requested template within the current tenant before
+            # persisting publish state, preventing cross-tenant template reuse.
+            target_template = self._template_service.get_online_template_by_uuid(
+                tenant=tenant,
+                template_uuid=config.template_uuid,
+            )
+            if target_template is None:
+                raise ValueError(
+                    f"Template not found or not online: uuid={config.template_uuid}, "
+                    f"tenant={tenant}"
+                )
+
         # Step 2: Check for concurrent active publish (SVC-PUB-15)
         publish_repo = self._publish_repo
         active_publish = publish_repo.get_active_by_bot_id(
@@ -592,6 +605,7 @@ class DefaultPublishService(PublishService):
                 tenant=tenant,
                 source_bot_id=bot_id,
                 new_config=new_bot_config,
+                new_template_uuid=config.template_uuid if config else None,
                 operator=operator,
             )
             # Store target_bot_id via PublishConfig field for use at completion

--- a/src/baas/tests/unit/adapters/web/test_bot_management_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_management_router.py
@@ -702,6 +702,7 @@ async def test_update_bot_success(mock_service):
         bot_desc="Updated description",
         bot_config=None,
         request_id=None,
+        template_uuid=None,
     )
 
 
@@ -750,6 +751,61 @@ async def test_update_bot_with_config(mock_service):
     call_kwargs = mock_service.update_bot.call_args.kwargs
     assert call_kwargs["bot_config"] is not None
     assert call_kwargs["request_id"] == "a" * 32
+    assert call_kwargs["template_uuid"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_bot_with_template_uuid(mock_service):
+    """POST /{bot_uuid}/update forwards an optional template override."""
+    now = datetime.now(tz=UTC)
+    update_resp = UpdateBotResponse(
+        id=1,
+        bot_uuid="BOT-001",
+        tenant="test_tenant",
+        env="dev",
+        domain="default",
+        is_deleted=0,
+        creator="user1",
+        modifier="operator1",
+        status="ACTIVE",
+        name="cfg-bot",
+        description=None,
+        template_uuid="TEMPLATE-new",
+        replica_desired=1,
+        replica_minimum=1,
+        replica_maximum=10,
+        auto_scaling_enabled=0,
+        sla_grade="standard",
+        gmt_create=now,
+        gmt_modified=now,
+        config=None,
+        devices=[],
+        publish_id=302,
+    )
+    mock_service.update_bot.return_value = update_resp
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/bots/BOT-001/update?tenant=test_tenant",
+            json={
+                "operator": "operator1",
+                "request_id": "b" * 32,
+                "template_uuid": "TEMPLATE-new",
+            },
+        )
+
+    assert resp.status_code == 200
+    mock_service.update_bot.assert_awaited_once_with(
+        tenant="test_tenant",
+        bot_uuid="BOT-001",
+        operator="operator1",
+        bot_name=None,
+        bot_desc=None,
+        bot_config=None,
+        request_id="b" * 32,
+        template_uuid="TEMPLATE-new",
+    )
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/repository/bot/test_orm_bot_repository.py
+++ b/src/baas/tests/unit/core/repository/bot/test_orm_bot_repository.py
@@ -619,6 +619,30 @@ class TestInsertBotRecord:
         assert result is not None
         mock_session.add.assert_called_once()
         mock_session.flush.assert_called_once()
+        added_model = mock_session.add.call_args[0][0]
+        assert added_model.template_uuid == "tpl-001"
+
+    def test_clone_with_template_override(self, repo, mock_session):
+        source_model, _ = _make_mock_bot_model(
+            id_val=5,
+            bot_uuid="bot-src",
+            template_uuid="TEMPLATE-old",
+        )
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            source_model
+        )
+
+        result = repo.insert_bot_record(
+            source_bot_id=5,
+            tenant="t1",
+            env="dev",
+            status="FAILED",
+            template_uuid="TEMPLATE-new",
+        )
+
+        assert result is not None
+        added_model = mock_session.add.call_args[0][0]
+        assert added_model.template_uuid == "TEMPLATE-new"
 
     def test_clone_with_existing_pending_cleans_up(self, repo, mock_session):
         source_model, source_record = _make_mock_bot_model(

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -3297,6 +3297,100 @@ class TestUpdateBotConfigUpdate:
                 )
 
     @pytest.mark.asyncio
+    async def test_update_bot_template_only_triggers_publish(self):
+        """A template-only change creates UPDATE while preserving stored config."""
+        mock_record = MagicMock()
+        mock_record.id = 1
+        mock_record.bot_uuid = "BOT-001"
+        mock_record.status = "ACTIVE"
+        mock_record.name = "Test Bot"
+        mock_record.extra_config = {"entity_type": "staff"}
+        mock_publish = MagicMock()
+        mock_publish.id = 778
+        mock_updated_bot = MagicMock()
+        mock_updated_bot.model_dump.return_value = {
+            "id": 1,
+            "bot_uuid": "BOT-001",
+            "tenant": "test_tenant",
+            "env": "dev",
+            "domain": "default",
+            "is_deleted": 0,
+            "creator": "user1",
+            "modifier": "user1",
+            "status": "ACTIVE",
+            "name": "Test Bot",
+            "description": None,
+            "template_uuid": "TEMPLATE-old",
+            "replica_desired": 1,
+            "replica_minimum": 1,
+            "replica_maximum": 10,
+            "auto_scaling_enabled": 0,
+            "sla_grade": "standard",
+            "gmt_create": "2024-01-01T00:00:00",
+            "gmt_modified": "2024-01-01T00:00:00",
+            "config": None,
+        }
+        mock_device_repo = MagicMock()
+        mock_device_repo.list_by_bot_id.return_value = [MagicMock()]
+        mock_publish_service = MagicMock()
+        mock_publish_service.create_publish = AsyncMock(return_value=mock_publish)
+        mock_bot_service = MagicMock()
+        mock_bot_service.get_bot = AsyncMock(return_value=mock_updated_bot)
+        mock_system_config_repo = MagicMock()
+        mock_system_config_repo.get_by_env_and_key.return_value = None
+        service = _make_service(
+            device_repo=mock_device_repo,
+            publish_service=mock_publish_service,
+            bot_service=mock_bot_service,
+            system_config_repo=mock_system_config_repo,
+        )
+
+        with patch.object(
+            service,
+            "_get_operational_bot_record_by_uuid_for_update",
+            return_value=mock_record,
+        ):
+            result = await service.update_bot(
+                tenant="test_tenant",
+                bot_uuid="BOT-001",
+                operator="user1",
+                request_id="template-update-request",
+                template_uuid="TEMPLATE-new",
+            )
+
+        assert result.publish_id == 778
+        publish_config = mock_publish_service.create_publish.call_args.kwargs["config"]
+        assert publish_config.template_uuid == "TEMPLATE-new"
+        assert publish_config.deploy_config is None
+
+    @pytest.mark.asyncio
+    async def test_update_bot_template_without_request_id(self):
+        """A template change requires a correlated UPDATE request."""
+        mock_record = MagicMock(
+            id=1,
+            bot_uuid="BOT-001",
+            status="ACTIVE",
+            name="Test Bot",
+            extra_config={},
+        )
+        service = _make_service()
+
+        with patch.object(
+            service,
+            "_get_operational_bot_record_by_uuid_for_update",
+            return_value=mock_record,
+        ):
+            with pytest.raises(
+                ValueError, match="request_id is required when updating template_uuid"
+            ):
+                await service.update_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    template_uuid="TEMPLATE-new",
+                )
+
+    @pytest.mark.asyncio
     async def test_update_bot_destroying_name_only(self):
         """Test update_bot allows name update for DESTROYING bot"""
         mock_record = MagicMock()
@@ -3383,6 +3477,34 @@ class TestUpdateBotConfigUpdate:
                     operator="user1",
                     bot_config=bot_config,
                     request_id="test-request-id-12345678901234567890",
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_bot_destroying_rejects_template(self):
+        """A DESTROYING bot cannot start a template migration."""
+        mock_record = MagicMock(
+            id=1,
+            bot_uuid="BOT-001",
+            status="DESTROYING",
+            extra_config={},
+        )
+        service = _make_service()
+
+        with patch.object(
+            service,
+            "_get_operational_bot_record_by_uuid_for_update",
+            return_value=mock_record,
+        ):
+            with pytest.raises(
+                ValueError,
+                match="Cannot update bot template while bot is in DESTROYING",
+            ):
+                await service.update_bot(
+                    tenant="test_tenant",
+                    bot_uuid="BOT-001",
+                    operator="user1",
+                    request_id="template-update-request",
+                    template_uuid="TEMPLATE-new",
                 )
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_service.py
@@ -409,6 +409,7 @@ class TestCreateBotRecord:
             status="PENDING",
             extra_config=None,
             name=None,
+            template_uuid=None,
             modifier="operator",
         )
         mock_bot_repo.get_by_id.assert_called_once_with(99, "test-tenant", "test")
@@ -448,6 +449,7 @@ class TestCreateBotRecord:
             source_bot_id=1,
             new_config=new_config,
             new_name="new-name",
+            new_template_uuid="TEMPLATE-new",
             operator="op",
         )
 
@@ -455,6 +457,7 @@ class TestCreateBotRecord:
         call_kwargs = mock_bot_repo.insert_bot_record.call_args.kwargs
         assert call_kwargs["extra_config"] is not None
         assert call_kwargs["name"] == "new-name"
+        assert call_kwargs["template_uuid"] == "TEMPLATE-new"
 
     @pytest.mark.asyncio
     async def test_create_bot_record_new_record_not_found_raises(

--- a/src/baas/tests/unit/core/service/publish_manage/test_publish_service.py
+++ b/src/baas/tests/unit/core/service/publish_manage/test_publish_service.py
@@ -229,6 +229,14 @@ class TestPublishCreation:
 
         assert result.publish_type == "UPDATE"
         assert result.status == "PENDING"
+        _publish_service_instance._template_service.get_online_template_by_uuid.assert_not_called()
+        _publish_service_instance._bot_service.create_bot_record.assert_awaited_once_with(
+            tenant="test_tenant",
+            source_bot_id=1,
+            new_config=None,
+            new_template_uuid=None,
+            operator="user1",
+        )
 
     @pytest.mark.asyncio
     async def test_create_publish_restart_type(self):
@@ -8531,7 +8539,10 @@ class TestCreatePublishUpdateConfigOverwrite:
             "secbaas.community.core.service.publish_manage._publish_service.get_current_env",
             return_value=mock_env,
         ):
-            config = PublishConfig(batch_capacity=5)
+            config = PublishConfig(
+                batch_capacity=5,
+                template_uuid="TEMPLATE-new",
+            )
             result = await _publish_service_instance.create_publish(
                 tenant="test_tenant",
                 bot_id=1,
@@ -8544,11 +8555,41 @@ class TestCreatePublishUpdateConfigOverwrite:
             assert result.status == "PENDING"
             # config.replica_desired should be set from bot
             assert config.replica_desired == 3
+            _publish_service_instance._template_service.get_online_template_by_uuid.assert_called_once_with(
+                tenant="test_tenant",
+                template_uuid="TEMPLATE-new",
+            )
+            create_call = _publish_service_instance._bot_service.create_bot_record.call_args.kwargs
+            assert create_call["new_template_uuid"] == "TEMPLATE-new"
 
             insert_call_args = (
                 _publish_service_instance._publish_repo.insert_publish.call_args
             )
             assert insert_call_args.kwargs["replica_desired"] == 3
+
+    @pytest.mark.asyncio
+    async def test_create_publish_update_rejects_unknown_template_before_insert(self):
+        """An invalid tenant-scoped template must not leave publish state behind."""
+        mock_bot = MagicMock(id=1, replica_desired=1)
+        _publish_service_instance._bot_service.get_bot = AsyncMock(
+            return_value=mock_bot
+        )
+        _publish_service_instance._template_service.get_online_template_by_uuid.return_value = None
+
+        with pytest.raises(ValueError, match="Template not found or not online"):
+            await _publish_service_instance.create_publish(
+                tenant="test_tenant",
+                bot_id=1,
+                publish_type=PublishType.UPDATE,
+                operator="user1",
+                request_id="template-update-request",
+                config=PublishConfig(
+                    replica_desired=1,
+                    template_uuid="TEMPLATE-missing",
+                ),
+            )
+
+        _publish_service_instance._publish_repo.insert_publish.assert_not_called()
 
 
 class TestCreatePublishRestartUnhealthy:


### PR DESCRIPTION
## Summary

- accept an optional `template_uuid` on the BaaS bot update API
- validate the target template as ONLINE within the current tenant before creating publish state
- carry the override into the UPDATE publish and persist it on the new PENDING bot record
- preserve the existing template and update behavior when `template_uuid` is omitted

## Root cause

The backend restart flow correctly resolved and sent the whitelist template UUID, but BaaS `UpdateBotRequest` did not define `template_uuid`. Pydantic therefore discarded the field, and the UPDATE workflow cloned the source bot record with its old template UUID.

## Compatibility

The new field is optional. Requests that do not provide `template_uuid` continue cloning the source bot template exactly as before. No database schema or frontend changes are required.

## Validation

- `uv run pytest -q tests/unit`: 7780 passed, 3 skipped, 8 xpassed
- changed-line coverage: 100% (26/26)
- Ruff checks passed
- `git diff --check` passed