### PR TITLE
fix(backend): harden service bot skills pool publication

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skills_pool/router.py
@@ -17,6 +17,7 @@ from agentclaw.community.api.skills_pool_recovery_service import (
     SkillsPoolRecoveryServiceProtocol,
 )
 from agentclaw.community.api.skills_pool_rollback_service import (
+    SkillsPoolRollbackOutcome,
     SkillsPoolRollbackServiceProtocol,
 )
 from agentclaw.community.api.skills_pool_rollout_service import (
@@ -418,12 +419,16 @@ async def rollback_bot(
         owner_id=request.owner_id,
         bot_id=bot_id,
     )
-    return _response(
-        await service.rollback(
-            scope=scope,
-            rollback_generation=request.rollback_generation,
-            lease_owner=f"operator-api:{uuid4().hex}",
-            operator=user.staffId,
-            note=request.note,
-        )
+    result = await service.rollback(
+        scope=scope,
+        rollback_generation=request.rollback_generation,
+        lease_owner=f"operator-api:{uuid4().hex}",
+        operator=user.staffId,
+        note=request.note,
     )
+    if result.outcome is SkillsPoolRollbackOutcome.SERVICE_BOT_UNSUPPORTED:
+        raise HTTPException(
+            status_code=409,
+            detail="Service Bot Skills Pool rollback is disabled",
+        )
+    return _response(result)

--- a/src/backend/src/agentclaw/community/api/skills_pool_rollback_service.py
+++ b/src/backend/src/agentclaw/community/api/skills_pool_rollback_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 from agentclaw.community.core.skills_pool.recovery_service import (
+    SkillsPoolRollbackOutcome,
     SkillsPoolRollbackResult,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
@@ -12,6 +13,13 @@ from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 
 @runtime_checkable
 class SkillsPoolRollbackServiceProtocol(Protocol):
+    """Operator rollback contract.
+
+    ``SERVICE_BOT_UNSUPPORTED`` is a terminal, non-retryable refusal: Service
+    Draft rollback requires a Runtime Pin-aware contract and is intentionally
+    outside this generic filesystem rollback API.
+    """
+
     async def rollback(
         self,
         *,
@@ -21,3 +29,10 @@ class SkillsPoolRollbackServiceProtocol(Protocol):
         operator: str,
         note: str,
     ) -> SkillsPoolRollbackResult: ...
+
+
+__all__ = [
+    "SkillsPoolRollbackOutcome",
+    "SkillsPoolRollbackResult",
+    "SkillsPoolRollbackServiceProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -657,20 +657,37 @@ class BotBuildService:
                 f"Running rsync skill command:{skill_cmd}"
             )
 
-            self._device_service.exec_shell_new(
+            result = self._device_service.exec_shell_new(
                 device_id=device_id,
                 shell_cmd=skill_cmd,
             )
+
+            if result.exit_code != 0:
+                logger.error(
+                    "[BotBuildService._sync_skill_links] "
+                    "Active Skills mapping snapshot failed: "
+                    f"device_id={device_id}, exit_code={result.exit_code}, "
+                    f"stderr={result.stderr}"
+                )
+                raise BotBuildMigrationError(
+                    "active Skills mapping snapshot failed: "
+                    f"exit_code={result.exit_code}, stderr={result.stderr}"
+                )
 
             logger.info(
                 "[BotBuildService._sync_skill_links] "
                 "Skill links synced successfully"
             )
+        except BotBuildMigrationError:
+            raise
         except Exception as e:
-            logger.warning(
+            logger.error(
                 f"[BotBuildService._sync_skill_links] "
-                f"Failed to synced links: {device_id}, {e}"
+                f"Active Skills mapping snapshot failed: {device_id}, {e}"
             )
+            raise BotBuildMigrationError(
+                f"active Skills mapping snapshot failed: {e}"
+            ) from e
 
     def _run_local_command(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_skills_manifest.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_skills_manifest.py
@@ -29,6 +29,8 @@ class CapturedServiceSkillsLayout:
     engine: str
     scope: BotSkillLayoutScope
     active_layout: SkillLayout
+    phase: SkillLayoutPhase
+    migration_generation: str | None
     layout_contract_version: str | None
 
 
@@ -61,6 +63,24 @@ class ServiceSkillsManifestBuilder:
             bot_id=str(bot.get("bot_id") or ""),
         )
         state = self._layout_repository.get(scope)
+
+        if state.phase not in {
+            SkillLayoutPhase.LEGACY_ACTIVE,
+            SkillLayoutPhase.POOL_ACTIVE,
+        }:
+            raise ServiceSkillsManifestError(
+                "service build requires a terminal Skills layout state"
+            )
+        if (
+            state.phase is SkillLayoutPhase.LEGACY_ACTIVE
+            and state.active_layout is not SkillLayout.LEGACY
+        ) or (
+            state.phase is SkillLayoutPhase.POOL_ACTIVE
+            and state.active_layout is not SkillLayout.POOL
+        ):
+            raise ServiceSkillsManifestError(
+                "service build found an inconsistent terminal Skills layout"
+            )
 
         if engine == "aicoding":
             raise ServiceSkillsManifestError(
@@ -95,9 +115,12 @@ class ServiceSkillsManifestBuilder:
             engine=engine,
             scope=scope,
             active_layout=state.active_layout,
-            layout_contract_version=(
-                state.layout_contract_version if is_pool else None
-            ),
+            phase=state.phase,
+            migration_generation=state.migration_generation,
+            # Capture the raw persisted value even for Legacy.  Legacy emits no
+            # Pool contract, but a concurrent writer changing this field still
+            # means the layout state moved while the physical snapshot ran.
+            layout_contract_version=state.layout_contract_version,
         )
 
     def finalize(
@@ -107,14 +130,12 @@ class ServiceSkillsManifestBuilder:
     ) -> dict[str, Any]:
         engine = captured.engine
         current = self._layout_repository.get(captured.scope)
-        current_contract = (
-            current.layout_contract_version
-            if current.active_layout is SkillLayout.POOL
-            else None
-        )
         if (
             current.active_layout is not captured.active_layout
-            or current_contract != captured.layout_contract_version
+            or current.phase is not captured.phase
+            or current.migration_generation != captured.migration_generation
+            or current.layout_contract_version
+            != captured.layout_contract_version
         ):
             raise ServiceSkillsManifestError(
                 "draft Skills layout changed during service build"
@@ -124,7 +145,11 @@ class ServiceSkillsManifestBuilder:
             "schema_version": 1,
             "engine": engine,
             "active_layout": captured.active_layout.value,
-            "layout_contract_version": captured.layout_contract_version,
+            "layout_contract_version": (
+                captured.layout_contract_version
+                if captured.active_layout is SkillLayout.POOL
+                else None
+            ),
         }
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
@@ -121,6 +121,18 @@ class SkillSymlinkListener(LifecycleBase):
                 )
                 return
 
+            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
+            if ctx.binding_id != event.binding_id:
+                logger.info(
+                    "[skill_symlink_listener] activated binding is no longer "
+                    "current, skipping: bot_id=%s event_binding_id=%s "
+                    "current_binding_id=%s",
+                    bot_id,
+                    event.binding_id,
+                    ctx.binding_id,
+                )
+                return
+
             from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 
             service = self._skill_set_factory.create(
@@ -132,7 +144,6 @@ class SkillSymlinkListener(LifecycleBase):
             mappings = service.get_symlink_mappings(user_id=owner_id, bolt_id=bot_id)
             symlinks = [sm.to_dict() for sm in mappings]
 
-            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
             device_sync = self._device_sync_dispatcher.dispatch(ctx)
             logger.info(
                 "[skill_symlink_listener] syncing symlinks: plugin=%s count=%d "

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -163,6 +163,7 @@ class SkillsPoolRollbackOutcome(StrEnum):
     LEGACY_ACTIVE = "legacy_active"
     NOT_FOUND = "not_found"
     NOT_POOL_ACTIVE = "not_pool_active"
+    SERVICE_BOT_UNSUPPORTED = "service_bot_unsupported"
     STALE_GENERATION = "stale_generation"
     INVALID_REQUEST = "invalid_request"
     EDIT_BUSY = "edit_busy"
@@ -211,6 +212,19 @@ class SkillsPoolRollbackService:
         operator: str,
         note: str,
     ) -> SkillsPoolRollbackResult:
+        # Service Drafts intentionally have no Pool -> Legacy operator rollback.
+        # Their image policy is coupled to the Pool-only runtime contract; the
+        # generic filesystem rollback cannot safely produce a deployable
+        # service artifact without also coordinating Runtime Pin. Keep that
+        # cross-domain recovery path closed until it has an explicit contract.
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        if bot is not None and bot.get("bot_type") == "service":
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.SERVICE_BOT_UNSUPPORTED,
+                evidence={"reason": "service_draft_pool_rollback_disabled"},
+                retryable=False,
+            )
+
         edit_lease = self._edit_guard.acquire_for_rollback(scope=scope)
         if edit_lease is None:
             return SkillsPoolRollbackResult(

--- a/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
+++ b/src/backend/tests/community/adapters/http/test_skills_pool_ops_router.py
@@ -259,6 +259,39 @@ async def test_rollback_route_supplies_a_unique_lease_owner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rollback_route_rejects_service_bot_rollback() -> None:
+    scope = BotSkillLayoutScope("pre", "entity-1", "service-bot-1")
+
+    class Query:
+        def get_bot(self, **_: object):
+            return SimpleNamespace(scope=scope)
+
+    class RollbackService:
+        async def rollback(self, **_: object) -> SkillsPoolRollbackResult:
+            return SkillsPoolRollbackResult(
+                SkillsPoolRollbackOutcome.SERVICE_BOT_UNSUPPORTED,
+                evidence={"reason": "service_draft_pool_rollback_disabled"},
+                retryable=False,
+            )
+
+    with pytest.raises(HTTPException) as captured:
+        await rollback_bot(
+            bot_id="service-bot-1",
+            request=RollbackRequest(
+                owner_id="owner-1",
+                rollback_generation="rollback-1",
+                note="must remain closed",
+            ),
+            user=SimpleNamespace(staffId="freddie"),
+            service=RollbackService(),
+            query=Query(),
+        )
+
+    assert captured.value.status_code == 409
+    assert captured.value.detail == "Service Bot Skills Pool rollback is disabled"
+
+
+@pytest.mark.asyncio
 async def test_invalid_rollout_config_is_an_explicit_operator_conflict() -> None:
     class InvalidConfig:
         def get_snapshot(self, **_: object):

--- a/src/backend/tests/community/core/events/test_end_to_end.py
+++ b/src/backend/tests/community/core/events/test_end_to_end.py
@@ -73,6 +73,7 @@ def test_report_device_alive_triggers_full_symlink_sync():
     mock_factory.create.return_value = fake_service
     mock_resolver = MagicMock()
     mock_ctx = MagicMock()
+    mock_ctx.binding_id = 7
     mock_resolver.resolve_for_bot.return_value = mock_ctx
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch.return_value = fake_sync_plugin
@@ -153,6 +154,9 @@ def test_report_device_alive_skip_token_check_bypasses_token_validation():
     mock_factory = MagicMock()
     mock_factory.create.return_value = fake_service
     mock_resolver = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.binding_id = 7
+    mock_resolver.resolve_for_bot.return_value = mock_ctx
     mock_dispatcher = MagicMock()
     mock_dispatcher.dispatch.return_value = fake_sync_plugin
 

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
@@ -1,6 +1,7 @@
 """Unit tests for ``ArcaSnapshotProducer`` — behavior-equivalent build wrap."""
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -179,6 +180,159 @@ def test_layout_is_captured_before_physical_build_starts(tmp_path) -> None:
     class _StateChangingBuild(_RecordingBuild):
         def build(self, bot, version=1):
             repository.state = pool_state
+            return super().build(bot, version)
+
+    producer = ArcaSnapshotProducer(
+        _StateChangingBuild(
+            {
+                "success": True,
+                "migration_path": "/snapshot/8/openclaw",
+                "build_target_path": str(target),
+            }
+        ),
+        ServiceSkillsManifestBuilder(repository),
+    )
+
+    with pytest.raises(
+        ServiceSkillsManifestError,
+        match="draft Skills layout changed during service build",
+    ):
+        producer.produce_artifact(
+            {
+                "bot_id": "b1",
+                "entity_id": "u1",
+                "env": "dev",
+                "active_engine": "openclaw",
+            },
+            8,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "phase",
+    [
+        SkillLayoutPhase.POOL_PREPARING,
+        SkillLayoutPhase.POOL_READY,
+        SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER,
+        SkillLayoutPhase.POOL_CUTOVER_FINALIZING,
+        SkillLayoutPhase.POOL_CUTOVER_COMMITTED,
+        SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+        SkillLayoutPhase.LEGACY_ROLLBACK_COMMITTED,
+        SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+    ],
+)
+def test_build_rejects_non_terminal_layout_before_physical_snapshot(
+    phase: SkillLayoutPhase,
+) -> None:
+    scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
+    state = BotSkillLayoutState(
+        scope=scope,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=phase,
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+    )
+    build = _RecordingBuild({"success": True})
+    producer = ArcaSnapshotProducer(
+        build,
+        ServiceSkillsManifestBuilder(_LayoutRepository(state)),
+    )
+
+    with pytest.raises(
+        ServiceSkillsManifestError,
+        match="terminal Skills layout state",
+    ):
+        producer.produce_artifact(
+            {
+                "bot_id": "b1",
+                "entity_id": "u1",
+                "env": "dev",
+                "active_engine": "openclaw",
+            },
+            8,
+        )
+
+    assert build.calls == []
+
+
+@pytest.mark.unit
+def test_build_rejects_phase_or_generation_drift_after_physical_snapshot(
+    tmp_path,
+) -> None:
+    target = tmp_path / "openclaw"
+    scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
+    initial = BotSkillLayoutState(
+        scope=scope,
+        active_layout=SkillLayout.POOL,
+        target_layout=None,
+        phase=SkillLayoutPhase.POOL_ACTIVE,
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+    )
+    repository = _LayoutRepository(initial)
+
+    class _StateChangingBuild(_RecordingBuild):
+        def build(self, bot, version=1):
+            repository.state = replace(
+                initial,
+                phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
+                migration_generation="generation-2",
+            )
+            return super().build(bot, version)
+
+    producer = ArcaSnapshotProducer(
+        _StateChangingBuild(
+            {
+                "success": True,
+                "migration_path": "/snapshot/8/openclaw",
+                "build_target_path": str(target),
+            }
+        ),
+        ServiceSkillsManifestBuilder(repository),
+    )
+
+    with pytest.raises(
+        ServiceSkillsManifestError,
+        match="draft Skills layout changed during service build",
+    ):
+        producer.produce_artifact(
+            {
+                "bot_id": "b1",
+                "entity_id": "u1",
+                "env": "dev",
+                "active_engine": "openclaw",
+            },
+            8,
+        )
+
+
+@pytest.mark.unit
+def test_legacy_build_rejects_contract_drift_after_physical_snapshot(
+    tmp_path,
+) -> None:
+    target = tmp_path / "openclaw"
+    scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
+    initial = BotSkillLayoutState(
+        scope=scope,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=SkillLayout.POOL,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE,
+        migration_generation=None,
+        persisted=True,
+        layout_contract_version=None,
+    )
+    repository = _LayoutRepository(initial)
+
+    class _StateChangingBuild(_RecordingBuild):
+        def build(self, bot, version=1):
+            repository.state = replace(
+                initial,
+                layout_contract_version="skills-pool-p3-v1",
+            )
             return super().build(bot, version)
 
     producer = ArcaSnapshotProducer(

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_mapping_snapshot.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_mapping_snapshot.py
@@ -1,0 +1,139 @@
+"""Bot Build 对 active Skills mapping 快照失败的行为测试。"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.bot_build_service import (
+    BotBuildMigrationError,
+    BotBuildService,
+)
+from agentclaw.community.core.workspace.engine_sandbox import (
+    EngineBuildPlan,
+    EngineSandboxRegistry,
+)
+from agentclaw.community.kernel.device_dto import CommandResult
+
+
+class _TestSandboxProvider:
+    @property
+    def engine_type(self) -> str:
+        return "test-engine"
+
+    def get_base_path(self) -> str:
+        return "/home/admin/.test-engine"
+
+    def get_build_plan(
+        self,
+        build_rsync_excludes_append: list[str] | None = None,
+    ) -> EngineBuildPlan:
+        return EngineBuildPlan(
+            engine_type=self.engine_type,
+            source_root_name=".test-engine",
+            migration_subpath="test-engine",
+            workspace_subdir="workspace",
+            mcp_config_relpath="workspace/config/mcporter.json",
+            skill_source_relpath="workspace/skills",
+            skill_target_relpath="workspace/skills",
+            rsync_excludes=[],
+        )
+
+
+def _make_service(device_service: MagicMock) -> BotBuildService:
+    registry = EngineSandboxRegistry()
+    registry.register(_TestSandboxProvider())
+    whitelist_service = MagicMock()
+    whitelist_service.is_bot_feature_enabled.return_value = False
+    return BotBuildService(
+        device_service=device_service,
+        baas_service=MagicMock(),
+        path_factory=MagicMock(),
+        passport_plugin=MagicMock(),
+        device_binding_repo=MagicMock(),
+        sandbox_registry=registry,
+        channel_service=MagicMock(),
+        bot_repository=MagicMock(),
+        common_whitelist_service=whitelist_service,
+        baas_template_resolver=MagicMock(),
+        teclaw_template_uuid="",
+    )
+
+
+def _arrange_build_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import agentclaw.community.core.service_bot.services.bot_build_service as build_module
+
+    nas_root = tmp_path / "nas"
+    (nas_root / ".test-engine").mkdir(parents=True)
+    monkeypatch.setattr(build_module, "get_bot_nas_dir", lambda **_: nas_root)
+    monkeypatch.setattr(
+        build_module,
+        "get_bot_dir",
+        lambda **_: tmp_path / "artifacts",
+    )
+    monkeypatch.setattr(
+        build_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "", ""),
+    )
+
+
+@pytest.mark.unit
+def test_build_fails_when_active_skill_mapping_snapshot_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    _arrange_build_paths(monkeypatch, tmp_path)
+    device_service = MagicMock()
+    device_service.exec_shell_new.side_effect = [
+        RuntimeError("sandbox unavailable"),
+        CommandResult(stdout='{"mcpServers": {}}', exit_code=0),
+    ]
+    service = _make_service(device_service)
+
+    with pytest.raises(
+        BotBuildMigrationError,
+        match="active Skills mapping snapshot failed",
+    ):
+        service.build(
+            bot={
+                "bot_id": "bot-1",
+                "entity_id": "owner-1",
+                "entity_type": "staff",
+                "device_id": "device-1",
+                "active_engine": "test-engine",
+            },
+            version=7,
+        )
+
+
+@pytest.mark.unit
+def test_build_fails_when_active_skill_mapping_snapshot_returns_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    _arrange_build_paths(monkeypatch, tmp_path)
+    device_service = MagicMock()
+    device_service.exec_shell_new.side_effect = [
+        CommandResult(stderr="rsync failed", exit_code=23, status="error"),
+        CommandResult(stdout='{"mcpServers": {}}', exit_code=0),
+    ]
+    service = _make_service(device_service)
+
+    with pytest.raises(
+        BotBuildMigrationError,
+        match="active Skills mapping snapshot failed.*exit_code=23",
+    ):
+        service.build(
+            bot={
+                "bot_id": "bot-1",
+                "entity_id": "owner-1",
+                "entity_type": "staff",
+                "device_id": "device-1",
+                "active_engine": "test-engine",
+            },
+            version=7,
+        )

--- a/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
@@ -43,6 +43,7 @@ def _make_listener(
 
     resolver = MagicMock()
     fake_ctx = MagicMock()
+    fake_ctx.binding_id = 42
     resolver.resolve_for_bot.return_value = fake_ctx
 
     dispatcher = MagicMock()
@@ -133,6 +134,55 @@ class TestHandleDeviceActivated:
 
         resolver.resolve_for_bot.assert_not_called()
         dispatcher.dispatch.assert_not_called()
+
+    def test_skips_when_event_binding_is_no_longer_current(self):
+        event = _make_event(binding_id=42)
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "default",
+            "owner_id": "u001",
+        }
+        sync_plugin = MagicMock()
+        service = MagicMock()
+        listener, factory, dispatcher, resolver = _make_listener(
+            service,
+            sync_plugin,
+            bot_query=bot_query,
+        )
+        resolver.resolve_for_bot.return_value.binding_id = 84
+
+        listener.handle(event)
+
+        resolver.resolve_for_bot.assert_called_once_with("default", "u001")
+        factory.create.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+        sync_plugin.sync_symlinks.assert_not_called()
+
+    def test_published_service_binding_never_uses_draft_db_mapping(self):
+        event = _make_event(binding_id=42, device_provider="baas")
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "service-bot-1",
+            "owner_id": "u001",
+            "bot_type": "service",
+        }
+        sync_plugin = MagicMock()
+        service = MagicMock()
+        listener, factory, dispatcher, resolver = _make_listener(
+            service,
+            sync_plugin,
+            bot_query=bot_query,
+        )
+        # Published Service bindings are version bindings.  The resolver owns
+        # only the current Draft binding, so the identities must never match.
+        resolver.resolve_for_bot.return_value.binding_id = 84
+
+        listener.handle(event)
+
+        resolver.resolve_for_bot.assert_called_once_with("service-bot-1", "u001")
+        factory.create.assert_not_called()
+        dispatcher.dispatch.assert_not_called()
+        sync_plugin.sync_symlinks.assert_not_called()
 
     def test_skips_when_bot_missing_owner(self):
         event = _make_event()

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
 from agentclaw.community.core.skills_pool.recovery_service import (
     ManualRepairResolution,
     SkillsPoolRollbackOutcome,
+    SkillsPoolRollbackResult,
     SkillsPoolRollbackService,
     SkillsPoolRecoveryOutcome,
     SkillsPoolRecoveryService,
@@ -298,6 +299,14 @@ class _ChangedBots:
         return None
 
 
+class _ServiceBots(_Bots):
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object]:
+        value = super().get_by_id_and_entity(bot_id, entity_id)
+        return {**value, "bot_type": "service"}
+
+
 class _AICodingBots(_Bots):
     def get_by_id_and_entity(
         self, bot_id: str, entity_id: str
@@ -455,6 +464,37 @@ async def test_new_rollback_uses_the_lease_acquired_by_begin() -> None:
 
     assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
     assert layouts.lease_acquire_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_service_draft_operator_rollback_is_rejected_before_state_change() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    edit_guard = _EditGuard()
+    service = SkillsPoolRollbackService(
+        bot_repository=_ServiceBots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=edit_guard,
+    )
+
+    result = await service.rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="service rollback must remain closed",
+    )
+
+    assert result == SkillsPoolRollbackResult(
+        SkillsPoolRollbackOutcome.SERVICE_BOT_UNSUPPORTED,
+        evidence={"reason": "service_draft_pool_rollback_disabled"},
+        retryable=False,
+    )
+    assert layouts.state == _pool_state()
+    assert layouts.events == []
+    assert runtime.events == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Service Bot Skills Pool publication had four fail-open or authority gaps:

- a failed active Skills mapping snapshot could still let a build continue;
- a generic DB-backed activation listener relied on binding data shape instead of validating the current Draft binding identity;
- a service build could snapshot a transitional or concurrently changing layout state;
- the generic Pool to Legacy operator rollback could be invoked for Service Drafts even though it cannot coordinate Runtime Pin.

These gaps could make a published artifact inconsistent with the Draft state that was approved, or let current Draft metadata reach the wrong runtime binding.

## Solution

- fail the service build when active Skills mapping rsync raises or returns non-zero;
- require activation event binding identity to equal the current Draft binding before DB-backed mapping sync, including an explicit Published Service regression case;
- build only from LEGACY_ACTIVE or POOL_ACTIVE and fail closed when layout, phase, migration generation, or raw layout contract changes during the physical snapshot;
- reject generic Service Bot Pool rollback before leases, layout changes, or runtime writes, and translate the domain outcome to HTTP 409;
- document the new non-retryable rollback outcome on the Service API contract.

## Validation

- 381 focused backend tests passed across Skills Pool, service deploy, mapping listener, build snapshot, event, and HTTP adapter suites;
- 54 focused implementation and architecture tests passed after review fixes;
- Ruff passed on all 12 changed files;
- git diff --check passed;
- two-axis review completed with zero remaining Standards or Spec blockers.

## Compatibility and risk

- Personal and Desktop rollback behavior is unchanged.
- Historical Service publishes without a Skills manifest retain explicit Legacy behavior.
- No release-time image and layout cross-validator, Service-specific engine gate, or after-create readiness hook is introduced.
- This PR does not modify Runtime Pin or implement Service Pool to Legacy recovery. Service rollback is deliberately closed until a Runtime Pin-aware contract exists.

## Spec

Implements the minimal guards confirmed by the 2026-08-05 Service Bot Runtime Pin and Skills Pool rollout grill, based on REL20260806.

## Related issues

Relates to #822.