### PR TITLE
fix: correct ARCA runtime spelling

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -71,7 +71,7 @@ from agentclaw.community.core.workspace.path_factory import (
 )
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     apply_default_image_to_ext,
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
@@ -376,7 +376,7 @@ class BotService:
         self,
         bot: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Mark a draft ARKA bot to follow the provider default image."""
+        """Mark a draft ARCA bot to follow the provider default image."""
         if bot.get("bot_type") != "service" or self.is_teclaw_bot(
             bot.get("active_engine")
         ):
@@ -1304,7 +1304,7 @@ class BotService:
         if resolved_bot_type == "service" and not self.is_teclaw_bot(
             resolved_active_engine
         ):
-            # New ARKA service bots intentionally follow the provider default.
+            # New ARCA service bots intentionally follow the provider default.
             # Persist an explicit marker so their future publish records are not
             # mistaken for legacy records that require Pin compatibility.
             ext = apply_default_image_to_ext(ext)

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
@@ -15,7 +15,7 @@ from agentclaw.community.core.events.types import DeviceAliveEvent
 from agentclaw.community.core.service_bot.repository.bot_publish_repository import (
     BotPublishRepositoryProtocol,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     persist_default_image_policy,
 )
 from agentclaw.community.kernel.lifecycle import LifecycleBase

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -9,7 +9,7 @@ from agentclaw.community.core.bot_management.utils import clear_baas_publish_fai
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.events.bus import get_event_bus
 from agentclaw.community.core.events.types import BaasPublishCompletedEvent
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     persist_default_image_policy,
 )
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry

--- a/src/backend/src/agentclaw/community/core/expert_chat/README.md
+++ b/src/backend/src/agentclaw/community/core/expert_chat/README.md
@@ -13,7 +13,7 @@ consumes:
   - "BotRepository"
   - "DeviceService + DeviceContextResolver"
   - "ServiceBot repo + BaasService"
-  - "CommonConfigService (legacy ARKA image policy resolution)"
+  - "CommonConfigService (legacy ARCA image policy resolution)"
   - "SkillSync guard"
   - "CollaboratorService (chat 权限校验)"
 internal_dependencies:

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -57,7 +57,7 @@ from agentclaw.community.core.service_bot.services.baas_service import (
     BaasServiceError,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     PublishImagePolicyResolver,
 )
 from agentclaw.community.core.service_bot.types import PublishStage

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
@@ -1,6 +1,6 @@
-"""ARKA service-bot image policy helpers.
+"""ARCA service-bot image policy helpers.
 
-New bots and successful draft restarts explicitly opt into the BaaS/ARKA
+New bots and successful draft restarts explicitly opt into the BaaS/ARCA
 default image. Published operations are reproducible: they read only the target
 publish record. Records created before the policy existed are lazily protected
 by the environment common-config and snapshot the configured image once.
@@ -28,9 +28,10 @@ IMAGE_POLICY_KEYS = (
     IMAGE_PIN_VALUE_KEY,
 )
 SERVICE_BOT_RUNTIME_KIND_KEY = "sbot_runtime_kind"
-RUNTIME_KIND_ARKA = "arka"
+RUNTIME_KIND_ARCA = "arca"
 RUNTIME_KIND_TECLAW = "teclaw"
-_RUNTIME_KINDS = {RUNTIME_KIND_ARKA, RUNTIME_KIND_TECLAW}
+_RUNTIME_KINDS = {RUNTIME_KIND_ARCA, RUNTIME_KIND_TECLAW}
+_LEGACY_RUNTIME_KIND_TYPO = "arka"
 
 
 
@@ -64,7 +65,7 @@ class ServiceBotImagePin:
 PublishExtWriter = Callable[[dict[str, Any]], None]
 
 
-def resolve_current_arka_image(
+def resolve_current_arca_image(
     common_config_service: CommonConfigService | None,
     *,
     env: str,
@@ -97,7 +98,7 @@ def runtime_kind_from_provider(device_provider: str | None) -> str | None:
     if device_provider == RUNTIME_KIND_TECLAW:
         return RUNTIME_KIND_TECLAW
     if device_provider in {"arca", "baas"}:
-        return RUNTIME_KIND_ARKA
+        return RUNTIME_KIND_ARCA
     return None
 
 
@@ -119,10 +120,12 @@ def resolve_publish_runtime_kind(
 
     New records carry ``sbot_runtime_kind``. Historical TeClaw records are
     recognized from their config artifact or stage bindings; the final fallback
-    is ARKA because ARKA predates the external-runtime publish format.
+    is ARCA because ARCA predates the external-runtime publish format.
     """
     ext = publish_record.ext or {}
     explicit = ext.get(SERVICE_BOT_RUNTIME_KIND_KEY)
+    if explicit == _LEGACY_RUNTIME_KIND_TYPO:
+        return RUNTIME_KIND_ARCA
     if explicit in _RUNTIME_KINDS:
         return explicit
 
@@ -143,10 +146,10 @@ def resolve_publish_runtime_kind(
                 return kind
 
     logger.warning(
-        "[arka_image_pin] publish runtime kind missing; using legacy ARKA fallback: publish_id=%s",
+        "[arca_image_pin] publish runtime kind missing; using legacy ARCA fallback: publish_id=%s",
         publish_record.id,
     )
-    return RUNTIME_KIND_ARKA
+    return RUNTIME_KIND_ARCA
 
 
 def has_explicit_image_policy(ext: dict[str, Any] | None) -> bool:
@@ -235,7 +238,7 @@ def resolve_publish_image_pin(
             f"Publish {publish_record.id} has an inconsistent image policy snapshot"
         )
 
-    image = resolve_current_arka_image(
+    image = resolve_current_arca_image(
         common_config_service,
         env=env or publish_record.env,
     )
@@ -247,7 +250,7 @@ def resolve_publish_image_pin(
         persist_ext(pinned_ext)
     publish_record.ext = pinned_ext
     logger.info(
-        "[arka_image_pin] snapshotted legacy publish image: publish_id=%s env=%s image=%s",
+        "[arca_image_pin] snapshotted legacy publish image: publish_id=%s env=%s image=%s",
         publish_record.id,
         env or publish_record.env,
         image,
@@ -344,7 +347,7 @@ class PublishImagePolicyResolver:
                 publish_record.ext = latest.ext
                 return resolve_publish_image_pin(latest)
 
-            image = resolve_current_arka_image(
+            image = resolve_current_arca_image(
                 self._common_config_service, env=latest.env
             )
             if image is None:
@@ -360,7 +363,7 @@ class PublishImagePolicyResolver:
             if updated is not None:
                 publish_record.ext = updated.ext
                 logger.info(
-                    "[arka_image_pin] snapshotted legacy publish image: "
+                    "[arca_image_pin] snapshotted legacy publish image: "
                     "publish_id=%s env=%s image=%s",
                     updated.id,
                     updated.env,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -26,14 +26,14 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
     PublishStatusInvalidError,
 )
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     apply_image_pin_to_ext,
     copy_image_policy_to_ext,
     has_explicit_image_policy,
-    resolve_current_arka_image,
+    resolve_current_arca_image,
     apply_runtime_kind_to_ext,
     runtime_kind_from_provider,
-    RUNTIME_KIND_ARKA,
+    RUNTIME_KIND_ARCA,
     RUNTIME_KIND_TECLAW,
     PublishImagePolicyResolver,
     ServiceBotImagePin,
@@ -249,22 +249,22 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 runtime_kind = (
                     RUNTIME_KIND_TECLAW
                     if self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
-                    else RUNTIME_KIND_ARKA
+                    else RUNTIME_KIND_ARCA
                 )
             ext = apply_runtime_kind_to_ext(ext, runtime_kind)
 
         # A new/default Bot carries an explicit marker and never consumes the
-        # legacy Pin switch. A pre-feature ARKA Bot has no policy marker; when
+        # legacy Pin switch. A pre-feature ARCA Bot has no policy marker; when
         # protection is enabled, freeze the configured image on the new publish
         # record so all published operations remain reproducible.
-        is_legacy_arka_service = (
+        is_legacy_arca_service = (
             isinstance(source_bot, dict)
             and source_bot.get("bot_type") == "service"
             and not self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
             and not has_explicit_image_policy(source_bot_ext)
         )
-        if is_legacy_arka_service:
-            legacy_image = resolve_current_arka_image(
+        if is_legacy_arca_service:
+            legacy_image = resolve_current_arca_image(
                 self._common_config_service, env=self._env
             )
             if legacy_image:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
@@ -1,9 +1,9 @@
-"""Publish-record ARKA image-policy resolution."""
+"""Publish-record ARCA image-policy resolution."""
 
 from __future__ import annotations
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
 )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -26,7 +26,7 @@ from agentclaw.community.core.service_bot.repository.models import (
 )
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
 )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     RUNTIME_KIND_TECLAW,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -158,10 +158,10 @@ class TestCreateBotBcnRegister:
         svc = _make_service()
         device_service = _attach_device_service(svc)
         common_config = MagicMock()
-        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        common_config.get_value.return_value = {"image": "registry/arca:v2"}
         svc._common_config_service = common_config
         template_config = {
-            "image": "registry/arka:v1",
+            "image": "registry/arca:v1",
             "envs": {"A": "1"},
         }
 
@@ -184,10 +184,10 @@ class TestCreateBotBcnRegister:
         }
         apply_kwargs = device_service.apply_device.call_args.kwargs
         assert apply_kwargs["template_config"] == {
-            "image": "registry/arka:v1",
+            "image": "registry/arca:v1",
             "envs": {"A": "1"},
         }
-        assert template_config["image"] == "registry/arka:v1"
+        assert template_config["image"] == "registry/arca:v1"
         common_config.get_value.assert_not_called()
 
     def test_claude_code_application_coding_does_not_trigger_bcn_register(self):

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -128,7 +128,7 @@ def _make_bot(
 
 class TestRestartBaasImagePolicy:
     def test_low_level_restart_uses_explicit_pin_without_mutating_template_snapshot(self):
-        template_config = {"image": "registry/arka:v1", "envs": {"A": "1"}}
+        template_config = {"image": "registry/arca:v1", "envs": {"A": "1"}}
         svc, baas, _ = _make_service(
             template_config=template_config,
             bot_type="service",
@@ -138,7 +138,7 @@ class TestRestartBaasImagePolicy:
             **_make_bot(bot_type="service", active_engine="openclaw"),
             "ext": {
                 "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_docker_image": "registry/arca:v2",
             },
         }
 
@@ -147,10 +147,10 @@ class TestRestartBaasImagePolicy:
         )
 
         assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
-            "image": "registry/arka:v2",
+            "image": "registry/arca:v2",
             "envs": {"A": "1"},
         }
-        assert template_config["image"] == "registry/arka:v1"
+        assert template_config["image"] == "registry/arca:v1"
 
     def test_restart_failure_does_not_persist_default_marker(self):
         svc, baas, _ = _make_service(
@@ -163,7 +163,7 @@ class TestRestartBaasImagePolicy:
             **_make_bot(bot_type="service", active_engine="openclaw"),
             "ext": {
                 "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_docker_image": "registry/arca:v2",
             },
         }
 
@@ -182,7 +182,7 @@ class TestRestartBaasImagePolicy:
         ("bot_type", "active_engine"),
         [("personal", "openclaw"), ("service", "teclaw")],
     )
-    def test_default_persistence_skips_non_arka_service_bot(
+    def test_default_persistence_skips_non_arca_service_bot(
         self,
         bot_type: str,
         active_engine: str,
@@ -196,7 +196,7 @@ class TestRestartBaasImagePolicy:
             **_make_bot(bot_type=bot_type, active_engine=active_engine),
             "ext": {
                 "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_docker_image": "registry/arca:v2",
             },
         }
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -945,7 +945,7 @@ class TestRestartGuardOrchestration:
         """草稿重启提交时只透传 DEFAULT intent，成功前不持久化标记。"""
         repo = FakeRestartLockRepo()
         common_config = MagicMock()
-        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        common_config.get_value.return_value = {"image": "registry/arca:v2"}
         bot = {
             **_make_bot(status="ACTIVE", binding_id=42, bot_type="service"),
             "ext": {"service_bot_config": {"device_count": 3}},
@@ -958,7 +958,7 @@ class TestRestartGuardOrchestration:
             task_queue_service=MagicMock(),
         )
         svc._template_service.get_template_config.return_value = {
-            "image": "registry/arka:v1",
+            "image": "registry/arca:v1",
             "envs": {"A": "1"},
         }
         device_service = MagicMock()
@@ -980,7 +980,7 @@ class TestRestartGuardOrchestration:
         assert payload["image_policy_on_success"] == "default"
         upgrade_kwargs = baas.upgrade_bot.call_args.kwargs
         assert upgrade_kwargs["template_config"] == {
-            "image": "registry/arka:v1",
+            "image": "registry/arca:v1",
             "envs": {"A": "1"},
         }
 

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -22,7 +22,7 @@ from agentclaw.community.core.service_bot.services.baas_service import (
     BaasServiceError,
     BotWsConnectionInfoResponse,
 )
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePolicyState,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -55,7 +55,7 @@ class MockPublishRecord:
             self.ext = {
                 "migration_path": "/nas/migration/path",
                 "sbot_use_default_image": True,
-                "sbot_runtime_kind": "arka",
+                "sbot_runtime_kind": "arca",
             }
 
 
@@ -150,7 +150,7 @@ def _wire_bot_build_service_async(bot_build_service, create_result=None, upgrade
 
 
 class TestResolvePublishImagePin:
-    def test_teclaw_skips_arka_policy_resolution(self):
+    def test_teclaw_skips_arca_policy_resolution(self):
         svc, _, baas, _, bot_repo, *_ = _make_service()
         record = MockPublishRecord(
             ext={"migration_path": "/nas/path", "sbot_runtime_kind": "teclaw"}
@@ -173,7 +173,7 @@ class TestResolvePublishImagePin:
         svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
             common_config_service=common_config
         )
-        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        common_config.get_value.return_value = {"image": "registry/arca:v2"}
         record = MockPublishRecord(ext={"migration_path": "/nas/path"})
         latest = MockPublishRecord(
             ext={"migration_path": "/nas/path", "unrelated": "preserved"}
@@ -193,10 +193,10 @@ class TestResolvePublishImagePin:
         )
 
         assert resolved.state == ImagePolicyState.PINNED
-        assert resolved.docker_image == "registry/arka:v2"
+        assert resolved.docker_image == "registry/arca:v2"
         assert latest.ext["unrelated"] == "preserved"
         assert latest.ext["sbot_pin_image"] is True
-        assert latest.ext["sbot_docker_image"] == "registry/arka:v2"
+        assert latest.ext["sbot_docker_image"] == "registry/arca:v2"
         assert record.ext == latest.ext
 
     def test_concurrent_explicit_policy_is_not_overwritten(self):
@@ -204,7 +204,7 @@ class TestResolvePublishImagePin:
         svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
             common_config_service=common_config
         )
-        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        common_config.get_value.return_value = {"image": "registry/arca:v2"}
         record = MockPublishRecord(ext={"migration_path": "/nas/path"})
         latest = MockPublishRecord(
             ext={"migration_path": "/nas/path", "sbot_use_default_image": True}
@@ -226,7 +226,7 @@ class TestResolvePublishImagePin:
         svc, _, baas, publish_repo, bot_repo, *_ = _make_service(
             common_config_service=common_config
         )
-        common_config.get_value.return_value = {"image": "registry/arka:v2"}
+        common_config.get_value.return_value = {"image": "registry/arca:v2"}
         record = MockPublishRecord(ext={"migration_path": "/nas/path"})
         latest = MockPublishRecord(ext={"migration_path": "/nas/path"})
         publish_repo.get_by_id.return_value = latest
@@ -382,7 +382,7 @@ class TestCreateContainer:
             USER_ID,
             migration_path="/nas/path",
             version=2,
-            docker_image="registry/arka:v2",
+            docker_image="registry/arca:v2",
         )
 
         bot_build_service.release_async.assert_called_once()
@@ -393,7 +393,7 @@ class TestCreateContainer:
         assert call_kwargs["device_count"] == 1
         assert call_kwargs["publish_stage"] == PublishStage.ONLINE
         assert call_kwargs["version"] == "2"
-        assert call_kwargs["docker_image"] == "registry/arka:v2"
+        assert call_kwargs["docker_image"] == "registry/arca:v2"
 
 
 class TestUpgradeContainer:
@@ -455,7 +455,7 @@ class TestUpgradeContainer:
             OWNER_ID,
             migration_path="/nas/path",
             version=3,
-            docker_image="registry/arka:v2",
+            docker_image="registry/arca:v2",
         )
 
         bot_build_service.upgrade_async.assert_called_once()
@@ -467,7 +467,7 @@ class TestUpgradeContainer:
         assert call_kwargs["device_count"] == 1
         assert call_kwargs["publish_stage"] == PublishStage.ONLINE
         assert call_kwargs["version"] == "3"
-        assert call_kwargs["docker_image"] == "registry/arka:v2"
+        assert call_kwargs["docker_image"] == "registry/arca:v2"
 
 
 class TestBuildConnection:
@@ -1213,7 +1213,7 @@ class TestGetCallerConnectionEdgeCases:
             ext={
                 "migration_path": "/path",
                 "sbot_use_default_image": True,
-                "sbot_runtime_kind": "arka",
+                "sbot_runtime_kind": "arca",
             },
         )
         record.version = None

--- a/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePinPersistenceError,
     ImagePinConfigError,
     ImagePolicyState,
     PublishImagePolicyResolver,
-    RUNTIME_KIND_ARKA,
+    RUNTIME_KIND_ARCA,
     RUNTIME_KIND_TECLAW,
     apply_default_image_to_ext,
     apply_image_pin_to_ext,
@@ -18,9 +18,10 @@ from agentclaw.community.core.service_bot.services.arka_image_pin import (
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
-    resolve_current_arka_image,
+    resolve_current_arca_image,
     resolve_publish_image_pin,
     resolve_publish_runtime_kind,
+    runtime_kind_from_provider,
 )
 
 
@@ -44,9 +45,9 @@ def _record(ext=None) -> BotPublishRecord:
 
 def test_resolve_current_image_uses_enabled_common_config():
     service = MagicMock()
-    service.get_value.return_value = {"image": " registry.example/arka:v2 "}
+    service.get_value.return_value = {"image": " registry.example/arca:v2 "}
 
-    assert resolve_current_arka_image(service, env="pre") == "registry.example/arka:v2"
+    assert resolve_current_arca_image(service, env="pre") == "registry.example/arca:v2"
     service.get_value.assert_called_once_with(
         business_code="service_bot",
         param_code="sbot_pin_image",
@@ -60,16 +61,16 @@ def test_resolve_current_image_returns_none_for_disabled_or_missing_config():
     service = MagicMock()
     service.get_value.return_value = None
 
-    assert resolve_current_arka_image(service, env="pre") is None
+    assert resolve_current_arca_image(service, env="pre") is None
 
 
-@pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arka:v2"])
+@pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arca:v2"])
 def test_resolve_current_image_rejects_enabled_malformed_config(value):
     service = MagicMock()
     service.get_value.return_value = value
 
     with pytest.raises(ImagePinConfigError, match="has no valid image"):
-        resolve_current_arka_image(service, env="pre")
+        resolve_current_arca_image(service, env="pre")
 
 
 def test_apply_pin_preserves_service_bot_config_and_clears_stale_pin():
@@ -106,7 +107,7 @@ def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     source = {
         "service_bot_config": {"device_count": 3},
         "sbot_pin_image": True,
-        "sbot_docker_image": "arka:v2",
+        "sbot_docker_image": "arca:v2",
     }
     target = {"config_artifact": {"schema_version": 4}}
     template = {"image": "template:v1", "envs": {"A": "1"}}
@@ -114,10 +115,10 @@ def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
     assert copy_image_policy_to_ext(source, target) == {
         "config_artifact": {"schema_version": 4},
         "sbot_pin_image": True,
-        "sbot_docker_image": "arka:v2",
+        "sbot_docker_image": "arca:v2",
     }
     assert overlay_image_pin_on_template_config(template, source) == {
-        "image": "arka:v2",
+        "image": "arca:v2",
         "envs": {"A": "1"},
     }
     assert template["image"] == "template:v1"
@@ -138,7 +139,7 @@ def test_publish_copy_supports_default_and_clears_stale_target_policy():
 
 
 def test_resolve_publish_image_pin_reads_only_publish_ext():
-    record = _record({"sbot_pin_image": True, "sbot_docker_image": "arka:v2"})
+    record = _record({"sbot_pin_image": True, "sbot_docker_image": "arca:v2"})
     common_config = MagicMock()
 
     resolved = resolve_publish_image_pin(
@@ -147,7 +148,7 @@ def test_resolve_publish_image_pin_reads_only_publish_ext():
 
     assert resolved.enabled is True
     assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "arka:v2"
+    assert resolved.docker_image == "arca:v2"
     common_config.get_value.assert_not_called()
 
 
@@ -182,7 +183,7 @@ def test_resolve_legacy_publish_with_disabled_config_keeps_platform_default():
 
 def test_resolve_legacy_publish_snapshots_pin_before_use():
     common_config = MagicMock()
-    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    common_config.get_value.return_value = {"image": "registry/arca:v2"}
     persist = MagicMock()
     record = _record({"migration_path": "/build/v1"})
 
@@ -195,10 +196,10 @@ def test_resolve_legacy_publish_snapshots_pin_before_use():
     expected_ext = {
         "migration_path": "/build/v1",
         "sbot_pin_image": True,
-        "sbot_docker_image": "registry/arka:v2",
+        "sbot_docker_image": "registry/arca:v2",
     }
     assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "registry/arka:v2"
+    assert resolved.docker_image == "registry/arca:v2"
     persist.assert_called_once_with(expected_ext)
     assert record.ext == expected_ext
 
@@ -210,7 +211,7 @@ def test_resolve_rejects_pin_without_image():
 
 def test_resolve_rejects_dangling_image_policy_field():
     with pytest.raises(ImagePinConfigError, match="inconsistent image policy"):
-        resolve_publish_image_pin(_record({"sbot_docker_image": "arka:v2"}))
+        resolve_publish_image_pin(_record({"sbot_docker_image": "arca:v2"}))
 
 
 def test_runtime_kind_prefers_publish_snapshot():
@@ -237,15 +238,26 @@ def test_runtime_kind_reads_string_stage_binding_provider():
 
     assert (
         resolve_publish_runtime_kind(record, binding_repository=binding_repo)
-        == RUNTIME_KIND_ARKA
+        == RUNTIME_KIND_ARCA
     )
     binding_repo.get_by_id.assert_called_once_with(42)
 
 
+@pytest.mark.parametrize("provider", ["arca", "baas"])
+def test_runtime_kind_from_arca_provider_uses_canonical_spelling(provider):
+    assert runtime_kind_from_provider(provider) == "arca"
+
+
+def test_runtime_kind_normalizes_legacy_arka_publish_snapshot():
+    record = _record({"sbot_runtime_kind": "arka"})
+
+    assert resolve_publish_runtime_kind(record) == "arca"
+
+
 def test_apply_runtime_kind_preserves_unrelated_ext():
-    assert apply_runtime_kind_to_ext({"migration_path": "/build/v1"}, "arka") == {
+    assert apply_runtime_kind_to_ext({"migration_path": "/build/v1"}, "arca") == {
         "migration_path": "/build/v1",
-        "sbot_runtime_kind": "arka",
+        "sbot_runtime_kind": "arca",
     }
 
 
@@ -256,14 +268,14 @@ def test_persisted_resolver_returns_successful_cas_snapshot():
             "migration_path": "/build/v1",
             "unrelated": "keep",
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         }
     )
     publish_repo = MagicMock()
     publish_repo.get_by_id.return_value = legacy
     publish_repo.compare_and_set_ext.return_value = persisted
     common_config = MagicMock()
-    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
         binding_repository=MagicMock(),
@@ -274,7 +286,7 @@ def test_persisted_resolver_returns_successful_cas_snapshot():
     resolved = resolver.resolve(original)
 
     assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "registry/arka:v2"
+    assert resolved.docker_image == "registry/arca:v2"
     assert original.ext == persisted.ext
     publish_repo.compare_and_set_ext.assert_called_once_with(
         publish_id=legacy.id,
@@ -313,7 +325,7 @@ def test_persisted_resolver_reloads_concurrent_default_after_cas_conflict():
     publish_repo.get_by_id.side_effect = [legacy, concurrent_default]
     publish_repo.compare_and_set_ext.return_value = None
     common_config = MagicMock()
-    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
         binding_repository=MagicMock(),
@@ -334,7 +346,7 @@ def test_persisted_resolver_fails_closed_after_repeated_cas_conflicts():
     publish_repo.get_by_id.return_value = legacy
     publish_repo.compare_and_set_ext.return_value = None
     common_config = MagicMock()
-    common_config.get_value.return_value = {"image": "registry/arka:v2"}
+    common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
         binding_repository=MagicMock(),

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_scale_bot.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_scale_bot.py
@@ -76,13 +76,13 @@ class TestBaasServiceScaleBot:
             request_id="req-1",
             target_count=3,
             config={
-                "deploy_config": {"docker_image": "registry/arka:v2"},
+                "deploy_config": {"docker_image": "registry/arca:v2"},
             },
         )
 
         assert http.calls_to("post")[0].kwargs["json"]["config"] == {
             "deploy_config": {
-                "docker_image": "registry/arka:v2",
+                "docker_image": "registry/arca:v2",
             },
         }
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -102,11 +102,11 @@ def test_release_routes_arca_pinned_image_to_template_config():
         user_id="u1",
         migration_path="/m/1",
         publish_stage=PublishStage.VERIFY,
-        docker_image="registry/arka:v2",
+        docker_image="registry/arca:v2",
     )
 
     assert baas.create_bot.call_args.kwargs["template_config"] == {
-        "image": "registry/arka:v2"
+        "image": "registry/arca:v2"
     }
 
 
@@ -186,16 +186,16 @@ def test_upgrade_routes_arca_pinned_image_to_template_config():
         user_id="u1",
         migration_path="/m/1",
         publish_stage=PublishStage.ONLINE,
-        docker_image="registry/arka:v2",
+        docker_image="registry/arca:v2",
     )
 
     assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
-        "image": "registry/arka:v2"
+        "image": "registry/arca:v2"
     }
 
 
 @pytest.mark.unit
-def test_teclaw_ignores_arka_docker_image():
+def test_teclaw_ignores_arca_docker_image():
     svc, baas = _svc("teclaw")
 
     svc.release(
@@ -204,7 +204,7 @@ def test_teclaw_ignores_arka_docker_image():
         migration_path="",
         publish_stage=PublishStage.VERIFY,
         delivery=DeliveryArtifact(_ARTIFACT),
-        docker_image="registry/arka:v2",
+        docker_image="registry/arca:v2",
     )
 
     baas.create_teclaw_bot.assert_called_once()

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -139,35 +139,35 @@ class TestCreatePublishImagePolicy:
                 "active_engine": "openclaw",
                 "ext": {"sbot_use_default_image": True},
             },
-            common_config_value={"image": "registry/arka:v2"},
+            common_config_value={"image": "registry/arca:v2"},
         )
 
         assert ext == {
             "migration_path": "/build/v1",
             "sbot_use_default_image": True,
-            "sbot_runtime_kind": "arka",
+            "sbot_runtime_kind": "arca",
         }
         common_config.get_value.assert_not_called()
 
-    def test_legacy_arka_bot_snapshots_enabled_common_config_image(self):
+    def test_legacy_arca_bot_snapshots_enabled_common_config_image(self):
         ext, common_config = self._create(
             source_bot={
                 "bot_type": "service",
                 "active_engine": "openclaw",
                 "ext": {"service_bot_config": {"device_count": 2}},
             },
-            common_config_value={"image": "registry/arka:v2"},
+            common_config_value={"image": "registry/arca:v2"},
         )
 
         assert ext == {
             "migration_path": "/build/v1",
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
-            "sbot_runtime_kind": "arka",
+            "sbot_docker_image": "registry/arca:v2",
+            "sbot_runtime_kind": "arca",
         }
         common_config.get_value.assert_called_once()
 
-    def test_legacy_arka_bot_stays_policyless_when_switch_disabled(self):
+    def test_legacy_arca_bot_stays_policyless_when_switch_disabled(self):
         ext, common_config = self._create(
             source_bot={
                 "bot_type": "service",
@@ -179,18 +179,18 @@ class TestCreatePublishImagePolicy:
 
         assert ext == {
             "migration_path": "/build/v1",
-            "sbot_runtime_kind": "arka",
+            "sbot_runtime_kind": "arca",
         }
         common_config.get_value.assert_called_once()
 
-    def test_teclaw_publish_does_not_consume_arka_common_config(self):
+    def test_teclaw_publish_does_not_consume_arca_common_config(self):
         ext, common_config = self._create(
             source_bot={
                 "bot_type": "service",
                 "active_engine": "teclaw",
                 "ext": None,
             },
-            common_config_value={"image": "registry/arka:v2"},
+            common_config_value={"image": "registry/arca:v2"},
             is_teclaw=True,
         )
 
@@ -303,7 +303,7 @@ class TestUpgradePublish:
             "ext": {
                 "service_bot_config": {"device_count": 3},
                 "sbot_pin_image": True,
-                "sbot_docker_image": "registry/arka:v2",
+                "sbot_docker_image": "registry/arca:v2",
             }
         }
 
@@ -312,7 +312,7 @@ class TestUpgradePublish:
 
         assert mock_repo.insert.call_args.args[0]["ext"] == {
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         }
 
     def test_upgrade_publish_not_found(self):

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -13,7 +13,7 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService, BotBuildServiceError
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePolicyState,
     ServiceBotImagePin,
     resolve_publish_image_pin as resolve_publish_image_pin_policy,
@@ -107,7 +107,7 @@ def _real_ledger():
 
 def _pf(*args, **kw):
     """Construct PublishFlowService for tests, defaulting the DI-required teclaw
-    promotion deps to Mocks (the arca/verify flow tests don't exercise them)."""
+    promotion deps to Mocks (the ARCA/verify flow tests don't exercise them)."""
     if "common_config_service" not in kw:
         common_config = Mock()
         common_config.get_value.return_value = None
@@ -152,7 +152,9 @@ def _pf(*args, **kw):
         def _resolve_runtime_kind(record):
             ext = record.ext or {}
             explicit = ext.get("sbot_runtime_kind")
-            if explicit in {"arka", "teclaw"}:
+            if explicit == "arka":
+                return "arca"
+            if explicit in {"arca", "teclaw"}:
                 return explicit
             artifact = ext.get("config_artifact")
             if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
@@ -164,7 +166,7 @@ def _pf(*args, **kw):
                 if isinstance(baas, Mock)
                 else None
             )
-            return "teclaw" if provider == "teclaw" else "arka"
+            return "teclaw" if provider == "teclaw" else "arca"
 
         publish_service.resolve_publish_runtime_kind.side_effect = _resolve_runtime_kind
     if "channel_overrides_reader" not in kw:
@@ -1091,7 +1093,7 @@ async def test_restart_sets_restarting_flag_in_ext():
             "binding": {"online": 1},
             "migration_path": "/path/to/artifact",
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     _setup_restart(svc, record)
@@ -1159,7 +1161,7 @@ async def test_restart_recreate_threads_config_artifact():
             "binding": {"online": 1},
             "config_artifact": artifact,
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     _setup_restart(svc, record)
@@ -1167,7 +1169,7 @@ async def test_restart_recreate_threads_config_artifact():
     result = await svc.execute_restart(publish_id=1, stage="online", operator="op")
     assert result["success"] is True
     assert build_service.release_async.await_args.kwargs["delivery"].config_artifact == artifact
-    assert build_service.release_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
+    assert build_service.release_async.await_args.kwargs["docker_image"] == "registry/arca:v2"
     # The recreate minted a fresh binding for the new bot.
     assert publish_service.create_device_binding.call_args.kwargs["device_id"] == "BOT-recreated"
     # BOT_NOT_FOUND = the record is already gone → nothing to retire.
@@ -1256,7 +1258,7 @@ async def test_restart_baas_not_live_target_upgrades_in_place():
             "binding": {"online": 1},
             "migration_path": "/m/1",
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     _setup_restart(svc, record, bot_uuid="BOT-old")
@@ -1265,7 +1267,7 @@ async def test_restart_baas_not_live_target_upgrades_in_place():
 
     assert result["success"] is True
     build_service.upgrade_async.assert_awaited_once()
-    assert build_service.upgrade_async.await_args.kwargs["docker_image"] == "registry/arka:v2"
+    assert build_service.upgrade_async.await_args.kwargs["docker_image"] == "registry/arca:v2"
     build_service.release_async.assert_not_awaited()
     build_service.retire_superseded_bot.assert_not_called()
 
@@ -1706,7 +1708,7 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
         ext={
             **_artifact_ext("draft"),
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     await svc._execute_verify_first_release(
@@ -1721,7 +1723,7 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
     # identity keys stable across the promotion
     assert delivered["engine_ext"]["bot_id"] == "b2"
     assert delivered["engine_ext"]["owner_id"] == "u1"
-    # TeClaw does not consume ARKA image Pin fields even if a historical row
+    # TeClaw does not consume ARCA image Pin fields even if a historical row
     # happens to contain them.
     assert build_service.release_async.await_args.kwargs["docker_image"] is None
 
@@ -1751,7 +1753,7 @@ async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
         ext={
             **_artifact_ext("draft"),
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     await svc._execute_verify_upgrade(
@@ -2300,7 +2302,7 @@ async def test_execute_rollback_uses_fixed_device_count_one():
         source_bot_id="bot-123",
         ext={
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry.example.com/arka/openclaw:v3",
+            "sbot_docker_image": "registry.example.com/arca/openclaw:v3",
         },
     )
 
@@ -2313,7 +2315,7 @@ async def test_execute_rollback_uses_fixed_device_count_one():
             "migration_path": "/tmp/build/v2",
             "binding": {"online": 100},  # binding_id
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry.example.com/arka/openclaw:v2",
+            "sbot_docker_image": "registry.example.com/arca/openclaw:v2",
             "skills_manifest": {
                 "schema_version": 1,
                 "engine": "openclaw",
@@ -2354,7 +2356,7 @@ async def test_execute_rollback_uses_fixed_device_count_one():
     assert upgrade_call.kwargs["device_count"] == 1
     assert (
         upgrade_call.kwargs["docker_image"]
-        == "registry.example.com/arka/openclaw:v2"
+        == "registry.example.com/arca/openclaw:v2"
     )
     assert upgrade_call.kwargs["extra_envs"] == {
         "AGENTCLAW_SKILLS_LAYOUT": "pool",
@@ -2629,9 +2631,9 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
         ext={
             "binding": {"online": 123},
             "skills_manifest": frozen_skills,
-            "sbot_runtime_kind": "arka",
+            "sbot_runtime_kind": "arca",
             "sbot_pin_image": True,
-            "sbot_docker_image": "registry/arka:v2",
+            "sbot_docker_image": "registry/arca:v2",
         },
     )
     binding = Mock()
@@ -2640,7 +2642,7 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
     publish_service.get_publish_by_id = Mock(return_value=record)
     publish_service.get_device_binding_by_id = Mock(return_value=binding)
     # The mutable Draft has already switched to TeClaw, but this historical
-    # Publish remains ARKA-owned and must still execute BaaS scale.
+    # Publish remains ARCA-owned and must still execute BaaS scale.
     bot_service.get_bot = Mock(return_value={
         "bot_id": "bot-source",
         "active_engine": "teclaw",
@@ -2661,7 +2663,7 @@ async def test_scale_bot_success_prefers_bot_ext_device_count():
     assert kwargs["target_count"] == 3
     assert kwargs["auto_approve_publish"] is True
     assert kwargs["config"] == {
-        "deploy_config": {"docker_image": "registry/arka:v2"}
+        "deploy_config": {"docker_image": "registry/arca:v2"}
     }
     # (#197) request_id is now the runner's deterministic op id (wall-clock id gone).
     assert kwargs["request_id"] == operation_request_id(10, "scale", "online", 1)
@@ -2742,7 +2744,7 @@ async def test_scale_bot_teclaw_returns_supported_message_without_baas_call():
     bot_service.get_bot = Mock(
         return_value={"bot_id": "bot-source", "active_engine": "openclaw", "ext": {}}
     )
-    # The current Draft is ARKA, but the immutable Publish is TeClaw-owned.
+    # The current Draft is ARCA, but the immutable Publish is TeClaw-owned.
     baas_service.resolve_container_provider.return_value = "baas"
 
     result = await svc.scale_bot(publish_id=15, operator="u1")

--- a/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
-from agentclaw.community.core.service_bot.services.arka_image_pin import (
+from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePolicyState,
     ServiceBotImagePin,
 )
@@ -36,7 +36,7 @@ class _ImagePolicyHarness(PublishImagePolicyMixin):
 
 def test_resolve_publish_image_pin_delegates_to_shared_publish_service_resolver():
     record = _record({"migration_path": "/build/v1"})
-    expected = ServiceBotImagePin(ImagePolicyState.PINNED, "registry/arka:v2")
+    expected = ServiceBotImagePin(ImagePolicyState.PINNED, "registry/arca:v2")
     svc = _ImagePolicyHarness()
     svc._publish_service.resolve_publish_image_pin.return_value = expected
 

--- a/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
+++ b/src/backend/tests/community/endpoints/test_expert_chat_caller_connection.py
@@ -171,7 +171,7 @@ def _seed_published_service_bot(world) -> None:
         "ext": {
             "migration_path": "/nas/migration/path",
             "sbot_use_default_image": True,
-            "sbot_runtime_kind": "arka",
+            "sbot_runtime_kind": "arca",
         },
     })
 

--- a/src/backend/tests/community/plugins/test_bot_publish_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_publish_unified.py
@@ -228,7 +228,7 @@ def test_compare_and_set_ext_rejects_stale_snapshot(repo):
     updated = repo.compare_and_set_ext(
         publish_id=rec.id,
         expected_ext={"concurrent": "old"},
-        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v2"},
+        ext={"sbot_pin_image": True, "sbot_docker_image": "arca:v2"},
     )
 
     assert updated is None
@@ -241,11 +241,11 @@ def test_compare_and_set_ext_supports_null_expected_ext(repo):
     updated = repo.compare_and_set_ext(
         publish_id=rec.id,
         expected_ext=None,
-        ext={"sbot_runtime_kind": "arka"},
+        ext={"sbot_runtime_kind": "arca"},
     )
 
     assert updated is not None
-    assert updated.ext == {"sbot_runtime_kind": "arka"}
+    assert updated.ext == {"sbot_runtime_kind": "arca"}
 
 
 def test_compare_and_set_status_with_ext_guards_both_snapshots(repo):

--- a/src/backend/tests/community/plugins/test_bot_repository_unified.py
+++ b/src/backend/tests/community/plugins/test_bot_repository_unified.py
@@ -256,7 +256,7 @@ def test_compare_and_set_ext_preserves_concurrent_bot_metadata(repo):
         bot_id="bot-1",
         owner_id="emp1",
         expected_ext={"owner": "first", "中文": "值"},
-        ext={"sbot_pin_image": True, "sbot_docker_image": "arka:v1"},
+        ext={"sbot_pin_image": True, "sbot_docker_image": "arca:v1"},
     )
     assert stale is None
     assert repo.get_by_id_and_owner("bot-1", "emp1")["ext"] == updated["ext"]
@@ -269,11 +269,11 @@ def test_compare_and_set_ext_supports_null_bot_ext(repo):
         bot_id="bot-1",
         owner_id="emp1",
         expected_ext=None,
-        ext={"sbot_runtime_kind": "arka"},
+        ext={"sbot_runtime_kind": "arca"},
     )
 
     assert updated is not None
-    assert updated["ext"] == {"sbot_runtime_kind": "arka"}
+    assert updated["ext"] == {"sbot_runtime_kind": "arca"}
 
 
 def test_list_and_count(repo):


### PR DESCRIPTION
## Summary

- correct the service-bot runtime kind from the misspelled arka value to canonical arca
- rename ARCA image-policy modules, symbols, comments, and test fixtures consistently
- keep backward-compatible reads for Publish records that already contain sbot_runtime_kind=arka
- preserve the Publish-owned provider routing from #823; TeClaw still ignores ARCA docker images

## Root cause

#823 introduced arka as the persisted runtime-kind spelling even though the provider and product name are ARCA. The implementation was internally consistent, so tests did not catch the protocol typo.

## Impact

New Publish records write sbot_runtime_kind=arca. Existing records containing arka remain readable and resolve to ARCA without mutating historical Publish data. No Provider routing or TeClaw image behavior changes.

## Validation

- 611 targeted backend tests passed across image policy, publish lifecycle, restart, rollback, scale, TeClaw routing, ExpertChat, and repository paths
- ruff check passed on the affected service-bot modules and tests
- git diff --check passed