### PR TITLE
fix(backend): read Desktop active skills from live runtime

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -696,7 +696,13 @@ async def get_active_skills(
         engine_type=effective_engine,
     )
 
-    active_skills = service.get_active_skills()
+    if is_desktop:
+        active_skills = await service.get_active_skills_from_device(
+            bot_id=effective_bot_id,
+            owner_id=effective_entity_id,
+        )
+    else:
+        active_skills = service.get_active_skills()
     logger.info(f"[skills.get_active_skills] Found {len(active_skills)} active skills")
     return ActiveSkillsResponse(
         success=True,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -477,6 +477,91 @@ class SkillService:
         skills.sort(key=lambda s: s.name)
         return skills
 
+    async def get_active_skills_from_device(
+        self, *, bot_id: str, owner_id: str
+    ) -> list[SkillInfo]:
+        """Read active Skill entries from a Bot's live device filesystem.
+
+        Desktop active roots are local to the user's device and therefore cannot
+        be observed through ``Path.iterdir()`` on the Backend host.  The runtime
+        entry itself remains authoritative: list its direct children, then read
+        ``SKILL.md`` through each entry so dangling links and unrelated folders
+        are not reported as active Skills.
+
+        Device I/O errors deliberately propagate.  Returning an empty list for
+        an unavailable runtime would make a transport failure indistinguishable
+        from a Bot with no active Skills.
+        """
+        device_fs = self._device_fs_factory(bot_id, owner_id)
+        entries = await device_fs.list_dir(str(self.active_dir), recursive=False)
+        if entries is None:
+            return []
+
+        skills: list[SkillInfo] = []
+        for entry in entries:
+            name = entry.get("name")
+            if (
+                not isinstance(name, str)
+                or not name
+                or name in {".", ".."}
+                or Path(name).name != name
+                or name in self.RESERVED_SKILL_NAMES
+            ):
+                continue
+
+            active_path = self.active_dir / name
+            content = await device_fs.read_file(str(active_path / "SKILL.md"))
+            if content is None:
+                content = await device_fs.read_file(str(active_path / "README.md"))
+            if content is None:
+                continue
+
+            try:
+                text = content.decode("utf-8")
+            except UnicodeDecodeError:
+                text = content.decode("gbk", errors="replace")
+            skill_info = SkillParser.parse_content(text)
+            if not skill_info:
+                continue
+
+            source_path = str(active_path)
+            skill_record = self.get_skill_by_link_name(name, bolt_id=bot_id)
+            locator = skill_record.get("git_path") if skill_record else None
+            if locator and locator.startswith(("git://", "local://")):
+                try:
+                    _, resolved_source = self.parse_skill_path(locator)
+                    source_path = str(resolved_source)
+                except ValueError:
+                    logger.warning(
+                        "[get_active_skills_from_device] Invalid locator for %s: %s",
+                        name,
+                        locator,
+                    )
+
+            skills.append(
+                SkillInfo(
+                    id=name,
+                    name=skill_info.get("name") or name,
+                    description=skill_info.get("description", ""),
+                    version=skill_info.get("version", "1.0.0"),
+                    category=skill_info.get("category", "general"),
+                    icon=self._get_icon_for_category(
+                        skill_info.get("category", "general")
+                    ),
+                    path=str(active_path),
+                    source_path=source_path,
+                    is_active=True,
+                    is_installed=True,
+                    capabilities=skill_info.get("capabilities", []),
+                    author=skill_info.get("author", ""),
+                    created_at=skill_info.get("created_at", ""),
+                    updated_at=skill_info.get("updated_at", ""),
+                )
+            )
+
+        skills.sort(key=lambda skill: skill.name)
+        return skills
+
     def get_active_skill(self, skill_id: str) -> SkillInfo | None:
         """获取单个已激活技能"""
         active_path = self.active_dir / skill_id

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -27,6 +27,7 @@ from injector import Injector, Module
 
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
 from agentclaw.community.adapters.http.skill_center.skills import router as skills_router
+from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -42,6 +43,7 @@ def _skill_service_di_app(
     *,
     device_sync_result=None,
     runtime_uses_pool_paths=False,
+    bot_type="personal",
 ):
     """Build a TestClient whose SkillService has AsyncMock methods.
 
@@ -62,6 +64,7 @@ def _skill_service_di_app(
         }
     )
     mock_skill_service.get_link_name = MagicMock(return_value="link_name")
+    mock_skill_service.get_active_skills_from_device = AsyncMock(return_value=[])
     mock_skill_service.runtime_uses_pool_paths = runtime_uses_pool_paths
 
     # Factory that returns the mock service from create()
@@ -98,6 +101,7 @@ def _skill_service_di_app(
         "bot_id": "default",
         "owner_id": "user_001",
         "active_engine": "openclaw",
+        "bot_type": bot_type,
     }
     mock_bot_repo.list_by_owner.return_value = (0, [])
 
@@ -141,6 +145,63 @@ def _skill_service_di_app(
     attach_injector(app, injector)
     client = TestClient(app, raise_server_exceptions=False)
     yield client, mock_skill_service, mock_skill_set_service
+
+
+class TestActiveSkillsRuntimeRead:
+    def test_desktop_active_list_reads_the_live_device(self, mock_ctx):
+        with _skill_service_di_app(
+            mock_ctx, bot_type="desktop"
+        ) as (client, mock_svc, _):
+            mock_svc.get_active_skills_from_device.return_value = [
+                SkillInfo(
+                    id="sp455-r2-oc-probe",
+                    name="sp455-r2-oc-probe",
+                    path=(
+                        "/home/admin/.openclaw/workspace/skills/"
+                        "sp455-r2-oc-probe"
+                    ),
+                    is_active=True,
+                    is_installed=True,
+                )
+            ]
+
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 200, response.text
+            assert response.json()["count"] == 1
+            assert response.json()["data"][0]["id"] == "sp455-r2-oc-probe"
+            mock_svc.get_active_skills_from_device.assert_awaited_once_with(
+                bot_id=mock_ctx.bot_id,
+                owner_id=mock_ctx.user_id,
+            )
+            mock_svc.get_active_skills.assert_not_called()
+
+    def test_non_desktop_active_list_keeps_management_filesystem_scan(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(mock_ctx) as (client, mock_svc, _):
+            mock_svc.get_active_skills.return_value = []
+
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 200, response.text
+            mock_svc.get_active_skills.assert_called_once_with()
+            mock_svc.get_active_skills_from_device.assert_not_awaited()
+
+    def test_desktop_active_list_does_not_mask_device_failure_as_empty(
+        self, mock_ctx
+    ):
+        with _skill_service_di_app(
+            mock_ctx, bot_type="desktop"
+        ) as (client, mock_svc, _):
+            mock_svc.get_active_skills_from_device.side_effect = RuntimeError(
+                "device offline"
+            )
+
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 500
+            mock_svc.get_active_skills.assert_not_called()
 
 
 @contextmanager

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -615,6 +615,143 @@ class TestSkillServiceGetActiveSkills:
         assert skills[0].name == "demo"
         assert skills[0].is_active is True
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "active_root",
+        [
+            "/home/admin/.openclaw/workspace/skills",
+            "/home/admin/.claude/skills",
+            "/home/admin/.hermes/skills",
+        ],
+    )
+    async def test_reads_desktop_active_skills_from_device_runtime(
+        self, skill_dirs, mock_skill_repo, active_root
+    ):
+        device_fs = MagicMock()
+        device_fs.list_dir = AsyncMock(
+            return_value=[
+                {
+                    "name": "skills-repo",
+                    "path": f"{active_root}/skills-repo",
+                    "is_dir": True,
+                },
+                {
+                    "name": "mcporter",
+                    "path": f"{active_root}/mcporter",
+                    "is_dir": True,
+                },
+                {
+                    "name": "../escape",
+                    "path": f"{active_root}/../escape",
+                    "is_dir": True,
+                },
+                {
+                    "name": "sp455-r2-oc-probe",
+                    "path": f"{active_root}/sp455-r2-oc-probe",
+                    "is_dir": True,
+                },
+                {
+                    "name": "empty-metadata",
+                    "path": f"{active_root}/empty-metadata",
+                    "is_dir": True,
+                },
+            ]
+        )
+
+        async def _read_file(path, **_kwargs):
+            if path.endswith("sp455-r2-oc-probe/SKILL.md"):
+                return (
+                    "---\nname: 运行时探针\n"
+                    "description: visible on the Desktop device\n---\n"
+                ).encode("gbk")
+            if path.endswith("empty-metadata/SKILL.md"):
+                return b""
+            return None
+
+        mock_skill_repo.get_by_link_name.return_value = {
+            "git_path": (
+                "local:///home/admin/runtime-pool/"
+                "skills-local/sp455-r2-oc-probe"
+            )
+        }
+
+        device_fs.read_file = AsyncMock(side_effect=_read_file)
+        device_fs_factory = MagicMock(return_value=device_fs)
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=Path(active_root),
+            repo_dir=skill_dirs["repo_dir"],
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=device_fs_factory,
+            git_sync_service_factory=MagicMock(),
+        )
+
+        skills = await svc.get_active_skills_from_device(
+            bot_id="desktop_bot_1", owner_id="405935"
+        )
+
+        assert [skill.id for skill in skills] == ["sp455-r2-oc-probe"]
+        assert skills[0].name == "运行时探针"
+        assert skills[0].description == "visible on the Desktop device"
+        assert skills[0].path == f"{active_root}/sp455-r2-oc-probe"
+        assert skills[0].source_path == (
+            "/home/admin/runtime-pool/skills-local/sp455-r2-oc-probe"
+        )
+        assert skills[0].is_active is True
+        device_fs_factory.assert_called_once_with("desktop_bot_1", "405935")
+        device_fs.list_dir.assert_awaited_once_with(
+            active_root, recursive=False
+        )
+        assert all("escape" not in call.args[0] for call in device_fs.read_file.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_device_active_list_propagates_runtime_listing_failure(
+        self, skill_dirs, mock_skill_repo
+    ):
+        device_fs = MagicMock()
+        device_fs.list_dir = AsyncMock(side_effect=RuntimeError("device offline"))
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=Path("/runtime/skills"),
+            repo_dir=skill_dirs["repo_dir"],
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=MagicMock(return_value=device_fs),
+            git_sync_service_factory=MagicMock(),
+        )
+
+        with pytest.raises(RuntimeError, match="device offline"):
+            await svc.get_active_skills_from_device(
+                bot_id="desktop_bot_1", owner_id="405935"
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_device_active_root_is_empty(
+        self, skill_dirs, mock_skill_repo
+    ):
+        device_fs = MagicMock()
+        device_fs.list_dir = AsyncMock(return_value=None)
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=Path("/runtime/skills"),
+            repo_dir=skill_dirs["repo_dir"],
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=MagicMock(return_value=device_fs),
+            git_sync_service_factory=MagicMock(),
+        )
+
+        assert await svc.get_active_skills_from_device(
+            bot_id="desktop_bot_1", owner_id="405935"
+        ) == []
+
 
 # ── TestSkillServiceMarketTree ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- make Desktop `GET /api/skills/active/list` read the Bot live device active root instead of the Backend host filesystem
- keep non-Desktop management-host scanning unchanged
- skip reserved, unrelated, dangling, and path-escaping entries; propagate device failures instead of reporting a false empty list

## Production evidence
- OpenClaw Bot `405935/desktop_bot_1785901349211`
- Skill `1120709` / `sp455-r2-oc-probe`
- activation trace `0be8ed2017859198842118576e7fdd` created the runtime link and live `SKILL.md` was readable
- active-list trace `0b446a3117859198952337835e5556` still returned count 0 before this fix

## Validation
- red tests reproduced Desktop runtime/API divergence before implementation
- 291 focused Skill Center, service, and architecture tests passed
- OpenClaw, Claude Code, and Hermes active roots covered by parameterized device-filesystem tests
- Ruff passed
- local Python SAST block scan passed
- diff-check passed

## Scope
- no gate, rollout, migration state-machine, mapping publication, Engine, or cloud Bot behavior changes
- no Spec or CLAUDE.md changes