### PR TITLE
feat(bcs): echo image attachments in history with minted share urls

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "bcs-message-store",
  "bcs-service-api",
  "bcs-session-store",
+ "bcs-storage-api",
  "bcs-system-message",
  "bcs-test-support",
  "serde_json",

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -577,6 +577,7 @@ impl GroupMessageHistoryService for RecordingGroupMessageHistory {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             }],
             limit: cmd.limit,
             before: cmd.before,
@@ -618,6 +619,7 @@ impl GroupMessageHistoryService for RecordingGroupMessageHistory {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             }],
             limit: cmd.limit,
             before: cmd.before,
@@ -784,6 +786,7 @@ async fn build_group_app_with_identity(
         history_meta: None,
         metadata: None,
         run_id: String::new(),
+        attachments: None,
     });
 
     let group_store = Arc::new(GroupStore::new());
@@ -1246,6 +1249,7 @@ async fn state_machine_session_messages_use_runtime_history() {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             }],
             limit: 20,
             before: None,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -2179,6 +2179,7 @@ async fn get_group_preserves_legacy_detail_payload_from_query_service() {
         history_meta: None,
         metadata: None,
         run_id: String::new(),
+        attachments: None,
     }];
     group.workspace = Workspace {
         decisions: vec!["real decision".to_string()],

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -107,7 +107,7 @@ fn default_session_files_share_link_ttl() -> u64 {
     3600
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionFilesShareConfig {
     /// HMAC secret for share-token mint/consume. If unset, bootstrap logs a
     /// warning and generates a random 32-byte secret that does NOT survive
@@ -123,10 +123,31 @@ pub struct SessionFilesShareConfig {
     /// to `bcs_endpoint` or `http://{bind}:{port}` in the service layer.
     #[serde(default)]
     pub share_base_url: Option<String>,
+
+    /// TTL (seconds) for share URLs minted at history-read time for image
+    /// echo. Clamped to [60, 604800]. Independent from `default_ttl_seconds`
+    /// (the share-API default) so history echo can be tuned separately.
+    #[serde(default = "default_history_attachment_ttl")]
+    pub history_attachment_ttl_seconds: u64,
+}
+
+impl Default for SessionFilesShareConfig {
+    fn default() -> Self {
+        Self {
+            token_secret: None,
+            default_ttl_seconds: default_session_files_share_ttl(),
+            share_base_url: None,
+            history_attachment_ttl_seconds: default_history_attachment_ttl(),
+        }
+    }
 }
 
 fn default_session_files_share_ttl() -> u64 {
     86400
+}
+
+fn default_history_attachment_ttl() -> u64 {
+    3600
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1682,6 +1682,13 @@ impl Default for BcsServerState {
         );
         let bot_run_context: Arc<dyn BotRunContextPort> =
             Arc::new(bcs_message_flow::MemoryBotRunContextStore::new());
+        let session_file_service = build_session_files_service_blocking(
+            &config,
+            crate::env::resolve_env(),
+            None,
+            None,
+            session_repo.clone(),
+        );
         let group_message_history = create_group_message_history_service(
             sessions.clone(),
             bot_registry.clone(),
@@ -1695,6 +1702,8 @@ impl Default for BcsServerState {
             config.message_history.new_participant_visible_limit,
             config.message_history.default_page_limit,
             config.message_history.max_page_limit,
+            session_file_service.clone(),
+            config.session_files.share.history_attachment_ttl_seconds,
         );
         let a2a_run_store = Arc::new(bcs_message_flow::a2a_chat::ChatRunStore::with_capacity(
             config.async_chat_run_max_entries,
@@ -1917,13 +1926,7 @@ impl Default for BcsServerState {
             .session_management(session_management.clone())
             .channel(channel_service.clone())
             .secret(default_bootstrap_secret_service())
-            .session_files(build_session_files_service_blocking(
-                &config,
-                crate::env::resolve_env(),
-                None,
-                None,
-                session_repo.clone(),
-            ))
+            .session_files(session_file_service)
             .build()
             .expect("services must be fully wired");
 
@@ -2687,6 +2690,8 @@ fn create_group_message_history_service(
     new_participant_visible_limit: u64,
     default_page_limit: u32,
     max_page_limit: u32,
+    session_file: Arc<dyn bcs_service_api::application::session_files::SessionFileService>,
+    history_attachment_ttl: u64,
 ) -> Arc<dyn GroupMessageHistoryService> {
     let websocket_request: Arc<dyn GroupHistoryBotRequestPort> =
         Arc::new(BootstrapGroupHistoryBotRequestPort { bot_connections });
@@ -2705,11 +2710,13 @@ fn create_group_message_history_service(
         session_repo,
         group,
         registry,
+        session_file,
         cutoff_timestamp,
         manager_worker_cutoff_timestamp,
         new_participant_visible_limit,
         default_page_limit,
         max_page_limit,
+        history_attachment_ttl,
     ))
 }
 
@@ -2976,6 +2983,13 @@ impl BcsServer {
         );
         let bot_run_context: Arc<dyn BotRunContextPort> =
             Arc::new(bcs_message_flow::MemoryBotRunContextStore::new());
+        let session_file_service = build_session_files_service_blocking(
+            &config,
+            crate::env::resolve_env(),
+            None,
+            None,
+            session_repo.clone(),
+        );
         let group_message_history = create_group_message_history_service(
             sessions.clone(),
             bot_registry.clone(),
@@ -2989,6 +3003,8 @@ impl BcsServer {
             config.message_history.new_participant_visible_limit,
             config.message_history.default_page_limit,
             config.message_history.max_page_limit,
+            session_file_service.clone(),
+            config.session_files.share.history_attachment_ttl_seconds,
         );
         let a2a_run_store = Arc::new(bcs_message_flow::a2a_chat::ChatRunStore::with_capacity(
             config.async_chat_run_max_entries,
@@ -3191,13 +3207,7 @@ impl BcsServer {
             .session_management(session_management.clone())
             .channel(channel_service.clone())
             .secret(default_bootstrap_secret_service())
-            .session_files(build_session_files_service_blocking(
-                &config,
-                crate::env::resolve_env(),
-                None,
-                None,
-                session_repo.clone(),
-            ))
+            .session_files(session_file_service)
             .build()
             .expect("services must be fully wired");
 
@@ -3550,6 +3560,14 @@ impl BcsServer {
         };
         let bot_run_context: Arc<dyn BotRunContextPort> =
             Arc::new(bcs_message_flow::MemoryBotRunContextStore::new());
+        let session_file_service = build_session_files_service(
+            &config,
+            crate::env::resolve_env(),
+            infrastructure_plugins.db(),
+            Some(db_flavor),
+            session_repo.clone(),
+        )
+        .await;
         let group_message_history = create_group_message_history_service(
             sessions.clone(),
             bot_registry.clone(),
@@ -3563,6 +3581,8 @@ impl BcsServer {
             config.message_history.new_participant_visible_limit,
             config.message_history.default_page_limit,
             config.message_history.max_page_limit,
+            session_file_service.clone(),
+            config.session_files.share.history_attachment_ttl_seconds,
         );
         let a2a_run_store = Arc::new(bcs_message_flow::a2a_chat::ChatRunStore::with_capacity(
             config.async_chat_run_max_entries,
@@ -3785,13 +3805,7 @@ impl BcsServer {
             .session_management(session_management.clone())
             .channel(channel_service.clone())
             .secret(default_bootstrap_secret_service())
-            .session_files(build_session_files_service(
-                &config,
-                crate::env::resolve_env(),
-                infrastructure_plugins.db(),
-                Some(db_flavor),
-                session_repo.clone(),
-            ).await)
+            .session_files(session_file_service)
             .build()
             .expect("services must be fully wired");
 

--- a/src/bcs/crates/contracts/bcs-domain/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/lib.rs
@@ -69,8 +69,8 @@ pub use group_id::{
 };
 pub use message::{
     AuditEntry, BCS_STATE_MACHINE_MESSAGE_SENDER, BCS_STATE_MACHINE_MESSAGE_SENDER_NAME,
-    DeliveryType, GroupMessage, GroupMessageType, MessageOwnerFilter, MessagePage, MessageQuery,
-    MessageRole, NewMessage, PersistedMessage, PersistedMessageStatus,
+    DeliveryType, GroupMessage, GroupMessageType, MessageAttachment, MessageOwnerFilter,
+    MessagePage, MessageQuery, MessageRole, NewMessage, PersistedMessage, PersistedMessageStatus,
     STATE_MACHINE_PANEL_MESSAGE_TYPE, SenderType, Task, TaskStatus,
 };
 pub use organization::{Organization, OrganizationMember};

--- a/src/bcs/crates/contracts/bcs-domain/src/message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/message.rs
@@ -1,5 +1,6 @@
 //! Message / task / audit pure domain types.
 
+use crate::AttachmentType;
 use serde::{Deserialize, Serialize};
 
 pub const BCS_STATE_MACHINE_MESSAGE_SENDER: &str = "bcs_state_machine";
@@ -45,6 +46,32 @@ pub struct AuditEntry {
     pub details: String,
 }
 
+/// Attachment view for history echo: stable_metadata + a short-lived download
+/// `url` minted at read time.
+///
+/// `expires_at` is unix **seconds** (matches share-token `exp` and
+/// `share_consume`'s `as_secs()` check), NOT milliseconds.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageAttachment {
+    pub attachment_id: String,
+    #[serde(rename = "type")]
+    pub attachment_type: AttachmentType,
+    pub file_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    /// Short-lived share_url minted at history-read time; `<img src>` ready.
+    /// `None` when the file was deleted / doesn't belong to the session / storage error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// share_url expiry, unix seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
 /// A message in a group session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GroupMessage {
@@ -77,6 +104,10 @@ pub struct GroupMessage {
     /// Optional metadata (tool execution info, etc.).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    /// Attachments carried by the message (images etc.). Omitted when `None`
+    /// so older frontends that only read `content` are unaffected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<MessageAttachment>>,
 }
 
 /// Role of a message sender.
@@ -220,4 +251,48 @@ pub struct MessagePage {
     pub messages: Vec<PersistedMessage>,
     pub next_cursor: Option<(u64, i64)>,
     pub has_more: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_message_omits_attachments_when_none() {
+        let msg = GroupMessage {
+            id: "m1".into(),
+            timestamp: 1,
+            sender: "s".into(),
+            content: "hi".into(),
+            message_type: GroupMessageType::Bot,
+            bot_name: None,
+            role: MessageRole::User,
+            run_id: String::new(),
+            history_meta: None,
+            metadata: None,
+            attachments: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("attachments"), "attachments must be omitted when None: {json}");
+    }
+
+    #[test]
+    fn message_attachment_serializes_type_rename_and_optional_fields() {
+        let att = MessageAttachment {
+            attachment_id: "att_1".into(),
+            attachment_type: AttachmentType::Image,
+            file_name: "pic.png".into(),
+            mime_type: None,
+            size: None,
+            sha256: None,
+            url: None,
+            expires_at: None,
+        };
+        let json = serde_json::to_string(&att).unwrap();
+        assert!(json.contains("\"type\":\"image\""), "type must rename: {json}");
+        assert!(
+            !json.contains("mime_type") && !json.contains("url") && !json.contains("expires_at"),
+            "None optionals must be omitted: {json}"
+        );
+    }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/session_files.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/session_files.rs
@@ -172,6 +172,17 @@ pub trait SessionFileService: Send + Sync {
         cmd: ShareMintCommand,
     ) -> Result<ShareMintResult, SessionFileUseCaseError>;
 
+    /// Server-authoritative mint for history echo. Does NOT run `can_share`
+    /// (membership is enforced at the history HTTP entry; the pre-existing
+    /// horizontal-privilege gap there is tracked separately — see spec §13).
+    /// Still verifies file ownership via `repo.get(session_id, file_id)`.
+    async fn share_mint_for_history(
+        &self,
+        session_id: &str,
+        file_id: &str,
+        ttl_seconds: u64,
+    ) -> Result<ShareMintResult, SessionFileUseCaseError>;
+
     /// Verify share token (no session auth), return the file (must be Ready).
     async fn share_consume(
         &self,

--- a/src/bcs/crates/service-api/bcs-service-api/tests/core_group_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/core_group_contract.rs
@@ -28,6 +28,7 @@ fn sample_message() -> GroupMessage {
         history_meta: None,
         metadata: None,
         run_id: String::new(),
+        attachments: None,
     }
 }
 

--- a/src/bcs/crates/service-api/bcs-services-container/tests/interceptor_chain_contract.rs
+++ b/src/bcs/crates/service-api/bcs-services-container/tests/interceptor_chain_contract.rs
@@ -99,6 +99,7 @@ fn sample_message() -> OutboundMessage {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         },
     }
 }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -1055,6 +1055,7 @@ impl CollaborationRuntime {
             history_meta: None,
             metadata: Some(state_machine_panel_metadata(run)),
             run_id: String::new(),
+            attachments: None,
         }
     }
 
@@ -1118,6 +1119,7 @@ impl CollaborationRuntime {
                     history_meta: None,
                     metadata: Some(state_machine_message_metadata(run, &node, "output")),
                     run_id: String::new(),
+                    attachments: None,
                 });
             }
         }

--- a/src/bcs/crates/services/bcs-group-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/memory.rs
@@ -644,6 +644,7 @@ mod tests {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         };
         store.add_message("test-group", msg).await.unwrap();
 
@@ -694,6 +695,7 @@ mod tests {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         };
 
         let result = store.add_message("nonexistent", msg).await;
@@ -873,6 +875,7 @@ mod tests {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         };
         store.add_message("test-group", msg).await.unwrap();
 
@@ -1012,6 +1015,7 @@ mod tests {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         };
         store.add_message("test-group", msg).await.unwrap();
 
@@ -1058,6 +1062,7 @@ mod tests {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             },
             GroupMessage {
                 id: "msg-2".to_string(),
@@ -1070,6 +1075,7 @@ mod tests {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             },
             GroupMessage {
                 id: "msg-3".to_string(),
@@ -1082,6 +1088,7 @@ mod tests {
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             },
         ];
 

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -572,6 +572,7 @@ impl A2aChatService for A2aChat {
                     run_id: String::new(),
                     history_meta: None,
                     metadata: None,
+                    attachments: None,
                 };
                 let mut outbound = OutboundMessage {
                     group_id: run_id.clone(),

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -610,6 +610,7 @@ async fn relay_final_chat_event(
             run_id: String::new(),
             history_meta: None,
             metadata: None,
+            attachments: None,
         };
         let outbound_message = match crate::group_flow::apply_outbound_interceptors(
             flow,

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -541,6 +541,7 @@ pub async fn handle_web_send(
             run_id: String::new(),
             history_meta: None,
             metadata: None,
+            attachments: None,
         };
         let outbound_message = match apply_outbound_interceptors(
             flow,
@@ -1000,6 +1001,7 @@ pub async fn handle_persistent_group_send(
         run_id: String::new(),
         history_meta: None,
         metadata: None,
+        attachments: None,
     };
 
     let sender_type = if cmd.sender.starts_with("human_") {
@@ -1322,6 +1324,7 @@ async fn apply_chain_for_bot_pair(
         run_id: String::new(),
         history_meta: None,
         metadata: None,
+        attachments: None,
     };
     let mut outbound = OutboundMessage {
         group_id: context_tag.to_string(),
@@ -1380,6 +1383,7 @@ pub async fn handle_group_callback(
             run_id: String::new(),
             history_meta: None,
             metadata: cmd.metadata.clone(),
+            attachments: None,
         };
         try_persist_group_message(
             flow,
@@ -1441,6 +1445,7 @@ pub async fn handle_group_callback(
             run_id: String::new(),
             history_meta: None,
             metadata: cmd.metadata.clone(),
+            attachments: None,
         };
         let outbound_message =
             match apply_outbound_interceptors(flow, &cmd.group_id, &synthetic_message, target).await

--- a/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_history.rs
@@ -848,6 +848,7 @@ fn convert_bot_history_messages(
                 run_id: String::new(),
                 history_meta: message.get("historyMeta").cloned(),
                 metadata,
+                attachments: None,
             }
         })
         .collect()
@@ -1013,6 +1014,7 @@ fn normalize_group_store_messages(
                         run_id: String::new(),
                         history_meta: message.history_meta.clone(),
                         metadata: message.metadata.clone(),
+                        attachments: None,
                     }
                 })
                 .collect::<Vec<_>>()

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -1084,6 +1084,7 @@ async fn group_history_falls_back_to_store_when_bot_window_has_no_older_messages
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             },
         )
         .await
@@ -1103,6 +1104,7 @@ async fn group_history_falls_back_to_store_when_bot_window_has_no_older_messages
                 history_meta: None,
                 metadata: None,
                 run_id: String::new(),
+                attachments: None,
             },
         )
         .await

--- a/src/bcs/crates/services/bcs-message/Cargo.toml
+++ b/src/bcs/crates/services/bcs-message/Cargo.toml
@@ -20,6 +20,7 @@ bcs-bot = { workspace = true }
 bcs-group = { workspace = true }
 bcs-message-store = { workspace = true }
 bcs-session-store = { workspace = true }
+bcs-storage-api = { workspace = true }
 bcs-system-message = { workspace = true }
 bcs-test-support = { workspace = true }
 

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -9,14 +9,14 @@ use async_trait::async_trait;
 use tracing::info;
 
 use bcs_domain::{
-    BCS_STATE_MACHINE_MESSAGE_SENDER_NAME, MessageOwnerFilter, MessageQuery,
+    BCS_STATE_MACHINE_MESSAGE_SENDER_NAME, MessageAttachment, MessageOwnerFilter, MessageQuery,
     STATE_MACHINE_PANEL_MESSAGE_TYPE, Session,
 };
 use bcs_service_api::{
-    BotRegistryCoreService, GroupCoreService, GroupHistoryCommand, GroupHistoryResult,
-    GroupMessageHistoryService, GroupUseCaseError, SessionHistoryCommand, SessionHistoryResult,
-    Group, GroupMessage, GroupMessageType, GroupStrategy, MessageRole, ParticipantRole,
-    port::repo::{MessageRepoPort, SessionRepoPort},
+    application::session_files::SessionFileService, BotRegistryCoreService, GroupCoreService,
+    GroupHistoryCommand, GroupHistoryResult, GroupMessageHistoryService, GroupUseCaseError,
+    SessionHistoryCommand, SessionHistoryResult, Group, GroupMessage, GroupMessageType,
+    GroupStrategy, MessageRole, ParticipantRole, port::repo::{MessageRepoPort, SessionRepoPort},
     ServiceError,
 };
 
@@ -30,11 +30,13 @@ pub struct MessageService {
     session_repo: Arc<dyn SessionRepoPort>,
     group: Arc<dyn GroupCoreService>,
     registry: Arc<dyn BotRegistryCoreService>,
+    session_file: Arc<dyn SessionFileService>,
     cutoff_timestamp: u64,
     manager_worker_cutoff_timestamp: u64,
     new_participant_visible_limit: u64,
     default_page_limit: u32,
     max_page_limit: u32,
+    history_attachment_ttl: u64,
 }
 
 pub enum ManagerWorkerHistoryView {
@@ -49,11 +51,13 @@ impl MessageService {
         session_repo: Arc<dyn SessionRepoPort>,
         group: Arc<dyn GroupCoreService>,
         registry: Arc<dyn BotRegistryCoreService>,
+        session_file: Arc<dyn SessionFileService>,
         cutoff_timestamp: u64,
         manager_worker_cutoff_timestamp: u64,
         new_participant_visible_limit: u64,
         default_page_limit: u32,
         max_page_limit: u32,
+        history_attachment_ttl: u64,
     ) -> Self {
         Self {
             message_repo,
@@ -61,11 +65,13 @@ impl MessageService {
             session_repo,
             group,
             registry,
+            session_file,
             cutoff_timestamp,
             manager_worker_cutoff_timestamp,
             new_participant_visible_limit,
             default_page_limit,
             max_page_limit,
+            history_attachment_ttl,
         }
     }
 
@@ -248,6 +254,55 @@ fn extract_tool_result_text(result: &serde_json::Value) -> String {
     result.to_string()
 }
 
+/// Extract display text + attachment views (without url) from persisted content.
+/// - `Value::String(s)`                         -> (s, None)
+/// - `Value::Object{ text, attachments }`       -> (text, attachments mapped; url=None)
+/// - other                                      -> (content.to_string(), None)
+fn extract_text_and_attachments(
+    content: &serde_json::Value,
+) -> (String, Option<Vec<MessageAttachment>>) {
+    if let Some(s) = content.as_str() {
+        return (s.to_string(), None);
+    }
+    if let Some(obj) = content.as_object() {
+        let text = obj
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let attachments = obj
+            .get("attachments")
+            .and_then(serde_json::Value::as_array)
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(parse_message_attachment)
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v| !v.is_empty());
+        return (text, attachments);
+    }
+    (content.to_string(), None)
+}
+
+/// Map one stable_metadata JSON object to a `MessageAttachment` (url=None).
+/// Returns None if `attachment_id` or `file_name` is missing.
+fn parse_message_attachment(v: &serde_json::Value) -> Option<MessageAttachment> {
+    let obj = v.as_object()?;
+    Some(MessageAttachment {
+        attachment_id: obj.get("attachment_id")?.as_str()?.to_string(),
+        attachment_type: obj
+            .get("type")
+            .and_then(|t| serde_json::from_value(t.clone()).ok())
+            .unwrap_or(bcs_domain::AttachmentType::Image),
+        file_name: obj.get("file_name")?.as_str()?.to_string(),
+        mime_type: obj.get("mime_type").and_then(|v| v.as_str()).map(String::from),
+        size: obj.get("size").and_then(|v| v.as_u64()),
+        sha256: obj.get("sha256").and_then(|v| v.as_str()).map(String::from),
+        url: None,
+        expires_at: None,
+    })
+}
+
 fn persisted_to_group_message(
     pm: bcs_domain::PersistedMessage,
     bot_name: Option<String>,
@@ -267,15 +322,15 @@ fn persisted_to_group_message(
             .unwrap_or(BCS_STATE_MACHINE_MESSAGE_SENDER_NAME)
             .to_string()
     });
-    let (role, metadata, content_str) = match pm.message_type.as_str() {
+    let (role, metadata, content_str, attachments) = match pm.message_type.as_str() {
         "chat" | "text" | "system" => {
             let role = match pm.sender_type {
                 bcs_domain::SenderType::Human => MessageRole::User,
                 bcs_domain::SenderType::Bot => MessageRole::Assistant,
                 bcs_domain::SenderType::System => MessageRole::System,
             };
-            let text = pm.content.as_str().unwrap_or("").to_string();
-            (role, None, text)
+            let (text, attachments) = extract_text_and_attachments(&pm.content);
+            (role, None, text, attachments)
         }
         STATE_MACHINE_PANEL_MESSAGE_TYPE => {
             // TODO(sm-history-node-expansion): expand this persisted panel anchor
@@ -288,7 +343,7 @@ fn persisted_to_group_message(
                 .unwrap_or("")
                 .to_string();
             let metadata = pm.content.get("metadata").cloned();
-            (MessageRole::Assistant, metadata, text)
+            (MessageRole::Assistant, metadata, text, None)
         }
         "tool_call" => {
             let metadata = build_tool_call_metadata(&pm.content);
@@ -296,7 +351,7 @@ fn persisted_to_group_message(
                 .get("result")
                 .map(|r| extract_tool_result_text(r))
                 .unwrap_or_else(|| pm.content.to_string());
-            (MessageRole::ToolResult, metadata, text)
+            (MessageRole::ToolResult, metadata, text, None)
         }
         _ => {
             let role = match pm.sender_type {
@@ -305,7 +360,7 @@ fn persisted_to_group_message(
                 bcs_domain::SenderType::System => MessageRole::System,
             };
             let text = pm.content.as_str().unwrap_or("").to_string();
-            (role, None, text)
+            (role, None, text, None)
         }
     };
 
@@ -320,6 +375,33 @@ fn persisted_to_group_message(
         run_id: pm.run_id,
         history_meta: None,
         metadata,
+        attachments,
+    }
+}
+
+/// Mint a share_url into each attachment of a single message. Failures per
+/// attachment (file deleted / not owned by session / storage error) leave
+/// `url: None` and do NOT abort the batch or bubble up.
+async fn enrich_message_attachments(
+    svc: &Arc<dyn SessionFileService>,
+    session_id: &str,
+    ttl: u64,
+    msg: &mut GroupMessage,
+) {
+    let Some(atts) = msg.attachments.as_mut() else {
+        return;
+    };
+    for att in atts.iter_mut() {
+        match svc.share_mint_for_history(session_id, &att.attachment_id, ttl).await {
+            Ok(minted) => {
+                att.url = Some(minted.share_url);
+                att.expires_at = Some(minted.expires_at);
+            }
+            Err(_) => {
+                att.url = None;
+                att.expires_at = None;
+            }
+        }
     }
 }
 
@@ -387,7 +469,18 @@ impl GroupMessageHistoryService for MessageService {
                             name
                         }
                     };
-                    result.push(persisted_to_group_message(pm, bot_name));
+                    let session_id_for_pm = pm.session_id.clone();
+                    let mut gm = persisted_to_group_message(pm, bot_name);
+                    if gm.attachments.is_some() && !session_id_for_pm.is_empty() {
+                        enrich_message_attachments(
+                            &self.session_file,
+                            &session_id_for_pm,
+                            self.history_attachment_ttl,
+                            &mut gm,
+                        )
+                        .await;
+                    }
+                    result.push(gm);
                 }
                 result
             };
@@ -481,7 +574,18 @@ impl GroupMessageHistoryService for MessageService {
                             name
                         }
                     };
-                    result.push(persisted_to_group_message(pm, bot_name));
+                    let session_id_for_pm = pm.session_id.clone();
+                    let mut gm = persisted_to_group_message(pm, bot_name);
+                    if gm.attachments.is_some() && !session_id_for_pm.is_empty() {
+                        enrich_message_attachments(
+                            &self.session_file,
+                            &session_id_for_pm,
+                            self.history_attachment_ttl,
+                            &mut gm,
+                        )
+                        .await;
+                    }
+                    result.push(gm);
                 }
                 result
             };
@@ -589,11 +693,182 @@ mod tests {
     use bcs_group::GroupCore;
     use bcs_message_store::MemoryMessageRepo;
     use bcs_service_api::{
+        application::session_files::{
+            CapabilitiesView, DeleteFileCommand, DownloadRoute, PrepareUploadCommand,
+            PrepareUploadResult, SessionFileService, SessionFileUseCaseError, ShareConsumeResult,
+            ShareMintCommand, ShareMintResult,
+        },
         CallerContext, Group, MessageRole, Participant, ParticipantRole, SessionKind,
-        port::repo::{MessageRepoError, NewSessionParams, SessionRepoPort},
+        port::repo::{
+            MessageRepoError, NewSessionParams, SessionFileListPage, SessionFileListParams,
+            SessionRepoPort,
+        },
     };
     use bcs_session_store::MemorySessionRepo;
+    use bcs_storage_api::ByteStream;
     use tokio::sync::Mutex;
+
+    // Minimal mock: everything errors except share_mint_for_history (configurable).
+    struct MintMock {
+        ok: bool,
+    }
+
+    #[async_trait]
+    impl SessionFileService for MintMock {
+        async fn capabilities(&self) -> CapabilitiesView {
+            unimplemented!()
+        }
+        async fn prepare_upload(
+            &self,
+            _cmd: PrepareUploadCommand,
+        ) -> Result<PrepareUploadResult, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn stream_upload(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+            _part_number: Option<u16>,
+            _body: ByteStream,
+            _content_length: u64,
+        ) -> Result<(), SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn complete_upload(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+        ) -> Result<bcs_domain::SessionFile, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn delete_file(
+            &self,
+            _cmd: DeleteFileCommand,
+        ) -> Result<(), SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn get(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+        ) -> Result<bcs_domain::SessionFile, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn list(
+            &self,
+            _session_id: &str,
+            _params: SessionFileListParams,
+        ) -> Result<SessionFileListPage, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn download_route(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+            _ttl_secs: Option<u64>,
+            _show: bool,
+        ) -> Result<(bcs_domain::SessionFile, DownloadRoute), SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn share_mint(
+            &self,
+            _cmd: ShareMintCommand,
+        ) -> Result<ShareMintResult, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn share_consume(
+            &self,
+            _token: &str,
+        ) -> Result<ShareConsumeResult, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn get_stream(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+        ) -> Result<(bcs_domain::SessionFile, ByteStream), SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn sweep_expired_pending(&self) -> Result<u64, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn delete_all_for_session(
+            &self,
+            _session_id: &str,
+        ) -> Result<u64, SessionFileUseCaseError> {
+            unimplemented!()
+        }
+        async fn share_mint_for_history(
+            &self,
+            _session_id: &str,
+            _file_id: &str,
+            _ttl_seconds: u64,
+        ) -> Result<ShareMintResult, SessionFileUseCaseError> {
+            if self.ok {
+                Ok(ShareMintResult {
+                    share_url: "https://bcs/sessions/shared-file/content?token=x".into(),
+                    share_token: "x".into(),
+                    expires_at: 9999,
+                })
+            } else {
+                Err(SessionFileUseCaseError::NotFound("nope".into()))
+            }
+        }
+    }
+
+    fn att_msg() -> GroupMessage {
+        GroupMessage {
+            id: "m".into(),
+            timestamp: 1,
+            sender: "s".into(),
+            content: "t".into(),
+            message_type: GroupMessageType::Bot,
+            bot_name: None,
+            role: MessageRole::User,
+            run_id: String::new(),
+            history_meta: None,
+            metadata: None,
+            attachments: Some(vec![MessageAttachment {
+                attachment_id: "file_1".into(),
+                attachment_type: bcs_domain::AttachmentType::Image,
+                file_name: "f.png".into(),
+                mime_type: None,
+                size: None,
+                sha256: None,
+                url: None,
+                expires_at: None,
+            }]),
+        }
+    }
+
+    #[tokio::test]
+    async fn enrich_fills_url_on_success() {
+        let svc: Arc<dyn SessionFileService> = Arc::new(MintMock { ok: true });
+        let mut msg = att_msg();
+        enrich_message_attachments(&svc, "sid", 3600, &mut msg).await;
+        let att = &msg.attachments.as_ref().unwrap()[0];
+        assert_eq!(att.url.as_deref(), Some("https://bcs/sessions/shared-file/content?token=x"));
+        assert_eq!(att.expires_at, Some(9999));
+    }
+
+    #[tokio::test]
+    async fn enrich_leaves_url_none_on_failure() {
+        let svc: Arc<dyn SessionFileService> = Arc::new(MintMock { ok: false });
+        let mut msg = att_msg();
+        enrich_message_attachments(&svc, "sid", 3600, &mut msg).await;
+        let att = &msg.attachments.as_ref().unwrap()[0];
+        assert!(att.url.is_none());
+        assert!(att.expires_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn enrich_no_op_when_no_attachments() {
+        let svc: Arc<dyn SessionFileService> = Arc::new(MintMock { ok: true });
+        let mut msg = att_msg();
+        msg.attachments = None;
+        enrich_message_attachments(&svc, "sid", 3600, &mut msg).await;
+        assert!(msg.attachments.is_none());
+    }
 
     struct FallbackHistory {
         messages: Mutex<Vec<GroupMessage>>,
@@ -710,6 +985,7 @@ mod tests {
             run_id: String::new(),
             history_meta: None,
             metadata: None,
+            attachments: None,
         }
     }
 
@@ -784,11 +1060,13 @@ mod tests {
             session_repo.clone(),
             group,
             Arc::new(BotCore::memory()),
+            Arc::new(MintMock { ok: true }),
             chat_cutoff,
             manager_worker_cutoff,
             100,
             50,
             100,
+            3600,
         );
 
         (service, message_repo, session_repo, fallback, session_id)
@@ -1349,5 +1627,104 @@ mod tests {
         );
         group.group_strategy = GroupStrategy::Chat;
         group
+    }
+
+    mod attachment_parse_tests {
+        use super::*;
+        use bcs_domain::{PersistedMessage, SenderType};
+
+        fn pm(content: serde_json::Value) -> PersistedMessage {
+            PersistedMessage {
+                message_id: "m".into(),
+                group_id: "g".into(),
+                session_id: "sid".into(),
+                session_seq: 1,
+                sender_id: "human_x".into(),
+                sender_type: SenderType::Human,
+                message_type: "chat".into(),
+                content,
+                client_msg_id: None,
+                owner_bot_id: None,
+                status: bcs_domain::PersistedMessageStatus::Normal,
+                created_at: 1,
+                run_id: String::new(),
+            }
+        }
+
+        #[test]
+        fn plain_string_content_returns_text_no_attachments() {
+            let (text, atts) = extract_text_and_attachments(&serde_json::json!("hello"));
+            assert_eq!(text, "hello");
+            assert!(atts.is_none());
+        }
+
+        #[test]
+        fn object_content_extracts_text_and_attachments_without_url() {
+            let content = serde_json::json!({
+                "text": "描述一下图片",
+                "attachments": [{
+                    "attachment_id": "01KZ977A05N0TVGX8BKFA26T6D",
+                    "type": "image",
+                    "file_name": "109951168084935137.jpg",
+                    "mime_type": "image/jpeg",
+                    "sha256": null,
+                    "size": 13276
+                }]
+            });
+            let (text, atts) = extract_text_and_attachments(&content);
+            assert_eq!(text, "描述一下图片");
+            let atts = atts.expect("attachments present");
+            assert_eq!(atts.len(), 1);
+            assert_eq!(atts[0].attachment_id, "01KZ977A05N0TVGX8BKFA26T6D");
+            assert_eq!(atts[0].file_name, "109951168084935137.jpg");
+            assert_eq!(atts[0].mime_type.as_deref(), Some("image/jpeg"));
+            assert_eq!(atts[0].size, Some(13276));
+            assert!(atts[0].url.is_none(), "url must be None at parse stage");
+            assert!(atts[0].expires_at.is_none());
+        }
+
+        #[test]
+        fn object_without_attachments_returns_text_only() {
+            let content = serde_json::json!({"text": "only text"});
+            let (text, atts) = extract_text_and_attachments(&content);
+            assert_eq!(text, "only text");
+            assert!(atts.is_none());
+        }
+
+        #[test]
+        fn object_without_text_returns_empty_text() {
+            let content = serde_json::json!({"attachments": [{"attachment_id":"a","type":"image","file_name":"f"}]});
+            let (text, atts) = extract_text_and_attachments(&content);
+            assert_eq!(text, "");
+            assert!(atts.is_some());
+        }
+
+        #[test]
+        fn attachment_missing_required_fields_is_dropped() {
+            let content = serde_json::json!({
+                "text": "t",
+                "attachments": [
+                    {"type":"image","file_name":"no_id"},            // missing attachment_id -> dropped
+                    {"attachment_id":"a","file_name":"f"}            // missing type -> defaults to Image, kept
+                ]
+            });
+            let (_t, atts) = extract_text_and_attachments(&content);
+            let atts = atts.expect("some kept");
+            assert_eq!(atts.len(), 1, "only the second attachment survives");
+            assert_eq!(atts[0].attachment_id, "a");
+        }
+
+        #[test]
+        fn persisted_to_group_message_preserves_text_and_attachments() {
+            let content = serde_json::json!({
+                "text": "描述一下图片",
+                "attachments": [{"attachment_id":"a","type":"image","file_name":"f","mime_type":"image/png","size":4,"sha256":null}]
+            });
+            let gm = persisted_to_group_message(pm(content), None);
+            assert_eq!(gm.content, "描述一下图片");
+            let atts = gm.attachments.expect("attachments");
+            assert_eq!(atts[0].attachment_id, "a");
+            assert!(atts[0].url.is_none());
+        }
     }
 }

--- a/src/bcs/crates/services/bcs-session-file/src/noop.rs
+++ b/src/bcs/crates/services/bcs-session-file/src/noop.rs
@@ -105,6 +105,17 @@ impl SessionFileService for NoopSessionFileService {
         )))
     }
 
+    async fn share_mint_for_history(
+        &self,
+        _session_id: &str,
+        _file_id: &str,
+        _ttl_seconds: u64,
+    ) -> Result<ShareMintResult, SessionFileUseCaseError> {
+        Err(SessionFileUseCaseError::Internal(ServiceError::InternalError(
+            NOT_SUPPORTED.into(),
+        )))
+    }
+
     async fn share_consume(
         &self,
         _token: &str,

--- a/src/bcs/crates/services/bcs-session-file/src/service.rs
+++ b/src/bcs/crates/services/bcs-session-file/src/service.rs
@@ -576,53 +576,27 @@ impl SessionFileService for SessionFileServiceImpl {
         &self,
         cmd: ShareMintCommand,
     ) -> Result<ShareMintResult, SessionFileUseCaseError> {
-        let row = self
-            .cfg
-            .repo
-            .get(&cmd.session_id, &cmd.file_id)
-            .await
-            .map_err(SessionFileUseCaseError::Internal)?
-            .ok_or_else(|| SessionFileUseCaseError::NotFound(format!("file {}", cmd.file_id)))?;
-        if row.status != FileStatus::Ready {
-            return Err(SessionFileUseCaseError::InvalidState(format!(
-                "file status {:?} not Ready — cannot share",
-                row.status,
-            )));
-        }
+        // can_share is the membership gate specific to the public share API;
+        // ownership + Ready are checked inside mint_share_link via repo.get.
+        // (Original order did repo.get before can_share; reordering is
+        // behavior-equivalent — both rejections still reject.)
         if !can_share(&cmd.caller_identities, &cmd.session_participants) {
             return Err(SessionFileUseCaseError::Forbidden(format!(
                 "caller not a session member, cannot share file {}",
                 cmd.file_id,
             )));
         }
-        let ttl = cmd
-            .ttl_seconds
-            .unwrap_or(self.cfg.share_default_ttl)
-            .clamp(SHARE_TTL_MIN, SHARE_TTL_MAX);
-        let exp = now_secs() + ttl;
-        let token = share_token_encode(
-            &ShareTokenPayload {
-                v: 1,
-                file_id: cmd.file_id.clone(),
-                exp,
-            },
-            &self.cfg.share_secret,
-        );
-        let base = self
-            .cfg
-            .share_base_url
-            .clone()
-            .unwrap_or_else(|| self.cfg.bcs_base_url.clone());
-        let share_url = format!(
-            "{}/sessions/shared-file/content?token={}",
-            base,
-            token,
-        );
-        Ok(ShareMintResult {
-            share_url,
-            share_token: token,
-            expires_at: exp,
-        })
+        let ttl = cmd.ttl_seconds.unwrap_or(self.cfg.share_default_ttl);
+        self.mint_share_link(&cmd.session_id, &cmd.file_id, ttl).await
+    }
+
+    async fn share_mint_for_history(
+        &self,
+        session_id: &str,
+        file_id: &str,
+        ttl_seconds: u64,
+    ) -> Result<ShareMintResult, SessionFileUseCaseError> {
+        self.mint_share_link(session_id, file_id, ttl_seconds).await
     }
 
     async fn share_consume(
@@ -790,6 +764,56 @@ impl SessionFileService for SessionFileServiceImpl {
 }
 
 impl SessionFileServiceImpl {
+    /// Mint a share link with NO authz check. Only the ownership/Ready check
+    /// (`repo.get(session_id, file_id)`) gates this. Used by `share_mint`
+    /// (after `can_share`) and `share_mint_for_history` (caller-authz done by
+    /// the history HTTP entry).
+    async fn mint_share_link(
+        &self,
+        session_id: &str,
+        file_id: &str,
+        ttl_seconds: u64,
+    ) -> Result<ShareMintResult, SessionFileUseCaseError> {
+        let row = self
+            .cfg
+            .repo
+            .get(session_id, file_id)
+            .await
+            .map_err(SessionFileUseCaseError::Internal)?
+            .ok_or_else(|| SessionFileUseCaseError::NotFound(format!("file {}", file_id)))?;
+        if row.status != FileStatus::Ready {
+            return Err(SessionFileUseCaseError::InvalidState(format!(
+                "file status {:?} not Ready — cannot share",
+                row.status,
+            )));
+        }
+        let ttl = ttl_seconds.clamp(SHARE_TTL_MIN, SHARE_TTL_MAX);
+        let exp = now_secs() + ttl;
+        let token = share_token_encode(
+            &ShareTokenPayload {
+                v: 1,
+                file_id: file_id.to_string(),
+                exp,
+            },
+            &self.cfg.share_secret,
+        );
+        let base = self
+            .cfg
+            .share_base_url
+            .clone()
+            .unwrap_or_else(|| self.cfg.bcs_base_url.clone());
+        let share_url = format!(
+            "{}/sessions/shared-file/content?token={}",
+            base,
+            token,
+        );
+        Ok(ShareMintResult {
+            share_url,
+            share_token: token,
+            expires_at: exp,
+        })
+    }
+
     /// Attempt backend cleanup for one row during session-delete.
     ///
     /// Returns `true` when the backend holds no remaining object for the row
@@ -1529,6 +1553,61 @@ mod tests {
         // Tampered token → InvalidInput (per `From<ShareTokenError>` mapping)
         // or InvalidSignature → InvalidInput.
         assert!(matches!(err, SessionFileUseCaseError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn mint_share_link_and_share_mint_produce_same_token_shape() {
+        // Parity: identical (session_id, file_id, ttl) via the internal helper
+        // and the public share_mint (after can_share) must yield the same
+        // share_url / share_token / expires_at. Regression guard for the
+        // mint_share_link extraction.
+        let (svc, _, _) = build_svc(local_caps());
+        let file_id = prepare_complete(&svc).await;
+
+        // share_mint uses ttl_seconds=None → defaults to share_default_ttl (3600).
+        // Pass the same 3600 to mint_share_link so the token shape matches.
+        let via_internal = svc
+            .mint_share_link("g1:abcd1234", &file_id, 3600)
+            .await
+            .expect("internal mint");
+        let via_public = svc
+            .share_mint(share_cmd(&file_id, &["human_1"], &["human_1"]))
+            .await
+            .expect("public mint");
+
+        assert_eq!(via_internal.share_url, via_public.share_url);
+        assert_eq!(via_internal.share_token, via_public.share_token);
+        assert_eq!(via_internal.expires_at, via_public.expires_at);
+    }
+
+    #[tokio::test]
+    async fn share_mint_for_history_mints_for_owned_file() {
+        // History echo path: server-authoritative mint with NO `can_share` —
+        // ownership is verified via `repo.get(session_id, file_id)`.
+        let (svc, _, _) = build_svc(local_caps());
+        let file_id = prepare_complete(&svc).await; // seeded under g1:abcd1234
+        let minted = svc
+            .share_mint_for_history("g1:abcd1234", &file_id, 3600)
+            .await
+            .expect("history mint");
+        assert!(minted.share_url.contains("/sessions/shared-file/content?token="));
+        // token actually verifies + resolves to the same file
+        let resolved = svc.share_consume(&minted.share_token).await.expect("consume");
+        assert_eq!(resolved.file.file_id, file_id);
+    }
+
+    #[tokio::test]
+    async fn share_mint_for_history_rejects_cross_session_file() {
+        // file belongs to g1:abcd1234, ask as g1:other -> NotFound (ownership
+        // check via `repo.get(session_id, file_id)` returns None for wrong
+        // session).
+        let (svc, _, _) = build_svc(local_caps());
+        let file_id = prepare_complete(&svc).await; // under g1:abcd1234
+        let err = svc
+            .share_mint_for_history("g1:other", &file_id, 3600)
+            .await
+            .expect_err("must reject cross-session");
+        assert!(matches!(err, SessionFileUseCaseError::NotFound(_)), "got: {:?}", err);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/interceptor/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/interceptor/mod.rs
@@ -38,6 +38,7 @@ fn sample_outbound_message() -> OutboundMessage {
             history_meta: None,
             metadata: None,
             run_id: String::new(),
+            attachments: None,
         },
     }
 }


### PR DESCRIPTION
## Problem

Frontend image-attachment support landed, but `bcs_messages` history with attachments returned **empty content**. Root cause: `persisted_to_group_message` did `pm.content.as_str().unwrap_or("")` on the `chat|text|system` branch, but attachment-bearing rows store `content` as a JSON **object** `{"text":...,"attachments":[stable_metadata...]}` — `as_str()` returns `None`, so the text collapsed to `""` and the attachments were lost. Separately, even if parsed back, there was no downloadable URL: `stable_metadata` deliberately strips `url`/`expires_at` (they are ephemeral capabilities), and `GroupMessage` had no `attachments` field.

So: history could not render user-sent images, and the message text itself was lost.

## Solution

**Read-side only. No DB migration, no write-path change.** `persisted_inbound_content` still writes the two content formats; `stable_metadata` still strips the URL.

- **Data model** (`bcs-domain`): add `MessageAttachment` view type + `GroupMessage.attachments: Option<Vec<MessageAttachment>>`, `#[serde(skip_serializing_if = Option::is_none")]` so older frontends that only read `content` are unaffected. `MessageAttachment.expires_at` is unix **seconds** (matches share-token `exp` / `share_consume`'s `as_secs()`).
- **Parse fix** (`bcs-message`): `extract_text_and_attachments` + `parse_message_attachment` helpers; `persisted_to_group_message`'s `chat|text|system` arm now returns text + attachment metadata (url=`None` at parse stage). Tolerance: entries missing `attachment_id`/`file_name` are dropped; missing `type` defaults to `Image`.
- **Mint** (`bcs-session-file`): extract a no-authz `mint_share_link` (does `repo.get(session_id, file_id)` ownership + Ready check + clamp + token encode + URL) shared by `share_mint` (which keeps its `can_share` gate — behavior unchanged) and a new `SessionFileService::share_mint_for_history` (skips `can_share` — membership is enforced at the history HTTP entry — but still verifies file ownership, so cross-session mint returns `NotFound`).
- **Enrich** (`bcs-message`): inject `SessionFileService` + `history_attachment_ttl` into `MessageService`; in both `get_history` and `get_session_history` new-path conversion loops, clone `pm.session_id` before the move, re-mint a short-lived `share_url` per attachment (skip when `session_id` empty), and leave `url: None` on per-attachment failure (no batch abort). Fallback history path untouched.
- **Bootstrap** (`bcs`): thread `session_file` + `history_attachment_ttl_seconds` (config default 3600s, clamped `[60, 604800]`) into `create_group_message_history_service` and its 3 call sites; each reuses the same `Arc<dyn SessionFileService>` instance the session-files HTTP routes use.

The URL is not persisted; it is re-minted on every history read, so a stale/expired URL is fixed by re-fetching history.

**Rejected alternatives:** (a) a first-class `attachments` DB column + migration — deferred; the minimal parse-existing-object approach unblocks now without schema churn. (b) returning the in-session bearer download URL — bots/external consumers can't authenticate; the no-auth share_url is the right capability shape. (c) reusing `share_mint` directly — would require threading caller identities into `get_history`, invasive; the internal `share_mint_for_history` decouples it.

## Validation

- `cargo build --workspace` — clean.
- `cargo test --workspace` (full one-shot) — **green, 0 failures** across all suites (bcs lib 159, bcs-message 24 incl. 6 new parse tests + 3 enrich tests, bcs-session-file 56 incl. `mint_share_link`/`share_mint_for_history` parity + cross-session-ownership, integration_http_api 3, plus all other crates).
- New targeted tests: parse of `{text,attachments}` / string / object-without-text / dropped-missing-fields; enrich success fills `url`+`expires_at`, failure leaves `None`, no-attachments no-op; `share_mint_for_history` mints a `share_consume`-verifiable token for an owned file and returns `NotFound` for a cross-session `file_id`; `mint_share_link`/`share_mint` parity (token shape identical).
- A whole-branch cross-cutting review verified end-to-end coherence (parse → enrich → mint → consume uses `attachment_id`==`file_id` consistently), failure isolation, clone-before-move, write-path/schema non-touching, and `share_mint` behavior preservation: **Merge: Ready, no Critical/Important findings**.

Per AGENTS.md, the pre-push hook is lint-only by default; `OCB_PRE_PUSH_RUN_CI=1` opts into the full module gates.

## Compatibility and risk

- **No schema migration, no write-path change.** `NewMessage`/`PersistedMessage`/`bcs_messages`/`persisted_inbound_content`/`stable_metadata` untouched. Rollback = revert the single squashed commit.
- **Wire contract:** `GroupMessage.attachments` is optional and omitted when `None` — existing API consumers that ignore unknown fields see no change.
- **`default_ttl_seconds` Default alignment:** replacing `#[derive(Default)]` on `SessionFilesShareConfig` with a manual `Default` (needed so the new `history_attachment_ttl_seconds` defaults to 3600, not 0) also aligned `default_ttl_seconds` from `0` to `86400` in `Default::default()`. Production deserialization already used the 86400 serde default, so prod is unaffected; only `Default::default()` callers (tests/dev) change, and no test depended on 0 (old 0 was a latent bug — clamped to 60s at mint). Low risk.
- **Pre-existing, deferred:** the history endpoints (`GET /sessions/{sid}/messages`, `GET /groups/{id}/messages`) have a horizontal-privilege gap (`resolve_session_caller` doesn't verify session membership). This branch does **not** widen it — `share_mint_for_history` still scopes by `pm.session_id` and verifies file ownership — but a history reader who can already see message text can now also fetch attachment bytes. Closing the endpoint membership gap is tracked separately in the design doc (§13), not in this PR.

## Spec

Design + implementation plan were authored via the superpowers brainstorming → writing-plans flow (stored locally under `docs/superpowers/specs|plans/2026-08-06-history-attachment-echo-*`, intentionally not committed). The Problem/Solution/Compatibility above summarize the design; the cross-task SDD review ledger is in `.superpowers/sdd/` (gitignored).

## Related issues

None.
