### PR TITLE
fix(engine): support legacy encodings in file preview

### DIFF
--- a/src/engine/src/engine/community/api/aicoding_sessions/router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/router.py
@@ -195,12 +195,22 @@ async def preview_file(
         description="可选：前端直传工作目录绝对路径，"
         "缺省回退 base/{session_id}",
     ),
+    encoding: str | None = Query(
+        None,
+        description="可选文件编码；支持 utf-8、gb18030、gbk；"
+        "为空时按 utf-8、gb18030、gbk 顺序尝试",
+    ),
 ) -> FilePreviewResponse:
     """Read a single workspace file (size-bounded, traversal-safe)."""
     check_capability(Capability.FILE_READ)
     service = _workspace_service()
     try:
-        content = await service.preview_file(session_id, path, cwd)
+        content = await service.preview_file(
+            session_id=session_id,
+            path=path,
+            cwd=cwd,
+            encoding=encoding,
+        )
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except NotADirectoryError as e:

--- a/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
+++ b/src/engine/src/engine/community/api/aicoding_sessions/tests/test_router.py
@@ -84,9 +84,23 @@ class FakeWorkspaceService:
             raise self.list_file_tree_raise
         return self.list_file_tree_return or []
 
-    async def preview_file(self, session_id: str, path: str, cwd: str | None = None):
+    async def preview_file(
+        self,
+        session_id: str,
+        path: str,
+        cwd: str | None = None,
+        encoding: str | None = None,
+    ):
         self.calls.append(
-            ("preview_file", {"session_id": session_id, "path": path, "cwd": cwd})
+            (
+                "preview_file",
+                {
+                    "session_id": session_id,
+                    "path": path,
+                    "cwd": cwd,
+                    "encoding": encoding,
+                },
+            )
         )
         if self.preview_file_raise:
             raise self.preview_file_raise
@@ -428,6 +442,29 @@ def test_files_preview_success(client, workspace_svc):
     assert resp.status_code == 200
     body = resp.json()
     assert body["data"] == {"content": "hi", "size": 2}
+    assert workspace_svc.calls[-1][1] == {
+        "session_id": "s1",
+        "path": "a.txt",
+        "cwd": None,
+        "encoding": None,
+    }
+
+
+@pytest.mark.parametrize("encoding", ["gbk", ""])
+def test_files_preview_forwards_encoding(client, workspace_svc, encoding):
+    workspace_svc.preview_file_return = FileContent(content="中文", size=4)
+
+    resp = client.get(
+        "/api/aicoding/sessions/files/preview",
+        params={
+            "session_id": "s1",
+            "path": "a.txt",
+            "encoding": encoding,
+        },
+    )
+
+    assert resp.status_code == 200
+    assert workspace_svc.calls[-1][1]["encoding"] == encoding
 
 
 @pytest.mark.parametrize(

--- a/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/tests/test_workspace_service.py
@@ -10,7 +10,7 @@
 
 2. 4 个实例方法 + ``_ensure_within_workspace`` 保护
    - ``list_file_tree`` —— AICoding workspace 本地扫描、基础设施目录剪枝 + 建树
-   - ``preview_file`` —— 校验 path/大小/路径穿越，读出 utf-8 文本
+   - ``preview_file`` —— 校验 path/大小/路径穿越，按指定编码或回退顺序解码文本
    - ``list_git_diff`` —— ``find .git`` + ``git status --porcelain`` 全流程
    - ``get_file_diff`` —— ``git diff HEAD`` 主路径 + untracked fallback
    - ``_ensure_within_workspace`` —— 防 ``..`` / 绝对路径穿越
@@ -596,6 +596,172 @@ async def test_preview_file_returns_decoded_content(workspace_dir: Path) -> None
     out = await service.preview_file(SESSION_ID, "a.txt")
     assert out.content == "hello 你好"
     assert out.size == len("hello 你好".encode("utf-8"))
+
+
+async def test_preview_file_auto_decodes_gbk_content(
+    workspace_dir: Path,
+) -> None:
+    text = "GBK 中文内容"
+    raw = text.encode("gbk")
+    target = str(workspace_dir / "gbk.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(SESSION_ID, "gbk.txt")
+
+    assert out.content == text
+    assert out.size == len(raw)
+
+
+async def test_preview_file_auto_decodes_gb18030_four_byte_content(
+    workspace_dir: Path,
+) -> None:
+    text = "GB18030 扩展字符：𠮷"
+    raw = text.encode("gb18030")
+    target = str(workspace_dir / "gb18030.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(SESSION_ID, "gb18030.txt")
+
+    assert out.content == text
+    assert out.size == len(raw)
+
+
+async def test_preview_file_auto_falls_back_to_utf8_replacement(
+    workspace_dir: Path,
+) -> None:
+    raw = b"text\xff\xff"
+    target = str(workspace_dir / "invalid.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(SESSION_ID, "invalid.txt")
+
+    assert out.content == "text��"
+    assert out.size == len(raw)
+
+
+@pytest.mark.parametrize("encoding", [None, "", " ", "\t"])
+async def test_preview_file_blank_encoding_uses_auto_mode(
+    workspace_dir: Path, encoding: str | None
+) -> None:
+    text = "自动识别 GBK"
+    raw = text.encode("gbk")
+    target = str(workspace_dir / "auto.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(
+        SESSION_ID, "auto.txt", encoding=encoding
+    )
+
+    assert out.content == text
+    assert out.size == len(raw)
+
+
+@pytest.mark.parametrize(
+    ("encoding", "text"),
+    [
+        ("utf-8", "UTF-8 内容"),
+        ("gb18030", "GB18030 扩展字符：𠮷"),
+        ("gbk", "GBK 内容"),
+    ],
+)
+async def test_preview_file_uses_explicit_encoding(
+    workspace_dir: Path, encoding: str, text: str
+) -> None:
+    raw = text.encode(encoding)
+    target = str(workspace_dir / "explicit.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(
+        SESSION_ID, "explicit.txt", encoding=encoding
+    )
+
+    assert out.content == text
+    assert out.size == len(raw)
+
+
+@pytest.mark.parametrize(
+    ("encoding", "codec"),
+    [
+        ("UTF-8", "utf-8"),
+        ("utf8", "utf-8"),
+        ("utf_8", "utf-8"),
+        ("GB18030", "gb18030"),
+        ("GBK", "gbk"),
+    ],
+)
+async def test_preview_file_normalizes_encoding_aliases(
+    workspace_dir: Path, encoding: str, codec: str
+) -> None:
+    text = "alias 内容"
+    raw = text.encode(codec)
+    target = str(workspace_dir / "alias.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(
+        SESSION_ID, "alias.txt", encoding=encoding
+    )
+
+    assert out.content == text
+    assert out.size == len(raw)
+
+
+async def test_preview_file_rejects_unsupported_encoding(
+    workspace_dir: Path,
+) -> None:
+    target = str(workspace_dir / "unsupported.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: b"text"})
+    )
+
+    with pytest.raises(ValueError, match="unsupported file encoding: big5"):
+        await service.preview_file(
+            SESSION_ID, "unsupported.txt", encoding="big5"
+        )
+
+
+async def test_preview_file_rejects_mismatched_explicit_encoding(
+    workspace_dir: Path,
+) -> None:
+    raw = "你好".encode("gbk")
+    target = str(workspace_dir / "mismatch.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="file content cannot be decoded with encoding utf-8",
+    ):
+        await service.preview_file(
+            SESSION_ID, "mismatch.txt", encoding="utf-8"
+        )
+
+
+async def test_preview_file_does_not_strip_utf8_bom(
+    workspace_dir: Path,
+) -> None:
+    raw = b"\xef\xbb\xbfcontent"
+    target = str(workspace_dir / "bom.txt")
+    service = _make_service(
+        file_plugin=FakeFilePlugin(read_map={target: raw})
+    )
+
+    out = await service.preview_file(SESSION_ID, "bom.txt")
+
+    assert out.content == "\ufeffcontent"
+    assert out.size == len(raw)
 
 
 async def test_preview_file_normalizes_path_and_strips_whitespace(

--- a/src/engine/src/engine/community/core/aicoding/workspace_service.py
+++ b/src/engine/src/engine/community/core/aicoding/workspace_service.py
@@ -45,6 +45,15 @@ CONTAINER_WORKSPACE_BASE = "/home/admin/.aicoding/workspace"
 # 10 MiB cap for inline preview to keep responses bounded.
 PREVIEW_MAX_BYTES = 10 * 1024 * 1024
 
+_ENCODING_ALIASES = {
+    "utf-8": "utf-8",
+    "utf8": "utf-8",
+    "utf_8": "utf-8",
+    "gb18030": "gb18030",
+    "gbk": "gbk",
+}
+_AUTO_DECODE_ENCODINGS = ("utf-8", "gb18030", "gbk")
+
 # Default number of workspace-relative levels returned by the file-tree API.
 # ``0`` is reserved for an unlimited recursive scan.
 DEFAULT_FILE_TREE_MAX_DEPTH = 3
@@ -76,6 +85,41 @@ def _build_file_tree_find_command(max_depth: int) -> str:
         "find -P . -ignore_readdir_race -mindepth 1 "
         f"{max_depth_arg}{_FILE_TREE_FIND_EXPRESSION}"
     )
+
+
+def _normalize_encoding(encoding: str | None) -> str | None:
+    """Normalize a supported preview encoding; blank values select auto mode."""
+    if encoding is None:
+        return None
+
+    value = encoding.strip().lower()
+    if not value:
+        return None
+
+    normalized = _ENCODING_ALIASES.get(value)
+    if normalized is None:
+        raise ValueError(f"unsupported file encoding: {encoding}")
+    return normalized
+
+
+def _decode_file_content(raw: bytes, encoding: str | None = None) -> str:
+    """Decode preview bytes using an explicit encoding or ordered fallbacks."""
+    normalized = _normalize_encoding(encoding)
+    if normalized is not None:
+        try:
+            return raw.decode(normalized)
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"file content cannot be decoded with encoding {normalized}"
+            ) from exc
+
+    for candidate in _AUTO_DECODE_ENCODINGS:
+        try:
+            return raw.decode(candidate)
+        except UnicodeDecodeError:
+            continue
+
+    return raw.decode("utf-8", errors="replace")
 
 
 def _resolve_workspace_base() -> str:
@@ -308,7 +352,11 @@ class WorkspaceService:
     # ── file preview ──────────────────────────────────────────────────
 
     async def preview_file(
-        self, session_id: str, path: str, cwd: str | None = None
+        self,
+        session_id: str,
+        path: str,
+        cwd: str | None = None,
+        encoding: str | None = None,
     ) -> FileContent:
         """Read a single workspace file (size-bounded, traversal-safe)."""
         if not path or not path.strip():
@@ -327,7 +375,7 @@ class WorkspaceService:
             )
 
         return FileContent(
-            content=raw.decode("utf-8", errors="replace"),
+            content=_decode_file_content(raw, encoding),
             size=size,
         )
 


### PR DESCRIPTION
## Problem
AICoding 文件预览固定使用 UTF-8 解码，GBK/GB18030 编码文件会出现乱码，且调用方无法指定文件编码。

## Solution
- 为 `GET /api/aicoding/sessions/files/preview` 增加非必填 `encoding` 查询参数。
- 支持显式指定 `utf-8`、`gb18030` 和 `gbk`，兼容 UTF-8 常用别名及大小写。
- 参数为空时依次严格尝试 UTF-8、GB18030、GBK，全部失败后使用 UTF-8 replacement 兜底返回。
- 显式编码不支持或解码失败时返回 HTTP 400，不自动切换其他编码。
- 不识别或剥离 BOM，不引入概率编码检测依赖，保持响应结构和原始字节 `size` 语义不变。

## Validation
- WorkspaceService 精准测试：100 passed。
- Router 精准测试：75 passed, 1 warning。
- Engine 完整 CI：2254 passed, 5 deselected, 17 warnings；line coverage 92.70%。
- 提交后、基于最新 `REL20260806` 执行 Engine Python SAST：通过。
- `git diff --check`：通过。
- rebase 到最新目标分支后再次尝试精准测试时，本地 `uv` 进程异常退出（exit 139），未获得新的测试结果；rebase 无冲突且功能补丁未改变。

## Compatibility and risk
- 现有调用方不传 `encoding` 时进入兼容解码流程，无需前端同步修改。
- 未修改响应 Schema 或 FileService Plugin API。
- 风险集中在文本编码选择；可通过回退本提交恢复原有固定 UTF-8 replacement 行为。
