### PR TITLE
fix(baas): use default 1800s callback timeout when not specified in bot update

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_manage/_bot_management_service.py
@@ -821,10 +821,9 @@ class DefaultBotManagementService(BotManageService):
                 existing_config.sla_grade = bot_config.sla_grade
             if bot_config.auto_approve_publish is not None:
                 existing_config.auto_approve_publish = bot_config.auto_approve_publish
-            if bot_config.callback_timeout_seconds is not None:
-                existing_config.callback_timeout_seconds = (
-                    bot_config.callback_timeout_seconds
-                )
+            existing_config.callback_timeout_seconds = (
+                bot_config.callback_timeout_seconds
+            )
 
         # Create publish via PublishService
         scale_amount = abs(target_count - current_count)
@@ -833,9 +832,10 @@ class DefaultBotManagementService(BotManageService):
             batch_capacity=min(10, scale_amount),
             auto_approve=auto_approve_publish,
             deploy_config=existing_config.deploy_config,
-            callback_timeout_seconds=resolve_callback_timeout(
-                existing_config.callback_timeout_seconds, self._system_config_repo
-            ),
+            callback_timeout_seconds=(
+                bot_config.callback_timeout_seconds if bot_config is not None else None
+            )
+            or DEFAULT_CALLBACK_TIMEOUT_SECONDS,
         )
         publish = await self._publish_service.create_publish(
             tenant=tenant,
@@ -976,10 +976,9 @@ class DefaultBotManagementService(BotManageService):
                     stored_config.sla_grade = bot_config.sla_grade
                 if bot_config.auto_approve_publish is not None:
                     stored_config.auto_approve_publish = bot_config.auto_approve_publish
-                if bot_config.callback_timeout_seconds is not None:
-                    stored_config.callback_timeout_seconds = (
-                        bot_config.callback_timeout_seconds
-                    )
+                stored_config.callback_timeout_seconds = (
+                    bot_config.callback_timeout_seconds
+                )
 
             # Also update name on the current bot if provided
             update_kwargs_name: dict[str, Any] = {"modifier": operator}
@@ -1003,9 +1002,12 @@ class DefaultBotManagementService(BotManageService):
                 replica_desired=device_count,
                 batch_capacity=min(5, device_count) if device_count > 0 else 5,
                 deploy_config=stored_config.deploy_config,
-                callback_timeout_seconds=resolve_callback_timeout(
-                    stored_config.callback_timeout_seconds, self._system_config_repo
-                ),
+                callback_timeout_seconds=(
+                    bot_config.callback_timeout_seconds
+                    if bot_config is not None
+                    else None
+                )
+                or DEFAULT_CALLBACK_TIMEOUT_SECONDS,
                 auto_approve=stored_config.auto_approve_publish,
                 template_uuid=template_uuid,
             )
@@ -1238,8 +1240,7 @@ class DefaultBotManagementService(BotManageService):
                 stored_config.sla_grade = config.sla_grade
             if config.auto_approve_publish is not None:
                 stored_config.auto_approve_publish = config.auto_approve_publish
-            if config.callback_timeout_seconds is not None:
-                stored_config.callback_timeout_seconds = config.callback_timeout_seconds
+            stored_config.callback_timeout_seconds = config.callback_timeout_seconds
 
             # Persist merged config to bot record
             bot_repo.update_bot(
@@ -1256,9 +1257,8 @@ class DefaultBotManagementService(BotManageService):
                 replica_desired=len(unique_device_uuids),
                 target_device_uuids=unique_device_uuids,
                 deploy_config=stored_config.deploy_config,
-                callback_timeout_seconds=resolve_callback_timeout(
-                    stored_config.callback_timeout_seconds, self._system_config_repo
-                ),
+                callback_timeout_seconds=config.callback_timeout_seconds
+                or DEFAULT_CALLBACK_TIMEOUT_SECONDS,
             )
         else:
             # No config change — use existing bot config for device records

--- a/src/baas/tests/e2e/asgi/baseline/test_callback_timeout_reset_on_update.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_callback_timeout_reset_on_update.py
@@ -1,0 +1,78 @@
+"""E2E test for callback_timeout_seconds default behavior on bot update.
+
+Verifies that when a bot is created with a custom callback_timeout_seconds=900
+and then updated without specifying callback_timeout_seconds, the UPDATE publish
+record uses the default 1800s (not the previous 900s).
+"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.e2e
+async def test_callback_timeout_resets_to_default_on_update(api, unique_id):
+    """Create bot with timeout=900, update without timeout, verify publish records."""
+    bot_name = f"test-cb-timeout-{unique_id}"
+
+    # 1. Create bot with callback_timeout_seconds=900
+    resp = await api.client.post(
+        api.bot_url(),
+        params=api.params(),
+        json={
+            "name": bot_name,
+            "template_uuid": "test-template",
+            "device_count": 1,
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+            "config": {
+                "callback_timeout_seconds": 900,
+            },
+        },
+    )
+    assert resp.status_code == 200, f"Create bot failed: {resp.status_code} {resp.text}"
+    data = resp.json()["data"]
+    bot_uuid = data["bot_uuid"]
+    create_publish_id = data["publish_id"]
+    assert create_publish_id is not None
+
+    # Verify CREATE publish record has callback_timeout_seconds=900
+    resp = await api.client.get(
+        api.publish_url(create_publish_id),
+        params=api.params(),
+    )
+    assert resp.status_code == 200
+    create_extra = resp.json()["data"].get("extra_config") or {}
+    assert create_extra.get("callback_timeout_seconds") == 900, (
+        f"CREATE publish should have callback_timeout_seconds=900, "
+        f"got {create_extra.get('callback_timeout_seconds')}"
+    )
+
+    # 2. Update bot without specifying callback_timeout_seconds
+    resp = await api.client.put(
+        api.bot_url(bot_uuid),
+        params=api.params(),
+        json={
+            "operator": "e2e-test",
+            "request_id": uuid.uuid4().hex,
+            "config": {
+                "sla_grade": "standard",
+            },
+        },
+    )
+    assert resp.status_code == 200, f"Update bot failed: {resp.status_code} {resp.text}"
+    update_publish_id = resp.json()["data"].get("publish_id")
+    assert update_publish_id is not None
+
+    # Verify UPDATE publish record has callback_timeout_seconds=1800 (default)
+    resp = await api.client.get(
+        api.publish_url(update_publish_id),
+        params=api.params(),
+    )
+    assert resp.status_code == 200
+    update_extra = resp.json()["data"].get("extra_config") or {}
+    assert update_extra.get("callback_timeout_seconds") == 1800, (
+        f"UPDATE publish should have callback_timeout_seconds=1800 (default), "
+        f"got {update_extra.get('callback_timeout_seconds')}"
+    )

--- a/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
+++ b/src/baas/tests/unit/core/service/bot_manage/test_bot_management_service.py
@@ -1300,7 +1300,9 @@ class TestScaleBot:
 
         call_kwargs = mock_publish_service.create_publish.call_args.kwargs
         publish_config = call_kwargs["config"]
-        assert publish_config.callback_timeout_seconds == 300
+        assert (
+            publish_config.callback_timeout_seconds == DEFAULT_CALLBACK_TIMEOUT_SECONDS
+        )
         assert publish_config.auto_approve is False
 
     @pytest.mark.asyncio
@@ -1375,7 +1377,9 @@ class TestScaleBot:
 
         call_kwargs = mock_publish_service.create_publish.call_args.kwargs
         publish_config = call_kwargs["config"]
-        assert publish_config.callback_timeout_seconds == 300  # from DB, not overridden
+        assert (
+            publish_config.callback_timeout_seconds == DEFAULT_CALLBACK_TIMEOUT_SECONDS
+        )
 
 
 class TestUpdateBot:
@@ -4514,7 +4518,7 @@ class TestUpdateBotConfigMerges:
 
     @pytest.mark.asyncio
     async def test_update_bot_preserves_existing_callback_timeout_when_none(self):
-        """Test update_bot preserves existing callback_timeout when incoming is None."""
+        """Test update_bot uses default 1800s when incoming callback_timeout is None."""
         mock_record = MagicMock()
         mock_record.id = 1
         mock_record.bot_uuid = "BOT-001"
@@ -4586,6 +4590,13 @@ class TestUpdateBotConfigMerges:
             )
 
             assert result.publish_id == 892
+            # Verify that None input → default 1800s (not old 1200)
+            create_publish_call = mock_publish_service.create_publish.call_args
+            publish_config = create_publish_call.kwargs["config"]
+            assert (
+                publish_config.callback_timeout_seconds
+                == DEFAULT_CALLBACK_TIMEOUT_SECONDS
+            )
 
 
 class TestAutoApprovePublish:


### PR DESCRIPTION
## Problem

When a bot is updated via `update_bot`, `update_devices`, or `scale_bot` APIs without explicitly providing `callback_timeout_seconds`, the publish record incorrectly retains the bot's last configured timeout value instead of falling back to the default 1800s. Operators cannot reset a bot's callback timeout to default by omitting the field — the old value persists indefinitely.

## Solution

In all three config-change code paths (`scale_bot`, `update_bot`, `update_devices`), replace `resolve_callback_timeout(stored_config.callback_timeout_seconds, ...)` with `bot_config.callback_timeout_seconds or DEFAULT_CALLBACK_TIMEOUT_SECONDS`. When the API doesn't specify a timeout (None), it falls through to the 1800s default.

Also removed the `is not None` guard on the stored config merge so omitted values propagate correctly.

## Validation

- 125/125 unit tests pass
- E2E test added: creates bot with timeout=900, updates without timeout, verifies publish record uses 1800s
- `test_update_bot_preserves_existing_callback_timeout_when_none` updated to assert default 1800s