### PR TITLE
feat(backend): log tenant and caller on every public API request

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/middleware.py
+++ b/src/backend/src/agentclaw/community/adapters/http/middleware.py
@@ -270,7 +270,9 @@ def install_middleware(
 
     Order matters: CORS first (so preflights short-circuit before auth),
     then UserContextMiddleware, then TraceIdMappingMiddleware, then the
-    tracer's own middleware via ``tracer.install(app)``.
+    tracer's own middleware via ``tracer.install(app)``, then the public
+    API's access log — which must sit outside everything whose work it
+    reports.
 
     Starlette ``add_middleware`` prepends, so the tracer (installed last)
     is *outermost* — it establishes the trace context before
@@ -304,6 +306,19 @@ def install_middleware(
 
     # 安装 tracer 插件的中间件（由 DI 按 profile 绑定的实现决定行为）
     tracer.install(app)
+
+    # The public API's access log. Added after everything it reports on, so it
+    # is *outside* all of them: the status it records is the one that reaches
+    # the wire (including one an exception handler produced), and the trace id,
+    # the resolved caller and the request's tenant are already on the scope by
+    # the time it reads them on the way out. Function-local import so this
+    # module stays importable without pulling in every public router — the same
+    # reason AvernetTenantMiddleware imports its seam lazily.
+    from agentclaw.community.adapters.http.openapi_v1.access_log import (
+        PublicApiAccessLogMiddleware,
+    )
+
+    app.add_middleware(PublicApiAccessLogMiddleware)
 
     # Add last so it is outermost: it must sanitize the shared ASGI scope
     # before tracer, auth context, and default access logging use it.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
@@ -110,6 +110,12 @@ _MAX_UA = 120
 #: makes a query safe to print, not short.
 _MAX_QUERY = 512
 
+#: Cap on the echoed ``X-Request-ID``. Same reasoning again, and this one is the
+#: cheapest to reach: the header is caller-supplied, the line is written even for
+#: a request answered ``401``, and a correlation handle that does not fit a uuid
+#: several times over is not a correlation handle.
+_MAX_REQUEST_ID = 128
+
 
 def redact_query(raw: str) -> str:
     """Replace the value of every credential-looking parameter in *raw*.
@@ -170,6 +176,11 @@ def _header(scope: Scope, name: str) -> str:
         if key.lower() == target:
             return value.decode("latin-1", "replace")
     return ""
+
+
+def _request_id(scope: Scope) -> str:
+    """The caller's ``X-Request-ID``, capped."""
+    return _header(scope, "x-request-id")[:_MAX_REQUEST_ID]
 
 
 def _client(scope: Scope) -> str:
@@ -274,7 +285,7 @@ class PublicApiAccessLogMiddleware:
             _kv("query", _query(scope)),
             _kv("client", _client(scope)),
             _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
-            _kv("request_id", _header(scope, "x-request-id")),
+            _kv("request_id", _request_id(scope)),
         ]
 
     def _log_completion(
@@ -304,7 +315,7 @@ class PublicApiAccessLogMiddleware:
                 *_identity_fields(scope),
                 _kv("query", _query(scope)),
                 _kv("trace_id", state.get("trace_id") or ""),
-                _kv("request_id", _header(scope, "x-request-id")),
+                _kv("request_id", _request_id(scope)),
                 _kv("client", _client(scope)),
                 _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
             ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
@@ -170,7 +170,16 @@ def _kv(key: str, value: object) -> str:
 
 
 def _header(scope: Scope, name: str) -> str:
-    """A request header by (lowercase) name, or ``""``."""
+    """A request header by (lowercase) name, or ``""``.
+
+    **Takes a name, and never returns the map.** Only a header chosen here by
+    hand reaches a log line, and the two that are — ``user-agent`` and
+    ``x-request-id`` — are neither credentials nor able to become one. Logging
+    the header map instead would mean this line's contents grow whenever
+    something upstream starts forwarding a new header, so a credential added
+    anywhere else would appear in the log with no edit here and no reason for
+    anyone to look. That holds for the *names* as much as the values.
+    """
     target = name.encode("latin-1")
     for key, value in scope.get("headers", ()):
         if key.lower() == target:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
@@ -1,0 +1,323 @@
+"""One log line per ``/openapi/v1`` request — the public API's AOP seam.
+
+Before this existed the public surface was silent on success. Every failure had
+a line (``dependencies.py`` logs a rejected principal, ``app.py`` logs every
+mapped and unmapped error), but a request that *worked* left no trace at all, so
+the first question asked of a live incident — *which tenant, and which caller,
+made this call?* — had no answer anywhere in the logs. Uvicorn's access line
+carries method, path and status and knows nothing about identity; the tenant is
+resolved in middleware and consumed by the ORM guard without ever being written
+down.
+
+This middleware is the one place that writes it down. It wraps the whole public
+surface rather than each handler, for the reason any cross-cutting concern is a
+middleware: a handler that forgets to log is invisible, and there are ~40 public
+handlers across nine routers.
+
+What one line carries, and why each field earns its place:
+
+``method`` / ``path`` / ``route``
+    ``path`` is the URL as called; ``route`` is the template that matched
+    (``/openapi/v1/bots/{bot_id}``), which is what makes lines aggregatable —
+    a thousand bot ids collapse to one route. ``route`` is absent on a 404,
+    which is itself the signal that nothing matched.
+``status`` / ``duration_ms``
+    The outcome and its cost. ``status=-`` with an ``error=`` field means the
+    request left this layer as an exception; the response was synthesised above
+    us by ``ServerErrorMiddleware``'s handler, which logs the traceback.
+``tenant`` / ``caller``
+    The point of the exercise. ``tenant`` is the data-isolation key the request
+    ran under — the same value ``AvernetTenantMiddleware`` bound and every
+    service read was confined to — and ``caller`` names each identity in the
+    verified set (``user:u-42+app:7``). A request whose principal did not verify
+    logs ``tenant=- caller=-``: it is about to be answered ``401``, and *why* it
+    failed is already on its own line from the verifier.
+``trace_id`` / ``request_id``
+    The correlation handles. ``trace_id`` ties this line to the rest of the
+    request's logs and to the ``X-Trace-ID`` the client got back; ``request_id``
+    is the caller's own ``X-Request-ID``, which is what a client can quote in a
+    bug report.
+``client`` / ``ua``
+    Which peer and which client build. Behind the gateway the peer is the
+    gateway, so ``ua`` is usually the more informative of the two.
+``query``
+    Redacted (see :func:`redact_query`). Query values are the one field here
+    that can carry a credential, so no value whose parameter name looks like a
+    secret is ever formatted into a line.
+
+Deliberately **not** logged: request and response bodies. They carry bot
+configuration, skill payloads and user content, they are unbounded, and nothing
+about "which tenant called this" needs them. A body is a debugging tool for one
+endpoint at a time, not a standing cost on every request.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+from fastapi import Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+from agentclaw.community.adapters.http.openapi_v1.dependencies import resolve_caller
+from agentclaw.community.core.gateway_principal import (
+    AccessKeyPrincipal,
+    AppPrincipal,
+    BotPrincipal,
+    GatewayPrincipal,
+    UserPrincipal,
+    VerifiedCaller,
+)
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+#: What an absent value reads as. A fixed placeholder rather than an omitted
+#: field so every line has the same shape and a missing value is visible as a
+#: missing value, not as a field that happened not to be emitted.
+_ABSENT = "-"
+
+#: Substrings that mark a query parameter as carrying a secret, matched against
+#: the parameter *name*, case-insensitively. Kept in step with the gateway's own
+#: ``_log_redaction`` list; not imported from it, because the gateway is a
+#: separate distribution the backend does not depend on.
+_CREDENTIAL_HINTS = (
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+    "authorization",
+    "signature",
+    "api_key",
+    "apikey",
+    "access_key",
+)
+
+_REDACTED = "<redacted>"
+
+_CREDENTIAL_PARAM = re.compile(
+    r"(^|&)([^=&]*(?:" + "|".join(_CREDENTIAL_HINTS) + r")[^=&]*=)[^&]*",
+    re.IGNORECASE,
+)
+
+#: Cap on the ``ua`` field. A User-Agent is caller-controlled and unbounded; a
+#: line is a log line, not a place to store whatever a client chooses to send.
+_MAX_UA = 120
+
+#: Cap on the redacted query. Same reasoning as ``_MAX_UA`` — the redaction
+#: makes a query safe to print, not short.
+_MAX_QUERY = 512
+
+
+def redact_query(raw: str) -> str:
+    """Replace the value of every credential-looking parameter in *raw*.
+
+    Rewrites the value and keeps the name, so a line still records *which*
+    parameters were sent — enough to reproduce a call — without copying a live
+    credential into the log.
+    """
+    return _CREDENTIAL_PARAM.sub(rf"\1\2{_REDACTED}", raw)
+
+
+def _principal_label(principal: GatewayPrincipal) -> str:
+    """``<type>:<id>`` for one identity, using the id that identifies it.
+
+    Each member of the union answers "who" with a different field, and the
+    match is exhaustive over the union rather than a ``getattr`` sweep: a new
+    principal kind should show up here as a missing branch at review time, not
+    as a silent ``unknown`` in production.
+    """
+    if isinstance(principal, UserPrincipal):
+        return f"user:{principal.subject.id}"
+    if isinstance(principal, AppPrincipal):
+        return f"app:{principal.app.app_id}"
+    if isinstance(principal, BotPrincipal):
+        return f"bot:{principal.bot.bot_uuid}"
+    if isinstance(principal, AccessKeyPrincipal):
+        # The access key's stable id, not the token it was presented with — the
+        # verifier never projects that credential onto our DTOs at all.
+        return f"access_key:{principal.access_key.access_key}"
+    return f"{principal.type}:{_ABSENT}"
+
+
+def caller_label(caller: VerifiedCaller) -> str:
+    """Every identity the verified set carries, e.g. ``user:u-42+app:7``.
+
+    The whole set, not just the user: a route that requires both a user and a
+    registered app is answering for two identities, and an incident about one of
+    them is unresolvable from the other.
+    """
+    return "+".join(_principal_label(p) for p in caller.principals) or _ABSENT
+
+
+def _kv(key: str, value: object) -> str:
+    """``key=value``, quoted when the value would otherwise break the line."""
+    text = str(value)
+    if not text:
+        return f"{key}={_ABSENT}"
+    if any(character in text for character in ' "\n\r\t'):
+        escaped = text.replace('"', '\\"').replace("\n", " ").replace("\r", " ")
+        return f'{key}="{escaped}"'
+    return f"{key}={text}"
+
+
+def _header(scope: Scope, name: str) -> str:
+    """A request header by (lowercase) name, or ``""``."""
+    target = name.encode("latin-1")
+    for key, value in scope.get("headers", ()):
+        if key.lower() == target:
+            return value.decode("latin-1", "replace")
+    return ""
+
+
+def _client(scope: Scope) -> str:
+    client = scope.get("client")
+    return client[0] if client else ""
+
+
+def _query(scope: Scope) -> str:
+    """The request's query string, redacted and capped."""
+    raw = scope.get("query_string", b"").decode("latin-1", "replace")
+    return redact_query(raw)[:_MAX_QUERY]
+
+
+def _route(scope: Scope) -> str:
+    """The matched route template, or ``""`` when nothing matched.
+
+    ``scope["route"]`` is set by the router while dispatching, so it is only
+    readable *after* the downstream app has run — which is why the completion
+    line carries it and the start line does not.
+    """
+    return getattr(scope.get("route"), "path", "")
+
+
+def _identity_fields(scope: Scope) -> list[str]:
+    """``tenant`` and ``caller`` for this request, from the verified principal.
+
+    Reads through :func:`resolve_caller`, which is cached on the request scope:
+    ``AvernetTenantMiddleware`` already resolved the caller before the route
+    ran, so this is a dictionary lookup and the line cannot disagree with the
+    tenant the request actually executed under.
+    """
+    caller = resolve_caller(Request(scope))
+    if caller is None:
+        return [_kv("tenant", _ABSENT), _kv("caller", _ABSENT)]
+    return [_kv("tenant", caller.tenant), _kv("caller", caller_label(caller))]
+
+
+class PublicApiAccessLogMiddleware:
+    """Emit one INFO line per completed ``/openapi/v1`` request.
+
+    A pure ASGI middleware, not ``BaseHTTPMiddleware``, for the same reason
+    ``AvernetTenantMiddleware`` is: no child task, so the timer, the response
+    status and the resolved caller are all read in the coroutine that awaited
+    the downstream app, and an exception propagates unchanged rather than
+    through a task boundary.
+
+    Installed *outside* every middleware whose work it reports on (see
+    ``install_middleware``), so the status it records is the one that goes on
+    the wire — including a status produced by an exception handler — and the
+    trace id and caller those inner layers stashed on the scope are already
+    there when it reads them.
+
+    Scoped to the public prefix. The internal ``/api`` surface has its own
+    clients, its own logging, and no principal to name; widening this to every
+    path would multiply log volume for nothing this line can say.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not scope.get("path", "").startswith(
+            PUBLIC_API_PREFIX
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        # A request that never finishes never reaches the completion line, so
+        # the arrival is recorded too — at DEBUG, because in the ordinary case
+        # it is the completion line that carries everything and doubling the
+        # volume to say "it started" is not worth an operator's attention.
+        logger.debug("openapi_request_start %s", " ".join(self._request_fields(scope)))
+
+        started = time.perf_counter()
+        status = 0
+
+        async def _send(message: Message) -> None:
+            nonlocal status
+            if message["type"] == "http.response.start":
+                status = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, _send)
+        except Exception as exc:
+            # The response is synthesised above us by ServerErrorMiddleware's
+            # handler, which logs the traceback; this line exists so the request
+            # still appears in the access log, with the identity fields that the
+            # traceback does not carry. Re-raised unchanged — deciding what a
+            # failed request answers is not this layer's business.
+            self._log_completion(
+                scope, status=0, started=started, error=type(exc).__name__
+            )
+            raise
+        self._log_completion(scope, status=status, started=started, error="")
+
+    def _request_fields(self, scope: Scope) -> list[str]:
+        """The fields known before the downstream app runs."""
+        return [
+            _kv("method", scope.get("method", "")),
+            _kv("path", scope.get("path", "")),
+            _kv("query", _query(scope)),
+            _kv("client", _client(scope)),
+            _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
+            _kv("request_id", _header(scope, "x-request-id")),
+        ]
+
+    def _log_completion(
+        self, scope: Scope, *, status: int, started: float, error: str
+    ) -> None:
+        """Write the line — and never be the reason a request fails.
+
+        This runs *after* the response has been sent, so an exception escaping
+        here would reach ``ServerErrorMiddleware`` with the response already
+        started: the caller would get a truncated body for a request that
+        actually succeeded. An access log is worth exactly nothing at that
+        price, so a failure to describe a request is swallowed into a line of
+        its own rather than allowed to change the request's outcome.
+        """
+        duration_ms = (time.perf_counter() - started) * 1000
+        try:
+            state = scope.get("state") or {}
+            # Self-sufficient on purpose: the start line above is DEBUG and off
+            # in every normal deployment, so this line repeats what it said
+            # rather than being readable only next to it.
+            fields = [
+                _kv("method", scope.get("method", "")),
+                _kv("path", scope.get("path", "")),
+                _kv("route", _route(scope)),
+                _kv("status", status or _ABSENT),
+                _kv("duration_ms", f"{duration_ms:.1f}"),
+                *_identity_fields(scope),
+                _kv("query", _query(scope)),
+                _kv("trace_id", state.get("trace_id") or ""),
+                _kv("request_id", _header(scope, "x-request-id")),
+                _kv("client", _client(scope)),
+                _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
+            ]
+            if error:
+                fields.append(_kv("error", error))
+        except Exception:
+            # A distinct prefix, not a degraded ``openapi_access`` line: a query
+            # counting access lines must not silently count failures as though
+            # they described a request.
+            logger.exception(
+                "openapi_access_failed to describe %s %s",
+                scope.get("method", ""),
+                scope.get("path", ""),
+            )
+            return
+        logger.info("openapi_access %s", " ".join(fields))

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
@@ -15,6 +15,11 @@ first, so it does the work and caches the outcome on the request scope; the
 dependency reuses it. Verifying twice would be wasted signature work and, worse,
 a window in which the two seams could disagree about who the caller is.
 
+:func:`resolve_caller` is that shared step, exported because the access log
+(``access_log.py``) is a third reader of it: it names the caller on every
+completed request and must name the *same* caller the route was scoped by, not a
+second opinion arrived at independently.
+
 Failure is uniform on purpose. No header, a bad signature, an expired token, an
 audience meant for another component, a payload we cannot parse — every one of
 them yields *no caller* and a ``401`` carrying the same fixed message. The
@@ -77,7 +82,7 @@ _UNSET = _Unset()
 Principal = VerifiedCaller
 
 
-def _resolve_caller(request: Request) -> VerifiedCaller | None:
+def resolve_caller(request: Request) -> VerifiedCaller | None:
     """Verify the forwarded principal once per request, caching the outcome.
 
     ``None`` means "no caller we can trust" — absent header or failed
@@ -137,7 +142,7 @@ def _verify_from_headers(request: Request) -> VerifiedCaller | None:
 
 async def require_principal(request: Request) -> Principal:
     """Return the verified caller, or raise :class:`MissingPrincipalError` (401)."""
-    caller = _resolve_caller(request)
+    caller = resolve_caller(request)
     if caller is None:
         raise MissingPrincipalError("no verified caller for this request")
     return caller
@@ -169,7 +174,7 @@ def resolve_avernet_tenant(request: Request) -> str:
     :func:`require_principal` and therefore answers ``401`` first — a property
     pinned by ``test_public_routes_require_principal``, not left to inspection.
     """
-    caller = _resolve_caller(request)
+    caller = resolve_caller(request)
     if caller is None:
         return DEFAULT_AVERNET_TENANT
     return caller.tenant

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
@@ -1,0 +1,246 @@
+"""The public API's access log: one line per request, naming tenant and caller.
+
+The gap this closes is a *silence* — a successful ``/openapi/v1`` request used to
+produce no log line at all, so the first question asked of a live incident
+("which tenant made this call?") had no answer. These tests pin the properties an
+operator actually reads the line for:
+
+- a successful request produces exactly one line, and it names the tenant and
+  every identity the verified caller carries;
+- a request whose principal did not verify still produces a line, saying so
+  rather than guessing a tenant;
+- an unhandled exception produces a line too, and does not change what the
+  request answers;
+- the internal ``/api`` surface is untouched;
+- a credential in the query string never reaches the log.
+
+The app wires the **real** ``AvernetTenantMiddleware`` in the production order,
+so the caller the line names is the cached one the route was scoped by rather
+than a second verification done for the log's benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from agentclaw.community.adapters.http.openapi_v1.access_log import (
+    PublicApiAccessLogMiddleware,
+    redact_query,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    PRINCIPAL_HEADER,
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+
+from .test_principal_seam import (  # noqa: F401  (signing_key is an autouse fixture)
+    TENANT,
+    mint,
+    signing_key,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Public probe routes behind the real tenant + access-log middleware.
+
+    Added in production order: the tenant middleware first, the access log
+    after, so the access log is the *outer* of the two and reads the caller the
+    inner one resolved.
+    """
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _unhandled_exception_handler,
+    )
+    from agentclaw.community.core.gateway_principal import PrincipalVerificationError
+
+    app = FastAPI()
+    app.add_middleware(AvernetTenantMiddleware)
+    app.add_middleware(PublicApiAccessLogMiddleware)
+    # Both handlers, registered exactly as ``app.py`` registers them: the
+    # principal errors go to the *inner* ExceptionMiddleware (so a 401 is a
+    # response this middleware observes), the catch-all to ServerErrorMiddleware
+    # outside it (so an unhandled error is an exception it observes). The two
+    # placements are what the status assertions below distinguish.
+    app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+    app.add_exception_handler(PrincipalVerificationError, _principal_error_handler)
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+
+    @app.get("/openapi/v1/bots/{bot_id}")
+    @envelope_errors
+    async def get_bot(
+        request: Request,
+        bot_id: str,
+        principal: Principal = Depends(require_principal),
+    ):
+        return envelope({"bot_id": bot_id}, request)
+
+    @app.get("/openapi/v1/bots/{bot_id}/boom")
+    @envelope_errors
+    async def boom(
+        request: Request,
+        bot_id: str,
+        principal: Principal = Depends(require_principal),
+    ):
+        raise RuntimeError("handler blew up")
+
+    @app.get("/api/bots/internal")
+    async def internal():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def access_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """The completion lines emitted during the block, in order."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("openapi_access ")
+    ]
+
+
+def field(line: str, key: str) -> str:
+    """The value of ``key=`` in a log line (unquoted)."""
+    for token in line.split(" "):
+        if token.startswith(f"{key}="):
+            return token[len(key) + 1 :].strip('"')
+    raise AssertionError(f"no {key}= in {line!r}")
+
+
+def test_successful_request_logs_tenant_and_caller(client, caplog):
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/openapi/v1/bots/bot-7", headers={PRINCIPAL_HEADER: mint(user_id="u-42")}
+        )
+
+    assert response.status_code == 200
+    lines = access_lines(caplog)
+    assert len(lines) == 1
+    line = lines[0]
+    assert field(line, "method") == "GET"
+    assert field(line, "path") == "/openapi/v1/bots/bot-7"
+    # The template, not the instance — a thousand bot ids aggregate to one route.
+    assert field(line, "route") == "/openapi/v1/bots/{bot_id}"
+    assert field(line, "status") == "200"
+    assert field(line, "tenant") == TENANT
+    assert field(line, "caller") == "user:u-42"
+    assert float(field(line, "duration_ms")) >= 0
+
+
+def test_caller_names_every_identity_in_the_set(client, caplog):
+    """A user+app route is answering for two identities; both are named."""
+    with caplog.at_level(logging.INFO):
+        client.get(
+            "/openapi/v1/bots/bot-7",
+            headers={PRINCIPAL_HEADER: mint(user_id="u-42", include_app=True)},
+        )
+
+    assert field(access_lines(caplog)[0], "caller") == "user:u-42+app:1"
+
+
+def test_unverified_caller_logs_absent_tenant(client, caplog):
+    """A 401 is logged, and the line does not invent a tenant for it."""
+    with caplog.at_level(logging.INFO):
+        response = client.get("/openapi/v1/bots/bot-7")
+
+    assert response.status_code == 401
+    line = access_lines(caplog)[0]
+    assert field(line, "status") == "401"
+    assert field(line, "tenant") == "-"
+    assert field(line, "caller") == "-"
+
+
+def test_unhandled_exception_is_logged_and_still_raised(client, caplog):
+    """The line records the failure; the response is still the handler's 500."""
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/openapi/v1/bots/bot-7/boom", headers={PRINCIPAL_HEADER: mint()}
+        )
+
+    assert response.status_code == 500
+    line = access_lines(caplog)[0]
+    assert field(line, "error") == "RuntimeError"
+    # No response status passed through this layer — the outer handler made one.
+    assert field(line, "status") == "-"
+    assert field(line, "tenant") == TENANT
+
+
+def test_internal_api_is_not_logged(client, caplog):
+    with caplog.at_level(logging.INFO):
+        assert client.get("/api/bots/internal").status_code == 200
+
+    assert access_lines(caplog) == []
+
+
+def test_query_is_logged_with_credentials_redacted(client, caplog):
+    with caplog.at_level(logging.INFO):
+        client.get(
+            "/openapi/v1/bots/bot-7?page=2&access_token=super-secret",
+            headers={PRINCIPAL_HEADER: mint()},
+        )
+
+    query = field(access_lines(caplog)[0], "query")
+    assert "super-secret" not in query
+    assert "page=2" in query
+    assert "access_token=<redacted>" in query
+
+
+def test_a_broken_log_line_does_not_break_the_request(client, caplog, monkeypatch):
+    """The access log runs after the response is sent; it must never fail it.
+
+    An exception escaping here would reach ``ServerErrorMiddleware`` with the
+    response already started, truncating a request that actually succeeded.
+    """
+    import agentclaw.community.adapters.http.openapi_v1.access_log as module
+
+    def _boom(scope):
+        raise RuntimeError("projection blew up")
+
+    monkeypatch.setattr(module, "_identity_fields", _boom)
+
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/openapi/v1/bots/bot-7", headers={PRINCIPAL_HEADER: mint()}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"bot_id": "bot-7"}
+    assert access_lines(caplog) == []
+    assert any(
+        record.getMessage().startswith("openapi_access_failed")
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("page=2", "page=2"),
+        ("token=abc", "token=<redacted>"),
+        ("a=1&api_key=abc&b=2", "a=1&api_key=<redacted>&b=2"),
+        ("X-Proxypass-Token=abc", "X-Proxypass-Token=<redacted>"),
+        # A parameter that merely *contains* an innocent word is left alone —
+        # redacting everything would make the field useless for debugging.
+        ("monkey=1", "monkey=1"),
+    ],
+)
+def test_redact_query(raw: str, expected: str):
+    assert redact_query(raw) == expected

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
@@ -203,6 +203,28 @@ def test_query_is_logged_with_credentials_redacted(client, caplog):
     assert "access_token=<redacted>" in query
 
 
+def test_caller_controlled_fields_are_capped(client, caplog):
+    """Every field a caller controls is bounded, including on an unauthenticated
+    request — this line is written for a 401 too, so the cap cannot depend on
+    having verified anyone first.
+    """
+    from agentclaw.community.adapters.http.openapi_v1.access_log import (
+        _MAX_REQUEST_ID,
+        _MAX_UA,
+    )
+
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/openapi/v1/bots/bot-7",
+            headers={"x-request-id": "R" * 8000, "user-agent": "U" * 8000},
+        )
+
+    assert response.status_code == 401  # no principal: the line still gets written
+    line = access_lines(caplog)[0]
+    assert len(field(line, "request_id")) == _MAX_REQUEST_ID
+    assert len(field(line, "ua")) == _MAX_UA
+
+
 def test_a_broken_log_line_does_not_break_the_request(client, caplog, monkeypatch):
     """The access log runs after the response is sent; it must never fail it.
 

--- a/src/gateway/src/gateway/community/adapters/web/_forward.py
+++ b/src/gateway/src/gateway/community/adapters/web/_forward.py
@@ -16,6 +16,7 @@ principal at the forwarder seam.
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from dataclasses import replace
 
@@ -24,9 +25,18 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.requests import HTTPConnection
 from starlette.responses import Response
 
+from gateway.community.adapters.web._log_redaction import redact_credentials
 from gateway.community.logger import get_logger
 from gateway.community.spi.auth import AuthError
-from gateway.community.spi.authn import CredentialBundle, Principal, PrincipalType
+from gateway.community.spi.authn import (
+    AccessKeyPrincipal,
+    AppPrincipal,
+    BotPrincipal,
+    CredentialBundle,
+    Principal,
+    PrincipalType,
+    UserPrincipal,
+)
 from gateway.community.spi.forwarder import ForwardRequest
 from gateway.community.spi.principal_signer import PrincipalSigner
 from gateway.community.tracer import get_tracer_plugin
@@ -79,6 +89,48 @@ def _target_url(base_url: str, path: str, request: Request) -> str:
     return f"{base}{path}" + (f"?{query}" if query else "")
 
 
+_ABSENT = "-"
+
+
+def _identity_label(identities: dict[PrincipalType, Principal]) -> tuple[str, str]:
+    """``(tenant, caller)`` for the log line, from the resolved identity set.
+
+    The gateway is the only hop that sees the credentials, so it is the only
+    place that can say *who* a request turned out to be; the upstream can only
+    report what it was told. Naming the identity set on both sides of the seam
+    is what makes a mismatch — a request scoped to a tenant the gateway did not
+    resolve — visible as a difference between two log lines instead of an
+    invisible one.
+
+    ``caller`` names each identity by the field that identifies it, so a
+    multi-identity route (user + app) is legible as such. No credential is
+    formatted: ``Bot.token`` and ``AccessKey.access_key_token`` are secrets the
+    gateway forwards, never ones it prints.
+    """
+    if not identities:
+        return _ABSENT, _ABSENT
+    labels = []
+    tenants = set()
+    for principal in identities.values():
+        if principal.tenant:
+            tenants.add(principal.tenant)
+        if isinstance(principal, UserPrincipal):
+            labels.append(f"user:{principal.subject.id}")
+        elif isinstance(principal, AppPrincipal):
+            labels.append(f"app:{principal.app.app_id}")
+        elif isinstance(principal, BotPrincipal):
+            labels.append(f"bot:{principal.bot.bot_uuid}")
+        elif isinstance(principal, AccessKeyPrincipal):
+            labels.append(f"access_key:{principal.access_key.access_key}")
+        else:
+            labels.append(f"{principal.type}:{_ABSENT}")
+    # A set that disagrees is logged as the several tenants it names rather than
+    # as one of them: downstream verification refuses such a token outright, and
+    # a log line that quietly picked a winner would hide exactly that failure.
+    tenant = "+".join(sorted(tenants)) if tenants else _ABSENT
+    return tenant, "+".join(labels)
+
+
 _PRINCIPAL_HEADER = "X-Avernet-Principal"
 # Inbound headers that must NEVER pass through to the upstream (call site
 # strips these when building ForwardRequest.headers). `host` is dropped so
@@ -109,6 +161,7 @@ async def _attach_identities(
 
 async def forward_request(request: Request) -> Response:
     """Resolve domain → authenticate → forward verbatim, streaming the response."""
+    started = time.perf_counter()
     path = request.url.path
     # Asked for the *HTTP* domain, not for whichever domain claims the path.
     # A socket domain is not a candidate here at all, so it can neither become an
@@ -170,12 +223,31 @@ async def forward_request(request: Request) -> Response:
             await cm.__aexit__(None, None, None)
 
     response = StreamingResponse(stream(), status_code=upstream.status_code)
+    tenant, caller = _identity_label(identities)
+    # The identity fields are the reason this line exists at all: an upstream can
+    # report the tenant it was *told*, only the gateway can report the tenant it
+    # *resolved*. ``duration_ms`` measures up to the upstream's response head —
+    # the body is still streaming when this is written, so it is time-to-first-
+    # byte, not the full transfer.
+    #
+    # The upstream URL carries the caller's query verbatim, and on this plane
+    # that query can hold a credential — the socket relay's is the documented
+    # case, but nothing stops an HTTP caller passing one the same way. The
+    # filter installed for uvicorn's own request lines does not reach this
+    # logger, so the value is redacted here, at the format site.
     logger.info(
-        "forward %s %s -> %s status=%d",
+        "forward %s %s -> %s status=%d duration_ms=%.1f tenant=%s caller=%s "
+        "domain=%s server=%s request_id=%s",
         request.method,
         path,
-        forward.url,
+        redact_credentials(forward.url),
         upstream.status_code,
+        (time.perf_counter() - started) * 1000,
+        tenant,
+        caller,
+        domain.name,
+        server.name,
+        _request_id() or _ABSENT,
     )
     # Set raw headers directly so duplicate headers (Set-Cookie) survive verbatim.
     response.raw_headers = [

--- a/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
+++ b/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
@@ -190,17 +190,28 @@ async def forward_websocket(websocket: WebSocket) -> None:
         subprotocols=tuple(websocket.scope.get("subprotocols") or ()),
     )
     tenant, caller = _identity_label(identities)
-    # Names, never values. Every header here is either forwarded from the client
-    # (Cookie, Authorization) or minted by us (the signed X-Avernet-Principal),
-    # so the map is a set of live credentials and printing it put them in the
-    # log on every handshake. The URL is redacted for the same reason: this
-    # plane's credential travels *in the query string* by design, because a
-    # browser's WebSocket API cannot set a header.
+    # THE HEADERS ARE NOT LOGGED, in any form — not their values, and not their
+    # names either. This map is where credentials live: what the client sent
+    # (Cookie, Authorization) plus the signed X-Avernet-Principal minted just
+    # above. Printing values put live credentials in the log on every handshake.
+    #
+    # Names alone leak nothing *today*, and that is exactly the wrong test to
+    # design against: the set is whatever the client sent plus whatever a future
+    # change forwards, so a credential added anywhere upstream would start
+    # appearing here with no edit to this line and no reason for anyone to look.
+    # A log field that grows new contents by someone else's change is not one
+    # this relay is willing to hold.
+    #
+    # The identity fields below say who the caller is, which is what an operator
+    # actually needs; ``strip_hop_by_hop`` and ``_INBOUND_STRIP`` decide what is
+    # forwarded, and their tests — not a log line — are where that is pinned.
+    # The URL is redacted for the same reason it is logged at all: this plane's
+    # credential travels *in the query string* by design, because a browser's
+    # WebSocket API cannot set a header.
     logger.info(
-        "ws forwarding request url=%s headers=%s subprotocols=%s "
+        "ws forwarding request url=%s subprotocols=%s "
         "tenant=%s caller=%s domain=%s server=%s",
         redact_credentials(request.url),
-        sorted(request.headers),
         request.subprotocols,
         tenant,
         caller,

--- a/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
+++ b/src/gateway/src/gateway/community/adapters/web/_relay_ws.py
@@ -45,7 +45,13 @@ from gateway.community.spi.ws_forwarder import (
     WebSocketUpstream,
 )
 
-from ._forward import _INBOUND_STRIP, _PRINCIPAL_HEADER, _bundle
+from ._forward import (
+    _INBOUND_STRIP,
+    _PRINCIPAL_HEADER,
+    _bundle,
+    _identity_label,
+)
+from ._log_redaction import redact_credentials
 
 logger = get_logger("relay_ws")
 
@@ -183,11 +189,23 @@ async def forward_websocket(websocket: WebSocket) -> None:
         headers=headers,
         subprotocols=tuple(websocket.scope.get("subprotocols") or ()),
     )
+    tenant, caller = _identity_label(identities)
+    # Names, never values. Every header here is either forwarded from the client
+    # (Cookie, Authorization) or minted by us (the signed X-Avernet-Principal),
+    # so the map is a set of live credentials and printing it put them in the
+    # log on every handshake. The URL is redacted for the same reason: this
+    # plane's credential travels *in the query string* by design, because a
+    # browser's WebSocket API cannot set a header.
     logger.info(
-        "ws forwarding request url=%s headers=%s subprotocols=%s",
-        request.url,
-        request.headers,
+        "ws forwarding request url=%s headers=%s subprotocols=%s "
+        "tenant=%s caller=%s domain=%s server=%s",
+        redact_credentials(request.url),
+        sorted(request.headers),
         request.subprotocols,
+        tenant,
+        caller,
+        domain.name,
+        domain.server.name,
     )
     try:
         cm = state.ws_forwarder.connect(request)

--- a/src/gateway/tests/integration/test_relay_ws_route.py
+++ b/src/gateway/tests/integration/test_relay_ws_route.py
@@ -9,6 +9,7 @@ entrypoint itself names no domain.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -25,7 +26,8 @@ from gateway.community.adapters.web._relay_ws import (
     relay_routes,
 )
 from gateway.community.core.forwarding import DomainMap
-from gateway.community.spi.auth import AuthError
+from gateway.community.spi.auth import AuthenticatedUser, AuthError
+from gateway.community.spi.authn import PrincipalType, UserPrincipal
 from gateway.community.spi.ws_forwarder import (
     WebSocketClosedError,
     WebSocketForwardRequest,
@@ -299,13 +301,63 @@ def test_handshake_headers_are_stripped_before_forwarding() -> None:
 
 def test_a_resolved_identity_is_signed_onto_the_upstream_handshake() -> None:
     app, auth, forwarder = _build()
-    auth.identities = {"user": object()}
+    # A real Principal, not a placeholder: the handshake path both signs the
+    # identity set and names it in the relay's log line, so a stand-in that is
+    # not of the declared type would not exercise what a handshake does.
+    auth.identities = {
+        PrincipalType.USER: UserPrincipal(
+            tenant="acme",
+            subject=AuthenticatedUser(id="u-42", username="alice@example.com"),
+        )
+    }
     with TestClient(app) as client:
         with client.websocket_connect(_PATH) as ws:
             ws.close(1000)
             _settled(forwarder)
     headers = forwarder.opened[0].request.headers
     assert headers["X-Avernet-Principal"] == "signed-for-engine_proxy"
+
+
+def test_the_handshake_log_line_names_the_caller_and_no_credential(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The relay's own log line is the socket plane's access log.
+
+    Everything it could print here is a credential: the query carries this
+    plane's token *by design* (a browser's WebSocket API can set no headers),
+    and the header map holds the forwarded Cookie/Authorization plus the signed
+    principal the gateway just minted. So it names the caller and the header
+    *names*, and nothing that can be replayed.
+    """
+    app, auth, forwarder = _build()
+    auth.identities = {
+        PrincipalType.USER: UserPrincipal(
+            tenant="acme",
+            subject=AuthenticatedUser(id="u-42", username="alice@example.com"),
+        )
+    }
+    with caplog.at_level(logging.INFO):
+        with TestClient(app) as client:
+            with client.websocket_connect(
+                _PATH, headers={"cookie": "session=super-secret"}
+            ) as ws:
+                ws.close(1000)
+                _settled(forwarder)
+
+    line = next(
+        message
+        for message in (record.getMessage() for record in caplog.records)
+        if message.startswith("ws forwarding request")
+    )
+    assert "tenant=acme" in line
+    assert "caller=user:u-42" in line
+    assert "x-proxypass-token=<redacted>" in line
+    assert "t.o.k" not in line
+    # The header names survive — enough to see what was forwarded — while the
+    # values, every one of them a live credential, do not.
+    assert "cookie" in line
+    assert "super-secret" not in line
+    assert "signed-for-engine_proxy" not in line
 
 
 def test_the_upstream_subprotocol_is_echoed_to_the_client() -> None:

--- a/src/gateway/tests/integration/test_relay_ws_route.py
+++ b/src/gateway/tests/integration/test_relay_ws_route.py
@@ -326,8 +326,14 @@ def test_the_handshake_log_line_names_the_caller_and_no_credential(
     Everything it could print here is a credential: the query carries this
     plane's token *by design* (a browser's WebSocket API can set no headers),
     and the header map holds the forwarded Cookie/Authorization plus the signed
-    principal the gateway just minted. So it names the caller and the header
-    *names*, and nothing that can be replayed.
+    principal the gateway just minted. So the line names the caller, and touches
+    the header map not at all.
+
+    The header assertions below are deliberately about a header the client chose
+    the name of. A future change that forwards a new credential must not be able
+    to make it appear in this log, and the only property that holds under such a
+    change is that the map is never enumerated — checking a fixed list of known
+    credential headers would pass right up until the day it mattered.
     """
     app, auth, forwarder = _build()
     auth.identities = {
@@ -339,7 +345,11 @@ def test_the_handshake_log_line_names_the_caller_and_no_credential(
     with caplog.at_level(logging.INFO):
         with TestClient(app) as client:
             with client.websocket_connect(
-                _PATH, headers={"cookie": "session=super-secret"}
+                _PATH,
+                headers={
+                    "cookie": "session=super-secret",
+                    "x-some-future-credential": "tomorrows-secret",
+                },
             ) as ws:
                 ws.close(1000)
                 _settled(forwarder)
@@ -353,11 +363,17 @@ def test_the_handshake_log_line_names_the_caller_and_no_credential(
     assert "caller=user:u-42" in line
     assert "x-proxypass-token=<redacted>" in line
     assert "t.o.k" not in line
-    # The header names survive — enough to see what was forwarded — while the
-    # values, every one of them a live credential, do not.
-    assert "cookie" in line
+    # No header reaches the line — not a value, and not a name. The forwarded
+    # ones, the gateway's own signed principal, and a header nobody has thought
+    # of yet are all covered by the same property.
     assert "super-secret" not in line
+    assert "tomorrows-secret" not in line
+    assert "cookie" not in line
+    assert "x-some-future-credential" not in line
     assert "signed-for-engine_proxy" not in line
+    # The forwarding itself is unchanged: what the log stops showing, the
+    # upstream still receives.
+    assert forwarder.opened[0].request.headers["cookie"] == "session=super-secret"
 
 
 def test_the_upstream_subprotocol_is_echoed_to_the_client() -> None:

--- a/src/gateway/tests/test_forward_access_log.py
+++ b/src/gateway/tests/test_forward_access_log.py
@@ -1,0 +1,197 @@
+"""The forward log line names the tenant and the caller it resolved.
+
+The gateway is the only hop that sees the caller's credentials, so it is the
+only one that can say what a request turned out to *be*. Until this line carried
+the identity set, a forwarded request produced a log entry that named a method,
+a path and a status and left the operator no way to tell which tenant it ran
+under — the question every public-API incident opens with.
+
+Two things are pinned here: the projection from an identity set to the line's
+fields (unit, exhaustive over the Principal union), and the fact that the line
+the running gateway emits actually carries them.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from gateway.community.adapters.web._forward import _identity_label
+from gateway.community.adapters.web.app import create_app
+from gateway.community.plugins.principal_signer.bare import (
+    BarePrincipalSigner,
+    PrincipalSignerConfig,
+)
+from gateway.community.spi.auth import AuthenticatedUser
+from gateway.community.spi.authn import (
+    AccessKey,
+    AccessKeyPrincipal,
+    AppPrincipal,
+    Bot,
+    BotPrincipal,
+    PrincipalType,
+    ThirdPartyApp,
+    UserPrincipal,
+)
+from gateway.community.spi.forwarder import ForwardRequest, ForwardResponse
+
+_TEST_KEY = "access-log-test-shared-secret-32b!!"
+
+
+def _user(user_id: str = "u-42", tenant: str = "acme") -> UserPrincipal:
+    return UserPrincipal(
+        tenant=tenant,
+        subject=AuthenticatedUser(id=user_id, username="alice@example.com"),
+    )
+
+
+def _app_principal(tenant: str = "acme") -> AppPrincipal:
+    return AppPrincipal(
+        tenant=tenant,
+        app=ThirdPartyApp(app_id=7, app_name="A", owners="o", tenant=tenant),
+    )
+
+
+# ── the projection ───────────────────────────────────────────────────────────
+
+
+def test_no_identity_reads_as_absent() -> None:
+    """An unauthenticated route forwards too, and its line must say so plainly."""
+    assert _identity_label({}) == ("-", "-")
+
+
+def test_user_identity_names_tenant_and_subject() -> None:
+    tenant, caller = _identity_label({PrincipalType.USER: _user()})
+    assert (tenant, caller) == ("acme", "user:u-42")
+
+
+def test_every_identity_in_the_set_is_named() -> None:
+    """A user+app route answers for two identities; one of them is not enough."""
+    tenant, caller = _identity_label(
+        {PrincipalType.USER: _user(), PrincipalType.APP: _app_principal()}
+    )
+    assert tenant == "acme"
+    assert caller == "user:u-42+app:7"
+
+
+def test_bot_and_access_key_identities_name_their_own_ids() -> None:
+    labels = _identity_label(
+        {
+            PrincipalType.BOT: BotPrincipal(
+                tenant="acme",
+                bot=Bot(
+                    bot_uuid="bot-1",
+                    owner_id="u-42",
+                    token="secret-bot-token",
+                    app_id=7,
+                    agent_code="ac",
+                    tenant="acme",
+                ),
+            ),
+            PrincipalType.ACCESS_KEY: AccessKeyPrincipal(
+                tenant="acme",
+                access_key=AccessKey(
+                    access_key="ak-1",
+                    access_key_token="secret-access-key-token",
+                    expire_at=datetime(2030, 1, 1, tzinfo=UTC),
+                ),
+            ),
+        }
+    )[1]
+    assert labels == "bot:bot-1+access_key:ak-1"
+    # The credentials the gateway forwards are never the ones it prints.
+    assert "secret-bot-token" not in labels
+    assert "secret-access-key-token" not in labels
+
+
+def test_disagreeing_tenants_are_all_named() -> None:
+    """A set that names two tenants is a bug the line must not hide.
+
+    The downstream verifier refuses such a token outright, so a line that
+    silently picked one of them would describe a request that cannot exist.
+    """
+    tenant, _ = _identity_label(
+        {
+            PrincipalType.USER: _user(tenant="tenant-a"),
+            PrincipalType.APP: _app_principal(tenant="tenant-b"),
+        }
+    )
+    assert tenant == "tenant-a+tenant-b"
+
+
+# ── the emitted line ─────────────────────────────────────────────────────────
+
+
+class _StubAuthenticator:
+    async def authenticate(self, method: str, path: str, creds: object) -> dict:
+        return {PrincipalType.USER: _user(), PrincipalType.APP: _app_principal()}
+
+
+class _StubForwarder:
+    @asynccontextmanager
+    async def forward(self, request: ForwardRequest):
+        async def _empty_body():
+            if False:  # pragma: no cover
+                yield
+
+        yield ForwardResponse(status_code=200, headers=[], body=_empty_body())
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.state.authenticator = _StubAuthenticator()
+    app.state.forwarder = _StubForwarder()
+    app.state.principal_signer = BarePrincipalSigner(
+        PrincipalSignerConfig(signing_key=_TEST_KEY)
+    )
+    return app
+
+
+async def test_successful_forward_logs_tenant_caller_and_upstream(
+    app, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.INFO):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/openapi/v1/bots?page=2")
+
+    assert response.status_code == 200
+    line = next(
+        message
+        for message in (record.getMessage() for record in caplog.records)
+        if message.startswith("forward GET /openapi/v1/bots")
+    )
+    assert "status=200" in line
+    assert "tenant=acme" in line
+    assert "caller=user:u-42+app:7" in line
+    # Which domain claimed the path and which upstream served it — the two
+    # routing decisions a forwarded request makes.
+    assert "domain=bots" in line
+    assert "server=backend" in line
+
+
+async def test_forwarded_query_credentials_are_redacted(
+    app, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The upstream URL carries the caller's query, credentials included.
+
+    The filter installed for uvicorn's own request lines does not cover this
+    logger, so the redaction has to happen where the line is formatted.
+    """
+    with caplog.at_level(logging.INFO):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.get("/openapi/v1/bots?x-proxypass-token=super-secret")
+
+    line = next(
+        message
+        for message in (record.getMessage() for record in caplog.records)
+        if message.startswith("forward GET /openapi/v1/bots")
+    )
+    assert "super-secret" not in line
+    assert "x-proxypass-token=<redacted>" in line


### PR DESCRIPTION
## Problem

The `/openapi/v1` surface is silent on success. Every *failure* has a line — `dependencies.py` logs a rejected principal, `app.py` logs mapped 4xx and unmapped 5xx — but a request that works leaves no trace at all. A `GET /openapi/v1/bots` that returns 200 produces nothing.

That makes the first question asked of a live incident unanswerable: **which tenant, and which caller, made this call?** Uvicorn's access line carries method, path and status and knows nothing about identity. The tenant is resolved by `AvernetTenantMiddleware` and consumed by the ORM guard without ever being written down. The gateway — the only hop that sees the caller's credentials, and so the only one that can say who a request turned out to *be* — logged a `forward` line naming a method, a path and a status, and nothing about the identity set it had just resolved.

Two credential exposures in the existing logging surfaced while adding this:

- the gateway's `forward` line logs the upstream URL, which carries the caller's query verbatim. The redaction filter installed for uvicorn's own request lines does not cover this logger.
- the WebSocket relay's handshake line logged the **whole header map** — the signed `X-Avernet-Principal` it had just minted, plus any forwarded `Cookie`/`Authorization` — and the unredacted URL, on a plane whose credential travels in the query string by design.

## Solution

**Backend — `PublicApiAccessLogMiddleware` (`adapters/http/openapi_v1/access_log.py`).** One INFO line per completed `/openapi/v1` request:

```
openapi_access method=GET path=/openapi/v1/bots/bot-7 route=/openapi/v1/bots/{bot_id}
  status=200 duration_ms=12.4 tenant=acme caller=user:u-42+app:7 query=page=2
  trace_id=… request_id=… client=10.0.0.5 ua="avernet-sdk/1.2"
```

A middleware rather than per-handler logging: there are ~40 public handlers across nine routers, and a handler that forgets to log is invisible. A pure ASGI middleware, not `BaseHTTPMiddleware`, for the same reason `AvernetTenantMiddleware` is — no child task, so the timer, the status and the caller are read in the coroutine that awaited the downstream app.

Field choices, and what each buys:

- `route` is the matched template, so a thousand bot ids aggregate to one route; absent on a 404, which is itself the signal.
- `tenant`/`caller` come from `resolve_caller`, the **same cached** verification the tenant middleware already ran — so the line cannot disagree with the tenant the request executed under, and costs no second signature check. `caller` names *every* identity in the set (`user:u-42+app:7`), because a user+app route is answering for two.
- an unverified principal logs `tenant=- caller=-` rather than inventing a tenant; *why* it failed is already on its own line from the verifier.
- `status=-` plus `error=` means the request left this layer as an exception, with the response synthesised above by `ServerErrorMiddleware`.
- every caller-controlled field is bounded: `ua` at 120, `query` at 512, `request_id` at 128.

Installed outside every middleware whose work it reports, and inside `CompatibilityCtokenMiddleware` so it sees the sanitized scope. Bodies are deliberately **not** logged — unbounded, and they carry bot configuration and user content. Writing the line is wrapped so a failure to *describe* a request can never change the request's outcome: it runs after the response is sent, where an escaping exception would truncate a request that actually succeeded.

`_resolve_caller` is promoted to `resolve_caller` — the access log is a legitimate third reader of that cache, alongside `require_principal` and `resolve_avernet_tenant`.

**Gateway — the same identity fields on `forward`**, plus `duration_ms` (time-to-first-byte; the body is still streaming), `domain`, `server` and `request_id`. Naming the identity set on both sides of the seam turns a mismatch — a request scoped to a tenant the gateway did not resolve — into a difference between two log lines instead of an invisible one. A set that names two tenants is logged as both rather than as one of them, since downstream verification refuses such a token outright.

**Headers are never logged, in any form.** The `forward` line redacts the upstream URL's query at the format site. The WebSocket relay's handshake line drops the header map entirely — not just its values, but its names too. Names alone leak nothing today, and that is the wrong test to design against: the set is whatever the client sent plus whatever a future change forwards, so a credential introduced anywhere upstream would begin appearing in that log with no edit to the line and nobody prompted to look. The backend's `_header()` helper takes a name and never returns the map, and says so in its docstring; the only two it is asked for are `user-agent` and `x-request-id`.

Not included, and worth a follow-up: the gateway does not mint an `X-Request-ID` when a caller omits one, so cross-hop correlation currently depends on the client sending one. BCS already has `TraceLayer` on its HTTP routes and was left alone.

## Validation

- `pytest tests/community` (backend, full): **10650 passed, 3 skipped**. One pre-existing architecture test, `test_router_files_use_http_machinery`, flagged the new module for importing `starlette.requests` instead of `fastapi`; switched to `from fastapi import Request`, matching `middleware.py`'s own idiom, rather than touching the rule.
- `pytest tests/` (gateway, excluding `e2e/`): **716 passed, 3 skipped**. Two environmental failures, both confirmed to reproduce with this branch's changes stashed: the `e2e/` health tests dial a server that is not running locally, and `test_bcn_dump_uses_the_gateway_managed_python_environment` hits a stale `src/bcs/uv.lock` in the dev container. Both are green in this PR's CI.
- `ruff check .` clean in both modules.

New tests:

- `test_access_log.py` (backend, 13 cases) — tenant/caller on success, multi-identity sets, `-` on an unverified caller, the exception path, `/api` untouched, query redaction, the caps on `request_id`/`ua` driven through the **unauthenticated** 401 path, and that a broken log line does not break the request.
- `test_forward_access_log.py` (gateway, 7 cases) — the identity projection exhaustively over the `Principal` union, including that bot and access-key *tokens* never appear, plus the emitted line.
- `test_relay_ws_route.py` gains a case sending a header whose name the client invents, asserting no header — invented, forwarded, or the gateway's own signed principal — reaches the log line, while the upstream still receives it. Its identity stub became a real `UserPrincipal`, since a bare `object()` no longer exercises what a handshake does.

## Compatibility and risk

Log output only — no contract, schema, config or migration impact. New INFO volume is one line per public request; the arrival line is DEBUG and off by default. Rollback is reverting the three commits. The redaction changes reduce what is printed, so anything parsing the gateway's lines for a URL query or for header names/values will see placeholders or nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011q3Fh8CmEFAeoLgBTWm18J