### PR TITLE
fix(backend): use Engine active root for Desktop Skill listing

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -9,6 +9,7 @@ import json
 import os
 import time
 import zipfile
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile
@@ -103,6 +104,11 @@ from agentclaw.community.di import Injected
 from agentclaw.community.api.skill_member_service import SkillMemberServiceProtocol
 from agentclaw.community.api.skill_parameter_service_factory import SkillParameterServiceFactoryProtocol
 from agentclaw.community.api.skill_publish_service import SkillPublishServiceProtocol
+from agentclaw.community.api.runtime_layout_probe_service import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeServiceProtocol,
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
 from agentclaw.community.api.skill_set_activator_factory import SkillSetActivatorFactoryProtocol
 from agentclaw.community.api.skill_set_service_factory import SkillSetServiceFactoryProtocol
@@ -153,6 +159,43 @@ _BOT_RUNTIME_UNAVAILABLE_MARKERS = (
     "agentclawproxy",
     "sandbox id is required",
 )
+_FILESYSTEM_LAYOUT_ENGINES = frozenset(
+    {"openclaw", "claude_code", "aicoding", "hermes"}
+)
+
+
+def _desktop_active_root_from_probe(
+    probe: RuntimeLayoutProbeResult,
+    *,
+    legacy_fallback: Path,
+) -> Path:
+    """Use the Engine-owned active root, with one old-image fallback."""
+    if probe.status is RuntimeLayoutProbeStatus.READY:
+        resolved_layout = probe.evidence.get("resolved_layout")
+        active_root = (
+            resolved_layout.get("active_root")
+            if isinstance(resolved_layout, dict)
+            else None
+        )
+        if (
+            not isinstance(active_root, str)
+            or not active_root
+            or not Path(active_root).is_absolute()
+            or ".." in Path(active_root).parts
+        ):
+            raise RuntimeError("runtime layout probe omitted a valid active root")
+        return Path(active_root)
+
+    if (
+        probe.status is RuntimeLayoutProbeStatus.NOT_CAPABLE
+        and probe.evidence.get("reason") == "runtime_layout_probe_endpoint_absent"
+    ):
+        return legacy_fallback
+
+    raise RuntimeError(
+        "runtime layout probe did not resolve an authoritative active root: "
+        f"status={probe.status.value} reason={probe.evidence.get('reason')}"
+    )
 
 
 def _normalize_upload_error_message(error_msg: str) -> str:
@@ -673,6 +716,7 @@ async def get_active_skills(
     bot_repo: BotRepository = Injected(BotRepository),
     path_factory: WorkspacePathFactory = Injected(WorkspacePathFactory),
     skill_service_factory: SkillServiceFactoryProtocol = Injected(SkillServiceFactoryProtocol),
+    runtime_layout_probe: RuntimeLayoutProbeServiceProtocol = Injected(RuntimeLayoutProbeServiceProtocol),
 ) -> ActiveSkillsResponse:
     """Get list of currently active skills (symlinked in skills directory)."""
     logger.info(f"[skills.get_active_skills] Request: user_id={ctx.user_id}, bot_id={ctx.bot_id}, entity_id={entity_id}")
@@ -682,6 +726,17 @@ async def get_active_skills(
 
     # Get user-specific paths using new directory structure
     skills_dir = path_factory.get_bot_skills_dir(effective_entity_id, effective_bot_id, effective_engine, effective_entity_type)
+    runtime_skills_dir = skills_dir
+    if is_desktop and effective_engine in _FILESYSTEM_LAYOUT_ENGINES:
+        probe = await runtime_layout_probe.probe_bot(
+            bot_id=effective_bot_id,
+            user_id=effective_entity_id,
+            engine=effective_engine,
+        )
+        runtime_skills_dir = _desktop_active_root_from_probe(
+            probe,
+            legacy_fallback=skills_dir,
+        )
     local_dir = path_factory.get_bot_skills_local_dir(effective_entity_id, effective_bot_id, effective_engine, effective_entity_type, is_desktop=is_desktop)
     path_factory.get_bot_engine_dir(effective_entity_id, effective_bot_id, effective_engine, effective_entity_type)
     repo_dir = path_factory.get_bot_skills_repo_dir(effective_entity_id, effective_bot_id, effective_engine, effective_entity_type, is_desktop=is_desktop)
@@ -700,6 +755,7 @@ async def get_active_skills(
         active_skills = await service.get_active_skills_from_device(
             bot_id=effective_bot_id,
             owner_id=effective_entity_id,
+            active_dir=runtime_skills_dir,
         )
     else:
         active_skills = service.get_active_skills()

--- a/src/backend/src/agentclaw/community/api/runtime_layout_probe_service.py
+++ b/src/backend/src/agentclaw/community/api/runtime_layout_probe_service.py
@@ -1,0 +1,30 @@
+"""Service API for resolving the current Engine runtime Skills layout."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+
+
+@runtime_checkable
+class RuntimeLayoutProbeServiceProtocol(Protocol):
+    """Ask the active Engine runtime to resolve its authoritative layout."""
+
+    async def probe_bot(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> RuntimeLayoutProbeResult: ...
+
+
+__all__ = [
+    "RuntimeLayoutProbeResult",
+    "RuntimeLayoutProbeServiceProtocol",
+    "RuntimeLayoutProbeStatus",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -478,7 +478,11 @@ class SkillService:
         return skills
 
     async def get_active_skills_from_device(
-        self, *, bot_id: str, owner_id: str
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        active_dir: Path | None = None,
     ) -> list[SkillInfo]:
         """Read active Skill entries from a Bot's live device filesystem.
 
@@ -492,8 +496,9 @@ class SkillService:
         an unavailable runtime would make a transport failure indistinguishable
         from a Bot with no active Skills.
         """
+        active_root = active_dir or self.active_dir
         device_fs = self._device_fs_factory(bot_id, owner_id)
-        entries = await device_fs.list_dir(str(self.active_dir), recursive=False)
+        entries = await device_fs.list_dir(str(active_root), recursive=False)
         if entries is None:
             return []
 
@@ -509,7 +514,7 @@ class SkillService:
             ):
                 continue
 
-            active_path = self.active_dir / name
+            active_path = active_root / name
             content = None
             skill_file = active_path / "SKILL.md"
             if await device_fs.exists(str(skill_file)):

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -51,6 +51,9 @@ from agentclaw.community.api.skill_propagation_service import (
     SkillPropagationServiceProtocol,
 )
 from agentclaw.community.api.skill_publish_service import SkillPublishServiceProtocol
+from agentclaw.community.api.runtime_layout_probe_service import (
+    RuntimeLayoutProbeServiceProtocol,
+)
 from agentclaw.community.api.skill_scan_service import SkillScanServiceProtocol
 from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
 from agentclaw.community.api.skill_set_activator_factory import (
@@ -97,6 +100,9 @@ from agentclaw.community.core.skill_center.services.skill_center_sync_service im
 )
 from agentclaw.community.core.skill_center.services.skill_member_service import (
     SkillMemberService,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    CurrentRuntimeLayoutProbeService,
 )
 from agentclaw.community.core.skill_center.services.market_sync import MarketSyncService
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
@@ -786,6 +792,14 @@ class SkillCenterModule(Module):
     def _skill_publish_service_protocol(
         self, svc: SkillPublishService
     ) -> SkillPublishServiceProtocol:
+        return svc
+
+    @singleton
+    @provider
+    @inject
+    def _runtime_layout_probe_service_protocol(
+        self, svc: CurrentRuntimeLayoutProbeService
+    ) -> RuntimeLayoutProbeServiceProtocol:
         return svc
 
     @singleton

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -16,6 +16,7 @@ it in run_in_threadpool.
 """
 import json
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -27,6 +28,14 @@ from injector import Injector, Module
 
 from agentclaw.community.adapters.http.dependencies import RequestContext, get_request_context
 from agentclaw.community.adapters.http.skill_center.skills import router as skills_router
+from agentclaw.community.api.runtime_layout_probe_service import (
+    RuntimeLayoutProbeServiceProtocol,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
 
 
@@ -44,6 +53,9 @@ def _skill_service_di_app(
     device_sync_result=None,
     runtime_uses_pool_paths=False,
     bot_type="personal",
+    engine_type="openclaw",
+    runtime_probe_result=None,
+    management_active_root=Path("/backend/legacy/skills"),
 ):
     """Build a TestClient whose SkillService has AsyncMock methods.
 
@@ -66,14 +78,19 @@ def _skill_service_di_app(
     mock_skill_service.get_link_name = MagicMock(return_value="link_name")
     mock_skill_service.get_active_skills_from_device = AsyncMock(return_value=[])
     mock_skill_service.runtime_uses_pool_paths = runtime_uses_pool_paths
+    mock_skill_service.active_dir = None
 
     # Factory that returns the mock service from create()
     mock_skill_service_factory = MagicMock()
-    mock_skill_service_factory.create.return_value = mock_skill_service
+    def _create_skill_service(**kwargs):
+        mock_skill_service.active_dir = kwargs.get("active_dir")
+        return mock_skill_service
+
+    mock_skill_service_factory.create.side_effect = _create_skill_service
 
     # Mock path_factory - all get_* methods return temp Path objects
     mock_path_factory = MagicMock()
-    mock_path_factory.get_bot_skills_dir.return_value = MagicMock()
+    mock_path_factory.get_bot_skills_dir.return_value = management_active_root
     mock_path_factory.get_bot_skills_local_dir.return_value = MagicMock()
     mock_path_factory.get_bot_engine_dir.return_value = MagicMock()
     mock_path_factory.get_bot_skills_repo_dir.return_value = MagicMock()
@@ -100,7 +117,7 @@ def _skill_service_di_app(
     mock_bot_repo.get_by_id_and_owner.return_value = {
         "bot_id": "default",
         "owner_id": "user_001",
-        "active_engine": "openclaw",
+        "active_engine": engine_type,
         "bot_type": bot_type,
     }
     mock_bot_repo.list_by_owner.return_value = (0, [])
@@ -116,6 +133,32 @@ def _skill_service_di_app(
     mock_resolver.resolve_for_bot.return_value = mock_ctx_obj
     mock_device_sync_dispatcher = MagicMock()
     mock_device_sync_dispatcher.dispatch.return_value = mock_device_sync
+
+    runtime_active_roots = {
+        "openclaw": "/home/admin/.openclaw/workspace/skills",
+        "claude_code": "/home/admin/.claude/skills",
+        "aicoding": "/home/admin/.claude/skills",
+        "hermes": "/home/admin/.hermes/skills",
+    }
+    if runtime_probe_result is None:
+        runtime_probe_result = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine=engine_type,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id="prep-test",
+            evidence={
+                "resolved_layout": {
+                    "active_root": runtime_active_roots.get(
+                        engine_type, "/unused/active"
+                    )
+                }
+            },
+        )
+    mock_runtime_layout_probe = MagicMock()
+    mock_runtime_layout_probe.probe_bot = AsyncMock(
+        return_value=runtime_probe_result
+    )
+    mock_skill_service.runtime_layout_probe = mock_runtime_layout_probe
 
     class _TestModule(Module):
         def configure(self, binder):
@@ -140,6 +183,10 @@ def _skill_service_di_app(
             binder.bind(DeviceContextResolver, to=mock_resolver)
             binder.bind(DeviceSyncDispatcher, to=mock_device_sync_dispatcher)
             binder.bind(BotRepository, to=mock_bot_repo)
+            binder.bind(
+                RuntimeLayoutProbeServiceProtocol,
+                to=mock_runtime_layout_probe,
+            )
 
     injector = Injector([_TestModule()])
     attach_injector(app, injector)
@@ -148,6 +195,33 @@ def _skill_service_di_app(
 
 
 class TestActiveSkillsRuntimeRead:
+    @pytest.mark.parametrize(
+        ("engine_type", "runtime_active_root"),
+        [
+            ("openclaw", "/home/admin/.openclaw/workspace/skills"),
+            ("claude_code", "/home/admin/.claude/skills"),
+            ("aicoding", "/home/admin/.claude/skills"),
+            ("hermes", "/home/admin/.hermes/skills"),
+        ],
+    )
+    def test_desktop_active_list_uses_engine_resolved_active_root(
+        self, mock_ctx, engine_type, runtime_active_root
+    ):
+        with _skill_service_di_app(
+            mock_ctx,
+            bot_type="desktop",
+            engine_type=engine_type,
+        ) as (client, mock_svc, _):
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 200, response.text
+            assert mock_svc.active_dir == Path("/backend/legacy/skills")
+            mock_svc.get_active_skills_from_device.assert_awaited_once_with(
+                bot_id=mock_ctx.bot_id,
+                owner_id=mock_ctx.user_id,
+                active_dir=Path(runtime_active_root),
+            )
+
     def test_desktop_active_list_reads_the_live_device(self, mock_ctx):
         with _skill_service_di_app(
             mock_ctx, bot_type="desktop"
@@ -173,6 +247,7 @@ class TestActiveSkillsRuntimeRead:
             mock_svc.get_active_skills_from_device.assert_awaited_once_with(
                 bot_id=mock_ctx.bot_id,
                 owner_id=mock_ctx.user_id,
+                active_dir=Path("/home/admin/.openclaw/workspace/skills"),
             )
             mock_svc.get_active_skills.assert_not_called()
 
@@ -186,6 +261,93 @@ class TestActiveSkillsRuntimeRead:
 
             assert response.status_code == 200, response.text
             mock_svc.get_active_skills.assert_called_once_with()
+            mock_svc.get_active_skills_from_device.assert_not_awaited()
+
+    def test_desktop_active_list_preserves_old_image_fallback(self, mock_ctx):
+        fallback_root = Path("/backend/legacy/skills")
+        old_image_probe = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+            engine="claude_code",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={"reason": "runtime_layout_probe_endpoint_absent"},
+        )
+        with _skill_service_di_app(
+            mock_ctx,
+            bot_type="desktop",
+            engine_type="claude_code",
+            runtime_probe_result=old_image_probe,
+            management_active_root=fallback_root,
+        ) as (client, mock_svc, _):
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 200, response.text
+            assert mock_svc.active_dir == fallback_root
+            mock_svc.get_active_skills_from_device.assert_awaited_once_with(
+                bot_id=mock_ctx.bot_id,
+                owner_id=mock_ctx.user_id,
+                active_dir=fallback_root,
+            )
+
+    def test_desktop_teclaw_keeps_artifact_layout_without_probe(self, mock_ctx):
+        management_root = Path("/backend/teclaw/skills")
+        with _skill_service_di_app(
+            mock_ctx,
+            bot_type="desktop",
+            engine_type="teclaw",
+            management_active_root=management_root,
+        ) as (client, mock_svc, _):
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 200, response.text
+            assert mock_svc.active_dir == management_root
+            mock_svc.get_active_skills_from_device.assert_awaited_once_with(
+                bot_id=mock_ctx.bot_id,
+                owner_id=mock_ctx.user_id,
+                active_dir=management_root,
+            )
+            mock_svc.runtime_layout_probe.probe_bot.assert_not_awaited()
+
+    def test_desktop_active_list_does_not_fallback_when_runtime_is_unbound(
+        self, mock_ctx
+    ):
+        unbound_probe = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+            engine="claude_code",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id=None,
+            evidence={"reason": "current_runtime_not_bound"},
+        )
+        with _skill_service_di_app(
+            mock_ctx,
+            bot_type="desktop",
+            engine_type="claude_code",
+            runtime_probe_result=unbound_probe,
+        ) as (client, mock_svc, _):
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 500
+            assert mock_svc.active_dir is None
+            mock_svc.get_active_skills_from_device.assert_not_awaited()
+
+    def test_desktop_active_list_fails_closed_on_invalid_resolved_root(self, mock_ctx):
+        invalid_probe = RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine="claude_code",
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            preparation_id="prep-test",
+            evidence={"resolved_layout": {"active_root": "relative/skills"}},
+        )
+        with _skill_service_di_app(
+            mock_ctx,
+            bot_type="desktop",
+            engine_type="claude_code",
+            runtime_probe_result=invalid_probe,
+        ) as (client, mock_svc, _):
+            response = client.get("/api/skills/active/list")
+
+            assert response.status_code == 500
+            assert mock_svc.active_dir is None
             mock_svc.get_active_skills_from_device.assert_not_awaited()
 
     def test_desktop_active_list_does_not_mask_device_failure_as_empty(

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -689,7 +689,7 @@ class TestSkillServiceGetActiveSkills:
             skill_repo=mock_skill_repo,
             skill_repo_sync=_lenient_skill_repo_sync(),
             category_repo=MagicMock(),
-            active_dir=Path(active_root),
+            active_dir=skill_dirs["active_dir"],
             repo_dir=skill_dirs["repo_dir"],
             local_dir=skill_dirs["local_dir"],
             market_cache=MagicMock(),
@@ -698,7 +698,9 @@ class TestSkillServiceGetActiveSkills:
         )
 
         skills = await svc.get_active_skills_from_device(
-            bot_id="desktop_bot_1", owner_id="405935"
+            bot_id="desktop_bot_1",
+            owner_id="405935",
+            active_dir=Path(active_root),
         )
 
         assert [skill.id for skill in skills] == ["sp455-r2-oc-probe"]


### PR DESCRIPTION
## Problem

Desktop `GET /api/skills/active/list` asked the live Engine to scan a path derived by Backend `WorkspacePathFactory`. That happens to match OpenClaw, but it maps Claude Code to `/home/admin/.claude_code/workspace/skills` while the Engine-owned Planner uses `/home/admin/.claude/skills`. The endpoint therefore returned `count=0` even though the live Claude Code runtime had readable active Skills. AICoding shares the Claude active root and was exposed to the same mismatch.

## Solution

- Resolve the authoritative Desktop `active_root` through the existing current-runtime layout probe before constructing `SkillService`.
- Keep the Backend management path as `SkillService.active_dir`; pass the Engine root only to the live-device read so Backend never creates runtime-only `/home/admin/...` paths locally.
- Cover all filesystem engines: OpenClaw, Claude Code, AICoding, and Hermes.
- Preserve old-image compatibility only when the live adapter explicitly reports that the layout-probe endpoint is absent.
- Fail closed for invalid, unbound, or transient probe results instead of silently scanning a guessed directory.
- Keep non-Desktop and Teclaw behavior unchanged.

## Validation

- Full Backend suite: `10590 passed`.
- Focused Skill API, Skill Service, runtime-probe, Teclaw, architecture, and DI wiring suites: `140 passed`.
- Relevant Engine Planner, mapping, layout activation, probe, downloader, and per-engine suites: `380 passed`.
- Live local composition test passed against actual OpenClaw, Claude Code, and Hermes agentboxes: the patched Backend route consumed each Engine probe root, read real Skill files, skipped corpus entries, and retained a separate Backend management root.
- Exact four-engine route assertions cover the Planner-resolved active roots.
- Compatibility assertions cover old-image endpoint absence, Teclaw bypass, invalid paths, and unbound runtimes.
- Ruff passed for all changed files.
- Local Python SAST block scan passed for all changed files.
- `git diff --check` passed.

## Compatibility and risk

This is Backend-only and does not require a new Engine/rootfs image. New images use the existing layout-probe contract. Old images retain the previous path behavior only after adapter liveness confirms that the probe endpoint is absent. No database schema, rollout gate, mapping contract, or external API response schema changes.

## Spec

Implements the Engine-owned Planner authority described by the Skills Pool P3 architecture and Desktop delivery for Avernet #455.

## Related issues

Relates to #455.
Follow-up to #817.
