### PR TITLE
fix(bcs): keep system notices in human session history via PersistMode

### DIFF
--- a/src/bcs/crates/contracts/bcs-domain/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/lib.rs
@@ -93,7 +93,7 @@ pub use session::{
     CallbackChannelConfig, CallbackConfig, Session, SessionKind, SessionStatus, ServiceSpec,
 };
 pub use system_message::{
-    SystemGroupMessage, SystemMessageEvent, SystemMessageEventKind
+    PersistMode, SystemGroupMessage, SystemMessageEvent, SystemMessageEventKind
 };
 pub use task_ledger::LedgerSummary;
 pub use invite::{InviteTargetType, InviteTokenPayload, InviteTokenError, encode as invite_token_encode, decode_and_verify as invite_token_decode_and_verify, decode_and_verify_no_expiry as invite_token_decode_no_expiry};

--- a/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
@@ -79,8 +79,30 @@ impl SystemMessageEvent {
     }
 }
 
+/// Persistence policy for a system group message.
+///
+/// Producers decide how each bot-facing message is recorded in the message
+/// store; the dispatcher executes the policy mechanically (it never inspects
+/// message content to decide ownership).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistMode {
+    /// Persist one record per recipient with `owner_bot_id = recipient`
+    /// (personalized per-bot context such as `[GROUP CONTEXT]`, only
+    /// readable by that bot's history view).
+    PerRecipient,
+    /// Persist exactly one record with `owner_bot_id = None` so the notice
+    /// joins the public history that human viewers read (their history
+    /// filter is `owner_bot_id IS NULL`). Bot viewers see it via
+    /// `PublicOrOwner`; use this for notices whose text is identical for
+    /// all recipients to avoid storing N identical copies.
+    Public,
+    /// Do not persist this message.
+    Skip,
+}
+
 pub struct SystemGroupMessage {
     pub recipients: Vec<String>,
     pub message: String,
     pub delivery_type: DeliveryType,
+    pub persist: PersistMode,
 }

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -1224,12 +1224,15 @@ mod tests {
     }
 
     /// End-to-end round-trip: `SystemMessageDispatcherImpl` persists system
-    /// messages with `owner_bot_id = Some(recipient)` into a REAL
-    /// `MemoryMessageRepo`, and `MessageService::get_session_history` with
-    /// `view_bot_id=recipient` returns that recipient's own copy, hides the
-    /// other recipients' copies, and still returns public (owner=None) records.
-    /// This locks the §数据流 bridge between the write side (per-recipient
-    /// ownership persistence) and the query side (`PublicOrOwner` scoping).
+    /// messages by `PersistMode` into a REAL `MemoryMessageRepo` — personalized
+    /// copies with `owner_bot_id = Some(recipient)` and shared notices as a
+    /// single public (`owner = None`) record — and
+    /// `MessageService::get_session_history` with `view_bot_id=recipient`
+    /// returns that recipient's own copy plus public records, hides other
+    /// recipients' copies, and lets human viewers (no bot view) read the
+    /// public notices. This locks the §数据流 bridge between the write side
+    /// (PersistMode-driven ownership) and the query side (`PublicOrOwner`
+    /// scoping).
     #[tokio::test]
     async fn system_message_dispatch_round_trips_through_message_service_view_scoping() {
         use bcs_system_message::SystemMessageDispatcherImpl;
@@ -1281,9 +1284,9 @@ mod tests {
             .await
             .expect("dispatch succeeded");
 
-        // Viewer = existing mgr: sees its own notification (owner=mgr) + the
-        // public anchor; must NOT see new-bot's context injection (owner=new-bot)
-        // nor the other workers' notification copies.
+        // Viewer = existing mgr: sees the public join notice (owner=None) +
+        // the public anchor; must NOT see new-bot's context injection
+        // (owner=new-bot).
         let res_existing = service
             .get_session_history(session_cmd(group_id, &session_id, Some(&existing_id)))
             .await
@@ -1293,12 +1296,17 @@ mod tests {
         assert!(existing_contents.contains(&"public-anchor"),
             "public owner=None records still visible to mgr");
         assert!(existing_contents.iter().any(|c| c.contains("已加入协作群")),
-            "mgr's own notification (owner=mgr) is returned");
+            "public join notice (owner=None) is returned to mgr");
+        assert_eq!(
+            existing_contents.iter().filter(|c| c.contains("已加入协作群")).count(),
+            1,
+            "the shared notice is a single public record, not per-bot copies"
+        );
         assert!(existing_contents.iter().all(|c| !c.contains("你加入了 BCS 协作群.")),
             "new-bot's context injection (owner=new-bot) is hidden from mgr");
 
-        // Viewer = new-bot: sees its own context injection (owner=new-bot) + the
-        // public anchor; must NOT see the notification copies (owner=existing).
+        // Viewer = new-bot: sees its own context injection (owner=new-bot) +
+        // the public anchor + the public join notice.
         let res_new = service
             .get_session_history(session_cmd(group_id, &session_id, Some(&new_bot_id)))
             .await
@@ -1309,8 +1317,24 @@ mod tests {
             "public owner=None records still visible to new-bot");
         assert!(new_contents.iter().any(|c| c.contains("你加入了 BCS 协作群.")),
             "new-bot's own context injection (owner=new-bot) is returned");
-        assert!(new_contents.iter().all(|c| !c.contains("已加入协作群")),
-            "existing participants' notification copies are hidden from new-bot");
+        assert!(new_contents.iter().any(|c| c.contains("已加入协作群")),
+            "public join notice (owner=None) is returned to new-bot");
+
+        // Viewer = human (no bot view): sees the public anchor + the public
+        // join notice; must NOT see any per-bot owned copy. This is the
+        // regression guard for system messages vanishing from human history.
+        let res_human = service
+            .get_session_history(session_cmd(group_id, &session_id, None))
+            .await
+            .expect("human view session history");
+        let human_contents: Vec<&str> =
+            res_human.messages.iter().map(|m| m.content.as_str()).collect();
+        assert!(human_contents.contains(&"public-anchor"),
+            "public owner=None records visible to human viewers");
+        assert!(human_contents.iter().any(|c| c.contains("已加入协作群")),
+            "public join notice is visible to human viewers");
+        assert!(human_contents.iter().all(|c| !c.contains("你加入了 BCS 协作群.")),
+            "per-bot owned copies stay hidden from human viewers");
     }
 
     fn group_fixture(group_id: &str, driver_bot_id: &str) -> Group {

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bcs_domain::{DeliveryType, Group, GroupStrategy, NewMessage, Participant, SenderType, SystemMessageEvent, SystemMessageEventKind};
+use bcs_domain::{DeliveryType, Group, GroupStrategy, NewMessage, Participant, PersistMode, SenderType, SystemGroupMessage, SystemMessageEvent, SystemMessageEventKind};
 use bcs_protocol::{
     build_chat_inject_frame, build_chat_send_frame, now_ms, BotDeliveryKind, GroupContextInput,
     GroupContextParticipant,
@@ -182,26 +182,41 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
 
         let (bot_messages, user_message) = producer.produce(&event, group, self.registry.as_ref(), participants).await;
 
-        // Persist system messages per recipient: one record per recipient with
-        // owner_bot_id = recipient, content = the original message. Empty
-        // recipients → no record (e.g. last bot leaving). user_message is NOT
-        // persisted (frontend-only).
+        // Persist system messages according to each message's PersistMode:
+        // - PerRecipient: one record per recipient with owner_bot_id = recipient
+        //   (personalized per-bot context, readable only in that bot's view).
+        // - Public: exactly one record with owner_bot_id = None so the notice
+        //   joins the public history that human viewers read (their history
+        //   filter is owner_bot_id IS NULL); persisted even when recipients is
+        //   empty (e.g. last bot leaving) since the event is still broadcast
+        //   to human viewers via user_message.
+        // - Skip: no record.
+        // user_message is NOT persisted (frontend-only).
         if let Some(ref repo) = self.message_repo {
             let mut persisted_count = 0usize;
+            let new_record = |msg: &SystemGroupMessage, owner_bot_id: Option<String>| NewMessage {
+                group_id: group.id.clone(),
+                session_id: session_id.to_string(),
+                sender_id: "system".to_string(),
+                sender_type: SenderType::System,
+                message_type: "system".to_string(),
+                content: serde_json::Value::String(msg.message.clone()),
+                client_msg_id: None,
+                owner_bot_id,
+                created_at: now_ms(),
+                run_id: String::new(),
+            };
             for msg in &bot_messages {
-                for recipient in &msg.recipients {
-                    let new_msg = NewMessage {
-                        group_id: group.id.clone(),
-                        session_id: session_id.to_string(),
-                        sender_id: "system".to_string(),
-                        sender_type: SenderType::System,
-                        message_type: "system".to_string(),
-                        content: serde_json::Value::String(msg.message.clone()),
-                        client_msg_id: None,
-                        owner_bot_id: Some(recipient.clone()),
-                        created_at: now_ms(),
-                        run_id: String::new(),
-                    };
+                let records: Vec<NewMessage> = match msg.persist {
+                    PersistMode::Skip => vec![],
+                    PersistMode::Public => vec![new_record(msg, None)],
+                    PersistMode::PerRecipient => msg
+                        .recipients
+                        .iter()
+                        .map(|recipient| new_record(msg, Some(recipient.clone())))
+                        .collect(),
+                };
+                for new_msg in records {
                     if let Err(e) = repo.append_message(new_msg).await {
                         tracing::warn!(
                             group_id = %group.id, error = %e,

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use bcs_domain::{
     ActorKind, DeliveryType, Group, GroupKind, GroupStatus, GroupStrategy, Participant,
-    ParticipantMode, ParticipantRole, RedactedToken, SystemGroupMessage, SystemMessageEvent,
-    SystemMessageEventKind,
+    ParticipantMode, ParticipantRole, PersistMode, RedactedToken, SystemGroupMessage,
+    SystemMessageEvent, SystemMessageEventKind,
 };
 use bcs_service_api::{
     ActorStatus, AgentCredentials, BotCapabilities, BotDeliveryCommand, BotDeliveryPort,
@@ -344,7 +344,10 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
     dispatcher.dispatch(event, &group, "session-test", &group.participants)
         .await.expect("dispatch");
 
-    // Persistence: one record per recipient.
+    // Persistence: the new-bot injection is per-recipient (owner=new-bot);
+    // the shared join notice is a single public record (owner=None) that
+    // human viewers and every bot's PublicOrOwner view read — no per-bot
+    // copies of the identical text.
     let appended = message_repo.appended().await;
     assert_eq!(appended.len(), 2);
     let injection = appended.iter().find(|m| m.owner_bot_id.as_deref() == Some(&new_bot_id))
@@ -353,10 +356,12 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
     assert_eq!(injection.message_type, "system");
     assert!(content_text(injection).contains("你加入了 BCS 协作群."),
         "new-bot context injection persisted under owner=new-bot");
-    let notice = appended.iter().find(|m| m.owner_bot_id.as_deref() == Some(&existing_bot_id))
-        .expect("existing-bot notification record");
+    let notice = appended.iter().find(|m| m.owner_bot_id.is_none())
+        .expect("public join notification record");
     assert!(content_text(notice).contains("已加入协作群"));
     assert!(!content_text(notice).contains("你加入了 BCS 协作群."));
+    assert!(!appended.iter().any(|m| m.owner_bot_id.as_deref() == Some(&existing_bot_id)),
+        "shared notice must not persist per-bot copies");
 
     // WS: exactly one publish, content = user_message (join notification),
     // NOT the new-bot context injection.
@@ -369,7 +374,7 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
 }
 
 #[tokio::test]
-async fn dispatch_bot_left_with_no_recipients_persists_zero_but_pushes_ws() {
+async fn dispatch_bot_left_with_no_recipients_persists_public_record_and_pushes_ws() {
     let leaving = "bot-only".to_string();
     let group = Group {
         id: "group-left".into(), label: None, status: GroupStatus::Active,
@@ -410,7 +415,10 @@ async fn dispatch_bot_left_with_no_recipients_persists_zero_but_pushes_ws() {
     dispatcher.dispatch(event, &group, "session-left", &group.participants)
         .await.expect("dispatch");
 
-    assert_eq!(message_repo.appended().await.len(), 0, "no recipients → 0 persisted records");
+    let appended = message_repo.appended().await;
+    assert_eq!(appended.len(), 1,
+        "no recipients → still a single public record for human history");
+    assert!(appended[0].owner_bot_id.is_none(), "public record has no owner");
     let published = frontend_delivery.published.lock().unwrap();
     assert_eq!(published.len(), 1);
     assert!(published[0].event_json.contains("已退出协作群"));
@@ -1277,6 +1285,7 @@ impl SystemMessageProducerService for WorkerOnlySessionContextProducer {
                 recipients: vec!["bot-worker".to_string()],
                 message: "worker-only context".to_string(),
                 delivery_type: DeliveryType::Inject,
+                persist: PersistMode::PerRecipient,
             }],
             None,
         )
@@ -1303,6 +1312,7 @@ impl SystemMessageProducerService for FixedProducer {
                 recipients: vec!["bot-provider".to_string()],
                 message: "member changed".to_string(),
                 delivery_type: DeliveryType::Inject,
+                persist: PersistMode::PerRecipient,
             }],
             None,
         )
@@ -1329,6 +1339,7 @@ impl SystemMessageProducerService for FixedSendProducer {
                 recipients: vec!["bot-provider".to_string()],
                 message: "member changed".to_string(),
                 delivery_type: DeliveryType::Send,
+                persist: PersistMode::PerRecipient,
             }],
             None,
         )
@@ -1355,6 +1366,7 @@ impl SystemMessageProducerService for FixedWebSocketSendProducer {
                 recipients: vec!["bot-ws".to_string()],
                 message: "member changed".to_string(),
                 delivery_type: DeliveryType::Send,
+                persist: PersistMode::PerRecipient,
             }],
             None,
         )

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_hidden_notice.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_hidden_notice.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, Participant, SystemMessageEvent, SystemMessageEventKind,
+    DeliveryType, Group, Participant, PersistMode, SystemMessageEvent, SystemMessageEventKind,
     SystemGroupMessage,
 };
 use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService};
@@ -33,10 +33,14 @@ impl SystemMessageProducerService for BotHiddenNoticeProducer {
 
         let message = format!("{} 已设置为「不可协作」", hidden_bot_name);
         let user_message = Some(message.clone());
+        // The notice text is identical for every recipient, so persist a
+        // single public record (owner = None) with the mentioner's message;
+        // the others' copy is delivered but not persisted again.
         let mut messages = vec![SystemGroupMessage {
             recipients: vec![mentioner_bot_id.clone()],
             message: message.clone(),
             delivery_type: DeliveryType::Send,
+            persist: PersistMode::Public,
         }];
 
         let others: Vec<String> = participants
@@ -50,6 +54,7 @@ impl SystemMessageProducerService for BotHiddenNoticeProducer {
                 recipients: others,
                 message,
                 delivery_type: DeliveryType::Inject,
+                persist: PersistMode::Skip,
             });
         }
 
@@ -124,14 +129,16 @@ mod tests {
             .await;
 
         assert_eq!(messages.len(), 2);
-        // First message: Send to mentioner
+        // First message: Send to mentioner; carries the single public record.
         assert_eq!(messages[0].recipients, vec!["bot-driver"]);
         assert!(messages[0].message.contains("HiddenBot"));
         assert!(messages[0].message.contains("不可协作"));
         assert_eq!(messages[0].delivery_type, DeliveryType::Send);
-        // Second message: Inject to other bots
+        assert_eq!(messages[0].persist, PersistMode::Public);
+        // Second message: Inject to other bots; identical text, not persisted.
         assert_eq!(messages[1].recipients, vec!["bot-hidden"]);
         assert_eq!(messages[1].delivery_type, DeliveryType::Inject);
+        assert_eq!(messages[1].persist, PersistMode::Skip);
         assert_eq!(user_message.as_deref(), Some("HiddenBot 已设置为「不可协作」"));
     }
 

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, GroupMessage, Participant, Skill, SystemMessageEvent,
+    DeliveryType, Group, GroupMessage, Participant, PersistMode, Skill, SystemMessageEvent,
     SystemMessageEventKind, SystemGroupMessage,
 };
 use bcs_service_api::{
@@ -51,16 +51,20 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         let new_bot_uuid = actor.bot_uuid.clone();
         let mut messages = Vec::new();
 
-        // 1. Full context injection to the newly joined bot.
+        // 1. Full context injection to the newly joined bot (personalized,
+        // persisted with owner = the new bot only).
         let new_bot_content =
             build_context_injection_message(group, participants, &new_bot_uuid, registry, &*self.history).await;
         messages.push(SystemGroupMessage {
             recipients: vec![new_bot_uuid.clone()],
             message: new_bot_content,
             delivery_type: DeliveryType::Inject,
+            persist: PersistMode::PerRecipient,
         });
 
-        // 2. Notification to other bots.
+        // 2. Notification to other bots — identical text for every recipient,
+        // so persist a single public record (owner = None) that human viewers
+        // also read in history.
         let registered = registry.get(&new_bot_uuid).await;
         let summary = format_notification(&new_bot_uuid, registered.as_ref());
         let user_message = Some(summary.clone());
@@ -69,13 +73,12 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
             .filter(|p| p.bot_uuid != new_bot_uuid)
             .map(|p| p.bot_uuid.clone())
             .collect();
-        if !others.is_empty() {
-            messages.push(SystemGroupMessage {
-                recipients: others,
-                message: summary,
-                delivery_type: DeliveryType::Inject,
-            });
-        }
+        messages.push(SystemGroupMessage {
+            recipients: others,
+            message: summary,
+            delivery_type: DeliveryType::Inject,
+            persist: PersistMode::Public,
+        });
         (messages, user_message)
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
@@ -228,6 +228,11 @@ async fn bot_joined_produces_context_injection_and_notification() {
     assert!(notification.recipients.contains(&"consultant-id".to_string()));
     assert!(!notification.recipients.contains(&"new-bot-id".to_string()));
 
+    // Persistence policy: the personalized injection is owned by the new bot;
+    // the identical-for-all notification is one public record (owner = None).
+    assert_eq!(injection.persist, bcs_domain::PersistMode::PerRecipient);
+    assert_eq!(notification.persist, bcs_domain::PersistMode::Public);
+
     // user_message is the OTHER-bots notification text (NOT the new-bot injection).
     assert_eq!(
         user_message.as_deref(),

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_left.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_left.rs
@@ -5,7 +5,8 @@
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, Participant, SystemMessageEvent, SystemMessageEventKind, SystemGroupMessage,
+    DeliveryType, Group, Participant, PersistMode, SystemMessageEvent, SystemMessageEventKind,
+    SystemGroupMessage,
 };
 use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService};
 
@@ -44,16 +45,16 @@ impl SystemMessageProducerService for BotLeftMessageProducer {
             .filter(|p| p.is_bot())
             .map(|p| p.bot_uuid.clone())
             .collect();
-        let bot_messages = if recipients.is_empty() {
-            vec![]
-        } else {
-            vec![SystemGroupMessage {
-                recipients,
-                message: user_text,
-                delivery_type: DeliveryType::Inject,
-            }]
-        };
-        // empty recipients does NOT block user_message (last bot leaving)
+        // Identical text for every recipient: persist a single public record
+        // (owner = None) that human viewers also read in history. Empty
+        // recipients still persists the public record and does NOT block
+        // user_message (last bot leaving).
+        let bot_messages = vec![SystemGroupMessage {
+            recipients,
+            message: user_text,
+            delivery_type: DeliveryType::Inject,
+            persist: PersistMode::Public,
+        }];
         (bot_messages, user_message)
     }
 }
@@ -192,7 +193,12 @@ mod tests {
             .produce(&event, &group, &registry, &group.participants)
             .await;
 
-        assert!(messages.is_empty(), "no other recipients → empty bot_messages");
+        // No bot recipients remain, but the message is still emitted so the
+        // dispatcher persists a single public record (owner = None) for
+        // human history.
+        assert_eq!(messages.len(), 1, "last bot leaving still emits the notice message");
+        assert!(messages[0].recipients.is_empty());
+        assert_eq!(messages[0].persist, PersistMode::Public);
         assert_eq!(
             user_message.as_deref(),
             Some("bot-1(bot-1) 已退出协作群"),

--- a/src/bcs/crates/services/bcs-system-message/src/producers/generic.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/generic.rs
@@ -4,7 +4,8 @@
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, Participant, SystemMessageEvent, SystemMessageEventKind, SystemGroupMessage,
+    DeliveryType, Group, Participant, PersistMode, SystemMessageEvent, SystemMessageEventKind,
+    SystemGroupMessage,
 };
 use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService};
 
@@ -44,13 +45,22 @@ impl SystemMessageProducerService for GenericNotificationMessageProducer {
         } else {
             receivers.iter().map(|p| p.bot_uuid.clone()).collect()
         };
-        let bot_messages = if recipients.is_empty() {
+        // Identical text for every recipient: persist a single public record
+        // (owner = None) that human viewers also read in history. Empty
+        // messages persist nothing.
+        let persist = if message.trim().is_empty() {
+            PersistMode::Skip
+        } else {
+            PersistMode::Public
+        };
+        let bot_messages = if recipients.is_empty() && persist == PersistMode::Skip {
             vec![]
         } else {
             vec![SystemGroupMessage {
                 recipients,
                 message: message.clone(),
                 delivery_type: DeliveryType::Inject,
+                persist,
             }]
         };
         (bot_messages, user_message)
@@ -108,7 +118,11 @@ mod tests {
         let (messages, user_message) = GenericNotificationMessageProducer
             .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
             .await;
-        assert!(messages.is_empty());
+        // No bot recipients, but the notice is still a public history record
+        // for human viewers (persisted with owner = None by the dispatcher).
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].recipients.is_empty());
+        assert_eq!(messages[0].persist, PersistMode::Public);
         assert_eq!(user_message.as_deref(), Some("维护开始"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/human_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/human_joined.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, Participant, SystemMessageEvent, SystemMessageEventKind,
+    DeliveryType, Group, Participant, PersistMode, SystemMessageEvent, SystemMessageEventKind,
     SystemGroupMessage,
 };
 use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService};
@@ -50,15 +50,14 @@ impl SystemMessageProducerService for HumanJoinedMessageProducer {
             .map(|p| p.bot_uuid.clone())
             .collect();
 
-        let bot_messages = if recipients.is_empty() {
-            vec![]
-        } else {
-            vec![SystemGroupMessage {
-                recipients,
-                message,
-                delivery_type: DeliveryType::Inject,
-            }]
-        };
+        // Identical text for every recipient: persist a single public record
+        // (owner = None) that human viewers also read in history.
+        let bot_messages = vec![SystemGroupMessage {
+            recipients,
+            message,
+            delivery_type: DeliveryType::Inject,
+            persist: PersistMode::Public,
+        }];
         (bot_messages, user_message)
     }
 }
@@ -108,7 +107,11 @@ mod tests {
             .produce(&event, &group, &NoopBotRegistryCoreService, &group.participants)
             .await;
 
-        assert!(messages.is_empty());
+        // No bot recipients, but the notice is still a public history record
+        // for human viewers (persisted with owner = None by the dispatcher).
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].recipients.is_empty());
+        assert_eq!(messages[0].persist, PersistMode::Public);
         assert_eq!(user_message.as_deref(), Some("Alice(human_42) 已加入协作群"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/participant_mode_changed.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use bcs_domain::{
-    ActorKind, DeliveryType, Group, Participant, ParticipantMode, SystemMessageEvent,
+    ActorKind, DeliveryType, Group, Participant, ParticipantMode, PersistMode, SystemMessageEvent,
     SystemMessageEventKind, SystemGroupMessage,
 };
 use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService};
@@ -69,15 +69,14 @@ impl SystemMessageProducerService for ParticipantModeChangedMessageProducer {
             .map(|p| p.bot_uuid.clone())
             .collect();
 
-        let bot_messages = if recipients.is_empty() {
-            vec![]
-        } else {
-            vec![SystemGroupMessage {
-                recipients,
-                message: content,
-                delivery_type: DeliveryType::Inject,
-            }]
-        };
+        // Identical text for every recipient: persist a single public record
+        // (owner = None) that human viewers also read in history.
+        let bot_messages = vec![SystemGroupMessage {
+            recipients,
+            message: content,
+            delivery_type: DeliveryType::Inject,
+            persist: PersistMode::Public,
+        }];
         (bot_messages, user_message)
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use bcs_domain::{
     CoordinationMode, CoordinationSurface, DeliveryType, Group, GroupStrategy, LedgerSummary,
-    Participant, ParticipantRole, SystemMessageEvent, SystemMessageEventKind, SystemGroupMessage,
+    Participant, ParticipantRole, PersistMode, SystemMessageEvent, SystemMessageEventKind,
+    SystemGroupMessage,
 };
 use bcs_service_api::{
     BotRegistryCoreService, SystemMessageProducerService, backfill_bot_names,
@@ -116,6 +117,10 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
                 recipients: vec![participant.bot_uuid.clone()],
                 message: context_message,
                 delivery_type,
+                // Personalized per-bot context: persist per recipient so each
+                // bot's history view reads its own copy; not visible to human
+                // viewers (their filter is owner_bot_id IS NULL).
+                persist: PersistMode::PerRecipient,
             });
         }
         // SessionContext does not emit a user-facing WS message: the bot

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -523,6 +523,12 @@ async fn driver_delivery_defaults_to_send_for_driver() {
         .find(|m| m.recipients == vec!["bot-peer".to_string()])
         .expect("peer receives context");
     assert_eq!(peer_message.delivery_type, DeliveryType::Inject);
+
+    // Personalized per-bot context is persisted per recipient; it must NOT
+    // produce a public (owner = None) record readable by human viewers.
+    assert!(messages
+        .iter()
+        .all(|m| m.persist == bcs_domain::PersistMode::PerRecipient));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Since #775 (per-recipient system-message ownership), every system message is persisted per recipient with `owner_bot_id = Some(recipient)` and **no `owner = None` record exists at all**. Human viewers reading `GET /sessions/{sid}/messages` (workbench passes `view_bot_id = human_xxx` or omits it) are scoped to `MessageOwnerFilter::IsNull` — public records only — so **all system notices (member join/leave, mode changes, generic notifications) vanish from human session history**. The live WS `user_message` broadcast still works, but after a refresh the notices are gone. Bot chat messages (persisted `owner = None`) are unaffected.

Fixing this from the read side (e.g. letting humans read the driver's copies) was rejected: per-recipient copies are personalized (`你是:…` context injection), which is exactly the leak #775 removed.

## Solution

Give `SystemGroupMessage` a `PersistMode` field so **producers — who know whether a message is personalized or a shared notice — own the persistence decision**, and the dispatcher executes it mechanically (no content inspection, no per-bot judgment):

- `PerRecipient`: one record per recipient, `owner = recipient` (unchanged behavior). Used by SessionContext per-bot context and BotJoined's new-bot injection.
- `Public`: exactly one record with `owner = None`, readable by humans (`IsNull` view) and every bot's `PublicOrOwner` view — consistent with `user_message`, which is already broadcast session-wide to all frontend viewers. Used for notices whose text is identical for all recipients (BotJoined / HumanJoined / BotLeft / ParticipantModeChanged / Generic / BotHiddenNotice). Persisted even with zero recipients (last bot leaving), matching the `user_message` broadcast. Also collapses the previous N identical per-bot copies into a single record.
- `Skip`: no record (BotHiddenNotice's duplicate "others" copy).

Read side is completely untouched (`PublicOrOwner` / `IsNull` / `Eq` semantics unchanged); no schema migration.

## Validation

- `cargo check --workspace --all-targets` clean.
- The existing end-to-end round-trip test in `bcs-message` (real dispatcher + real `MemoryMessageRepo` + `get_session_history`) updated to the new contract and extended with a **human viewer (`view_bot_id = None`) assertion**: public notices are returned, per-bot owned copies stay hidden — the direct regression guard for this bug. It also asserts the shared notice is a single record, not per-bot copies.
- Producer unit tests updated/extended to lock each producer's `PersistMode` choice (BotJoined injection=`PerRecipient` + notice=`Public`; SessionContext all `PerRecipient`; BotHiddenNotice mentioner=`Public` + others=`Skip`; BotLeft/Generic/HumanJoined emit the public message even with zero recipients).
- Dispatcher tests updated: BotJoined persists injection (owned) + public notice (no per-bot copies); last-bot-leaving persists one public record (test renamed accordingly).
- Full runs green: `bcs-domain`, `bcs-system-message`, `bcs-message`, `bcs-message-store`, `bcs-message-flow`, `bcs-app-session`, `bcs-group`, and bootstrap human integration tests (`human_dm_group_integration` 10, `human_regress_integration` 19).

## Compatibility and risk

- **Backward compatible read path**: no query/filter changes; bot viewers see the same notices (now via the public record instead of an identical per-bot copy) with no duplicates.
- **Two accepted behavior changes** (discussed and intentional): ManagerWorker workers (`Eq(worker)` view) no longer see join/leave notices in history — their view stays scoped to task messages; and a newly joined bot now sees the public "X joined" notice about itself in history (it receives no active delivery of it — persistence and delivery are now decoupled by `PersistMode`).
- **Historical data**: notices persisted before this change remain invisible to humans (they were never stored as public records); no migration. New events from deploy onward are covered.