### PR TITLE
perf(backend): cut unit-test wall clock from 9m33s to 2m17s

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -69,6 +69,11 @@ dev = [
   "ruff>=0.14.13",
   "pytest>=8.0.0",
   "pytest-asyncio>=0.23.0",
+  # pytest-xdist: the suite is ~10.6k tests and runs ~10min serially. Workers are
+  # separate processes, so the in-memory SQLite engine and every module-level
+  # singleton are already isolated per worker; `--dist loadfile` additionally
+  # keeps a file's tests together. See scripts/ci_test.sh.
+  "pytest-xdist>=3.6",
   "fakeredis>=2.20",
   "moto[s3]>=5.0",
   "socksio>=1.0.0",

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -61,10 +61,23 @@ if [[ ! -x "$backend_python" ]]; then
   backend_python="$python_bin"
 fi
 
+# Parallel workers. ``auto`` = one worker per core; ``0`` runs pytest in-process
+# with no xdist at all (needed for --pdb, and the escape hatch if a worker-level
+# problem ever has to be bisected). Workers are separate processes, so the
+# in-memory SQLite engine, the DI singletons and the FastAPI ``app`` object are
+# isolated per worker for free; ``--dist loadfile`` additionally keeps every test
+# in a file on one worker so file-local ordering is preserved.
+pytest_workers="${BACKEND_CI_PYTEST_WORKERS:-auto}"
+xdist_args=()
+if [[ "$pytest_workers" != "0" ]]; then
+  xdist_args=(-n "$pytest_workers" --dist loadfile)
+fi
+
 set +e
 DEPLOY_PROFILE=test \
 PYTHONPATH="$backend_dir/src:$backend_dir:${PYTHONPATH:-}" \
 run_without_git_local_env "$backend_python" -m pytest tests/community -v \
+  "${xdist_args[@]}" \
   --continue-on-collection-errors \
   --junitxml="$junit_report" \
   --cov="$ci_workspace/src/backend/src" \

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -73,6 +73,14 @@ if [[ "$pytest_workers" != "0" ]]; then
   xdist_args=(-n "$pytest_workers" --dist loadfile)
 fi
 
+# Coverage measurement core. ``sysmon`` is coverage.py's PEP 669 (sys.monitoring)
+# backend, available on the 3.12 interpreter this project pins. It is
+# substantially cheaper than the default settrace core — measured on the full
+# suite under ``-n 4``: 418.56s default vs 214.60s sysmon, same 85% total. Only
+# line coverage is collected here (no ``--cov-branch``), which is what sysmon
+# supports well before 3.14. Set ``BACKEND_CI_COVERAGE_CORE=ctrace`` to fall back.
+export COVERAGE_CORE="${BACKEND_CI_COVERAGE_CORE:-sysmon}"
+
 set +e
 DEPLOY_PROFILE=test \
 PYTHONPATH="$backend_dir/src:$backend_dir:${PYTHONPATH:-}" \

--- a/src/backend/src/agentclaw/community/core/bot_management/services/sync_to_downstream.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/sync_to_downstream.py
@@ -23,6 +23,11 @@ logger = get_logger()
 # HTTP 超时（秒）— 真实 BCSFuse 处理较慢，需要足够的超时时间
 HTTP_TIMEOUT_SECONDS = 15
 MAX_RETRIES = 3
+# Base of the exponential backoff between retries: attempt N waits
+# ``RETRY_BACKOFF_BASE_SECONDS * 2 ** (N - 1)``. Named rather than inlined so a
+# test asserting retry *counts* can collapse the waits without patching
+# ``time.sleep`` process-wide.
+RETRY_BACKOFF_BASE_SECONDS = 1.0
 
 # link_type → MCP server code 映射
 _LINK_TYPE_TO_MCP_CODE = {
@@ -176,7 +181,7 @@ def sync_to_ecb(
                 logger.warning(f"[sync_to_ecb] Attempt {attempt}/{MAX_RETRIES} failed: {exc}")
                 if attempt == MAX_RETRIES:
                     return {"success": False, "error": str(exc)}
-                delay = 2 ** (attempt - 1)
+                delay = RETRY_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1)
                 logger.info(f"[sync_to_ecb] Retrying in {delay}s...")
                 time.sleep(delay)
     except Exception as exc:
@@ -239,7 +244,7 @@ def sync_to_bcsfuse(
                 logger.warning(f"[sync_to_bcsfuse] Attempt {attempt}/{MAX_RETRIES} failed: {exc}")
                 if attempt == MAX_RETRIES:
                     return {"success": False, "error": str(exc)}
-                delay = 2 ** (attempt - 1)
+                delay = RETRY_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1)
                 logger.info(f"[sync_to_bcsfuse] Retrying in {delay}s...")
                 time.sleep(delay)
     except Exception as exc:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_publish_service.py
@@ -471,6 +471,14 @@ class SkillPublishService:
         oss_path = f"{_OSS_PUBLISH_PREFIX}/{skill_name}/{ts}/{version}.zip"
 
         git_path = skill.get("git_path", "")
+        # ``_resolve_skill_dir`` maps an empty ``git_path`` to ``Path("")``, which
+        # normalises to ``PosixPath('.')`` — the process CWD. ``is_dir()`` says True
+        # for it, so the fail-fast guard below waves it through and the zip loop
+        # packs the entire working directory. A skill with no ``git_path`` has
+        # nothing to publish; reject it before resolving.
+        if not git_path:
+            raise FileNotFoundError("技能目录不存在: git_path 为空，无法打包发布")
+
         base = self._resolve_skill_dir(git_path)
 
         if not base.is_dir():

--- a/src/backend/tests/community/core/bot_management/services/test_sync_to_downstream.py
+++ b/src/backend/tests/community/core/bot_management/services/test_sync_to_downstream.py
@@ -1,12 +1,26 @@
 """Tests for core.bot_management.services.sync_to_downstream."""
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from agentclaw.community.core.bot_management.services import sync_to_downstream
 from agentclaw.community.core.bot_management.services.sync_to_downstream import (
     _LINK_TYPE_TO_MCP_CODE,
     sync_to_ecb,
     sync_to_bcsfuse,
     sync_all,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch):
+    """Neutralise the exponential ``time.sleep`` between sync retries.
+
+    ``sync_to_ecb`` / ``sync_to_bcsfuse`` sleep 1s then 2s before giving up after
+    ``MAX_RETRIES``. The exhaustion tests assert the *call count*, never the
+    spacing, so the sleeps were 6s of dead wall-clock.
+    """
+    monkeypatch.setattr(sync_to_downstream, "RETRY_BACKOFF_BASE_SECONDS", 0.0)
 
 
 class TestLinkTypeMappings:

--- a/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
+++ b/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
@@ -868,6 +868,19 @@ class TestVerifyOwnership:
 class TestPublishPolling:
     """Tests for publish progress polling logic."""
 
+    @pytest.fixture(autouse=True)
+    def _instant_poll_interval(self, monkeypatch):
+        """Drop ``_POLL_INTERVAL_SECONDS`` to zero for this class.
+
+        ``_poll_publish_progress`` sleeps the interval *before* its first status
+        query, so each of these tests paid the full 5s even though the very first
+        mocked response is terminal — 20s of pure wall-clock across the class. The
+        loop structure and exit conditions are unchanged by a zero interval; the
+        four tests that assert on timeout behaviour drive ``time.monotonic``
+        themselves and already patch ``time.sleep``, so they are unaffected.
+        """
+        monkeypatch.setattr(DesktopBotService, "_POLL_INTERVAL_SECONDS", 0)
+
     def test_poll_success_triggers_device_alive_instead_of_update_local_status(self):
         """SUCCESS 时应调 _trigger_device_alive(device_id)，不单独调 _update_local_status。"""
         service, mocks = _make_service_with_mocks()

--- a/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
+++ b/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
@@ -14,6 +14,29 @@ from agentclaw.community.core.service_bot.services.baas_service import BaasServi
 from agentclaw.community.plugin_api.passport import PassportError
 
 
+@pytest.fixture(autouse=True)
+def _no_real_polling_thread():
+    """Never let a test in this module spawn a real publish-polling daemon thread.
+
+    ``_start_publish_polling`` runs ``_poll_publish_progress`` on a
+    ``threading.Thread``, polling the BaaS publish endpoint every 5s for up to
+    180s. Two entry points reach it — ``restart()`` (``TestRestart``) and
+    ``create_after_authorization()`` → ``_execute_creation`` (``TestCreate``) —
+    and neither test class mocked it, so every such test left a live thread
+    retrying against an unreachable endpoint for three minutes. That outlived the
+    test, and once the suite got fast enough to finish inside the 180s window it
+    outlived the pytest session too: the thread then logged into an already-closed
+    capture stream, yielding `ValueError: I/O operation on closed file` noise at
+    the end of a run (~70 occurrences).
+
+    The three tests that assert polling *is* started re-patch the same attribute
+    themselves, which layers cleanly on top of this. ``TestPublishPolling`` calls
+    ``_poll_publish_progress`` directly and is unaffected.
+    """
+    with patch.object(DesktopBotService, "_start_publish_polling"):
+        yield
+
+
 class TestHelpers:
     def test_generate_request_id_consistent(self):
         a = _generate_request_id("bot1", "entity1", "staff", "dev", "create")
@@ -868,22 +891,36 @@ class TestVerifyOwnership:
 class TestPublishPolling:
     """Tests for publish progress polling logic."""
 
-    @pytest.fixture(autouse=True)
-    def _instant_poll_interval(self, monkeypatch):
-        """Drop ``_POLL_INTERVAL_SECONDS`` to zero for this class.
+    @pytest.fixture
+    def poll_service(self):
+        """Build a service whose poll loop does not sleep between queries.
 
-        ``_poll_publish_progress`` sleeps the interval *before* its first status
-        query, so each of these tests paid the full 5s even though the very first
-        mocked response is terminal — 20s of pure wall-clock across the class. The
-        loop structure and exit conditions are unchanged by a zero interval; the
-        four tests that assert on timeout behaviour drive ``time.monotonic``
-        themselves and already patch ``time.sleep``, so they are unaffected.
+        ``_poll_publish_progress`` sleeps ``_POLL_INTERVAL_SECONDS`` *before* its
+        first status query, so each of these tests paid the full 5s even though
+        the very first mocked response is terminal — 20s of pure wall-clock across
+        the class. The loop structure and exit conditions are unchanged by a zero
+        interval; the tests that assert on timeout behaviour drive
+        ``time.monotonic`` themselves and already patch ``time.sleep``.
+
+        The zero is set **per instance**, not on
+        ``DesktopBotService._POLL_INTERVAL_SECONDS``. Something in this suite
+        leaves a real ``_start_publish_polling`` daemon thread running against an
+        unreachable endpoint, and a class-level patch is visible to it: its 5s-paced
+        retry loop becomes a hot spin for the whole patch window. That was observed
+        directly — a full run logged 84 "query failed (will retry)" warnings from
+        that thread while a class-level patch was in place. An instance attribute
+        is invisible to it.
         """
-        monkeypatch.setattr(DesktopBotService, "_POLL_INTERVAL_SECONDS", 0)
+        def _make():
+            service, mocks = _make_service_with_mocks()
+            service._POLL_INTERVAL_SECONDS = 0
+            return service, mocks
 
-    def test_poll_success_triggers_device_alive_instead_of_update_local_status(self):
+        return _make
+
+    def test_poll_success_triggers_device_alive_instead_of_update_local_status(self, poll_service):
         """SUCCESS 时应调 _trigger_device_alive(device_id)，不单独调 _update_local_status。"""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         service._trigger_device_alive = MagicMock()
 
         with patch("httpx.Client") as mock_client:
@@ -904,9 +941,9 @@ class TestPublishPolling:
         # _update_local_status 不应再被单独调用（由 report_device_alive 内部处理）
         mocks["binding_repo"].update_status.assert_not_called()
 
-    def test_poll_failed_still_calls_update_local_status(self):
+    def test_poll_failed_still_calls_update_local_status(self, poll_service):
         """FAILED 时走原有 _update_local_status 逻辑。"""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         service._trigger_device_alive = MagicMock()
 
         with patch("httpx.Client") as mock_client:
@@ -928,14 +965,14 @@ class TestPublishPolling:
             binding_id="1", status="FAILED",
         )
 
-    def test_service_holds_device_service_reference(self):
+    def test_service_holds_device_service_reference(self, poll_service):
         """DesktopBotService 应持有 device_service 属性。"""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         assert hasattr(service, "_device_service")
         assert service._device_service is mocks["device_service"]
 
-    def test_poll_success_updates_status_to_active(self):
-        service, mocks = _make_service_with_mocks()
+    def test_poll_success_updates_status_to_active(self, poll_service):
+        service, mocks = poll_service()
         service._trigger_device_alive = MagicMock()
 
         with patch("httpx.Client") as mock_client:
@@ -961,8 +998,8 @@ class TestPublishPolling:
         # _update_local_status 不再被调用（由 report_device_alive 内部处理）
         mocks["binding_repo"].update_status.assert_not_called()
 
-    def test_poll_failed_updates_status_to_failed(self):
-        service, mocks = _make_service_with_mocks()
+    def test_poll_failed_updates_status_to_failed(self, poll_service):
+        service, mocks = poll_service()
 
         with patch("httpx.Client") as mock_client:
             mock_response = MagicMock()
@@ -989,9 +1026,9 @@ class TestPublishPolling:
 
     @patch("time.sleep", return_value=None)
     @patch("time.monotonic")
-    def test_poll_timeout_keeps_pending_and_sets_downloading(self, mock_monotonic, mock_sleep):
+    def test_poll_timeout_keeps_pending_and_sets_downloading(self, mock_monotonic, mock_sleep, poll_service):
         """Poll timeout should keep PENDING + ext.start_status=DOWNLOADING, delegate to periodic scan."""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         # Simulate time progression: start=0, then each call advances 10s
         # After 19 calls (190s > 180s timeout), loop exits
         call_count = [0]
@@ -1041,9 +1078,9 @@ class TestPublishPolling:
 
     @patch("time.sleep", return_value=None)
     @patch("time.monotonic")
-    def test_poll_retries_on_query_error(self, mock_monotonic, mock_sleep):
+    def test_poll_retries_on_query_error(self, mock_monotonic, mock_sleep, poll_service):
         """Network errors during polling are retried, not treated as failure."""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         service._trigger_device_alive = MagicMock()
         # time: 0, 5, 10 - within timeout
         mock_monotonic.side_effect = [0, 0, 5, 5, 10, 10]
@@ -1077,9 +1114,9 @@ class TestPublishPolling:
 
     @patch("time.sleep", return_value=None)
     @patch("time.monotonic")
-    def test_poll_uses_extended_timeout_for_non_default_engine(self, mock_monotonic, mock_sleep):
+    def test_poll_uses_extended_timeout_for_non_default_engine(self, mock_monotonic, mock_sleep, poll_service):
         """非默认引擎(如 claude_code)使用更长的轮询超时(600s 而非 180s)。"""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         # Simulate time progression: start=0, then each call advances 20s
         # After 10 calls (200s > 180s default timeout), loop should NOT exit
         # because extended timeout is 600s. After 31 calls (620s > 600s), it exits.
@@ -1162,8 +1199,8 @@ class TestPublishPolling:
     @patch(
         "agentclaw.community.core.desktop_bot.services.desktop_bot_service.DesktopBotService._start_publish_polling"
     )
-    def test_create_continue_starts_polling_when_publish_id_present(self, mock_start_poll):
-        service, mocks = _make_service_with_mocks()
+    def test_create_continue_starts_polling_when_publish_id_present(self, mock_start_poll, poll_service):
+        service, mocks = poll_service()
         mocks["passport"].query_agent_passport.return_value = {
             "agent_code": "ac-001",
         }
@@ -1191,8 +1228,8 @@ class TestPublishPolling:
     @patch(
         "agentclaw.community.core.desktop_bot.services.desktop_bot_service.DesktopBotService._start_publish_polling"
     )
-    def test_create_continue_skips_polling_when_no_publish_id(self, mock_start_poll):
-        service, mocks = _make_service_with_mocks()
+    def test_create_continue_skips_polling_when_no_publish_id(self, mock_start_poll, poll_service):
+        service, mocks = poll_service()
         mocks["passport"].query_agent_passport.return_value = {
             "agent_code": "ac-001",
         }
@@ -1210,8 +1247,8 @@ class TestPublishPolling:
     @patch(
         "agentclaw.community.core.desktop_bot.services.desktop_bot_service.DesktopBotService._start_publish_polling"
     )
-    def test_restart_starts_polling_when_publish_id_present(self, mock_start_poll):
-        service, mocks = _make_service_with_mocks()
+    def test_restart_starts_polling_when_publish_id_present(self, mock_start_poll, poll_service):
+        service, mocks = poll_service()
         _setup_local_lookup(mocks, bot_id="desktop_bot_001")
         mocks["baas"].restart_bot.return_value = {"publish_id": 5}
         mocks["baas"].approve_publish.return_value = {"status": "SUCCESS"}
@@ -1230,8 +1267,8 @@ class TestPublishPolling:
     @patch(
         "agentclaw.community.core.desktop_bot.services.desktop_bot_service.DesktopBotService._start_publish_polling"
     )
-    def test_restart_skips_polling_when_no_publish_id(self, mock_start_poll):
-        service, mocks = _make_service_with_mocks()
+    def test_restart_skips_polling_when_no_publish_id(self, mock_start_poll, poll_service):
+        service, mocks = poll_service()
         _setup_local_lookup(mocks, bot_id="desktop_bot_001", device_id="m-001")
         mocks["baas"].restart_bot.return_value = {}
 
@@ -1242,9 +1279,9 @@ class TestPublishPolling:
     @patch(
         "agentclaw.community.core.desktop_bot.services.desktop_bot_service.DesktopBotService._start_publish_polling"
     )
-    def test_restart_passes_engine_type_to_polling(self, mock_start_poll):
+    def test_restart_passes_engine_type_to_polling(self, mock_start_poll, poll_service):
         """重启时 active_engine 透传到 _start_publish_polling。"""
-        service, mocks = _make_service_with_mocks()
+        service, mocks = poll_service()
         _setup_local_lookup(mocks, bot_id="desktop_bot_001", active_engine="claude_code")
         mocks["baas"].restart_bot.return_value = {"publish_id": 5}
         mocks["baas"].approve_publish.return_value = {"status": "SUCCESS"}

--- a/src/backend/tests/community/core/harness/services/test_llm_request_retry.py
+++ b/src/backend/tests/community/core/harness/services/test_llm_request_retry.py
@@ -87,6 +87,20 @@ def _fresh_semaphore(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch):
+    """Collapse ``_retry_delay`` to zero for every test in this module.
+
+    ``_request_with_retry`` sleeps a real ``_RETRY_DELAYS`` backoff (2s / 5s / 10s
+    plus jitter) between attempts. What these tests assert is the *classification*
+    — how many attempts happen and with which body — never the wall-clock spacing,
+    so the sleeps are pure suite latency: they cost ~74s across this file alone.
+    Patch the delay source rather than ``asyncio.sleep`` so the retry loop's own
+    control flow stays exercised verbatim.
+    """
+    monkeypatch.setattr(llm_mod, "_retry_delay", lambda attempt: 0.0)
+
+
 def _llm(http: _ScriptedHttpClient) -> LLM:
     return LLM(
         base_url="http://llm.local",

--- a/src/backend/tests/community/core/resources/test_resource_file_service.py
+++ b/src/backend/tests/community/core/resources/test_resource_file_service.py
@@ -342,13 +342,23 @@ async def test_upload_empty_filename_raises():
 
 
 @pytest.mark.asyncio
-async def test_upload_too_large_raises():
-    from agentclaw.community.core.resources.services.file_service import MAX_FILE_SIZE
+async def test_upload_too_large_raises(monkeypatch):
+    # The real ceiling is 500MB. Materialising ``b"x" * (500MB + 1)`` to trip the
+    # ``len(data) > MAX_FILE_SIZE`` check cost ~11.6s of allocation alone — the
+    # single slowest non-retry test in the suite. Shrink the ceiling instead: the
+    # guard being asserted compares a length against this module global, so a
+    # 16-byte limit exercises exactly the same branch.
+    # ``resource_file_service`` binds the constant into its own namespace with
+    # ``from ... import MAX_FILE_SIZE``, so that is the name the guard reads.
+    from agentclaw.community.core.services import resource_file_service
+
+    monkeypatch.setattr(resource_file_service, "MAX_FILE_SIZE", 16)
 
     svc, _ = _svc(provider="arca", device_fs=MagicMock())
     with pytest.raises(ValueError):
         await svc.upload_file(
-            **_COORDS, target_dir="", filename="big.csv", data=b"x" * (MAX_FILE_SIZE + 1),
+            **_COORDS, target_dir="", filename="big.csv",
+            data=b"x" * (resource_file_service.MAX_FILE_SIZE + 1),
         )
 
 

--- a/src/backend/tests/community/core/skill_center/services/test_skill_publish_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_publish_service.py
@@ -7,6 +7,7 @@
   - 打包上传 (O1-O4)
   - SC_STATUS_MAP 映射 (M1-M8)
 """
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +25,16 @@ from agentclaw.community.plugins.local.oss_storage import MockObjectStoragePlugi
 # ── helpers ──────────────────────────────────────────────────────────
 
 
+# Every ``publish()`` / ``upgrade()`` test reaches ``_pack_and_upload``, which zips
+# the skill's ``git_path`` directory for real. Point the default at one tiny
+# directory created once for this module so each of those tests packs a single
+# file. The default used to be ``""``; ``_resolve_skill_dir("")`` hands back
+# ``Path("")`` — the process CWD — so every one of them zipped the whole
+# ``src/backend`` checkout (``.venv`` included, ~250MB) and took ~11s apiece.
+_DEFAULT_SKILL_DIR = Path(tempfile.mkdtemp(prefix="skill-publish-default-"))
+(_DEFAULT_SKILL_DIR / "SKILL.md").write_text("test")
+
+
 def _make_skill(**overrides) -> dict:
     """构造一个 skill dict，可按需覆盖字段。"""
     base = {
@@ -34,7 +45,7 @@ def _make_skill(**overrides) -> dict:
         "version": 1,
         "skill_uuid": "uuid-abc",
         "link_name": "test-skill",
-        "git_path": "",
+        "git_path": str(_DEFAULT_SKILL_DIR),
         "source_type": "git",
         "category": "general",
         "tags": "[]",
@@ -586,6 +597,21 @@ class TestPackAndUpload:
         svc, _, _, _, oss = _make_service(skill=skill)
 
         with pytest.raises(FileNotFoundError, match="技能目录不存在"):
+            svc.publish("1")
+
+        oss.put_object.assert_not_called()
+
+    def test_empty_git_path_raises_instead_of_packing_cwd(self):
+        """O5: git_path 为空 → FileNotFoundError，绝不打包 CWD。
+
+        ``_resolve_skill_dir("")`` returns ``Path("")``, which normalises to the
+        process CWD and passes ``is_dir()``. Without the empty-``git_path`` guard
+        the packer would zip the whole working directory and upload it to OSS.
+        """
+        skill = _make_skill(status="DEVELOPING", git_path="")
+        svc, _, _, _, oss = _make_service(skill=skill)
+
+        with pytest.raises(FileNotFoundError, match="git_path 为空"):
             svc.publish("1")
 
         oss.put_object.assert_not_called()

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -35,6 +35,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "respx" },
     { name = "ruff" },
@@ -71,6 +72,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "responses", specifier = ">=0.26.1" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.14.13" },
@@ -349,6 +351,15 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e" },
     { url = "https://mirrors.aliyun.com/pypi/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b" },
     { url = "https://mirrors.aliyun.com/pypi/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec" },
 ]
 
 [[package]]
@@ -803,6 +814,19 @@ dependencies = [
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The backend community suite takes over 10 minutes. In CI the `Backend unit
tests` gate spent **665s** on its test step; locally a serial run was 573s. That
is slow enough that contributors skip it and CI feedback is late.

Profiling turned up three separate causes, in increasing order of how much they
cost:

**1. The suite ran single-threaded.** ~10.6k tests, one process.

**2. Five test files did real work no assertion depended on** (~180s of the 573s
serial run):

| Test | Cost | What it was actually doing |
| --- | --- | --- |
| `test_skill_publish_service.py::TestPublish` | ~70s | Zipping the entire `src/backend` checkout — `.venv` included, 213MB / 12.7k files — once per test |
| `test_llm_request_retry.py` | ~74s | Sleeping the real `_RETRY_DELAYS` backoff (2s/5s/10s + jitter) between retry attempts |
| `test_resource_file_service.py::test_upload_too_large_raises` | ~11.6s | Materialising a 500MB `bytes` object to trip a `len(data) > MAX_FILE_SIZE` check |
| `test_desktop_bot_service.py::TestPublishPolling` | ~20s | Sleeping the 5s poll interval before reading an already-terminal mocked response |
| `test_sync_to_downstream.py` | ~6s | Sleeping the exponential retry backoff before asserting a call count |

The zip case is the notable one. The default test skill had `git_path=""`;
`_resolve_skill_dir("")` returns `Path("")`, which normalises to `PosixPath('.')`
— the process CWD. `Path("").is_dir()` is `True`, so `_pack_and_upload`'s
fail-fast guard waved it through and the packer zipped the working directory.
That is not only slow: in production, publishing a skill with an empty
`git_path` would zip the backend's whole working directory and upload it to OSS.

**3. Under `--cov`, the coverage tracer dominated everything else.** This only
became visible after fixing 1 and 2: the first CI run on this branch came in at
471s, a 29% improvement, against a 4.2× improvement measured locally *without*
coverage. The gap was the tracer.

## Solution

**Parallelism.** `pytest-xdist` with `-n auto --dist loadfile`. The suite needed
no isolation work: xdist workers are separate processes, so the in-memory SQLite
engine (`StaticPool`, module-level singleton), the DI singletons and the shared
FastAPI `app` object are already per-worker. `--dist loadfile` keeps a file's
tests on one worker, preserving file-local ordering. Behind
`BACKEND_CI_PYTEST_WORKERS` (default `auto`; `0` disables xdist for `--pdb`).

**Coverage core.** `COVERAGE_CORE=sysmon` selects coverage.py's PEP 669
(`sys.monitoring`) backend, available on the pinned 3.12 interpreter. Measured
on the full suite under `-n 4`: **418.56s default core vs 214.60s sysmon**, same
85% total. Only line coverage is collected (no `--cov-branch`), which is what
sysmon supports well before 3.14. `BACKEND_CI_COVERAGE_CORE=ctrace` falls back.

**The five slow tests.** Each fix removes work no assertion depended on:

- `_pack_and_upload` rejects an empty `git_path` instead of packing the CWD. The
  default test skill points at a one-file temp dir; a new test pins the guard.
- `_retry_delay` patched to `0.0` — the delay *source*, not `asyncio.sleep`, so
  the retry loop's control flow still runs verbatim. Those tests assert attempt
  counts and request bodies, never spacing.
- The file-size test shrinks `MAX_FILE_SIZE` to 16 bytes. Same branch, same guard.
- `_POLL_INTERVAL_SECONDS` drops to `0` for the polling tests — on the service
  *instance*, see below.
- `sync_to_downstream`'s inlined `2 ** (attempt - 1)` becomes
  `RETRY_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1)`, giving the test a seam.
  `monkeypatch.setattr(module.time, "sleep", ...)` was rejected — it patches the
  stdlib `time` module process-wide.

**A leaked daemon thread, surfaced by the speedup.** `_start_publish_polling`
runs `_poll_publish_progress` on a `threading.Thread` that polls BaaS every 5s
for up to 180s. Both `restart()` and `create_after_authorization()` reach it, and
neither `TestRestart` nor `TestCreate` mocked it — so those tests have always
left live threads retrying an unreachable endpoint for three minutes. That was
invisible only because the suite used to take *longer* than the poll window; now
that it finishes inside 180s, the threads outlive the pytest session and log into
a closed capture stream (~70 `I/O operation on closed file` tracebacks per run).
A module-level autouse fixture patches the spawn point out; the three tests that
assert polling *starts* re-patch it themselves.

This also forced `TestPublishPolling`'s zero interval onto the service instance
rather than the class: a class-level patch is visible to those leaked threads and
turns their 5s retry loop into a hot spin — one run logged 84 retry warnings from
a single thread.

Two production files change (`skill_publish_service.py`,
`sync_to_downstream.py`); everything else is test- or CI-side.

## Validation

### CI — `Backend unit tests`, `Run unit tests with coverage` step (includes `uv sync --frozen`), 4-core `ubuntu-latest`

| | Step | pytest itself |
| --- | --- | --- |
| `dev` baseline ([run 30988490273](https://github.com/inclusionAI/Avernet/actions/runs/30988490273)) | 665s — 11m05s | — |
| xdist + test fixes ([run 31022545162](https://github.com/inclusionAI/Avernet/actions/runs/31022545162)) | 471s — 7m51s | 444.81s |
| **+ sysmon + thread-leak fix** ([run 31027013217](https://github.com/inclusionAI/Avernet/actions/runs/31027013217)) | **191s — 3m11s** | **172.88s** |

**3.5× faster in CI.** All 7 checks green on both commits.

Coverage is unaffected by the sysmon switch — the gate output is identical
except for 2 statements out of 66,352 (0.003%, thread-timing noise):

| | line coverage | change-line | TOTAL missed |
| --- | --- | --- | --- |
| default core | 85.15% | 100.00% (5/5) | 9851 / 66352 |
| sysmon | 85.15% | 100.00% (5/5) | 9853 / 66352 |

`backend CI gate passed`, `case pass rate: 100.00% (10688/10688)`, workers
`gw0`–`gw3`, and **zero** poller warnings / closed-file tracebacks in the CI log.

### Locally, isolating each contribution

Full suite, 4 cores, `10640 passed, 3 skipped` in every configuration:

| Configuration | Wall clock |
| --- | --- |
| Baseline (`dev`, serial, no coverage) | 573s |
| Serial + the five test fixes | 359s |
| xdist `-n 4` only, no test fixes | 189s |
| xdist `-n 4` + test fixes | 137s |
| xdist + fixes + **coverage**, default core | 418.56s |
| xdist + fixes + **coverage**, sysmon | 214.60s |
| Final (all changes, coverage + sysmon) | 197.87s |

Baseline collects 10,639 tests; this branch 10,640 — the extra one is the new
empty-`git_path` guard test. (CI collects 10,688: a different environment enables
some tests this sandbox skips.)

- Parallel correctness: the xdist-only run was made *before* any test change, so
  the 189s figure isolates parallelism, and it passed clean — no test depends on
  cross-file ordering or on state shared between workers.
- The disk-leak guard in `pytest_sessionfinish` was checked under `-n 2`: with a
  planted `backend.db` it still fails the run (exit 1).
- The final local run has zero poller warnings and zero closed-file tracebacks,
  down from ~70.
- `ruff check` passes on every changed file.

Remaining hot spots, deliberately left alone: the architecture tests AST-walk the
source tree (~25s total, real work) and several repository tests sleep 1–2s
because SQLite's `CURRENT_TIMESTAMP` is second-granular (~15s, needs a
clock-injection seam). Both parallelise across workers.

## Compatibility and risk

`_pack_and_upload` raising on an empty `git_path` is a behaviour change: a
publish that previously produced a garbage archive of the server's working
directory now fails fast with `FileNotFoundError`. Every other call shape —
`git://`, `local://`, absolute paths, missing directories — is untouched.

`COVERAGE_CORE=sysmon` changes how coverage is measured, not what is gated. Two
CI runs agree to within 0.003% and the reported percentage is identical. If it
ever misbehaves, `BACKEND_CI_COVERAGE_CORE=ctrace` restores the old core without
a revert. Note it is a poor fit for branch coverage before Python 3.14 — if
`--cov-branch` is ever added here, revisit this.

`uv.lock` was extended by hand (+24 lines: `pytest-xdist`, `execnet`) rather than
regenerated. The lock pins `mirrors.aliyun.com` URLs the authoring sandbox could
not reach, and re-resolving through PyPI would have rewritten all 504 of them.
The added entries use the mirror's URL scheme with upstream sha256 digests;
`uv lock --check` reports the lock consistent with `pyproject.toml`, and CI's
`uv sync --frozen` installed from it successfully on both commits.

Rollback: `BACKEND_CI_PYTEST_WORKERS=0` and/or `BACKEND_CI_COVERAGE_CORE=ctrace`
restore the previous behaviour without reverting code.