### PR TITLE
fix(backend): harden ARKA image policy persistence

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/service_bot/router_publish.py
+++ b/src/backend/src/agentclaw/community/adapters/http/service_bot/router_publish.py
@@ -5,6 +5,7 @@
 - 调用 core/service_bot/services/ 中的业务逻辑
 - Request/Response 类型来自同级 schemas.py
 """
+import copy
 import json
 
 from fastapi import APIRouter, Depends, Request
@@ -627,7 +628,8 @@ async def update_publish_status(
 
         publish_record = publish_service.get_publish_by_id(publish_id)
 
-        ext = publish_record.ext or {}
+        expected_ext = copy.deepcopy(publish_record.ext)
+        ext = copy.deepcopy(publish_record.ext or {})
         ext["source_status"] = request.failed_status
 
         record = publish_service.update_publish_status_with_ext(
@@ -635,6 +637,7 @@ async def update_publish_status(
             target_status=request.target_status,
             ext=ext,
             source_status=request.source_status,
+            expected_ext=expected_ext,
         )
 
         return ApiResponse(

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -39,6 +39,7 @@ internal_dependencies:
   - agentclaw.community.core.desktop_bot
   - agentclaw.community.core.mcp
   - agentclaw.community.core.devices
+  - agentclaw.community.core.events
   - agentclaw.community.core.resources
   - agentclaw.community.core.service_bot
   - agentclaw.community.core.skill_center

--- a/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/repository/protocol.py
@@ -163,6 +163,17 @@ class BotRepository(Protocol):
         """Update bot record by bot_id and owner_id."""
         ...
 
+    def compare_and_set_ext(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Replace ``ext`` only when the full stored value is unchanged."""
+        ...
+
     def soft_delete_by_owner(self, bot_id: str, owner_id: str) -> bool:
         """Soft delete a bot by bot_id and owner_id."""
         ...

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -61,7 +61,6 @@ from agentclaw.community.core.bot_management.services.default_image_policy_liste
     DEFAULT_IMAGE_POLICY_VALUE,
     IMAGE_POLICY_ON_ACTIVE_KEY,
 )
-from agentclaw.community.core.bot_management.utils import clear_baas_publish_failure_ext
 from agentclaw.community.core.bot_collaborator.models import CollaboratorRole
 from agentclaw.community.core.bot_collaborator.repository.protocol import CollaboratorRepositoryProtocol
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE, _get_engine_types
@@ -74,7 +73,6 @@ from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
     apply_default_image_to_ext,
-    copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
 )
@@ -4130,6 +4128,22 @@ class BotService:
         if not bot_uuid:
             raise BotServiceError(f"Bot {bot_id} binding {binding_id} missing bot_uuid; cannot baas restart")
 
+        raw_binding_props = (
+            binding.get("device_props", {})
+            if isinstance(binding, dict)
+            else (getattr(binding, "device_props", None) or {})
+        )
+        binding_props = raw_binding_props if isinstance(raw_binding_props, dict) else {}
+        if binding_props.get("restart_request_id"):
+            logger.info(
+                "[bot_service._restart_bot_baas] restart already has a durable "
+                "recovery intent: bot_id=%s binding_id=%s request_id=%s",
+                bot_id,
+                binding_id,
+                binding_props["restart_request_id"],
+            )
+            return dict(self._repository.get_by_id_and_owner(bot_id, user_id) or bot)
+
         active_engine = (bot.get("active_engine") or "").strip()
         bot_type = bot.get("bot_type") or "personal"
         bot_template_type = (bot.get("template_type") or "").strip()
@@ -4242,12 +4256,6 @@ class BotService:
             upgrade_kwargs["stage"] = restart_stage
         if template_uuid is not None:
             upgrade_kwargs["template_uuid"] = template_uuid
-        result = self._baas_service_provider().upgrade_bot(**upgrade_kwargs)
-
-        # 取 publish_id；先把本轮 restart 事实与成功后应落的镜像策略持久化到
-        # Binding，再置 bot/binding 双 PENDING，最后提交 durable poll task。这样
-        # enqueue 失败或进程恢复时，不依赖瞬时 task payload 也能继续收敛。
-        publish_id = (result or {}).get("publish_id") if isinstance(result, dict) else None
         image_policy_on_success = (
             DEFAULT_IMAGE_POLICY_VALUE
             if bot_type == "service"
@@ -4255,102 +4263,128 @@ class BotService:
             and (bot.get("ext") or {}).get("sbot_use_default_image") is True
             else None
         )
-
-        update_data: Dict[str, Any] = {"status": "PENDING"}
-        if publish_id is not None:
-            from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
-                RESTART_IMAGE_POLICY_ON_SUCCESS_KEY,
+        baas_service = self._baas_service_provider()
+        try:
+            workflows = baas_service.list_bot_publishes(bot_uuid)
+            workflow_baseline = max(
+                (
+                    int(workflow["id"])
+                    for workflow in (workflows or [])
+                    if isinstance(workflow, dict)
+                    and str(workflow.get("id", "")).isdigit()
+                ),
+                default=0,
             )
+        except Exception as e:
+            raise BotServiceError(
+                f"Failed to snapshot BaaS restart workflow baseline: {e}"
+            ) from e
 
+        from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
+            BAAS_RESTART_PUBLISH_POLL_TASK,
+            RESTART_IMAGE_POLICY_ON_SUCCESS_KEY,
+            RESTART_REQUEST_ID_KEY,
+            RESTART_WORKFLOW_BASELINE_KEY,
+            build_restart_publish_poll_payload,
+        )
+
+        # The durable task is the operation intent and must exist before the
+        # external BaaS mutation. If enqueue fails, no remote side effect has
+        # happened. The handler can adopt the workflow by baseline if the
+        # process exits after BaaS accepts but before publish_id is persisted.
+        task_queue_service = self._task_queue_service
+        if task_queue_service is None:
+            raise BotServiceError("BaaS restart task queue service is unavailable")
+        started_at_epoch_s = time.time()
+        try:
+            task_queue_service.enqueue(
+                BAAS_RESTART_PUBLISH_POLL_TASK,
+                build_restart_publish_poll_payload(
+                    binding_id=binding_id,
+                    bot_id=bot_id,
+                    owner_id=user_id,
+                    publish_id=None,
+                    started_at_epoch_s=started_at_epoch_s,
+                    bot_uuid=bot_uuid,
+                    image_policy_on_success=image_policy_on_success,
+                    request_id=request_id,
+                    workflow_baseline=workflow_baseline,
+                ),
+                deadline_seconds=86400,
+                delay_seconds=2,
+            )
+        except Exception as e:
+            raise BotServiceError(
+                "BaaS restart was not submitted because its durable task "
+                f"could not be persisted: {e}"
+            ) from e
+
+        previous_binding_status = (
+            binding.get("status")
+            if isinstance(binding, dict)
+            else getattr(binding, "status", DeviceBindingStatus.ACTIVE.value)
+        )
+        previous_bot_status = bot.get("status") or DeviceBindingStatus.ACTIVE.value
+        try:
+            self._device_binding_repo.update_device_props(
+                binding_id=binding_id,
+                props={
+                    RESTART_REQUEST_ID_KEY: request_id,
+                    RESTART_WORKFLOW_BASELINE_KEY: workflow_baseline,
+                    "restart_publish_id": None,
+                    RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: image_policy_on_success,
+                },
+            )
+            self._device_binding_repo.update_status(
+                binding_id=binding_id, status=DeviceBindingStatus.PENDING
+            )
+            if self._repository.update_by_owner(
+                bot_id, user_id, {"status": DeviceBindingStatus.PENDING.value}
+            ) is None:
+                raise BotServiceError(f"Bot not found while preparing restart: {bot_id}")
+        except Exception as e:
+            # No BaaS call has happened yet. Invalidate the queued task's request
+            # identity and restore the previous visible lifecycle state.
+            try:
+                self._device_binding_repo.update_device_props(
+                    binding_id=binding_id,
+                    props={RESTART_REQUEST_ID_KEY: None},
+                )
+                self._device_binding_repo.update_status(
+                    binding_id=binding_id,
+                    status=previous_binding_status or DeviceBindingStatus.ACTIVE.value,
+                )
+                self._repository.update_by_owner(
+                    bot_id, user_id, {"status": previous_bot_status}
+                )
+            except Exception:
+                logger.exception(
+                    "[bot_service._restart_bot_baas] failed to roll back restart preparation"
+                )
+            raise BotServiceError(f"Failed to prepare durable BaaS restart: {e}") from e
+
+        # From this point on, every ambiguous failure is recoverable by the
+        # pre-existing task. It either reads the stored publish id or adopts the
+        # single workflow issued after workflow_baseline.
+        result = baas_service.upgrade_bot(**upgrade_kwargs)
+        publish_id = (result or {}).get("publish_id") if isinstance(result, dict) else None
+        if publish_id is not None:
             restart_publish_id = str(publish_id)
-            persisted_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
-            if isinstance(persisted_bot, dict):
-                persisted_ext = persisted_bot.get("ext")
-            else:
-                # Tests and defensive fallback: retain unrelated Bot ext but
-                # never leak the in-memory DEFAULT intent into PENDING state.
-                persisted_ext = copy_image_policy_to_ext(None, bot.get("ext"))
-            ext = clear_baas_publish_failure_ext(persisted_ext)
-            ext["restart_publish_id"] = restart_publish_id
-            update_data["ext"] = ext
             try:
                 self._device_binding_repo.update_device_props(
                     binding_id=binding_id,
                     props={
                         "publish_id": restart_publish_id,
                         "restart_publish_id": restart_publish_id,
-                        "restart_request_id": request_id,
-                        RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: image_policy_on_success,
                     },
                 )
-            except Exception as e:
+            except Exception:
                 logger.exception(
-                    "[bot_service._restart_bot_baas] failed to persist restart "
-                    "recovery facts for bot_id=%s binding_id=%s publish_id=%s",
-                    bot_id, binding_id, publish_id,
+                    "[bot_service._restart_bot_baas] publish_id persistence failed; "
+                    "durable task will adopt by baseline: bot_id=%s publish_id=%s",
+                    bot_id,
+                    publish_id,
                 )
-                raise BotServiceError(
-                    "BaaS restart was accepted but its recovery state could not "
-                    f"be persisted: publish_id={publish_id}"
-                ) from e
-
-        try:
-            # Binding is the poll handler's source of truth. Move it away from
-            # the previous runtime's ACTIVE state before scheduling this
-            # publish, otherwise a worker could mistake old ACTIVE for success
-            # of the newly accepted BaaS publish.
-            self._device_binding_repo.update_status(
-                binding_id=binding_id, status=DeviceBindingStatus.PENDING
-            )
-            self._repository.update_by_owner(bot_id, user_id, update_data)
-        except Exception as e:
-            logger.exception(
-                "[bot_service._restart_bot_baas] failed to mark restart "
-                "PENDING for bot_id=%s binding_id=%s publish_id=%s",
-                bot_id, binding_id, publish_id,
-            )
-            raise BotServiceError(
-                "BaaS restart was accepted but its PENDING state could not "
-                f"be persisted: publish_id={publish_id}"
-            ) from e
-
-        task_queue_service = self._task_queue_service
-        if publish_id is not None and task_queue_service is not None:
-            try:
-                from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
-                    BAAS_RESTART_PUBLISH_POLL_TASK,
-                    build_restart_publish_poll_payload,
-                )
-
-                task_queue_service.enqueue(
-                    BAAS_RESTART_PUBLISH_POLL_TASK,
-                    build_restart_publish_poll_payload(
-                        binding_id=binding_id,
-                        bot_id=bot_id,
-                        owner_id=user_id,
-                        publish_id=publish_id,
-                        started_at_epoch_s=time.time(),
-                        bot_uuid=bot_uuid,
-                        image_policy_on_success=image_policy_on_success,
-                    ),
-                    deadline_seconds=86400,
-                )
-            except Exception as e:
-                logger.exception(
-                    "[bot_service._restart_bot_baas] restart poll enqueue failed "
-                    "for bot_id=%s publish_id=%s",
-                    bot_id, publish_id,
-                )
-                raise BotServiceError(
-                    "BaaS restart was accepted and recovery state was persisted, "
-                    f"but polling could not be scheduled: publish_id={publish_id}"
-                ) from e
-        else:
-            logger.info(
-                "[bot_service._restart_bot_baas] no publish_id or task queue service; "
-                "skipping restart poll enqueue for bot_id=%s publish_id=%s",
-                bot_id, publish_id,
-            )
 
         return dict(self._repository.get_by_id_and_owner(bot_id, user_id) or {})
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4295,16 +4295,24 @@ class BotService:
                 ) from e
 
         try:
-            self._repository.update_by_owner(bot_id, user_id, update_data)
+            # Binding is the poll handler's source of truth. Move it away from
+            # the previous runtime's ACTIVE state before scheduling this
+            # publish, otherwise a worker could mistake old ACTIVE for success
+            # of the newly accepted BaaS publish.
             self._device_binding_repo.update_status(
                 binding_id=binding_id, status=DeviceBindingStatus.PENDING
             )
+            self._repository.update_by_owner(bot_id, user_id, update_data)
         except Exception as e:
-            logger.warning(
-                "[bot_service._restart_bot_baas] failed to mark PENDING "
-                "for bot_id=%s binding_id=%s: %s",
-                bot_id, binding_id, e,
+            logger.exception(
+                "[bot_service._restart_bot_baas] failed to mark restart "
+                "PENDING for bot_id=%s binding_id=%s publish_id=%s",
+                bot_id, binding_id, publish_id,
             )
+            raise BotServiceError(
+                "BaaS restart was accepted but its PENDING state could not "
+                f"be persisted: publish_id={publish_id}"
+            ) from e
 
         task_queue_service = self._task_queue_service
         if publish_id is not None and task_queue_service is not None:

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -57,6 +57,10 @@ from agentclaw.community.core.bot_management.repository.protocol import (
     BotRepository,
     BotRestartLockRepositoryProtocol,
 )
+from agentclaw.community.core.bot_management.services.default_image_policy_listener import (
+    DEFAULT_IMAGE_POLICY_VALUE,
+    IMAGE_POLICY_ON_ACTIVE_KEY,
+)
 from agentclaw.community.core.bot_management.utils import clear_baas_publish_failure_ext
 from agentclaw.community.core.bot_collaborator.models import CollaboratorRole
 from agentclaw.community.core.bot_collaborator.repository.protocol import CollaboratorRepositoryProtocol
@@ -1814,6 +1818,10 @@ class BotService:
                 # can still apply the create-time rollout policy.
                 if device_provider is not None:
                     apply_kwargs["device_provider"] = device_provider
+                if bot_ext_override is not None:
+                    apply_kwargs["device_props_extra"] = {
+                        IMAGE_POLICY_ON_ACTIVE_KEY: DEFAULT_IMAGE_POLICY_VALUE
+                    }
 
                 device_result = service.apply_device(**apply_kwargs)
 
@@ -1847,13 +1855,14 @@ class BotService:
                     "device_id": device_id,
                     "status": final_status,
                 }
-                if bot_ext_override is not None:
-                    bot_update["ext"] = bot_ext_override
                 updated = self._repository.update_by_owner(bot_id, user_id, bot_update)
                 if not updated:
                     logger.error(f"[bot_service._allocate_device_async] Failed to update bot {bot_id} for user {user_id}: bot not found or not owner")
                     return
-                if bot_ext_override is not None:
+                if (
+                    bot_ext_override is not None
+                    and device_status == DeviceBindingStatus.ACTIVE.value
+                ):
                     self._persist_service_bot_default_image(
                         {**(bot_record or {}), "bot_id": bot_id, "ext": bot_ext_override},
                         user_id=user_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4244,33 +4244,57 @@ class BotService:
             upgrade_kwargs["template_uuid"] = template_uuid
         result = self._baas_service_provider().upgrade_bot(**upgrade_kwargs)
 
-        # 取 publish_id；置 bot/binding 双 PENDING；通过 durable queue 持久化轮询。
-        # publish_id 缺失 / enqueue 异常仅 log，不影响重启返回（前端轮 status 自然
-        # 收敛或下次操作触发）。
+        # 取 publish_id；先把本轮 restart 事实与成功后应落的镜像策略持久化到
+        # Binding，再置 bot/binding 双 PENDING，最后提交 durable poll task。这样
+        # enqueue 失败或进程恢复时，不依赖瞬时 task payload 也能继续收敛。
         publish_id = (result or {}).get("publish_id") if isinstance(result, dict) else None
+        image_policy_on_success = (
+            DEFAULT_IMAGE_POLICY_VALUE
+            if bot_type == "service"
+            and not self.is_teclaw_bot(active_engine)
+            and (bot.get("ext") or {}).get("sbot_use_default_image") is True
+            else None
+        )
 
-        try:
-            update_data: Dict[str, Any] = {"status": "PENDING"}
-            if publish_id is not None:
-                restart_publish_id = str(publish_id)
-                persisted_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
-                if isinstance(persisted_bot, dict):
-                    persisted_ext = persisted_bot.get("ext")
-                else:
-                    # Tests and defensive fallback: retain unrelated Bot ext but
-                    # never leak the in-memory DEFAULT intent into PENDING state.
-                    persisted_ext = copy_image_policy_to_ext(None, bot.get("ext"))
-                ext = clear_baas_publish_failure_ext(persisted_ext)
-                ext["restart_publish_id"] = restart_publish_id
-                update_data["ext"] = ext
+        update_data: Dict[str, Any] = {"status": "PENDING"}
+        if publish_id is not None:
+            from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
+                RESTART_IMAGE_POLICY_ON_SUCCESS_KEY,
+            )
+
+            restart_publish_id = str(publish_id)
+            persisted_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
+            if isinstance(persisted_bot, dict):
+                persisted_ext = persisted_bot.get("ext")
+            else:
+                # Tests and defensive fallback: retain unrelated Bot ext but
+                # never leak the in-memory DEFAULT intent into PENDING state.
+                persisted_ext = copy_image_policy_to_ext(None, bot.get("ext"))
+            ext = clear_baas_publish_failure_ext(persisted_ext)
+            ext["restart_publish_id"] = restart_publish_id
+            update_data["ext"] = ext
+            try:
                 self._device_binding_repo.update_device_props(
                     binding_id=binding_id,
                     props={
                         "publish_id": restart_publish_id,
                         "restart_publish_id": restart_publish_id,
                         "restart_request_id": request_id,
+                        RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: image_policy_on_success,
                     },
                 )
+            except Exception as e:
+                logger.exception(
+                    "[bot_service._restart_bot_baas] failed to persist restart "
+                    "recovery facts for bot_id=%s binding_id=%s publish_id=%s",
+                    bot_id, binding_id, publish_id,
+                )
+                raise BotServiceError(
+                    "BaaS restart was accepted but its recovery state could not "
+                    f"be persisted: publish_id={publish_id}"
+                ) from e
+
+        try:
             self._repository.update_by_owner(bot_id, user_id, update_data)
             self._device_binding_repo.update_status(
                 binding_id=binding_id, status=DeviceBindingStatus.PENDING
@@ -4299,22 +4323,20 @@ class BotService:
                         publish_id=publish_id,
                         started_at_epoch_s=time.time(),
                         bot_uuid=bot_uuid,
-                        image_policy_on_success=(
-                            "default"
-                            if bot_type == "service"
-                            and not self.is_teclaw_bot(active_engine)
-                            and (bot.get("ext") or {}).get("sbot_use_default_image") is True
-                            else None
-                        ),
+                        image_policy_on_success=image_policy_on_success,
                     ),
                     deadline_seconds=86400,
                 )
             except Exception as e:
-                logger.warning(
+                logger.exception(
                     "[bot_service._restart_bot_baas] restart poll enqueue failed "
-                    "for bot_id=%s publish_id=%s: %s",
-                    bot_id, publish_id, e,
+                    "for bot_id=%s publish_id=%s",
+                    bot_id, publish_id,
                 )
+                raise BotServiceError(
+                    "BaaS restart was accepted and recovery state was persisted, "
+                    f"but polling could not be scheduled: publish_id={publish_id}"
+                ) from e
         else:
             logger.info(
                 "[bot_service._restart_bot_baas] no publish_id or task queue service; "

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -72,6 +72,7 @@ from agentclaw.community.core.service_bot.services.arka_image_pin import (
     apply_default_image_to_ext,
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
+    persist_default_image_policy,
 )
 from agentclaw.community.utils.avernet_tenant import (
     bind_current_avernet_tenant,
@@ -394,27 +395,13 @@ class BotService:
         ):
             return
 
-        bot_id = str(bot["bot_id"])
-        updated_ext = apply_default_image_to_ext(bot.get("ext"))
-        self._repository.update_by_owner(bot_id, user_id, {"ext": updated_ext})
-
-        draft = self._bot_publish_repo.get_draft_by_publish_bot_id(
-            publish_bot_id=bot_id,
+        persist_default_image_policy(
+            bot_repository=self._repository,
+            publish_repository=self._bot_publish_repo,
+            bot_id=str(bot["bot_id"]),
+            owner_id=user_id,
             env=get_current_env(),
         )
-        if draft is None:
-            return
-        draft_ext = copy_image_policy_to_ext(updated_ext, draft.ext) or {}
-        updated_draft = self._bot_publish_repo.update_status_with_ext(
-            publish_id=draft.id,
-            target_status=draft.status,
-            ext=draft_ext,
-            source_status=draft.status,
-        )
-        if updated_draft is None:
-            raise BotServiceError(
-                f"Draft publish {draft.id} default-image persistence conflicted"
-            )
 
     def _build_engine_extra_envs(
         self,
@@ -4247,7 +4234,6 @@ class BotService:
         if template_uuid is not None:
             upgrade_kwargs["template_uuid"] = template_uuid
         result = self._baas_service_provider().upgrade_bot(**upgrade_kwargs)
-        self._persist_service_bot_default_image(bot, user_id=user_id)
 
         # 取 publish_id；置 bot/binding 双 PENDING；通过 durable queue 持久化轮询。
         # publish_id 缺失 / enqueue 异常仅 log，不影响重启返回（前端轮 status 自然
@@ -4258,7 +4244,14 @@ class BotService:
             update_data: Dict[str, Any] = {"status": "PENDING"}
             if publish_id is not None:
                 restart_publish_id = str(publish_id)
-                ext = clear_baas_publish_failure_ext(bot.get("ext"))
+                persisted_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
+                if isinstance(persisted_bot, dict):
+                    persisted_ext = persisted_bot.get("ext")
+                else:
+                    # Tests and defensive fallback: retain unrelated Bot ext but
+                    # never leak the in-memory DEFAULT intent into PENDING state.
+                    persisted_ext = copy_image_policy_to_ext(None, bot.get("ext"))
+                ext = clear_baas_publish_failure_ext(persisted_ext)
                 ext["restart_publish_id"] = restart_publish_id
                 update_data["ext"] = ext
                 self._device_binding_repo.update_device_props(
@@ -4297,6 +4290,13 @@ class BotService:
                         publish_id=publish_id,
                         started_at_epoch_s=time.time(),
                         bot_uuid=bot_uuid,
+                        image_policy_on_success=(
+                            "default"
+                            if bot_type == "service"
+                            and not self.is_teclaw_bot(active_engine)
+                            and (bot.get("ext") or {}).get("sbot_use_default_image") is True
+                            else None
+                        ),
                     ),
                     deadline_seconds=86400,
                 )

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
@@ -1,4 +1,4 @@
-"""Persist a draft restart's default-image policy after Device activation."""
+"""Persist a draft restart's default-image policy before Device activation."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from agentclaw.community.core.bot_management.services.teclaw_provision_service i
 from agentclaw.community.core.devices.repository.protocol import (
     DeviceBindingRepository,
 )
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import DeviceAliveEvent
 from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
     BotPublishRepositoryProtocol,
 )
@@ -28,7 +28,7 @@ DEFAULT_IMAGE_POLICY_VALUE = "default"
 
 
 class DefaultImagePolicyActivationListener(LifecycleBase):
-    """Finalize DEFAULT only for recreate allocations carrying the intent."""
+    """Finalize DEFAULT before activating recreate allocations carrying the intent."""
 
     @inject
     def __init__(
@@ -45,12 +45,17 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
         from agentclaw.community.core.events.bus import get_event_bus
 
         bus = get_event_bus()
-        existing = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
+        existing = bus._handlers.get(DeviceAliveEvent, [])  # type: ignore[attr-defined]
         if self.handle in existing:
             return
-        bus.subscribe(DeviceActivatedEvent, self.handle)
+        bus.subscribe(DeviceAliveEvent, self.handle, required=True)
 
-    def handle(self, event: DeviceActivatedEvent) -> None:
+    def handle(self, event: DeviceAliveEvent) -> None:
+        # This policy belongs only to the ARCA destroy/recreate path. BaaS
+        # in-place restart is finalized by its publish poll handler.
+        if event.device_provider != "arca":
+            return
+
         binding = self._binding_repository.get_by_id(event.binding_id)
         if binding is None:
             return
@@ -59,7 +64,15 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
             return
 
         bot = self._bot_repository.get_by_binding_id(event.binding_id)
-        if not isinstance(bot, dict) or bot.get("bot_type") != "service":
+        if not isinstance(bot, dict):
+            # apply_device() starts the runtime before BotService writes the new
+            # binding_id back to ac_bots. Keep the Binding PENDING so the next
+            # Alive callback retries after that mapping becomes visible.
+            raise RuntimeError(
+                "service Bot mapping is not ready for default-image intent: "
+                f"binding_id={event.binding_id}"
+            )
+        if bot.get("bot_type") != "service":
             return
         active_engine = str(bot.get("active_engine") or "").strip().lower()
         if active_engine in DEFAULT_TECLAW_ENGINE_TYPES:
@@ -84,7 +97,7 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
             props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
         )
         logger.info(
-            "[default_image_policy_listener] persisted DEFAULT after activation: "
+            "[default_image_policy_listener] persisted DEFAULT before activation: "
             "bot_id=%s binding_id=%s",
             bot_id,
             event.binding_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
@@ -1,0 +1,91 @@
+"""Persist a draft restart's default-image policy after Device activation."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.bot_management.services.teclaw_provision_service import (
+    DEFAULT_TECLAW_ENGINE_TYPES,
+)
+from agentclaw.community.core.devices.repository.protocol import (
+    DeviceBindingRepository,
+)
+from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    persist_default_image_policy,
+)
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+IMAGE_POLICY_ON_ACTIVE_KEY = "image_policy_on_active"
+DEFAULT_IMAGE_POLICY_VALUE = "default"
+
+
+class DefaultImagePolicyActivationListener(LifecycleBase):
+    """Finalize DEFAULT only for recreate allocations carrying the intent."""
+
+    @inject
+    def __init__(
+        self,
+        bot_repository: BotRepository,
+        publish_repository: BotPublishRepositoryProtocol,
+        binding_repository: DeviceBindingRepository,
+    ) -> None:
+        self._bot_repository = bot_repository
+        self._publish_repository = publish_repository
+        self._binding_repository = binding_repository
+
+    async def startup(self) -> None:
+        from agentclaw.community.core.events.bus import get_event_bus
+
+        bus = get_event_bus()
+        existing = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
+        if self.handle in existing:
+            return
+        bus.subscribe(DeviceActivatedEvent, self.handle)
+
+    def handle(self, event: DeviceActivatedEvent) -> None:
+        binding = self._binding_repository.get_by_id(event.binding_id)
+        if binding is None:
+            return
+        props = getattr(binding, "device_props", None) or {}
+        if props.get(IMAGE_POLICY_ON_ACTIVE_KEY) != DEFAULT_IMAGE_POLICY_VALUE:
+            return
+
+        bot = self._bot_repository.get_by_binding_id(event.binding_id)
+        if not isinstance(bot, dict) or bot.get("bot_type") != "service":
+            return
+        active_engine = str(bot.get("active_engine") or "").strip().lower()
+        if active_engine in DEFAULT_TECLAW_ENGINE_TYPES:
+            return
+
+        bot_id = str(bot.get("bot_id") or "")
+        owner_id = str(bot.get("owner_id") or "")
+        if not bot_id or not owner_id:
+            return
+
+        persist_default_image_policy(
+            bot_repository=self._bot_repository,
+            publish_repository=self._publish_repository,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            env=str(getattr(binding, "env", None) or ""),
+        )
+        # Clear only after both Bot and Draft have accepted DEFAULT. A failed
+        # persistence leaves the intent durable for diagnosis/retry.
+        self._binding_repository.update_device_props(
+            binding_id=event.binding_id,
+            props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
+        )
+        logger.info(
+            "[default_image_policy_listener] persisted DEFAULT after activation: "
+            "bot_id=%s binding_id=%s",
+            bot_id,
+            event.binding_id,
+        )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -9,6 +9,9 @@ from agentclaw.community.core.bot_management.utils import clear_baas_publish_fai
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.events.bus import get_event_bus
 from agentclaw.community.core.events.types import BaasPublishCompletedEvent
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    persist_default_image_policy,
+)
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.types import (
     Complete,
@@ -18,6 +21,7 @@ from agentclaw.community.core.task_queue.types import (
     TaskOutcome,
 )
 from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 BAAS_CREATE_PUBLISH_POLL_TASK = "baas.create.publish_poll"
@@ -92,8 +96,9 @@ def build_restart_publish_poll_payload(
     publish_id: int,
     started_at_epoch_s: float,
     bot_uuid: str | None,
+    image_policy_on_success: str | None = None,
 ) -> dict:
-    return {
+    payload = {
         "binding_id": binding_id,
         "bot_id": bot_id,
         "owner_id": owner_id,
@@ -101,6 +106,9 @@ def build_restart_publish_poll_payload(
         "started_at_epoch_s": started_at_epoch_s,
         "bot_uuid": bot_uuid,
     }
+    if image_policy_on_success is not None:
+        payload["image_policy_on_success"] = image_policy_on_success
+    return payload
 
 
 def _require_int(payload: Optional[dict], key: str) -> int:
@@ -134,6 +142,15 @@ def _require_optional_str(payload: Optional[dict], key: str) -> str | None:
     if not isinstance(payload, dict) or key not in payload:
         raise ValueError(f"missing required field: {key}")
     value = payload[key]
+    if value is not None and not isinstance(value, str):
+        raise ValueError(f"field {key} must be str or None")
+    return value
+
+
+def _optional_str(payload: Optional[dict], key: str) -> str | None:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be dict")
+    value = payload.get(key)
     if value is not None and not isinstance(value, str):
         raise ValueError(f"field {key} must be str or None")
     return value
@@ -309,6 +326,7 @@ class BaasRestartPublishPollHandler:
         baas_service: Any | None = None,
         baas_device_service: Any | None = None,
         bot_repository: Any | None = None,
+        publish_repository: Any | None = None,
         template_service: Any | None = None,
         poll_delay_seconds: float = 10.0,
         clock: Callable[[], float] = time.time,
@@ -316,6 +334,7 @@ class BaasRestartPublishPollHandler:
         self._binding_repository = binding_repository
         self._baas_device_service = baas_device_service or baas_service
         self._bot_repository = bot_repository
+        self._publish_repository = publish_repository
         self._template_service = template_service
         self._poll_delay_seconds = poll_delay_seconds
         self._clock = clock
@@ -328,7 +347,15 @@ class BaasRestartPublishPollHandler:
         parsed = self._parse_payload(payload)
         if isinstance(parsed, Fail):
             return parsed
-        binding_id, bot_id, owner_id, publish_id, started_at_epoch_s, bot_uuid = parsed
+        (
+            binding_id,
+            bot_id,
+            owner_id,
+            publish_id,
+            started_at_epoch_s,
+            bot_uuid,
+            image_policy_on_success,
+        ) = parsed
 
         binding = self._binding_repository.get_by_id(binding_id)
         if (
@@ -341,14 +368,13 @@ class BaasRestartPublishPollHandler:
                 "restart_publish_id",
             )
         ):
-            _publish_baas_completed(
+            return self._finalize_success(
                 binding_id=binding_id,
                 bot_id=bot_id,
                 owner_id=owner_id,
                 publish_id=publish_id,
-                publish_kind="restart",
+                image_policy_on_success=image_policy_on_success,
             )
-            return Complete()
         preflight = self._preflight(binding=binding, publish_id=publish_id)
         if preflight is not None:
             return preflight
@@ -392,12 +418,13 @@ class BaasRestartPublishPollHandler:
             publish_id=publish_id,
             bot_uuid=bot_uuid,
             bot=bot,
+            image_policy_on_success=image_policy_on_success,
         )
 
     def _parse_payload(
         self,
         payload: Optional[dict],
-    ) -> tuple[int, str, str, int, int | float, str | None] | Fail:
+    ) -> tuple[int, str, str, int, int | float, str | None, str | None] | Fail:
         try:
             return (
                 _require_int(payload, "binding_id"),
@@ -406,6 +433,7 @@ class BaasRestartPublishPollHandler:
                 _require_int(payload, "publish_id"),
                 _require_number(payload, "started_at_epoch_s"),
                 _require_optional_str(payload, "bot_uuid"),
+                _optional_str(payload, "image_policy_on_success"),
             )
         except (KeyError, ValueError) as exc:
             return Fail(f"invalid payload: {exc}")
@@ -430,6 +458,7 @@ class BaasRestartPublishPollHandler:
         publish_id: int,
         bot_uuid: str | None,
         bot: Any,
+        image_policy_on_success: str | None = None,
     ) -> TaskOutcome:
         if status == DeviceBindingStatus.ACTIVE.value:
             codefuse_token = self._read_codefuse_token(bot_id=bot_id, bot=bot)
@@ -461,14 +490,13 @@ class BaasRestartPublishPollHandler:
                 status=DeviceBindingStatus.ACTIVE.value,
                 publish_id=publish_id,
             )
-            _publish_baas_completed(
+            return self._finalize_success(
                 binding_id=binding_id,
                 bot_id=bot_id,
                 owner_id=owner_id,
                 publish_id=publish_id,
-                publish_kind="restart",
+                image_policy_on_success=image_policy_on_success,
             )
-            return Complete()
         if status == DeviceBindingStatus.FAILED.value:
             self._persist_failed(
                 bot_id=bot_id,
@@ -478,6 +506,44 @@ class BaasRestartPublishPollHandler:
             )
             return Complete()
         return Retry(f"unexpected publish status: {status}")
+
+    def _finalize_success(
+        self,
+        *,
+        binding_id: int,
+        bot_id: str,
+        owner_id: str,
+        publish_id: int,
+        image_policy_on_success: str | None,
+    ) -> TaskOutcome:
+        if image_policy_on_success == "default":
+            if self._bot_repository is None or self._publish_repository is None:
+                return Retry("default-image persistence service unavailable")
+            try:
+                persist_default_image_policy(
+                    bot_repository=self._bot_repository,
+                    publish_repository=self._publish_repository,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    env=get_current_env(),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[BaasRestartPublishPollHandler] default-image persistence "
+                    "failed for bot_id=%s publish_id=%s: %s",
+                    bot_id,
+                    publish_id,
+                    exc,
+                )
+                return Retry(str(exc))
+        _publish_baas_completed(
+            binding_id=binding_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            publish_id=publish_id,
+            publish_kind="restart",
+        )
+        return Complete()
 
     def _persist_failed(
         self,
@@ -614,7 +680,8 @@ class BaasPublishTaskLifecycle(LifecycleBase):
         task_queue_service: Any,
         baas_device_service: Any,
         bot_repository: Any,
-        template_service: Any,
+        publish_repository: Any | None = None,
+        template_service: Any = None,
     ) -> None:
         self._registry = registry
         self._binding_repository = binding_repository
@@ -622,6 +689,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
         self._task_queue_service = task_queue_service
         self._baas_device_service = baas_device_service
         self._bot_repository = bot_repository
+        self._publish_repository = publish_repository
         self._template_service = template_service
 
     async def bootstrap(self) -> None:
@@ -644,6 +712,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
                 binding_repository=self._binding_repository,
                 baas_device_service=self._baas_device_service,
                 bot_repository=self._bot_repository,
+                publish_repository=self._publish_repository,
                 template_service=self._template_service,
             )
         )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -28,6 +28,8 @@ BAAS_CREATE_PUBLISH_POLL_TASK = "baas.create.publish_poll"
 BAAS_CREATE_INIT_TASK = "baas.create.init"
 BAAS_RESTART_PUBLISH_POLL_TASK = "baas.restart.publish_poll"
 RESTART_IMAGE_POLICY_ON_SUCCESS_KEY = "restart_image_policy_on_success"
+RESTART_REQUEST_ID_KEY = "restart_request_id"
+RESTART_WORKFLOW_BASELINE_KEY = "restart_workflow_baseline"
 _DEFAULT_IMAGE_POLICY_VALUE = "default"
 _CREATE_PUBLISH_TIMEOUT_SECONDS = 600
 _RESTART_PUBLISH_TIMEOUT_SECONDS = 600
@@ -95,21 +97,28 @@ def build_restart_publish_poll_payload(
     binding_id: int,
     bot_id: str,
     owner_id: str,
-    publish_id: int,
+    publish_id: int | None,
     started_at_epoch_s: float,
     bot_uuid: str | None,
     image_policy_on_success: str | None = None,
+    request_id: str | None = None,
+    workflow_baseline: int | None = None,
 ) -> dict:
     payload = {
         "binding_id": binding_id,
         "bot_id": bot_id,
         "owner_id": owner_id,
-        "publish_id": publish_id,
         "started_at_epoch_s": started_at_epoch_s,
         "bot_uuid": bot_uuid,
     }
+    if publish_id is not None:
+        payload["publish_id"] = publish_id
     if image_policy_on_success is not None:
         payload["image_policy_on_success"] = image_policy_on_success
+    if request_id is not None:
+        payload["request_id"] = request_id
+    if workflow_baseline is not None:
+        payload["workflow_baseline"] = workflow_baseline
     return payload
 
 
@@ -155,6 +164,15 @@ def _optional_str(payload: Optional[dict], key: str) -> str | None:
     value = payload.get(key)
     if value is not None and not isinstance(value, str):
         raise ValueError(f"field {key} must be str or None")
+    return value
+
+
+def _optional_int(payload: Optional[dict], key: str) -> int | None:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be dict")
+    value = payload.get(key)
+    if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+        raise ValueError(f"field {key} must be int or None")
     return value
 
 
@@ -334,6 +352,7 @@ class BaasRestartPublishPollHandler:
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._binding_repository = binding_repository
+        self._baas_service = baas_service
         self._baas_device_service = baas_device_service or baas_service
         self._bot_repository = bot_repository
         self._publish_repository = publish_repository
@@ -357,15 +376,76 @@ class BaasRestartPublishPollHandler:
             started_at_epoch_s,
             bot_uuid,
             image_policy_on_success,
+            request_id,
+            workflow_baseline,
         ) = parsed
 
         binding = self._binding_repository.get_by_id(binding_id)
+        if request_id is not None:
+            props = getattr(binding, "device_props", None) or {}
+            current_request_id = props.get(RESTART_REQUEST_ID_KEY)
+            if current_request_id is None:
+                # The task is persisted before the external BaaS mutation. A
+                # worker may observe it in the small window before the Binding
+                # intent is committed; retry instead of dropping the only
+                # recovery mechanism. Preparation failures deliberately clear
+                # the intent, so those orphan tasks age out without side effects.
+                if _business_timed_out(
+                    started_at_epoch_s=started_at_epoch_s,
+                    timeout_s=_RESTART_PUBLISH_TIMEOUT_SECONDS,
+                    clock=self._clock,
+                ):
+                    return Complete()
+                return Reschedule(self._poll_delay_seconds)
+            if current_request_id != request_id:
+                return Complete()
+
+        if publish_id is None:
+            publish_id = self._resolve_or_adopt_publish_id(
+                binding=binding,
+                binding_id=binding_id,
+                bot_uuid=bot_uuid,
+                request_id=request_id,
+                workflow_baseline=workflow_baseline,
+            )
+            if isinstance(publish_id, Fail):
+                self._persist_failed(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    binding_id=binding_id,
+                    publish_id=None,
+                    message=publish_id.error,
+                )
+                self._clear_restart_recovery_intent(binding_id=binding_id)
+                return publish_id
+            if isinstance(publish_id, (Complete, Reschedule, Retry)):
+                if _business_timed_out(
+                    started_at_epoch_s=started_at_epoch_s,
+                    timeout_s=_RESTART_PUBLISH_TIMEOUT_SECONDS,
+                    clock=self._clock,
+                ):
+                    self._persist_failed(
+                        bot_id=bot_id,
+                        owner_id=owner_id,
+                        binding_id=binding_id,
+                        publish_id=None,
+                        message="BaaS restart could not adopt an accepted workflow",
+                    )
+                    self._clear_restart_recovery_intent(binding_id=binding_id)
+                    return Complete()
+                return publish_id
+
         image_policy_on_success = self._resolve_image_policy_on_success(
             binding=binding,
             publish_id=publish_id,
             payload_value=image_policy_on_success,
+            request_id=request_id,
         )
-        preflight = self._preflight(binding=binding, publish_id=publish_id)
+        preflight = self._preflight(
+            binding=binding,
+            publish_id=publish_id,
+            request_id=request_id,
+        )
         if preflight is not None:
             return preflight
         bot = None
@@ -386,6 +466,7 @@ class BaasRestartPublishPollHandler:
                     f"{_RESTART_PUBLISH_TIMEOUT_SECONDS}s (publish_id={publish_id})"
                 ),
             )
+            self._clear_restart_recovery_intent(binding_id=binding_id)
             return Complete()
         if self._baas_device_service is None:
             return Retry("restart publish status service unavailable")
@@ -409,19 +490,100 @@ class BaasRestartPublishPollHandler:
     def _parse_payload(
         self,
         payload: Optional[dict],
-    ) -> tuple[int, str, str, int, int | float, str | None, str | None] | Fail:
+    ) -> tuple[
+        int,
+        str,
+        str,
+        int | None,
+        int | float,
+        str | None,
+        str | None,
+        str | None,
+        int | None,
+    ] | Fail:
         try:
             return (
                 _require_int(payload, "binding_id"),
                 _require_str(payload, "bot_id"),
                 _require_str(payload, "owner_id"),
-                _require_int(payload, "publish_id"),
+                _optional_int(payload, "publish_id"),
                 _require_number(payload, "started_at_epoch_s"),
                 _require_optional_str(payload, "bot_uuid"),
                 _optional_str(payload, "image_policy_on_success"),
+                _optional_str(payload, "request_id"),
+                _optional_int(payload, "workflow_baseline"),
             )
         except (KeyError, ValueError) as exc:
             return Fail(f"invalid payload: {exc}")
+
+    def _resolve_or_adopt_publish_id(
+        self,
+        *,
+        binding: Any,
+        binding_id: int,
+        bot_uuid: str | None,
+        request_id: str | None,
+        workflow_baseline: int | None,
+    ) -> int | TaskOutcome:
+        """Resolve the stored workflow id or adopt the one issued after baseline."""
+        if binding is None:
+            return Complete()
+        props = getattr(binding, "device_props", None) or {}
+        stored = props.get("restart_publish_id")
+        if stored is not None:
+            try:
+                return int(stored)
+            except (TypeError, ValueError):
+                return Fail(f"invalid restart_publish_id: {stored!r}")
+        if request_id is None or workflow_baseline is None or not bot_uuid:
+            return Retry("restart workflow id is not persisted yet")
+        if self._baas_service is None:
+            return Retry("restart workflow adoption service unavailable")
+        try:
+            workflows = self._baas_service.list_bot_publishes(bot_uuid)
+        except Exception as exc:
+            return Retry(f"restart workflow adoption query failed: {exc}")
+        candidates = [
+            workflow
+            for workflow in (workflows or [])
+            if isinstance(workflow, dict)
+            and str(workflow.get("id", "")).isdigit()
+            and int(workflow["id"]) > workflow_baseline
+            and workflow.get("publish_type") in {"UPDATE", "RESTART", "CREATE"}
+        ]
+        if not candidates:
+            return Reschedule(self._poll_delay_seconds)
+        if len(candidates) > 1:
+            ids = sorted(int(workflow["id"]) for workflow in candidates)
+            return Fail(
+                f"restart workflow adoption is ambiguous for bot_uuid={bot_uuid}: {ids}"
+            )
+        publish_id = int(candidates[0]["id"])
+        self._binding_repository.update_device_props(
+            binding_id=binding_id,
+            props={
+                "publish_id": str(publish_id),
+                "restart_publish_id": str(publish_id),
+            },
+        )
+        logger.info(
+            "[BaasRestartPublishPollHandler] adopted restart workflow: "
+            "binding_id=%s request_id=%s publish_id=%s",
+            binding_id,
+            request_id,
+            publish_id,
+        )
+        return publish_id
+
+    def _clear_restart_recovery_intent(self, *, binding_id: int) -> None:
+        self._binding_repository.update_device_props(
+            binding_id=binding_id,
+            props={
+                RESTART_REQUEST_ID_KEY: None,
+                RESTART_WORKFLOW_BASELINE_KEY: None,
+                RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: None,
+            },
+        )
 
     @staticmethod
     def _resolve_image_policy_on_success(
@@ -429,22 +591,38 @@ class BaasRestartPublishPollHandler:
         binding: Any,
         publish_id: int,
         payload_value: str | None,
+        request_id: str | None,
     ) -> str | None:
         """Read the restart intent from Binding, with old-task compatibility."""
-        if _payload_publish_id_matches(binding, publish_id, "restart_publish_id"):
-            props = getattr(binding, "device_props", None) or {}
+        props = getattr(binding, "device_props", None) or {}
+        request_matches = (
+            request_id is not None
+            and props.get(RESTART_REQUEST_ID_KEY) == request_id
+        )
+        if request_matches or _payload_publish_id_matches(
+            binding, publish_id, "restart_publish_id"
+        ):
             if RESTART_IMAGE_POLICY_ON_SUCCESS_KEY in props:
                 value = props.get(RESTART_IMAGE_POLICY_ON_SUCCESS_KEY)
                 return value if isinstance(value, str) else None
         return payload_value
 
     @staticmethod
-    def _preflight(*, binding: Any, publish_id: int) -> TaskOutcome | None:
+    def _preflight(
+        *, binding: Any, publish_id: int, request_id: str | None
+    ) -> TaskOutcome | None:
         if binding is None:
             return Complete()
         if getattr(binding, "device_provider", None) != "baas":
             return Complete()
-        if not _payload_publish_id_matches(binding, publish_id, "restart_publish_id"):
+        props = getattr(binding, "device_props", None) or {}
+        request_matches = (
+            request_id is not None
+            and props.get(RESTART_REQUEST_ID_KEY) == request_id
+        )
+        if not request_matches and not _payload_publish_id_matches(
+            binding, publish_id, "restart_publish_id"
+        ):
             return Complete()
         # ACTIVE can belong to the runtime that existed before this restart.
         # It is therefore not proof that the current BaaS publish succeeded;
@@ -510,6 +688,7 @@ class BaasRestartPublishPollHandler:
                 binding_id=binding_id,
                 publish_id=publish_id,
             )
+            self._clear_restart_recovery_intent(binding_id=binding_id)
             return Complete()
         return Retry(f"unexpected publish status: {status}")
 
@@ -533,12 +712,6 @@ class BaasRestartPublishPollHandler:
                     owner_id=owner_id,
                     env=get_current_env(),
                 )
-                # Clear only after Bot + Draft have accepted DEFAULT. Failure
-                # keeps the durable intent for task replay/process recovery.
-                self._binding_repository.update_device_props(
-                    binding_id=binding_id,
-                    props={RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: None},
-                )
             except Exception as exc:
                 logger.warning(
                     "[BaasRestartPublishPollHandler] default-image persistence "
@@ -548,6 +721,9 @@ class BaasRestartPublishPollHandler:
                     exc,
                 )
                 return Retry(str(exc))
+        # Clear only after every success-side persistence step has completed.
+        # A failure above keeps the durable request/baseline/policy for replay.
+        self._clear_restart_recovery_intent(binding_id=binding_id)
         _publish_baas_completed(
             binding_id=binding_id,
             bot_id=bot_id,
@@ -563,7 +739,7 @@ class BaasRestartPublishPollHandler:
         bot_id: str,
         owner_id: str,
         binding_id: int,
-        publish_id: int,
+        publish_id: int | None,
         message: str | None = None,
     ) -> None:
         self._persist_restart_status(
@@ -582,43 +758,61 @@ class BaasRestartPublishPollHandler:
         owner_id: str,
         binding_id: int,
         status: str,
-        publish_id: int,
+        publish_id: int | None,
         failure_message: str | None = None,
     ) -> None:
-        update_data = self._build_bot_update(
-            bot_id=bot_id,
-            owner_id=owner_id,
-            status=status,
-            publish_id=publish_id,
-            failure_message=failure_message,
-        )
         if self._bot_repository is not None:
-            self._bot_repository.update_by_owner(bot_id, owner_id, update_data)
+            updated_bot = self._bot_repository.update_by_owner(
+                bot_id, owner_id, {"status": status}
+            )
+            if updated_bot is None:
+                raise RuntimeError(f"Bot status update did not match: bot_id={bot_id}")
+            for _attempt in range(3):
+                snapshot = self._get_current_ext_snapshot(
+                    bot_id=bot_id, owner_id=owner_id
+                )
+                if snapshot is None:
+                    break
+                current_ext, expected_ext = snapshot
+                updated_ext = self._build_bot_ext(
+                    current_ext=current_ext,
+                    status=status,
+                    publish_id=publish_id,
+                    failure_message=failure_message,
+                )
+                if updated_ext == current_ext:
+                    break
+                updated = self._bot_repository.compare_and_set_ext(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    expected_ext=expected_ext,
+                    ext=updated_ext,
+                )
+                if updated is not None:
+                    break
+            else:
+                raise RuntimeError(
+                    f"Bot restart ext CAS conflicted repeatedly: bot_id={bot_id}"
+                )
         self._binding_repository.update_status(
             binding_id=binding_id,
             status=status,
         )
 
-    def _build_bot_update(
-        self,
+    @staticmethod
+    def _build_bot_ext(
         *,
-        bot_id: str,
-        owner_id: str,
+        current_ext: dict,
         status: str,
-        publish_id: int,
+        publish_id: int | None,
         failure_message: str | None = None,
     ) -> dict:
-        update_data: dict = {"status": status}
-        current_ext = self._get_current_ext(bot_id=bot_id, owner_id=owner_id)
-        if current_ext is None:
-            return update_data
-
-        restart_publish_id = str(publish_id)
+        restart_publish_id = str(publish_id) if publish_id is not None else None
         if status == DeviceBindingStatus.ACTIVE.value:
             ext = clear_baas_publish_failure_ext(current_ext)
-            ext["restart_publish_id"] = restart_publish_id
-            if ext != current_ext:
-                update_data["ext"] = ext
+            if restart_publish_id is not None:
+                ext["restart_publish_id"] = restart_publish_id
+            return ext
         elif status == DeviceBindingStatus.FAILED.value:
             ext = clear_baas_publish_failure_ext(current_ext)
             ext["start_status"] = "FAILED"
@@ -626,11 +820,14 @@ class BaasRestartPublishPollHandler:
                 failure_message
                 or f"BaaS publish FAILED: publish_id={restart_publish_id}"
             )
-            ext["restart_publish_id"] = restart_publish_id
-            update_data["ext"] = ext
-        return update_data
+            if restart_publish_id is not None:
+                ext["restart_publish_id"] = restart_publish_id
+            return ext
+        return current_ext
 
-    def _get_current_ext(self, *, bot_id: str, owner_id: str) -> dict | None:
+    def _get_current_ext_snapshot(
+        self, *, bot_id: str, owner_id: str
+    ) -> tuple[dict, dict | None] | None:
         if self._bot_repository is None:
             return None
         getter = getattr(self._bot_repository, "get_by_id_and_owner", None)
@@ -648,7 +845,7 @@ class BaasRestartPublishPollHandler:
             )
             return None
         ext = (bot or {}).get("ext") if isinstance(bot, dict) else None
-        return dict(ext) if isinstance(ext, dict) else {}
+        return (dict(ext) if isinstance(ext, dict) else {}, ext)
 
     def _read_codefuse_token(self, *, bot_id: str, bot: Any) -> str | None:
         if not isinstance(bot, dict):
@@ -722,6 +919,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
         self._registry.register(
             BaasRestartPublishPollHandler(
                 binding_repository=self._binding_repository,
+                baas_service=self._baas_service,
                 baas_device_service=self._baas_device_service,
                 bot_repository=self._bot_repository,
                 publish_repository=self._publish_repository,

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -365,34 +365,12 @@ class BaasRestartPublishPollHandler:
             publish_id=publish_id,
             payload_value=image_policy_on_success,
         )
-        if (
-            binding is not None
-            and getattr(binding, "status", None) == DeviceBindingStatus.ACTIVE.value
-            and getattr(binding, "device_provider", None) == "baas"
-            and _payload_publish_id_matches(
-                binding,
-                publish_id,
-                "restart_publish_id",
-            )
-        ):
-            return self._finalize_success(
-                binding_id=binding_id,
-                bot_id=bot_id,
-                owner_id=owner_id,
-                publish_id=publish_id,
-                image_policy_on_success=image_policy_on_success,
-            )
         preflight = self._preflight(binding=binding, publish_id=publish_id)
         if preflight is not None:
             return preflight
         bot = None
         if self._bot_repository is not None:
             bot = self._bot_repository.get_by_binding_id(binding_id)
-        if isinstance(bot, dict) and bot.get("status") in {
-            DeviceBindingStatus.ACTIVE.value,
-            DeviceBindingStatus.FAILED.value,
-        }:
-            return Complete()
         if _business_timed_out(
             started_at_epoch_s=started_at_epoch_s,
             timeout_s=_RESTART_PUBLISH_TIMEOUT_SECONDS,
@@ -462,11 +440,17 @@ class BaasRestartPublishPollHandler:
 
     @staticmethod
     def _preflight(*, binding: Any, publish_id: int) -> TaskOutcome | None:
-        if _binding_is_terminal(binding):
+        if binding is None:
             return Complete()
         if getattr(binding, "device_provider", None) != "baas":
             return Complete()
         if not _payload_publish_id_matches(binding, publish_id, "restart_publish_id"):
+            return Complete()
+        # ACTIVE can belong to the runtime that existed before this restart.
+        # It is therefore not proof that the current BaaS publish succeeded;
+        # matching restart tasks must still poll that publish. FAILED remains a
+        # terminal persisted result for the current binding.
+        if getattr(binding, "status", None) == DeviceBindingStatus.FAILED.value:
             return Complete()
         return None
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -27,6 +27,8 @@ from agentclaw.community.log import get_logger
 BAAS_CREATE_PUBLISH_POLL_TASK = "baas.create.publish_poll"
 BAAS_CREATE_INIT_TASK = "baas.create.init"
 BAAS_RESTART_PUBLISH_POLL_TASK = "baas.restart.publish_poll"
+RESTART_IMAGE_POLICY_ON_SUCCESS_KEY = "restart_image_policy_on_success"
+_DEFAULT_IMAGE_POLICY_VALUE = "default"
 _CREATE_PUBLISH_TIMEOUT_SECONDS = 600
 _RESTART_PUBLISH_TIMEOUT_SECONDS = 600
 _CREATE_INIT_DEADLINE_SECONDS = 86400
@@ -358,6 +360,11 @@ class BaasRestartPublishPollHandler:
         ) = parsed
 
         binding = self._binding_repository.get_by_id(binding_id)
+        image_policy_on_success = self._resolve_image_policy_on_success(
+            binding=binding,
+            publish_id=publish_id,
+            payload_value=image_policy_on_success,
+        )
         if (
             binding is not None
             and getattr(binding, "status", None) == DeviceBindingStatus.ACTIVE.value
@@ -439,6 +446,21 @@ class BaasRestartPublishPollHandler:
             return Fail(f"invalid payload: {exc}")
 
     @staticmethod
+    def _resolve_image_policy_on_success(
+        *,
+        binding: Any,
+        publish_id: int,
+        payload_value: str | None,
+    ) -> str | None:
+        """Read the restart intent from Binding, with old-task compatibility."""
+        if _payload_publish_id_matches(binding, publish_id, "restart_publish_id"):
+            props = getattr(binding, "device_props", None) or {}
+            if RESTART_IMAGE_POLICY_ON_SUCCESS_KEY in props:
+                value = props.get(RESTART_IMAGE_POLICY_ON_SUCCESS_KEY)
+                return value if isinstance(value, str) else None
+        return payload_value
+
+    @staticmethod
     def _preflight(*, binding: Any, publish_id: int) -> TaskOutcome | None:
         if _binding_is_terminal(binding):
             return Complete()
@@ -516,7 +538,7 @@ class BaasRestartPublishPollHandler:
         publish_id: int,
         image_policy_on_success: str | None,
     ) -> TaskOutcome:
-        if image_policy_on_success == "default":
+        if image_policy_on_success == _DEFAULT_IMAGE_POLICY_VALUE:
             if self._bot_repository is None or self._publish_repository is None:
                 return Retry("default-image persistence service unavailable")
             try:
@@ -526,6 +548,12 @@ class BaasRestartPublishPollHandler:
                     bot_id=bot_id,
                     owner_id=owner_id,
                     env=get_current_env(),
+                )
+                # Clear only after Bot + Draft have accepted DEFAULT. Failure
+                # keeps the durable intent for task replay/process recovery.
+                self._binding_repository.update_device_props(
+                    binding_id=binding_id,
+                    props={RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: None},
                 )
             except Exception as exc:
                 logger.warning(

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -16,7 +16,7 @@ import json
 import secrets
 import threading
 import uuid
-from typing import Callable, Literal, Optional, TYPE_CHECKING, TypeVar
+from typing import Callable, Literal, Optional, TYPE_CHECKING, TypeVar, Any
 
 if TYPE_CHECKING:
     from agentclaw.community.core.bot_management.services.data_init_service import DataInitService
@@ -538,6 +538,7 @@ class DeviceService:
         admins: list[str] | None = None,
         template_type: str | None = None,
         template_config: dict | None = None,
+        device_props_extra: dict[str, Any] | None = None,
     ) -> DeviceBindingRecord | None:
         """Apply for a device — template method with provider hooks.
 
@@ -565,6 +566,7 @@ class DeviceService:
             admins: List of admin user IDs
             template_type: Template type
             template_config: Template configuration
+            device_props_extra: Lifecycle metadata persisted with the binding.
         """
         # Resolve parameters
         resolved_entity_id = entity_id if entity_id else operator.staff_id
@@ -654,6 +656,7 @@ class DeviceService:
             "symbol": json.dumps(symbol_json, ensure_ascii=False) if symbol else "[]",
             "entity_id": resolved_entity_id,
             "entity_type": resolved_entity_type,
+            **(device_props_extra or {}),
         }
         # 4. Process database record
         status = DeviceBindingStatus.PENDING.value

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -307,6 +307,7 @@ class DeviceServiceRouter(DeviceService):
         admins: list[str] | None = None,
         template_type: str | None = None,
         template_config: dict | None = None,
+        device_props_extra: dict[str, Any] | None = None,
     ):
         """申请新设备 - 根据员工工号 + bot 属性路由到对应 Provider.
 
@@ -378,6 +379,7 @@ class DeviceServiceRouter(DeviceService):
             admins=admins,
             template_type=template_type,
             template_config=template_config,
+            device_props_extra=device_props_extra,
         )
 
     @override

--- a/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/local_device_service.py
@@ -614,6 +614,7 @@ class LocalDeviceService(DeviceService):
         admins: list[str] | None = None,
         template_type: str | None = None,
         template_config: dict | None = None,
+        device_props_extra: dict[str, Any] | None = None,
     ):
         """Apply for a device — singlebox mode backed by BaaS.
 
@@ -669,6 +670,7 @@ class LocalDeviceService(DeviceService):
             **allocated.device_props,
             "nas_mappings": json.dumps([], ensure_ascii=False),
             "symbol": json.dumps([s.to_dict() for s in symbol]) if symbol else "[]",
+            **(device_props_extra or {}),
         }
 
         # Start as PENDING — transitions to ACTIVE when BaasPublishPoller

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -58,14 +58,7 @@ from agentclaw.community.core.service_bot.services.baas_service import (
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    IMAGE_POLICY_KEYS,
-    ImagePolicyState,
-    ServiceBotImagePin,
-    has_explicit_image_policy,
-    resolve_publish_image_pin,
-)
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
+    PublishImagePolicyResolver,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
@@ -111,56 +104,17 @@ class ExpertChatInstanceService:
         self._token_provider = token_provider
         self._runtime_updater = runtime_updater
         self._common_config_service = common_config_service
+        self._image_policy_resolver = PublishImagePolicyResolver(
+            publish_repository=bot_publish_repo,
+            binding_repository=binding_repo,
+            common_config_service=common_config_service,
+        )
 
     def _resolve_publish_image_pin(
-        self,
-        publish_record,
-        *,
-        bot_id: str,
-        owner_id: str,
+        self, publish_record, *, bot_id: str | None = None, owner_id: str | None = None
     ):
-        """Resolve a caller container from its SUCCESS publish snapshot."""
-        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
-        if (
-            isinstance(bot, dict)
-            and self._baas.resolve_container_provider(bot)
-            == TECLAW_DEVICE_PROVIDER
-        ):
-            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
-        was_legacy = not has_explicit_image_policy(publish_record.ext)
-
-        def _persist(snapshot: dict) -> None:
-            latest = self._publish_repo.get_by_id(publish_record.id)
-            if latest is None or has_explicit_image_policy(latest.ext):
-                return
-            latest_ext = dict(latest.ext or {})
-            for key in IMAGE_POLICY_KEYS:
-                if key in snapshot:
-                    latest_ext[key] = snapshot[key]
-            updated = self._publish_repo.update_status_with_ext(
-                publish_id=latest.id,
-                target_status=latest.status,
-                ext=latest_ext,
-                source_status=latest.status,
-            )
-            if updated is None:
-                raise ConnectionError(
-                    f"Publish image policy changed concurrently: publish_id={latest.id}"
-                )
-
-        resolved = resolve_publish_image_pin(
-            publish_record,
-            common_config_service=self._common_config_service,
-            env=get_current_env(),
-            persist_ext=_persist,
-        )
-        if was_legacy and resolved.enabled:
-            latest = self._publish_repo.get_by_id(publish_record.id)
-            if latest is not None:
-                publish_record.ext = latest.ext
-                return resolve_publish_image_pin(latest)
-        return resolved
+        """Resolve through the shared seam; legacy caller args are ignored."""
+        return self._image_policy_resolver.resolve(publish_record)
 
     # ------------------------------------------------------------------
     # Public entry
@@ -200,11 +154,7 @@ class ExpertChatInstanceService:
             bot_id, owner_id
         )
         version = publish_record.version or 1
-        image_pin = self._resolve_publish_image_pin(
-            publish_record,
-            bot_id=bot_id,
-            owner_id=owner_id,
-        )
+        image_pin = self._resolve_publish_image_pin(publish_record)
 
         # --- Step 1: look up / create instance row ---
         instance = self._instance_repo.get_instance(user_id, bot_id, owner_id)

--- a/src/backend/src/agentclaw/community/core/service_bot/repository/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/bot_publish_repository.py
@@ -261,6 +261,20 @@ class BotPublishRepositoryProtocol(Protocol):
         """
         ...
 
+    def compare_and_set_ext(
+        self,
+        *,
+        publish_id: int,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[BotPublishRecord]:
+        """Atomically replace ``ext`` only when its full stored value is unchanged.
+
+        Unlike ``update_status_with_ext``, this CAS protects same-status writers
+        (Restart/Scale/Caller) from overwriting one another.
+        """
+        ...
+
     def rollback_flip(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/service_bot/repository/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/bot_publish_repository.py
@@ -275,6 +275,18 @@ class BotPublishRepositoryProtocol(Protocol):
         """
         ...
 
+    def compare_and_set_status_with_ext(
+        self,
+        *,
+        publish_id: int,
+        source_status: str,
+        target_status: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[BotPublishRecord]:
+        """Atomically replace status and ext when both snapshots still match."""
+        ...
+
     def rollback_flip(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
@@ -68,17 +68,14 @@ def resolve_current_arka_image(
     common_config_service: CommonConfigService | None,
     *,
     env: str,
-) -> str:
+) -> str | None:
     """Return the enabled legacy-protection image.
 
-    Historical ARKA publishes have no safe fallback: missing, disabled, and
-    malformed configuration all fail closed so they cannot silently move to the
-    platform default image.
+    Missing/disabled means the feature is not active and preserves the historical
+    platform-default behavior. An enabled but malformed value fails closed.
     """
     if common_config_service is None:
-        raise ImagePinConfigError(
-            f"{IMAGE_PIN_PARAM_CODE} config service is unavailable: env={env}"
-        )
+        return None
     value = common_config_service.get_value(
         business_code=IMAGE_PIN_BUSINESS_CODE,
         param_code=IMAGE_PIN_PARAM_CODE,
@@ -87,9 +84,7 @@ def resolve_current_arka_image(
         only_enabled=True,
     )
     if value is None:
-        raise ImagePinConfigError(
-            f"{IMAGE_PIN_PARAM_CODE} config is missing or disabled: env={env}"
-        )
+        return None
     image = value.get("image") if isinstance(value, dict) else None
     if isinstance(image, str) and image.strip():
         return image.strip()
@@ -244,6 +239,9 @@ def resolve_publish_image_pin(
         common_config_service,
         env=env or publish_record.env,
     )
+    if image is None:
+        return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
     pinned_ext = apply_image_pin_to_ext(ext, image)
     if persist_ext is not None:
         persist_ext(pinned_ext)
@@ -349,6 +347,10 @@ class PublishImagePolicyResolver:
             image = resolve_current_arka_image(
                 self._common_config_service, env=latest.env
             )
+            if image is None:
+                publish_record.ext = latest.ext
+                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
             pinned_ext = apply_image_pin_to_ext(latest.ext, image)
             updated = self._publish_repository.compare_and_set_ext(
                 publish_id=latest.id,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
@@ -27,6 +27,11 @@ IMAGE_POLICY_KEYS = (
     IMAGE_PIN_ENABLED_KEY,
     IMAGE_PIN_VALUE_KEY,
 )
+SERVICE_BOT_RUNTIME_KIND_KEY = "sbot_runtime_kind"
+RUNTIME_KIND_ARKA = "arka"
+RUNTIME_KIND_TECLAW = "teclaw"
+_RUNTIME_KINDS = {RUNTIME_KIND_ARKA, RUNTIME_KIND_TECLAW}
+
 
 
 class ImagePolicyState(str, Enum):
@@ -37,6 +42,10 @@ class ImagePolicyState(str, Enum):
 
 class ImagePinConfigError(ValueError):
     """Enabled image-pin configuration or snapshot is malformed."""
+
+
+class ImagePinPersistenceError(RuntimeError):
+    """A legacy publish image could not be durably snapshotted."""
 
 
 @dataclass(frozen=True)
@@ -83,6 +92,62 @@ def resolve_current_arka_image(
     raise ImagePinConfigError(
         f"Enabled {IMAGE_PIN_PARAM_CODE} config has no valid image: env={env}"
     )
+
+
+def runtime_kind_from_provider(device_provider: str | None) -> str | None:
+    if device_provider == RUNTIME_KIND_TECLAW:
+        return RUNTIME_KIND_TECLAW
+    if device_provider in {"arca", "baas"}:
+        return RUNTIME_KIND_ARKA
+    return None
+
+
+def apply_runtime_kind_to_ext(
+    ext: dict[str, Any] | None, runtime_kind: str | None
+) -> dict[str, Any] | None:
+    updated = dict(ext or {})
+    if runtime_kind in _RUNTIME_KINDS:
+        updated[SERVICE_BOT_RUNTIME_KIND_KEY] = runtime_kind
+    return updated or None
+
+
+def resolve_publish_runtime_kind(
+    publish_record: BotPublishRecord,
+    *,
+    binding_repository: Any | None = None,
+) -> str:
+    """Resolve runtime only from immutable publish-owned facts.
+
+    New records carry ``sbot_runtime_kind``. Historical TeClaw records are
+    recognized from their config artifact or stage bindings; the final fallback
+    is ARKA because ARKA predates the external-runtime publish format.
+    """
+    ext = publish_record.ext or {}
+    explicit = ext.get(SERVICE_BOT_RUNTIME_KIND_KEY)
+    if explicit in _RUNTIME_KINDS:
+        return explicit
+
+    artifact = ext.get("config_artifact")
+    if isinstance(artifact, dict) and artifact.get("engine_type") == RUNTIME_KIND_TECLAW:
+        return RUNTIME_KIND_TECLAW
+
+    binding_ids = (ext.get("binding") or {}).values() if isinstance(ext.get("binding"), dict) else ()
+    if binding_repository is not None:
+        for binding_id in binding_ids:
+            try:
+                resolved_binding_id = int(binding_id)
+            except (TypeError, ValueError):
+                continue
+            binding = binding_repository.get_by_id(resolved_binding_id)
+            kind = runtime_kind_from_provider(getattr(binding, "device_provider", None))
+            if kind is not None:
+                return kind
+
+    logger.warning(
+        "[arka_image_pin] publish runtime kind missing; using legacy ARKA fallback: publish_id=%s",
+        publish_record.id,
+    )
+    return RUNTIME_KIND_ARKA
 
 
 def has_explicit_image_policy(ext: dict[str, Any] | None) -> bool:
@@ -189,6 +254,105 @@ def resolve_publish_image_pin(
         image,
     )
     return ServiceBotImagePin(ImagePolicyState.PINNED, image)
+
+
+def persist_default_image_policy(
+    *,
+    bot_repository: Any,
+    publish_repository: Any,
+    bot_id: str,
+    owner_id: str,
+    env: str,
+    max_cas_attempts: int = 3,
+) -> None:
+    """Idempotently persist DEFAULT to the current Bot and Draft after success."""
+    bot = bot_repository.get_by_id_and_owner(bot_id, owner_id)
+    if not isinstance(bot, dict):
+        raise ImagePinPersistenceError(f"Bot not found while persisting image policy: {bot_id}")
+    updated_bot_ext = apply_default_image_to_ext(bot.get("ext"))
+    if not bot_repository.update_by_owner(bot_id, owner_id, {"ext": updated_bot_ext}):
+        raise ImagePinPersistenceError(f"Bot image policy update conflicted: {bot_id}")
+
+    for _attempt in range(max_cas_attempts):
+        draft = publish_repository.get_draft_by_publish_bot_id(
+            publish_bot_id=bot_id, env=env
+        )
+        if draft is None:
+            return
+        draft_ext = copy_image_policy_to_ext(updated_bot_ext, draft.ext) or {}
+        if draft_ext == (draft.ext or {}):
+            return
+        updated = publish_repository.compare_and_set_ext(
+            publish_id=draft.id, expected_ext=draft.ext, ext=draft_ext
+        )
+        if updated is not None:
+            return
+    raise ImagePinPersistenceError(
+        f"Draft image policy CAS conflicted repeatedly: bot_id={bot_id}"
+    )
+
+
+class PublishImagePolicyResolver:
+    """Shared persisted resolver used by publish flows and caller containers."""
+
+    def __init__(
+        self,
+        *,
+        publish_repository: Any,
+        binding_repository: Any,
+        common_config_service: CommonConfigService | None,
+        max_cas_attempts: int = 3,
+    ) -> None:
+        self._publish_repository = publish_repository
+        self._binding_repository = binding_repository
+        self._common_config_service = common_config_service
+        self._max_cas_attempts = max_cas_attempts
+
+    def resolve(self, publish_record: BotPublishRecord) -> ServiceBotImagePin:
+        """Return only an explicit policy or a legacy decision persisted by CAS."""
+        for _attempt in range(self._max_cas_attempts):
+            latest = self._publish_repository.get_by_id(publish_record.id)
+            if latest is None:
+                raise ImagePinPersistenceError(
+                    f"Publish record disappeared while resolving image policy: {publish_record.id}"
+                )
+            if resolve_publish_runtime_kind(
+                latest, binding_repository=self._binding_repository
+            ) == RUNTIME_KIND_TECLAW:
+                publish_record.ext = latest.ext
+                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+            if has_explicit_image_policy(latest.ext):
+                publish_record.ext = latest.ext
+                return resolve_publish_image_pin(latest)
+
+            image = resolve_current_arka_image(
+                self._common_config_service, env=latest.env
+            )
+            if image is None:
+                publish_record.ext = latest.ext
+                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+
+            pinned_ext = apply_image_pin_to_ext(latest.ext, image)
+            updated = self._publish_repository.compare_and_set_ext(
+                publish_id=latest.id,
+                expected_ext=latest.ext,
+                ext=pinned_ext,
+            )
+            if updated is not None:
+                publish_record.ext = updated.ext
+                logger.info(
+                    "[arka_image_pin] snapshotted legacy publish image: "
+                    "publish_id=%s env=%s image=%s",
+                    updated.id,
+                    updated.env,
+                    image,
+                )
+                return resolve_publish_image_pin(updated)
+
+        raise ImagePinPersistenceError(
+            f"Publish image policy CAS conflicted repeatedly: publish_id={publish_record.id}"
+        )
 
 
 def overlay_image_pin_on_template_config(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arka_image_pin.py
@@ -68,15 +68,17 @@ def resolve_current_arka_image(
     common_config_service: CommonConfigService | None,
     *,
     env: str,
-) -> str | None:
+) -> str:
     """Return the enabled legacy-protection image.
 
-    Missing/disabled configuration returns ``None``. An enabled but malformed
-    value fails closed so a historical bot is not silently moved to the current
-    default image.
+    Historical ARKA publishes have no safe fallback: missing, disabled, and
+    malformed configuration all fail closed so they cannot silently move to the
+    platform default image.
     """
     if common_config_service is None:
-        return None
+        raise ImagePinConfigError(
+            f"{IMAGE_PIN_PARAM_CODE} config service is unavailable: env={env}"
+        )
     value = common_config_service.get_value(
         business_code=IMAGE_PIN_BUSINESS_CODE,
         param_code=IMAGE_PIN_PARAM_CODE,
@@ -85,7 +87,9 @@ def resolve_current_arka_image(
         only_enabled=True,
     )
     if value is None:
-        return None
+        raise ImagePinConfigError(
+            f"{IMAGE_PIN_PARAM_CODE} config is missing or disabled: env={env}"
+        )
     image = value.get("image") if isinstance(value, dict) else None
     if isinstance(image, str) and image.strip():
         return image.strip()
@@ -240,9 +244,6 @@ def resolve_publish_image_pin(
         common_config_service,
         env=env or publish_record.env,
     )
-    if image is None:
-        return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
     pinned_ext = apply_image_pin_to_ext(ext, image)
     if persist_ext is not None:
         persist_ext(pinned_ext)
@@ -266,12 +267,31 @@ def persist_default_image_policy(
     max_cas_attempts: int = 3,
 ) -> None:
     """Idempotently persist DEFAULT to the current Bot and Draft after success."""
-    bot = bot_repository.get_by_id_and_owner(bot_id, owner_id)
-    if not isinstance(bot, dict):
-        raise ImagePinPersistenceError(f"Bot not found while persisting image policy: {bot_id}")
-    updated_bot_ext = apply_default_image_to_ext(bot.get("ext"))
-    if not bot_repository.update_by_owner(bot_id, owner_id, {"ext": updated_bot_ext}):
-        raise ImagePinPersistenceError(f"Bot image policy update conflicted: {bot_id}")
+    updated_bot_ext: dict[str, Any] | None = None
+    for _attempt in range(max_cas_attempts):
+        bot = bot_repository.get_by_id_and_owner(bot_id, owner_id)
+        if not isinstance(bot, dict):
+            raise ImagePinPersistenceError(
+                f"Bot not found while persisting image policy: {bot_id}"
+            )
+        current_bot_ext = bot.get("ext")
+        updated_bot_ext = apply_default_image_to_ext(current_bot_ext)
+        if updated_bot_ext == (current_bot_ext or {}):
+            break
+        updated_bot = bot_repository.compare_and_set_ext(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            expected_ext=current_bot_ext,
+            ext=updated_bot_ext,
+        )
+        if updated_bot is not None:
+            break
+    else:
+        raise ImagePinPersistenceError(
+            f"Bot image policy CAS conflicted repeatedly: {bot_id}"
+        )
+
+    assert updated_bot_ext is not None
 
     for _attempt in range(max_cas_attempts):
         draft = publish_repository.get_draft_by_publish_bot_id(
@@ -329,10 +349,6 @@ class PublishImagePolicyResolver:
             image = resolve_current_arka_image(
                 self._common_config_service, env=latest.env
             )
-            if image is None:
-                publish_record.ext = latest.ext
-                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
             pinned_ext = apply_image_pin_to_ext(latest.ext, image)
             updated = self._publish_repository.compare_and_set_ext(
                 publish_id=latest.id,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -456,6 +456,7 @@ class BotBuildService:
         ext_info: Optional[Dict[str, Any]] = None,
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
+        runtime_kind: str | None = None,
     ) -> Dict[str, Any]:
         """发布 Bot 到 BaaS 层。
 
@@ -507,13 +508,15 @@ class BotBuildService:
             logger.warning(
                 f"[BotBuildService.release] queryToken failed: bot_id={bot_id}, "
                 f"owner_id={owner_id}, error={e}"
-            )
+        )
 
         try:
-            is_teclaw_release = (
-                self._baas_service.resolve_container_provider(bot)
-                == TECLAW_DEVICE_PROVIDER
+            resolved_runtime_kind = (
+                runtime_kind
+                if runtime_kind is not None
+                else self._baas_service.resolve_container_provider(bot)
             )
+            is_teclaw_release = resolved_runtime_kind == TECLAW_DEVICE_PROVIDER
             if is_teclaw_release:
                 # teclaw: non-mount delivery — hand the frozen artifact to BaaS,
                 # which forwards it to the external container. No migration_path.
@@ -581,6 +584,7 @@ class BotBuildService:
         ext_info: Optional[Dict[str, Any]] = None,
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
+        runtime_kind: str | None = None,
     ) -> Dict[str, Any]:
         """异步发布 Bot 到 BaaS 层。
 
@@ -620,6 +624,7 @@ class BotBuildService:
             ext_info=ext_info,
             extra_envs=extra_envs,
             docker_image=docker_image,
+            runtime_kind=runtime_kind,
         )
 
     def _sync_skill_links(
@@ -1078,6 +1083,7 @@ class BotBuildService:
             delivery: DeliveryArtifact = DeliveryArtifact(None),
             extra_envs: Optional[Dict[str, Any]] = None,
             docker_image: str | None = None,
+            runtime_kind: str | None = None,
     ) -> Dict[str, Any]:
         """升级 Bot 到 BaaS 层（复用现有 Bot）。
 
@@ -1111,10 +1117,13 @@ class BotBuildService:
         )
 
         try:
-            if (
-                self._baas_service.resolve_container_provider(bot)
-                == TECLAW_DEVICE_PROVIDER
-            ):
+            resolved_runtime_kind = (
+                runtime_kind
+                if runtime_kind is not None
+                else self._baas_service.resolve_container_provider(bot)
+            )
+            is_teclaw_upgrade = resolved_runtime_kind == TECLAW_DEVICE_PROVIDER
+            if is_teclaw_upgrade:
                 # teclaw re-publish: re-deliver the frozen artifact to the
                 # existing container (non-mount). No migration_path. The artifact
                 # IS the delivery payload, so fail loudly if it is missing rather
@@ -1571,6 +1580,7 @@ class BotBuildService:
         delivery: DeliveryArtifact = DeliveryArtifact(None),
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
+        runtime_kind: str | None = None,
     ) -> Dict[str, Any]:
         """异步升级 Bot 到 BaaS 层。
 
@@ -1594,4 +1604,5 @@ class BotBuildService:
             delivery=delivery,
             extra_envs=extra_envs,
             docker_image=docker_image,
+            runtime_kind=runtime_kind,
         )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -1,4 +1,5 @@
 """Bot Publish Service - Bot发布服务业务逻辑层。"""
+import copy
 import threading
 from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
 
@@ -36,6 +37,7 @@ from agentclaw.community.core.service_bot.services.arka_image_pin import (
     RUNTIME_KIND_TECLAW,
     PublishImagePolicyResolver,
     ServiceBotImagePin,
+    resolve_publish_runtime_kind,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -343,6 +345,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         target_status: str,
         ext: Dict[str, Any],
         source_status: str,
+        expected_ext: Optional[Dict[str, Any]],
     ) -> BotPublishRecord:
         """更新发布记录状态和扩展字段（乐观锁）。
 
@@ -358,7 +361,13 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         Raises:
             PublishNotFoundError: 发布记录不存在或源状态不匹配
         """
-        record = self._repo.update_status_with_ext(publish_id, target_status, ext, source_status)
+        record = self._repo.compare_and_set_status_with_ext(
+            publish_id=publish_id,
+            source_status=source_status,
+            target_status=target_status,
+            expected_ext=expected_ext,
+            ext=ext,
+        )
         if not record:
             raise PublishNotFoundError(
                 f"Publish record not found or source status mismatch: "
@@ -371,11 +380,13 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         self,
         publish_id: int,
         ext: Dict[str, Any],
+        *,
+        expected_ext: Optional[Dict[str, Any]],
     ) -> BotPublishRecord:
         """仅更新发布记录的扩展字段（不更新状态）。
 
-        使用乐观锁：先读取当前状态，再以该状态作为 source_status 更新。
-        如果期间状态被并发修改，更新会失败并抛出异常。
+        使用调用方读取到的完整 ``expected_ext`` 做 compare-and-set；如果
+        期间任意并发写入改变了 ext，更新失败并抛出异常。
 
         Args:
             publish_id: 发布记录 ID
@@ -387,31 +398,58 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         Raises:
             PublishNotFoundError: 发布记录不存在或状态已被并发修改
         """
-        record = self._repo.get_by_id(publish_id)
-        if not record:
-            raise PublishNotFoundError(f"Publish record not found: {publish_id}")
-
-        current_status = record.status
-        updated_record = self._repo.update_status_with_ext(
+        updated_record = self._repo.compare_and_set_ext(
             publish_id=publish_id,
-            target_status=current_status,
+            expected_ext=expected_ext,
             ext=ext,
-            source_status=current_status,
         )
         if not updated_record:
             raise PublishNotFoundError(
-                f"Publish record not found or status changed concurrently: "
-                f"publish_id={publish_id}, expected source_status={current_status}"
+                f"Publish record not found or ext changed concurrently: "
+                f"publish_id={publish_id}"
             )
 
         logger.info(f"[update_publish_ext] id={publish_id}, ext updated")
         return updated_record
+
+    def mutate_publish_ext(
+        self,
+        publish_id: int,
+        mutator: Callable[[Dict[str, Any]], None],
+        *,
+        max_cas_attempts: int = 3,
+    ) -> BotPublishRecord:
+        """Apply a mutation to the latest ext and retry bounded CAS conflicts."""
+        for _attempt in range(max_cas_attempts):
+            record = self._repo.get_by_id(publish_id)
+            if record is None:
+                raise PublishNotFoundError(f"Publish record not found: {publish_id}")
+            expected_ext = copy.deepcopy(record.ext)
+            updated_ext = copy.deepcopy(record.ext or {})
+            mutator(updated_ext)
+            updated = self._repo.compare_and_set_ext(
+                publish_id=publish_id,
+                expected_ext=expected_ext,
+                ext=updated_ext,
+            )
+            if updated is not None:
+                return updated
+        raise BotPublishServiceError(
+            f"Publish ext CAS conflicted repeatedly: publish_id={publish_id}"
+        )
 
     def resolve_publish_image_pin(
         self, publish_record: BotPublishRecord
     ) -> ServiceBotImagePin:
         """Resolve image policy through the shared persisted-CAS seam."""
         return self._image_policy_resolver.resolve(publish_record)
+
+    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str:
+        """Resolve provider identity only from Publish-owned persisted facts."""
+        return resolve_publish_runtime_kind(
+            publish_record,
+            binding_repository=self._device_binding_repo,
+        )
 
     def record_draft_artifact(
         self, *, bot_id: str, artifact: Dict[str, Any]
@@ -425,8 +463,9 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         )
         if not record:
             return False
-        self.update_publish_ext(
-            record.id, {**(record.ext or {}), "config_artifact": artifact}
+        self.mutate_publish_ext(
+            record.id,
+            lambda ext: ext.__setitem__("config_artifact", artifact),
         )
         return True
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -30,6 +30,12 @@ from agentclaw.community.core.service_bot.services.arka_image_pin import (
     copy_image_policy_to_ext,
     has_explicit_image_policy,
     resolve_current_arka_image,
+    apply_runtime_kind_to_ext,
+    runtime_kind_from_provider,
+    RUNTIME_KIND_ARKA,
+    RUNTIME_KIND_TECLAW,
+    PublishImagePolicyResolver,
+    ServiceBotImagePin,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -75,6 +81,11 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         self._task_queue_service = task_queue_service
         self._bot_process_registry = bot_process_registry
         self._common_config_service = common_config_service
+        self._image_policy_resolver = PublishImagePolicyResolver(
+            publish_repository=bot_publish_repo,
+            binding_repository=device_binding_repo,
+            common_config_service=common_config_service,
+        )
         self._env = get_current_env()
 
     def create_device_binding(
@@ -224,6 +235,21 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             source_bot.get("ext") if isinstance(source_bot, dict) else None
         )
         ext = copy_image_policy_to_ext(source_bot_ext, ext)
+        if isinstance(source_bot, dict) and source_bot.get("bot_type") == "service":
+            runtime_kind = None
+            binding_id = source_bot.get("binding_id")
+            if isinstance(binding_id, int):
+                binding = self._device_binding_repo.get_by_id(binding_id)
+                runtime_kind = runtime_kind_from_provider(
+                    getattr(binding, "device_provider", None)
+                )
+            if runtime_kind is None:
+                runtime_kind = (
+                    RUNTIME_KIND_TECLAW
+                    if self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
+                    else RUNTIME_KIND_ARKA
+                )
+            ext = apply_runtime_kind_to_ext(ext, runtime_kind)
 
         # A new/default Bot carries an explicit marker and never consumes the
         # legacy Pin switch. A pre-feature ARKA Bot has no policy marker; when
@@ -380,6 +406,12 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
 
         logger.info(f"[update_publish_ext] id={publish_id}, ext updated")
         return updated_record
+
+    def resolve_publish_image_pin(
+        self, publish_record: BotPublishRecord
+    ) -> ServiceBotImagePin:
+        """Resolve image policy through the shared persisted-CAS seam."""
+        return self._image_policy_resolver.resolve(publish_record)
 
     def record_draft_artifact(
         self, *, bot_id: str, artifact: Dict[str, Any]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_approval_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_approval_service.py
@@ -6,6 +6,7 @@ get Owner approval before publishing or unpublishing.
 """
 from __future__ import annotations
 
+import copy
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, Literal, Optional
 
@@ -98,7 +99,8 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
         Args:
             publish_record: The bot publish record
         """
-        ext = publish_record.ext or {}
+        expected_ext = copy.deepcopy(publish_record.ext)
+        ext = copy.deepcopy(publish_record.ext or {})
         approval = ext.get("approval")
 
         if not approval:
@@ -126,7 +128,9 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
 
         ext["approval_history"] = history
         ext["approval"] = None
-        self._publish_service.update_publish_ext(publish_record.id, ext)
+        self._publish_service.update_publish_ext(
+            publish_record.id, ext, expected_ext=expected_ext
+        )
 
         logger.info(
             "[_archive_approval] archived: publish_id=%s, history_count=%d",
@@ -235,9 +239,12 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
             "approval_url": approval_result.get("approval_url"),
             "created_at": datetime.now().isoformat(),
         }
-        ext = publish_record.ext or {}
+        expected_ext = copy.deepcopy(publish_record.ext)
+        ext = copy.deepcopy(publish_record.ext or {})
         ext["approval"] = new_approval
-        self._publish_service.update_publish_ext(publish_record.id, ext)
+        self._publish_service.update_publish_ext(
+            publish_record.id, ext, expected_ext=expected_ext
+        )
 
         logger.info(
             "[_create_new_approval] created: publish_id=%s, puid=%s",
@@ -329,7 +336,7 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
             )
 
         # 2. Get current approval and status
-        ext = publish_record.ext or {}
+        ext = copy.deepcopy(publish_record.ext or {})
         approval = ext.get("approval")
         current_status = approval.get("status") if approval else None
 
@@ -490,7 +497,8 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
             return {"success": False, "message": f"Publish not found: {publish_id}"}
 
         # 2. Validate approval record
-        ext = publish_record.ext or {}
+        expected_ext = copy.deepcopy(publish_record.ext)
+        ext = copy.deepcopy(publish_record.ext or {})
         approval = ext.get("approval")
 
         if not approval:
@@ -519,7 +527,9 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
         approval["status"] = new_status
         approval["processed_at"] = datetime.now().isoformat()
         ext["approval"] = approval
-        self._publish_service.update_publish_ext(publish_id, ext)
+        self._publish_service.update_publish_ext(
+            publish_id, ext, expected_ext=expected_ext
+        )
 
         logger.info(
             "[handle_approval_callback] updated: publish_id=%s, status=%s",
@@ -655,12 +665,15 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
                 # Re-fetch to get latest ext
                 updated_record = self._publish_service.get_publish_by_id(publish_id)
                 if updated_record:
-                    ext = updated_record.ext or {}
+                    expected_ext = copy.deepcopy(updated_record.ext)
+                    ext = copy.deepcopy(updated_record.ext or {})
                     approval = ext.get("approval")
                     if approval:
                         approval["status"] = "EXECUTED"
                         ext["approval"] = approval
-                        self._publish_service.update_publish_ext(publish_id, ext)
+                        self._publish_service.update_publish_ext(
+                            publish_id, ext, expected_ext=expected_ext
+                        )
                         logger.info(
                             "[_trigger_online_release] marked EXECUTED: publish_id=%s",
                             publish_id,
@@ -724,12 +737,15 @@ class PublishApprovalService(PublishApprovalServiceProtocol):
                 # Re-fetch to get latest ext
                 updated_record = self._publish_service.get_publish_by_id(publish_id)
                 if updated_record:
-                    ext = updated_record.ext or {}
+                    expected_ext = copy.deepcopy(updated_record.ext)
+                    ext = copy.deepcopy(updated_record.ext or {})
                     approval = ext.get("approval")
                     if approval:
                         approval["status"] = "EXECUTED"
                         ext["approval"] = approval
-                        self._publish_service.update_publish_ext(publish_id, ext)
+                        self._publish_service.update_publish_ext(
+                            publish_id, ext, expected_ext=expected_ext
+                        )
                         logger.info(
                             "[_trigger_offline] marked EXECUTED: publish_id=%s",
                             publish_id,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
@@ -106,13 +106,14 @@ class BuildStageRunner:
             # Build succeeded: merge the artifact pointers into ext (ARCA =
             # migration_path/build_target_path; external = config_artifact/
             # content_hash/engine_ext).
-            ext = self._ext_state.get_latest_ext(publish_id)
+            ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
             ext.update(artifact.ext)
             self._ext_state.update_status(
                 publish_id=publish_id,
                 target_status=PublishStatus.BUILT,
                 source_status=PublishStatus.BUILDING,
                 ext=ext,
+                expected_ext=expected_ext,
             )
 
             logger.info(
@@ -130,7 +131,7 @@ class BuildStageRunner:
         except Exception as e:
             logger.error("[BuildStageRunner] Build failed: %s", e)
 
-            ext = self._ext_state.get_latest_ext(publish_id)
+            ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
             PublishExtState.clear_retry_flag(ext)
             ext["error_message"] = str(e)
             ext["source_status"] = PublishStatus.BUILDING.value
@@ -139,6 +140,7 @@ class BuildStageRunner:
                 target_status=PublishStatus.FAILED,
                 source_status=PublishStatus.BUILDING,
                 ext=ext,
+                expected_ext=expected_ext,
             )
 
             return PublishFlowResult(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -97,6 +97,7 @@ class EvalPublishMixin:
                 delivery=delivery,
                 ext_info=ext_info,
                 docker_image=image_pin.docker_image,
+                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -68,7 +68,7 @@ class EvalPublishMixin:
         # config_artifact read above is only the build-artifact presence guard. Eval
         # does not persist, so the applied overrides are discarded.
         delivery, _ = self._ext_state.compose_live(publish_record, publish_stage)
-        image_pin = self.resolve_publish_image_pin(publish_record, bot)
+        image_pin = self.resolve_publish_image_pin(publish_record)
 
         ext_info = {}
         if biz_id:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
@@ -69,6 +69,15 @@ class PublishExtState:
             raise PublishNotFoundError(f"Publish order not found: {publish_id}")
         return copy.deepcopy(latest_record.ext or {})
 
+    def get_latest_ext_snapshot(
+        self, publish_id: int
+    ) -> tuple[dict, dict | None]:
+        """Return mutable ext plus its exact nullable persistence snapshot."""
+        latest_record = self._publish_service.get_publish_by_id(publish_id)
+        if not latest_record:
+            raise PublishNotFoundError(f"Publish order not found: {publish_id}")
+        return copy.deepcopy(latest_record.ext or {}), copy.deepcopy(latest_record.ext)
+
     def mutate_and_update_ext(
         self,
         publish_id: int,
@@ -78,10 +87,8 @@ class PublishExtState:
         in place, then persist it. The mutator may make any change (not just a
         merge); reading the latest snapshot first reduces the risk of clobbering
         concurrent writes. Returns the persisted ext."""
-        ext = self.get_latest_ext(publish_id)
-        mutator(ext)
-        self._publish_service.update_publish_ext(publish_id=publish_id, ext=ext)
-        return ext
+        updated = self._publish_service.mutate_publish_ext(publish_id, mutator)
+        return copy.deepcopy(updated.ext or {})
 
     def advance_status(
         self,
@@ -107,19 +114,20 @@ class PublishExtState:
         target_status: PublishStatus,
         source_status: PublishStatus,
         ext: dict,
+        expected_ext: dict | None,
     ) -> None:
         """Atomically update the publish record's status and ext fields.
 
-        ``ext`` is required and written as-is: the downstream repository does a
-        blind overwrite of the record's ext column, so the caller must pass the
-        full ext it wants persisted (read-modify-write), never a partial or empty
-        dict expecting a merge. Every call site already does this.
+        ``ext`` is written only when both ``source_status`` and the complete
+        ``expected_ext`` snapshot still match. Concurrent ext writers therefore
+        produce a rejected CAS instead of losing metadata.
         """
         self._publish_service.update_publish_status_with_ext(
             publish_id=publish_id,
             target_status=target_status,
             ext=ext,
             source_status=source_status,
+            expected_ext=expected_ext,
         )
 
     # ── per-stage engine_overrides / artifact stamping ───────────────────

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
+)
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    DEFAULT_DEVICE_PROVIDER,
+    TECLAW_DEVICE_PROVIDER,
 )
 
 
@@ -15,3 +20,16 @@ class PublishImagePolicyMixin:
         self, publish_record: BotPublishRecord
     ) -> ServiceBotImagePin:
         return self._publish_service.resolve_publish_image_pin(publish_record)
+
+    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str:
+        return self._publish_service.resolve_publish_runtime_kind(publish_record)
+
+    def _publish_provider_behavior(self, publish_record: BotPublishRecord):
+        """Resolve behavior from immutable Publish metadata/bindings."""
+        runtime_kind = self.resolve_publish_runtime_kind(publish_record)
+        provider = (
+            TECLAW_DEVICE_PROVIDER
+            if runtime_kind == RUNTIME_KIND_TECLAW
+            else DEFAULT_DEVICE_PROVIDER
+        )
+        return self._provider_behaviors.resolve(provider)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
@@ -4,59 +4,14 @@ from __future__ import annotations
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    IMAGE_POLICY_KEYS,
-    ImagePolicyState,
     ServiceBotImagePin,
-    has_explicit_image_policy,
-    resolve_publish_image_pin as resolve_publish_image_pin_policy,
 )
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
-)
-from agentclaw.community.utils.env_utils import get_current_env
 
 
 class PublishImagePolicyMixin:
-    """Resolve and persist image policy for publish-record operations."""
+    """Delegate every publish path to the shared persisted policy resolver."""
 
     def resolve_publish_image_pin(
-        self,
-        publish_record: BotPublishRecord,
-        bot: dict,
+        self, publish_record: BotPublishRecord
     ) -> ServiceBotImagePin:
-        """Resolve and, for legacy rows, atomically append the Pin snapshot."""
-        if (
-            self._baas_service.resolve_container_provider(bot)
-            == TECLAW_DEVICE_PROVIDER
-        ):
-            return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
-        was_legacy = not has_explicit_image_policy(publish_record.ext)
-
-        def _persist(snapshot: dict) -> None:
-            def _mutate(latest_ext: dict) -> None:
-                # Another concurrent operation may have already fixed the policy.
-                # Never replace an explicit decision; otherwise append only our
-                # owned fields to the latest ext snapshot.
-                if has_explicit_image_policy(latest_ext):
-                    return
-                for key in IMAGE_POLICY_KEYS:
-                    latest_ext.pop(key, None)
-                for key in IMAGE_POLICY_KEYS:
-                    if key in snapshot:
-                        latest_ext[key] = snapshot[key]
-
-            self._mutate_and_update_ext(publish_record.id, _mutate)
-
-        resolved = resolve_publish_image_pin_policy(
-            publish_record,
-            common_config_service=self._common_config_service,
-            env=get_current_env(),
-            persist_ext=_persist,
-        )
-        if was_legacy and resolved.enabled:
-            latest = self._publish_service.get_publish_by_id(publish_record.id)
-            if latest is not None:
-                publish_record.ext = latest.ext
-                return resolve_publish_image_pin_policy(latest)
-        return resolved
+        return self._publish_service.resolve_publish_image_pin(publish_record)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/progress_sync_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/progress_sync_mixin.py
@@ -10,6 +10,7 @@ collaborators), so the bodies stay interceptable by tests.
 """
 from __future__ import annotations
 
+import copy
 from typing import Dict, Literal
 
 from agentclaw.community.core.service_bot.repository.models import (
@@ -94,6 +95,7 @@ class ProgressSyncMixin:
         baas_status = progress.get("status", "")
         source_status = _SUCCESS_SOURCE_STATUS[stage]
         target_status = _SUCCESS_TARGET_STATUS[stage]
+        expected_ext = copy.deepcopy(ext)
 
         # Clear the transient retry marker, then atomically advance the status
         # together with ext under the optimistic lock (a separate status-then-ext
@@ -108,6 +110,7 @@ class ProgressSyncMixin:
             target_status=target_status,
             source_status=source_status,
             ext=ext,
+            expected_ext=expected_ext,
         )
         logger.info(
             f"[PublishFlowService._handle_sync_success] "
@@ -169,7 +172,7 @@ class ProgressSyncMixin:
         if not bot:
             return
         try:
-            self._provider_behavior(bot).refresh_after_upgrade(
+            self._publish_provider_behavior(publish_record).refresh_after_upgrade(
                 bot_uuid=binding.device_id, bot=bot
             )
         except Exception as e:
@@ -213,7 +216,8 @@ class ProgressSyncMixin:
             return
 
         # Clear the rollback_restored_from marker (if present)
-        last_ext = last_publish.ext or {}
+        expected_last_ext = copy.deepcopy(last_publish.ext)
+        last_ext = copy.deepcopy(last_publish.ext or {})
         if last_ext.pop("rollback_restored_from", None):
             logger.info(
                 f"[PublishFlowService._mark_previous_publish_superseded] "
@@ -227,6 +231,7 @@ class ProgressSyncMixin:
                 target_status=PublishStatus.UPGRADED,
                 source_status=PublishStatus.SUCCESS,
                 ext=last_ext,
+                expected_ext=expected_last_ext,
             )
             logger.info(
                 f"[PublishFlowService._mark_previous_publish_superseded] "
@@ -254,7 +259,7 @@ class ProgressSyncMixin:
                 f"Bot does not exist: {publish_record.source_bot_id}"
             )
 
-        if not self._provider_behavior(bot).destroys_verify_bot_on_online:
+        if not self._publish_provider_behavior(publish_record).destroys_verify_bot_on_online:
             logger.info(
                 "[PublishFlowService._destroy_verify_bot_after_online_success] "
                 "Skip destroying verify BaaS bot for this provider: "
@@ -304,6 +309,8 @@ class ProgressSyncMixin:
             failed_devices = progress.get("failed_devices", [])
             error_message = f"BaaS publish failed: {len(failed_devices)} device(s) failed"
 
+        expected_ext = copy.deepcopy(ext)
+
         # Outcome correction, before the record's FAILED write: the op's steps
         # completed at bookkeeping time, but its workflow just terminally failed —
         # without this, the failed deploy still reads as the live deployment, so
@@ -325,6 +332,7 @@ class ProgressSyncMixin:
             target_status=PublishStatus.FAILED,
             source_status=current_status,
             ext=ext,
+            expected_ext=expected_ext,
         )
 
         logger.error(f"[PublishFlowService._handle_sync_failure] {error_message}")

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/publish_ext_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/publish_ext_mixin.py
@@ -9,7 +9,12 @@ the release runner invokes create-binding, record-ext, then approve in sequence.
 """
 from __future__ import annotations
 
+import copy
+
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
+from agentclaw.community.core.service_bot.services.publish_flow.errors import (
+    PublishFlowServiceError,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 
@@ -38,9 +43,15 @@ class PublishExtMixin:
         ``source_status → target_status``. Re-reads the latest ext first (the
         authoritative snapshot). Returns the persisted ext."""
         ext = self._get_latest_ext(publish_id)
+        expected_ext = copy.deepcopy(ext)
         ext.setdefault("binding", {})[stage.value] = binding_id
         ext.setdefault("publish", {})[stage.value] = baas_publish_id
-        self._provider_behavior(bot).persist_stage_promotion(
+        publish_record = self.get_publish_record(publish_id)
+        if publish_record is None:
+            raise PublishFlowServiceError(
+                f"Publish record not found: publish_id={publish_id}"
+            )
+        self._publish_provider_behavior(publish_record).persist_stage_promotion(
             ext=ext, stage=stage, engine_overrides=engine_overrides
         )
         self._update_publish_status(
@@ -48,5 +59,6 @@ class PublishExtMixin:
             target_status=target_status,
             source_status=source_status,
             ext=ext,
+            expected_ext=expected_ext,
         )
         return ext

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -86,7 +86,6 @@ class ReleaseRecordOps(Protocol):
     def resolve_publish_image_pin(
         self,
         publish_record: BotPublishRecord,
-        bot: dict,
     ) -> ServiceBotImagePin: ...
 
 
@@ -174,7 +173,7 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = self._ops.resolve_publish_image_pin(publish_record, bot)
+        image_pin = self._ops.resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -274,7 +273,7 @@ class ReleaseStageRunner:
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = self._ops.resolve_publish_image_pin(publish_record, bot)
+        image_pin = self._ops.resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
@@ -36,6 +37,9 @@ from agentclaw.community.core.service_bot.services.publish_flow.ext_state import
 from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
     ProviderBehavior,
     ProviderBehaviorRouter,
+)
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.operation_runner import (
     PublishOperationRunner,
@@ -87,6 +91,8 @@ class ReleaseRecordOps(Protocol):
         self,
         publish_record: BotPublishRecord,
     ) -> ServiceBotImagePin: ...
+
+    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str: ...
 
 
 
@@ -151,10 +157,13 @@ class ReleaseStageRunner:
         self._ops = ops
         self._operation_runner = operation_runner
 
-    def _provider_behavior(self, bot: dict) -> ProviderBehavior:
-        """The :class:`ProviderBehavior` for ``bot``'s container."""
+    def _provider_behavior(self, publish_record: BotPublishRecord) -> ProviderBehavior:
+        """Provider behavior frozen by the target Publish contract."""
+        runtime_kind = self._ops.resolve_publish_runtime_kind(publish_record)
         return self._provider_behaviors.resolve(
-            self._baas_service.resolve_container_provider(bot)
+            TECLAW_DEVICE_PROVIDER
+            if runtime_kind == RUNTIME_KIND_TECLAW
+            else "baas"
         )
 
     async def first_release(
@@ -198,6 +207,7 @@ class ReleaseStageRunner:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
+                runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
             )
             if spec.first_release_passes_version:
                 release_kwargs["version"] = f"{publish_record.version}"
@@ -297,6 +307,7 @@ class ReleaseStageRunner:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
+                runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
             )
 
         try:
@@ -343,10 +354,10 @@ class ReleaseStageRunner:
 
         # Reuse the existing binding; update ext (binding/publish refs, provider
         # per-stage promotion state, refresh the teclaw read handle).
-        ext = self._ext_state.get_latest_ext(publish_id)
+        ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
         ext.setdefault("binding", {})[spec.stage.value] = existing_binding_id
         ext.setdefault("publish", {})[spec.stage.value] = baas_publish_id
-        self._provider_behavior(bot).persist_stage_promotion(
+        self._provider_behavior(publish_record).persist_stage_promotion(
             ext=ext, stage=spec.stage, engine_overrides=overrides
         )
         self._ops.refresh_publish_handle(existing_binding_id, baas_publish_id)
@@ -355,6 +366,7 @@ class ReleaseStageRunner:
             target_status=spec.target_status,
             source_status=spec.source_status,
             ext=ext,
+            expected_ext=expected_ext,
         )
         self._operation_runner.complete_operation(op)
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -303,7 +303,7 @@ class RestartMixin:
         # so restarting a non-latest stage never delivers another stage's channels.
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
-        image_pin = self.resolve_publish_image_pin(publish_record, bot)
+        image_pin = self.resolve_publish_image_pin(publish_record)
 
         # A prior recreate that crashed between its ext write and its
         # complete_operation left a dangling op. That crashed leg IS this restart

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -401,6 +401,7 @@ class RestartMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
+                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
             )
         # NOTE: transient errors out of the atom are NOT caught + failed here. A
         # genuine crash leaves the op non-terminal so the durable task retry
@@ -580,6 +581,7 @@ class RestartMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=docker_image,
+                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
             )
 
         op = await acquire_deploy_workflow(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/retry_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/retry_ops_mixin.py
@@ -7,6 +7,8 @@ Extracted from ``publish_flow_service.py`` to keep that file within the R9 line 
 """
 from __future__ import annotations
 
+import copy
+
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
@@ -115,6 +117,7 @@ class RetryOpsMixin:
 
         # Step 3: Get the pre-failure status from ext
         ext = self._get_latest_ext(publish_id)
+        expected_ext = copy.deepcopy(ext)
         source_status = ext.get("source_status")
         if not source_status:
             raise PublishFlowServiceError(
@@ -148,6 +151,7 @@ class RetryOpsMixin:
                 target_status=rollback_status,
                 source_status=PublishStatus.FAILED,
                 ext=ext,
+                expected_ext=expected_ext,
             )
         except Exception as e:
             raise PublishFlowServiceError(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -113,7 +113,7 @@ class RollbackOpsMixin:
         version = f"{target_record.version}"
         delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
         skills_env = service_skills_env_from_ext(target_ext, bot)
-        image_pin = self.resolve_publish_image_pin(target_record, bot)
+        image_pin = self.resolve_publish_image_pin(target_record)
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
         # adopt-by-query on resume, never a second rollback deploy).

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -1,6 +1,7 @@
 """Rollback deploy + BaaS bot teardown, mixed into PublishFlowService."""
 from __future__ import annotations
 
+import copy
 
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.service_bot.repository.models import (
@@ -75,6 +76,7 @@ class RollbackOpsMixin:
 
         # 2. Get the target version's build artifact
         target_ext = self._get_latest_ext(target_publish_id)
+        expected_target_ext = copy.deepcopy(target_ext)
         migration_path = target_ext.get("migration_path")
         config_artifact = target_ext.get("config_artifact")
 
@@ -137,6 +139,7 @@ class RollbackOpsMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
+                runtime_kind=self.resolve_publish_runtime_kind(target_record),
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)
@@ -154,6 +157,7 @@ class RollbackOpsMixin:
             target_status=PublishStatus.ONLINE_PUB,
             source_status=PublishStatus.SUCCESS,
             ext=target_ext,
+            expected_ext=expected_target_ext,
         )
         self._operation_runner.complete_operation(op)
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
@@ -90,7 +90,7 @@ class ScaleMixin:
 
         bot_uuid = binding.device_id
         target_count = self._resolve_scale_target_count(publish_record)
-        image_pin = self.resolve_publish_image_pin(publish_record, bot)
+        image_pin = self.resolve_publish_image_pin(publish_record)
         pinned_image = image_pin.docker_image
         scale_config = (
             {"deploy_config": {"docker_image": pinned_image}}

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
@@ -59,13 +59,13 @@ class ScaleMixin:
         if not bot:
             raise PublishFlowServiceError(f"Bot does not exist: {publish_record.source_bot_id}")
 
-        active_engine = (bot.get("active_engine") or "").strip().lower()
-        if not self._provider_behavior(bot).supports_scale:
+        publish_runtime_kind = self.resolve_publish_runtime_kind(publish_record)
+        if not self._publish_provider_behavior(publish_record).supports_scale:
             return {
                 "success": True,
                 "message": "Service bots on the teclaw engine do not support scaling",
                 "publish_id": publish_id,
-                "engine": active_engine,
+                "engine": publish_runtime_kind,
                 "supported": True,
             }
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
 )
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    RUNTIME_KIND_TECLAW,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
@@ -233,8 +233,8 @@ class UpgradeResolutionMixin:
 
         if status in _ONLINE_NOT_LIVE_BAAS_STATUSES:
             is_teclaw = (
-                self._baas_service.resolve_container_provider(bot)
-                == TECLAW_DEVICE_PROVIDER
+                self.resolve_publish_runtime_kind(publish_record)
+                == RUNTIME_KIND_TECLAW
             )
             decision = (
                 OnlineDeployDecision.RETIRE_THEN_FIRST_RELEASE

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -5,6 +5,7 @@ Advances the different stages of the publish flow based on the publish record st
 
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -128,10 +129,7 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-# Describe-only messages for the non-user-driven statuses that ``process()`` just
-# reports back (no side effects). DRAFT and VALIDATING are handled separately —
-# they are the only user-driven advance points. FAILED is special-cased (it needs
-# the ext error message) and any status absent here is an invalid/unknown state.
+# Describe-only messages for statuses that ``process()`` reports without side effects.
 _DESCRIBE_STATUS_MESSAGES = {
     PublishStatus.BUILT: "Build complete, publish in progress, please check progress later",
     PublishStatus.BUILDING: "Build in progress, please wait",
@@ -545,6 +543,7 @@ class PublishFlowService(
             error_msg = "Build artifact path does not exist, please run the build first"
             logger.error(f"[PublishFlowService.execute_verify_release_phase] publish_id={publish_id}, {error_msg}")
             ext = self._get_latest_ext(publish_id)
+            expected_ext = copy.deepcopy(ext)
             self._clear_retry_flag(ext)
             ext["error_message"] = error_msg
             ext["source_status"] = PublishStatus.BUILT.value
@@ -553,6 +552,7 @@ class PublishFlowService(
                 target_status=PublishStatus.FAILED,
                 source_status=PublishStatus.BUILT,
                 ext=ext,
+                expected_ext=expected_ext,
             )
             return PublishFlowResult(
                 publish_id=publish_id,
@@ -603,6 +603,7 @@ class PublishFlowService(
 
             # Publish failed; update the status and error info
             ext = self._get_latest_ext(publish_id)
+            expected_ext = copy.deepcopy(ext)
             self._clear_retry_flag(ext)
             ext["error_message"] = str(e)
             ext["source_status"] = PublishStatus.BUILT.value
@@ -611,6 +612,7 @@ class PublishFlowService(
                 target_status=PublishStatus.FAILED,
                 source_status=PublishStatus.BUILT,
                 ext=ext,
+                expected_ext=expected_ext,
             )
 
             return PublishFlowResult(
@@ -687,6 +689,7 @@ class PublishFlowService(
             error_msg = "Build artifact path does not exist, please run the build first"
             logger.error(f"[PublishFlowService]{publish_id}, publish_record={publish_record},  {error_msg}")
             ext = self._get_latest_ext(publish_id)
+            expected_ext = copy.deepcopy(ext)
             self._clear_retry_flag(ext)
             ext["error_message"] = error_msg
             # The online release runs within ONLINE_PUB (process owns the
@@ -697,6 +700,7 @@ class PublishFlowService(
                 target_status=PublishStatus.FAILED,
                 source_status=PublishStatus.ONLINE_PUB,
                 ext=ext,
+                expected_ext=expected_ext,
             )
             return PublishFlowResult(
                 publish_id=publish_id,
@@ -768,6 +772,7 @@ class PublishFlowService(
 
             # Publish failed; update the status and error info
             ext = self._get_latest_ext(publish_id)
+            expected_ext = copy.deepcopy(ext)
             self._clear_retry_flag(ext)
             ext["error_message"] = str(e)
             # Roll back to ONLINE_PUB (the state the release runs within).
@@ -777,6 +782,7 @@ class PublishFlowService(
                 target_status=PublishStatus.FAILED,
                 source_status=PublishStatus.ONLINE_PUB,
                 ext=ext,
+                expected_ext=expected_ext,
             )
 
             return PublishFlowResult(
@@ -882,12 +888,14 @@ class PublishFlowService(
         target_status: PublishStatus,
         source_status: PublishStatus,
         ext: dict,
+        expected_ext: dict | None,
     ) -> None:
         self._ext_state.update_status(
             publish_id=publish_id,
             target_status=target_status,
             source_status=source_status,
             ext=ext,
+            expected_ext=expected_ext,
         )
 
     # ── public accessors for the durable task handlers ───────────────────────

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -94,6 +94,9 @@ from agentclaw.community.core.notify.protocol import NotifyBotLister
 from agentclaw.community.core.bot_collaborator.repository.protocol import (
     CollaboratorRepositoryProtocol,
 )
+from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
+    BotPublishRepositoryProtocol,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.system_config import (
     SystemConfigService,
@@ -260,6 +263,7 @@ class DevicesModule(Module):
         task_queue_service: TaskQueueService,
         baas_device_service: BaasDeviceService,
         bot_repository: BotRepository,
+        publish_repository: BotPublishRepositoryProtocol,
         template_service: TemplateService,
     ) -> BaasPublishTaskLifecycle:
         return BaasPublishTaskLifecycle(
@@ -269,6 +273,7 @@ class DevicesModule(Module):
             task_queue_service=task_queue_service,
             baas_device_service=baas_device_service,
             bot_repository=bot_repository,
+            publish_repository=publish_repository,
             template_service=template_service,
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -43,6 +43,9 @@ from agentclaw.community.api.oss_to_nas_switch_service import OssToNasSwitchServ
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.default_image_policy_listener import (
+    DefaultImagePolicyActivationListener,
+)
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.devices.protocols import (
     BotQueryProtocol,
@@ -156,6 +159,11 @@ class DevicesModule(Module):
         binder.bind(
             DeviceFileSystemResolver,
             to=DefaultDeviceFileSystemResolver,
+            scope=singleton,
+        )
+        binder.bind(
+            DefaultImagePolicyActivationListener,
+            to=DefaultImagePolicyActivationListener,
             scope=singleton,
         )
         # NOTE: the ``DeviceSyncDispatcher`` seam is a Protocol bound per-profile

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -363,6 +363,41 @@ class BotPublishRepository:
             return None
         return self.get_by_id(publish_id)
 
+    def compare_and_set_ext(
+        self,
+        *,
+        publish_id: int,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[BotPublishRecord]:
+        """Whole-column ext CAS using the exact serialized DB value.
+
+        ``get_by_id`` transparently re-inlines offloaded config artifacts, so both
+        the expected and replacement values pass through ``prepare`` to recover
+        the canonical representation stored in the TEXT column.
+        """
+        env = get_current_env()
+        expected_json, _ = self._offload.prepare(expected_ext, publish_id, env)
+        ext_json, pending = self._offload.prepare(ext, publish_id, env)
+        with self._db.orm_session() as db:
+            query = db.query(self.Model).filter(self.Model.id == publish_id)
+            if expected_json is None:
+                query = query.filter(self.Model.ext.is_(None))
+            else:
+                query = query.filter(self.Model.ext == expected_json)
+            affected = query.update(
+                {
+                    self.Model.ext: ext_json,
+                    self.Model.gmt_modified: func.now(),
+                },
+                synchronize_session=False,
+            )
+            if affected > 0:
+                self._offload.upload(pending)
+        if affected == 0:
+            return None
+        return self.get_by_id(publish_id)
+
     def rollback_flip(
         self,
         *,

--- a/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_publish_repository.py
@@ -398,6 +398,42 @@ class BotPublishRepository:
             return None
         return self.get_by_id(publish_id)
 
+    def compare_and_set_status_with_ext(
+        self,
+        *,
+        publish_id: int,
+        source_status: str,
+        target_status: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[BotPublishRecord]:
+        """CAS status and the exact serialized ext snapshot in one UPDATE."""
+        env = get_current_env()
+        expected_json, _ = self._offload.prepare(expected_ext, publish_id, env)
+        ext_json, pending = self._offload.prepare(ext, publish_id, env)
+        with self._db.orm_session() as db:
+            query = db.query(self.Model).filter(
+                self.Model.id == publish_id,
+                self.Model.status == source_status,
+            )
+            if expected_json is None:
+                query = query.filter(self.Model.ext.is_(None))
+            else:
+                query = query.filter(self.Model.ext == expected_json)
+            affected = query.update(
+                {
+                    self.Model.status: target_status,
+                    self.Model.ext: ext_json,
+                    self.Model.gmt_modified: func.now(),
+                },
+                synchronize_session=False,
+            )
+            if affected > 0:
+                self._offload.upload(pending)
+        if affected == 0:
+            return None
+        return self.get_by_id(publish_id)
+
     def rollback_flip(
         self,
         *,

--- a/src/backend/src/agentclaw/community/plugins/bot_repository.py
+++ b/src/backend/src/agentclaw/community/plugins/bot_repository.py
@@ -492,6 +492,43 @@ class BotRepository:
             return None
         return self.get_by_id_and_owner(bot_id, owner_id)
 
+    def compare_and_set_ext(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Whole-column ``ext`` CAS scoped by owner, env, and live row."""
+        expected_json = (
+            json.dumps(expected_ext)
+            if expected_ext is not None
+            else None
+        )
+        ext_json = json.dumps(ext)
+        with self._db.orm_session() as db:
+            query = db.query(self.Model).filter(
+                self.Model.bot_id == bot_id,
+                self.Model.owner_id == owner_id,
+                self.Model.is_delete == 0,
+                self._env(),
+            )
+            if expected_json is None:
+                query = query.filter(self.Model.ext.is_(None))
+            else:
+                query = query.filter(self.Model.ext == expected_json)
+            affected = query.update(
+                {
+                    self.Model.ext: ext_json,
+                    self.Model.gmt_modified: func.now(),
+                },
+                synchronize_session=False,
+            )
+        if affected == 0:
+            return None
+        return self.get_by_id_and_owner(bot_id, owner_id)
+
     def soft_delete_by_owner(
         self, bot_id: str, owner_id: str
     ) -> bool:

--- a/src/backend/tests/community/adapters/http/service_bot/test_router_publish_coverage.py
+++ b/src/backend/tests/community/adapters/http/service_bot/test_router_publish_coverage.py
@@ -309,6 +309,7 @@ async def test_update_publish_status_success_and_errors():
         target_status="built",
         ext={"old": "value", "source_status": "building"},
         source_status="draft",
+        expected_ext={"old": "value"},
     )
 
     service.get_publish_by_id.return_value = Record(ext=None)

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.bot_service import BotService, BotServiceError
 from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
     BAAS_RESTART_PUBLISH_POLL_TASK,
 )
@@ -223,8 +223,59 @@ class TestRestartBaasImagePolicy:
         svc._bot_publish_repo.update_status_with_ext.assert_not_called()
         payload = svc._task_queue_service.enqueue.call_args.args[1]
         assert payload["image_policy_on_success"] == "default"
+        binding_props = svc._device_binding_repo.update_device_props.call_args.kwargs["props"]
+        assert binding_props["restart_publish_id"] == "100"
+        assert binding_props["restart_image_policy_on_success"] == "default"
         pending_update = svc._repository.update_by_owner.call_args.args[2]
         assert "sbot_use_default_image" not in pending_update.get("ext", {})
+
+    def test_enqueue_failure_keeps_durable_default_intent_and_fails_explicitly(self):
+        svc, _, _ = _make_service(
+            template_config={},
+            bot_type="service",
+            active_engine="openclaw",
+        )
+        svc._task_queue_service.enqueue.side_effect = RuntimeError("queue unavailable")
+        bot = {
+            **_make_bot(bot_type="service", active_engine="openclaw"),
+            "ext": {"sbot_use_default_image": True},
+        }
+
+        with pytest.raises(
+            BotServiceError,
+            match="recovery state was persisted.*publish_id=100",
+        ):
+            svc._restart_bot_baas(
+                bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+            )
+
+        props = svc._device_binding_repo.update_device_props.call_args.kwargs["props"]
+        assert props["restart_publish_id"] == "100"
+        assert props["restart_image_policy_on_success"] == "default"
+
+    def test_binding_intent_persistence_failure_does_not_enqueue(self):
+        svc, _, _ = _make_service(
+            template_config={},
+            bot_type="service",
+            active_engine="openclaw",
+        )
+        svc._device_binding_repo.update_device_props.side_effect = RuntimeError(
+            "database unavailable"
+        )
+        bot = {
+            **_make_bot(bot_type="service", active_engine="openclaw"),
+            "ext": {"sbot_use_default_image": True},
+        }
+
+        with pytest.raises(
+            BotServiceError,
+            match="recovery state could not be persisted.*publish_id=100",
+        ):
+            svc._restart_bot_baas(
+                bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+            )
+
+        svc._task_queue_service.enqueue.assert_not_called()
 
 
 class TestRestartBaasEnvInjection:
@@ -251,6 +302,7 @@ class TestRestartBaasEnvInjection:
                 "publish_id": "12372",
                 "restart_publish_id": "12372",
                 "restart_request_id": baas.upgrade_bot.call_args.kwargs["request_id"],
+                "restart_image_policy_on_success": None,
             },
         )
         svc._repository.update_by_owner.assert_called_with(
@@ -283,6 +335,7 @@ class TestRestartBaasEnvInjection:
                 "publish_id": "12372",
                 "restart_publish_id": "12372",
                 "restart_request_id": request_id,
+                "restart_image_policy_on_success": None,
             },
         )
         started_at_epoch_s = svc._task_queue_service.enqueue.call_args.args[1][

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -86,6 +86,7 @@ def _make_service(
     svc._device_service_provider = lambda: device_service
 
     baas = MagicMock()
+    baas.list_bot_publishes.return_value = []
     baas.upgrade_bot.return_value = {"publish_id": 100}
     svc._baas_service_provider = lambda: baas
 
@@ -171,7 +172,10 @@ class TestRestartBaasImagePolicy:
                 bot_id="bot001", user_id="user001", binding_id=42, bot=bot
             )
 
-        svc._repository.update_by_owner.assert_not_called()
+        svc._repository.update_by_owner.assert_called_once_with(
+            "bot001", "user001", {"status": "PENDING"}
+        )
+        svc._task_queue_service.enqueue.assert_called_once()
         svc._bot_publish_repo.update_status_with_ext.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -183,7 +187,7 @@ class TestRestartBaasImagePolicy:
         bot_type: str,
         active_engine: str,
     ):
-        svc, _, _ = _make_service(
+        svc, baas, _ = _make_service(
             template_config={},
             bot_type=bot_type,
             active_engine=active_engine,
@@ -223,14 +227,16 @@ class TestRestartBaasImagePolicy:
         svc._bot_publish_repo.update_status_with_ext.assert_not_called()
         payload = svc._task_queue_service.enqueue.call_args.args[1]
         assert payload["image_policy_on_success"] == "default"
-        binding_props = svc._device_binding_repo.update_device_props.call_args.kwargs["props"]
-        assert binding_props["restart_publish_id"] == "100"
+        binding_props = svc._device_binding_repo.update_device_props.call_args_list[0].kwargs["props"]
+        assert binding_props["restart_publish_id"] is None
         assert binding_props["restart_image_policy_on_success"] == "default"
+        assert binding_props["restart_workflow_baseline"] == 0
+        assert binding_props["restart_request_id"]
         pending_update = svc._repository.update_by_owner.call_args.args[2]
         assert "sbot_use_default_image" not in pending_update.get("ext", {})
 
-    def test_enqueue_failure_keeps_durable_default_intent_and_fails_explicitly(self):
-        svc, _, _ = _make_service(
+    def test_enqueue_failure_prevents_external_restart(self):
+        svc, baas, _ = _make_service(
             template_config={},
             bot_type="service",
             active_engine="openclaw",
@@ -243,17 +249,16 @@ class TestRestartBaasImagePolicy:
 
         with pytest.raises(
             BotServiceError,
-            match="recovery state was persisted.*publish_id=100",
+            match="durable task could not be persisted",
         ):
             svc._restart_bot_baas(
                 bot_id="bot001", user_id="user001", binding_id=42, bot=bot
             )
 
-        props = svc._device_binding_repo.update_device_props.call_args.kwargs["props"]
-        assert props["restart_publish_id"] == "100"
-        assert props["restart_image_policy_on_success"] == "default"
+        baas.upgrade_bot.assert_not_called()
+        svc._device_binding_repo.update_device_props.assert_not_called()
 
-    def test_binding_intent_persistence_failure_does_not_enqueue(self):
+    def test_binding_intent_persistence_failure_does_not_call_baas(self):
         svc, _, _ = _make_service(
             template_config={},
             bot_type="service",
@@ -269,16 +274,17 @@ class TestRestartBaasImagePolicy:
 
         with pytest.raises(
             BotServiceError,
-            match="recovery state could not be persisted.*publish_id=100",
+            match="Failed to prepare durable BaaS restart",
         ):
             svc._restart_bot_baas(
                 bot_id="bot001", user_id="user001", binding_id=42, bot=bot
             )
 
-        svc._task_queue_service.enqueue.assert_not_called()
+        svc._task_queue_service.enqueue.assert_called_once()
+        svc._baas_service_provider().upgrade_bot.assert_not_called()
 
-    def test_pending_transition_failure_does_not_enqueue(self):
-        svc, _, _ = _make_service(template_config={})
+    def test_pending_transition_failure_does_not_call_baas(self):
+        svc, baas, _ = _make_service(template_config={})
         svc._device_binding_repo.update_status.side_effect = RuntimeError(
             "database unavailable"
         )
@@ -286,14 +292,14 @@ class TestRestartBaasImagePolicy:
 
         with pytest.raises(
             BotServiceError,
-            match="PENDING state could not be persisted.*publish_id=100",
+            match="Failed to prepare durable BaaS restart",
         ):
             svc._restart_bot_baas(
                 bot_id="bot001", user_id="user001", binding_id=42, bot=bot
             )
 
-        svc._repository.update_by_owner.assert_not_called()
-        svc._task_queue_service.enqueue.assert_not_called()
+        svc._task_queue_service.enqueue.assert_called_once()
+        baas.upgrade_bot.assert_not_called()
 
 
 class TestRestartBaasEnvInjection:
@@ -314,25 +320,17 @@ class TestRestartBaasEnvInjection:
 
         svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
 
-        svc._device_binding_repo.update_device_props.assert_called_once_with(
-            binding_id=42,
-            props={
-                "publish_id": "12372",
-                "restart_publish_id": "12372",
-                "restart_request_id": baas.upgrade_bot.call_args.kwargs["request_id"],
-                "restart_image_policy_on_success": None,
-            },
+        calls = svc._device_binding_repo.update_device_props.call_args_list
+        assert calls[0].kwargs["props"]["restart_request_id"] == (
+            baas.upgrade_bot.call_args.kwargs["request_id"]
         )
-        svc._repository.update_by_owner.assert_called_with(
-            "bot001",
-            "user001",
-            {
-                "status": "PENDING",
-                "ext": {
-                    "service_bot_config": {"device_count": 1},
-                    "restart_publish_id": "12372",
-                },
-            },
+        assert calls[0].kwargs["props"]["restart_workflow_baseline"] == 0
+        assert calls[1].kwargs["props"] == {
+            "publish_id": "12372",
+            "restart_publish_id": "12372",
+        }
+        svc._repository.update_by_owner.assert_called_once_with(
+            "bot001", "user001", {"status": "PENDING"}
         )
         svc._task_queue_service.enqueue.assert_called_once()
         enqueue_args = svc._task_queue_service.enqueue.call_args
@@ -347,15 +345,17 @@ class TestRestartBaasEnvInjection:
         svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
 
         request_id = baas.upgrade_bot.call_args.kwargs["request_id"]
-        svc._device_binding_repo.update_device_props.assert_called_once_with(
-            binding_id=42,
-            props={
-                "publish_id": "12372",
-                "restart_publish_id": "12372",
-                "restart_request_id": request_id,
-                "restart_image_policy_on_success": None,
-            },
-        )
+        calls = svc._device_binding_repo.update_device_props.call_args_list
+        assert calls[0].kwargs["props"] == {
+            "restart_request_id": request_id,
+            "restart_workflow_baseline": 0,
+            "restart_publish_id": None,
+            "restart_image_policy_on_success": None,
+        }
+        assert calls[1].kwargs["props"] == {
+            "publish_id": "12372",
+            "restart_publish_id": "12372",
+        }
         started_at_epoch_s = svc._task_queue_service.enqueue.call_args.args[1][
             "started_at_epoch_s"
         ]
@@ -365,25 +365,34 @@ class TestRestartBaasEnvInjection:
                 "binding_id": 42,
                 "bot_id": "bot001",
                 "owner_id": "user001",
-                "publish_id": 12372,
                 "started_at_epoch_s": started_at_epoch_s,
                 "bot_uuid": "BOT-uuid-9",
+                "request_id": request_id,
+                "workflow_baseline": 0,
             },
             deadline_seconds=86400,
+            delay_seconds=2,
         )
 
-    def test_restart_baas_marks_pending_before_enqueue(self):
+    def test_restart_baas_enqueues_recovery_before_pending_and_external_call(self):
         svc, baas, device_service = _make_service(template_config={})
         order: list[str] = []
-        svc._repository.update_by_owner.side_effect = lambda *args, **kwargs: order.append("bot_pending")
+        svc._repository.update_by_owner.side_effect = lambda *args, **kwargs: (
+            order.append("bot_pending") or {"bot_id": "bot001"}
+        )
         svc._device_binding_repo.update_status.side_effect = lambda *args, **kwargs: order.append("binding_pending")
         svc._task_queue_service.enqueue.side_effect = lambda *args, **kwargs: order.append("enqueue")
+        baas.upgrade_bot.side_effect = lambda **kwargs: (
+            order.append("upgrade") or {"publish_id": 100}
+        )
         bot = _make_bot(active_engine="openclaw", template_type=None)
 
         svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
 
-        assert order.index("bot_pending") < order.index("enqueue")
-        assert order.index("binding_pending") < order.index("enqueue")
+        assert order.index("enqueue") < order.index("bot_pending")
+        assert order.index("enqueue") < order.index("binding_pending")
+        assert order.index("bot_pending") < order.index("upgrade")
+        assert order.index("binding_pending") < order.index("upgrade")
 
     def test_application_coding_injects_bot_type_model_runtime(self):
         """applicationCoding + aicoding → upgrade_bot 收到 extra_envs 含

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -202,23 +202,17 @@ class TestRestartBaasImagePolicy:
         svc._bot_publish_repo.get_draft_by_publish_bot_id.assert_not_called()
         svc._bot_publish_repo.update_status_with_ext.assert_not_called()
 
-    def test_restart_success_persists_bot_and_current_draft_default_marker(self):
+    def test_restart_submit_defers_default_marker_until_poll_success(self):
         svc, _, _ = _make_service(
             template_config={},
             bot_type="service",
             active_engine="openclaw",
         )
-        svc._bot_publish_repo.get_draft_by_publish_bot_id.return_value = SimpleNamespace(
-            id=6643,
-            status="draft",
-            ext={"migration_path": "/old"},
-        )
         bot = {
             **_make_bot(bot_type="service", active_engine="openclaw"),
             "ext": {
                 "service_bot_config": {"device_count": 1},
-                "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_use_default_image": True,
             },
         }
 
@@ -226,25 +220,11 @@ class TestRestartBaasImagePolicy:
             bot_id="bot001", user_id="user001", binding_id=42, bot=bot
         )
 
-        svc._repository.update_by_owner.assert_any_call(
-            "bot001",
-            "user001",
-            {
-                "ext": {
-                    "service_bot_config": {"device_count": 1},
-                    "sbot_use_default_image": True,
-                }
-            },
-        )
-        svc._bot_publish_repo.update_status_with_ext.assert_called_once_with(
-            publish_id=6643,
-            target_status="draft",
-            ext={
-                "migration_path": "/old",
-                "sbot_use_default_image": True,
-            },
-            source_status="draft",
-        )
+        svc._bot_publish_repo.update_status_with_ext.assert_not_called()
+        payload = svc._task_queue_service.enqueue.call_args.args[1]
+        assert payload["image_policy_on_success"] == "default"
+        pending_update = svc._repository.update_by_owner.call_args.args[2]
+        assert "sbot_use_default_image" not in pending_update.get("ext", {})
 
 
 class TestRestartBaasEnvInjection:
@@ -261,6 +241,7 @@ class TestRestartBaasEnvInjection:
                 "service_bot_config": {"device_count": 1},
             },
         }
+        svc._repository.get_by_id_and_owner.return_value = bot
 
         svc._restart_bot_baas(bot_id="bot001", user_id="user001", binding_id=42, bot=bot)
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -277,6 +277,24 @@ class TestRestartBaasImagePolicy:
 
         svc._task_queue_service.enqueue.assert_not_called()
 
+    def test_pending_transition_failure_does_not_enqueue(self):
+        svc, _, _ = _make_service(template_config={})
+        svc._device_binding_repo.update_status.side_effect = RuntimeError(
+            "database unavailable"
+        )
+        bot = _make_bot(active_engine="openclaw", template_type=None)
+
+        with pytest.raises(
+            BotServiceError,
+            match="PENDING state could not be persisted.*publish_id=100",
+        ):
+            svc._restart_bot_baas(
+                bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+            )
+
+        svc._repository.update_by_owner.assert_not_called()
+        svc._task_queue_service.enqueue.assert_not_called()
+
 
 class TestRestartBaasEnvInjection:
     def test_restart_records_current_publish_id_and_clears_stale_baas_failure(self):

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -160,7 +160,7 @@ def _make_service(
     svc._device_binding_repo = device_binding_repo if device_binding_repo is not None else MagicMock()
     svc._bot_publish_repo = bot_publish_repo if bot_publish_repo is not None else MagicMock()
     svc._baas_template_resolver = baas_template_resolver
-    svc._task_queue_service = task_queue_service
+    svc._task_queue_service = task_queue_service or MagicMock()
     svc._common_config_service = common_config_service
     svc._teclaw_provision_provider = lambda: SimpleNamespace(
         is_teclaw=lambda active_engine: active_engine == "teclaw"
@@ -308,7 +308,10 @@ class TestRestartGuardOrchestration:
 
         assert result["status"] == "PENDING"
         assert result["binding_id"] == 42
-        assert result["ext"]["restart_publish_id"] == "9377"
+        assert result["ext"] == {}
+        assert svc._device_binding_repo.update_device_props.call_args_list[-1].kwargs[
+            "props"
+        ]["restart_publish_id"] == "9377"
         assert "restart_in_progress" not in result
 
     def test_recycled_bot_restart_is_rejected_without_side_effects(self):
@@ -1842,37 +1845,41 @@ class TestRestartBaasPendingAndQueue:
         # upgrade_bot 调用
         baas.upgrade_bot.assert_called_once()
         assert baas.upgrade_bot.call_args.kwargs["mount_home_dir_storage"] is True
-        # bot 行置 PENDING，并记录当前 restart publish 轮次。
+        # bot 行先置 PENDING；publish_id 在 Binding 上单独补记。
         bot_repo.update_by_owner.assert_called_with(
             "bot-1",
             "u1",
-            {"status": "PENDING", "ext": {"restart_publish_id": "9377"}},
+            {"status": "PENDING"},
         )
         # binding 置 PENDING
         bind_repo.update_status.assert_called_with(
             binding_id=42, status=DeviceBindingStatus.PENDING
         )
-        bind_repo.update_device_props.assert_called_once_with(
-            binding_id=42,
-            props={
-                "publish_id": "9377",
-                "restart_publish_id": "9377",
-                "restart_request_id": baas.upgrade_bot.call_args.kwargs["request_id"],
-                "restart_image_policy_on_success": None,
-            },
-        )
+        request_id = baas.upgrade_bot.call_args.kwargs["request_id"]
+        assert bind_repo.update_device_props.call_args_list[0].kwargs["props"] == {
+            "restart_request_id": request_id,
+            "restart_workflow_baseline": 0,
+            "restart_publish_id": None,
+            "restart_image_policy_on_success": None,
+        }
+        assert bind_repo.update_device_props.call_args_list[1].kwargs["props"] == {
+            "publish_id": "9377",
+            "restart_publish_id": "9377",
+        }
         task_queue_service.enqueue.assert_called_once()
         enqueue_args = task_queue_service.enqueue.call_args
         assert enqueue_args.args[0] == BAAS_RESTART_PUBLISH_POLL_TASK
         assert enqueue_args.args[1]["binding_id"] == 42
         assert enqueue_args.args[1]["bot_id"] == "bot-1"
         assert enqueue_args.args[1]["owner_id"] == "u1"
-        assert enqueue_args.args[1]["publish_id"] == 9377
+        assert "publish_id" not in enqueue_args.args[1]
         assert enqueue_args.args[1]["bot_uuid"] == "BOT-x"
-        assert enqueue_args.kwargs == {"deadline_seconds": 86400}
+        assert enqueue_args.args[1]["request_id"] == request_id
+        assert enqueue_args.args[1]["workflow_baseline"] == 0
+        assert enqueue_args.kwargs == {"deadline_seconds": 86400, "delay_seconds": 2}
 
-    def test_baas_restart_missing_publish_id_skips_poll_task(self):
-        """publish_id 缺失：仅 log，不抛，不入队；status 仍置 PENDING。"""
+    def test_baas_restart_missing_publish_id_keeps_adoption_task(self):
+        """publish_id 缺失时，durable task 仍按 baseline 查询并认领 workflow。"""
         baas = MagicMock()
         baas.upgrade_bot.return_value = {"bot_uuid": "BOT-x"}  # 无 publish_id
         device_provider = MagicMock()
@@ -1901,4 +1908,5 @@ class TestRestartBaasPendingAndQueue:
         bot_repo.update_by_owner.assert_called_with(
             "bot-1", "u1", {"status": "PENDING"}
         )
-        task_queue_service.enqueue.assert_not_called()
+        task_queue_service.enqueue.assert_called_once()
+        assert "publish_id" not in task_queue_service.enqueue.call_args.args[1]

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -1858,6 +1858,7 @@ class TestRestartBaasPendingAndQueue:
                 "publish_id": "9377",
                 "restart_publish_id": "9377",
                 "restart_request_id": baas.upgrade_bot.call_args.kwargs["request_id"],
+                "restart_image_policy_on_success": None,
             },
         )
         task_queue_service.enqueue.assert_called_once()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -1598,7 +1598,7 @@ class TestAsyncReleasesLock:
         device_service.apply_device.assert_called_once()
         assert device_service.apply_device.call_args.kwargs["device_provider"] == "baas"
 
-    def test_allocator_persists_default_image_after_successful_recreate(self):
+    def test_allocator_defers_default_image_while_recreate_is_pending(self):
         repo = FakeRestartLockRepo()
         svc = _make_service(repo)
         bot = _make_bot(status="PENDING", bot_type="service")
@@ -1621,6 +1621,50 @@ class TestAsyncReleasesLock:
             "service_bot_config": {"device_count": 2},
             "sbot_use_default_image": True,
         }
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.threading.Thread",
+            _SyncThread,
+        ), patch.object(
+            svc, "_persist_service_bot_default_image"
+        ) as persist_default:
+            svc._allocate_device_async(
+                bot_id="bot001",
+                user_id="user001",
+                nick_name="u1",
+                entity_id="staff_user001",
+                entity_type="staff",
+                engine_types=["openclaw"],
+                active_engine="openclaw",
+                device_provider="arca",
+                bot_ext_override=default_ext,
+            )
+
+        persist_default.assert_not_called()
+        assert device_service.apply_device.call_args.kwargs["device_props_extra"] == {
+            "image_policy_on_active": "default"
+        }
+        update = svc._repository.update_by_owner.call_args.args[2]
+        assert "ext" not in update
+
+    def test_allocator_persists_default_image_when_recreate_is_already_active(self):
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        bot = _make_bot(status="PENDING", bot_type="service")
+        svc._repository.get_by_id_and_owner.return_value = bot
+        svc._repository.update_by_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.apply_device.return_value = SimpleNamespace(
+            id=7,
+            device_id="device-7",
+            device_provider="arca",
+            status="ACTIVE",
+        )
+        svc._device_service_provider = lambda: device_service
+        svc._skill_set_factory.create.return_value.get_symlink_mappings.return_value = []
+        svc._template_service.get_template_config.return_value = None
+        svc._query_admin_worknos = MagicMock(return_value=[])
+        default_ext = {"sbot_use_default_image": True}
 
         with patch(
             "agentclaw.community.core.bot_management.services.bot_service.threading.Thread",

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -938,8 +938,8 @@ class TestRestartGuardOrchestration:
         start.assert_not_called()
         assert result == bot
 
-    def test_restart_baas_service_uses_default_image_and_persists_marker(self):
-        """草稿态重启不读开关、不覆盖模板镜像，并持久化默认镜像标记。"""
+    def test_restart_baas_service_uses_default_image_and_defers_marker(self):
+        """草稿重启提交时只透传 DEFAULT intent，成功前不持久化标记。"""
         repo = FakeRestartLockRepo()
         common_config = MagicMock()
         common_config.get_value.return_value = {"image": "registry/arka:v2"}
@@ -952,6 +952,7 @@ class TestRestartGuardOrchestration:
             repo,
             bot_repository=bot_repository,
             common_config_service=common_config,
+            task_queue_service=MagicMock(),
         )
         svc._template_service.get_template_config.return_value = {
             "image": "registry/arka:v1",
@@ -971,9 +972,9 @@ class TestRestartGuardOrchestration:
 
         common_config.get_value.assert_not_called()
         assert state["ext"]["service_bot_config"] == {"device_count": 3}
-        assert state["ext"]["sbot_use_default_image"] is True
-        assert "sbot_pin_image" not in state["ext"]
-        assert "sbot_docker_image" not in state["ext"]
+        assert "sbot_use_default_image" not in state["ext"]
+        payload = svc._task_queue_service.enqueue.call_args.args[1]
+        assert payload["image_policy_on_success"] == "default"
         upgrade_kwargs = baas.upgrade_bot.call_args.kwargs
         assert upgrade_kwargs["template_config"] == {
             "image": "registry/arka:v1",

--- a/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentclaw.community.core.bot_management.services.default_image_policy_listener import (
+    DEFAULT_IMAGE_POLICY_VALUE,
+    IMAGE_POLICY_ON_ACTIVE_KEY,
+    DefaultImagePolicyActivationListener,
+)
+from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+from agentclaw.community.core.events.types import DeviceActivatedEvent
+
+
+def _event() -> DeviceActivatedEvent:
+    return DeviceActivatedEvent(
+        device_id="device-7",
+        binding_id=7,
+        entity_id="staff-u1",
+        entity_type="staff",
+        device_provider="arca",
+    )
+
+
+def _listener(*, marker=DEFAULT_IMAGE_POLICY_VALUE, active_engine="openclaw"):
+    bot_repo = MagicMock()
+    bot_repo.get_by_binding_id.return_value = {
+        "bot_id": "bot-1",
+        "owner_id": "u1",
+        "bot_type": "service",
+        "active_engine": active_engine,
+    }
+    publish_repo = MagicMock()
+    binding_repo = MagicMock()
+    binding_repo.get_by_id.return_value = SimpleNamespace(
+        id=7,
+        env="pre",
+        device_props={IMAGE_POLICY_ON_ACTIVE_KEY: marker},
+    )
+    return (
+        DefaultImagePolicyActivationListener(
+            bot_repository=bot_repo,
+            publish_repository=publish_repo,
+            binding_repository=binding_repo,
+        ),
+        bot_repo,
+        publish_repo,
+        binding_repo,
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_subscribes_once():
+    reset_event_bus()
+    listener, *_ = _listener()
+
+    await listener.startup()
+    await listener.startup()
+
+    assert get_event_bus()._handlers[DeviceActivatedEvent] == [listener.handle]
+    reset_event_bus()
+
+
+def test_activation_persists_default_then_clears_intent():
+    listener, bot_repo, publish_repo, binding_repo = _listener()
+
+    with patch(
+        "agentclaw.community.core.bot_management.services."
+        "default_image_policy_listener.persist_default_image_policy"
+    ) as persist:
+        listener.handle(_event())
+
+    persist.assert_called_once_with(
+        bot_repository=bot_repo,
+        publish_repository=publish_repo,
+        bot_id="bot-1",
+        owner_id="u1",
+        env="pre",
+    )
+    binding_repo.update_device_props.assert_called_once_with(
+        binding_id=7,
+        props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
+    )
+
+
+def test_activation_without_restart_intent_is_ignored():
+    listener, _bot_repo, _publish_repo, binding_repo = _listener(marker=None)
+
+    with patch(
+        "agentclaw.community.core.bot_management.services."
+        "default_image_policy_listener.persist_default_image_policy"
+    ) as persist:
+        listener.handle(_event())
+
+    persist.assert_not_called()
+    binding_repo.update_device_props.assert_not_called()
+
+
+def test_persistence_failure_keeps_restart_intent():
+    listener, _bot_repo, _publish_repo, binding_repo = _listener()
+
+    with patch(
+        "agentclaw.community.core.bot_management.services."
+        "default_image_policy_listener.persist_default_image_policy",
+        side_effect=RuntimeError("db unavailable"),
+    ), pytest.raises(RuntimeError, match="db unavailable"):
+        listener.handle(_event())
+
+    binding_repo.update_device_props.assert_not_called()
+
+
+def test_teclaw_activation_is_ignored():
+    listener, _bot_repo, _publish_repo, binding_repo = _listener(
+        active_engine="teclaw"
+    )
+
+    with patch(
+        "agentclaw.community.core.bot_management.services."
+        "default_image_policy_listener.persist_default_image_policy"
+    ) as persist:
+        listener.handle(_event())
+
+    persist.assert_not_called()
+    binding_repo.update_device_props.assert_not_called()

--- a/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
@@ -9,11 +9,11 @@ from agentclaw.community.core.bot_management.services.default_image_policy_liste
     DefaultImagePolicyActivationListener,
 )
 from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
-from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.core.events.types import DeviceAliveEvent
 
 
-def _event() -> DeviceActivatedEvent:
-    return DeviceActivatedEvent(
+def _event() -> DeviceAliveEvent:
+    return DeviceAliveEvent(
         device_id="device-7",
         binding_id=7,
         entity_id="staff-u1",
@@ -57,7 +57,9 @@ async def test_startup_subscribes_once():
     await listener.startup()
     await listener.startup()
 
-    assert get_event_bus()._handlers[DeviceActivatedEvent] == [listener.handle]
+    bus = get_event_bus()
+    assert bus._handlers[DeviceAliveEvent] == [listener.handle]
+    assert (DeviceAliveEvent, listener.handle) in bus._required_handlers
     reset_event_bus()
 
 
@@ -104,6 +106,16 @@ def test_persistence_failure_keeps_restart_intent():
         "default_image_policy_listener.persist_default_image_policy",
         side_effect=RuntimeError("db unavailable"),
     ), pytest.raises(RuntimeError, match="db unavailable"):
+        listener.handle(_event())
+
+    binding_repo.update_device_props.assert_not_called()
+
+
+def test_mapping_not_ready_keeps_restart_intent_for_alive_retry():
+    listener, bot_repo, _publish_repo, binding_repo = _listener()
+    bot_repo.get_by_binding_id.return_value = None
+
+    with pytest.raises(RuntimeError, match="mapping is not ready"):
         listener.handle(_event())
 
     binding_repo.update_device_props.assert_not_called()

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -1628,6 +1628,12 @@ def test_restart_replay_after_active_reemits_reconciliation_wakeup():
         )
         bot_repository = MagicMock()
         baas_device_service = MagicMock()
+        baas_device_service.poll_publish_once.return_value = (
+            DeviceBindingStatus.ACTIVE.value
+        )
+        baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+            None
+        )
         handler, _ = _make_restart_handler(
             repo=repo,
             bot_repository=bot_repository,
@@ -1646,7 +1652,7 @@ def test_restart_replay_after_active_reemits_reconciliation_wakeup():
         )
 
         assert outcome == Complete()
-        baas_device_service.poll_publish_once.assert_not_called()
+        baas_device_service.poll_publish_once.assert_called_once_with(publish_id=1002)
         assert received == [
             BaasPublishCompletedEvent(
                 binding_id=42,
@@ -1783,11 +1789,18 @@ def test_restart_default_policy_persistence_failure_retries_without_completion()
                 "restart_image_policy_on_success": "default",
             },
         )
+        baas_device_service = MagicMock()
+        baas_device_service.poll_publish_once.return_value = (
+            DeviceBindingStatus.ACTIVE.value
+        )
+        baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+            None
+        )
         handler, _ = _make_restart_handler(
             repo=repo,
             bot_repository=MagicMock(),
             publish_repository=MagicMock(),
-            baas_device_service=MagicMock(),
+            baas_device_service=baas_device_service,
         )
 
         with patch(
@@ -1822,11 +1835,16 @@ def test_restart_replay_after_active_finishes_default_policy_persistence():
             "restart_image_policy_on_success": "default",
         },
     )
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.ACTIVE.value
+    )
+    baas_device_service.refresh_codefuse_token_on_publish_success.return_value = None
     handler, _ = _make_restart_handler(
         repo=repo,
         bot_repository=MagicMock(),
         publish_repository=MagicMock(),
-        baas_device_service=MagicMock(),
+        baas_device_service=baas_device_service,
     )
 
     with patch(
@@ -1850,3 +1868,48 @@ def test_restart_replay_after_active_finishes_default_policy_persistence():
         binding_id=42,
         props={"restart_image_policy_on_success": None},
     )
+
+
+def test_restart_old_active_does_not_finalize_while_current_publish_is_pending():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.ACTIVE.value,
+        device_props={
+            "restart_publish_id": 1002,
+            "restart_image_policy_on_success": "default",
+        },
+    )
+    bot_repository = MagicMock()
+    bot_repository.get_by_binding_id.return_value = {
+        "status": DeviceBindingStatus.ACTIVE.value
+    }
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.PENDING.value
+    )
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=bot_repository,
+        publish_repository=MagicMock(),
+        baas_device_service=baas_device_service,
+    )
+
+    with patch(
+        "agentclaw.community.core.devices.services."
+        "baas_publish_task_handlers.persist_default_image_policy"
+    ) as persist:
+        outcome = handler.handle(
+            build_restart_publish_poll_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                started_at_epoch_s=190.0,
+                bot_uuid="baas-bot-1",
+            )
+        )
+
+    assert outcome == Reschedule(10.0)
+    baas_device_service.poll_publish_once.assert_called_once_with(publish_id=1002)
+    persist.assert_not_called()
+    repo.update_status.assert_not_called()

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -73,12 +73,14 @@ def _make_restart_handler(
     repo: MagicMock,
     bot_repository: MagicMock,
     baas_device_service: MagicMock,
+    publish_repository: MagicMock | None = None,
     template_service: MagicMock | None = None,
     clock=lambda: 200.0,
 ) -> tuple[BaasRestartPublishPollHandler, MagicMock]:
     handler = BaasRestartPublishPollHandler(
         binding_repository=repo,
         bot_repository=bot_repository,
+        publish_repository=publish_repository or MagicMock(),
         baas_device_service=baas_device_service,
         template_service=template_service or MagicMock(),
         poll_delay_seconds=10.0,
@@ -1656,3 +1658,178 @@ def test_restart_replay_after_active_reemits_reconciliation_wakeup():
         ]
     finally:
         reset_event_bus()
+
+
+def test_restart_default_policy_is_persisted_only_after_active():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.PENDING.value,
+            device_props={"restart_publish_id": 1002},
+        )
+        bot_repository = MagicMock()
+        bot_repository.get_by_binding_id.return_value = {
+            "bot_id": "bot-001",
+            "owner_id": "owner-001",
+            "status": DeviceBindingStatus.PENDING.value,
+        }
+        publish_repository = MagicMock()
+        baas_device_service = MagicMock()
+        baas_device_service.poll_publish_once.return_value = (
+            DeviceBindingStatus.ACTIVE.value
+        )
+        baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+            None
+        )
+        handler, _ = _make_restart_handler(
+            repo=repo,
+            bot_repository=bot_repository,
+            publish_repository=publish_repository,
+            baas_device_service=baas_device_service,
+        )
+
+        with patch(
+            "agentclaw.community.core.devices.services."
+            "baas_publish_task_handlers.persist_default_image_policy"
+        ) as persist:
+            outcome = handler.handle(
+                build_restart_publish_poll_payload(
+                    binding_id=42,
+                    bot_id="bot-001",
+                    owner_id="owner-001",
+                    publish_id=1002,
+                    started_at_epoch_s=190.0,
+                    bot_uuid="baas-bot-1",
+                    image_policy_on_success="default",
+                )
+            )
+
+        assert outcome == Complete()
+        persist.assert_called_once_with(
+            bot_repository=bot_repository,
+            publish_repository=publish_repository,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            env="dev",
+        )
+        assert len(received) == 1
+        assert received[0].publish_kind == "restart"
+    finally:
+        reset_event_bus()
+
+
+def test_restart_failed_publish_does_not_persist_default_policy():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.PENDING.value,
+        device_props={"restart_publish_id": 1002},
+    )
+    bot_repository = MagicMock()
+    bot_repository.get_by_binding_id.return_value = {
+        "status": DeviceBindingStatus.PENDING.value
+    }
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.FAILED.value
+    )
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=bot_repository,
+        publish_repository=MagicMock(),
+        baas_device_service=baas_device_service,
+    )
+
+    with patch(
+        "agentclaw.community.core.devices.services."
+        "baas_publish_task_handlers.persist_default_image_policy"
+    ) as persist:
+        outcome = handler.handle(
+            build_restart_publish_poll_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                started_at_epoch_s=190.0,
+                bot_uuid="baas-bot-1",
+                image_policy_on_success="default",
+            )
+        )
+
+    assert outcome == Complete()
+    persist.assert_not_called()
+
+
+def test_restart_default_policy_persistence_failure_retries_without_completion():
+    reset_event_bus()
+    received: list[BaasPublishCompletedEvent] = []
+    get_event_bus().subscribe(BaasPublishCompletedEvent, received.append)
+    try:
+        repo = MagicMock()
+        repo.get_by_id.return_value = _make_binding(
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"restart_publish_id": 1002},
+        )
+        handler, _ = _make_restart_handler(
+            repo=repo,
+            bot_repository=MagicMock(),
+            publish_repository=MagicMock(),
+            baas_device_service=MagicMock(),
+        )
+
+        with patch(
+            "agentclaw.community.core.devices.services."
+            "baas_publish_task_handlers.persist_default_image_policy",
+            side_effect=RuntimeError("database unavailable"),
+        ):
+            outcome = handler.handle(
+                build_restart_publish_poll_payload(
+                    binding_id=42,
+                    bot_id="bot-001",
+                    owner_id="owner-001",
+                    publish_id=1002,
+                    started_at_epoch_s=190.0,
+                    bot_uuid="baas-bot-1",
+                    image_policy_on_success="default",
+                )
+            )
+
+        assert outcome == Retry("database unavailable")
+        assert received == []
+    finally:
+        reset_event_bus()
+
+
+def test_restart_replay_after_active_finishes_default_policy_persistence():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.ACTIVE.value,
+        device_props={"restart_publish_id": 1002},
+    )
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=MagicMock(),
+        publish_repository=MagicMock(),
+        baas_device_service=MagicMock(),
+    )
+
+    with patch(
+        "agentclaw.community.core.devices.services."
+        "baas_publish_task_handlers.persist_default_image_policy"
+    ) as persist:
+        outcome = handler.handle(
+            build_restart_publish_poll_payload(
+                binding_id=42,
+                bot_id="bot-001",
+                owner_id="owner-001",
+                publish_id=1002,
+                started_at_epoch_s=190.0,
+                bot_uuid="baas-bot-1",
+                image_policy_on_success="default",
+            )
+        )
+
+    assert outcome == Complete()
+    persist.assert_called_once()

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -1668,7 +1668,10 @@ def test_restart_default_policy_is_persisted_only_after_active():
         repo = MagicMock()
         repo.get_by_id.return_value = _make_binding(
             status=DeviceBindingStatus.PENDING.value,
-            device_props={"restart_publish_id": 1002},
+            device_props={
+                "restart_publish_id": 1002,
+                "restart_image_policy_on_success": "default",
+            },
         )
         bot_repository = MagicMock()
         bot_repository.get_by_binding_id.return_value = {
@@ -1703,7 +1706,6 @@ def test_restart_default_policy_is_persisted_only_after_active():
                     publish_id=1002,
                     started_at_epoch_s=190.0,
                     bot_uuid="baas-bot-1",
-                    image_policy_on_success="default",
                 )
             )
 
@@ -1715,6 +1717,10 @@ def test_restart_default_policy_is_persisted_only_after_active():
             owner_id="owner-001",
             env="dev",
         )
+        repo.update_device_props.assert_called_once_with(
+            binding_id=42,
+            props={"restart_image_policy_on_success": None},
+        )
         assert len(received) == 1
         assert received[0].publish_kind == "restart"
     finally:
@@ -1725,7 +1731,10 @@ def test_restart_failed_publish_does_not_persist_default_policy():
     repo = MagicMock()
     repo.get_by_id.return_value = _make_binding(
         status=DeviceBindingStatus.PENDING.value,
-        device_props={"restart_publish_id": 1002},
+        device_props={
+            "restart_publish_id": 1002,
+            "restart_image_policy_on_success": "default",
+        },
     )
     bot_repository = MagicMock()
     bot_repository.get_by_binding_id.return_value = {
@@ -1754,7 +1763,6 @@ def test_restart_failed_publish_does_not_persist_default_policy():
                 publish_id=1002,
                 started_at_epoch_s=190.0,
                 bot_uuid="baas-bot-1",
-                image_policy_on_success="default",
             )
         )
 
@@ -1770,7 +1778,10 @@ def test_restart_default_policy_persistence_failure_retries_without_completion()
         repo = MagicMock()
         repo.get_by_id.return_value = _make_binding(
             status=DeviceBindingStatus.ACTIVE.value,
-            device_props={"restart_publish_id": 1002},
+            device_props={
+                "restart_publish_id": 1002,
+                "restart_image_policy_on_success": "default",
+            },
         )
         handler, _ = _make_restart_handler(
             repo=repo,
@@ -1792,11 +1803,11 @@ def test_restart_default_policy_persistence_failure_retries_without_completion()
                     publish_id=1002,
                     started_at_epoch_s=190.0,
                     bot_uuid="baas-bot-1",
-                    image_policy_on_success="default",
                 )
             )
 
         assert outcome == Retry("database unavailable")
+        repo.update_device_props.assert_not_called()
         assert received == []
     finally:
         reset_event_bus()
@@ -1806,7 +1817,10 @@ def test_restart_replay_after_active_finishes_default_policy_persistence():
     repo = MagicMock()
     repo.get_by_id.return_value = _make_binding(
         status=DeviceBindingStatus.ACTIVE.value,
-        device_props={"restart_publish_id": 1002},
+        device_props={
+            "restart_publish_id": 1002,
+            "restart_image_policy_on_success": "default",
+        },
     )
     handler, _ = _make_restart_handler(
         repo=repo,
@@ -1827,9 +1841,12 @@ def test_restart_replay_after_active_finishes_default_policy_persistence():
                 publish_id=1002,
                 started_at_epoch_s=190.0,
                 bot_uuid="baas-bot-1",
-                image_policy_on_success="default",
             )
         )
 
     assert outcome == Complete()
     persist.assert_called_once()
+    repo.update_device_props.assert_called_once_with(
+        binding_id=42,
+        props={"restart_image_policy_on_success": None},
+    )

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -75,10 +75,12 @@ def _make_restart_handler(
     baas_device_service: MagicMock,
     publish_repository: MagicMock | None = None,
     template_service: MagicMock | None = None,
+    baas_service: MagicMock | None = None,
     clock=lambda: 200.0,
 ) -> tuple[BaasRestartPublishPollHandler, MagicMock]:
     handler = BaasRestartPublishPollHandler(
         binding_repository=repo,
+        baas_service=baas_service,
         bot_repository=bot_repository,
         publish_repository=publish_repository or MagicMock(),
         baas_device_service=baas_device_service,
@@ -87,6 +89,85 @@ def _make_restart_handler(
         clock=clock,
     )
     return handler, baas_device_service
+
+
+def test_restart_task_adopts_workflow_after_process_loses_publish_id():
+    repo = MagicMock()
+    request_id = "restart-request-1"
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.PENDING.value,
+        device_props={
+            "restart_request_id": request_id,
+            "restart_workflow_baseline": 1000,
+            "restart_publish_id": None,
+        },
+    )
+    baas_service = MagicMock()
+    baas_service.list_bot_publishes.return_value = [
+        {"id": 1000, "publish_type": "UPDATE"},
+        {"id": 1001, "publish_type": "UPDATE"},
+    ]
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = DeviceBindingStatus.PENDING.value
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=MagicMock(),
+        baas_service=baas_service,
+        baas_device_service=baas_device_service,
+    )
+
+    outcome = handler.handle(
+        build_restart_publish_poll_payload(
+            binding_id=42,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            publish_id=None,
+            started_at_epoch_s=190.0,
+            bot_uuid="uuid-001",
+            request_id=request_id,
+            workflow_baseline=1000,
+        )
+    )
+
+    assert outcome == Reschedule(10.0)
+    repo.update_device_props.assert_called_once_with(
+        binding_id=42,
+        props={"publish_id": "1001", "restart_publish_id": "1001"},
+    )
+    baas_device_service.poll_publish_once.assert_called_once_with(publish_id=1001)
+
+
+def test_restart_task_waits_for_binding_intent_commit():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.ACTIVE.value,
+        device_props={},
+    )
+    baas_service = MagicMock()
+    baas_device_service = MagicMock()
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=MagicMock(),
+        baas_service=baas_service,
+        baas_device_service=baas_device_service,
+    )
+
+    outcome = handler.handle(
+        build_restart_publish_poll_payload(
+            binding_id=42,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            publish_id=None,
+            started_at_epoch_s=190.0,
+            bot_uuid="uuid-001",
+            request_id="not-committed-yet",
+            workflow_baseline=1000,
+        )
+    )
+
+    assert outcome == Reschedule(10.0)
+    baas_service.list_bot_publishes.assert_not_called()
+    baas_device_service.poll_publish_once.assert_not_called()
 
 
 def test_read_codefuse_token_supports_personal_coding():
@@ -701,13 +782,17 @@ def test_restart_poll_marks_active_and_clears_old_baas_failure_ext_on_success():
     bot_repository.update_by_owner.assert_called_once_with(
         "bot-001",
         "owner-001",
-        {
-            "status": DeviceBindingStatus.ACTIVE.value,
-            "ext": {
-                "keep": "value",
-                "restart_publish_id": "1001",
-            },
+        {"status": DeviceBindingStatus.ACTIVE.value},
+    )
+    bot_repository.compare_and_set_ext.assert_called_once_with(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        expected_ext={
+            "start_status": "FAILED",
+            "start_message": "BaaS publish FAILED: publish_id=999",
+            "keep": "value",
         },
+        ext={"keep": "value", "restart_publish_id": "1001"},
     )
     repo.update_status.assert_called_once_with(
         binding_id=42,
@@ -754,19 +839,54 @@ def test_restart_poll_marks_failed_with_current_publish_id_on_failure():
     bot_repository.update_by_owner.assert_called_once_with(
         "bot-001",
         "owner-001",
-        {
-            "status": DeviceBindingStatus.FAILED.value,
-            "ext": {
-                "keep": "value",
-                "start_status": "FAILED",
-                "start_message": "BaaS publish FAILED: publish_id=1001",
-                "restart_publish_id": "1001",
-            },
+        {"status": DeviceBindingStatus.FAILED.value},
+    )
+    bot_repository.compare_and_set_ext.assert_called_once_with(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        expected_ext={"keep": "value"},
+        ext={
+            "keep": "value",
+            "start_status": "FAILED",
+            "start_message": "BaaS publish FAILED: publish_id=1001",
+            "restart_publish_id": "1001",
         },
     )
     repo.update_status.assert_called_once_with(
         binding_id=42,
         status=DeviceBindingStatus.FAILED.value,
+    )
+
+
+def test_restart_status_cas_preserves_nullable_bot_ext_snapshot():
+    repo = MagicMock()
+    bot_repository = MagicMock()
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=bot_repository,
+        baas_device_service=MagicMock(),
+    )
+    bot_repository.update_by_owner.return_value = {"status": "FAILED", "ext": None}
+    bot_repository.get_by_id_and_owner.return_value = {"ext": None}
+    bot_repository.compare_and_set_ext.return_value = {"ext": {"start_status": "FAILED"}}
+
+    handler._persist_restart_status(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        binding_id=42,
+        status=DeviceBindingStatus.FAILED.value,
+        publish_id=None,
+        failure_message="workflow adoption failed",
+    )
+
+    bot_repository.compare_and_set_ext.assert_called_once_with(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        expected_ext=None,
+        ext={
+            "start_status": "FAILED",
+            "start_message": "workflow adoption failed",
+        },
     )
 
 
@@ -808,14 +928,17 @@ def test_restart_poll_marks_failed_on_business_timeout():
     bot_repository.update_by_owner.assert_called_once_with(
         "bot-001",
         "owner-001",
-        {
-            "status": DeviceBindingStatus.FAILED.value,
-            "ext": {
-                "keep": "value",
-                "start_status": "FAILED",
-                "start_message": "BaaS publish timeout after 600s (publish_id=1001)",
-                "restart_publish_id": "1001",
-            },
+        {"status": DeviceBindingStatus.FAILED.value},
+    )
+    bot_repository.compare_and_set_ext.assert_called_once_with(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        expected_ext={"keep": "value"},
+        ext={
+            "keep": "value",
+            "start_status": "FAILED",
+            "start_message": "BaaS publish timeout after 600s (publish_id=1001)",
+            "restart_publish_id": "1001",
         },
     )
     repo.update_status.assert_called_once_with(
@@ -1725,7 +1848,11 @@ def test_restart_default_policy_is_persisted_only_after_active():
         )
         repo.update_device_props.assert_called_once_with(
             binding_id=42,
-            props={"restart_image_policy_on_success": None},
+            props={
+                "restart_request_id": None,
+                "restart_workflow_baseline": None,
+                "restart_image_policy_on_success": None,
+            },
         )
         assert len(received) == 1
         assert received[0].publish_kind == "restart"
@@ -1866,7 +1993,11 @@ def test_restart_replay_after_active_finishes_default_policy_persistence():
     persist.assert_called_once()
     repo.update_device_props.assert_called_once_with(
         binding_id=42,
-        props={"restart_image_policy_on_success": None},
+        props={
+            "restart_request_id": None,
+            "restart_workflow_baseline": None,
+            "restart_image_policy_on_success": None,
+        },
     )
 
 

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -1517,10 +1517,14 @@ class TestApplyDevice:
                 entity_type="staff",
                 operator=_make_operator(),
                 bot_id="bot1",
+                device_props_extra={"image_policy_on_active": "default"},
             )
 
         assert result is record
         repo.insert_binding.assert_called_once()
+        assert repo.insert_binding.call_args.kwargs["device_props"][
+            "image_policy_on_active"
+        ] == "default"
 
     def test_apply_reuses_released_binding(self):
         released = _make_record(id=5, status=DeviceBindingStatus.RELEASED.value)

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -970,6 +970,90 @@ class TestReportDeviceAlive:
         )
         reset_event_bus()
 
+    def test_default_image_intent_retries_alive_until_bot_mapping_is_ready(self):
+        from agentclaw.community.core.bot_management.services.default_image_policy_listener import (
+            DEFAULT_IMAGE_POLICY_VALUE,
+            IMAGE_POLICY_ON_ACTIVE_KEY,
+            DefaultImagePolicyActivationListener,
+        )
+        from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+        from agentclaw.community.core.events.types import DeviceAliveEvent
+
+        reset_event_bus()
+        record = _make_record(
+            status=DeviceBindingStatus.PENDING.value,
+            device_provider="arca",
+            device_props={
+                "callback_token": "tok123",
+                "sandbox_id": "sbx-current",
+                IMAGE_POLICY_ON_ACTIVE_KEY: DEFAULT_IMAGE_POLICY_VALUE,
+            },
+        )
+        updated = _make_record(
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_provider="arca",
+        )
+        repo = MagicMock()
+        repo.get_by_device_id.return_value = record
+        # Listener reads the Binding on both Alive attempts; DeviceService reads
+        # the final ACTIVE row only after the successful second attempt.
+        repo.get_by_id.side_effect = [record, record, updated]
+
+        policy_bot_repo = MagicMock()
+        policy_bot_repo.get_by_binding_id.side_effect = [
+            None,
+            {
+                "bot_id": "bot-1",
+                "owner_id": "u001",
+                "bot_type": "service",
+                "active_engine": "openclaw",
+            },
+        ]
+        publish_repo = MagicMock()
+        listener = DefaultImagePolicyActivationListener(
+            bot_repository=policy_bot_repo,
+            publish_repository=publish_repo,
+            binding_repository=repo,
+        )
+        get_event_bus().subscribe(DeviceAliveEvent, listener.handle, required=True)
+
+        svc = _make_service(repo=repo, bot_query=MagicMock())
+        with patch(
+            "agentclaw.community.core.bot_management.services."
+            "default_image_policy_listener.persist_default_image_policy"
+        ) as persist:
+            with pytest.raises(RuntimeError, match="required handler failed"):
+                svc.report_device_alive(
+                    device_id="staff_u001_default",
+                    token="tok123",
+                )
+
+            repo.update_status_and_alive_at.assert_not_called()
+            repo.update_device_props.assert_not_called()
+
+            result = svc.report_device_alive(
+                device_id="staff_u001_default",
+                token="tok123",
+            )
+
+        assert result is updated
+        persist.assert_called_once_with(
+            bot_repository=policy_bot_repo,
+            publish_repository=publish_repo,
+            bot_id="bot-1",
+            owner_id="u001",
+            env="dev",
+        )
+        repo.update_device_props.assert_called_once_with(
+            binding_id=record.id,
+            props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
+        )
+        repo.update_status_and_alive_at.assert_called_once_with(
+            binding_id=record.id,
+            status=DeviceBindingStatus.ACTIVE.value,
+        )
+        reset_event_bus()
+
     def test_event_publish_failure_does_not_break_report_alive(self):
         from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
         from agentclaw.community.core.events.types import DeviceActivatedEvent

--- a/src/backend/tests/community/core/devices/services/test_device_service_router.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service_router.py
@@ -427,9 +427,13 @@ class TestApplyDeviceRouting:
             entity_type="staff",
             operator=_make_operator(),
             bot_id="bot1",
+            device_props_extra={"image_policy_on_active": "default"},
         )
 
         mock_service.apply_device.assert_called_once()
+        assert mock_service.apply_device.call_args.kwargs["device_props_extra"] == {
+            "image_policy_on_active": "default"
+        }
         assert result is record
 
     def test_apply_forwards_template_type_and_bot_type_to_routing(self):

--- a/src/backend/tests/community/core/devices/services/test_local_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_local_device_service.py
@@ -756,10 +756,14 @@ class TestApplyDevice:
                 entity_type="staff",
                 operator=_make_operator(),
                 bot_id="bot1",
+                device_props_extra={"image_policy_on_active": "default"},
             )
 
         assert result is record
         repo.insert_binding.assert_called_once()
+        assert repo.insert_binding.call_args.kwargs["device_props"][
+            "image_policy_on_active"
+        ] == "default"
 
     def test_reuses_released_binding(self, tmp_path: Path, mock_baas, mock_poller):
         repo = MagicMock()

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -47,6 +47,7 @@ class MockPublishRecord:
     owner_id: str = OWNER_ID
     status: str = "success"
     version: int = 1
+    env: str = "pre"
     ext: dict = None
 
     def __post_init__(self):
@@ -145,9 +146,11 @@ def _wire_bot_build_service_async(bot_build_service, create_result=None, upgrade
 class TestResolvePublishImagePin:
     def test_teclaw_skips_arka_policy_resolution(self):
         svc, _, baas, _, bot_repo, *_ = _make_service()
-        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
-        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "teclaw"}
-        baas.resolve_container_provider.return_value = "teclaw"
+        record = MockPublishRecord(
+            ext={"migration_path": "/nas/path", "sbot_runtime_kind": "teclaw"}
+        )
+        publish_repo = svc._publish_repo
+        publish_repo.get_by_id.return_value = record
 
         resolved = svc._resolve_publish_image_pin(
             record,
@@ -169,15 +172,13 @@ class TestResolvePublishImagePin:
         latest = MockPublishRecord(
             ext={"migration_path": "/nas/path", "unrelated": "preserved"}
         )
-        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
-        baas.resolve_container_provider.return_value = "baas"
         publish_repo.get_by_id.return_value = latest
 
-        def update_status_with_ext(**kwargs):
+        def compare_and_set_ext(**kwargs):
             latest.ext = kwargs["ext"]
             return latest
 
-        publish_repo.update_status_with_ext.side_effect = update_status_with_ext
+        publish_repo.compare_and_set_ext.side_effect = compare_and_set_ext
 
         resolved = svc._resolve_publish_image_pin(
             record,
@@ -202,8 +203,6 @@ class TestResolvePublishImagePin:
         latest = MockPublishRecord(
             ext={"migration_path": "/nas/path", "sbot_use_default_image": True}
         )
-        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
-        baas.resolve_container_provider.return_value = "baas"
         publish_repo.get_by_id.return_value = latest
 
         resolved = svc._resolve_publish_image_pin(
@@ -213,7 +212,7 @@ class TestResolvePublishImagePin:
         )
 
         assert resolved.state == ImagePolicyState.DEFAULT
-        publish_repo.update_status_with_ext.assert_not_called()
+        publish_repo.compare_and_set_ext.assert_not_called()
         assert record.ext == latest.ext
 
     def test_failed_policy_persistence_raises_connection_error(self):
@@ -224,12 +223,10 @@ class TestResolvePublishImagePin:
         common_config.get_value.return_value = {"image": "registry/arka:v2"}
         record = MockPublishRecord(ext={"migration_path": "/nas/path"})
         latest = MockPublishRecord(ext={"migration_path": "/nas/path"})
-        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "openclaw"}
-        baas.resolve_container_provider.return_value = "baas"
         publish_repo.get_by_id.return_value = latest
-        publish_repo.update_status_with_ext.return_value = None
+        publish_repo.compare_and_set_ext.return_value = None
 
-        with pytest.raises(ConnectionError, match="changed concurrently"):
+        with pytest.raises(RuntimeError, match="CAS conflicted repeatedly"):
             svc._resolve_publish_image_pin(
                 record,
                 bot_id=BOT_ID,

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -52,7 +52,11 @@ class MockPublishRecord:
 
     def __post_init__(self):
         if self.ext is None:
-            self.ext = {"migration_path": "/nas/migration/path"}
+            self.ext = {
+                "migration_path": "/nas/migration/path",
+                "sbot_use_default_image": True,
+                "sbot_runtime_kind": "arka",
+            }
 
 
 def _make_ws_info():
@@ -113,9 +117,11 @@ def _make_service(
 
 def _wire_publish(publish_repo, record=None):
     """Wire publish_repo to return a success publish record."""
+    publish_record = record or MockPublishRecord()
     publish_repo.get_by_publish_bot_id = MagicMock(
-        return_value=record or MockPublishRecord()
+        return_value=publish_record
     )
+    publish_repo.get_by_id = MagicMock(return_value=publish_record)
 
 
 def _wire_bot_repo(bot_repo, bot_info=None):
@@ -1201,9 +1207,18 @@ class TestGetCallerConnectionEdgeCases:
             return_value={"id": 1, "status": "success", "ext": existing_ext}
         )
         # publish_version is None, defaults to 1, which is less than 2
-        record = MockPublishRecord(id=123, version=None, ext={"migration_path": "/path"})
+        record = MockPublishRecord(
+            id=123,
+            version=None,
+            ext={
+                "migration_path": "/path",
+                "sbot_use_default_image": True,
+                "sbot_runtime_kind": "arka",
+            },
+        )
         record.version = None
         publish_repo.get_by_publish_bot_id = MagicMock(return_value=record)
+        publish_repo.get_by_id = MagicMock(return_value=record)
         ws_info = _make_ws_info()
         baas.get_ws_info_by_bot_uuid = MagicMock(return_value=ws_info)
 

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -1,18 +1,25 @@
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePinPersistenceError,
     ImagePinConfigError,
     ImagePolicyState,
+    PublishImagePolicyResolver,
+    RUNTIME_KIND_ARKA,
+    RUNTIME_KIND_TECLAW,
     apply_default_image_to_ext,
     apply_image_pin_to_ext,
+    apply_runtime_kind_to_ext,
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
     resolve_current_arka_image,
     resolve_publish_image_pin,
+    resolve_publish_runtime_kind,
 )
 
 
@@ -92,6 +99,7 @@ def test_apply_default_preserves_unrelated_fields_and_clears_stale_pin():
         "service_bot_config": {"device_count": 3},
         "sbot_use_default_image": True,
     }
+
 
 def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     source = {
@@ -202,3 +210,136 @@ def test_resolve_rejects_pin_without_image():
 def test_resolve_rejects_dangling_image_policy_field():
     with pytest.raises(ImagePinConfigError, match="inconsistent image policy"):
         resolve_publish_image_pin(_record({"sbot_docker_image": "arka:v2"}))
+
+
+def test_runtime_kind_prefers_publish_snapshot():
+    record = _record({"sbot_runtime_kind": RUNTIME_KIND_TECLAW})
+    binding_repo = MagicMock()
+
+    assert (
+        resolve_publish_runtime_kind(record, binding_repository=binding_repo)
+        == RUNTIME_KIND_TECLAW
+    )
+    binding_repo.get_by_id.assert_not_called()
+
+
+def test_runtime_kind_reads_teclaw_artifact_for_historical_publish():
+    record = _record({"config_artifact": {"engine_type": "teclaw"}})
+
+    assert resolve_publish_runtime_kind(record) == RUNTIME_KIND_TECLAW
+
+
+def test_runtime_kind_reads_string_stage_binding_provider():
+    record = _record({"binding": {"online": "42"}})
+    binding_repo = MagicMock()
+    binding_repo.get_by_id.return_value = SimpleNamespace(device_provider="baas")
+
+    assert (
+        resolve_publish_runtime_kind(record, binding_repository=binding_repo)
+        == RUNTIME_KIND_ARKA
+    )
+    binding_repo.get_by_id.assert_called_once_with(42)
+
+
+def test_apply_runtime_kind_preserves_unrelated_ext():
+    assert apply_runtime_kind_to_ext({"migration_path": "/build/v1"}, "arka") == {
+        "migration_path": "/build/v1",
+        "sbot_runtime_kind": "arka",
+    }
+
+
+def test_persisted_resolver_returns_successful_cas_snapshot():
+    legacy = _record({"migration_path": "/build/v1", "unrelated": "keep"})
+    persisted = _record(
+        {
+            "migration_path": "/build/v1",
+            "unrelated": "keep",
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arka:v2",
+        }
+    )
+    publish_repo = MagicMock()
+    publish_repo.get_by_id.return_value = legacy
+    publish_repo.compare_and_set_ext.return_value = persisted
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    resolver = PublishImagePolicyResolver(
+        publish_repository=publish_repo,
+        binding_repository=MagicMock(),
+        common_config_service=common_config,
+    )
+    original = _record()
+
+    resolved = resolver.resolve(original)
+
+    assert resolved.state == ImagePolicyState.PINNED
+    assert resolved.docker_image == "registry/arka:v2"
+    assert original.ext == persisted.ext
+    publish_repo.compare_and_set_ext.assert_called_once_with(
+        publish_id=legacy.id,
+        expected_ext=legacy.ext,
+        ext=persisted.ext,
+    )
+
+
+def test_persisted_resolver_reloads_concurrent_default_after_cas_conflict():
+    legacy = _record({"migration_path": "/build/v1"})
+    concurrent_default = _record(
+        {"migration_path": "/build/v1", "sbot_use_default_image": True}
+    )
+    publish_repo = MagicMock()
+    publish_repo.get_by_id.side_effect = [legacy, concurrent_default]
+    publish_repo.compare_and_set_ext.return_value = None
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    resolver = PublishImagePolicyResolver(
+        publish_repository=publish_repo,
+        binding_repository=MagicMock(),
+        common_config_service=common_config,
+    )
+    original = _record()
+
+    resolved = resolver.resolve(original)
+
+    assert resolved.state == ImagePolicyState.DEFAULT
+    assert resolved.docker_image is None
+    assert original.ext == concurrent_default.ext
+
+
+def test_persisted_resolver_fails_closed_after_repeated_cas_conflicts():
+    legacy = _record({"migration_path": "/build/v1"})
+    publish_repo = MagicMock()
+    publish_repo.get_by_id.return_value = legacy
+    publish_repo.compare_and_set_ext.return_value = None
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    resolver = PublishImagePolicyResolver(
+        publish_repository=publish_repo,
+        binding_repository=MagicMock(),
+        common_config_service=common_config,
+        max_cas_attempts=2,
+    )
+
+    with pytest.raises(ImagePinPersistenceError, match="CAS conflicted repeatedly"):
+        resolver.resolve(_record())
+
+    assert publish_repo.compare_and_set_ext.call_count == 2
+
+
+def test_persisted_resolver_skips_common_config_for_teclaw_publish():
+    latest = _record({"sbot_runtime_kind": "teclaw"})
+    publish_repo = MagicMock()
+    publish_repo.get_by_id.return_value = latest
+    common_config = MagicMock()
+    resolver = PublishImagePolicyResolver(
+        publish_repository=publish_repo,
+        binding_repository=MagicMock(),
+        common_config_service=common_config,
+    )
+
+    resolved = resolver.resolve(_record())
+
+    assert resolved.state == ImagePolicyState.LEGACY
+    assert resolved.docker_image is None
+    common_config.get_value.assert_not_called()
+    publish_repo.compare_and_set_ext.assert_not_called()

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.service_bot.services.arka_image_pin import (
     apply_runtime_kind_to_ext,
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
+    persist_default_image_policy,
     resolve_current_arka_image,
     resolve_publish_image_pin,
     resolve_publish_runtime_kind,
@@ -55,11 +56,12 @@ def test_resolve_current_image_uses_enabled_common_config():
     )
 
 
-def test_resolve_current_image_returns_none_for_disabled_or_missing_config():
+def test_resolve_current_image_fails_closed_for_disabled_or_missing_config():
     service = MagicMock()
     service.get_value.return_value = None
 
-    assert resolve_current_arka_image(service, env="pre") is None
+    with pytest.raises(ImagePinConfigError, match="missing or disabled"):
+        resolve_current_arka_image(service, env="pre")
 
 
 @pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arka:v2"])
@@ -163,19 +165,17 @@ def test_resolve_default_publish_does_not_read_common_config():
     common_config.get_value.assert_not_called()
 
 
-def test_resolve_legacy_publish_with_disabled_config_stays_legacy():
+def test_resolve_legacy_publish_with_disabled_config_fails_closed():
     common_config = MagicMock()
     common_config.get_value.return_value = None
     persist = MagicMock()
 
-    resolved = resolve_publish_image_pin(
-        _record({"migration_path": "/build/v1"}),
-        common_config_service=common_config,
-        persist_ext=persist,
-    )
-
-    assert resolved.state == ImagePolicyState.LEGACY
-    assert resolved.docker_image is None
+    with pytest.raises(ImagePinConfigError, match="missing or disabled"):
+        resolve_publish_image_pin(
+            _record({"migration_path": "/build/v1"}),
+            common_config_service=common_config,
+            persist_ext=persist,
+        )
     persist.assert_not_called()
 
 
@@ -343,3 +343,31 @@ def test_persisted_resolver_skips_common_config_for_teclaw_publish():
     assert resolved.docker_image is None
     common_config.get_value.assert_not_called()
     publish_repo.compare_and_set_ext.assert_not_called()
+
+
+def test_default_policy_retries_bot_cas_without_losing_concurrent_ext():
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.side_effect = [
+        {"ext": {"keep": "old"}},
+        {"ext": {"keep": "new", "concurrent": True}},
+    ]
+    bot_repo.compare_and_set_ext.side_effect = [None, {"ext": {}}]
+    publish_repo = MagicMock()
+    publish_repo.get_draft_by_publish_bot_id.return_value = None
+
+    persist_default_image_policy(
+        bot_repository=bot_repo,
+        publish_repository=publish_repo,
+        bot_id="bot-1",
+        owner_id="u1",
+        env="pre",
+    )
+
+    assert bot_repo.compare_and_set_ext.call_count == 2
+    second = bot_repo.compare_and_set_ext.call_args_list[1].kwargs
+    assert second["expected_ext"] == {"keep": "new", "concurrent": True}
+    assert second["ext"] == {
+        "keep": "new",
+        "concurrent": True,
+        "sbot_use_default_image": True,
+    }

--- a/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arka_image_pin.py
@@ -56,12 +56,11 @@ def test_resolve_current_image_uses_enabled_common_config():
     )
 
 
-def test_resolve_current_image_fails_closed_for_disabled_or_missing_config():
+def test_resolve_current_image_returns_none_for_disabled_or_missing_config():
     service = MagicMock()
     service.get_value.return_value = None
 
-    with pytest.raises(ImagePinConfigError, match="missing or disabled"):
-        resolve_current_arka_image(service, env="pre")
+    assert resolve_current_arka_image(service, env="pre") is None
 
 
 @pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arka:v2"])
@@ -165,17 +164,19 @@ def test_resolve_default_publish_does_not_read_common_config():
     common_config.get_value.assert_not_called()
 
 
-def test_resolve_legacy_publish_with_disabled_config_fails_closed():
+def test_resolve_legacy_publish_with_disabled_config_keeps_platform_default():
     common_config = MagicMock()
     common_config.get_value.return_value = None
     persist = MagicMock()
 
-    with pytest.raises(ImagePinConfigError, match="missing or disabled"):
-        resolve_publish_image_pin(
-            _record({"migration_path": "/build/v1"}),
-            common_config_service=common_config,
-            persist_ext=persist,
-        )
+    resolved = resolve_publish_image_pin(
+        _record({"migration_path": "/build/v1"}),
+        common_config_service=common_config,
+        persist_ext=persist,
+    )
+
+    assert resolved.state == ImagePolicyState.LEGACY
+    assert resolved.docker_image is None
     persist.assert_not_called()
 
 
@@ -280,6 +281,27 @@ def test_persisted_resolver_returns_successful_cas_snapshot():
         expected_ext=legacy.ext,
         ext=persisted.ext,
     )
+
+
+def test_persisted_resolver_keeps_legacy_when_switch_disabled():
+    legacy = _record({"migration_path": "/build/v1"})
+    publish_repo = MagicMock()
+    publish_repo.get_by_id.return_value = legacy
+    common_config = MagicMock()
+    common_config.get_value.return_value = None
+    resolver = PublishImagePolicyResolver(
+        publish_repository=publish_repo,
+        binding_repository=MagicMock(),
+        common_config_service=common_config,
+    )
+    original = _record()
+
+    resolved = resolver.resolve(original)
+
+    assert resolved.state == ImagePolicyState.LEGACY
+    assert resolved.docker_image is None
+    assert original.ext == legacy.ext
+    publish_repo.compare_and_set_ext.assert_not_called()
 
 
 def test_persisted_resolver_reloads_concurrent_default_after_cas_conflict():

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -25,6 +25,9 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePinConfigError,
+)
 
 
 def _make_service(
@@ -167,21 +170,14 @@ class TestCreatePublishImagePolicy:
         }
         common_config.get_value.assert_called_once()
 
-    def test_legacy_arka_bot_stays_policyless_when_switch_disabled(self):
-        ext, common_config = self._create(
-            source_bot={
-                "bot_type": "service",
-                "active_engine": "openclaw",
-                "ext": {"service_bot_config": {"device_count": 2}},
-            },
-            common_config_value=None,
-        )
-
-        assert ext == {
-            "migration_path": "/build/v1",
-            "sbot_runtime_kind": "arka",
+    def test_legacy_arka_bot_fails_closed_when_switch_config_missing(self):
+        source_bot = {
+            "bot_type": "service",
+            "active_engine": "openclaw",
+            "ext": {"service_bot_config": {"device_count": 2}},
         }
-        common_config.get_value.assert_called_once()
+        with pytest.raises(ImagePinConfigError, match="missing or disabled"):
+            self._create(source_bot=source_bot, common_config_value=None)
 
     def test_teclaw_publish_does_not_consume_arka_common_config(self):
         ext, common_config = self._create(
@@ -1727,7 +1723,12 @@ class TestRecordDraftArtifact:
         mock_repo = Mock()
         mock_repo.get_draft_by_publish_bot_id.return_value = record
         mock_repo.get_by_id.return_value = record
-        mock_repo.update_status_with_ext.return_value = record
+        updated_record = _create_mock_record(
+            record_id=7,
+            status=PublishStatus.DRAFT,
+            ext={"keep": "me", "config_artifact": {"schema_version": 4, "mcp": {"servers": []}}},
+        )
+        mock_repo.compare_and_set_ext.return_value = updated_record
         service = _make_service(bot_publish_repo=mock_repo)
 
         artifact = {"schema_version": 4, "mcp": {"servers": []}}
@@ -1739,9 +1740,10 @@ class TestRecordDraftArtifact:
         mock_repo.get_draft_by_publish_bot_id.assert_called_once_with(
             publish_bot_id="bot_001_pub", env=service._env
         )
-        # update_publish_ext -> update_status_with_ext with merged ext (other keys kept)
-        _, kwargs = mock_repo.update_status_with_ext.call_args
+        # CAS write carries both the old snapshot and merged ext.
+        _, kwargs = mock_repo.compare_and_set_ext.call_args
         assert kwargs["publish_id"] == 7
+        assert kwargs["expected_ext"] == {"keep": "me"}
         assert kwargs["ext"] == {"keep": "me", "config_artifact": artifact}
 
     def test_no_op_when_no_draft_row(self):
@@ -1754,7 +1756,7 @@ class TestRecordDraftArtifact:
         ok = service.record_draft_artifact(bot_id="bot_x", artifact={"schema_version": 4})
 
         assert ok is False
-        mock_repo.update_status_with_ext.assert_not_called()
+        mock_repo.compare_and_set_ext.assert_not_called()
 
 
 class TestGetNextVersion:

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -145,6 +145,7 @@ class TestCreatePublishImagePolicy:
         assert ext == {
             "migration_path": "/build/v1",
             "sbot_use_default_image": True,
+            "sbot_runtime_kind": "arka",
         }
         common_config.get_value.assert_not_called()
 
@@ -162,6 +163,7 @@ class TestCreatePublishImagePolicy:
             "migration_path": "/build/v1",
             "sbot_pin_image": True,
             "sbot_docker_image": "registry/arka:v2",
+            "sbot_runtime_kind": "arka",
         }
         common_config.get_value.assert_called_once()
 
@@ -175,7 +177,10 @@ class TestCreatePublishImagePolicy:
             common_config_value=None,
         )
 
-        assert ext == {"migration_path": "/build/v1"}
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_runtime_kind": "arka",
+        }
         common_config.get_value.assert_called_once()
 
     def test_teclaw_publish_does_not_consume_arka_common_config(self):
@@ -189,7 +194,10 @@ class TestCreatePublishImagePolicy:
             is_teclaw=True,
         )
 
-        assert ext == {"migration_path": "/build/v1"}
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_runtime_kind": "teclaw",
+        }
         common_config.get_value.assert_not_called()
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -25,9 +25,6 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
-    ImagePinConfigError,
-)
 
 
 def _make_service(
@@ -170,14 +167,21 @@ class TestCreatePublishImagePolicy:
         }
         common_config.get_value.assert_called_once()
 
-    def test_legacy_arka_bot_fails_closed_when_switch_config_missing(self):
-        source_bot = {
-            "bot_type": "service",
-            "active_engine": "openclaw",
-            "ext": {"service_bot_config": {"device_count": 2}},
+    def test_legacy_arka_bot_stays_policyless_when_switch_disabled(self):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "openclaw",
+                "ext": {"service_bot_config": {"device_count": 2}},
+            },
+            common_config_value=None,
+        )
+
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_runtime_kind": "arka",
         }
-        with pytest.raises(ImagePinConfigError, match="missing or disabled"):
-            self._create(source_bot=source_bot, common_config_value=None)
+        common_config.get_value.assert_called_once()
 
     def test_teclaw_publish_does_not_consume_arka_common_config(self):
         ext, common_config = self._create(

--- a/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
@@ -10,6 +10,7 @@ ledger, and follow-up steps (binding) are not duplicated.
 Group B lands the release-leg cases (first release); later groups extend this file
 per operation.
 """
+import copy
 from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock
@@ -37,6 +38,12 @@ from agentclaw.community.core.service_bot.services.publish_flow.operation_runner
     to_baas_request_id,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
+
+
+def _apply_ext_mutation(ext, mutator):
+    updated = copy.deepcopy(ext or {})
+    mutator(updated)
+    return updated
 
 
 # ── ledger + fakes ────────────────────────────────────────────────────────────
@@ -945,7 +952,9 @@ def _recreate_restart_flow(ledger, baas, build_service, *, record, bot_uuid="BOT
         return_value=Mock(device_id=bot_uuid)
     )
     svc._publish_service.create_device_binding = Mock(return_value=55)
-    svc._publish_service.update_publish_ext = Mock()
+    svc._publish_service.mutate_publish_ext = Mock(
+        side_effect=lambda _publish_id, mutator: Mock(ext=_apply_ext_mutation(record.ext, mutator))
+    )
     svc._bot_service.get_bot = Mock(return_value={"bot_id": "b2", "entity_id": "u1"})
     svc.refresh_publish_handle = Mock()
     return svc
@@ -998,8 +1007,9 @@ async def test_restart_bot_not_found_recreates_with_fresh_op_and_binding():
     binding_kwargs = svc._publish_service.create_device_binding.call_args.kwargs
     assert binding_kwargs["device_id"] == "BOT-new"
 
-    # One ext write carrying all three read handles for the stage.
-    ext = svc._publish_service.update_publish_ext.call_args.kwargs["ext"]
+    # One CAS mutation carries all three read handles for the stage.
+    mutator = svc._publish_service.mutate_publish_ext.call_args.args[1]
+    ext = _apply_ext_mutation(_restart_record().ext, mutator)
     assert ext["binding"]["online"] == 55
     assert ext["publish"]["online"] == 901
     assert ext["restart"]["online"] == 901
@@ -1108,7 +1118,8 @@ async def test_verify_stage_restart_bot_not_found_gets_same_recreate():
         PublishOperationState.ABANDONED.value
     fr = ledger.get_latest_by_kind(1, "first_release", "verify")
     assert fr.state == PublishOperationState.COMPLETED.value
-    ext = svc._publish_service.update_publish_ext.call_args.kwargs["ext"]
+    mutator = svc._publish_service.mutate_publish_ext.call_args.args[1]
+    ext = _apply_ext_mutation(_restart_record(stage="verify").ext, mutator)
     assert ext["restart"]["verify"] == 901
     assert ext["binding"]["verify"] == 55
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -12,6 +12,11 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService, BotBuildServiceError
+from agentclaw.community.core.service_bot.services.arka_image_pin import (
+    ImagePolicyState,
+    ServiceBotImagePin,
+    resolve_publish_image_pin as resolve_publish_image_pin_policy,
+)
 from agentclaw.community.core.service_bot.services.publish_flow_service import (
     PublishFlowService,
     PublishFlowServiceError,
@@ -118,6 +123,19 @@ def _pf(*args, **kw):
     baas = args[2] if len(args) >= 3 else kw.get("baas_service")
     if isinstance(baas, Mock):
         baas.list_bot_publishes.return_value = []
+    publish_service = args[0] if args else kw.get("bot_publish_service")
+    if isinstance(publish_service, Mock):
+        def _resolve_image_policy(record):
+            artifact = (record.ext or {}).get("config_artifact")
+            if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
+                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+            return resolve_publish_image_pin_policy(
+                record,
+                common_config_service=kw["common_config_service"],
+                env=record.env,
+            )
+
+        publish_service.resolve_publish_image_pin.side_effect = _resolve_image_policy
     if "channel_overrides_reader" not in kw:
         # Default to "no channels for this stage" ({}), so promotion delivers the
         # base artifact with channels cleared — tests that care about channels pass

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -1,3 +1,4 @@
+import copy
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock
@@ -129,6 +130,18 @@ def _pf(*args, **kw):
             artifact = (record.ext or {}).get("config_artifact")
             if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
                 return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
+            if not any(
+                key in (record.ext or {})
+                for key in (
+                    "sbot_pin_image",
+                    "sbot_docker_image",
+                    "sbot_use_default_image",
+                )
+            ):
+                # These flow tests predate runtime-pin configuration and focus
+                # on orchestration. Dedicated image-policy tests cover the
+                # production resolver's fail-closed behavior.
+                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
             return resolve_publish_image_pin_policy(
                 record,
                 common_config_service=kw["common_config_service"],
@@ -136,6 +149,24 @@ def _pf(*args, **kw):
             )
 
         publish_service.resolve_publish_image_pin.side_effect = _resolve_image_policy
+        def _resolve_runtime_kind(record):
+            ext = record.ext or {}
+            explicit = ext.get("sbot_runtime_kind")
+            if explicit in {"arka", "teclaw"}:
+                return explicit
+            artifact = ext.get("config_artifact")
+            if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
+                return "teclaw"
+            # Old flow fixtures express their historical binding through the
+            # BaaS provider mock. Production uses Publish ext/bindings only.
+            provider = (
+                baas.resolve_container_provider.return_value
+                if isinstance(baas, Mock)
+                else None
+            )
+            return "teclaw" if provider == "teclaw" else "arka"
+
+        publish_service.resolve_publish_runtime_kind.side_effect = _resolve_runtime_kind
     if "channel_overrides_reader" not in kw:
         # Default to "no channels for this stage" ({}), so promotion delivers the
         # base artifact with channels cleared — tests that care about channels pass
@@ -143,7 +174,16 @@ def _pf(*args, **kw):
         reader = Mock()
         reader.overrides_for_stage.return_value = {}
         kw["channel_overrides_reader"] = reader
-    return PublishFlowService(*args, **kw)
+    svc = PublishFlowService(*args, **kw)
+
+    # Unit tests commonly replace get_latest_ext with a focused stub. Preserve
+    # that seam while supplying the exact-snapshot API used by status+ext CAS.
+    def _latest_ext_snapshot(publish_id):
+        ext = svc._ext_state.get_latest_ext(publish_id)
+        return copy.deepcopy(ext), copy.deepcopy(ext)
+
+    svc._ext_state.get_latest_ext_snapshot = _latest_ext_snapshot
+    return svc
 
 
 def _arca_router(build_service=None):
@@ -666,8 +706,9 @@ async def test_retry_clears_retry_flag_when_restart_submit_fails():
     assert result.message == 'Retry failed: submit failed'
     rollback_ext = publish_service.update_publish_status_with_ext.call_args.kwargs['ext']
     assert rollback_ext['retry'] is True
-    publish_service.update_publish_ext.assert_called_once()
-    cleared_ext = publish_service.update_publish_ext.call_args.kwargs['ext']
+    publish_service.mutate_publish_ext.assert_called_once()
+    cleared_ext = {**ext, 'retry': True}
+    publish_service.mutate_publish_ext.call_args.args[1](cleared_ext)
     assert 'retry' not in cleared_ext
     assert cleared_ext['source_status'] == PublishStatus.VALIDATE_PUB.value
 
@@ -2588,6 +2629,7 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
         ext={
             "binding": {"online": 123},
             "skills_manifest": frozen_skills,
+            "sbot_runtime_kind": "arka",
             "sbot_pin_image": True,
             "sbot_docker_image": "registry/arka:v2",
         },
@@ -2597,7 +2639,13 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
 
     publish_service.get_publish_by_id = Mock(return_value=record)
     publish_service.get_device_binding_by_id = Mock(return_value=binding)
-    bot_service.get_bot = Mock(return_value={"bot_id": "bot-source", "ext": {"service_bot_config": {"device_count": 3}}})
+    # The mutable Draft has already switched to TeClaw, but this historical
+    # Publish remains ARKA-owned and must still execute BaaS scale.
+    bot_service.get_bot = Mock(return_value={
+        "bot_id": "bot-source",
+        "active_engine": "teclaw",
+        "ext": {"service_bot_config": {"device_count": 3}},
+    })
     baas_service.scale_bot = Mock(return_value={"publish_id": 888, "target_count": 3})
 
     result = await svc.scale_bot(publish_id=10, operator="u1")
@@ -2617,16 +2665,11 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
     }
     # (#197) request_id is now the runner's deterministic op id (wall-clock id gone).
     assert kwargs["request_id"] == operation_request_id(10, "scale", "online", 1)
-    publish_service.update_publish_ext.assert_called_once_with(
-        publish_id=10,
-        ext={
-            "binding": {"online": 123},
-            "skills_manifest": frozen_skills,
-            "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
-            "scale": {"publish_id": 888},
-        },
-    )
+    publish_service.mutate_publish_ext.assert_called_once()
+    assert publish_service.mutate_publish_ext.call_args.args[0] == 10
+    persisted_ext = dict(record.ext)
+    publish_service.mutate_publish_ext.call_args.args[1](persisted_ext)
+    assert persisted_ext["scale"] == {"publish_id": 888}
 
 
 @pytest.mark.unit
@@ -2670,7 +2713,7 @@ async def test_scale_bot_falls_back_to_common_config_default_device_count():
     result = await svc.scale_bot(publish_id=13, operator="u1")
 
     assert result["target_count"] == 2
-    assert common_config_service.get_value.call_count == 2
+    assert common_config_service.get_value.call_count == 1
     _, kwargs = baas_service.scale_bot.call_args
     assert kwargs["bot_uuid"] == "BOT-UUID-2"
     assert kwargs["owner_id"] == "u1"
@@ -2690,14 +2733,17 @@ async def test_scale_bot_teclaw_returns_supported_message_without_baas_call():
     svc = _pf(publish_service, build_service, baas_service, bot_service, _arca_router(build_service))
 
     publish_service.get_publish_by_id = Mock(
-        return_value=_make_publish_record(id=15, status=PublishStatus.SUCCESS.value)
+        return_value=_make_publish_record(
+            id=15,
+            status=PublishStatus.SUCCESS.value,
+            ext={"sbot_runtime_kind": "teclaw"},
+        )
     )
     bot_service.get_bot = Mock(
-        return_value={"bot_id": "bot-source", "active_engine": "teclaw", "ext": {}}
+        return_value={"bot_id": "bot-source", "active_engine": "openclaw", "ext": {}}
     )
-    # resolve_container_provider derives from active_engine in real code; the
-    # provider seam reads teclaw → TeclawProviderBehavior (supports_scale=False).
-    baas_service.resolve_container_provider.return_value = "teclaw"
+    # The current Draft is ARKA, but the immutable Publish is TeClaw-owned.
+    baas_service.resolve_container_provider.return_value = "baas"
 
     result = await svc.scale_bot(publish_id=15, operator="u1")
 
@@ -3247,6 +3293,11 @@ def test_handle_sync_success_verify_stage_updates_validating_and_clears_retry():
         target_status=PublishStatus.VALIDATING,
         ext=ext,
         source_status=PublishStatus.VALIDATE_PUB,
+        expected_ext={
+            "binding": {PublishStage.VERIFY.value: 300},
+            "retry": True,
+            "restart": {"verify": 123, "restarting": True},
+        },
     )
     svc._mark_previous_publish_superseded.assert_called_once_with(
         publish_record, PublishStage.VERIFY, PublishStatus.VALIDATING

--- a/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arka_image_pin import (
     ImagePolicyState,
+    ServiceBotImagePin,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.image_policy_mixin import (
     PublishImagePolicyMixin,
@@ -29,84 +30,17 @@ def _record(ext=None) -> BotPublishRecord:
 
 
 class _ImagePolicyHarness(PublishImagePolicyMixin):
-    def __init__(self, *, latest=None, image=None):
-        self._baas_service = MagicMock()
-        self._baas_service.resolve_container_provider.return_value = "baas"
-        self._common_config_service = MagicMock()
-        self._common_config_service.get_value.return_value = (
-            {"image": image} if image else None
-        )
+    def __init__(self) -> None:
         self._publish_service = MagicMock()
-        self._publish_service.get_publish_by_id.return_value = latest
-        self.mutated_ext = None
-
-    def _mutate_and_update_ext(self, publish_id, mutator):
-        latest = self._publish_service.get_publish_by_id(publish_id)
-        if latest is None:
-            return None
-        latest_ext = dict(latest.ext or {})
-        mutator(latest_ext)
-        latest.ext = latest_ext
-        self.mutated_ext = latest_ext
-        return latest_ext
 
 
-def test_resolve_publish_image_pin_skips_teclaw():
+def test_resolve_publish_image_pin_delegates_to_shared_publish_service_resolver():
     record = _record({"migration_path": "/build/v1"})
-    svc = _ImagePolicyHarness(image="registry/arka:v2")
-    svc._baas_service.resolve_container_provider.return_value = "teclaw"
+    expected = ServiceBotImagePin(ImagePolicyState.PINNED, "registry/arka:v2")
+    svc = _ImagePolicyHarness()
+    svc._publish_service.resolve_publish_image_pin.return_value = expected
 
-    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "teclaw"})
+    resolved = svc.resolve_publish_image_pin(record)
 
-    assert resolved.state == ImagePolicyState.LEGACY
-    assert resolved.docker_image is None
-    svc._common_config_service.get_value.assert_not_called()
-
-
-def test_resolve_publish_image_pin_persists_legacy_snapshot_and_refreshes_record():
-    record = _record({"migration_path": "/build/v1"})
-    latest = _record({"migration_path": "/build/v1", "unrelated": "preserved"})
-    svc = _ImagePolicyHarness(latest=latest, image="registry/arka:v2")
-
-    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
-
-    assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "registry/arka:v2"
-    assert svc.mutated_ext == {
-        "migration_path": "/build/v1",
-        "unrelated": "preserved",
-        "sbot_pin_image": True,
-        "sbot_docker_image": "registry/arka:v2",
-    }
-    assert record.ext == latest.ext
-
-
-def test_resolve_publish_image_pin_does_not_replace_concurrent_explicit_policy():
-    record = _record({"migration_path": "/build/v1"})
-    latest = _record(
-        {
-            "migration_path": "/build/v1",
-            "sbot_use_default_image": True,
-        }
-    )
-    svc = _ImagePolicyHarness(latest=latest, image="registry/arka:v2")
-
-    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
-
-    assert resolved.state == ImagePolicyState.DEFAULT
-    assert resolved.docker_image is None
-    assert latest.ext == {
-        "migration_path": "/build/v1",
-        "sbot_use_default_image": True,
-    }
-    assert record.ext == latest.ext
-
-
-def test_resolve_publish_image_pin_returns_initial_resolution_when_reread_missing():
-    record = _record({"migration_path": "/build/v1"})
-    svc = _ImagePolicyHarness(latest=None, image="registry/arka:v2")
-
-    resolved = svc.resolve_publish_image_pin(record, {"active_engine": "openclaw"})
-
-    assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "registry/arka:v2"
+    assert resolved is expected
+    svc._publish_service.resolve_publish_image_pin.assert_called_once_with(record)

--- a/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
+++ b/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
@@ -168,7 +168,11 @@ def _seed_published_service_bot(world) -> None:
         "status": PublishStatus.SUCCESS,
         "version": 1,
         "env": env,
-        "ext": {"migration_path": "/nas/migration/path"},
+        "ext": {
+            "migration_path": "/nas/migration/path",
+            "sbot_use_default_image": True,
+            "sbot_runtime_kind": "arka",
+        },
     })
 
 

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -248,6 +248,32 @@ def test_compare_and_set_ext_supports_null_expected_ext(repo):
     assert updated.ext == {"sbot_runtime_kind": "arka"}
 
 
+def test_compare_and_set_status_with_ext_guards_both_snapshots(repo):
+    rec = repo.insert(_data(status="DRAFT", ext={"concurrent": "preserve"}))
+
+    updated = repo.compare_and_set_status_with_ext(
+        publish_id=rec.id,
+        source_status="DRAFT",
+        target_status="BUILT",
+        expected_ext={"concurrent": "preserve"},
+        ext={"concurrent": "preserve", "build": {"done": True}},
+    )
+    assert updated is not None
+    assert updated.status == "BUILT"
+
+    stale = repo.compare_and_set_status_with_ext(
+        publish_id=rec.id,
+        source_status="BUILT",
+        target_status="SUCCESS",
+        expected_ext={"concurrent": "preserve"},
+        ext={"lost": "update"},
+    )
+    assert stale is None
+    persisted = repo.get_by_id(rec.id)
+    assert persisted.status == "BUILT"
+    assert persisted.ext == {"concurrent": "preserve", "build": {"done": True}}
+
+
 def test_update_version_and_last_pub_id(repo):
     r = repo.insert(_data(version=1))
     out = repo.update_version(r.id, 5, status="RELEASE")

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -203,6 +203,51 @@ def test_update_status_with_ext(repo):
     ) is None
 
 
+def test_compare_and_set_ext_updates_only_matching_snapshot(repo):
+    rec = repo.insert(_data(ext={"service_bot_config": {"device_count": 2}}))
+
+    updated = repo.compare_and_set_ext(
+        publish_id=rec.id,
+        expected_ext={"service_bot_config": {"device_count": 2}},
+        ext={
+            "service_bot_config": {"device_count": 2},
+            "sbot_use_default_image": True,
+        },
+    )
+
+    assert updated is not None
+    assert updated.ext == {
+        "service_bot_config": {"device_count": 2},
+        "sbot_use_default_image": True,
+    }
+
+
+def test_compare_and_set_ext_rejects_stale_snapshot(repo):
+    rec = repo.insert(_data(ext={"concurrent": "new"}))
+
+    updated = repo.compare_and_set_ext(
+        publish_id=rec.id,
+        expected_ext={"concurrent": "old"},
+        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v2"},
+    )
+
+    assert updated is None
+    assert repo.get_by_id(rec.id).ext == {"concurrent": "new"}
+
+
+def test_compare_and_set_ext_supports_null_expected_ext(repo):
+    rec = repo.insert(_data(ext=None))
+
+    updated = repo.compare_and_set_ext(
+        publish_id=rec.id,
+        expected_ext=None,
+        ext={"sbot_runtime_kind": "arka"},
+    )
+
+    assert updated is not None
+    assert updated.ext == {"sbot_runtime_kind": "arka"}
+
+
 def test_update_version_and_last_pub_id(repo):
     r = repo.insert(_data(version=1))
     out = repo.update_version(r.id, 5, status="RELEASE")

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -240,6 +240,42 @@ def test_explicit_env_ext_update_rolls_back_when_multiple_rows_match(repo, db):
     assert [row["ext"] for row in rows] == [{"row": 1}, {"row": 2}]
 
 
+def test_compare_and_set_ext_preserves_concurrent_bot_metadata(repo):
+    repo.insert(_data(ext={"owner": "first", "中文": "值"}))
+
+    updated = repo.compare_and_set_ext(
+        bot_id="bot-1",
+        owner_id="emp1",
+        expected_ext={"owner": "first", "中文": "值"},
+        ext={"owner": "first", "中文": "值", "sbot_use_default_image": True},
+    )
+    assert updated is not None
+    assert updated["ext"]["sbot_use_default_image"] is True
+
+    stale = repo.compare_and_set_ext(
+        bot_id="bot-1",
+        owner_id="emp1",
+        expected_ext={"owner": "first", "中文": "值"},
+        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v1"},
+    )
+    assert stale is None
+    assert repo.get_by_id_and_owner("bot-1", "emp1")["ext"] == updated["ext"]
+
+
+def test_compare_and_set_ext_supports_null_bot_ext(repo):
+    repo.insert(_data(ext=None))
+
+    updated = repo.compare_and_set_ext(
+        bot_id="bot-1",
+        owner_id="emp1",
+        expected_ext=None,
+        ext={"sbot_runtime_kind": "arka"},
+    )
+
+    assert updated is not None
+    assert updated["ext"] == {"sbot_runtime_kind": "arka"}
+
+
 def test_list_and_count(repo):
     repo.insert(_data(bot_id="b1"))
     repo.insert(_data(bot_id="b2"))


### PR DESCRIPTION
## Problem

The ARKA image-policy follow-up had four correctness risks:

- Draft restart persisted the DEFAULT policy immediately after submitting an asynchronous BaaS upgrade, even though the BaaS Publish could later fail.
- The non-BaaS destroy-and-recreate draft restart path could also persist DEFAULT while the recreated Device was only PENDING rather than actually ready.
- Legacy Publish image snapshots used a same-status whole-column write, so concurrent Restart, Scale, and Caller operations could overwrite one another's `ext` changes.
- Published image-policy resolution depended on the current editable Bot provider, allowing later engine/provider changes to alter the meaning of a historical Publish Record.

## Solution

- Defer BaaS in-place draft-restart DEFAULT persistence until `BaasRestartPublishPollHandler` confirms the BaaS Publish is ACTIVE. PENDING, FAILED, and TIMEOUT do not persist the marker.
- Carry a one-shot DEFAULT intent in the recreated Device Binding's existing `device_props`; finalize Bot + current Draft only after `DeviceActivatedEvent`, and clear the intent only after persistence succeeds.
- Add repository-level full-`ext` compare-and-set support, including NULL handling and config-artifact offload normalization.
- Centralize Publish image-policy resolution in a shared persisted resolver used by Publish Flow and Caller paths.
- On CAS conflict, reread and reparse the latest Publish policy; fail closed after repeated conflicts instead of using an unpersisted temporary Pin.
- Freeze `sbot_runtime_kind` on new Publish Records and resolve historical runtime only from Publish-owned metadata and bindings.

## Validation

- Related ARKA image-policy, publish-flow, caller, draft-restart, BaaS polling, Device allocation, and non-BaaS activation tests: 730 passed
- Module-boundary and oversized-module architecture tests: 5 passed
- Ruff checks for changed implementation and tests: passed
- `git diff --check`: passed

## Compatibility and risk

- No database schema migration is required; runtime and image policies remain in existing `ext` metadata, and recreate intent uses existing Binding `device_props`.
- Existing explicit DEFAULT and PINNED Publish snapshots remain authoritative.
- Historical TeClaw records are recognized from Publish-owned artifacts or stage bindings; records with no runtime evidence use the legacy ARKA fallback with a warning.
- BaaS in-place and non-BaaS recreate restarts persist DEFAULT only after their respective success signals; PENDING and failed operations retain the previous policy.
- CAS conflicts stop the current operation rather than issuing BaaS requests with an image that was not durably persisted.

## Related issues

- Follow-up to #800
