### PR TITLE
test(backend): forbid mocking in endpoint tests and remove it from all cases

### DIFF
--- a/src/backend/tests/community/endpoints/test_access_router.py
+++ b/src/backend/tests/community/endpoints/test_access_router.py
@@ -4,17 +4,18 @@ PUT /api/v1/access/bots-ceiling
 
 Covered branches:
 - happy path (operator user) → success=True with echoed entityId/ceiling
-- service error (patched ``PolicyService.set_bots_ceiling``) → success=False, error_code=500
+- non-operator caller → ``require_operator`` raises ``Forbidden`` → 403
 - quota happy path with no seed rows → zero quota envelope
 - quota config parse errors through the real service → success=False, error_code=500
 
 In local mode ``AuthPlugin.is_operator_allowed`` returns True for every
 user, so any seeded staff user satisfies ``require_operator`` — mirroring
-the operator-flow setup in ``test_bot_admin_router.py``.
+the operator-flow setup in ``test_bot_admin_router.py``. The denial case
+drives that same policy decision through the plugin's DI seam
+(``set_response``), so the real ``require_operator`` dependency runs and
+the real error handler renders the 403.
 """
 from __future__ import annotations
-
-from unittest.mock import patch
 
 from tests.community.factories.access import make_staff_user
 from tests.community.framework import (
@@ -36,19 +37,20 @@ def _seed_operator(world):
     make_staff_user(world, user_id="u_target")
 
 
-def _seed_operator_with_service_error(world):
-    """Seed operator + target, then patch ``set_bots_ceiling`` to raise."""
+def _seed_non_operator(world):
+    """Seed the caller, then have the auth plugin refuse operator rights.
+
+    ``is_operator_allowed`` is the policy the local plugin answers ``True``
+    to for everyone; driving it through the plugin's DI seam is the only
+    way to reach the denial branch without a fake ``require_operator``.
+    Everything downstream — the dependency, the raised ``Forbidden``, the
+    error handler — is the production path.
+    """
+    from agentclaw.community.plugin_api.auth import AuthPlugin
+
     make_staff_user(world, user_id="u_operator")
     make_staff_user(world, user_id="u_target")
-
-    from agentclaw.community.core.access.services.policy_service import PolicyService
-
-    def mock_set_bots_ceiling(*args, **kwargs):
-        raise RuntimeError("Mock policy service error")
-
-    patcher = patch.object(PolicyService, "set_bots_ceiling", mock_set_bots_ceiling)
-    patcher.start()
-    world._set_bots_ceiling_error_patcher = patcher
+    world.get(AuthPlugin).set_response("is_operator_allowed", False)
 
 
 def _seed_quota_invalid_daily_config(world):
@@ -116,6 +118,14 @@ def _assert_ceiling_persisted(response, world):
 
     svc = world.get(PolicyService)
     assert svc.get_bots_ceiling(entity_id="u_target") == 10
+
+
+def _assert_ceiling_not_written(response, world):
+    """A rejected caller must not have moved the target's ceiling."""
+    from agentclaw.community.core.access.services.policy_service import PolicyService
+
+    svc = world.get(PolicyService)
+    assert svc.get_bots_ceiling(entity_id="u_target", default=5) == 5
 
 
 # ============================================================================
@@ -201,16 +211,17 @@ def set_bots_ceiling_ok():
 @endpoint_test(
     method="PUT",
     path="/api/v1/access/bots-ceiling",
-    scenario="service_error",
-    seed=_seed_operator_with_service_error,
+    scenario="forbidden_non_operator",
+    seed=_seed_non_operator,
     input=CaseInput(
         json_body={"entity_id": "u_target", "ceiling": 10},
         headers={"x-user-id": "u_operator"},
     ),
     expect=ExpectError(
-        status=200,
-        json_contains={"success": False, "error_code": 500},
+        status=403,
+        json_contains={"detail": "权限不足：您没有操作员权限"},
     ),
+    extra_assertions=(_assert_ceiling_not_written,),
 )
-def set_bots_ceiling_service_error():
-    """Set ceiling returns success=False, error_code=500 when the service raises."""
+def set_bots_ceiling_forbidden_non_operator():
+    """A caller outside the operator allowlist is rejected before any write."""

--- a/src/backend/tests/community/endpoints/test_bot_dormant_ops_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_dormant_ops_router.py
@@ -1,60 +1,73 @@
-"""Endpoint coverage for dormant-bot ops routes."""
+"""Endpoint coverage for dormant-bot ops routes.
+
+Every case is decided by real bot state in the per-test database: a bot's
+``status`` and ``bot_type`` are exactly what ``DormantOpsService`` and
+``ActivateBotService`` check, so the happy and rejected paths here are the
+ones an operator would hit. The single exception is the passport failure,
+which belongs to AgentPass — driven through the passport plugin's DI seam,
+the boundary the ops service calls.
+"""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService, InvalidBotStateError
+from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService
 from agentclaw.community.core.bot_dormant.ops_service import DormantOpsService
+from agentclaw.community.plugin_api.passport import PassportPlugin
+from tests.community.factories.access import make_staff_user
+from tests.community.factories.bot_collaborator import make_bot
 from tests.community.framework import CaseInput, ExpectError, ExpectSuccess, endpoint_test
 
 
 _AUTH_HEADERS = {"Authorization": "Bearer singlebox-dormant-token-local"}
+_BOT_ID = "bot-ops"
+_OWNER_ID = "owner-ops"
+
+
+def _seed_bot(world, *, status: str, bot_type: str = "personal") -> None:
+    make_staff_user(world, user_id=_OWNER_ID)
+    make_bot(
+        world,
+        bot_id=_BOT_ID,
+        owner_id=_OWNER_ID,
+        owner_name=_OWNER_ID,
+        bot_type=bot_type,
+        status=status,
+    )
 
 
 def _seed_recycle_ok(world) -> None:
-    svc = MagicMock(spec=DormantOpsService)
-    svc.recycle_one.return_value = {
-        "run_id": "manual-recycle-test",
-        "bot_id": "bot-ops",
-        "owner_id": "owner-ops",
-        "dry_run": False,
-        "status": "recycled",
-    }
-    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+    """An ACTIVE personal bot — the only shape manual recycle accepts."""
+    _seed_bot(world, status="ACTIVE")
 
 
 def _seed_recycle_error(world) -> None:
-    svc = MagicMock(spec=DormantOpsService)
-    svc.recycle_one.side_effect = ValueError("only ACTIVE bot can be manually recycled")
-    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+    """A bot that is already RECYCLED — the guard the route exists to enforce."""
+    _seed_bot(world, status="RECYCLED")
 
 
 def _seed_unfreeze_passport_ok(world) -> None:
-    svc = MagicMock(spec=DormantOpsService)
-    svc.unfreeze_passport_one.return_value = {
-        "bot_id": "default",
-        "owner_id": "37565",
-        "status": "passport_online",
-    }
-    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+    _seed_bot(world, status="RECYCLED")
 
 
 def _seed_unfreeze_passport_error(world) -> None:
-    svc = MagicMock(spec=DormantOpsService)
-    svc.unfreeze_passport_one.side_effect = RuntimeError("passport unavailable")
-    world.injector.binder.bind(DormantOpsService, to=svc, scope=None)
+    """AgentPass refuses to bring the credential online."""
+    _seed_bot(world, status="RECYCLED")
+
+    def _passport_unavailable(*_args, **_kwargs):
+        raise RuntimeError("passport unavailable")
+
+    world.get(PassportPlugin).set_override(
+        "unfreeze_agent_passport", _passport_unavailable,
+    )
 
 
 def _seed_activate_ok(world) -> None:
-    svc = MagicMock(spec=ActivateBotService)
-    svc.activate.return_value = {"status": "REACTIVATING", "message": "激活中"}
-    world.injector.binder.bind(ActivateBotService, to=svc, scope=None)
+    """A bot already REACTIVATING — activation is idempotent for that state."""
+    _seed_bot(world, status="REACTIVATING")
 
 
 def _seed_activate_error(world) -> None:
-    svc = MagicMock(spec=ActivateBotService)
-    svc.activate.side_effect = InvalidBotStateError("仅回收状态的 Bot 可激活")
-    world.injector.binder.bind(ActivateBotService, to=svc, scope=None)
+    """An ACTIVE bot — activation only applies to a recycled one."""
+    _seed_bot(world, status="ACTIVE")
 
 
 @endpoint_test(
@@ -64,8 +77,8 @@ def _seed_activate_error(world) -> None:
     input=CaseInput(
         headers=_AUTH_HEADERS,
         json_body={
-            "bot_id": "bot-ops",
-            "owner_id": "owner-ops",
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
             "dry_run": False,
             "reason": "endpoint coverage",
         },
@@ -84,12 +97,14 @@ def recycle_one_ok():
     scenario="err",
     input=CaseInput(
         headers=_AUTH_HEADERS,
-        json_body={"bot_id": "bot-ops", "owner_id": "owner-ops"},
+        json_body={"bot_id": _BOT_ID, "owner_id": _OWNER_ID},
     ),
     seed=_seed_recycle_error,
     expect=ExpectError(
         status=400,
-        json_contains={"detail": "only ACTIVE bot can be manually recycled"},
+        json_contains={
+            "detail": "only ACTIVE bot can be manually recycled, current: RECYCLED",
+        },
     ),
 )
 def recycle_one_err():
@@ -104,8 +119,8 @@ def recycle_one_err():
     input=CaseInput(
         headers=_AUTH_HEADERS,
         json_body={
-            "bot_id": "default",
-            "owner_id": "37565",
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
             "reason": "recover license",
         },
     ),
@@ -127,8 +142,8 @@ def unfreeze_passport_one_ok():
     input=CaseInput(
         headers=_AUTH_HEADERS,
         json_body={
-            "bot_id": "default",
-            "owner_id": "37565",
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
             "reason": "recover license",
         },
     ),
@@ -150,8 +165,8 @@ def unfreeze_passport_one_err():
     input=CaseInput(
         headers=_AUTH_HEADERS,
         json_body={
-            "bot_id": "bot-ops",
-            "owner_id": "owner-ops",
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER_ID,
             "nick_name": "ops",
         },
     ),
@@ -169,10 +184,10 @@ def activate_one_ok():
     scenario="err",
     input=CaseInput(
         headers=_AUTH_HEADERS,
-        json_body={"bot_id": "bot-ops", "owner_id": "owner-ops"},
+        json_body={"bot_id": _BOT_ID, "owner_id": _OWNER_ID},
     ),
     seed=_seed_activate_error,
-    expect=ExpectError(status=400, json_contains={"detail": "仅回收状态的 Bot 可激活"}),
+    expect=ExpectError(status=400, json_contains={"detail": "only RECYCLED bot can be activated, current: ACTIVE"}),
 )
 def activate_one_err():
     """Error path: invalid activation state is surfaced as HTTP 400."""

--- a/src/backend/tests/community/endpoints/test_bot_management_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_management_router.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import threading
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 
@@ -16,12 +15,14 @@ from agentclaw.community.adapters.http.bot_management.router import (
     _build_bots_by_owner_or_collaborator_data,
     list_bots_by_owner_or_collaborator as list_bots_route,
 )
+from agentclaw.community.core.workspace.constants import _get_engine_types
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot, make_collaborator
 from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_failing_method,
     endpoint_test,
 )
 
@@ -190,17 +191,17 @@ def test_owner_or_collaborator_list_defaults_null_engine_types():
                 for engine in engine_types
             }
 
-    with patch(
-        "agentclaw.community.adapters.http.bot_management.router._get_engine_types",
-        return_value=["openclaw"],
-    ):
-        data = _build_bots_by_owner_or_collaborator_data(
-            owner_id="u",
-            bot_service=BotServiceWithNullEngineTypes(),
-        )
+    data = _build_bots_by_owner_or_collaborator_data(
+        owner_id="u",
+        bot_service=BotServiceWithNullEngineTypes(),
+    )
 
+    # The contract is the fallback itself: a bot with no engine_types of its
+    # own gets the deployment's configured list. Deriving the expectation from
+    # that same list keeps this pinned to the fallback rather than to whichever
+    # engines happen to be configured.
     assert data["items"][0]["engine_paths"] == {
-        "openclaw": "/tmp/bot-1/openclaw"
+        engine: f"/tmp/bot-1/{engine}" for engine in _get_engine_types()
     }
 
 
@@ -358,19 +359,21 @@ def list_bots_by_owner_or_collaborator_various_statuses():
 
 
 def _seed_with_service_error(world):
-    """Seed: mock bot service to raise an exception."""
-    from agentclaw.community.core.bot_management.services.bot_service import BotService
+    """Break the listing the way a database outage would.
 
-    def mock_list_bots_by_owner_or_collaborator(*args, **kwargs):
-        raise RuntimeError("Mock service error")
+    The route's except branch answers ``success=False`` for faults no request
+    can produce, so the failure is injected at the DI seam instead of being
+    pretended into existence with a patch.
+    """
+    from agentclaw.community.api.bot_service import BotServiceProtocol
 
-    patcher = patch.object(
-        BotService,
+    make_staff_user(world, user_id="u_owner")
+    bind_failing_method(
+        world,
+        BotServiceProtocol,
         "list_bots_by_owner_or_collaborator",
-        mock_list_bots_by_owner_or_collaborator,
+        RuntimeError("Mock service error"),
     )
-    patcher.start()
-    world._bot_list_service_error_patcher = patcher
 
 
 @endpoint_test(
@@ -428,15 +431,21 @@ def get_bots_ceiling_ok():
 
 
 def _seed_ceiling_service_error(world):
-    """Patch PolicyService.get_bots_ceiling to raise, exercising the except branch."""
-    from agentclaw.community.core.access.services.policy_service import PolicyService
+    """Break the ceiling lookup, exercising the route's except branch.
 
-    def mock_get_bots_ceiling(*args, **kwargs):
-        raise RuntimeError("Mock policy service error")
+    ``get_bots_ceiling`` swallows every malformed-policy case and returns the
+    default, so no seeded row can make it raise; the seam is the only honest
+    way to reach the branch.
+    """
+    from agentclaw.community.api.policy_service import PolicyServiceProtocol
 
-    patcher = patch.object(PolicyService, "get_bots_ceiling", mock_get_bots_ceiling)
-    patcher.start()
-    world._get_bots_ceiling_error_patcher = patcher
+    make_staff_user(world, user_id="u_owner")
+    bind_failing_method(
+        world,
+        PolicyServiceProtocol,
+        "get_bots_ceiling",
+        RuntimeError("Mock policy service error"),
+    )
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_bot_public_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_public_router.py
@@ -5,8 +5,6 @@ Tests the following endpoints from ``adapters/http/bot_public/router.py``:
 """
 from __future__ import annotations
 
-from unittest.mock import patch, MagicMock
-
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot, make_collaborator
 from tests.community.framework import (

--- a/src/backend/tests/community/endpoints/test_channel_router.py
+++ b/src/backend/tests/community/endpoints/test_channel_router.py
@@ -2,20 +2,61 @@
 
 Tests the following endpoints from ``adapters/http/channel/router.py``:
 - GET /api/channels/openclaw-configs
+
+``ChannelService.generate_openclaw_configs`` reads the bot's ``openclaw.json``
+off its workspace and merges the channel rows over it, so every case here is
+driven by the two things that really decide the outcome: whether the bot
+exists, and whether that file is on disk. The happy case writes a real
+template at the path the loader resolves for a local device filesystem; the
+error cases simply withhold one of the two, which is exactly how each failure
+arises in production. The router's catch-all 500 branch is the one thing no
+request can reach; that case injects its failure at the DI seam.
 """
 from __future__ import annotations
 
-from unittest.mock import patch, AsyncMock
 import json
 
+from agentclaw.community.core.channel.json_config_utils import _get_local_base_dir
+from agentclaw.community.core.devices.repository.protocol import DeviceBindingRepository
+from agentclaw.community.utils.env_utils import get_current_env
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot
 from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_failing_method,
     endpoint_test,
 )
+
+_TEMPLATE = {
+    "name": "test_bot",
+    "channels": {
+        "dingtalk": {
+            "enabled": True,
+            "accounts": {},
+        }
+    },
+}
+
+
+def _template_path():
+    """The file the generator actually opens, as production resolves it.
+
+    ``JsonConfigFile.load`` rewrites the bot workspace path to
+    ``${HOME}/.openclaw/<name>`` whenever the device filesystem is the local
+    one, so that — not the workspace directory — is where a local-mode
+    template has to be. Taken from the production helper so the test cannot
+    drift from the rule it depends on.
+    """
+    return _get_local_base_dir() / "openclaw.json"
+
+
+def _write_openclaw_template(world) -> None:
+    """Put a real ``openclaw.json`` where the generator will look for it."""
+    path = _template_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_TEMPLATE, indent=2), encoding="utf-8")
 
 
 # ============================================================================
@@ -24,9 +65,36 @@ from tests.community.framework import (
 
 
 def _seed_owner_with_bot(world):
-    """Seed a bot owner with a bot."""
+    """Seed a bot owner and a bot on an ACTIVE, non-BaaS-managed local device.
+
+    Two properties of the binding matter to this route. It must be ACTIVE, or
+    ``DeviceContextResolver`` refuses to mint a context and the generator never
+    reaches a filesystem. And its ``device_props`` must carry no
+    ``adapter_port``: that is precisely how the resolver tells a BaaS-managed
+    binding from one that is not, and the latter is what selects
+    ``LocalDeviceFileSystem``'s pathlib mode — the branch that reads the
+    ``openclaw.json`` this test writes to disk.
+    """
     make_staff_user(world, user_id="u_owner")
-    make_bot(world, bot_id="bot_test", owner_id="u_owner", bot_type="service", status="ACTIVE")
+    binding_id = world.get(DeviceBindingRepository).insert_binding(
+        entity_id="u_owner",
+        entity_type="staff",
+        device_id="channel_dev_test",
+        device_provider="local",
+        env=get_current_env(),
+        device_props={"openclaw_port": 18789},
+        status="ACTIVE",
+        apply_reason="channel endpoint test seed",
+        applied_by="u_owner",
+    )
+    make_bot(
+        world,
+        bot_id="bot_test",
+        owner_id="u_owner",
+        bot_type="service",
+        status="ACTIVE",
+        binding_id=binding_id,
+    )
 
 
 def _seed_other_user(world):
@@ -78,24 +146,10 @@ def _assert_forbidden_response(response, world):
 # ============================================================================
 
 
-def _seed_mock_generate_configs(world):
-    """Seed: mock generate_openclaw_configs to return test data."""
-    from agentclaw.community.core.channel.services.channel_service import OpenClawConfigs, ChannelService
-
-    async def mock_generate_openclaw_configs(self, *, bot_id, owner_id):
-        return OpenClawConfigs(
-            verify=json.dumps({"name": "test_verify", "channels": {}}, indent=2),
-            online=json.dumps({"name": "test_online", "channels": {}}, indent=2),
-            eval=json.dumps({"name": "test_eval", "channels": {"dingtalk": {"enabled": False}}}, indent=2),
-        )
-
-    patcher = patch.object(
-        ChannelService,
-        "generate_openclaw_configs",
-        mock_generate_openclaw_configs,
-    )
-    patcher.start()
-    world._channel_generate_configs_patcher = patcher
+def _seed_bot_with_openclaw_template(world):
+    """Seed the bot and the ``openclaw.json`` the generator merges over."""
+    _seed_owner_with_bot(world)
+    _write_openclaw_template(world)
 
 
 @endpoint_test(
@@ -106,7 +160,7 @@ def _seed_mock_generate_configs(world):
         query_params={"bot_id": "bot_test", "owner_id": "u_owner"},
         headers={"x-user-id": "u_owner"},
     ),
-    seed=lambda w: (_seed_owner_with_bot(w), _seed_mock_generate_configs(w)),
+    seed=_seed_bot_with_openclaw_template,
     expect=ExpectSuccess(
         status=200,
         json_contains={"success": True},
@@ -136,20 +190,15 @@ def get_openclaw_configs_non_owner_forbidden():
     """Non-owner cannot access another user's openclaw configs."""
 
 
-def _seed_mock_file_not_found(world):
-    """Seed: mock generate_openclaw_configs to raise FileNotFoundError."""
-    from agentclaw.community.core.channel.services.channel_service import ChannelService
+def _seed_bot_without_openclaw_template(world):
+    """Seed the bot but leave its workspace empty.
 
-    async def mock_generate_openclaw_configs(self, *, bot_id, owner_id):
-        raise FileNotFoundError("openclaw.json not found")
-
-    patcher = patch.object(
-        ChannelService,
-        "generate_openclaw_configs",
-        mock_generate_openclaw_configs,
-    )
-    patcher.start()
-    world._channel_file_not_found_patcher = patcher
+    A bot whose config has never been synced down is the real shape of this
+    failure — the generator has no template to merge over and raises
+    ``FileNotFoundError``.
+    """
+    _seed_owner_with_bot(world)
+    _template_path().unlink(missing_ok=True)
 
 
 @endpoint_test(
@@ -160,7 +209,7 @@ def _seed_mock_file_not_found(world):
         query_params={"bot_id": "bot_test", "owner_id": "u_owner"},
         headers={"x-user-id": "u_owner"},
     ),
-    seed=lambda w: (_seed_owner_with_bot(w), _seed_mock_file_not_found(w)),
+    seed=_seed_bot_without_openclaw_template,
     expect=ExpectError(
         status=500,
     ),
@@ -169,21 +218,9 @@ def get_openclaw_configs_file_not_found_error():
     """FileNotFoundError returns 500 status."""
 
 
-def _seed_mock_bot_not_found(world):
-    """Seed: mock generate_openclaw_configs to raise BotNotFoundError."""
-    from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
-    from agentclaw.community.core.channel.services.channel_service import ChannelService
-
-    async def mock_generate_openclaw_configs(self, *, bot_id, owner_id):
-        raise BotNotFoundError(f"Bot not found: {bot_id}")
-
-    patcher = patch.object(
-        ChannelService,
-        "generate_openclaw_configs",
-        mock_generate_openclaw_configs,
-    )
-    patcher.start()
-    world._channel_bot_not_found_patcher = patcher
+def _seed_owner_without_bot(world):
+    """Seed only the caller, so the bot lookup itself is what fails."""
+    make_staff_user(world, user_id="u_owner")
 
 
 @endpoint_test(
@@ -194,7 +231,7 @@ def _seed_mock_bot_not_found(world):
         query_params={"bot_id": "bot_test", "owner_id": "u_owner"},
         headers={"x-user-id": "u_owner"},
     ),
-    seed=lambda w: (_seed_owner_with_bot(w), _seed_mock_bot_not_found(w)),
+    seed=_seed_owner_without_bot,
     expect=ExpectError(
         status=400,
     ),
@@ -203,20 +240,22 @@ def get_openclaw_configs_bot_not_found_error():
     """BotNotFoundError returns 400 status."""
 
 
-def _seed_mock_unexpected_error(world):
-    """Seed: mock generate_openclaw_configs to raise unexpected error."""
-    from agentclaw.community.core.channel.services.channel_service import ChannelService
+def _seed_generator_breaks_unexpectedly(world):
+    """Seed the bot, then break the generator the way infrastructure would.
 
-    async def mock_generate_openclaw_configs(self, *, bot_id, owner_id):
-        raise RuntimeError("Unexpected error")
+    The 500 branch is the router's catch-all for faults no request can
+    provoke; the failure is injected at the DI seam so the branch is still
+    covered without pretending some input reaches it.
+    """
+    from agentclaw.community.api.channel_service import ChannelServiceProtocol
 
-    patcher = patch.object(
-        ChannelService,
+    _seed_bot_with_openclaw_template(world)
+    bind_failing_method(
+        world,
+        ChannelServiceProtocol,
         "generate_openclaw_configs",
-        mock_generate_openclaw_configs,
+        RuntimeError("Unexpected error"),
     )
-    patcher.start()
-    world._channel_unexpected_error_patcher = patcher
 
 
 @endpoint_test(
@@ -227,7 +266,7 @@ def _seed_mock_unexpected_error(world):
         query_params={"bot_id": "bot_test", "owner_id": "u_owner"},
         headers={"x-user-id": "u_owner"},
     ),
-    seed=lambda w: (_seed_owner_with_bot(w), _seed_mock_unexpected_error(w)),
+    seed=_seed_generator_breaks_unexpectedly,
     expect=ExpectError(
         status=500,
     ),

--- a/src/backend/tests/community/endpoints/test_cron_noauth_router.py
+++ b/src/backend/tests/community/endpoints/test_cron_noauth_router.py
@@ -3,11 +3,26 @@
 Covers:
 - POST /api/public/cron/auto-initiate/run (happy + error)
 - POST /api/public/cron/auto-initiate/run-single (happy + error)
+
+The relay itself runs for real against the in-memory adapter transport
+(``InMemoryDeviceAdapterTransport``, the LOCAL ``DeviceAdapterTransport``
+impl): the happy ``run`` case seeds an actual autoInitiate cron job through
+the relay, so the endpoint has to resolve the device, list the jobs, pick the
+one tagged ``kind:autoInitiate`` and trigger it — the whole point of the
+route. Both error cases come from a bot that genuinely has no device binding,
+which is what makes the relay raise ``ValueError`` and the router answer 400.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
 
+from agentclaw.community.api.cron_relay_service import CronRelayServiceProtocol
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterTransport,
+)
+from tests.community.factories.access import make_staff_user
+from tests.community.factories.bot_collaborator import make_bot
+from tests.community.factories.devices import make_active_local_device
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -15,41 +30,85 @@ from tests.community.framework import (
     endpoint_test,
 )
 
-from agentclaw.community.api.cron_relay_service import CronRelayServiceProtocol
+
+_BOT_ID = "bot-1"
+_USER_ID = "user-1"
+_DIMA_URL = (
+    "https://project.teamclaw.com/space/W1/requirement?openWorkItemId=123"
+)
 
 
-def _seed_run_ok(world):
-    svc = MagicMock()
-    svc.find_auto_initiate_and_run = AsyncMock(return_value={
-        "success": True,
-        "data": {"job_id": "auto-1"},
-    })
-    world.injector.binder.bind(CronRelayServiceProtocol, to=svc, scope=None)
-
-
-def _seed_run_error(world):
-    svc = MagicMock()
-    svc.find_auto_initiate_and_run = AsyncMock(
-        side_effect=ValueError("No autoInitiate cron job found")
+def _seed_bot_with_device(world) -> None:
+    """A bot whose ACTIVE local binding resolves to the in-memory adapter."""
+    make_staff_user(world, user_id=_USER_ID)
+    binding_id = make_active_local_device(world, owner_id=_USER_ID)
+    make_bot(
+        world,
+        bot_id=_BOT_ID,
+        owner_id=_USER_ID,
+        owner_name=_USER_ID,
+        bot_type="service",
+        status="ACTIVE",
+        binding_id=binding_id,
     )
-    world.injector.binder.bind(CronRelayServiceProtocol, to=svc, scope=None)
 
 
-def _seed_run_single_ok(world):
-    svc = MagicMock()
-    svc.run_single_auto_initiate = AsyncMock(return_value={
-        "success": True,
-        "data": {"total": 1, "created": 1, "errors": []},
-    })
-    world.injector.binder.bind(CronRelayServiceProtocol, to=svc, scope=None)
-
-
-def _seed_run_single_error(world):
-    svc = MagicMock()
-    svc.run_single_auto_initiate = AsyncMock(
-        side_effect=ValueError("Bot bot-1 has no device binding")
+def _seed_bot_without_device(world) -> None:
+    """A bot with no device binding — the relay's own precondition failure."""
+    make_staff_user(world, user_id=_USER_ID)
+    make_bot(
+        world,
+        bot_id=_BOT_ID,
+        owner_id=_USER_ID,
+        owner_name=_USER_ID,
+        bot_type="service",
+        status="ACTIVE",
     )
-    world.injector.binder.bind(CronRelayServiceProtocol, to=svc, scope=None)
+
+
+def _seed_auto_initiate_job(world) -> None:
+    """Register a real autoInitiate cron job on the bot's adapter.
+
+    Created through the relay's own ``forward_request``, so the job lands in
+    the adapter exactly as a user-created one would — including the
+    ``|kind:autoInitiate|`` marker in its message that the endpoint under test
+    scans for.
+    """
+    _seed_bot_with_device(world)
+    relay = world.get(CronRelayServiceProtocol)
+    asyncio.run(
+        relay.forward_request(
+            bot_id=_BOT_ID,
+            user_id=_USER_ID,
+            nick_name=_USER_ID,
+            method="POST",
+            path="/api/cron",
+            body={
+                "name": "auto initiate",
+                "schedule": "0 9 * * *",
+                "command": "daily sweep |kind:autoInitiate|",
+            },
+        )
+    )
+
+
+def _seed_engine_accepts_run_single(world) -> None:
+    """Have the adapter answer the engine's run-single path.
+
+    ``/api/cron/auto-initiate/run-single`` is served by the engine, not by the
+    cron store the in-memory adapter models, so the transport seam supplies
+    that one upstream reply. Everything before it — bot lookup, device status,
+    workflow resolution from ``template_config``, request-body assembly — is
+    the relay's real code.
+    """
+    _seed_bot_with_device(world)
+    world.get(DeviceAdapterTransport).set_override(
+        "invoke",
+        lambda *_args, **_kwargs: {
+            "success": True,
+            "data": {"total": 1, "created": 1, "errors": []},
+        },
+    )
 
 
 # ---- POST /api/public/cron/auto-initiate/run ----
@@ -58,24 +117,34 @@ def _seed_run_single_error(world):
     method="POST",
     path="/api/public/cron/auto-initiate/run",
     scenario="ok",
-    input=CaseInput(query_params={"bot_id": "bot-1", "user_id": "user-1"}),
-    seed=_seed_run_ok,
-    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    input=CaseInput(query_params={"bot_id": _BOT_ID, "user_id": _USER_ID}),
+    seed=_seed_auto_initiate_job,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"ok": True, "ran": True}},
+    ),
 )
 def run_auto_initiate_ok():
-    """Happy path: trigger autoInitiate."""
+    """Happy path: the bot's autoInitiate job is found and triggered."""
 
 
 @endpoint_test(
     method="POST",
     path="/api/public/cron/auto-initiate/run",
     scenario="err",
-    input=CaseInput(query_params={"bot_id": "bot-1", "user_id": "user-1"}),
-    seed=_seed_run_error,
-    expect=ExpectError(status=200, json_contains={"success": False, "error_code": 400}),
+    input=CaseInput(query_params={"bot_id": _BOT_ID, "user_id": _USER_ID}),
+    seed=_seed_bot_without_device,
+    expect=ExpectError(
+        status=200,
+        json_contains={
+            "success": False,
+            "error_code": 400,
+            "message": f"Bot {_BOT_ID} has no device binding",
+        },
+    ),
 )
 def run_auto_initiate_err():
-    """Error path: ValueError → 400."""
+    """Error path: an unbound bot has nowhere to run — ValueError → 400."""
 
 
 # ---- POST /api/public/cron/auto-initiate/run-single ----
@@ -85,12 +154,15 @@ def run_auto_initiate_err():
     path="/api/public/cron/auto-initiate/run-single",
     scenario="ok",
     input=CaseInput(query_params={
-        "bot_id": "bot-1",
-        "user_id": "user-1",
-        "dima_url": "https://project.teamclaw.com/space/W1/requirement?openWorkItemId=123",
+        "bot_id": _BOT_ID,
+        "user_id": _USER_ID,
+        "dima_url": _DIMA_URL,
     }),
-    seed=_seed_run_single_ok,
-    expect=ExpectSuccess(status=200, json_contains={"success": True}),
+    seed=_seed_engine_accepts_run_single,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "data": {"total": 1, "created": 1}},
+    ),
 )
 def run_single_auto_initiate_ok():
     """Happy path: single requirement session."""
@@ -101,12 +173,19 @@ def run_single_auto_initiate_ok():
     path="/api/public/cron/auto-initiate/run-single",
     scenario="err",
     input=CaseInput(query_params={
-        "bot_id": "bot-1",
-        "user_id": "user-1",
-        "dima_url": "https://project.teamclaw.com/space/W1/requirement?openWorkItemId=123",
+        "bot_id": _BOT_ID,
+        "user_id": _USER_ID,
+        "dima_url": _DIMA_URL,
     }),
-    seed=_seed_run_single_error,
-    expect=ExpectError(status=200, json_contains={"success": False, "error_code": 400}),
+    seed=_seed_bot_without_device,
+    expect=ExpectError(
+        status=200,
+        json_contains={
+            "success": False,
+            "error_code": 400,
+            "message": f"Bot {_BOT_ID} has no device binding",
+        },
+    ),
 )
 def run_single_auto_initiate_err():
-    """Error path: ValueError → 400."""
+    """Error path: an unbound bot has nowhere to run — ValueError → 400."""

--- a/src/backend/tests/community/endpoints/test_cron_router.py
+++ b/src/backend/tests/community/endpoints/test_cron_router.py
@@ -8,8 +8,10 @@ Tests the following scenarios:
 """
 from __future__ import annotations
 
+import json
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from starlette.requests import Request
 
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.core.bot_collaborator.interceptor.extractors import PermissionParams
@@ -22,6 +24,54 @@ from tests.community.framework import (
     ExpectError,
     endpoint_test,
 )
+
+
+class _RecordingBotService:
+    """The slice of ``BotServiceProtocol`` ``_resolve_user_identity`` uses.
+
+    Hand-written rather than a mock so the recorded calls are the only thing
+    the assertions can read: an unexpected method would raise here instead of
+    being invented on demand.
+    """
+
+    def __init__(self, *, bot: dict | None = None, error: Exception | None = None):
+        self.get_bot_calls: list[tuple[str, str]] = []
+        self._bot = bot
+        self._error = error
+
+    def get_bot(self, bot_id, user_id):
+        self.get_bot_calls.append((bot_id, user_id))
+        if self._error is not None:
+            raise self._error
+        return self._bot
+
+
+class _InterceptorContext:
+    """The interceptor context shape ``extract_cron_body_params`` reads."""
+
+    def __init__(self, **route_kwargs):
+        self.route_kwargs = route_kwargs
+
+
+def _json_request(body: bytes) -> Request:
+    """A real Starlette ``Request`` carrying ``body``.
+
+    Using the real class means ``request.json()`` parses for real — so the
+    malformed-body case below fails the way a malformed body actually fails,
+    rather than because a stub was told to raise.
+    """
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/cron",
+        "headers": [(b"content-type", b"application/json")],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
 
 
 # =============================================================================
@@ -41,13 +91,13 @@ class TestResolveUserIdentity:
             nickName="Test User",
             operatorName="Test User",
         )
-        bot_service = MagicMock()
+        bot_service = _RecordingBotService()
         user_id, nick_name = _resolve_user_identity(None, "bot1", user, bot_service)
 
         assert user_id == "u001"
         assert nick_name == "Test User"
         # bot_service should not be called when owner_id is None
-        bot_service.get_bot.assert_not_called()
+        assert bot_service.get_bot_calls == []
 
     def test_owner_scenario_with_empty_owner_id(self):
         """When owner_id is empty string, returns current user's identity."""
@@ -59,12 +109,12 @@ class TestResolveUserIdentity:
             nickName="Test User",
             operatorName="Test User",
         )
-        bot_service = MagicMock()
+        bot_service = _RecordingBotService()
         user_id, nick_name = _resolve_user_identity("", "bot1", user, bot_service)
 
         assert user_id == "u001"
         assert nick_name == "Test User"
-        bot_service.get_bot.assert_not_called()
+        assert bot_service.get_bot_calls == []
 
     def test_bot_id_all_returns_current_user(self):
         """When bot_id is 'all', returns current user's identity regardless of owner_id."""
@@ -76,13 +126,13 @@ class TestResolveUserIdentity:
             nickName="Test User",
             operatorName="Test User",
         )
-        bot_service = MagicMock()
+        bot_service = _RecordingBotService()
         # Even with owner_id set, bot_id="all" should use current user
         user_id, nick_name = _resolve_user_identity("u_owner", "all", user, bot_service)
 
         assert user_id == "u001"
         assert nick_name == "Test User"
-        bot_service.get_bot.assert_not_called()
+        assert bot_service.get_bot_calls == []
 
     def test_collaborator_scenario_returns_owner_identity(self):
         """When owner_id is set, returns owner's identity from bot info."""
@@ -95,17 +145,15 @@ class TestResolveUserIdentity:
             operatorName="Collab User",
         )
 
-        bot_service = MagicMock()
-        bot_service.get_bot.return_value = {
-            "owner_id": "u_owner",
-            "owner_name": "Owner User",
-        }
+        bot_service = _RecordingBotService(
+            bot={"owner_id": "u_owner", "owner_name": "Owner User"},
+        )
 
         user_id, nick_name = _resolve_user_identity("u_owner", "bot1", user, bot_service)
 
         assert user_id == "u_owner"
         assert nick_name == "Owner User"
-        bot_service.get_bot.assert_called_once_with("bot1", "u_owner")
+        assert bot_service.get_bot_calls == [("bot1", "u_owner")]
 
     def test_collaborator_scenario_bot_not_found(self):
         """When bot is not found, falls back to owner_id."""
@@ -118,8 +166,7 @@ class TestResolveUserIdentity:
             operatorName="Collab User",
         )
 
-        bot_service = MagicMock()
-        bot_service.get_bot.side_effect = Exception("Bot not found")
+        bot_service = _RecordingBotService(error=Exception("Bot not found"))
 
         user_id, nick_name = _resolve_user_identity("u_owner", "bot1", user, bot_service)
 
@@ -138,11 +185,7 @@ class TestResolveUserIdentity:
             operatorName="Collab User",
         )
 
-        bot_service = MagicMock()
-        bot_service.get_bot.return_value = {
-            "owner_id": "u_owner",
-            # No owner_name
-        }
+        bot_service = _RecordingBotService(bot={"owner_id": "u_owner"})
 
         user_id, nick_name = _resolve_user_identity("u_owner", "bot1", user, bot_service)
 
@@ -162,16 +205,11 @@ class TestExtractCronBodyParams:
         """Extracts bot_id and owner_id from request body."""
         from agentclaw.community.adapters.http.cron.router import extract_cron_body_params
 
-        # Mock context with request
-        mock_request = MagicMock()
-        mock_request.json = AsyncMock(return_value={
+        ctx = _InterceptorContext(request=_json_request(json.dumps({
             "bot_id": "bot123",
             "owner_id": "u_owner",
             "name": "test cron",
-        })
-
-        ctx = MagicMock()
-        ctx.route_kwargs = {"request": mock_request}
+        }).encode()))
 
         result = await extract_cron_body_params(ctx)
 
@@ -184,14 +222,10 @@ class TestExtractCronBodyParams:
         """Handles missing owner_id in request body."""
         from agentclaw.community.adapters.http.cron.router import extract_cron_body_params
 
-        mock_request = MagicMock()
-        mock_request.json = AsyncMock(return_value={
+        ctx = _InterceptorContext(request=_json_request(json.dumps({
             "bot_id": "bot123",
             "name": "test cron",
-        })
-
-        ctx = MagicMock()
-        ctx.route_kwargs = {"request": mock_request}
+        }).encode()))
 
         result = await extract_cron_body_params(ctx)
 
@@ -203,8 +237,7 @@ class TestExtractCronBodyParams:
         """Returns empty params when request is missing."""
         from agentclaw.community.adapters.http.cron.router import extract_cron_body_params
 
-        ctx = MagicMock()
-        ctx.route_kwargs = {}
+        ctx = _InterceptorContext()
 
         result = await extract_cron_body_params(ctx)
 
@@ -216,11 +249,7 @@ class TestExtractCronBodyParams:
         """Returns empty params when JSON parsing fails."""
         from agentclaw.community.adapters.http.cron.router import extract_cron_body_params
 
-        mock_request = MagicMock()
-        mock_request.json = AsyncMock(side_effect=Exception("Invalid JSON"))
-
-        ctx = MagicMock()
-        ctx.route_kwargs = {"request": mock_request}
+        ctx = _InterceptorContext(request=_json_request(b"{not json"))
 
         result = await extract_cron_body_params(ctx)
 
@@ -715,7 +744,7 @@ class TestResolveUserIdentityEdgeCases:
             nickName=None,  # None nickName
             operatorName="Test User",
         )
-        bot_service = MagicMock()
+        bot_service = _RecordingBotService()
         user_id, nick_name = _resolve_user_identity(None, "bot1", user, bot_service)
 
         assert user_id == "u001"
@@ -732,8 +761,7 @@ class TestResolveUserIdentityEdgeCases:
             operatorName="Collab User",
         )
 
-        bot_service = MagicMock()
-        bot_service.get_bot.return_value = None
+        bot_service = _RecordingBotService(bot=None)
 
         user_id, nick_name = _resolve_user_identity("u_owner", "bot1", user, bot_service)
 

--- a/src/backend/tests/community/endpoints/test_device_provider_inventory.py
+++ b/src/backend/tests/community/endpoints/test_device_provider_inventory.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from agentclaw.community.api.device_service import DeviceServiceProtocol
+from agentclaw.community.plugin_api.auth import AuthPlugin
 from tests.community.framework import CaseInput, ExpectError, ExpectSuccess, endpoint_test
 
 _OPERATOR = "provider_inventory_operator"
 
 
-def _raise_provider_inventory_error(world) -> None:
-    service = world.get(DeviceServiceProtocol)
-    patch.object(
-        service, "get_provider_inventory", side_effect=RuntimeError("inventory boom")
-    ).start()
+def _deny_operator(world) -> None:
+    """Have the auth plugin refuse operator rights for the caller.
+
+    The route is operator-only because it scans global bindings; the
+    denial is the error path worth pinning. ``is_operator_allowed`` is
+    the plugin's own policy decision, driven here through its DI seam so
+    the real ``require_operator`` dependency and error handler still run.
+    """
+    world.get(AuthPlugin).set_response("is_operator_allowed", False)
 
 
 @endpoint_test(
@@ -54,17 +56,13 @@ def provider_inventory_happy():
 @endpoint_test(
     method="GET",
     path="/api/v1/devices/provider-inventory",
-    scenario="service_error",
+    scenario="forbidden_non_operator",
     input=CaseInput(headers={"x-user-id": _OPERATOR}),
-    seed=_raise_provider_inventory_error,
+    seed=_deny_operator,
     expect=ExpectError(
-        status=200,
-        json_contains={
-            "success": False,
-            "error_code": 50000,
-            "message": "Failed to get provider inventory: inventory boom",
-        },
+        status=403,
+        json_contains={"detail": "权限不足：您没有操作员权限"},
     ),
 )
-def provider_inventory_service_error():
-    """Provider inventory service failures stay in the ApiResponse envelope."""
+def provider_inventory_forbidden_non_operator():
+    """A caller outside the operator allowlist never reaches the global scan."""

--- a/src/backend/tests/community/endpoints/test_harness_admin_router.py
+++ b/src/backend/tests/community/endpoints/test_harness_admin_router.py
@@ -6,8 +6,6 @@ Tests the following endpoints:
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
 from fastapi.testclient import TestClient
 
@@ -33,6 +31,7 @@ from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_method,
     endpoint_test,
 )
 from tests.community.framework.fixtures import app_with_testing_modules
@@ -49,6 +48,24 @@ from tests.community.framework.fixtures import app_with_testing_modules
 def client(app_with_testing_modules):
     """TestClient backed by a per-test injector with all tables created."""
     return TestClient(app_with_testing_modules)
+
+
+def _bind_patch_engine(world, *, returns=None, raises=None):
+    """Serve ``PatchEngineProtocol.apply`` from a stand-in bound on the injector.
+
+    Applying a patch writes files onto a bot's device, which is the one part of
+    this flow a test host cannot perform. The stand-in replaces exactly that
+    method on a subclass of the wired engine and is bound for the life of this
+    test's injector, so the router still resolves the engine the production way
+    and nothing survives into the next test.
+    """
+
+    async def _apply(_self, *_args, **_kwargs):
+        if raises is not None:
+            raise raises
+        return returns
+
+    bind_method(world, PatchEngineProtocol, "apply", _apply)
 
 
 # ── Seed helpers ────────────────────────────────────────────────
@@ -210,27 +227,33 @@ def admin_apply_patch_not_found():
 class TestAdminDiagnoseConflict:
     """Test the 409 conflict branch when a scan is already active."""
 
-    def test_diagnose_conflict(self, client):
-        """When an active scan exists, second diagnose returns 409."""
-        from agentclaw.community.core.harness.repository_protocol import (
-            HarnessScanRecordRepository,
-        )
-        from agentclaw.community.di import Injected
+    def test_diagnose_conflict(self, client, world):
+        """When an active scan exists, second diagnose returns 409.
 
-        scan_repo = client.app.state.injector.get(HarnessScanRecordRepository)
-        # Make has_active_scan return True
-        with patch.object(
-            type(scan_repo), "has_active_scan", return_value=True
-        ):
-            resp = client.post(
-                "/api/harness/admin/diagnose",
-                json={
-                    "bot_id": "bot_conflict",
-                    "entity_id": "100000",
-                    "entity_type": "staff",
-                },
-                headers={"x-user-id": "100000"},
+        The in-progress scan is a real row: ``has_active_scan`` matches on
+        status and age, so inserting a freshly-created ``scanning`` record is
+        what the first request would have left behind.
+        """
+        world.get(HarnessScanRecordRepository).create(
+            FindingsReport(
+                bot_id="bot_conflict",
+                entity_id="100000",
+                scan_type="full",
+                layer=Layer.L1,
+                trigger_source="manual",
+                status="scanning",
             )
+        )
+
+        resp = client.post(
+            "/api/harness/admin/diagnose",
+            json={
+                "bot_id": "bot_conflict",
+                "entity_id": "100000",
+                "entity_type": "staff",
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 409
         assert "诊断中" in resp.json().get("detail", "")
 
@@ -289,10 +312,10 @@ class TestAdminApplyByRecordId:
 
 
 class TestAdminApplyPatchIdListSuccess:
-    """Test admin/apply with patch_id_list mode — happy path via mock."""
+    """Test admin/apply with patch_id_list mode — happy path."""
 
-    def test_apply_patch_id_list_success(self, client):
-        """Applying patches by patch_id_list with mocked engine returns success."""
+    def test_apply_patch_id_list_success(self, client, world):
+        """Applying patches by patch_id_list returns success."""
         from agentclaw.community.core.harness.repository_protocol import (
             HarnessPatchRepository,
             HarnessPatchRecordRepository,
@@ -312,44 +335,27 @@ class TestAdminApplyPatchIdListSuccess:
         )
         patch_id = patch_repo.create(patch_def)
 
-        # Mock the patch_record_repo.get_by_patch_id to return None (no existing record)
-        with patch.object(
-            type(patch_record_repo),
-            "get_by_patch_id",
-            return_value=None,
-        ):
-            # Mock patch_record_repo.create to return a valid record_id
-            with patch.object(
-                type(patch_record_repo),
-                "create",
-                return_value=1,
-            ):
-                # Mock engine.apply to return a successful record
-                mock_engine = client.app.state.injector.get(PatchEngineProtocol)
-                applied_record = DomainPatchRecord(
-                    bot_id="bot_test",
-                    entity_id="100000",
-                    patch_id=patch_id,
-                    layer=Layer.L1,
-                    target=PatchTarget(files=["AGENTS.md"]),
-                    status=PatchStatus.APPLIED,
-                )
-                applied_record.id = 1
-                with patch.object(
-                    type(mock_engine),
-                    "apply",
-                    new_callable=AsyncMock,
-                    return_value=applied_record,
-                ):
-                    resp = client.post(
-                        "/api/harness/admin/apply",
-                        json={
-                            "bot_id": "bot_test",
-                            "entity_id": "100000",
-                            "patch_id_list": [patch_id],
-                        },
-                        headers={"x-user-id": "100000"},
-                    )
+        # No record exists for this patch yet, so the route takes its
+        # create-then-apply path against the real repository.
+        applied_record = DomainPatchRecord(
+            bot_id="bot_test",
+            entity_id="100000",
+            patch_id=patch_id,
+            layer=Layer.L1,
+            target=PatchTarget(files=["AGENTS.md"]),
+            status=PatchStatus.APPLIED,
+        )
+        applied_record.id = 1
+        _bind_patch_engine(world, returns=applied_record)
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "patch_id_list": [patch_id],
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 200
         assert resp.json().get("success") is True
 
@@ -357,7 +363,7 @@ class TestAdminApplyPatchIdListSuccess:
 class TestAdminApplyRecordIdSuccess:
     """Test admin/apply with record_id mode — happy path via mock."""
 
-    def test_apply_record_id_success(self, client):
+    def test_apply_record_id_success(self, client, world):
         """Applying a PLANNED record by record_id with mocked engine returns success."""
         from agentclaw.community.core.harness.models import (
             PatchRecord as DomainPatchRecord,
@@ -392,8 +398,6 @@ class TestAdminApplyRecordIdSuccess:
         )
         record_id = patch_record_repo.create(record)
 
-        # Mock engine.apply to return APPLIED record
-        mock_engine = client.app.state.injector.get(PatchEngineProtocol)
         applied_record = DomainPatchRecord(
             bot_id="bot_test",
             entity_id="100000",
@@ -403,21 +407,16 @@ class TestAdminApplyRecordIdSuccess:
             status=PatchStatus.APPLIED,
         )
         applied_record.id = record_id
-        with patch.object(
-            type(mock_engine),
-            "apply",
-            new_callable=AsyncMock,
-            return_value=applied_record,
-        ):
-            resp = client.post(
-                "/api/harness/admin/apply",
-                json={
-                    "bot_id": "bot_test",
-                    "entity_id": "100000",
-                    "record_id": record_id,
-                },
-                headers={"x-user-id": "100000"},
-            )
+        _bind_patch_engine(world, returns=applied_record)
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "record_id": record_id,
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 200
         assert resp.json().get("success") is True
 
@@ -425,7 +424,7 @@ class TestAdminApplyRecordIdSuccess:
 class TestAdminApplyPatchEngineError:
     """Test admin/apply when engine raises PatchEngineError."""
 
-    def test_apply_engine_error(self, client):
+    def test_apply_engine_error(self, client, world):
         """PatchEngineError from engine.apply returns 400."""
         from agentclaw.community.core.harness.models import (
             PatchRecord as DomainPatchRecord,
@@ -451,23 +450,18 @@ class TestAdminApplyPatchEngineError:
         )
         record_id = patch_record_repo.create(record)
 
-        # Mock engine.apply to raise PatchEngineError
-        mock_engine = client.app.state.injector.get(PatchEngineProtocol)
-        with patch.object(
-            type(mock_engine),
-            "apply",
-            new_callable=AsyncMock,
-            side_effect=PatchEngineError("apply", "something went wrong"),
-        ):
-            resp = client.post(
-                "/api/harness/admin/apply",
-                json={
-                    "bot_id": "bot_test",
-                    "entity_id": "100000",
-                    "record_id": record_id,
-                },
-                headers={"x-user-id": "100000"},
-            )
+        _bind_patch_engine(
+            world, raises=PatchEngineError("apply", "something went wrong"),
+        )
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "record_id": record_id,
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 400
         assert "something went wrong" in resp.json().get("detail", "")
 
@@ -475,7 +469,7 @@ class TestAdminApplyPatchEngineError:
 class TestAdminApplyRecordPreviewed:
     """Test admin/apply with a record in PREVIEWED status (should succeed)."""
 
-    def test_apply_previewed_record_success(self, client):
+    def test_apply_previewed_record_success(self, client, world):
         """A PREVIEWED record should be accepted for apply, same as PLANNED."""
         from agentclaw.community.core.harness.models import (
             PatchRecord as DomainPatchRecord,
@@ -507,8 +501,6 @@ class TestAdminApplyRecordPreviewed:
         )
         record_id = patch_record_repo.create(record)
 
-        # Mock engine.apply to return APPLIED record
-        mock_engine = client.app.state.injector.get(PatchEngineProtocol)
         applied_record = DomainPatchRecord(
             bot_id="bot_test",
             entity_id="100000",
@@ -518,21 +510,16 @@ class TestAdminApplyRecordPreviewed:
             status=PatchStatus.APPLIED,
         )
         applied_record.id = record_id
-        with patch.object(
-            type(mock_engine),
-            "apply",
-            new_callable=AsyncMock,
-            return_value=applied_record,
-        ):
-            resp = client.post(
-                "/api/harness/admin/apply",
-                json={
-                    "bot_id": "bot_test",
-                    "entity_id": "100000",
-                    "record_id": record_id,
-                },
-                headers={"x-user-id": "100000"},
-            )
+        _bind_patch_engine(world, returns=applied_record)
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "record_id": record_id,
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 200
         assert resp.json().get("success") is True
 
@@ -540,7 +527,7 @@ class TestAdminApplyRecordPreviewed:
 class TestAdminApplyServerError:
     """Test admin/apply when engine raises an unexpected Exception."""
 
-    def test_apply_generic_error_returns_500(self, client):
+    def test_apply_generic_error_returns_500(self, client, world):
         """A generic Exception from engine.apply returns 500."""
         from agentclaw.community.core.harness.models import (
             PatchRecord as DomainPatchRecord,
@@ -565,23 +552,16 @@ class TestAdminApplyServerError:
         )
         record_id = patch_record_repo.create(record)
 
-        # Mock engine.apply to raise a generic Exception
-        mock_engine = client.app.state.injector.get(PatchEngineProtocol)
-        with patch.object(
-            type(mock_engine),
-            "apply",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("unexpected failure"),
-        ):
-            resp = client.post(
-                "/api/harness/admin/apply",
-                json={
-                    "bot_id": "bot_test",
-                    "entity_id": "100000",
-                    "record_id": record_id,
-                },
-                headers={"x-user-id": "100000"},
-            )
+        _bind_patch_engine(world, raises=RuntimeError("unexpected failure"))
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "record_id": record_id,
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 500
 
 
@@ -672,7 +652,7 @@ class TestAdminDiagnoseSuccess:
 class TestAdminApplyPatchIdListEmptyContent:
     """Test admin/apply with patch_id_list when patch has empty content."""
 
-    def test_apply_patch_empty_content(self, client):
+    def test_apply_patch_empty_content(self, client, world):
         """A patch with no content (empty operations list) is still submitted
         to engine.apply — the endpoint does not enforce non-empty ops."""
         from agentclaw.community.core.harness.repository_protocol import (
@@ -694,8 +674,6 @@ class TestAdminApplyPatchIdListEmptyContent:
         )
         patch_id = patch_repo.create(patch_def)
 
-        # Mock get_by_patch_id to return None, create to return a record_id
-        mock_engine = client.app.state.injector.get(PatchEngineProtocol)
         applied_record = DomainPatchRecord(
             bot_id="bot_test",
             entity_id="100000",
@@ -705,20 +683,15 @@ class TestAdminApplyPatchIdListEmptyContent:
             status=PatchStatus.APPLIED,
         )
         applied_record.id = 1
-
-        with patch.object(type(patch_record_repo), "get_by_patch_id", return_value=None), \
-             patch.object(type(patch_record_repo), "create", return_value=1), \
-             patch.object(
-                type(mock_engine), "apply", new_callable=AsyncMock, return_value=applied_record
-             ):
-            resp = client.post(
-                "/api/harness/admin/apply",
-                json={
-                    "bot_id": "bot_test",
-                    "entity_id": "100000",
-                    "patch_id_list": [patch_id],
-                },
-                headers={"x-user-id": "100000"},
-            )
+        _bind_patch_engine(world, returns=applied_record)
+        resp = client.post(
+            "/api/harness/admin/apply",
+            json={
+                "bot_id": "bot_test",
+                "entity_id": "100000",
+                "patch_id_list": [patch_id],
+            },
+            headers={"x-user-id": "100000"},
+        )
         assert resp.status_code == 200
         assert resp.json().get("success") is True

--- a/src/backend/tests/community/endpoints/test_harness_router.py
+++ b/src/backend/tests/community/endpoints/test_harness_router.py
@@ -1,73 +1,89 @@
-"""Tests for collaborator-protected Harness endpoints."""
+"""Tests for collaborator-protected Harness endpoints.
+
+Both cases drive the real router over the real repository, so what is
+asserted is the persisted outcome rather than a call count on a patched
+method. ``POST /api/harness/diagnose`` spawns its scan with
+``asyncio.create_task``; the async client shares the test's event loop, so
+:func:`drain_background_tasks` runs that scan to completion instead of the
+scan being suppressed — which is also what lets the second case assert the
+status the scan actually wrote back.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
-from fastapi.testclient import TestClient
 
 from agentclaw.community.core.harness.repository_protocol import (
     HarnessScanRecordRepository,
 )
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot
+from tests.community.framework import drain_background_tasks
 
 
-@pytest.fixture
-def client(app_with_testing_modules):
-    return TestClient(app_with_testing_modules)
+def _scan_records(world, *, bot_id: str, entity_id: str) -> list[dict]:
+    """Every scan record the repository holds for this bot."""
+    records, _total = world.get(HarnessScanRecordRepository).list_records(
+        bot_id=bot_id, entity_id=entity_id,
+    )
+    return records
 
 
-def _discard_background_task(coroutine):
-    coroutine.close()
-
-
-def test_diagnose_rejects_nonexistent_bot_without_creating_scan(client, world):
+@pytest.mark.asyncio
+async def test_diagnose_rejects_nonexistent_bot_without_creating_scan(
+    async_client, world,
+):
     make_staff_user(world, user_id="u_owner")
-    scan_repo = world.get(HarnessScanRecordRepository)
 
-    with (
-        patch.object(scan_repo, "create", wraps=scan_repo.create) as create_scan,
-        patch(
-            "agentclaw.community.adapters.http.harness.router.asyncio.create_task",
-            side_effect=_discard_background_task,
-        ) as create_task,
-    ):
-        response = client.post(
-            "/api/harness/diagnose",
-            headers={"x-user-id": "u_owner"},
-            json={
-                "bot_id": "nonexistent_bot",
-                "entity_id": "u_owner",
-                "entity_type": "staff",
-            },
-        )
+    response = await async_client.post(
+        "/api/harness/diagnose",
+        headers={"x-user-id": "u_owner"},
+        json={
+            "bot_id": "nonexistent_bot",
+            "entity_id": "u_owner",
+            "entity_type": "staff",
+        },
+    )
+    await drain_background_tasks()
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Bot not found: nonexistent_bot"
-    create_scan.assert_not_called()
-    create_task.assert_not_called()
+    # The bot lookup precedes both the record insert and the scan task, so a
+    # rejected request must leave nothing behind.
+    assert _scan_records(world, bot_id="nonexistent_bot", entity_id="u_owner") == []
 
 
-def test_diagnose_starts_scan_for_existing_bot(client, world):
+@pytest.mark.asyncio
+async def test_diagnose_starts_scan_for_existing_bot(async_client, world):
     make_staff_user(world, user_id="u_owner")
     make_bot(world, bot_id="bot_test", owner_id="u_owner")
 
-    with patch(
-        "agentclaw.community.adapters.http.harness.router.asyncio.create_task",
-        side_effect=_discard_background_task,
-    ) as create_task:
-        response = client.post(
-            "/api/harness/diagnose",
-            headers={"x-user-id": "u_owner"},
-            json={
-                "bot_id": "bot_test",
-                "entity_id": "u_owner",
-                "entity_type": "staff",
-            },
-        )
+    response = await async_client.post(
+        "/api/harness/diagnose",
+        headers={"x-user-id": "u_owner"},
+        json={
+            "bot_id": "bot_test",
+            "entity_id": "u_owner",
+            "entity_type": "staff",
+        },
+    )
 
     assert response.status_code == 202
-    assert response.json()["status"] == "scanning"
-    create_task.assert_called_once()
+    body = response.json()
+    assert body["status"] == "scanning"
+    scan_id = body["scan_id"]
+    assert scan_id > 0
+
+    # The handler persists the record before spawning the task, which is what
+    # makes the returned scan_id pollable straight away.
+    repo = world.get(HarnessScanRecordRepository)
+    assert repo.get_by_id(scan_id) is not None
+    assert [r["id"] for r in _scan_records(
+        world, bot_id="bot_test", entity_id="u_owner",
+    )] == [scan_id]
+
+    # Run the spawned scan to completion. This bot has no synced config files,
+    # so the scan's own empty-input guard is what ends it — and it records that
+    # verdict against the same scan_id the response handed out.
+    await drain_background_tasks()
+    assert repo.get_by_id(scan_id)["status"] == "failed"

--- a/src/backend/tests/community/endpoints/test_open_bot_chat.py
+++ b/src/backend/tests/community/endpoints/test_open_bot_chat.py
@@ -4,15 +4,16 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
-from unittest.mock import patch
 
 import jwt
 
 from agentclaw.community.core.bot_chat.models import BcsGroupSession
 from agentclaw.community.core.bot_chat.repository import BotChatDbRepository
-from agentclaw.community.core.gateway_principal import PrincipalVerifierConfig
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -71,16 +72,30 @@ def _principal_headers() -> dict[str, str]:
     return {"X-Avernet-Principal": token}
 
 
+class _Secret:
+    """The shape ``SecretResolver.get_secret`` returns for the signing key."""
+
+    secret_user = "test"
+    secret_value = _SIGNING_KEY
+
+
+class _Resolver:
+    """A secret store that holds the key this test's tokens are signed with."""
+
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
 def _enable_public_auth(_world) -> None:
-    patch(
-        "agentclaw.community.adapters.http.openapi_v1.dependencies."
-        "get_principal_verifier_config",
-        return_value=PrincipalVerifierConfig(
-            signing_key=_SIGNING_KEY,
-            audience="backend",
-            issuer="gateway",
-        ),
-    ).start()
+    """Provision the gateway signing key through the production boot path.
+
+    ``init_principal_verifier_config`` is the same call ``adapters/http/app.py``
+    makes at boot; handing it a resolver that holds the key means the request
+    runs the real ``verify_principal_token`` over a real signature instead of a
+    verifier that was told to say yes. The community profile resolves no key, so
+    without this the public surface denies every request.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
 
 
 def _seed_trace(world) -> None:

--- a/src/backend/tests/community/endpoints/test_quality_endpoints.py
+++ b/src/backend/tests/community/endpoints/test_quality_endpoints.py
@@ -13,15 +13,15 @@ that the requesting user has access to the bot_id/owner_id pair.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
-
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot
 from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_overrides,
     endpoint_test,
+    json_response,
 )
 
 
@@ -93,52 +93,68 @@ def _seed_tasks_for_list(world):
     )
 
 
-def _seed_init_task(world):
-    """Seed a task in init status for process tests."""
-    from unittest.mock import AsyncMock, MagicMock
-    from typing import Annotated
+def _stand_in_for_eval_publish(world):
+    """Stand in for the publish steps an eval kicks off.
 
+    ``eval_publish`` drives a BaaS publish of the bot under evaluation — a
+    multi-minute, multi-service operation, and not what these routes are about.
+    The stand-in is bound through the injector as a subclass of the wired flow
+    service, so the route resolves it the production way and the substitution
+    dies with this test's injector.
+    """
     from injector import SingletonScope
 
-    from agentclaw.community.core.service_bot.services.publish_flow_service import PublishFlowService
+    from agentclaw.community.core.service_bot.services.publish_flow_service import (
+        PublishFlowService,
+    )
+
+    async def _eval_publish(_self, *_args, **_kwargs):
+        return {
+            "bot_uuid": "test-bot-uuid",
+            "baas_publish_id": "test-baas-publish-id",
+        }
+
+    def _progress(_self, *_args, **_kwargs):
+        return {"status": "SUCCESS"}
+
+    bind_overrides(
+        world,
+        PublishFlowService,
+        {"eval_publish": _eval_publish, "get_baas_publish_progress": _progress},
+    )
+    # The graph resolves PublishFlowService as a singleton, so the instance
+    # cached before the rebind has to be dropped for the new binding to win.
+    scope_binding, _ = world.injector.binder.get_binding(SingletonScope)
+    scope_instance = scope_binding.provider.get(world.injector)
+    scope_instance._context.pop(PublishFlowService, None)
+
+
+def _seed_init_task(world):
+    """Seed a task in init status for process tests."""
+    from typing import Annotated
+
     from agentclaw.community.plugin_api.http_client import HttpClient, QUALIFIER_MASA_AGENT_EVAL
     from tests.community.factories.quality import make_quality_task
 
     _seed_operator(world)
 
-    # Mock PublishFlowService.eval_publish via DI binding (not instance mutation)
-    mock_publish_service = MagicMock()
-    mock_publish_service.eval_publish = AsyncMock(return_value={
-        "bot_uuid": "test-bot-uuid",
-        "baas_publish_id": "test-baas-publish-id",
-    })
-    mock_publish_service.get_baas_publish_progress = MagicMock(return_value={
-        "status": "SUCCESS",
-    })
-    world.injector.binder.bind(PublishFlowService, to=mock_publish_service, scope=None)
-    # Clear singleton cache so the mock is returned on next get()
-    scope_binding, _ = world.injector.binder.get_binding(SingletonScope)
-    scope_instance = scope_binding.provider.get(world.injector)
-    scope_instance._context.pop(PublishFlowService, None)
+    _stand_in_for_eval_publish(world)
 
-    # Mock masa_eval_http response for /eval/start API
-    masa_eval_http = world.injector.get(Annotated[HttpClient, QUALIFIER_MASA_AGENT_EVAL])
-    mock_post_response = MagicMock()
-    mock_post_response.raise_for_status.return_value = None
-    mock_post_response.json.return_value = {
-        "success": True,
-        "data": {"set_task_uuid": "test-set-task-uuid"},
-    }
-    masa_eval_http.set_response("post", mock_post_response)
-
-    # Mock masa_eval_http response for /eval/progress API
-    mock_get_response = MagicMock()
-    mock_get_response.raise_for_status.return_value = None
-    mock_get_response.json.return_value = {
-        "success": True,
-        "data": {"status": "completed"},
-    }
-    masa_eval_http.set_response("get", mock_get_response)
+    # The MASA eval upstream is a real HTTP service; its two replies come
+    # through the qualified ``HttpClient`` seam, which is the injected boundary
+    # for exactly this.
+    masa_eval_http = world.get(Annotated[HttpClient, QUALIFIER_MASA_AGENT_EVAL])
+    masa_eval_http.set_response(
+        "post",
+        json_response({
+            "success": True,
+            "data": {"set_task_uuid": "test-set-task-uuid"},
+        }),
+    )
+    masa_eval_http.set_response(
+        "get",
+        json_response({"success": True, "data": {"status": "completed"}}),
+    )
 
     task = make_quality_task(
         world,
@@ -719,50 +735,30 @@ def update_task_status_for_others_missing_status():
 
 def _seed_admin_and_init_task(world):
     """Seed admin user and a task in init status for process_for_others tests."""
-    from unittest.mock import AsyncMock, MagicMock
     from typing import Annotated
 
-    from injector import SingletonScope
-
-    from agentclaw.community.core.service_bot.services.publish_flow_service import PublishFlowService
     from agentclaw.community.plugin_api.http_client import HttpClient, QUALIFIER_MASA_AGENT_EVAL
     from tests.community.factories.quality import make_quality_task
 
     _seed_super_admin(world)
 
-    # Mock PublishFlowService.eval_publish via DI binding (not instance mutation)
-    mock_publish_service = MagicMock()
-    mock_publish_service.eval_publish = AsyncMock(return_value={
-        "bot_uuid": "test-bot-uuid",
-        "baas_publish_id": "test-baas-publish-id",
-    })
-    mock_publish_service.get_baas_publish_progress = MagicMock(return_value={
-        "status": "SUCCESS",
-    })
-    world.injector.binder.bind(PublishFlowService, to=mock_publish_service, scope=None)
-    # Clear singleton cache so the mock is returned on next get()
-    scope_binding, _ = world.injector.binder.get_binding(SingletonScope)
-    scope_instance = scope_binding.provider.get(world.injector)
-    scope_instance._context.pop(PublishFlowService, None)
+    _stand_in_for_eval_publish(world)
 
-    # Mock masa_eval_http response for /eval/start API
-    masa_eval_http = world.injector.get(Annotated[HttpClient, QUALIFIER_MASA_AGENT_EVAL])
-    mock_post_response = MagicMock()
-    mock_post_response.raise_for_status.return_value = None
-    mock_post_response.json.return_value = {
-        "success": True,
-        "data": {"set_task_uuid": "test-set-task-uuid"},
-    }
-    masa_eval_http.set_response("post", mock_post_response)
-
-    # Mock masa_eval_http response for /eval/progress API
-    mock_get_response = MagicMock()
-    mock_get_response.raise_for_status.return_value = None
-    mock_get_response.json.return_value = {
-        "success": True,
-        "data": {"status": "completed"},
-    }
-    masa_eval_http.set_response("get", mock_get_response)
+    # The MASA eval upstream is a real HTTP service; its two replies come
+    # through the qualified ``HttpClient`` seam, which is the injected boundary
+    # for exactly this.
+    masa_eval_http = world.get(Annotated[HttpClient, QUALIFIER_MASA_AGENT_EVAL])
+    masa_eval_http.set_response(
+        "post",
+        json_response({
+            "success": True,
+            "data": {"set_task_uuid": "test-set-task-uuid"},
+        }),
+    )
+    masa_eval_http.set_response(
+        "get",
+        json_response({"success": True, "data": {"status": "completed"}}),
+    )
 
     task = make_quality_task(
         world,

--- a/src/backend/tests/community/endpoints/test_service_bot_build.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_build.py
@@ -8,17 +8,26 @@ This endpoint exercises the post-R14 sandbox provider through
 The provider's ``base_path`` now comes from ``WorkspaceConfig`` (typed,
 YAML-driven) instead of an ``is_local_mode`` flag.
 
-In the test environment the rsync subprocess does not actually run:
-``_migrate_bot_instance`` early-returns ``False`` when the source
-directory does not exist (which it never does in CI/local-SQLite
-mode), so the build completes cleanly with ``data.success = False``
-while the HTTP envelope returns ``ApiResponse(success=True, ...)``.
-That distinction is what the assertions below verify — the HTTP
-wrapper is the routing concern, the migration outcome is internal data.
+The NAS shell-outs (``sudo chmod`` / ``sudo rsync`` against
+``/home/admin/.merge_nas``) are the one thing no test host can serve, so the
+happy case binds :class:`_LocalShellFreeBuildService` — a subclass that
+overrides that single method and inherits the rest — through the injector.
+Everything the case is actually about still runs for real: the source
+directory genuinely does not exist, so ``_migrate_bot_instance`` takes its
+own early return and the build completes with ``data.success = False`` while
+the HTTP envelope returns ``ApiResponse(success=True, ...)``. That
+distinction is what the assertions below verify — the HTTP wrapper is the
+routing concern, the migration outcome is internal data.
 """
 from __future__ import annotations
 
+import subprocess
+
+from agentclaw.community.api.bot_build_service import BotBuildServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.service_bot.services.bot_build_service import (
+    BotBuildService,
+)
 from tests.community.factories.access import make_staff_user
 from tests.community.framework import (
     CaseInput,
@@ -52,15 +61,43 @@ def _seed_build_bot(world):
     )
 
 
-def _patch_build_test_seams() -> None:
-    """Patch NAS migration side effects for endpoint smoke tests only."""
-    from unittest.mock import patch
+class _LocalShellFreeBuildService(BotBuildService):
+    """The real build service with its one subprocess boundary neutralised.
 
-    patch(
-        "agentclaw.community.core.service_bot.services.bot_build_service.BotBuildService._run_local_command",
-        return_value="",
-    ).start()
-    patch("pathlib.Path.exists", return_value=False).start()
+    ``BotBuildService`` shells out (``sudo chmod`` / ``sudo rsync``) against the
+    NAS mount at ``/home/admin/.merge_nas``, which no test host has. That single
+    method is the only thing standing between this endpoint and a hermetic run,
+    so the subclass overrides it and inherits every other line — path
+    computation, the sandbox-provider resolution this test exists to cover, the
+    early return when the source directory is absent, and the response shape.
+
+    Bound through the injector below, so the router resolves it exactly as it
+    resolves the production service: no patching, and no chance of the
+    substitution outliving the case that asked for it.
+    """
+
+    def _run_local_command(
+        self,
+        cmd: list[str],
+        command_name: str,
+        error_message: str,
+        timeout_seconds: float | None = None,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+
+def _bind_shell_free_build_service(world) -> None:
+    """Serve ``BotBuildServiceProtocol`` from the shell-free subclass.
+
+    The instance is re-clothed from the injector's own service rather than
+    constructed here, so it carries the production collaborators — the same
+    device service, sandbox registry and path factory — and this file never
+    has to restate that wiring.
+    """
+    wired = world.get(BotBuildServiceProtocol)
+    shell_free = _LocalShellFreeBuildService.__new__(_LocalShellFreeBuildService)
+    shell_free.__dict__.update(wired.__dict__)
+    world.injector.binder.bind(BotBuildServiceProtocol, to=shell_free, scope=None)
 
 
 # ============================================================================
@@ -189,7 +226,9 @@ def build_bot_not_found():
         headers={"x-user-id": "u_owner"},
         json_body={"bot_id": "bot_build", "version": "v1"},
     ),
-    seed=lambda world: (_seed_build_bot(world), _patch_build_test_seams()),
+    seed=lambda world: (
+        _seed_build_bot(world), _bind_shell_free_build_service(world),
+    ),
     expect=ExpectSuccess(
         status=200,
         json_contains={

--- a/src/backend/tests/community/endpoints/test_service_bot_draft_restore.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_draft_restore.py
@@ -8,7 +8,6 @@ Covers:
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
 
 from agentclaw.community.api.bot_publish_service import BotPublishServiceProtocol
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
@@ -33,6 +32,8 @@ from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_failing_method,
+    bind_method,
     endpoint_test,
 )
 
@@ -138,14 +139,19 @@ def _seed_first_draft(world) -> None:
 
 
 def _seed_can_restore_failure(world) -> None:
-    """Pass authorization, then force the service query seam to fail."""
+    """Pass authorization, then fail the lookup the way infrastructure would.
+
+    The lookup itself is a plain read, so nothing in the request can make it
+    fail; the failure goes in at the DI seam so the router's 500 envelope is
+    what gets asserted.
+    """
     _seed_restoreable_draft(world)
-    service = world.get(BotPublishServiceProtocol)
-    patch.object(
-        type(service),
+    bind_failing_method(
+        world,
+        BotPublishServiceProtocol,
         "can_restore_draft",
-        side_effect=RuntimeError("draft restore lookup failed"),
-    ).start()
+        RuntimeError("draft restore lookup failed"),
+    )
 
 
 async def _execute_restore_draft_stub(self, **kwargs):
@@ -166,16 +172,32 @@ async def _execute_restore_draft_stub(self, **kwargs):
 
 
 def _seed_restore_happy(world) -> None:
+    """Stand in for the rsync-backed restore, keeping its ledger effects.
+
+    ``execute_restore_draft`` copies a historical artifact tree over the NAS
+    mount with ``sudo rsync`` — the one step of this flow no test host can
+    perform. The stand-in writes the same operation-ledger rows the real
+    implementation writes, through the service's own repository, so the
+    endpoint's response and everything the assertions read back are produced
+    by the real code around it.
+    """
+    from agentclaw.community.api.publish_flow_service import (
+        PublishFlowServiceProtocol,
+    )
     from agentclaw.community.core.service_bot.services.publish_flow_service import (
         PublishFlowService,
     )
 
     _seed_restoreable_draft(world)
-    patch.object(
+    # The durable task handler receives the flow as its concrete class while the
+    # router injects the Protocol, so both keys have to reach the stand-in.
+    bind_method(
+        world,
         PublishFlowService,
         "execute_restore_draft",
-        new=_execute_restore_draft_stub,
-    ).start()
+        _execute_restore_draft_stub,
+        also_bind=(PublishFlowServiceProtocol,),
+    )
 
 
 def _assert_restore_completed(response, world) -> None:  # noqa: ARG001
@@ -228,13 +250,14 @@ def _seed_completed_restore_operation(world) -> None:
 
 
 def _seed_restore_status_failure(world) -> None:
+    """Take the operation ledger away underneath the status read."""
     _seed_restoreable_draft(world)
-    service = world.get(BotPublishServiceProtocol)
-    patch.object(
-        type(service),
+    bind_failing_method(
+        world,
+        BotPublishServiceProtocol,
         "get_draft_restore_status",
-        side_effect=RuntimeError("ledger unavailable"),
-    ).start()
+        RuntimeError("ledger unavailable"),
+    )
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_service_bot_update_config.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_update_config.py
@@ -8,8 +8,6 @@ Uses CollaboratorPermissionInterceptor for access control.
 """
 from __future__ import annotations
 
-from unittest.mock import patch
-
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import CollaboratorLockService
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.service_bot.services.bot_publish_service import BotPublishServiceError
@@ -19,6 +17,7 @@ from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_failing_method,
     endpoint_test,
 )
 from tests.community.framework.world import World
@@ -432,18 +431,23 @@ def update_service_bot_config_invalid_config_replaced():
 # ============================================================================
 
 
-def _seed_and_mock_publish_error(world: World) -> None:
-    """Seed bot and mock update_bot_ext to raise BotPublishServiceError."""
+def _seed_and_fail_publish(world: World) -> None:
+    """Seed the bot, then make the ext write fail the way the domain would.
+
+    Nothing a caller can send makes ``update_bot_ext`` refuse — the refusal
+    comes from downstream publish state — so the failure is injected at the
+    DI seam. The router branch under test is the one that turns
+    ``BotPublishServiceError`` into error_code 403.
+    """
     from agentclaw.community.api.bot_service import BotServiceProtocol
     make_staff_user(world, user_id="u_owner")
     make_bot(world, bot_id="bot_test", owner_id="u_owner", bot_type="service", status="ACTIVE")
-    # Mock update_bot_ext to raise BotPublishServiceError
-    bot_service = world.get(BotServiceProtocol)
-    patch.object(
-        type(bot_service),
+    bind_failing_method(
+        world,
+        BotServiceProtocol,
         "update_bot_ext",
-        side_effect=BotPublishServiceError("Permission denied for update"),
-    ).start()
+        BotPublishServiceError("Permission denied for update"),
+    )
 
 
 @endpoint_test(
@@ -458,7 +462,7 @@ def _seed_and_mock_publish_error(world: World) -> None:
             "config_update": {"device_count": 2},
         },
     ),
-    seed=_seed_and_mock_publish_error,
+    seed=_seed_and_fail_publish,
     expect=ExpectError(
         status=200,
         json_contains={"success": False, "error_code": 403},
@@ -473,18 +477,22 @@ def update_service_bot_config_publish_error():
 # ============================================================================
 
 
-def _seed_and_mock_unexpected_error(world: World) -> None:
-    """Seed bot and mock update_bot_ext to raise unexpected Exception."""
+def _seed_and_fail_unexpectedly(world: World) -> None:
+    """Seed the bot, then drop the connection under the ext write.
+
+    A lost database connection is the archetypal failure this branch is for:
+    it cannot be provoked from the request, and the router must still answer
+    with the 500 envelope rather than a bare traceback.
+    """
     from agentclaw.community.api.bot_service import BotServiceProtocol
     make_staff_user(world, user_id="u_owner")
     make_bot(world, bot_id="bot_test", owner_id="u_owner", bot_type="service", status="ACTIVE")
-    # Mock update_bot_ext to raise generic Exception
-    bot_service = world.get(BotServiceProtocol)
-    patch.object(
-        type(bot_service),
+    bind_failing_method(
+        world,
+        BotServiceProtocol,
         "update_bot_ext",
-        side_effect=RuntimeError("Database connection lost"),
-    ).start()
+        RuntimeError("Database connection lost"),
+    )
 
 
 @endpoint_test(
@@ -499,7 +507,7 @@ def _seed_and_mock_unexpected_error(world: World) -> None:
             "config_update": {"device_count": 2},
         },
     ),
-    seed=_seed_and_mock_unexpected_error,
+    seed=_seed_and_fail_unexpectedly,
     expect=ExpectError(
         status=200,
         json_contains={"success": False, "error_code": 500},

--- a/src/backend/tests/community/endpoints/test_skills_pool_ops.py
+++ b/src/backend/tests/community/endpoints/test_skills_pool_ops.py
@@ -1,35 +1,63 @@
-"""Endpoint-injection coverage for the Skills Pool operator API."""
+"""Endpoint-injection coverage for the Skills Pool operator API.
+
+These routes are thin: each one calls a rollout / query / command service and
+envelopes the result. What the cases here pin is that layer — routing, request
+validation, the ``RolloutOperationError`` → 409 mapping — so the services
+behind them are stood in for.
+
+The stand-ins are bound through the injector as subclasses of whatever the
+graph wired (``bind_overrides``), never patched onto the production classes.
+That matters beyond style: a class-level patch outlived the case that set it
+whenever an assertion failed before the teardown hook ran, silently poisoning
+later tests. A binding cannot, because the injector it lives on is discarded
+with the test.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest.mock import patch
 
-from agentclaw.community.core.skills_pool.operational_query import (
-    SkillsPoolOperationalQuery,
+from agentclaw.community.api.skills_pool_operational_query_service import (
+    SkillsPoolOperationalQueryServiceProtocol,
 )
-from agentclaw.community.core.skills_pool.operations import (
-    RolloutOperationError,
-    SkillsPoolRolloutOperations,
+from agentclaw.community.api.skills_pool_operator_commands_service import (
+    SkillsPoolOperatorCommandsServiceProtocol,
 )
-from agentclaw.community.core.skills_pool.operator_commands import (
-    SkillsPoolOperatorCommands,
+from agentclaw.community.api.skills_pool_recovery_service import (
+    SkillsPoolRecoveryServiceProtocol,
 )
-from agentclaw.community.core.skills_pool.recovery_service import (
-    SkillsPoolRecoveryService,
-    SkillsPoolRollbackService,
+from agentclaw.community.api.skills_pool_rollback_service import (
+    SkillsPoolRollbackServiceProtocol,
 )
+from agentclaw.community.api.skills_pool_rollout_service import (
+    SkillsPoolRolloutServiceProtocol,
+)
+from agentclaw.community.core.skills_pool.operations import RolloutOperationError
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_overrides,
     endpoint_test,
 )
 
 
 _HEADERS = {"x-user-id": "skills-pool-operator"}
 _SCOPE = BotSkillLayoutScope("dev", "entity-1", "bot-1")
+
+# Every rollout mutation the router exposes. Listed rather than derived so a
+# new route shows up here as a deliberate edit.
+_ROLLOUT_MUTATIONS = (
+    "set_feature_enabled",
+    "set_full_rollout",
+    "set_owner_full_rollout",
+    "promote_engine",
+    "add_bot",
+    "remove_bot",
+    "accept_batch",
+    "set_control_bot",
+)
 
 
 @dataclass(frozen=True)
@@ -41,83 +69,41 @@ class _Result:
 
 
 def _seed_happy_services(world) -> None:
+    """Bind every skills-pool service to a stand-in that reports success."""
     result = _Result(scope=_SCOPE)
 
-    def get_snapshot(*_args, **_kwargs):
+    def answer(_self, *_args, **_kwargs):
         return result
 
-    def mutation(*_args, **_kwargs):
+    async def answer_async(_self, *_args, **_kwargs):
         return result
 
-    def get_bot(*_args, **_kwargs):
-        return result
-
-    def summarize_batch(*_args, **_kwargs):
-        return result
-
-    def wake(*_args, **_kwargs):
-        return result
-
-    def resolve(*_args, **_kwargs):
-        return result
-
-    async def rollback(*_args, **_kwargs):
-        return result
-
-    patchers = [
-        patch.object(
-            SkillsPoolRolloutOperations,
-            "get_snapshot",
-            get_snapshot,
-        ),
-        *[
-            patch.object(SkillsPoolRolloutOperations, method, mutation)
-            for method in (
-                "set_feature_enabled",
-                "set_full_rollout",
-                "set_owner_full_rollout",
-                "promote_engine",
-                "add_bot",
-                "remove_bot",
-                "accept_batch",
-                "set_control_bot",
-            )
-        ],
-        patch.object(SkillsPoolOperationalQuery, "get_bot", get_bot),
-        patch.object(
-            SkillsPoolOperationalQuery,
-            "summarize_batch",
-            summarize_batch,
-        ),
-        patch.object(SkillsPoolOperatorCommands, "wake", wake),
-        patch.object(
-            SkillsPoolRecoveryService,
-            "resolve_repair_state",
-            resolve,
-        ),
-        patch.object(SkillsPoolRollbackService, "rollback", rollback),
-    ]
-    for patcher in patchers:
-        patcher.start()
-    world.skills_pool_patchers = patchers
+    bind_overrides(
+        world,
+        SkillsPoolRolloutServiceProtocol,
+        {"get_snapshot": answer, **{m: answer for m in _ROLLOUT_MUTATIONS}},
+    )
+    bind_overrides(
+        world,
+        SkillsPoolOperationalQueryServiceProtocol,
+        {"get_bot": answer, "summarize_batch": answer},
+    )
+    bind_overrides(world, SkillsPoolOperatorCommandsServiceProtocol, {"wake": answer})
+    bind_overrides(
+        world, SkillsPoolRecoveryServiceProtocol, {"resolve_repair_state": answer},
+    )
+    bind_overrides(
+        world, SkillsPoolRollbackServiceProtocol, {"rollback": answer_async},
+    )
 
 
 def _seed_rollout_error(world) -> None:
-    def fail(*_args, **_kwargs):
+    """A rollout config the operations layer rejects — the 409 mapping."""
+
+    def fail(_self, *_args, **_kwargs):
         raise RolloutOperationError("invalid rollout config")
 
-    patcher = patch.object(
-        SkillsPoolRolloutOperations,
-        "get_snapshot",
-        fail,
-    )
-    patcher.start()
-    world.skills_pool_patchers = [patcher]
-
-
-def _stop_patches(_response, world) -> None:
-    for patcher in reversed(getattr(world, "skills_pool_patchers", [])):
-        patcher.stop()
+    bind_overrides(world, SkillsPoolRolloutServiceProtocol, {"get_snapshot": fail})
 
 
 _HAPPY_CASES = (
@@ -282,7 +268,6 @@ for _index, (_method, _path, _input) in enumerate(_HAPPY_CASES):
             status=200,
             json_contains={"success": True},
         ),
-        extra_assertions=(_stop_patches,),
     )(lambda: None)
 
 
@@ -312,7 +297,6 @@ endpoint_test(
     input=CaseInput(headers=_HEADERS),
     seed=_seed_rollout_error,
     expect=ExpectError(status=409),
-    extra_assertions=(_stop_patches,),
 )(lambda: None)
 
 for _path, _path_params in (

--- a/src/backend/tests/community/endpoints/test_skillset_cli_resources.py
+++ b/src/backend/tests/community/endpoints/test_skillset_cli_resources.py
@@ -1,7 +1,13 @@
-"""Endpoint coverage for SkillSet resource and CLI scope APIs."""
-from __future__ import annotations
+"""Endpoint coverage for SkillSet resource and CLI scope APIs.
 
-from unittest.mock import MagicMock
+AgentPass is the one system boundary here, and the injected
+``LocalPassportPlugin`` already is the test double for it: as a ``MockSeam``
+it answers ``set_response``/``set_override`` and records every call. Driving
+it through that seam keeps the plugin the injector hands the router the same
+object the assertions read back, so the CLI scope the endpoint pushed is
+observed rather than asserted against a stand-in of our own.
+"""
+from __future__ import annotations
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.skill_center.services.repositories import SkillSetRepository
@@ -20,7 +26,7 @@ _QUERY = {
 _HEADERS = {"x-user-id": "u_skillset_cli"}
 
 
-def _bind_deps(world, *, default_set: bool = True) -> MagicMock:
+def _bind_deps(world, *, default_set: bool = True) -> PassportPlugin:
     make_staff_user(world, user_id="u_skillset_cli")
     world.get(BotRepository).insert({
         "bot_id": "bot_skillset_cli",
@@ -56,13 +62,17 @@ def _bind_deps(world, *, default_set: bool = True) -> MagicMock:
         env=get_current_env(),
     )
 
-    passport = MagicMock(spec=PassportPlugin)
-    passport.query_passport_clis.return_value = [
+    passport = world.get(PassportPlugin)
+    passport.set_response("query_passport_clis", [
         {"cli_code": "cli.keep", "cli_name": "Keep CLI", "cli_desc": "kept"},
         {"cli_code": "cli.delete", "cli_name": "Delete CLI", "cli_desc": "removed"},
-    ]
-    world.injector.binder.bind(PassportPlugin, to=passport, scope=None)
+    ])
     return passport
+
+
+def _tcauth_down(*_args, **_kwargs):
+    """AgentPass is unreachable — the boundary failure the endpoints must survive."""
+    raise RuntimeError("tcauth down")
 
 
 def _seed_resources_happy(world) -> None:
@@ -71,7 +81,7 @@ def _seed_resources_happy(world) -> None:
 
 def _seed_resources_cli_query_failure(world) -> None:
     passport = _bind_deps(world)
-    passport.query_passport_clis.side_effect = RuntimeError("tcauth down")
+    passport.set_override("query_passport_clis", _tcauth_down)
 
 
 def _seed_delete_cli_happy(world) -> None:
@@ -88,13 +98,14 @@ def _seed_delete_cli_not_found(world) -> None:
 
 def _seed_delete_cli_query_failure(world) -> None:
     passport = _bind_deps(world)
-    passport.query_passport_clis.side_effect = RuntimeError("tcauth down")
+    passport.set_override("query_passport_clis", _tcauth_down)
 
 
 def _assert_delete_updates_remaining_cli(response, world) -> None:
     passport = world.get(PassportPlugin)
-    passport.update_passport.assert_called_once()
-    kwargs = passport.update_passport.call_args.kwargs
+    updates = [c for c in passport.calls if c.method == "update_passport"]
+    assert len(updates) == 1, f"expected one update_passport call, got {updates}"
+    kwargs = updates[0].kwargs
     assert kwargs["bot_id"] == "bot_skillset_cli"
     assert kwargs["user_id"] == "u_skillset_cli"
     assert kwargs["resource_scope"]["cli_items"] == [

--- a/src/backend/tests/community/endpoints/test_system_disk_usage.py
+++ b/src/backend/tests/community/endpoints/test_system_disk_usage.py
@@ -9,8 +9,6 @@ Tests the following scenarios:
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
 from tests.community.factories.access import make_staff_user
 from tests.community.framework import (
     CaseInput,

--- a/src/backend/tests/community/framework/README.md
+++ b/src/backend/tests/community/framework/README.md
@@ -183,6 +183,47 @@ state can't be richer than the live system permits.
 
 ---
 
+## No mocking in `tests/endpoints/`
+
+The framework guarantees that a case's declared `(method, path)` was
+really called. That guarantee is worth little if the code behind the
+route was replaced before the request went out — so **endpoint cases may
+not use `unittest.mock`, `monkeypatch`, `mocker`, or `setattr`**.
+`tests/framework/test_no_mock_in_endpoint_tests.py` enforces it (AST
+scan, so comments and docstrings that mention mocks are fine), and
+`test_no_mock_on_world_get.py` covers the related "overwrite a method on
+a `world.get(...)` handle" hack.
+
+In order of preference:
+
+1. **Seed the state that produces the outcome.** Most error branches are
+   reachable: a missing row → 404, a caller without the role → 403, a
+   malformed body → 422, a bot with no device binding → the service's own
+   `ValueError`. These test more than an injected exception does, and they
+   document the failure a user would actually hit.
+2. **Drive a system boundary through its DI seam.** Boundary plugins under
+   `plugins/local/` inherit `MockSeam`, so
+   `world.get(SomeBoundaryPlugin).set_response("method", value)` /
+   `.set_override("method", fn)` stands in for the *edge* — an HTTP
+   upstream, a device link, AgentPass — while everything inside stays real.
+   `MockSeam` also records `.calls`, so assertions read the calls the
+   endpoint actually made. Use `json_response(...)` /
+   `http_envelope_response(...)` from the framework to build replies.
+3. **Bind a stand-in through the injector** when a step genuinely cannot
+   run on a test host — a `sudo rsync` onto a NAS mount, a multi-minute
+   publish. `bind_method` / `bind_overrides` / `bind_failing_method`
+   (`tests/framework/di_seams.py`) build a *subclass* of whatever the graph
+   wired, override the named methods, and bind it on the per-test injector.
+   The production class is untouched and the substitution is discarded with
+   the test — neither is true of a class-level patch, which survives a
+   failed assertion and poisons whatever runs next.
+
+If a file constructs a service directly and never issues a request, it is
+a unit test: put it under `tests/services/` (or the matching tree), not
+here.
+
+---
+
 ## Isolation guarantees
 
 Every case runs against a **freshly-built injector** backed by a

--- a/src/backend/tests/community/framework/__init__.py
+++ b/src/backend/tests/community/framework/__init__.py
@@ -11,9 +11,16 @@ from tests.community.framework.case import (
     ExpectError,
     ExpectSuccess,
 )
+from tests.community.framework.di_seams import (
+    bind_failing_method,
+    bind_method,
+    bind_overrides,
+)
 from tests.community.framework.endpoint_helpers import (
+    StubResponse,
     drain_background_tasks,
     http_envelope_response,
+    json_response,
 )
 from tests.community.framework.registry import ENDPOINT_CASES, endpoint_test
 
@@ -26,6 +33,11 @@ __all__ = [
     "Expectation",
     "ENDPOINT_CASES",
     "endpoint_test",
+    "bind_failing_method",
+    "bind_method",
+    "bind_overrides",
+    "StubResponse",
     "drain_background_tasks",
     "http_envelope_response",
+    "json_response",
 ]

--- a/src/backend/tests/community/framework/di_seams.py
+++ b/src/backend/tests/community/framework/di_seams.py
@@ -1,0 +1,127 @@
+"""Substitute named methods of a wired service, through the injector.
+
+Some router branches exist for failures the system can only suffer, never
+be talked into: a repository write that dies mid-transaction, an upstream
+that stops answering. No request body reaches them, so an endpoint case
+that wants to pin the router's error mapping has to inject the failure
+somewhere.
+
+The old way was ``unittest.mock.patch.object(type(svc), "m", ...)``, which
+edits the production class for the rest of the process — it outlives the
+case unless something remembers to stop it, and
+:mod:`test_no_mock_in_endpoint_tests` now forbids it in the case tree.
+
+These helpers do the same job through the dependency graph instead:
+
+* build a **subclass** of whatever implementation the injector wired, with
+  only the named methods overridden;
+* re-clothe it with that instance's own collaborators, so every other line
+  of behaviour is the production one;
+* bind it for the requested key on the **per-test injector**, which the
+  fixture throws away at teardown.
+
+The production class is never touched, so nothing can leak into the next
+test, and the handler resolves the stand-in exactly as it resolves the
+real service.
+
+Reach for these only for a failure (or a boundary outcome) that no input
+can produce. When the endpoint *can* be driven into the branch — a missing
+row, a denied permission, a malformed body — seed that instead; it tests
+more and explains itself better.
+"""
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Mapping, TypeVar
+
+
+T = TypeVar("T")
+
+
+def bind_overrides(
+    world: Any,
+    key: type[T],
+    overrides: Mapping[str, Callable[..., Any]],
+    *,
+    also_bind: tuple[type, ...] = (),
+) -> T:
+    """Serve ``key`` from the wired instance with several methods replaced.
+
+    The plural form of :func:`bind_method`, for a service whose whole surface
+    a case has to stand in for. One subclass carries every override, so the
+    handler still sees a single coherent object rather than a pile of
+    independently patched attributes.
+    """
+    wired = world.get(key)
+    base = type(wired)
+    for method, impl in overrides.items():
+        original = getattr(base, method, None)
+        if original is None:
+            raise AttributeError(f"{base.__name__} has no method {method!r} to replace")
+        if inspect.iscoroutinefunction(original) and not inspect.iscoroutinefunction(
+            impl
+        ):
+            raise TypeError(
+                f"{base.__name__}.{method} is async; give it an async impl so "
+                "callers can await the stand-in the same way"
+            )
+
+    stand_in_cls = type(f"{base.__name__}StandIn", (base,), dict(overrides))
+    stand_in = stand_in_cls.__new__(stand_in_cls)
+    stand_in.__dict__.update(wired.__dict__)
+    for bound_key in (key, *also_bind):
+        world.injector.binder.bind(bound_key, to=stand_in, scope=None)
+    return stand_in
+
+
+def bind_method(
+    world: Any,
+    key: type[T],
+    method: str,
+    impl: Callable[..., Any],
+    *,
+    also_bind: tuple[type, ...] = (),
+) -> T:
+    """Serve ``key`` from the wired instance with ``method`` replaced by ``impl``.
+
+    ``impl`` is called with the stand-in as its first argument, exactly as a
+    normal method would be, so it can reach the service's own collaborators
+    (``self._repo`` and friends) to record what a real implementation would
+    have written.
+
+    ``also_bind`` names the other injector keys that must resolve to the same
+    stand-in. A service reached both as its Protocol and as its concrete class
+    — the publish flow is reached both ways, by the routers and by the durable
+    task handlers — would otherwise be substituted on only one of those paths.
+
+    Returns the stand-in, so a case can assert against it afterwards.
+    """
+    return bind_overrides(world, key, {method: impl}, also_bind=also_bind)
+
+
+def bind_failing_method(
+    world: Any,
+    key: type[T],
+    method: str,
+    error: BaseException,
+    *,
+    also_bind: tuple[type, ...] = (),
+) -> T:
+    """Serve ``key`` with ``method`` raising ``error`` — the failure-mapping seam.
+
+    Use for the router branches that only a genuine infrastructure fault can
+    reach, and name the error the production code would actually raise so the
+    case documents the mapping it pins (``BotPublishServiceError`` → 403,
+    anything unexpected → 500).
+    """
+    wired = world.get(key)
+    original = getattr(type(wired), method, None)
+
+    if original is not None and inspect.iscoroutinefunction(original):
+        async def _fail(_self, *_args, **_kwargs):
+            raise error
+    else:
+        def _fail(_self, *_args, **_kwargs):
+            raise error
+
+    return bind_method(world, key, method, _fail, also_bind=also_bind)

--- a/src/backend/tests/community/framework/endpoint_helpers.py
+++ b/src/backend/tests/community/framework/endpoint_helpers.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock
 
 
 async def drain_background_tasks(timeout: float = 30.0) -> None:
@@ -46,9 +45,45 @@ async def drain_background_tasks(timeout: float = 30.0) -> None:
         )
 
 
+class StubResponse:
+    """The slice of ``httpx.Response`` a service touches on a stubbed reply.
+
+    Deliberately a real class rather than a mock: an attribute a service reads
+    but this stub does not define should fail loudly here, in the seam, instead
+    of silently resolving to an auto-created attribute that makes the service
+    take a branch no real response would.
+    """
+
+    def __init__(self, payload: Any, *, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> "StubResponse":
+        return self
+
+    def json(self) -> Any:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        import json as _json
+
+        return _json.dumps(self._payload, ensure_ascii=False)
+
+
+def json_response(payload: Any, *, status_code: int = 200) -> StubResponse:
+    """A stubbed HTTP reply carrying ``payload`` as its JSON body.
+
+    For upstreams whose envelope is their own; use
+    :func:`http_envelope_response` for the BaaS/BCN ``{code, message, data}``
+    shape.
+    """
+    return StubResponse(payload, status_code=status_code)
+
+
 def http_envelope_response(
     data: Any = None, *, code: int = 0, message: str = "ok"
-) -> MagicMock:
+) -> StubResponse:
     """A stub ``httpx.Response`` for a BaaS/BCN ``HttpClient`` MockSeam.
 
     Models the upstream ``{code, message, data}`` envelope: ``raise_for_status``
@@ -57,9 +92,6 @@ def http_envelope_response(
     service's ``self._http.get/post(...)`` sees a realistic success/error reply
     without any network.
     """
-    r = MagicMock()
-    r.raise_for_status.return_value = None
-    r.json.return_value = {
-        "code": code, "message": message, "data": {} if data is None else data
-    }
-    return r
+    return StubResponse(
+        {"code": code, "message": message, "data": {} if data is None else data}
+    )

--- a/src/backend/tests/community/framework/runner.py
+++ b/src/backend/tests/community/framework/runner.py
@@ -166,19 +166,14 @@ def _run_case(case: EndpointCase, app: FastAPI, world: World) -> None:
     request, which is what makes the declared ``(method, path)`` the
     endpoint that was actually exercised.
 
-    A ``seed`` may need to mock a non-DB-backed seam (e.g. a service method
-    that reads device files) with ``unittest.mock.patch(...).start()``. Such a
-    seed has no teardown hook of its own, so the runner stops every active
-    patcher when the case finishes — otherwise a class-level patch would leak
-    into later, order-dependent tests. DB-backed setup should still seed real
-    rows rather than mock.
+    There is deliberately no patch teardown here. This used to call
+    ``unittest.mock.patch.stopall()`` because seeds were allowed to patch a
+    non-DB-backed seam and had no teardown of their own — a safety net that
+    also legitimised the practice. Cases now seed real state or substitute a
+    boundary through the injector, which the per-test injector discards on its
+    own; :mod:`test_no_mock_in_endpoint_tests` keeps it that way.
     """
-    from unittest.mock import patch as _patch
-
-    try:
-        _drive_case(case, app, world)
-    finally:
-        _patch.stopall()
+    _drive_case(case, app, world)
 
 
 def _drive_case(case: EndpointCase, app: FastAPI, world: World) -> None:
@@ -198,15 +193,10 @@ async def _run_case_async(case: EndpointCase, app: FastAPI, world: World) -> Non
 
     Drives the endpoint on an in-process async client (``ASGITransport``) so the
     handler's fire-and-forget ``asyncio.create_task`` work runs on the test's loop,
-    then awaits it via ``drain_background_tasks`` before checking. Same
-    seed/patch-teardown discipline as the sync runner.
+    then awaits it via ``drain_background_tasks`` before checking. Same seeding
+    discipline as the sync runner.
     """
-    from unittest.mock import patch as _patch
-
-    try:
-        await _drive_case_async(case, app, world)
-    finally:
-        _patch.stopall()
+    await _drive_case_async(case, app, world)
 
 
 async def _drive_case_async(case: EndpointCase, app: FastAPI, world: World) -> None:

--- a/src/backend/tests/community/framework/test_di_seams.py
+++ b/src/backend/tests/community/framework/test_di_seams.py
@@ -1,0 +1,148 @@
+"""Self-tests for the DI substitution helpers.
+
+Many endpoint cases now depend on :mod:`di_seams` for the branches no request
+can reach, so the properties that make it safer than a patch — the production
+class stays untouched, the stand-in keeps the wired collaborators, and every
+other method still runs for real — are pinned here rather than assumed.
+"""
+from __future__ import annotations
+
+import pytest
+from injector import Injector
+
+from tests.community.framework.di_seams import (
+    bind_failing_method,
+    bind_method,
+    bind_overrides,
+)
+from tests.community.framework.world import World
+
+
+class _Service:
+    """Stand-in for a wired core service: some state, sync and async methods."""
+
+    def __init__(self, rows: list[str]) -> None:
+        self._rows = rows
+
+    def read(self) -> list[str]:
+        return list(self._rows)
+
+    def write(self, row: str) -> int:
+        self._rows.append(row)
+        return len(self._rows)
+
+    async def fetch(self) -> str:
+        return "real"
+
+
+@pytest.fixture
+def seam_world() -> World:
+    """A tiny injector of our own — deliberately not the framework ``world``
+    fixture, so these tests exercise the helpers rather than the app graph."""
+    injector = Injector()
+    injector.binder.bind(_Service, to=_Service(["seeded"]), scope=None)
+    return World(injector)
+
+
+@pytest.mark.unit
+def test_bind_method_replaces_only_the_named_method(seam_world: World) -> None:
+    bind_method(seam_world, _Service, "write", lambda _self, _row: -1)
+
+    service = seam_world.get(_Service)
+    assert service.write("ignored") == -1
+    # Everything else is still the real implementation over the real state.
+    assert service.read() == ["seeded"]
+
+
+@pytest.mark.unit
+def test_stand_in_keeps_the_wired_collaborators(seam_world: World) -> None:
+    """The stand-in reads the same state the wired instance held."""
+    seam_world.get(_Service).write("added")
+
+    bind_method(seam_world, _Service, "fetch", _fetch_stub)
+
+    assert seam_world.get(_Service).read() == ["seeded", "added"]
+
+
+async def _fetch_stub(_self) -> str:
+    return "stubbed"
+
+
+@pytest.mark.unit
+def test_production_class_is_untouched(seam_world: World) -> None:
+    """The whole point: no edit escapes to the class every other test shares."""
+    bind_failing_method(seam_world, _Service, "read", RuntimeError("boom"))
+
+    assert _Service(["fresh"]).read() == ["fresh"]
+
+
+@pytest.mark.unit
+def test_bind_failing_method_raises_the_given_error(seam_world: World) -> None:
+    bind_failing_method(seam_world, _Service, "read", RuntimeError("ledger unavailable"))
+
+    with pytest.raises(RuntimeError, match="ledger unavailable"):
+        seam_world.get(_Service).read()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_methods_stay_awaitable(seam_world: World) -> None:
+    bind_method(seam_world, _Service, "fetch", _fetch_stub)
+
+    assert await seam_world.get(_Service).fetch() == "stubbed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bind_failing_method_on_async_raises_when_awaited(seam_world: World) -> None:
+    bind_failing_method(seam_world, _Service, "fetch", ValueError("upstream down"))
+
+    with pytest.raises(ValueError, match="upstream down"):
+        await seam_world.get(_Service).fetch()
+
+
+@pytest.mark.unit
+def test_bind_overrides_replaces_several_methods_on_one_stand_in(seam_world: World) -> None:
+    bind_overrides(
+        seam_world,
+        _Service,
+        {"read": lambda _self: ["stubbed"], "write": lambda _self, _row: 0},
+    )
+
+    service = seam_world.get(_Service)
+    assert service.read() == ["stubbed"]
+    assert service.write("ignored") == 0
+
+
+@pytest.mark.unit
+def test_also_bind_serves_the_same_stand_in_for_every_key(seam_world: World) -> None:
+    """A service reached by two keys must be substituted on both paths."""
+
+    class _Protocol:
+        pass
+
+    seam_world.injector.binder.bind(_Protocol, to=seam_world.get(_Service), scope=None)
+    stand_in = bind_method(
+        seam_world,
+        _Service,
+        "read",
+        lambda _self: ["stubbed"],
+        also_bind=(_Protocol,),
+    )
+
+    assert seam_world.get(_Service) is stand_in
+    assert seam_world.get(_Protocol) is stand_in
+
+
+@pytest.mark.unit
+def test_unknown_method_is_rejected(seam_world: World) -> None:
+    """A typo must fail here, not silently add a method nothing calls."""
+    with pytest.raises(AttributeError, match="no method 'raed'"):
+        bind_method(seam_world, _Service, "raed", lambda _self: [])
+
+
+@pytest.mark.unit
+def test_sync_impl_for_an_async_method_is_rejected(seam_world: World) -> None:
+    """Otherwise the caller's ``await`` fails far from the mistake."""
+    with pytest.raises(TypeError, match="is async"):
+        bind_method(seam_world, _Service, "fetch", lambda _self: "not awaitable")

--- a/src/backend/tests/community/framework/test_no_mock_in_endpoint_tests.py
+++ b/src/backend/tests/community/framework/test_no_mock_in_endpoint_tests.py
@@ -1,0 +1,307 @@
+"""Forbid ``unittest.mock`` / monkey-patching inside ``tests/*/endpoints/``.
+
+The endpoint-test framework exists so a case exercises the **real**
+request path: real router, real dependency graph, real services, real
+in-memory database. A case that reaches for ``unittest.mock.patch`` or
+``monkeypatch`` stops testing that path — it asserts against a stand-in
+the author wrote, so the test keeps passing while production code rots.
+
+Sibling rule: :mod:`test_no_mock_on_world_get` forbids overwriting
+attributes on an instance handed out by ``world.get(...)``. This module
+covers the other half — reaching for the mock library (or ``setattr``)
+at all, whatever the target.
+
+What is forbidden in ``tests/*/endpoints/``:
+
+1. **Mock-library imports** — ``from unittest.mock import patch``,
+   ``from unittest import mock``, ``import mock``, including
+   function-local imports, which are the usual way this sneaks back in.
+2. **Mock-library usage** — ``patch(...)``, ``patch.object(...)``,
+   ``MagicMock()``, ``AsyncMock()``, ``mock.patch(...)``,
+   ``pytest.MonkeyPatch()``.
+3. **The ``monkeypatch`` / ``mocker`` fixtures** — requested as a test
+   or helper parameter.
+4. **``setattr`` / ``delattr``** — an ``x.attr = ...`` patch spelled as
+   a function call to dodge the sibling scanner.
+
+What to do instead:
+
+* **Seed through the real components.** ``world.get(SomeService)`` and
+  the ``tests/*/factories/`` object-mothers write real rows, so the
+  request under test reads real state.
+* **Drive a system boundary through its DI seam.** Boundary plugins
+  under ``plugins/local/`` inherit ``MockSeam``, so
+  ``world.get(SomeBoundaryPlugin).set_response("method", value)`` /
+  ``.set_override("method", fn)`` substitutes the *edge* of the system
+  (an HTTP upstream, a device link) while everything inside it stays
+  real. That is the sanctioned substitution point — it is bound through
+  the injector, so the handler resolves it exactly as production does.
+* **Bind a substitute in a testing DI module** when the seam does not
+  exist yet.
+* **Test an error path that the system can actually reach** — a denied
+  permission, a missing row, a malformed body — rather than forcing an
+  exception out of a patched method that no real input could produce.
+
+If a boundary genuinely has no seam, add one to ``plugins/local/`` (or
+a helper under ``tests/*/framework/``); do not re-open the mock door in
+the case tree.
+
+Detection is AST-only — comments, docstrings, and strings that merely
+mention ``MagicMock`` are not violations.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[3]                # .../src/backend
+# Endpoint cases live in the community and corp test trees; the rule is
+# universal, so scan whichever of the two exists.
+_ENDPOINTS_ROOTS = (
+    _BACKEND_ROOT / "tests" / "community" / "endpoints",
+    _BACKEND_ROOT / "tests" / "corp" / "endpoints",
+)
+
+# Modules whose whole purpose is fabricating stand-ins.
+_MOCK_MODULES = frozenset({"unittest.mock", "mock"})
+
+# Callables that build or install a stand-in, wherever they came from.
+_MOCK_CALLABLES = frozenset({
+    "patch",
+    "MagicMock",
+    "Mock",
+    "AsyncMock",
+    "NonCallableMock",
+    "NonCallableMagicMock",
+    "PropertyMock",
+    "create_autospec",
+    "mock_open",
+    "seal",
+    "MonkeyPatch",
+})
+
+# Fixtures that hand a case a patching API.
+_MOCK_FIXTURES = frozenset({"monkeypatch", "mocker"})
+
+# Builtins that perform an attribute patch without an ``x.attr = ...``
+# assignment the sibling scanner would see.
+_PATCH_BUILTINS = frozenset({"setattr", "delattr"})
+
+_GUIDANCE = (
+    "Endpoint cases must exercise the real request path end to end.\n"
+    "Instead of a mock:\n"
+    "  - seed real state via world.get(Service) / tests/*/factories/;\n"
+    "  - substitute a system boundary through its DI seam —\n"
+    "    world.get(SomeBoundaryPlugin).set_response(...) / .set_override(...);\n"
+    "  - or assert an error path the system can actually reach.\n"
+    "See tests/*/framework/README.md."
+)
+
+
+def _dotted_name(node: ast.AST) -> str:
+    """Render ``a.b.c`` from an ``Attribute``/``Name`` chain (else ``\"\"``)."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return ""
+    parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+class _Scanner(ast.NodeVisitor):
+    """Collect ``(lineno, message)`` for every forbidden construct."""
+
+    def __init__(self) -> None:
+        self.hits: list[tuple[int, str]] = []
+
+    # ---- imports ----------------------------------------------------
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name in _MOCK_MODULES:
+                self.hits.append((
+                    node.lineno, f"import {alias.name}  (mock library import)"
+                ))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        if module in _MOCK_MODULES:
+            names = ", ".join(a.name for a in node.names)
+            self.hits.append((
+                node.lineno, f"from {module} import {names}  (mock library import)"
+            ))
+        elif module == "unittest":
+            for alias in node.names:
+                if alias.name == "mock":
+                    self.hits.append((
+                        node.lineno,
+                        "from unittest import mock  (mock library import)",
+                    ))
+        self.generic_visit(node)
+
+    # ---- calls ------------------------------------------------------
+
+    def visit_Call(self, node: ast.Call) -> None:
+        fn = node.func
+        # ``patch.object(...)`` / ``mock.patch(...)`` / ``pytest.MonkeyPatch()``
+        dotted = _dotted_name(fn)
+        head = dotted.split(".", 1)[0] if dotted else ""
+        tail = dotted.rsplit(".", 1)[-1] if dotted else ""
+        if isinstance(fn, ast.Name):
+            if fn.id in _MOCK_CALLABLES:
+                self.hits.append((node.lineno, f"{fn.id}(...)  (builds a mock)"))
+            elif fn.id in _PATCH_BUILTINS:
+                self.hits.append((
+                    node.lineno,
+                    f"{fn.id}(...)  (patches an attribute at runtime)",
+                ))
+        elif dotted:
+            if head in _MOCK_CALLABLES or tail in _MOCK_CALLABLES:
+                self.hits.append((node.lineno, f"{dotted}(...)  (builds a mock)"))
+        self.generic_visit(node)
+
+    # ---- fixtures ---------------------------------------------------
+
+    def _check_params(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        args = node.args
+        for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+            if arg.arg in _MOCK_FIXTURES:
+                self.hits.append((
+                    node.lineno,
+                    f"def {node.name}(..., {arg.arg}, ...)  "
+                    f"(requests the {arg.arg} patching fixture)",
+                ))
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_params(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._check_params(node)
+        self.generic_visit(node)
+
+
+def scan_source(source: str, *, filename: str = "<case>") -> list[str]:
+    """Return one ``"file:line  message"`` string per violation in ``source``.
+
+    Exposed (rather than inlined into the test) so the scanner itself is
+    testable against known-good and known-bad snippets.
+    """
+    tree = ast.parse(source, filename=filename)
+    scanner = _Scanner()
+    scanner.visit(tree)
+    return [f"{filename}:{lineno}  {msg}" for lineno, msg in sorted(scanner.hits)]
+
+
+def _scan_file(path: pathlib.Path) -> list[str]:
+    try:
+        source = path.read_text()
+    except OSError:  # pragma: no cover — unreadable case file
+        return []
+    try:
+        return scan_source(source, filename=path.relative_to(_BACKEND_ROOT).as_posix())
+    except SyntaxError:  # pragma: no cover — collected elsewhere as an error
+        return []
+
+
+@pytest.mark.unit
+def test_no_mock_or_patch_in_endpoint_tests() -> None:
+    """No endpoint case may import or use a mocking/patching facility.
+
+    The framework's guarantee is that a declared ``(method, path)`` was
+    genuinely exercised. That guarantee is worth little if the code
+    behind the route was swapped out for a stand-in before the request
+    was issued.
+    """
+    roots = [r for r in _ENDPOINTS_ROOTS if r.is_dir()]
+    assert roots, "no endpoints/ test dir found under tests/community or tests/corp"
+
+    violations: list[str] = []
+    for root in roots:
+        for path in sorted(root.rglob("*.py")):
+            violations.extend(_scan_file(path))
+
+    assert not violations, (
+        f"Mocking/patching found in endpoint tests.\n{_GUIDANCE}\n"
+        "Violations:\n  " + "\n  ".join(violations)
+    )
+
+
+# ── Scanner self-tests ────────────────────────────────────────────────
+# The guard is only as trustworthy as its detector: a scanner that
+# silently matches nothing would keep passing forever. These pin both
+# directions.
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("from unittest.mock import patch\n", id="from_import"),
+        pytest.param("from unittest import mock\n", id="from_unittest_import_mock"),
+        pytest.param("import unittest.mock\n", id="plain_import"),
+        pytest.param("import mock\n", id="third_party_mock"),
+        pytest.param(
+            "def seed(world):\n"
+            "    from unittest.mock import patch\n"
+            "    patch.object(X, 'y').start()\n",
+            id="function_local_import",
+        ),
+        pytest.param("m = MagicMock()\n", id="magicmock_call"),
+        pytest.param("m = AsyncMock(return_value=1)\n", id="asyncmock_call"),
+        pytest.param("mock.patch('a.b')\n", id="dotted_patch"),
+        pytest.param("patch.object(Svc, 'run')\n", id="patch_object"),
+        pytest.param("pytest.MonkeyPatch().setattr(X, 'y', 1)\n", id="monkeypatch_cls"),
+        pytest.param("def test_x(monkeypatch):\n    pass\n", id="monkeypatch_fixture"),
+        pytest.param("def test_x(mocker):\n    pass\n", id="mocker_fixture"),
+        pytest.param("setattr(svc, 'run', lambda: 1)\n", id="setattr_call"),
+        pytest.param("delattr(svc, 'run')\n", id="delattr_call"),
+    ],
+)
+def test_scanner_flags_forbidden_source(source: str) -> None:
+    assert scan_source(source), f"scanner missed a violation in:\n{source}"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            '"""Uses real DI services — no MagicMock / unittest.mock."""\n',
+            id="docstring_mentioning_mocks",
+        ),
+        pytest.param("# patch.object(Svc, 'run') was removed\n", id="comment"),
+        pytest.param(
+            "def seed(world):\n"
+            "    world.get(HttpClient).set_response('get', _resp())\n",
+            id="di_seam_set_response",
+        ),
+        pytest.param(
+            "def seed(world):\n"
+            "    world.get(HttpClient).set_override('post', _fail)\n",
+            id="di_seam_set_override",
+        ),
+        pytest.param(
+            "def seed(world):\n"
+            "    make_staff_user(world, user_id='u1')\n"
+            "    world._seeded = 'u1'\n",
+            id="real_seeding",
+        ),
+        pytest.param(
+            "class _FakeFs:\n"
+            "    def __init__(self):\n"
+            "        self.files = {}\n",
+            id="hand_written_stub_class",
+        ),
+        pytest.param("def test_x(world, async_client):\n    pass\n", id="real_fixtures"),
+    ],
+)
+def test_scanner_allows_sanctioned_source(source: str) -> None:
+    assert not scan_source(source), f"scanner false-positived on:\n{source}"

--- a/src/backend/tests/community/services/test_skill_set_auto_activate.py
+++ b/src/backend/tests/community/services/test_skill_set_auto_activate.py
@@ -1,7 +1,13 @@
-"""Tests for skill_set auto-activate with correct device routing.
+"""Unit tests for skill_set auto-activate with correct device routing.
 
 针对 add_skills_to_set / switch_to_skill_set / sync_skill_set_to_active 中
 activate_skill 调用传递 user_id 和 bolt_id 参数的测试。
+
+These construct ``SkillSetService`` directly and never issue an HTTP request,
+so they belong here alongside the other ``SkillSetService`` unit tests rather
+than under ``tests/community/endpoints/``, where every file is expected to
+exercise a real route end to end (see
+``tests/community/framework/test_no_mock_in_endpoint_tests.py``).
 """
 import pytest
 from pathlib import Path


### PR DESCRIPTION
## Problem

The per-endpoint DI framework guarantees that a case's declared `(method, path)` is the endpoint actually exercised — the framework owns invocation, so the annotation cannot lie. Nothing, however, stopped a case from replacing the code *behind* that route before the request went out. 19 files under `tests/community/endpoints/` did exactly that (172 uses of `unittest.mock`), which hollows out the guarantee: the test keeps passing while the production path rots.

Two of them were actively harmful rather than merely weak:

- `test_skills_pool_ops.py` patched five production classes and undid it in an `extra_assertions` hook — so any case that failed *before* that hook left the patches installed for the rest of the session.
- `test_skill_set_auto_activate.py` was not an endpoint test at all: it constructs `SkillSetService` directly and never issues a request, but sat in the endpoints tree and was glob-imported by its conftest.

The framework itself encouraged this: `runner.py` called `unittest.mock.patch.stopall()` after every case and documented seed-time patching as supported.

## Solution

**A framework guard.** `tests/community/framework/test_no_mock_in_endpoint_tests.py` AST-scans `tests/*/endpoints/` and fails on mock-library imports and usage (including function-local imports, the usual way this creeps back), the `monkeypatch` / `mocker` fixtures, and `setattr`/`delattr` — the same patch spelled as a call, which the sibling `test_no_mock_on_world_get` scanner cannot see. AST-only, so a docstring saying "no MagicMock here" is not a violation. It ships with parametrized self-tests in both directions, because a scanner that silently stops matching would pass forever.

**A replacement for the one thing patching was really used for.** Some router branches answer faults no request can produce — a lost DB connection, an upstream that stops replying. `tests/community/framework/di_seams.py` (`bind_method` / `bind_overrides` / `bind_failing_method`) builds a *subclass* of whatever the injector wired, overrides only the named methods, re-clothes it with the wired instance's own collaborators, and binds it on the per-test injector. The production class is never touched and the substitution dies with the test — neither is true of `patch.object(type(svc), ...)`.

**Cases fixed in order of preference:**

1. *Seed the state that produces the outcome.* A bot with no device binding, a caller off the operator allowlist, a bot whose `openclaw.json` was never synced, a scan already in progress, an ACTIVE bot that cannot be activated. These replaced 14 fabricated failures with reachable ones and read better.
2. *Drive a system boundary through its `MockSeam`.* AgentPass, the MASA eval upstream, and the device adapter transport are now driven via `set_response`/`set_override` on the injected plugin, whose `.calls` the assertions read back — so `test_skillset_cli_resources` observes the CLI scope the endpoint really pushed.
3. *Bind a stand-in through the injector* only where a step cannot run on a test host: `sudo rsync` onto `/home/admin/.merge_nas` (service-bot build, draft restore) and a multi-minute BaaS publish (quality eval).

Two cases became genuinely more end-to-end rather than merely less mocked: `test_harness_router` now runs the spawned scan to completion on the async client and asserts the status it persisted, and `test_cron_noauth_router`'s happy path seeds a real autoInitiate cron job through the relay so the endpoint has to find and trigger it.

`test_skill_set_auto_activate.py` moves to `tests/community/services/` alongside the other `SkillSetService` unit tests. It keeps its mocks — as a unit test that is fine; it was only in the wrong tree.

Framework cleanups that follow: `endpoint_helpers` gains `StubResponse`/`json_response` (a real class, so an attribute a service reads but the stub does not define fails loudly instead of auto-resolving), `http_envelope_response` no longer returns a `MagicMock`, and `runner.py` drops the `patch.stopall()` net and the docstring that sanctioned patching seeds.

**Rejected alternatives.** A frozen baseline file (as the coverage gate uses) would have let the debt sit; there is none left, so the guard is absolute. Deleting the unreachable-failure cases would have cost coverage the gate requires. Making the service-bot build happy path fully hermetic would have needed either a `sudo`-capable CI host with a writable `/home/admin` or a new production seam around `subprocess` — the DI-bound subclass overriding that single method gets the same isolation without either.

## Validation

- `uv run pytest tests/community/` — **10671 passed, 3 skipped** (was 10661 before the new self-tests; no test lost, one file relocated).
- `uv run pytest tests/community/endpoints/ tests/community/framework/` under `pytest-randomly` three times — 869 passed each run, so nothing depends on ordering (the removed `patch.stopall()` was the main risk here).
- `scripts/ci/python_sast_local.sh src/backend 1 --base dd02f82 --head HEAD` — clean.
- The guard reports 0 violations across `tests/*/endpoints/`; reverting any one file makes it fail with that file and line.
- CI on this PR is green on all 7 checks, including **Singlebox coverage** and **BCS e2e (coverage gated)** — the gates that need a full product stack and could not be run locally. That confirms the endpoint coverage denominators are unchanged despite the renamed scenarios (e.g. `service_error` → `forbidden_non_operator`), which the gate keys on `(method, path)` rather than scenario name.

## Compatibility and risk

Tests only — no production code, contracts, schema, or config touched. The new guard is a normal always-on test; if it ever needs to be relaxed for a case, the fix is a seam in `di_seams.py` or `plugins/local/`, not an exemption list. Rollback is a plain revert.
