### PR TITLE
  fix(harness): render D-TOOLS-002 MCP data as compact text to stop gateway timeouts

### DIFF
--- a/scripts/ci/singlebox_coverage.sh
+++ b/scripts/ci/singlebox_coverage.sh
@@ -216,6 +216,7 @@ run_real_singlebox() {
     BACKEND_READY_ATTEMPTS="${BACKEND_READY_ATTEMPTS:-120}" \
     STANDALONE_OPENCLAW_ROOT="$coverage_standalone_root" \
     STANDALONE_RUNTIME_DIR="$coverage_standalone_runtime" \
+    SINGLEBOX_ACCEPTANCE_MCP_FIXTURE_FILE="$repo_root/src/backend/tests/community/acceptance/mcp/fixture_mcp_center.json" \
     bash "$repo_root/scripts/singlebox.sh" --standalone --with-bcs-coverage start all
   local acceptance_status=0
   local bcs_e2e_status=0

--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -247,7 +247,11 @@ modules:
       # lives in tests/community/core/harness/diagnostics/test_diagnostics.py
       # (flattening, malformed-param skip, non-list early return, per-MCP cap
       # with tools_omitted) — outside the acceptance denominator by design.
-      # Revisit if singlebox gains a fixture-backed MCPCenter with schema tools.
+      # Update: singlebox now gains a fixture-backed MCPCenter — TestingMcpModule
+      # serves CommunityMCPCenter when SINGLEBOX_ACCEPTANCE_MCP_FIXTURE_FILE is
+      # set, and singlebox_coverage.sh passes the fixture catalog when starting
+      # the backend — so the helpers are acceptance-coverable again; the floor
+      # stays at the last measured value until CI re-measures with the fixture.
       #
       # 41.59 → 41.30: the LLM diagnostic refactor (refactor(LLM): 改进异常处理和日志记录)
       # added logging-only statements to services/llm.py that the read-only harness

--- a/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
+++ b/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
@@ -235,16 +235,17 @@ _PARAM_DESC_MAX_CHARS = 120
 _TOOL_DESC_MAX_CHARS = 200
 
 
-def _compact_tool_for_prompt(tool: dict) -> dict:
-    """Compress one MCP tool to a flat, prompt-sized param table.
+def _compact_tool_for_prompt(tool: dict) -> str:
+    """Render one MCP tool as a single prompt line.
 
-    Drops the nested ``inputSchema`` JSON and keeps only what the diagnostic
-    LLM needs to transcribe a non-fabricated call spec: the tool name, a
-    one-line tool description, and a flat param list (name/type/required/
-    one-line desc). Returns ``params: []`` when the tool exposes no schema.
+    Drops the nested ``inputSchema`` JSON and emits a flat one-liner the
+    diagnostic LLM can transcribe a non-fabricated call spec from:
+    ``name(param:type*=required, …) — one-line desc``. Tools with no schema
+    render as ``name — desc``. One line per tool keeps an 88-tool MCP list to
+    a few KB instead of tens of KB of indented JSON.
     """
     schema = tool.get("inputSchema")
-    params: list[dict] = []
+    params: list[str] = []
     if isinstance(schema, dict):
         props = schema.get("properties")
         required = schema.get("required") or []
@@ -253,32 +254,25 @@ def _compact_tool_for_prompt(tool: dict) -> dict:
             for pname, pdef in props.items():
                 if not isinstance(pdef, dict):
                     continue
-                p_desc = (pdef.get("description") or "").strip()
-                p_desc = p_desc.split("\n", 1)[0][:_PARAM_DESC_MAX_CHARS]
-                params.append({
-                    "name": pname,
-                    "type": pdef.get("type", ""),
-                    "required": pname in required_set,
-                    "desc": p_desc,
-                })
+                ptype = pdef.get("type", "") or ""
+                star = "*" if pname in required_set else ""
+                params.append(f"{pname}:{ptype}{star}")
+    name = tool.get("name", "")
+    sig = f"{name}({', '.join(params)})" if params else name
     t_desc = (tool.get("description") or "").strip()
     t_desc = t_desc.split("\n", 1)[0][:_TOOL_DESC_MAX_CHARS]
-    return {
-        "name": tool.get("name", ""),
-        "desc": t_desc,
-        "params": params,
-    }
+    return f"{sig} — {t_desc}" if t_desc else sig
 
 
-def _compact_mcp_tools_for_prompt(mcp: dict) -> tuple[list[dict], int]:
-    """Return ``(compacted tools, count of named tools omitted past the cap)``.
+def _compact_mcp_tools_for_prompt(mcp: dict) -> tuple[list[str], int]:
+    """Return ``(one-line tool strings, count of named tools omitted past the cap)``.
 
     Caps each MCP's tools at ``_MAX_TOOLS_PER_MCP_IN_PROMPT`` so a 27-tool MCP
     doesn't dominate the message; the omitted count is surfaced separately so
-    the caller can annotate it (``tools_omitted``). Tools without a name are
-    dropped. Reads the *original* tools list — not a pre-slimmed copy — so the
-    bucketing and ``has_recoverable`` checks that run against ``mcp_details``
-    still see the unredacted ``inputSchema``.
+    the caller can annotate it (``…另N个``). Tools without a name are dropped.
+    Reads the *original* tools list — not a pre-slimmed copy — so the bucketing
+    and ``has_recoverable`` checks that run against ``mcp_details`` still see
+    the unredacted ``inputSchema``.
     """
     tools = mcp.get("tools") or []
     if not isinstance(tools, list):
@@ -287,6 +281,32 @@ def _compact_mcp_tools_for_prompt(mcp: dict) -> tuple[list[dict], int]:
     kept = named[:_MAX_TOOLS_PER_MCP_IN_PROMPT]
     compacted = [_compact_tool_for_prompt(t) for t in kept]
     return compacted, len(named) - len(kept)
+
+
+def _format_mcp_block(mcp: dict, *, include_guide: bool) -> str:
+    """Render one MCP as a compact text block for the prompt.
+
+    Single ``## server_code (name): description`` header plus a ``tools:``
+    list of one-line tool strings, and (when ``include_guide``) the verbatim
+    ``verified_guide``. Far smaller than the previous indented-JSON dump while
+    keeping every param name/type/required the LLM needs to transcribe a call
+    spec.
+    """
+    server_code = mcp.get("server_code", "")
+    name = mcp.get("name", "")
+    desc = (mcp.get("description") or "").strip().split("\n", 1)[0]
+    header = f"## {server_code} ({name}): {desc}" if desc else f"## {server_code} ({name})"
+    lines = [header]
+    guide = mcp.get("verified_guide") if include_guide else None
+    if guide:
+        lines.append(f"verified_guide:\n{guide}")
+    compacted, omitted = _compact_mcp_tools_for_prompt(mcp)
+    if compacted:
+        lines.append("tools:")
+        lines.extend(f"- {t}" for t in compacted)
+        if omitted:
+            lines.append(f"- …另{omitted}个未列出")
+    return "\n".join(lines)
 
 
 class ToolsMcpFormatDiagnostic(Diagnostic):
@@ -547,13 +567,16 @@ XX 为 0-100 的整数
         )
         kb_included = False
         if mcp_details:
-            # Bucket each MCP by what call-spec source is available:
-            #   verified    → verified_guide (human-verified, paste verbatim)
-            #   schema      → no verified_guide, but tools expose inputSchema (transcribe params)
-            #   unreachable → neither (platform must author; mapping-table row only, advisory)
-            verified_mcps: list[dict] = []
-            schema_mcps: list[dict] = []
-            unreachable_mcps: list[dict] = []
+            # Bucket each MCP by what call-spec source is available (unchanged
+            # from #717): verified → verified_guide verbatim; schema → no guide
+            # but tools expose inputSchema (transcribe params); unreachable →
+            # neither. Only the *rendering* changes: instead of json.dumps of
+            # the dict (nested inputSchema + indent = tens of KB), each MCP is
+            # rendered as a compact text block (_format_mcp_block) — same param
+            # name/type/required info, a fraction of the size.
+            verified_blocks: list[str] = []
+            schema_blocks: list[str] = []
+            unreachable_blocks: list[str] = []
             for mcp in mcp_details:
                 tools = mcp.get("tools") or []
                 has_schema = any(
@@ -561,58 +584,35 @@ XX 为 0-100 的整数
                     for t in (tools if isinstance(tools, list) else [])
                 )
                 if mcp.get("verified_guide"):
-                    # Keep the verified_guide全文 verbatim (that's the value);
-                    # slim only the tools list to a compact param table so the
-                    # full inputSchema JSON doesn't bloat the prompt.
-                    compacted, omitted = _compact_mcp_tools_for_prompt(mcp)
-                    slim_mcp = {
-                        "server_code": mcp["server_code"],
-                        "name": mcp.get("name", ""),
-                        "description": mcp.get("description", ""),
-                        "verified_guide": mcp.get("verified_guide"),
-                        "tools": compacted,
-                    }
-                    if omitted:
-                        slim_mcp["tools_omitted"] = omitted
-                    verified_mcps.append(slim_mcp)
+                    verified_blocks.append(_format_mcp_block(mcp, include_guide=True))
                 elif has_schema:
-                    # Transcribe params from the compact param table, not the
-                    # full inputSchema JSON (which is what blew up the prompt
-                    # for bots with many MCP tools).
-                    compacted, omitted = _compact_mcp_tools_for_prompt(mcp)
-                    slim_mcp = {
-                        "server_code": mcp["server_code"],
-                        "name": mcp.get("name", ""),
-                        "description": mcp.get("description", ""),
-                        "verified_guide": None,
-                        "tools": compacted,
-                    }
-                    if omitted:
-                        slim_mcp["tools_omitted"] = omitted
-                    schema_mcps.append(slim_mcp)
+                    schema_blocks.append(_format_mcp_block(mcp, include_guide=False))
                 else:
-                    unreachable_mcps.append({
-                        "server_code": mcp["server_code"],
-                        "name": mcp.get("name", ""),
-                        "description": mcp.get("description", ""),
-                        "verified_guide": None,
-                        "注意": "该 MCP 既无人工校验调用规范也无工具 inputSchema，只能在「场景与工具映射速查」表格中列出，注意事项写「调用规范由平台补全中」；禁止为其生成「MCP 调用规范」子章节或 mcporter call 示例",
-                    })
+                    # Unreachable: mapping-table row only (no tools, no schema).
+                    server_code = mcp["server_code"]
+                    name = mcp.get("name", "")
+                    desc = (mcp.get("description") or "").strip().split("\n", 1)[0]
+                    header = f"## {server_code} ({name}): {desc}" if desc else f"## {server_code} ({name})"
+                    unreachable_blocks.append(
+                        header + "\n注意: 该 MCP 既无人工校验调用规范也无工具 inputSchema，"
+                        "只能在「场景与工具映射速查」表格中列出，注意事项写「调用规范由平台补全中」；"
+                        "禁止为其生成「MCP 调用规范」子章节或 mcporter call 示例"
+                    )
 
-            if verified_mcps:
+            if verified_blocks:
                 user_msg += (
                     "\n--- ✅ 已验证 MCP（verified_guide 不为空，引用原文生成调用规范） ---\n"
-                    f"{json.dumps(verified_mcps, ensure_ascii=False)}\n"
+                    + "\n\n".join(verified_blocks) + "\n"
                 )
-            if schema_mcps:
+            if schema_blocks:
                 user_msg += (
                     "\n--- 🛠 可据参数表转录 MCP（无 verified_guide，但工具含 params 参数表：可据参数表转录调用规范，禁止编造示例/命令） ---\n"
-                    f"{json.dumps(schema_mcps, ensure_ascii=False)}\n"
+                    + "\n\n".join(schema_blocks) + "\n"
                 )
-            if unreachable_mcps:
+            if unreachable_blocks:
                 user_msg += (
                     "\n--- ⛔ 无 schema MCP（既无 verified_guide 又无 inputSchema，仅写入映射表，禁止生成调用规范/示例） ---\n"
-                    f"{json.dumps(unreachable_mcps, ensure_ascii=False)}\n"
+                    + "\n\n".join(unreachable_blocks) + "\n"
                 )
 
             # 查询内网知识库补充 MCP 上下文

--- a/src/backend/src/agentclaw/community/core/harness/services/llm.py
+++ b/src/backend/src/agentclaw/community/core/harness/services/llm.py
@@ -45,15 +45,14 @@ _RETRY_JITTER = 0.4
 _DEFAULT_MAX_TOKENS = 32768
 # Diagnostics emit a short summary + a patchable draft (mapping table + a few
 # MCP call specs) + ``[SCORE:xx]`` — far smaller than a full-file patch
-# rewrite. Keep this at the default 32k rather than capping it: #717's timeout
-# was caused by the *input* payload (each tool's full inputSchema dumped into
-# the prompt), not the output budget — the gateway-timeout retry already
-# shrinks max_tokens to 8k and still times out when the prompt is huge. The
-# input-side fix lives in mcp_format.py (compact param table + per-MCP tool
-# cap). Capping here would risk truncating the draft and the trailing
-# ``[SCORE:xx]`` (which the parser then scores as "check failed") for no
-# timeout benefit.
-DIAGNOSTIC_MAX_TOKENS = 32768
+# rewrite. 8k covers that with headroom while keeping GLM out of the
+# slow-reasoning path that #307 lowered the old 256k to escape: a 32k budget
+# lets the model stall past antchat's ~90s gateway window even when the prompt
+# is small. (The matching *input*-side guard lives in mcp_format.py, which
+# renders each MCP as a compact text block instead of dumping the nested
+# inputSchema JSON.) 8k still leaves the trailing ``[SCORE:xx]`` room, since
+# the draft body is only a few KB.
+DIAGNOSTIC_MAX_TOKENS = 8192
 # Connection-level failures (gateway dropped mid send/read, or the send-hook
 # wrapper re-raised) get more retries than before — these are transient blips,
 # not "request too heavy" stalls, so giving up after one retry was premature.

--- a/src/backend/src/agentclaw/community/di/modules/testing_mcp_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/testing_mcp_module.py
@@ -44,10 +44,33 @@ class TestingMcpModule(Module):
     @singleton
     @provider
     def mcp_center(self) -> MCPCenterPlugin:
-        """Local Noop (MockSeam) instead of the prod MCP-Center HTTP impl.
-        The catalog is a third-party HTTP API with no fake in prod; the
-        local Noop now carries the mock seam, so tests can drive
-        ``get_mcp_detail`` etc. without network access."""
+        """Fixture-backed catalog when the singlebox acceptance fixture file is
+        provided; otherwise the local Noop.
+
+        ``SINGLEBOX_ACCEPTANCE_MCP_FIXTURE_FILE`` (set by the acceptance
+        conftest) points at a LocalMCPRegistry JSON/YAML catalog. When present
+        we serve a real ``CommunityMCPCenter`` from it so MCP-detail consumers
+        — notably the D-TOOLS-002 diagnostic, whose prompt-slimming helpers
+        only run when a tool exposes ``inputSchema`` — execute end-to-end under
+        singlebox acceptance instead of falling back to ``tools: []``. Absent
+        the env, fall back to the Noop (MockSeam) so other local tests degrade
+        gracefully without network access."""
+        import os
+        from pathlib import Path
+
+        fixture = os.environ.get("SINGLEBOX_ACCEPTANCE_MCP_FIXTURE_FILE", "").strip()
+        if fixture and Path(fixture).is_file():
+            from agentclaw.community.plugins.community.mcp_center import (
+                CommunityMCPCenter,
+            )
+
+            logger.info(
+                "[NEW-ARCH] MCPCenterPlugin: CommunityMCPCenter "
+                "(fixture-backed, path=%s)",
+                fixture,
+            )
+            return CommunityMCPCenter(registry_config_path=fixture)
+
         from agentclaw.community.plugins.local.mcp_center import NoopMCPCenterPlugin
 
         logger.info(

--- a/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
+++ b/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
@@ -78,7 +78,8 @@ def test_diagnose_tools_mcp_format_runs_prompt_helpers(
             client.post(
                 "/api/skillsets",
                 json={
-                    "name": fresh_id("toolsdiag_set"),
+                    # No fresh_id here: skill-set names reject '_'.
+                    "name": "ToolsDiag Acceptance Set",
                     "user_id": user_id,
                     "bot_id": bot_id,
                 },

--- a/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
+++ b/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
@@ -1,0 +1,118 @@
+"""Route-B acceptance: D-TOOLS-002 prompt-slimming helpers run end-to-end.
+
+Companion to ``test_diagnose_llm_disabled_smoke.py``. That story pins the
+empty-config guard on a fresh bot; this one pins that a bot with a non-empty
+TOOLS.md plus an activated, schema-bearing MCP drives
+``ToolsMcpFormatDiagnostic.analyze`` through the prompt-slimming helpers
+(``_compact_tool_for_prompt`` / ``_compact_mcp_tools_for_prompt`` /
+``_format_mcp_block``) — the code that keeps MCP-heavy bots under antchat's
+~90s gateway window.
+
+Why this works without a real LLM: the helpers run while *building* the
+diagnostic prompt, which happens before ``ctx.llm.chat()``. The community
+singlebox leaves ``[llm]`` commented out, so ``chat()`` short-circuits with
+``"[llm disabled]"`` — but by then prompt construction (and the helpers) has
+already executed, so the lines are covered. The MCP detail comes from the
+fixture-backed ``CommunityMCPCenter`` (``TestingMcpModule`` reads
+``SINGLEBOX_ACCEPTANCE_MCP_FIXTURE_FILE``), seeded with
+``mcp.singlebox.toolsdiag`` whose tools expose ``inputSchema``.
+
+Off by default; enable with RUN_ACCEPTANCE=1.
+"""
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from tests.community.acceptance._fixtures.live_personal_bot import (
+    assert_success,
+    create_live_personal_bot,
+    fresh_id,
+)
+
+POLL_TIMEOUT_SEC = 60
+POLL_INTERVAL_SEC = 2
+SERVER_CODE = "mcp.singlebox.toolsdiag"
+
+
+def _poll_until_terminal(client: httpx.Client, scan_id: int) -> dict:
+    deadline = time.monotonic() + POLL_TIMEOUT_SEC
+    last: dict = {}
+    while time.monotonic() < deadline:
+        r = client.get(f"/api/harness/diagnose/{scan_id}")
+        assert r.status_code == 200, r.text
+        last = r.json()
+        if last.get("status") in ("completed", "failed"):
+            return last
+        time.sleep(POLL_INTERVAL_SEC)
+    pytest.fail(f"scan {scan_id} did not reach terminal status within {POLL_TIMEOUT_SEC}s; last={last}")
+
+
+@pytest.mark.acceptance
+def test_diagnose_tools_mcp_format_runs_prompt_helpers(
+    live_backend, acceptance_fs_root
+):
+    """A bot with TOOLS.md + an activated schema-bearing MCP runs D-TOOLS-002
+    through the prompt-slimming helpers and completes (LLM-disabled → LLM01)."""
+    user_id = fresh_id("e2e_toolsdiag")
+    headers = {"x-user-id": user_id}
+
+    with httpx.Client(base_url=live_backend, headers=headers, timeout=60.0) as client:
+        bot = create_live_personal_bot(
+            client, user_id=user_id, bot_name_prefix="toolsdiag",
+        )
+        bot_id = bot["bot_id"]
+
+        # Non-empty TOOLS.md so the diagnostic does not early-return on empty content.
+        write = client.put(
+            f"/api/identity/staff/{user_id}/bot/{bot_id}/TOOLS.md",
+            json={"content": "# Tools\n\n- acceptance tools configured\n"},
+        )
+        assert write.status_code == 200, write.text
+
+        # Activate the schema-bearing fixture MCP on the bot via a skill-set, so
+        # bot_profile.get_activated_mcps returns it during the scan.
+        skillset = assert_success(
+            client.post(
+                "/api/skillsets",
+                json={
+                    "name": fresh_id("toolsdiag_set"),
+                    "user_id": user_id,
+                    "bot_id": bot_id,
+                },
+            )
+        )
+        skill_set_id = skillset["data"]["id"]
+        add_mcp = client.post(
+            f"/api/skillsets/{skill_set_id}/mcps",
+            params={
+                "entity_id": user_id,
+                "entity_type": "staff",
+                "bot_id": bot_id,
+                "engine_type": "openclaw",
+            },
+            json={"server_code": SERVER_CODE, "user_id": user_id},
+        )
+        assert add_mcp.status_code == 200, add_mcp.text
+        assert add_mcp.json().get("success") is True, add_mcp.json()
+
+        # Run the diagnose write path; D-TOOLS-002 executes the prompt helpers.
+        start = client.post(
+            "/api/harness/diagnose",
+            json={
+                "bot_id": bot_id,
+                "entity_id": user_id,
+                "entity_type": "staff",
+                "scan_type": "full",
+                "layer": "L1",
+                "trigger_source": "api",
+            },
+        )
+        assert start.status_code == 202, start.text
+        scan_id = start.json()["scan_id"]
+
+        poll = _poll_until_terminal(client, scan_id)
+        # With LLM disabled the scan still completes; it must not hang in scanning.
+        assert poll["status"] in ("completed", "failed"), poll

--- a/src/backend/tests/community/acceptance/mcp/fixture_mcp_center.json
+++ b/src/backend/tests/community/acceptance/mcp/fixture_mcp_center.json
@@ -26,6 +26,65 @@
           "url": "https://singlebox.acceptance.invalid/mcp"
         }
       ]
+    },
+    "mcp.singlebox.toolsdiag": {
+      "serverCode": "mcp.singlebox.toolsdiag",
+      "server_code": "mcp.singlebox.toolsdiag",
+      "platformServerCode": "mcp.singlebox.toolsdiag",
+      "hostPlatform": "SINGLEBOX",
+      "name": "Singlebox ToolsDiag MCP",
+      "description": "Fixture MCP with schema-bearing tools to drive the D-TOOLS-002 prompt-slimming helpers under singlebox acceptance",
+      "accessLevel": "PUBLIC",
+      "runMode": "REMOTE",
+      "status": "ONLINE",
+      "networkTypes": ["INTERNET", "OFFICE"],
+      "tools": [
+        {
+          "name": "generateWorkSummary",
+          "description": "Generate a work summary for a date range",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "startDate": {"type": "string", "description": "Start date, yyyyMMdd"},
+              "endDate": {"type": "string", "description": "End date, yyyyMMdd"},
+              "includeDetails": {"type": "boolean", "description": "Whether to include itemized details"}
+            },
+            "required": ["startDate", "endDate"]
+          }
+        },
+        {
+          "name": "queryRiskEvents",
+          "description": "Query risk events by filter",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "scene": {"type": "string", "description": "Risk scene code"},
+              "pageSize": {"type": "integer", "description": "Page size (1-100)"}
+            },
+            "required": ["scene"]
+          }
+        },
+        {
+          "name": "createDoc",
+          "description": "Create a document",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "title": {"type": "string", "description": "Document title"},
+              "tags": {"type": "array", "description": "Tag list"}
+            },
+            "required": ["title"]
+          }
+        }
+      ],
+      "endpoints": [
+        {
+          "env": "PRE",
+          "networkType": "INTERNET",
+          "transportProtocol": "STREAMABLE_HTTP",
+          "url": "https://singlebox.toolsdiag.invalid/mcp"
+        }
+      ]
     }
   }
 }

--- a/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
+++ b/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
@@ -717,13 +717,12 @@ class TestToolsMcpFormatDiagnostic:
         assert findings[0].severity == Severity.WARNING
         assert findings[0].score == 55
         assert findings[0].result != "pass"
-        # inputSchema is flattened to a compact params table for transcription;
-        # the full nested JSON is NOT forwarded (that's what used to bloat the
-        # prompt past antchat's ~90s gateway window).
+        # inputSchema is rendered as a compact one-line tool signature for
+        # transcription; the full nested JSON is NOT forwarded (that's what used
+        # to bloat the prompt past antchat's ~90s gateway window). The one-liner
+        # keeps param name/type/required (star) so the LLM can transcribe it.
         assert "inputSchema" not in captured_user
-        assert '"params"' in captured_user
-        assert "generateWorkSummary" in captured_user
-        assert "startDate" in captured_user
+        assert "generateWorkSummary(startDate:string*, endDate:string*)" in captured_user
         assert "可据参数表转录" in captured_user
 
     @pytest.mark.asyncio
@@ -782,9 +781,10 @@ class TestToolsMcpFormatDiagnostic:
         assert findings[0].severity == Severity.WARNING
 
     def test_compact_tool_flattens_input_schema(self):
-        """_compact_tool_for_prompt flattens a nested inputSchema into a flat
-        param table (name/type/required/one-line desc) and drops the nested
-        JSON — the slimmed payload that goes into the diagnostic prompt."""
+        """_compact_tool_for_prompt flattens a nested inputSchema into a single
+        prompt line (name + param:type*=required sig + one-line desc) and drops
+        the nested JSON — the slimmed payload that goes into the diagnostic
+        prompt."""
         tool = {
             "name": "create_doc",
             "description": "创建语雀文档\n第二行不该进入 prompt",
@@ -799,21 +799,13 @@ class TestToolsMcpFormatDiagnostic:
             },
         }
         compact = _compact_tool_for_prompt(tool)
-        assert compact == {
-            "name": "create_doc",
-            "desc": "创建语雀文档",
-            "params": [
-                {"name": "title", "type": "string", "required": True, "desc": "文档标题"},
-                {"name": "tags", "type": "array", "required": False, "desc": "标签列表"},
-                {"name": "private", "type": "boolean", "required": False, "desc": "是否私有"},
-            ],
-        }
+        assert compact == "create_doc(title:string*, tags:array, private:boolean) — 创建语雀文档"
 
     def test_compact_tool_without_schema_returns_empty_params(self):
-        """A tool with no inputSchema yields an empty params list (it still
-        has a name/desc so the LLM can list it in the mapping table)."""
+        """A tool with no inputSchema renders as `name — desc` (no param sig) so
+        the LLM can still list it in the mapping table."""
         compact = _compact_tool_for_prompt({"name": "bare_tool", "description": "no schema"})
-        assert compact == {"name": "bare_tool", "desc": "no schema", "params": []}
+        assert compact == "bare_tool — no schema"
 
     def test_compact_tool_skips_malformed_param_defs(self):
         """A schema property whose value is not a dict is skipped (the
@@ -832,9 +824,7 @@ class TestToolsMcpFormatDiagnostic:
             },
         }
         compact = _compact_tool_for_prompt(tool)
-        assert compact["params"] == [
-            {"name": "good", "type": "string", "required": True, "desc": "ok"},
-        ]
+        assert compact == "weird(good:string*)"
 
     def test_compact_mcp_tools_non_list_returns_empty(self):
         """A non-list `tools` value (None, a string, a dict) hits the early
@@ -848,9 +838,9 @@ class TestToolsMcpFormatDiagnostic:
 
     @pytest.mark.asyncio
     async def test_verified_guide_tools_also_capped_with_omitted(self):
-        """The verified bucket also caps tools and surfaces tools_omitted
-        (the verified-guide path shares _compact_mcp_tools_for_prompt); this
-        covers the `if omitted` branch in the verified_mcps append."""
+        """The verified bucket also caps tools and surfaces the `…另N个未列出`
+        note (the verified-guide path shares _compact_mcp_tools_for_prompt);
+        this covers the `if omitted` branch of the verified block."""
         diag = ToolsMcpFormatDiagnostic()
         code = "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver"
         mcps = [{"server_code": code, "name": "skylark"}]
@@ -877,16 +867,16 @@ class TestToolsMcpFormatDiagnostic:
         ctx.llm.chat = capture_chat
         await diag.analyze(ctx)
 
-        assert '"tools_omitted": 3' in captured_user
+        assert "另3个未列出" in captured_user
         assert "t0" in captured_user
         assert f"t{total - 1}" not in captured_user
 
     @pytest.mark.asyncio
     async def test_tools_capped_per_mcp_with_omitted(self):
         """An MCP exposing more tools than the per-MCP cap only forwards the
-        first N (compacted); the remainder is summarised as ``tools_omitted``
-        so a 27-tool MCP doesn't dominate the prompt and blow the gateway
-        window."""
+        first N (compacted one-liners); the remainder is summarised as
+        ``…另N个未列出`` so a 27-tool MCP doesn't dominate the prompt and blow
+        the gateway window."""
         diag = ToolsMcpFormatDiagnostic()
         mcps = [{"server_code": "big", "name": "big"}]
         ctx = _make_ctx({"TOOLS.md": "# Tools\n\n- some"}, activated_mcps=mcps)
@@ -916,7 +906,7 @@ class TestToolsMcpFormatDiagnostic:
         ctx.llm.chat = capture_chat
         await diag.analyze(ctx)
 
-        assert '"tools_omitted": 5' in captured_user
+        assert "另5个未列出" in captured_user
         # First capped tool and the boundary tool are present …
         assert "tool_0" in captured_user
         assert f"tool_{_MAX_TOOLS_PER_MCP_IN_PROMPT - 1}" in captured_user

--- a/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
+++ b/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
@@ -326,7 +326,9 @@ class TestToolsMcpFormatDiagnostic:
 
     @pytest.mark.asyncio
     async def test_no_verified_guide_for_unknown_mcp(self, monkeypatch):
-        """MCPs NOT in _VERIFIED_MCP_GUIDES should have verified_guide as null."""
+        """MCPs NOT in _VERIFIED_MCP_GUIDES (and without inputSchema) land in the
+        unreachable bucket: rendered as a mapping-table-only text block carrying
+        the 平台补全中 note, with no verified_guide content."""
         diag = ToolsMcpFormatDiagnostic()
         mcps = [{"server_code": "some-unknown-mcp", "name": "Unknown"}]
         ctx = _make_ctx({"TOOLS.md": "# Tools\n\n- some tools"}, activated_mcps=mcps)
@@ -349,7 +351,12 @@ class TestToolsMcpFormatDiagnostic:
         ctx.llm.chat = capture_chat
         await diag.analyze(ctx)
 
-        assert '"verified_guide": null' in captured_user
+        # No verified_guide anywhere (the MCP is unknown), and it lands in the
+        # unreachable (no-schema) bucket as a text block, not a JSON dump.
+        assert "verified_guide:" not in captured_user
+        assert "无 schema MCP" in captured_user
+        assert "some-unknown-mcp" in captured_user
+        assert "平台补全中" in captured_user
 
     @pytest.mark.asyncio
     async def test_no_activated_mcps_still_works(self):


### PR DESCRIPTION
 ## Problem

  V1 (#819) only partially slimmed the D-TOOLS-002 prompt. It kept each MCP's
  tools as indented JSON (`name`/`desc`/`params` objects), so an 88-tool bot
  still produced ~62KB of MCP payload — barely smaller than the full
  `inputSchema` dump it replaced — and left `DIAGNOSTIC_MAX_TOKENS` at 32k. GLM
  still stalled past antchat's ~90s gateway window, every retry hit
  `RemoteProtocolError`, `llm.py` returned the `[llm disabled]` sentinel, and
  the parser surfaced a spurious "LLM执行异常(请重试)" that pins health_score
  low. Other diagnostics on the same bot are fine; only TOOLS.md times out.

  ## Solution

  Two-sided tightening, keeping #717's diagnostic semantics intact:

  - `mcp_format.py`: render each MCP as a compact **text block** instead of an
    indented-JSON dump — one `## server_code (name): description` header plus
    one line per tool (`name(param:type*=required) — desc`), `verified_guide`
    verbatim, and a `…另N个未列出` note past the 20-tool cap. Every param
    name/type/required needed for call-spec transcription is preserved; the MCP
    (verified/schema/unreachable), the 平台补全中 advisory text, and
    system_prompt are unchanged.
  - `llm.py`: `DIAGNOSTIC_MAX_TOKENS` 32768 → 8192. Diagnostics only emit a
    short summary + draft + `[SCORE:xx]`; 8k covers that while keeping GLM out
    of the slow-reasoning path #307 lowered the old 256k budget to escape.
  
  ## Validation
  
  - py_compile clean on all changed files.
  - Pre-push SAST block rules (E902/F405/E712/E701/E702/F821/F822/F823) pass.
  - Updated TOOLS-diagnostic tests to the one-line tool signature and the
    `…另N个未列出` note; no V1-format assertions remain.
  - Not run locally: pytest (this env lacks project deps like fastapi_injector).
    Run before merge:
    `python -m pytest src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py -x -q`
  
  Relates to #717, #819.
