### PR TITLE
fix(backend): skip non-skill desktop active entries

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -510,9 +510,14 @@ class SkillService:
                 continue
 
             active_path = self.active_dir / name
-            content = await device_fs.read_file(str(active_path / "SKILL.md"))
-            if content is None:
-                content = await device_fs.read_file(str(active_path / "README.md"))
+            content = None
+            skill_file = active_path / "SKILL.md"
+            if await device_fs.exists(str(skill_file)):
+                content = await device_fs.read_file(str(skill_file))
+            else:
+                readme_file = active_path / "README.md"
+                if await device_fs.exists(str(readme_file)):
+                    content = await device_fs.read_file(str(readme_file))
             if content is None:
                 continue
 

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -675,6 +675,14 @@ class TestSkillServiceGetActiveSkills:
             )
         }
 
+        device_fs.exists = AsyncMock(
+            side_effect=lambda path: path.endswith(
+                (
+                    "sp455-r2-oc-probe/SKILL.md",
+                    "empty-metadata/SKILL.md",
+                )
+            )
+        )
         device_fs.read_file = AsyncMock(side_effect=_read_file)
         device_fs_factory = MagicMock(return_value=device_fs)
         svc = SkillService(
@@ -729,6 +737,57 @@ class TestSkillServiceGetActiveSkills:
             await svc.get_active_skills_from_device(
                 bot_id="desktop_bot_1", owner_id="405935"
             )
+
+    @pytest.mark.asyncio
+    async def test_device_active_list_skips_entries_without_skill_metadata(
+        self, skill_dirs, mock_skill_repo
+    ):
+        active_root = "/home/admin/.claude/skills"
+        device_fs = MagicMock()
+        device_fs.list_dir = AsyncMock(
+            return_value=[
+                {
+                    "name": "mcporter",
+                    "path": f"{active_root}/mcporter",
+                    "is_dir": True,
+                },
+                {
+                    "name": "direct-skill",
+                    "path": f"{active_root}/direct-skill",
+                    "is_dir": True,
+                },
+            ]
+        )
+        device_fs.exists = AsyncMock(
+            side_effect=lambda path: path.endswith("direct-skill/SKILL.md")
+        )
+
+        async def _read_file(path, **_kwargs):
+            if path.endswith("direct-skill/SKILL.md"):
+                return b"---\nname: direct-skill\n---\n"
+            raise AssertionError(f"must not read missing metadata: {path}")
+
+        device_fs.read_file = AsyncMock(side_effect=_read_file)
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=Path(active_root),
+            repo_dir=skill_dirs["repo_dir"],
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=MagicMock(return_value=device_fs),
+            git_sync_service_factory=MagicMock(),
+        )
+
+        skills = await svc.get_active_skills_from_device(
+            bot_id="desktop_bot_1", owner_id="405935"
+        )
+
+        assert [skill.id for skill in skills] == ["direct-skill"]
+        device_fs.read_file.assert_awaited_once_with(
+            f"{active_root}/direct-skill/SKILL.md"
+        )
 
     @pytest.mark.asyncio
     async def test_missing_device_active_root_is_empty(


### PR DESCRIPTION
## Problem

The Desktop active-Skill listing introduced by #815 reads `SKILL.md` directly for every active-root child. Real BaaS device reads raise on a missing file (including HTTP 404), while the original unit double returned `None`. A legitimate non-Skill entry such as `mcporter` could therefore make `/api/skills/active/list` return 500 even when the actual active Skill links were healthy.

## Solution

Use the existing device-filesystem `exists()` probe before reading `SKILL.md` or the historical `README.md` fallback. Entries without either metadata file are ignored; device transport/server failures still propagate and are not converted to an empty list. Cloud/non-Desktop behavior is unchanged.

## Validation

- Regression test demonstrated the pre-fix failure against the real `read_file`/`exists` contract.
- 157 focused Skill CRUD, SkillSet, device-sync, recovery-listener, and multi-engine path tests passed.
- 11 focused Desktop active-list tests passed.
- Ruff passed for both changed files.
- Python SAST block scan passed for both changed files.
- `git diff --check` passed.

## Compatibility and risk

No API, schema, rollout-state, mapping, or runtime layout contract changes. The change only filters active-root children that are not valid Skills before attempting to read their metadata.

## Related issues

Follow-up to #815 and the #797 pre acceptance.