### PR TITLE
feat(backend): log every error the public API converts to a response

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -544,6 +544,30 @@ rebuild it. Everything below is category-agnostic and lives in
   - Add *your* category's errors to `ENVELOPE_ERRORS`. Anything unmapped escapes
     to the app 500 handler — which now envelopes it too, but with a generic
     message.
+  - **Every converted failure is logged, with its traceback and the handler's
+    arguments** — see the next bullet. You inherit this; do not add per-handler
+    `try/except: logger.error(...)` around a mapped error.
+- **`error_logging.py`** (`adapters/http/`) — the diagnostics half of the fixed
+  message rule. Because the response says only "Not found", the log line is the
+  *only* record of what actually happened, so `@envelope_errors` emits one per
+  failure: exception type, the internal message, the concrete path plus the route
+  template, and the arguments the handler was called with. Level follows status
+  (`4xx` → warning, `5xx` → error); both carry the traceback, because an error
+  reaching this path was raised inside a handler and the trace is a short chain
+  of our own frames pointing at the check that refused the request. What you need
+  to know when adding a category:
+  - **Capture is lazy** — a successful request pays nothing.
+  - **Values are summarized, not dumped**: strings truncated, collections capped,
+    bytes reduced to a size, request bodies rendered from `model_dump()`, and
+    injected services dropped rather than rendered.
+  - **Names that look like credentials are redacted** (`token`, `password`,
+    `secret`, `authorization`, `api_key`, `signature`, `cookie`, …), at any
+    nesting depth. `Request` and `Headers` are opaque by type — `Request` is a
+    `Mapping` over its ASGI scope, so walking it would put the raw header list
+    in the log. **If your category adds a body field holding a credential whose
+    name is not on that list, add the substring to `_SENSITIVE_NAME_PARTS`.**
+  - An **unmapped** error is re-raised, and the arguments are stashed on the
+    request scope so `app.py`'s handler logs the same detail from further out.
 - **`contracts.py`** — `Envelope[T]` / `Page[T]` / `Deleted` / `NameCheck` plus
   `ErrorEnvelope` and `ERROR_RESPONSES`. `ERROR_RESPONSES` is attached **once**
   in `openapi_v1/__init__.py::build_public_router()`, so every route on every
@@ -1243,3 +1267,27 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   and DI wiring are gone), and a dated amendment in
   `src/gateway/docs/2026-07-21-auth-design.md` §4.6, whose original text made
   `tenant` mandatory on every principal.
+- **2026-08-05** — **Every error this surface converts now leaves a log record.**
+  `@envelope_errors` mapped a domain error to its status and fixed message and
+  logged *nothing*, so a caller's report of a 404 or a 409 could not be traced to
+  a raise site: the fixed-message rule keeps the diagnosis out of the response,
+  and there was nowhere else it went. The decorator now emits one line per
+  failure — exception type and its internal message, method, concrete path, route
+  template, and the handler's own arguments — with the traceback attached.
+  4xx logs at warning, 5xx at error; both carry the trace, because these errors
+  are raised *inside* a handler, so the trace is a short chain of our own frames,
+  not an ASGI stack. Routine unauthenticated traffic is unaffected: the auth
+  seam raises in a dependency, which `app.py` still answers and logs without one.
+  New `adapters/http/error_logging.py` owns the capture — lazy (a successful
+  request pays nothing), bounded (strings, collections and nesting all capped;
+  bytes reduced to a size), and redacting by *name* at any depth, with `Request`
+  and `Headers` opaque by type since `Request` is a `Mapping` over its ASGI scope
+  and walking it would log the raw `Authorization` header. Unmapped errors are
+  still re-raised, with the arguments stashed on the request scope so `app.py`
+  logs the same detail from further out; the `DomainError` handler additionally
+  logs 4xx (one compact line, no traceback) where it previously logged nothing,
+  and the public 422 handler now records which field failed validation — `loc` /
+  `type` / `msg` only, never the caller's `input` value. **If your category adds
+  a body field holding a credential, add its name substring to
+  `_SENSITIVE_NAME_PARTS`.** No status code, response body, or envelope shape
+  changed.

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -478,11 +478,19 @@ async def _http_exception_handler(
         # detail survives. It also covers an ``HTTPException`` raised *inside* a
         # public handler: ``@envelope_errors`` does not map that type, so it
         # arrives here with the handler's arguments already stashed.
-        log = logger.error if exc.status_code >= 500 else logger.warning
+        #
+        # 5xx carries the traceback like every other 5xx path here, because a
+        # handler-raised one ("Upload storage failed", "cron service returned no
+        # data") is diagnosed by its raise site. 4xx does not: the common case is
+        # Starlette's own routing 404/405, raised before any handler, whose stack
+        # is framework internals rather than anything we would read.
+        is_server_error = exc.status_code >= 500
+        log = logger.error if is_server_error else logger.warning
         log(
             "[Public %s] HTTPException on %s %s: %s%s",
             exc.status_code, request.method, request.url.path, exc.detail,
             params_suffix(request),
+            exc_info=exc if is_server_error else None,
         )
         return _public_error_envelope(exc.status_code, request, exc.headers)
     return await http_exception_handler(request, exc)

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -324,6 +324,9 @@ from agentclaw.community.core.errors import (  # noqa: E402
     Unauthorized,
     ValidationError,
 )
+from agentclaw.community.adapters.http.error_logging import (  # noqa: E402
+    params_suffix,
+)
 from agentclaw.community.adapters.http.openapi_v1.errors import (  # noqa: E402
     MissingPrincipalError,
 )
@@ -414,13 +417,30 @@ def _public_mapped_error(request: Request, exc: Exception) -> JSONResponse | Non
 @app.exception_handler(DomainError)
 async def _domain_error_handler(request: Request, exc: DomainError) -> JSONResponse:
     status = _DOMAIN_ERROR_STATUS_MAP.get(type(exc), 500)
-    # 4xx/3xx are expected client-side flow (bad input, missing auth) — logging
-    # every one would be noise. 5xx means a core service signalled an internal
-    # failure; emit a full traceback so the cause is recoverable from logs.
+    # 5xx means a core service signalled an internal failure; emit a full
+    # traceback so the cause is recoverable from logs. 4xx is expected
+    # client-side flow (bad input, missing auth), so it gets one compact line
+    # without a traceback: enough to see that the request was refused and with
+    # what arguments, without a per-401 stack in the log file. It used to get
+    # nothing at all, which is why a refused request could not be traced.
+    #
+    # 3xx stays silent: the only one is ``LoginRedirectRequired``, an ordinary
+    # step in the login flow rather than a failure to diagnose.
+    #
+    # ``params_suffix`` is empty unless the public surface's ``@envelope_errors``
+    # captured the handler's arguments on the way past, so the message shape is
+    # unchanged for internal routes that never had them.
     if status >= 500:
         logger.exception(
-            "[DomainError 5xx] %s on %s %s: %s",
+            "[DomainError 5xx] %s on %s %s: %s%s",
             type(exc).__name__, request.method, request.url.path, exc.detail,
+            params_suffix(request),
+        )
+    elif status >= 400:
+        logger.warning(
+            "[DomainError %s] %s on %s %s: %s%s",
+            status, type(exc).__name__, request.method, request.url.path,
+            exc.detail, params_suffix(request),
         )
     if _is_public_api(request):
         return _public_error_envelope(status, request)
@@ -453,6 +473,17 @@ async def _http_exception_handler(
     they got it wrong but not what would be right.
     """
     if _is_public_api(request):
+        # The public response is the bare reason phrase — ``exc.detail`` is
+        # replaced, not returned — so this line is the only place the raised
+        # detail survives. It also covers an ``HTTPException`` raised *inside* a
+        # public handler: ``@envelope_errors`` does not map that type, so it
+        # arrives here with the handler's arguments already stashed.
+        log = logger.error if exc.status_code >= 500 else logger.warning
+        log(
+            "[Public %s] HTTPException on %s %s: %s%s",
+            exc.status_code, request.method, request.url.path, exc.detail,
+            params_suffix(request),
+        )
         return _public_error_envelope(exc.status_code, request, exc.headers)
     return await http_exception_handler(request, exc)
 
@@ -476,6 +507,18 @@ async def _validation_error_handler(
     from agentclaw.community.adapters.http.openapi_v1.responses import error_response
 
     if request.url.path.startswith(PUBLIC_API_PREFIX):
+        # "Invalid request" is all the caller gets, so which field failed is
+        # only knowable from here. ``loc``/``type``/``msg`` only — the ``input``
+        # each error carries is the caller's raw value, which is exactly the
+        # payload this surface must not copy into a log file.
+        logger.warning(
+            "[Public 422] validation failed on %s %s: %s",
+            request.method, request.url.path,
+            [
+                {"loc": e.get("loc"), "type": e.get("type"), "msg": e.get("msg")}
+                for e in exc.errors()
+            ],
+        )
         return error_response(422, "Invalid request", request)
     return await request_validation_exception_handler(request, exc)
 
@@ -495,8 +538,9 @@ async def _data_proxy_error_handler(
     detail: dict[str, object] = {"error": exc.message, "op": exc.op}
     if status >= 500:
         logger.exception(
-            "[DataProxyError 5xx] %s on %s %s: %s",
+            "[DataProxyError 5xx] %s on %s %s: %s%s",
             type(exc).__name__, request.method, request.url.path, exc.message,
+            params_suffix(request),
         )
     return JSONResponse(
         status_code=status,
@@ -537,8 +581,9 @@ async def _principal_error_handler(request: Request, exc: Exception) -> JSONResp
     # "Unauthorized" the table gives every failure here, so a forger still
     # cannot tell which part of a token was rejected.
     logger.warning(
-        "[Public 401] %s on %s %s: %s",
+        "[Public 401] %s on %s %s: %s%s",
         type(exc).__name__, request.method, request.url.path, exc,
+        params_suffix(request),
     )
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
@@ -581,21 +626,22 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
         # treats 4xx.
         if mapped.status_code < 500:
             logger.warning(
-                "[Public %s] %s on %s %s",
+                "[Public %s] %s on %s %s%s",
                 mapped.status_code, type(exc).__name__, request.method,
-                request.url.path,
+                request.url.path, params_suffix(request),
             )
             return mapped
         logger.exception(
-            "[Public %s] %s on %s %s",
+            "[Public %s] %s on %s %s%s",
             mapped.status_code, type(exc).__name__, request.method,
-            request.url.path,
+            request.url.path, params_suffix(request),
         )
         return mapped
 
     logger.exception(
-        "[Unhandled exception] %s on %s %s",
+        "[Unhandled exception] %s on %s %s%s",
         type(exc).__name__, request.method, request.url.path,
+        params_suffix(request),
     )
     # The public surface guarantees the Envelope on every response, including
     # the ones nobody anticipated. Enumerating each new escapee in

--- a/src/backend/src/agentclaw/community/adapters/http/error_logging.py
+++ b/src/backend/src/agentclaw/community/adapters/http/error_logging.py
@@ -1,0 +1,351 @@
+"""Diagnostics for HTTP errors the adapter layer converts into responses.
+
+Every error the HTTP boundary answers with — a domain error mapped to an
+Envelope by ``openapi_v1.responses.envelope_errors``, a ``DomainError`` mapped
+by ``app.py``, an exception nobody anticipated — used to leave behind either
+nothing at all or a single line naming the exception type. Neither is enough to
+debug a production report: the type says *what* failed, not *where* it was
+raised or *what the caller asked for*, and the public surface deliberately
+returns a fixed message, so the response body carries no diagnosis either.
+
+This module supplies the two missing halves and nothing else:
+
+- **the traceback** — logged with the error, so the raise site is recoverable;
+- **the call parameters** — the arguments the handler was actually invoked
+  with, captured at the moment the exception unwinds through the decorator that
+  converts it.
+
+Capture is lazy: nothing here runs on a successful request. The summarizer is
+deliberately conservative — it keeps data-shaped values, redacts anything whose
+name looks like a credential, truncates long strings and collections, and
+drops injected services rather than trying to render them.
+
+Nothing in here may raise. A logging path that throws turns a mapped 404 into
+an unhandled 500, so :func:`log_public_error` and :func:`params_suffix` are
+guarded; a failure to describe an error must never replace the error.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from collections.abc import Mapping, Sequence, Set
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from fastapi import Request
+from pydantic import BaseModel
+from starlette.background import BackgroundTasks
+from starlette.datastructures import Headers, QueryParams, URL, UploadFile
+from starlette.requests import HTTPConnection
+from starlette.responses import Response
+
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+# What a redacted value renders as. Fixed string, no length hint: the length of
+# a secret is itself a fact about the secret.
+REDACTED = "***redacted***"
+
+# Substring match against the *parameter or field name*, lowercased. Names are
+# matched, never values — a value-based heuristic would both miss credentials
+# that do not look like one and redact ordinary ids that happen to.
+_SENSITIVE_NAME_PARTS: tuple[str, ...] = (
+    "token",
+    "password",
+    "passwd",
+    "secret",
+    "credential",
+    "authorization",
+    "auth_header",
+    "api_key",
+    "apikey",
+    "access_key",
+    "accesskey",
+    "private_key",
+    "privatekey",
+    "signature",
+    "cookie",
+    "session",
+)
+
+# Budgets. A log line is a diagnosis, not a payload dump: a request body with a
+# 200KB skill package or a 500-item list must not be reproduced in the log file.
+_MAX_STR_CHARS = 200
+_MAX_ITEMS = 20
+_MAX_MAPPING_KEYS = 30
+_MAX_DEPTH = 4
+_MAX_RENDERED_CHARS = 2000
+
+# Where a handler's captured parameters wait for an app-level handler. Starlette
+# backs ``request.state`` with the ASGI scope dict by reference, so what the
+# decorator stores inside the route is what the exception handler reads after
+# the exception has unwound past it.
+_PARAMS_STATE_ATTR = "avernet_error_call_params"
+
+# Transport objects that must never be walked, even though some of them *are*
+# mappings. ``Request`` implements ``Mapping`` over its ASGI scope, so the
+# generic mapping branch below would happily render the whole scope — the raw
+# header list (``Authorization``, the signed principal token), the app object,
+# the DI injector. ``Headers`` has the same problem one level down. None of them
+# carries handler input the summarizer does not already get from the named
+# parameters, so they are opaque by type rather than filtered by key.
+_TRANSPORT_TYPES: tuple[type, ...] = (
+    HTTPConnection,  # Request and WebSocket
+    Response,
+    Headers,
+    QueryParams,
+    URL,
+    BackgroundTasks,
+)
+
+
+class _Opaque:
+    """Stand-in for a value the summarizer will not render.
+
+    Injected services, repositories, plugin handles, ``Request`` itself: values
+    that carry no request data and whose ``repr`` can be enormous or can touch
+    live connections. Nested occurrences render as ``<BotService>``; top-level
+    ones are dropped entirely by :func:`capture_call_params`, because a line
+    listing five injected dependencies buries the two arguments that matter.
+    """
+
+    __slots__ = ("type_name",)
+
+    def __init__(self, value: object) -> None:
+        self.type_name = type(value).__name__
+
+    def __repr__(self) -> str:
+        return f"<{self.type_name}>"
+
+
+def _is_sensitive(name: str) -> bool:
+    lowered = name.lower()
+    return any(part in lowered for part in _SENSITIVE_NAME_PARTS)
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= _MAX_STR_CHARS:
+        return text
+    return f"{text[:_MAX_STR_CHARS]}…(+{len(text) - _MAX_STR_CHARS} chars)"
+
+
+def _summarize(value: Any, depth: int = 0) -> Any:
+    """A log-safe, size-bounded projection of ``value``.
+
+    Returns primitives as themselves and everything else as a bounded structure
+    of primitives, so the caller can ``repr`` the result without risking a huge
+    line or a side effect from someone's custom ``__repr__``.
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, _TRANSPORT_TYPES):
+        return _Opaque(value)
+    if isinstance(value, str):
+        return _truncate(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        # Never the content: it is either binary noise or an upload payload.
+        return f"<{type(value).__name__} {len(bytes(value))} bytes>"
+    if isinstance(value, Enum):
+        return _summarize(value.value, depth)
+    if isinstance(value, (UUID, Decimal, datetime, date, time)):
+        return str(value)
+
+    if depth >= _MAX_DEPTH:
+        return _Opaque(value)
+
+    # Pydantic request bodies — the single most useful thing on this line.
+    # Matched by type, never by ``hasattr(value, "model_dump")``: duck-typing
+    # here means *calling* an attribute off an arbitrary object, and a test
+    # double answers every attribute — the duck-typed version called
+    # ``model_dump()`` on every injected AsyncMock and left un-awaited
+    # coroutines behind it.
+    if isinstance(value, BaseModel):
+        try:
+            dumped = value.model_dump()
+        except Exception:  # noqa: BLE001 — a body we cannot dump is not a reason to lose the log
+            return _Opaque(value)
+        if isinstance(dumped, Mapping):
+            return _summarize_mapping(dumped, depth)
+        return _summarize(dumped, depth + 1)
+
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        try:
+            fields = {f.name: getattr(value, f.name) for f in dataclasses.fields(value)}
+        except Exception:  # noqa: BLE001 — same reasoning as the model_dump guard
+            return _Opaque(value)
+        return _summarize_mapping(fields, depth)
+
+    if isinstance(value, Mapping):
+        return _summarize_mapping(value, depth)
+
+    # Uploads: identity only, never the stream. By type for the same reason as
+    # the model branch above — a mock answers ``filename`` too.
+    if isinstance(value, UploadFile):
+        return f"<upload filename={value.filename!r}>"
+
+    if isinstance(value, (list, tuple, Set)) or (
+        isinstance(value, Sequence) and not isinstance(value, str)
+    ):
+        items = list(value)
+        head = [_summarize(item, depth + 1) for item in items[:_MAX_ITEMS]]
+        if len(items) > _MAX_ITEMS:
+            head.append(f"…(+{len(items) - _MAX_ITEMS} more)")
+        return head
+
+    return _Opaque(value)
+
+
+def _summarize_mapping(mapping: Mapping[Any, Any], depth: int) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for index, (key, item) in enumerate(mapping.items()):
+        name = str(key)
+        if index >= _MAX_MAPPING_KEYS:
+            out["…"] = f"(+{len(mapping) - _MAX_MAPPING_KEYS} more keys)"
+            break
+        out[name] = REDACTED if _is_sensitive(name) else _summarize(item, depth + 1)
+    return out
+
+
+def capture_call_params(
+    signature: inspect.Signature,
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    """The handler's arguments, by name, projected into log-safe values.
+
+    ``signature`` is the *undecorated* handler's, so positional arguments get
+    their real names. Values that are not request data — the ``Request``, the
+    injected services every public handler declares — are dropped rather than
+    listed as ``<BotService>``, which would push the arguments that matter off
+    the end of the line.
+    """
+    try:
+        bound = signature.bind_partial(*args, **kwargs)
+    except TypeError:
+        # Signature and call disagree (shouldn't happen — FastAPI built the
+        # call from this signature). Fall back to whatever was passed by name.
+        bound_arguments: Mapping[str, Any] = dict(kwargs)
+    else:
+        bound_arguments = bound.arguments
+
+    params: dict[str, Any] = {}
+    for name, value in bound_arguments.items():
+        if _is_sensitive(name):
+            params[name] = REDACTED
+            continue
+        summarized = _summarize(value)
+        if isinstance(summarized, _Opaque):
+            continue
+        params[name] = summarized
+    return params
+
+
+def remember_call_params(request: Request, params: Mapping[str, Any]) -> None:
+    """Stash captured parameters for the app-level handler further out.
+
+    An exception the route decorator does not map is re-raised and answered by
+    ``app.py``, which is far past the frame that knew the arguments. Storing
+    them on the request scope is what lets that handler log the same detail.
+    """
+    try:
+        setattr(request.state, _PARAMS_STATE_ATTR, dict(params))
+    except Exception:  # noqa: BLE001 — diagnostics must not break the response
+        pass
+
+
+def recall_call_params(request: Request) -> dict[str, Any]:
+    """Parameters stashed by :func:`remember_call_params`, or ``{}``."""
+    try:
+        stored = getattr(request.state, _PARAMS_STATE_ATTR, None)
+    except Exception:  # noqa: BLE001 — see remember_call_params
+        return {}
+    return dict(stored) if isinstance(stored, Mapping) else {}
+
+
+def format_call_params(params: Mapping[str, Any]) -> str:
+    """Render captured parameters as one bounded ``k=v, k=v`` string."""
+    if not params:
+        return ""
+    rendered = ", ".join(f"{name}={value!r}" for name, value in params.items())
+    if len(rendered) > _MAX_RENDERED_CHARS:
+        rendered = f"{rendered[:_MAX_RENDERED_CHARS]}…(truncated)"
+    return rendered
+
+
+def params_suffix(request: Request) -> str:
+    """`` params={...}`` for the request's stashed parameters, else ``""``.
+
+    Appended to the app-level handlers' existing log lines so their message
+    format is unchanged when nothing was captured.
+    """
+    try:
+        rendered = format_call_params(recall_call_params(request))
+    except Exception:  # noqa: BLE001 — diagnostics must not break the response
+        return ""
+    return f" params={{{rendered}}}" if rendered else ""
+
+
+def _scope_str(request: Request, key: str) -> str:
+    try:
+        return str(request.scope.get(key, "") or "")
+    except Exception:  # noqa: BLE001 — see log_public_error
+        return ""
+
+
+def _route_path(request: Request) -> str:
+    """The matched route *template* (``/openapi/v1/bots/{bot_id}``).
+
+    Logged next to the concrete path because it is what groups occurrences of
+    the same failure across different ids.
+    """
+    try:
+        return str(getattr(request.scope.get("route"), "path", "") or "")
+    except Exception:  # noqa: BLE001 — see log_public_error
+        return ""
+
+
+def log_public_error(
+    request: Request,
+    exc: BaseException,
+    *,
+    status: int,
+    params: Mapping[str, Any] | None = None,
+) -> None:
+    """Log an error the public surface converted into an enveloped response.
+
+    Level follows the status: ``5xx`` is our failure (``error``), ``4xx`` is the
+    caller's (``warning``). Both carry the traceback. That is deliberate for
+    4xx too — the errors reaching this path are raised *inside* a handler by a
+    service, so the traceback is a short chain of our own frames pointing at the
+    check that rejected the request, and knowing which of a handler's four
+    ``NotFound`` raises fired is the whole question when a caller reports a 404
+    they did not expect. Routine unauthenticated traffic does not come through
+    here: the auth seam raises in a dependency, which ``app.py`` answers and
+    logs without a traceback.
+    """
+    try:
+        if params is None:
+            params = recall_call_params(request)
+        log = logger.error if status >= 500 else logger.warning
+        log(
+            "[Public %s] %s on %s %s route=%s params={%s}: %s",
+            status,
+            type(exc).__name__,
+            _scope_str(request, "method"),
+            _scope_str(request, "path"),
+            _route_path(request) or "-",
+            format_call_params(params),
+            exc,
+            exc_info=exc,
+        )
+    except Exception:  # noqa: BLE001
+        # A broken log line must never turn a mapped 404 into an unhandled 500.
+        # Nothing to report it *to* — the logger is the thing that just failed.
+        pass

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -16,6 +16,7 @@ a builder on success and let the decorator handle the mapped failures.
 
 from __future__ import annotations
 
+import inspect
 from functools import wraps
 from http import HTTPStatus
 from json import JSONDecodeError
@@ -24,6 +25,11 @@ from typing import Awaitable, Callable, Mapping, TypeVar
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
+from agentclaw.community.adapters.http.error_logging import (
+    capture_call_params,
+    log_public_error,
+    remember_call_params,
+)
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     CODE_ACCEPTED,
     CODE_CREATED,
@@ -415,7 +421,17 @@ def envelope_errors(
     The wrapped handler must take a ``request: Request`` parameter (used for the
     error envelope's ``request_id``). Unmapped exceptions are re-raised so the
     app's 500 handler still owns them.
+
+    Every failure is also logged here, with its traceback and the arguments the
+    handler was called with. This is the only frame that has both: the public
+    response carries a fixed message by design, so without this the sole record
+    of a mapped failure was the status code on the access log. Capture is lazy —
+    a successful request pays nothing — and the parameters are stashed on the
+    request for the unmapped case, where ``app.py`` logs further out.
     """
+    # Resolved once, at import: ``fn`` is the undecorated handler, so the bind
+    # in the except-branch recovers real parameter names for positional args.
+    signature = inspect.signature(fn)
 
     @wraps(fn)
     async def wrapper(*args: object, **kwargs: object) -> object:
@@ -425,9 +441,17 @@ def envelope_errors(
             request = _find_request(args, kwargs)
             if request is None:
                 raise
+            params = capture_call_params(signature, args, kwargs)
+            # Stashed before the mapping decision: an unmapped error is
+            # re-raised out of this frame, and the handler that catches it can
+            # no longer see the arguments.
+            remember_call_params(request, params)
             response = mapped_error_response(exc, request)
             if response is None:
                 raise
+            log_public_error(
+                request, exc, status=response.status_code, params=params
+            )
             return response
 
     return wrapper

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     CODE_ACCEPTED,
@@ -24,6 +27,18 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotPermissionError,
 )
+
+
+class _BotUpdate(BaseModel):
+    """Body model for the end-to-end route below.
+
+    Module level on purpose: ``from __future__ import annotations`` makes the
+    handler's annotations strings, and FastAPI resolves them against the
+    function's *globals*.
+    """
+
+    bot_name: str
+    api_token: str = "s3cret"
 
 
 def _request(trace_id: str | None = "trace-123") -> Request:
@@ -120,6 +135,123 @@ async def test_envelope_errors_passes_through_unmapped():
 
     with pytest.raises(ValueError, match="boom"):
         await handler(request=_request())
+
+
+# ── Diagnostics: every converted failure leaves a log record ─────────────────
+# The public response carries a fixed message, so without these the only trace
+# of a mapped failure is the status code on the access log.
+
+
+@pytest.mark.asyncio
+async def test_mapped_error_is_logged_with_traceback_and_params(caplog):
+    @envelope_errors
+    async def handler(bot_id: str, request: Request, page: int):
+        raise BotNotFoundError("Bot not found: b-123")
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await handler("b-123", request=_request(), page=2)
+
+    assert resp.status_code == 404
+    record = caplog.records[-1]
+    assert record.levelno == logging.WARNING, "4xx is the caller's fault"
+    assert record.exc_info is not None, "the raise site must be recoverable"
+    message = record.getMessage()
+    assert "BotNotFoundError" in message
+    # The internal text is kept OUT of the response but must appear in the log —
+    # that asymmetry is the entire point of this path.
+    assert "Bot not found: b-123" in message
+    assert "bot_id='b-123'" in message and "page=2" in message
+
+
+@pytest.mark.asyncio
+async def test_mapped_5xx_is_logged_at_error_level(caplog):
+    from agentclaw.community.core.bot_management.services.bot_service import (
+        BotServiceError,
+    )
+
+    @envelope_errors
+    async def handler(request: Request):
+        raise BotServiceError("device provisioning failed")
+
+    with caplog.at_level(logging.DEBUG):
+        resp = await handler(request=_request())
+
+    assert resp.status_code == 500
+    assert caplog.records[-1].levelno == logging.ERROR
+
+
+@pytest.mark.asyncio
+async def test_unmapped_error_stashes_params_for_the_app_handler():
+    """An unmapped error is answered by ``app.py``, far past the frame that knew
+    the arguments — so the decorator leaves them on the request."""
+    from agentclaw.community.adapters.http.error_logging import recall_call_params
+
+    request = _request()
+
+    @envelope_errors
+    async def handler(bot_id: str, request: Request):
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        await handler("b-9", request=request)
+
+    assert recall_call_params(request) == {"bot_id": "b-9"}
+
+
+def test_end_to_end_through_a_real_route(caplog):
+    """The whole chain over a served request: body, path param, route template.
+
+    The unit tests above call the wrapped handler directly; this one proves the
+    same line comes out when FastAPI does the calling, including the route
+    *template* that groups occurrences of one failure across different ids.
+    """
+    import json
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.post("/openapi/v1/bots/{bot_id}")
+    @envelope_errors
+    async def update_bot(bot_id: str, body: _BotUpdate, request: Request):
+        raise BotNotFoundError(f"Bot not found: {bot_id}")
+
+    with caplog.at_level(logging.DEBUG):
+        resp = TestClient(app).post(
+            "/openapi/v1/bots/b-42", json={"bot_name": "alpha"}
+        )
+
+    assert resp.status_code == 404
+    assert json.loads(resp.content)["message"] == "Not found"
+
+    # Not ``records[-1]``: the test client's own httpx logger also records here.
+    record = next(r for r in caplog.records if "[Public 404]" in r.getMessage())
+    message = record.getMessage()
+    assert "POST /openapi/v1/bots/b-42" in message
+    assert "route=/openapi/v1/bots/{bot_id}" in message
+    assert "bot_id='b-42'" in message
+    assert "'bot_name': 'alpha'" in message
+    # The body's credential field is named, never valued.
+    assert "s3cret" not in message
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_successful_request_logs_nothing_and_captures_nothing(caplog):
+    from agentclaw.community.adapters.http.error_logging import recall_call_params
+
+    request = _request()
+
+    @envelope_errors
+    async def handler(bot_id: str, request: Request):
+        return envelope({"bot_id": bot_id}, request)
+
+    with caplog.at_level(logging.DEBUG):
+        await handler("b-1", request=request)
+
+    assert caplog.records == []
+    assert recall_call_params(request) == {}
 
 
 # ── Envelope shape (Track C) ─────────────────────────────────────────────────

--- a/src/backend/tests/community/adapters/http/test_error_logging.py
+++ b/src/backend/tests/community/adapters/http/test_error_logging.py
@@ -1,0 +1,300 @@
+"""Unit tests for the adapter-layer error diagnostics helper.
+
+Covers the three things the log line depends on being true: the summarizer is
+bounded (no payload dumps), credential-shaped names never render, and nothing
+in the module raises — a broken diagnostic must not replace the error it was
+supposed to describe.
+"""
+
+from __future__ import annotations
+
+import inspect
+import io
+import logging
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from uuid import UUID
+
+import pytest
+from fastapi import Request
+from pydantic import BaseModel
+
+from agentclaw.community.adapters.http import error_logging
+from agentclaw.community.adapters.http.error_logging import (
+    REDACTED,
+    capture_call_params,
+    format_call_params,
+    log_public_error,
+    params_suffix,
+    recall_call_params,
+    remember_call_params,
+)
+
+
+def _request(method: str = "GET", path: str = "/openapi/v1/bots") -> Request:
+    return Request(
+        {"type": "http", "method": method, "path": path, "state": {}, "headers": []}
+    )
+
+
+class _Body(BaseModel):
+    bot_name: str
+    api_token: str = "s3cret"
+
+
+class _Engine(str, Enum):
+    TECLAW = "teclaw"
+
+
+@dataclass
+class _Caller:
+    user_id: str
+    session_token: str
+
+
+class _Service:
+    """Stands in for an injected dependency."""
+
+
+# ============================================================
+# capture_call_params — names, filtering, redaction
+# ============================================================
+
+def _capture(fn, *args, **kwargs) -> dict:
+    return capture_call_params(inspect.signature(fn), args, kwargs)
+
+
+def test_captures_named_and_positional_arguments():
+    def handler(bot_id: str, page: int, request=None):
+        ...
+
+    assert _capture(handler, "bot-1", page=3) == {"bot_id": "bot-1", "page": 3}
+
+
+def test_drops_request_and_injected_services():
+    def handler(bot_id: str, request, bot_service, page: int):
+        ...
+
+    params = _capture(handler, "bot-1", _request(), _Service(), 2)
+    assert params == {"bot_id": "bot-1", "page": 2}
+
+
+def test_request_is_never_walked_as_a_mapping():
+    """``Request`` is a ``Mapping`` over its ASGI scope — walking it would put
+    the raw header list (Authorization, the signed principal token) and the DI
+    injector into the log line."""
+    def handler(request, bot_id: str):
+        ...
+
+    authed = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/openapi/v1/bots",
+            "state": {},
+            "headers": [(b"authorization", b"Bearer super-secret")],
+        }
+    )
+    rendered = format_call_params(_capture(handler, authed, "bot-1"))
+    assert "super-secret" not in rendered
+    assert "authorization" not in rendered.lower()
+    assert rendered == "bot_id='bot-1'"
+
+
+def test_headers_object_is_opaque():
+    def handler(headers):
+        ...
+
+    from starlette.datastructures import Headers
+
+    params = _capture(handler, Headers({"authorization": "Bearer super-secret"}))
+    assert "super-secret" not in format_call_params(params)
+
+
+def test_redacts_sensitive_parameter_names():
+    def handler(token: str, password: str, bot_id: str):
+        ...
+
+    params = _capture(handler, "abc", "hunter2", "bot-1")
+    assert params == {"token": REDACTED, "password": REDACTED, "bot_id": "bot-1"}
+
+
+def test_redacts_sensitive_fields_inside_a_request_body():
+    def handler(body: _Body):
+        ...
+
+    params = _capture(handler, _Body(bot_name="alpha"))
+    assert params["body"] == {"bot_name": "alpha", "api_token": REDACTED}
+
+
+def test_dataclass_and_enum_and_uuid_render_as_data():
+    def handler(caller: _Caller, engine: _Engine, trace: UUID):
+        ...
+
+    params = _capture(
+        handler,
+        _Caller(user_id="u1", session_token="tok"),
+        _Engine.TECLAW,
+        UUID(int=1),
+    )
+    assert params["caller"] == {"user_id": "u1", "session_token": REDACTED}
+    assert params["engine"] == "teclaw"
+    assert params["trace"] == "00000000-0000-0000-0000-000000000001"
+
+
+def test_long_strings_are_truncated():
+    def handler(blob: str):
+        ...
+
+    params = _capture(handler, "x" * 5000)
+    rendered = params["blob"]
+    assert len(rendered) < 300
+    assert rendered.endswith("chars)")
+
+
+def test_long_lists_are_truncated():
+    def handler(items: list):
+        ...
+
+    params = _capture(handler, list(range(100)))
+    assert len(params["items"]) == 21
+    assert "more" in params["items"][-1]
+
+
+def test_bytes_render_as_a_size_not_content():
+    def handler(payload: bytes):
+        ...
+
+    assert _capture(handler, b"abcdef")["payload"] == "<bytes 6 bytes>"
+
+
+def test_deeply_nested_values_stop_at_the_depth_limit():
+    def handler(tree: dict):
+        ...
+
+    deep = {"a": {"b": {"c": {"d": {"e": {"f": 1}}}}}}
+    rendered = format_call_params(_capture(handler, deep))
+    assert "<dict>" in rendered
+
+
+def test_capture_survives_a_model_that_cannot_be_dumped():
+    class Exploding(BaseModel):
+        def model_dump(self, *args, **kwargs):
+            raise RuntimeError("nope")
+
+    def handler(body):
+        ...
+
+    # Unrenderable at top level ⇒ dropped, not raised.
+    assert _capture(handler, Exploding()) == {}
+
+
+def test_attributes_are_never_called_on_an_arbitrary_object():
+    """Duck-typing ``model_dump``/``filename`` means *invoking* an attribute on
+    whatever was passed. A test double answers every attribute, so the duck-typed
+    version called ``model_dump()`` on every injected AsyncMock and left
+    un-awaited coroutines behind it."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    def handler(service, other):
+        ...
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any RuntimeWarning fails this test
+        assert _capture(handler, AsyncMock(), MagicMock()) == {}
+
+
+def test_upload_renders_as_a_filename_not_a_stream():
+    from starlette.datastructures import UploadFile
+
+    def handler(file):
+        ...
+
+    upload = UploadFile(filename="skill.zip", file=io.BytesIO(b"payload"))
+    assert _capture(handler, upload)["file"] == "<upload filename='skill.zip'>"
+    assert "payload" not in format_call_params(_capture(handler, upload))
+
+
+def test_capture_survives_a_signature_mismatch():
+    def handler(bot_id: str):
+        ...
+
+    params = capture_call_params(
+        inspect.signature(handler), (), {"unexpected": "value"}
+    )
+    assert params == {"unexpected": "value"}
+
+
+# ============================================================
+# remember / recall / params_suffix
+# ============================================================
+
+def test_params_round_trip_through_the_request_scope():
+    request = _request()
+    remember_call_params(request, {"bot_id": "b1"})
+    assert recall_call_params(request) == {"bot_id": "b1"}
+    assert params_suffix(request) == " params={bot_id='b1'}"
+
+
+def test_params_suffix_is_empty_when_nothing_was_captured():
+    assert params_suffix(_request()) == ""
+
+
+def test_format_call_params_is_bounded():
+    rendered = format_call_params({f"k{i}": "v" * 100 for i in range(50)})
+    assert rendered.endswith("(truncated)")
+    assert len(rendered) < 2100
+
+
+# ============================================================
+# log_public_error — level by status, traceback, no raising
+# ============================================================
+
+@pytest.mark.parametrize(
+    "status,expected_level",
+    [(404, logging.WARNING), (409, logging.WARNING), (502, logging.ERROR)],
+)
+def test_level_follows_status_and_traceback_is_attached(
+    caplog, status, expected_level,
+):
+    request = _request(method="POST", path="/openapi/v1/bots/b1")
+    with caplog.at_level(logging.DEBUG):
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            log_public_error(request, exc, status=status, params={"bot_id": "b1"})
+
+    record = caplog.records[-1]
+    assert record.levelno == expected_level
+    assert record.exc_info is not None, "traceback must be attached"
+    message = record.getMessage()
+    assert f"[Public {status}]" in message
+    assert "ValueError" in message
+    assert "POST /openapi/v1/bots/b1" in message
+    assert "params={bot_id='b1'}" in message
+
+
+def test_log_falls_back_to_stashed_params(caplog):
+    request = _request()
+    remember_call_params(request, {"page": 3})
+    with caplog.at_level(logging.DEBUG):
+        log_public_error(request, ValueError("boom"), status=500)
+    assert "params={page=3}" in caplog.records[-1].getMessage()
+
+
+def test_log_never_raises_even_if_the_logger_does(monkeypatch):
+    def explode(*args, **kwargs):
+        raise RuntimeError("logging backend down")
+
+    monkeypatch.setattr(error_logging.logger, "warning", explode)
+    monkeypatch.setattr(error_logging.logger, "error", explode)
+    # No exception escapes: a failed log must never turn a mapped 4xx into a 500.
+    log_public_error(_request(), ValueError("boom"), status=404)
+
+
+def test_log_survives_a_request_without_method_or_path(caplog):
+    bare = Request({"type": "http", "state": {}})
+    with caplog.at_level(logging.DEBUG):
+        log_public_error(bare, ValueError("boom"), status=404)
+    assert "[Public 404]" in caplog.records[-1].getMessage()

--- a/src/backend/tests/community/api/test_domain_error_handler.py
+++ b/src/backend/tests/community/api/test_domain_error_handler.py
@@ -151,6 +151,60 @@ def test_5xx_domain_error_logs_traceback_but_4xx_does_not(client, monkeypatch):
     assert sum(1 for s in fmt_strings if "DomainError 5xx" in s) == 1
 
 
+def test_4xx_domain_error_logs_one_compact_warning(client, monkeypatch):
+    """A refused request used to leave no trace at all. It now logs one line —
+    without a traceback, so a per-401 stack does not bury the real 5xx ones."""
+    from agentclaw.community.adapters.http import app as app_mod
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, "warning",
+        lambda *a, **k: calls.append((a, k)),
+    )
+    client.get("/raise/notfound")
+    assert any("[DomainError %s]" in str(a[0]) for a, _ in calls), \
+        f"expected a 4xx DomainError warning, got: {calls}"
+    assert all("exc_info" not in k for _, k in calls), \
+        "4xx must not carry a traceback"
+
+    # 3xx stays silent: LoginRedirectRequired is a step in the login flow, not
+    # a failure anyone debugs.
+    calls.clear()
+    client.get("/raise/redirect")
+    assert calls == [], f"302 must not log, got: {calls}"
+
+
+def test_handler_logs_the_params_stashed_by_the_public_decorator(monkeypatch):
+    """The arguments captured inside the route survive to the app-level handler.
+
+    ``@envelope_errors`` re-raises anything it does not map; by the time this
+    handler answers, the frame that knew the arguments is gone, so the decorator
+    leaves them on the request scope for exactly this reason.
+    """
+    from agentclaw.community.adapters.http import app as app_mod
+    from agentclaw.community.adapters.http.error_logging import remember_call_params
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, "exception",
+        lambda *a, **k: calls.append((a, k)),
+    )
+
+    app = FastAPI()
+    app.add_exception_handler(DomainError, app_mod._domain_error_handler)
+
+    @app.get("/boom")
+    async def boom(request: Request):
+        remember_call_params(request, {"bot_id": "b-77"})
+        raise InternalError("kaboom")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    assert client.get("/boom").status_code == 500
+    rendered = [str(a) for a, _ in calls]
+    assert any("b-77" in line for line in rendered), \
+        f"expected the stashed params in the log args, got: {rendered}"
+
+
 # ============================================================
 # Trace-ID propagation — every response carries X-Trace-ID
 # ============================================================

--- a/src/backend/tests/community/api/test_domain_error_handler.py
+++ b/src/backend/tests/community/api/test_domain_error_handler.py
@@ -206,6 +206,63 @@ def test_handler_logs_the_params_stashed_by_the_public_decorator(monkeypatch):
 
 
 # ============================================================
+# Public HTTPException — 5xx keeps the traceback, 4xx does not
+# ============================================================
+
+def _public_http_exception_client():
+    """Mount the real ``_http_exception_handler`` on public-prefixed routes."""
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from agentclaw.community.adapters.http import app as app_mod
+    from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+
+    app = FastAPI()
+    app.add_exception_handler(
+        StarletteHTTPException, app_mod._http_exception_handler
+    )
+
+    @app.get(f"{PUBLIC_API_PREFIX}/boom/{{status}}")
+    async def boom(status: int):
+        raise StarletteHTTPException(status_code=status, detail=f"boom-{status}")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(
+    "status,level,wants_traceback",
+    [
+        # Handler-raised: the raise site is the diagnosis. Both of these are live
+        # on the public surface (routines 500, resources upload 502) and neither
+        # is in ENVELOPE_ERRORS, so they land in this handler.
+        (502, "error", True),
+        (500, "error", True),
+        # Starlette's own routing failures dominate 4xx here; their stack is
+        # framework internals, so the message alone is the useful part.
+        (404, "warning", False),
+    ],
+)
+def test_public_http_exception_logging(monkeypatch, status, level, wants_traceback):
+    from agentclaw.community.adapters.http import app as app_mod
+    from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, level, lambda *a, **k: calls.append((a, k)),
+    )
+    resp = _public_http_exception_client().get(f"{PUBLIC_API_PREFIX}/boom/{status}")
+    assert resp.status_code == status
+
+    assert calls, f"expected a {level} log for {status}"
+    args, kwargs = calls[-1]
+    assert f"boom-{status}" in args, "the raised detail must survive in the log"
+    if wants_traceback:
+        assert kwargs.get("exc_info") is not None, \
+            "a 5xx HTTPException must carry its raise site"
+    else:
+        assert kwargs.get("exc_info") is None
+
+
+# ============================================================
 # Trace-ID propagation — every response carries X-Trace-ID
 # ============================================================
 


### PR DESCRIPTION
## Problem

On the public `/openapi/v1` surface a thrown domain error is converted to an HTTP
status and a **fixed** public message — internal ids and internal-language text
must not reach an external caller. That rule is correct, and it means the
response body carries no diagnosis at all.

`@envelope_errors` did that conversion for all 82 public handlers and logged
**nothing**. So when a caller reported an unexpected 404, 409 or 502, the only
record on our side was a status code in the access log: not the exception type,
not the raise site, not the arguments that produced it. The internal `/api`
surface had a narrower version of the same gap — `DomainError` 4xx was answered
silently, and public routing/validation failures were never recorded either.

## Solution

Log at the framework level, in the one frame that has both halves of the answer.

**`@envelope_errors` now emits one record per failure** — exception type, the
*internal* message, method, concrete path, matched route template, and the
handler's own arguments — with the traceback attached. Level follows status:
4xx → warning, 5xx → error.

```
[Public 404] BotNotFoundError on POST /openapi/v1/bots/b-42 route=/openapi/v1/bots/{bot_id}
  params={bot_id='b-42', body={'bot_name': 'alpha', 'api_token': '***redacted***'}}: Bot not found: b-42
```

Both levels carry the traceback deliberately. Errors reaching this path are
raised *inside* a handler, so the trace is a short chain of our own frames
pointing at the check that refused the request — which of a handler's four
`NotFound` raises fired is the whole question when a caller reports a 404 they
did not expect. Routine unauthenticated traffic does not come through here: the
auth seam raises in a **dependency**, which `app.py` still answers and logs
without a trace, so this does not put a stack behind every 401.

**New `adapters/http/error_logging.py`** owns capture and formatting:

- **Lazy** — nothing runs on a successful request; the arguments are summarized
  only as the exception unwinds.
- **Bounded** — strings truncated, collections and mapping keys capped, nesting
  depth-limited, bytes reduced to a size, the whole rendering capped. A log line
  is a diagnosis, not a payload dump.
- **Redacting by name**, at any nesting depth (`token`, `password`, `secret`,
  `authorization`, `api_key`, `signature`, `cookie`, …). Names are matched, never
  values.
- **`Request` and `Headers` are opaque by type.** `Request` implements `Mapping`
  over its ASGI scope, so the generic mapping branch would have rendered the raw
  header list — `Authorization`, the signed principal token — into the log. Found
  by a test, kept honest by one.
- **Pydantic bodies and uploads are matched by type, never `hasattr`.**
  Duck-typing `model_dump` means *calling* an attribute on an arbitrary object;
  the first draft did that and called `model_dump()` on every injected
  `AsyncMock`, leaving un-awaited coroutines behind it.
- **Injected services are dropped**, not rendered as `<BotService>` — five
  dependency placeholders would push the two arguments that matter off the line.
- **Never raises.** A broken diagnostic must not turn a mapped 404 into an
  unhandled 500, so the logging entrypoints are guarded.

**App-level handlers pick up the same detail.** An unmapped error is re-raised
past the decorator, so the arguments are stashed on the request scope (Starlette
backs `request.state` with the ASGI scope by reference) and `app.py` appends them
to its existing log lines. Also there: `DomainError` 4xx now logs one compact
line without a traceback where it logged nothing; 3xx stays silent, being
`LoginRedirectRequired` — a step in the login flow, not a failure. Public
`HTTPException` and public 422 validation failures now log too, the latter with
`loc`/`type`/`msg` only — never the caller's raw `input` value, which is exactly
the payload this surface must not copy into a log file.

**Rejected:** a config knob for whether 4xx carries a traceback (speculative
configurability, per `AGENTS.md`); logging inside `mapped_error_response`, which
is shared with `app.py`'s backstop and would double-log the dependency path;
per-handler `try/except: logger.error(...)`, which is what "framework level"
exists to avoid.

## Validation

Run from `src/backend` with `uv run pytest`:

- **Full backend suite: 10641 passed, 3 skipped** (8m59s).
- **New** `tests/community/adapters/http/test_error_logging.py` — 24 cases:
  parameter naming/binding, service and `Request` filtering, redaction at top
  level and inside bodies, the `Request`-as-`Mapping` leak, `Headers` opacity,
  the never-call-arbitrary-attributes guarantee, truncation of strings /
  collections / depth / rendered length, upload summarization, level-by-status,
  traceback attachment, and that a logger which throws does not break the
  response.
- **Extended** `openapi_v1/test_responses.py` — mapped 4xx/5xx log with
  traceback and params; the internal message appears in the log while staying
  out of the body; unmapped errors stash params; a successful request logs and
  captures nothing; plus an end-to-end case through a real FastAPI route
  asserting the route template, path param, body field, and that a credential
  field's *value* never appears.
- **Extended** `api/test_domain_error_handler.py` — 4xx logs one compact warning
  with no traceback, 302 stays silent, and stashed params reach the app-level
  handler.
- `scripts/ci/python_sast_local.sh src/backend`: exits non-zero on this tree, but
  every finding is pre-existing (bundled `.venv` packages, and four `E999`s plus
  some `E117`/`E702`s in files this change does not touch). No finding names a
  changed file.

## Compatibility and risk

No status code, response body, envelope shape, or header changes — this is
additive logging only, and the existing wire-format tests pass unmodified.

The visible risk is **log volume**: 4xx on the public surface now costs a warning
with a short traceback, and internal `DomainError` 4xx costs one line. The two
high-frequency categories are deliberately excluded — dependency-raised 401s keep
their existing traceback-free warning, and 3xx logs nothing at all.

Rollback is the revert: `error_logging.py` is a new leaf module, and every other
edit is confined to log statements.

## Related issues

None.
