### PR TITLE
Feat/sse support interaction

### DIFF
--- a/src/baas/sqls/migrate_baas_bot_run_interaction.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_interaction.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `baas_bot_run_interaction` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `session_key` varchar(512) NOT NULL COMMENT 'engine sessionKey',
+  `interaction_id` varchar(160) NOT NULL COMMENT 'engine interactionId',
+  `state` varchar(32) NOT NULL COMMENT 'requested/queued/dispatching/resolved/expired/failed',
+  `payload` JSON NOT NULL COMMENT '完整 interaction 协议快照 JSON',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_session_interaction` (`session_key`, `interaction_id`),
+  KEY `idx_session_state` (`session_key`, `state`)
+) AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COMMENT = 'Bot run human interaction state';

--- a/src/baas/sqls/migrate_baas_bot_run_interaction.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_interaction.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS `baas_bot_run_interaction` (
   `interaction_id` varchar(160) NOT NULL COMMENT 'engine interactionId',
   `state` varchar(32) NOT NULL COMMENT 'requested/queued/dispatching/resolved/expired/failed',
   `payload` JSON NOT NULL COMMENT '完整 interaction 协议快照 JSON',
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_session_interaction` (`session_key`, `interaction_id`),
   KEY `idx_session_state` (`session_key`, `state`)

--- a/src/baas/sqls/migrate_baas_bot_run_queue_chunk.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_queue_chunk.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `baas_bot_run_queue_chunk` (
    `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   `run_id`      varchar(128) NOT NULL COMMENT '关联 baas_bot_run.run_id',
   `seq`         int(11) NOT NULL COMMENT 'chunk 序号，严格递增',
-  `chunk_type`  varchar(16) NOT NULL COMMENT 'delta / final / error / usage / agent',
+  `chunk_type`  varchar(16) NOT NULL COMMENT 'delta / final / error / usage / agent / interaction',
   `content`     mediumtext DEFAULT NULL COMMENT 'chunk 内容 (JSON 或纯文本)',
   `metadata`    text DEFAULT NULL COMMENT 'chunk 元数据 JSON (engine_frame 等)',
   PRIMARY KEY (`id`),

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -18,6 +18,12 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     ExtraInfo,
+    InteractionResolveAcceptedPayload,
+    InteractionResolveEnvelope,
+    InteractionResolveError,
+    InteractionResolveErrorEnvelope,
+    InteractionResolveResponse,
+    InteractionResolveSuccessEnvelope,
     MessageRequest,
     MessageResponse,
     MessageResponseData,
@@ -43,6 +49,10 @@ from secbaas.community.api.sse import (
     with_sse_heartbeat,
 )
 from secbaas.community.bootstrap import ApplicationContainer
+from secbaas.community.core.service.bot_interaction import (
+    BotInteractionService,
+    InteractionServiceError,
+)
 from secbaas.community.logger import get_logger
 
 logger = get_logger("router-open-api")
@@ -311,6 +321,64 @@ async def deliver_message_stream(
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },
+    )
+
+
+@router.post(
+    "/messages/interactions/resolve",
+    summary="Resolve an interaction requested on a message stream",
+    response_model=InteractionResolveResponse,
+    responses={
+        200: {
+            "description": "Resolve request accepted or rejected as RPC res envelope"
+        },
+        401: {"description": "Authentication failed"},
+        403: {"description": "Forbidden"},
+    },
+)
+@inject
+async def resolve_message_interaction(
+    request: InteractionResolveEnvelope,
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    interaction_service: BotInteractionService = Depends(
+        Provide[ApplicationContainer.services.bot_interaction_service]
+    ),
+) -> InteractionResolveResponse:
+    """HTTP uplink for SSE stream interactions.
+
+    The HTTP response is the protocol ``res`` envelope. ``ok=true`` means the
+    answer was persisted and queued for the owner worker; final application is
+    later pushed on the same SSE stream as ``interaction.resolve``.
+    """
+    if api_key_record.app_type not in ("system", "app"):
+        logger.warning(
+            "resolve_message_interaction forbidden: app_type=%s",
+            api_key_record.app_type,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": OpenAPICode.FORBIDDEN,
+                "message": get_code_message(OpenAPICode.FORBIDDEN),
+            },
+        )
+
+    envelope = request.model_dump(by_alias=True)
+    try:
+        result = interaction_service.resolve(
+            session_key=request.params.session_key,
+            interaction_id=request.params.interaction_id,
+            decision=request.params.decision,
+            request_envelope=envelope,
+        )
+    except InteractionServiceError as exc:
+        return InteractionResolveErrorEnvelope(
+            id=request.id,
+            error=InteractionResolveError(code=exc.code, message=str(exc)),
+        )
+    return InteractionResolveSuccessEnvelope(
+        id=request.id,
+        payload=InteractionResolveAcceptedPayload(interaction_id=result.interaction_id),
     )
 
 

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -348,7 +348,7 @@ async def resolve_message_interaction(
 
     The HTTP response is the protocol ``res`` envelope. ``ok=true`` means the
     answer was persisted and queued for the owner worker; final application is
-    later pushed on the same SSE stream as ``interaction.resolve``.
+    later pushed on the same SSE stream as ``interaction.resolved``.
     """
     if api_key_record.app_type not in ("system", "app"):
         logger.warning(

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -1,7 +1,7 @@
 """Open API request/response model definitions"""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -107,6 +107,59 @@ class StreamMessageRequest(BaseModel):
             "biz_scene (str, optional): Business scene/category tag. Defaults to 'default' when absent."
         ),
     )
+
+
+class InteractionResolveParams(BaseModel):
+    """Validated parameters for ``interaction.resolve``."""
+
+    session_key: str = Field(..., alias="sessionKey", min_length=1)
+    interaction_id: str = Field(..., alias="interactionId", min_length=1)
+    decision: str = Field(..., min_length=1)
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class InteractionResolveEnvelope(BaseModel):
+    """HTTP uplink envelope for ``interaction.resolve``."""
+
+    type: Literal["req"]
+    id: str = Field(..., min_length=1, description="Client request id")
+    method: Literal["interaction.resolve"]
+    params: InteractionResolveParams
+
+    model_config = {"extra": "forbid"}
+
+
+class InteractionResolveAcceptedPayload(BaseModel):
+    interaction_id: str = Field(..., alias="interactionId")
+    accepted: Literal[True] = True
+    delivery_status: Literal["queued"] = Field(default="queued", alias="deliveryStatus")
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class InteractionResolveError(BaseModel):
+    code: str
+    message: str
+
+
+class InteractionResolveSuccessEnvelope(BaseModel):
+    type: Literal["res"] = "res"
+    id: str
+    ok: Literal[True] = True
+    payload: InteractionResolveAcceptedPayload
+
+
+class InteractionResolveErrorEnvelope(BaseModel):
+    type: Literal["res"] = "res"
+    id: str
+    ok: Literal[False] = False
+    error: InteractionResolveError
+
+
+InteractionResolveResponse = (
+    InteractionResolveSuccessEnvelope | InteractionResolveErrorEnvelope
+)
 
 
 class MessageResponseData(BaseModel):

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -168,6 +168,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         local_user_machine_repo=repository.local_user_machine_repository,
         bot_run_repository=repository.bot_run_repository,
         bot_run_queue_repository=repository.bot_run_queue_repository,
+        bot_run_interaction_repository=repository.bot_run_interaction_repository,
         bot_run_queue_chunk_repository=repository.bot_run_queue_chunk_repository,
         bot_qpm_repository=repository.bot_qpm_repository,
         distributed_lock_repository=repository.distributed_lock_repository,

--- a/src/baas/src/secbaas/community/bootstrap/_core_repository.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_repository.py
@@ -8,6 +8,9 @@ from secbaas.community.core.repository.bot import OrmBotRepository
 from secbaas.community.core.repository.bot_device_rel import OrmBotDeviceRelRepository
 from secbaas.community.core.repository.bot_qpm import OrmBotQpmRepository
 from secbaas.community.core.repository.bot_run import OrmBotRunRepository
+from secbaas.community.core.repository.bot_run_interaction import (
+    OrmBotRunInteractionRepository,
+)
 from secbaas.community.core.repository.bot_run_queue import OrmBotRunQueueRepository
 from secbaas.community.core.repository.bot_run_queue_chunk import (
     OrmBotRunQueueChunkRepository,
@@ -101,6 +104,11 @@ class CoreRepositoryContainer(containers.DeclarativeContainer):
         ZDAS_ORM=_orm_repo(OrmBotRunQueueRepository),
         SQLITE_ORM=_orm_repo(OrmBotRunQueueRepository),
         MARIADB_ORM=_orm_repo(OrmBotRunQueueRepository),
+    )
+    bot_run_interaction_repository = providers.Selector(
+        config.plugins.database.plugin_database,
+        ZDAS_ORM=_orm_repo(OrmBotRunInteractionRepository),
+        SQLITE_ORM=_orm_repo(OrmBotRunInteractionRepository),
     )
     bot_run_queue_chunk_repository = providers.Selector(
         config.plugins.database.plugin_database,

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -12,6 +12,7 @@ from secbaas.community.core.service.bcn.uplink import (
     BcnUplinkClient,
     BcnUplinkConfig,
 )
+from secbaas.community.core.service.bot_interaction import BotInteractionService
 from secbaas.community.core.service.bot_manage import (
     DefaultBotCrudService,
     DefaultBotManagementService,
@@ -193,6 +194,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
     local_user_machine_repo = providers.Dependency()
     bot_run_repository = providers.Dependency()
     bot_run_queue_repository = providers.Dependency()
+    bot_run_interaction_repository = providers.Dependency()
     bot_run_queue_chunk_repository = providers.Dependency()
     bot_qpm_repository = providers.Dependency()
     distributed_lock_repository = providers.Dependency()
@@ -216,6 +218,11 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         repository=system_config_repo,
     )
 
+    bot_interaction_service = providers.Singleton(
+        BotInteractionService,
+        repository=bot_run_interaction_repository,
+    )
+
     chat_client_pool = providers.Singleton(
         AsyncChatClientPool,
         max_size=config.chat_client_pool.max_size,
@@ -225,6 +232,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         max_retries=config.chat_client_pool.max_retries,
         retry_base_backoff=config.chat_client_pool.retry_base_backoff,
         system_config_service=system_config_service,
+        interaction_service=bot_interaction_service,
     )
 
     tenant_service = providers.Singleton(

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/__init__.py
@@ -1,0 +1,25 @@
+"""Public exports for bot_run_interaction repository."""
+
+from ._orm_model import BotRunInteractionModel
+from ._orm_repository import OrmBotRunInteractionRepository
+from ._protocol import BotRunInteractionRepository
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+    JsonObject,
+)
+
+__all__ = [
+    "BotRunInteractionCreateResult",
+    "BotRunInteractionModel",
+    "BotRunInteractionPayload",
+    "BotRunInteractionPayloadPatch",
+    "BotRunInteractionRecord",
+    "BotRunInteractionRepository",
+    "InteractionState",
+    "JsonObject",
+    "OrmBotRunInteractionRepository",
+]

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
@@ -1,0 +1,78 @@
+"""ORM model for baas_bot_run_interaction."""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Column,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+
+from secbaas.community.spi.database import Base
+
+from ._record import (
+    BotRunInteractionPayload,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+class BotRunInteractionModel(Base):
+    """Minimal interaction state table.
+
+    ``payload`` stores the complete protocol snapshot as JSON text for maximum
+    DB compatibility; the migration uses JSON where available.
+    """
+
+    __tablename__ = "baas_bot_run_interaction"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    session_key = Column(String(512), nullable=False)
+    interaction_id = Column(String(160), nullable=False)
+    state = Column(String(32), nullable=False)
+    payload = Column(Text, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    updated_at = Column(
+        TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "session_key", "interaction_id", name="uk_session_interaction"
+        ),
+        Index("idx_session_state", "session_key", "state"),
+    )
+
+    def to_record(self) -> BotRunInteractionRecord:
+        try:
+            decoded = json.loads(self.payload)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError("invalid interaction payload JSON") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError("interaction payload must be a JSON object")
+        if self.state not in {
+            "requested",
+            "queued",
+            "dispatching",
+            "resolved",
+            "expired",
+            "failed",
+        }:
+            raise ValueError(f"invalid interaction state: {self.state}")
+        return BotRunInteractionRecord(
+            id=self.id,
+            session_key=self.session_key,
+            interaction_id=self.interaction_id,
+            state=cast(InteractionState, self.state),
+            payload=BotRunInteractionPayload.from_dict(decoded),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
@@ -39,8 +39,8 @@ class BotRunInteractionModel(Base):
     interaction_id = Column(String(160), nullable=False)
     state = Column(String(32), nullable=False)
     payload = Column(Text, nullable=False)
-    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
-    updated_at = Column(
+    gmt_create = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    gmt_modified = Column(
         TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
@@ -73,6 +73,6 @@ class BotRunInteractionModel(Base):
             interaction_id=self.interaction_id,
             state=cast(InteractionState, self.state),
             payload=BotRunInteractionPayload.from_dict(decoded),
-            created_at=self.created_at,
-            updated_at=self.updated_at,
+            created_at=self.gmt_create,
+            updated_at=self.gmt_modified,
         )

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_repository.py
@@ -1,0 +1,164 @@
+"""ORM repository for ``baas_bot_run_interaction``."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+from sqlalchemy.exc import IntegrityError
+
+from secbaas.community.core.repository import OrmConnectionMixin, with_orm_session
+
+from ._orm_model import BotRunInteractionModel
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+def _dump(payload: BotRunInteractionPayload) -> str:
+    return json.dumps(payload.to_dict(), ensure_ascii=False, separators=(",", ":"))
+
+
+class OrmBotRunInteractionRepository(OrmConnectionMixin):
+    def __init__(self, database) -> None:
+        self._database = database
+
+    @with_orm_session
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult:
+        # Engine may redeliver an event. The unique key owns idempotency and an
+        # existing row must never be rolled back to requested.
+        row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+        if row is not None:
+            return BotRunInteractionCreateResult(record=row.to_record(), created=False)
+
+        row = BotRunInteractionModel(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            state="requested",
+            payload=_dump(payload),
+        )
+        self._session.add(row)
+        try:
+            self._session.flush()
+        except IntegrityError:
+            self._session.rollback()
+            row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+            if row is None:
+                raise
+            return BotRunInteractionCreateResult(record=row.to_record(), created=False)
+        return BotRunInteractionCreateResult(record=row.to_record(), created=True)
+
+    @with_orm_session
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None:
+        row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+        return row.to_record() if row is not None else None
+
+    @with_orm_session
+    def transition(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        from_states: frozenset[InteractionState],
+        to_state: InteractionState,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        return self._atomic_update(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            allowed_states=from_states,
+            to_state=to_state,
+            patch=patch,
+        )
+
+    @with_orm_session
+    def merge_payload(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        return self._atomic_update(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            allowed_states=allowed_states,
+            to_state=None,
+            patch=patch,
+        )
+
+    def _atomic_update(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        to_state: InteractionState | None,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        """Lock, validate state, and merge the JSON payload in one transaction.
+
+        The row lock serializes payload read/merge/write on production MySQL.
+        The UPDATE still carries the allowed-state predicate, so state-machine
+        races are rejected without a separate version column. SQLAlchemy omits
+        ``FOR UPDATE`` on SQLite, while the conditional UPDATE preserves the
+        unit-test/runtime fallback behavior.
+        """
+        row = self._get_row(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            for_update=True,
+        )
+        if row is None or row.state not in allowed_states:
+            return None
+
+        current = row.to_record()
+        next_payload = current.payload.merge(patch)
+        values = {"payload": _dump(next_payload)}
+        if to_state is not None:
+            values["state"] = to_state
+
+        count = (
+            self._session.query(BotRunInteractionModel)
+            .filter(
+                BotRunInteractionModel.session_key == session_key,
+                BotRunInteractionModel.interaction_id == interaction_id,
+                BotRunInteractionModel.state.in_(allowed_states),
+            )
+            .update(values, synchronize_session=False)
+        )
+        if count != 1:
+            return None
+        return replace(
+            current,
+            state=to_state or current.state,
+            payload=next_payload,
+        )
+
+    def _get_row(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        for_update: bool = False,
+    ) -> BotRunInteractionModel | None:
+        query = self._session.query(BotRunInteractionModel).filter(
+            BotRunInteractionModel.session_key == session_key,
+            BotRunInteractionModel.interaction_id == interaction_id,
+        )
+        if for_update:
+            query = query.with_for_update()
+        return query.one_or_none()

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_protocol.py
@@ -1,0 +1,47 @@
+"""Repository protocol for bot run interactions."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+@runtime_checkable
+class BotRunInteractionRepository(Protocol):
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult: ...
+
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None: ...
+
+    def transition(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        from_states: frozenset[InteractionState],
+        to_state: InteractionState,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None: ...
+
+    def merge_payload(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None: ...

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
@@ -1,0 +1,171 @@
+"""Bot run interaction records and persisted payload contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Literal
+
+InteractionState = Literal[
+    "requested",
+    "queued",
+    "dispatching",
+    "resolved",
+    "expired",
+    "failed",
+]
+JsonObject = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionPayloadPatch:
+    """Fields that may be appended after the requested row is created.
+
+    Initial request metadata is intentionally absent: a later transition must
+    never replace the original requested snapshot, allowed decisions, or
+    deadline.
+    """
+
+    decision: str | None = None
+    client_req: JsonObject | None = None
+    engine_req: JsonObject | None = None
+    engine_res: JsonObject | None = None
+    resolved: JsonObject | None = None
+    dispatch_error: str | None = None
+    expire_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionPayload:
+    """Validated representation of the interaction table's ``payload`` JSON.
+
+    Protocol frames are opaque snapshots. Only the few fields used by the
+    state machine are represented explicitly, so callers never inspect nested
+    request/response dictionaries to recover identity or dispatch input.
+    """
+
+    requested: JsonObject
+    allowed_decisions: tuple[str, ...] = ()
+    expires_at_ms: int | None = None
+    decision: str | None = None
+    client_req: JsonObject | None = None
+    engine_req: JsonObject | None = None
+    engine_res: JsonObject | None = None
+    resolved: JsonObject | None = None
+    dispatch_error: str | None = None
+    expire_reason: str | None = None
+
+    @classmethod
+    def from_dict(cls, value: JsonObject) -> BotRunInteractionPayload:
+        """Decode persisted JSON strictly instead of hiding corrupt rows."""
+        return cls(
+            requested=_required_object(value, "requested"),
+            allowed_decisions=_optional_str_tuple(value, "allowedDecisions"),
+            expires_at_ms=_optional_int(value, "expiresAtMs"),
+            decision=_optional_str(value, "decision"),
+            client_req=_optional_object(value, "clientReq"),
+            engine_req=_optional_object(value, "engineReq"),
+            engine_res=_optional_object(value, "engineRes"),
+            resolved=_optional_object(value, "resolved"),
+            dispatch_error=_optional_str(value, "dispatchError"),
+            expire_reason=_optional_str(value, "expireReason"),
+        )
+
+    def to_dict(self) -> JsonObject:
+        values: JsonObject = {
+            "requested": self.requested,
+            "allowedDecisions": (
+                list(self.allowed_decisions) if self.allowed_decisions else None
+            ),
+            "expiresAtMs": self.expires_at_ms,
+            "decision": self.decision,
+            "clientReq": self.client_req,
+            "engineReq": self.engine_req,
+            "engineRes": self.engine_res,
+            "resolved": self.resolved,
+            "dispatchError": self.dispatch_error,
+            "expireReason": self.expire_reason,
+        }
+        return {key: item for key, item in values.items() if item is not None}
+
+    def merge(self, patch: BotRunInteractionPayloadPatch) -> BotRunInteractionPayload:
+        changes = {
+            field: item
+            for field, item in (
+                ("decision", patch.decision),
+                ("client_req", patch.client_req),
+                ("engine_req", patch.engine_req),
+                ("engine_res", patch.engine_res),
+                ("resolved", patch.resolved),
+                ("dispatch_error", patch.dispatch_error),
+                ("expire_reason", patch.expire_reason),
+            )
+            if item is not None
+        }
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionRecord:
+    """``baas_bot_run_interaction`` row."""
+
+    id: int
+    session_key: str
+    interaction_id: str
+    state: InteractionState
+    payload: BotRunInteractionPayload
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionCreateResult:
+    record: BotRunInteractionRecord
+    created: bool
+
+
+def _required_object(value: JsonObject, key: str) -> JsonObject:
+    item = value.get(key)
+    if not isinstance(item, dict):
+        raise ValueError(f"interaction payload {key} must be an object")
+    return item
+
+
+def _optional_object(value: JsonObject, key: str) -> JsonObject | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, dict):
+        raise ValueError(f"interaction payload {key} must be an object")
+    return item
+
+
+def _optional_str(value: JsonObject, key: str) -> str | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"interaction payload {key} must be a non-empty string")
+    return item
+
+
+def _optional_int(value: JsonObject, key: str) -> int | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise ValueError(f"interaction payload {key} must be an integer")
+    return item
+
+
+def _optional_str_tuple(value: JsonObject, key: str) -> tuple[str, ...]:
+    if key not in value:
+        return ()
+    item = value[key]
+    if not isinstance(item, list) or any(
+        not isinstance(decision, str) or not decision for decision in item
+    ):
+        raise ValueError(
+            f"interaction payload {key} must be an array of non-empty strings"
+        )
+    return tuple(item)

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
@@ -1,0 +1,21 @@
+"""Bot interaction core service."""
+
+from ._service import (
+    BotInteractionService,
+    InteractionBadRequestError,
+    InteractionConflictError,
+    InteractionDispatch,
+    InteractionNotFoundError,
+    InteractionResolveResult,
+    InteractionServiceError,
+)
+
+__all__ = [
+    "BotInteractionService",
+    "InteractionBadRequestError",
+    "InteractionConflictError",
+    "InteractionDispatch",
+    "InteractionNotFoundError",
+    "InteractionResolveResult",
+    "InteractionServiceError",
+]

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
@@ -1,0 +1,219 @@
+"""Core service for SSE + HTTP human interaction answers."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRepository,
+    JsonObject,
+)
+
+
+class InteractionServiceError(Exception):
+    """Base interaction service error."""
+
+    code = "INTERACTION_ERROR"
+
+
+class InteractionBadRequestError(InteractionServiceError):
+    code = "BAD_REQUEST"
+
+
+class InteractionNotFoundError(InteractionServiceError):
+    code = "NOT_FOUND"
+
+
+class InteractionConflictError(InteractionServiceError):
+    code = "CONFLICT"
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionDispatch:
+    """Validated command claimed by the websocket owner."""
+
+    session_key: str
+    interaction_id: str
+    decision: str
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionResolveResult:
+    """Successful state transition returned to an uplink adapter."""
+
+    interaction_id: str
+
+
+class BotInteractionService:
+    """Transport-agnostic interaction state service.
+
+    Transport adapters validate protocol shapes and pass identity explicitly.
+    The service never rediscovers ``session_key`` or ``interaction_id`` inside
+    opaque protocol snapshots.
+    """
+
+    def __init__(self, repository: BotRunInteractionRepository) -> None:
+        self._repo = repository
+
+    def record_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: JsonObject,
+        allowed_decisions: tuple[str, ...],
+        expires_at_ms: int | None,
+    ) -> bool:
+        result = self._repo.create_requested(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            payload=BotRunInteractionPayload(
+                requested=envelope,
+                allowed_decisions=allowed_decisions,
+                expires_at_ms=expires_at_ms,
+            ),
+        )
+        return result.created
+
+    def resolve(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        decision: str,
+        request_envelope: JsonObject,
+    ) -> InteractionResolveResult:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        if record is None:
+            raise InteractionNotFoundError("interaction not found")
+        if record.state != "requested":
+            raise InteractionConflictError(f"interaction state is {record.state}")
+        if self._is_expired(record.payload.expires_at_ms):
+            self.mark_expired(session_key=session_key, interaction_id=interaction_id)
+            raise InteractionConflictError("interaction expired")
+        if (
+            record.payload.allowed_decisions
+            and decision not in record.payload.allowed_decisions
+        ):
+            raise InteractionBadRequestError(
+                "decision is not allowed by interaction options"
+            )
+
+        updated = self._repo.transition(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            from_states=frozenset({"requested"}),
+            to_state="queued",
+            patch=BotRunInteractionPayloadPatch(
+                decision=decision,
+                client_req=request_envelope,
+            ),
+        )
+        if updated is None:
+            raise InteractionConflictError("interaction already resolved or queued")
+        return InteractionResolveResult(interaction_id=interaction_id)
+
+    def claim_for_dispatch(
+        self, *, session_key: str, interaction_id: str
+    ) -> InteractionDispatch | None:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        if record is None or record.state != "queued":
+            return None
+        decision = record.payload.decision
+        if decision is None:
+            self.mark_failed(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                error="queued interaction has no decision",
+            )
+            return None
+        claimed = self._repo.transition(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            from_states=frozenset({"queued"}),
+            to_state="dispatching",
+            patch=BotRunInteractionPayloadPatch(),
+        )
+        if claimed is None:
+            return None
+        return InteractionDispatch(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            decision=decision,
+        )
+
+    def should_poll(self, *, session_key: str, interaction_id: str) -> bool:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        return record is not None and record.state in {"requested", "queued"}
+
+    def record_engine_exchange(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        engine_req: JsonObject,
+        engine_res: JsonObject,
+    ) -> bool:
+        return (
+            self._repo.merge_payload(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                allowed_states=frozenset({"dispatching"}),
+                patch=BotRunInteractionPayloadPatch(
+                    engine_req=engine_req,
+                    engine_res=engine_res,
+                ),
+            )
+            is not None
+        )
+
+    def mark_resolved(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: JsonObject,
+    ) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"requested", "queued", "dispatching"}),
+                to_state="resolved",
+                patch=BotRunInteractionPayloadPatch(resolved=envelope),
+            )
+            is not None
+        )
+
+    def mark_expired(self, *, session_key: str, interaction_id: str) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"requested", "queued"}),
+                to_state="expired",
+                patch=BotRunInteractionPayloadPatch(
+                    expire_reason="interaction deadline elapsed"
+                ),
+            )
+            is not None
+        )
+
+    def mark_failed(self, *, session_key: str, interaction_id: str, error: str) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"queued", "dispatching"}),
+                to_state="failed",
+                patch=BotRunInteractionPayloadPatch(dispatch_error=error),
+            )
+            is not None
+        )
+
+    @staticmethod
+    def _is_expired(expires_at_ms: int | None) -> bool:
+        return expires_at_ms is not None and int(time.time() * 1000) > expires_at_ms

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -34,7 +34,7 @@ from ._interaction_protocol import (
     JsonObject,
 )
 from ._session_key_matcher import SessionKeyMatcher
-from ._session_state import _SessionState
+from ._session_state import SessionState
 
 logger = get_logger("core-bot-run")
 
@@ -201,7 +201,7 @@ class AsyncChatClient:
         self._condition = asyncio.Condition()
 
         # sessionKey → _SessionState 分流表
-        self._sessions: dict[str, _SessionState] = {}
+        self._sessions: dict[str, SessionState] = {}
 
         # sessionKey 模糊匹配器：服务端返回的 sessionKey 可能比客户端注册的长，
         # 通过 contains 匹配从 store 中回溯查找客户端注册的原始 key
@@ -264,7 +264,6 @@ class AsyncChatClient:
         _client.on_event("agent", self._on_agent)
         _client.on_event("interaction.requested", self._on_interaction_requested)
         _client.on_event("interaction.resolved", self._on_interaction_resolved)
-        _client.on_event("interaction.resolve", self._on_interaction_resolved)
         _client.on_event("error", self._on_error)
         _client.on_event("*", self._log_event)
         _client.on_disconnect(self._on_disconnect)
@@ -273,7 +272,12 @@ class AsyncChatClient:
             logger.info("Connecting...")
 
         # 直接 await 异步连接，不再需要 run_in_executor
-        hello = await _client.connect()
+        hello: dict[str, Any] | None = None
+        try:
+            hello = await _client.connect()
+        except Exception as e:
+            logger.error(f"Connect failed: {e}")
+            raise e
         self._client = _client
         # 启动后台重连监控（仅在 max_retries > 0 时）
         if self._max_retries > 0 and self._reconnect_monitor is None:
@@ -367,7 +371,7 @@ class AsyncChatClient:
                     state.agent_complete.clear()
                     state.trace_context = trace_ctx
                 else:
-                    state = _SessionState(trace_context=trace_ctx)
+                    state = SessionState(trace_context=trace_ctx)
                     self._sessions[session_key] = state
 
             try:
@@ -494,7 +498,7 @@ class AsyncChatClient:
                     state.agent_complete.clear()
                     state.trace_context = trace_ctx
                 else:
-                    state = _SessionState(trace_context=trace_ctx)
+                    state = SessionState(trace_context=trace_ctx)
                     self._sessions[session_key] = state
 
                 # 流式模式：创建 queue 并绑定到 state
@@ -569,6 +573,7 @@ class AsyncChatClient:
             message: 要注入的消息内容
             session_key: 会话 key，不传则自动生成
             auth_token: 认证令牌，为空时传 OPEN_API:NOT_PROVIDED
+            chat_metadata: 对话元数据
         """
         if session_key is None:
             session_key = f"{uuid.uuid4().hex}"
@@ -665,19 +670,19 @@ class AsyncChatClient:
 
     # ── 私有方法 ──────────────────────────────────────────────────────────
 
-    def _get_session(self, session_key: str) -> _SessionState | None:
+    def _get_session(self, session_key: str) -> SessionState | None:
         """获取指定 sessionKey 的状态（支持模糊匹配）。"""
         result = self._session_matcher.find(session_key)
         return result.state if result else None
 
     @staticmethod
-    def _emit_stream_chunk(state: _SessionState, chunk: StreamChunk) -> None:
+    def _emit_stream_chunk(state: SessionState, chunk: StreamChunk) -> None:
         if state.stream_queue is not None:
             state.stream_queue.put_nowait(chunk)
 
     @staticmethod
     def _handle_terminal_error(
-        state: _SessionState, session_key: str, error_msg: str, source: str
+        state: SessionState, session_key: str, error_msg: str, source: str
     ) -> None:
         msg = error_msg or f"{source} error"
         logger.warning("[%s] error: sessionKey=%s, errMsg=%s", source, session_key, msg)
@@ -693,7 +698,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """内部 chat 事件处理器。
 
@@ -777,7 +782,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """内部 agent 事件处理器。
 
@@ -864,22 +869,24 @@ class AsyncChatClient:
         payload: JsonObject,
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """Persist and expose a validated engine interaction request."""
+        if self._interaction_service is None:
+            logger.debug("interaction processing is disabled; skip requested event")
+            return
+
         event = EngineInteractionRequestedEvent.from_payload(
             session_key=session_key,
             payload=payload,
         )
-        created = True
-        if self._interaction_service is not None:
-            created = self._interaction_service.record_requested(
-                session_key=event.session_key,
-                interaction_id=event.interaction_id,
-                envelope=event.envelope,
-                allowed_decisions=event.allowed_decisions,
-                expires_at_ms=event.expires_at_ms,
-            )
+        created = self._interaction_service.record_requested(
+            session_key=event.session_key,
+            interaction_id=event.interaction_id,
+            envelope=event.envelope,
+            allowed_decisions=event.allowed_decisions,
+            expires_at_ms=event.expires_at_ms,
+        )
         if created and state is not None:
             self._emit_stream_chunk(
                 state,
@@ -893,8 +900,11 @@ class AsyncChatClient:
                 ),
             )
 
-        if self._interaction_service is None or self._client is None:
+        # Engine events normally arrive only on an active client. Keep persistence
+        # and SSE delivery above, but do not start a dispatcher without an uplink.
+        if self._client is None:
             return
+
         task_key = (event.session_key, event.interaction_id)
         if task_key in self._interaction_tasks:
             return
@@ -918,20 +928,22 @@ class AsyncChatClient:
         payload: JsonObject,
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
-        """Persist one terminal event and expose it as interaction.resolve."""
+        """Persist and expose one terminal interaction.resolved event."""
+        if self._interaction_service is None:
+            logger.debug("interaction processing is disabled; skip resolved event")
+            return
+
         event = EngineInteractionResolvedEvent.from_payload(
             session_key=session_key,
             payload=payload,
         )
-        applied = True
-        if self._interaction_service is not None:
-            applied = self._interaction_service.mark_resolved(
-                session_key=event.session_key,
-                interaction_id=event.interaction_id,
-                envelope=event.envelope,
-            )
+        applied = self._interaction_service.mark_resolved(
+            session_key=event.session_key,
+            interaction_id=event.interaction_id,
+            envelope=event.envelope,
+        )
         if not applied:
             return
 
@@ -942,7 +954,7 @@ class AsyncChatClient:
                     type="interaction",
                     content="",
                     metadata={
-                        "event": "interaction.resolve",
+                        "event": "interaction.resolved",
                         "payload": event.envelope,
                     },
                 ),
@@ -1046,7 +1058,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """error 处理器
         Args:
@@ -1075,7 +1087,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """兜底事件处理器
 
@@ -1200,9 +1212,6 @@ class AsyncChatClient:
                     )
                     new_client.on_event(
                         "interaction.resolved", self._on_interaction_resolved
-                    )
-                    new_client.on_event(
-                        "interaction.resolve", self._on_interaction_resolved
                     )
                     new_client.on_event("error", self._on_error)
                     new_client.on_event("*", self._log_event)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -25,7 +26,13 @@ from secbaas.community.api.sse import StreamChunk
 from secbaas.community.logger import get_logger
 from secbaas.community.tracer import get_tracer_plugin
 
+from ..bot_interaction import BotInteractionService
 from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
+from ._interaction_protocol import (
+    EngineInteractionRequestedEvent,
+    EngineInteractionResolvedEvent,
+    JsonObject,
+)
 from ._session_key_matcher import SessionKeyMatcher
 from ._session_state import _SessionState
 
@@ -150,6 +157,7 @@ class AsyncChatClient:
         max_retries: int = 1,
         retry_base_backoff: float = 0.5,
         ignore_case: bool = False,
+        interaction_service: BotInteractionService | None = None,
     ):
         """初始化客户端
 
@@ -176,6 +184,8 @@ class AsyncChatClient:
         self._max_retries = max_retries
         self._retry_base_backoff = retry_base_backoff
         self._ignore_case = ignore_case
+        self._interaction_service = interaction_service
+        self._interaction_tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
 
         # 并发信号量：限制单连接总并发会话数，提供背压
         self._concurrency_sem: asyncio.Semaphore | None = (
@@ -252,6 +262,9 @@ class AsyncChatClient:
 
         _client.on_event("chat", self._on_chat)
         _client.on_event("agent", self._on_agent)
+        _client.on_event("interaction.requested", self._on_interaction_requested)
+        _client.on_event("interaction.resolved", self._on_interaction_resolved)
+        _client.on_event("interaction.resolve", self._on_interaction_resolved)
         _client.on_event("error", self._on_error)
         _client.on_event("*", self._log_event)
         _client.on_disconnect(self._on_disconnect)
@@ -604,6 +617,13 @@ class AsyncChatClient:
             await self._client.close()
             self._client = None
 
+        interaction_tasks = list(self._interaction_tasks.values())
+        for task in interaction_tasks:
+            task.cancel()
+        if interaction_tasks:
+            await asyncio.gather(*interaction_tasks, return_exceptions=True)
+        self._interaction_tasks.clear()
+
         # 清理所有 session state，并唤醒等待中的协程
         async with self._condition:
             self._sessions.clear()
@@ -838,6 +858,188 @@ class AsyncChatClient:
         else:
             state.last_stream_is_assistant = False
 
+    @_with_session_trace("_on_interaction_requested")
+    def _on_interaction_requested(
+        self,
+        payload: JsonObject,
+        *,
+        session_key: str,
+        state: _SessionState | None,
+    ) -> None:
+        """Persist and expose a validated engine interaction request."""
+        event = EngineInteractionRequestedEvent.from_payload(
+            session_key=session_key,
+            payload=payload,
+        )
+        created = True
+        if self._interaction_service is not None:
+            created = self._interaction_service.record_requested(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                envelope=event.envelope,
+                allowed_decisions=event.allowed_decisions,
+                expires_at_ms=event.expires_at_ms,
+            )
+        if created and state is not None:
+            self._emit_stream_chunk(
+                state,
+                StreamChunk(
+                    type="interaction",
+                    content="",
+                    metadata={
+                        "event": "interaction.requested",
+                        "payload": event.envelope,
+                    },
+                ),
+            )
+
+        if self._interaction_service is None or self._client is None:
+            return
+        task_key = (event.session_key, event.interaction_id)
+        if task_key in self._interaction_tasks:
+            return
+        task = asyncio.create_task(
+            self._dispatch_interaction_answer(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                deadline_ms=event.expires_at_ms,
+            )
+        )
+        self._interaction_tasks[task_key] = task
+        task.add_done_callback(
+            lambda completed, key=task_key: self._discard_interaction_task(
+                key, completed
+            )
+        )
+
+    @_with_session_trace("_on_interaction_resolved")
+    def _on_interaction_resolved(
+        self,
+        payload: JsonObject,
+        *,
+        session_key: str,
+        state: _SessionState | None,
+    ) -> None:
+        """Persist one terminal event and expose it as interaction.resolve."""
+        event = EngineInteractionResolvedEvent.from_payload(
+            session_key=session_key,
+            payload=payload,
+        )
+        applied = True
+        if self._interaction_service is not None:
+            applied = self._interaction_service.mark_resolved(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                envelope=event.envelope,
+            )
+        if not applied:
+            return
+
+        if state is not None:
+            self._emit_stream_chunk(
+                state,
+                StreamChunk(
+                    type="interaction",
+                    content="",
+                    metadata={
+                        "event": "interaction.resolve",
+                        "payload": event.envelope,
+                    },
+                ),
+            )
+
+    def _discard_interaction_task(
+        self,
+        key: tuple[str, str],
+        completed: asyncio.Task[None],
+    ) -> None:
+        if self._interaction_tasks.get(key) is completed:
+            self._interaction_tasks.pop(key, None)
+        if completed.cancelled():
+            return
+        error = completed.exception()
+        if error is not None:
+            logger.error(
+                "[interaction] dispatch task failed: sessionKey=%s interactionId=%s",
+                key[0],
+                key[1],
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    async def _dispatch_interaction_answer(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        deadline_ms: int | None,
+    ) -> None:
+        """Poll the DB, claim one queued answer, and send it to the engine."""
+        interaction_service = self._interaction_service
+        if interaction_service is None:
+            return
+        if deadline_ms is None:
+            deadline_ms = int(time.time() * 1000) + 300_000
+
+        while int(time.time() * 1000) <= deadline_ms:
+            command = interaction_service.claim_for_dispatch(
+                session_key=session_key,
+                interaction_id=interaction_id,
+            )
+            if command is not None:
+                client = self._client
+                if client is None:
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error="engine websocket is disconnected",
+                    )
+                    return
+                try:
+                    exchange = await client.interaction_resolve(
+                        interaction_id=command.interaction_id,
+                        decision=command.decision,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[interaction] dispatch failed: sessionKey=%s interactionId=%s",
+                        session_key,
+                        interaction_id,
+                        exc_info=True,
+                    )
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error=str(exc),
+                    )
+                    return
+
+                interaction_service.record_engine_exchange(
+                    session_key=session_key,
+                    interaction_id=interaction_id,
+                    engine_req=exchange.request,
+                    engine_res=exchange.response,
+                )
+                if not exchange.accepted:
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error=exchange.error_message
+                        or "engine rejected interaction.resolve",
+                    )
+                return
+
+            if not interaction_service.should_poll(
+                session_key=session_key,
+                interaction_id=interaction_id,
+            ):
+                return
+            await asyncio.sleep(0.2)
+
+        interaction_service.mark_expired(
+            session_key=session_key,
+            interaction_id=interaction_id,
+        )
+
     @_with_session_trace("_on_error")
     def _on_error(
         self,
@@ -993,6 +1195,15 @@ class AsyncChatClient:
                     )
                     new_client.on_event("chat", self._on_chat)
                     new_client.on_event("agent", self._on_agent)
+                    new_client.on_event(
+                        "interaction.requested", self._on_interaction_requested
+                    )
+                    new_client.on_event(
+                        "interaction.resolved", self._on_interaction_resolved
+                    )
+                    new_client.on_event(
+                        "interaction.resolve", self._on_interaction_resolved
+                    )
                     new_client.on_event("error", self._on_error)
                     new_client.on_event("*", self._log_event)
                     new_client.on_disconnect(self._on_disconnect)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
@@ -70,7 +70,8 @@ class AsyncChatClientPool:
             session_key_timeout: 同一 sessionKey 并发等待超时（秒）
             max_retries: WS 断连后自动重连次数，0 表示不重试
             retry_base_backoff: 重连退避基数（秒）
-            system_config_service: 系统配置服务，传递给 AsyncChatClient 用于读取开关
+            system_config_service: 系统配置服务，用于创建连接时读取运行开关
+            interaction_service: 交互持久化与应答服务；仅在交互开关启用时注入连接
         """
         self._max_size = max_size
         self._max_conns_per_sandbox = max_conns_per_sandbox
@@ -180,7 +181,9 @@ class AsyncChatClientPool:
                 max_retries=self._max_retries,
                 retry_base_backoff=self._retry_base_backoff,
                 ignore_case=self._read_ignore_case(self._system_config_service),
-                interaction_service=self._interaction_service,
+                interaction_service=self._interaction_service
+                if self._enable_process_interaction(self._system_config_service)
+                else None,
             )
             await new_client.connect()
 
@@ -237,6 +240,25 @@ class AsyncChatClientPool:
         except Exception:
             logger.warning(
                 "failed to read session_key_ignore_case config, defaulting to false",
+                exc_info=True,
+            )
+            return False
+        if resp is None:
+            return False
+        return (resp.conf_value or "").strip().lower() == "true"
+
+    @staticmethod
+    def _enable_process_interaction(
+        system_config_service: SystemConfigManageService | None,
+    ) -> bool:
+        """读取新连接是否启用 interaction 事件处理，缺省为关闭。"""
+        if system_config_service is None:
+            return False
+        try:
+            resp = system_config_service.get_config(SystemConfigKey.INTERACTION_PROCESS)
+        except Exception:
+            logger.warning(
+                "failed to read interaction_process config, defaulting to false",
                 exc_info=True,
             )
             return False

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
@@ -23,6 +23,7 @@ from secbaas.community.api.config_manage import SystemConfigManageService
 from secbaas.community.core.service.config import SystemConfigKey
 from secbaas.community.logger import get_logger
 
+from ..bot_interaction import BotInteractionService
 from ._async_chat_client import AsyncChatClient
 
 logger = get_logger("core-bot-run")
@@ -58,6 +59,7 @@ class AsyncChatClientPool:
         max_retries: int = 1,
         retry_base_backoff: float = 0.5,
         system_config_service: SystemConfigManageService | None = None,
+        interaction_service: BotInteractionService | None = None,
     ) -> None:
         """初始化连接池
 
@@ -77,6 +79,7 @@ class AsyncChatClientPool:
         self._max_retries = max_retries
         self._retry_base_backoff = retry_base_backoff
         self._system_config_service = system_config_service
+        self._interaction_service = interaction_service
         # sandbox_id -> 连接列表
         self._clients: dict[str, list[_ConnEntry]] = {}
         # per-key lock，保护同一 sandbox_id 的并发创建
@@ -177,6 +180,7 @@ class AsyncChatClientPool:
                 max_retries=self._max_retries,
                 retry_base_backoff=self._retry_base_backoff,
                 ignore_case=self._read_ignore_case(self._system_config_service),
+                interaction_service=self._interaction_service,
             )
             await new_client.connect()
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -26,6 +26,11 @@ from websockets.asyncio.client import ClientConnection
 from secbaas.community.core.utils.env_utils import is_dev
 from secbaas.community.logger import get_logger
 
+from ._interaction_protocol import (
+    EngineInteractionResolveExchange,
+    build_interaction_resolve_request,
+)
+
 logger = get_logger("core-bot-run")
 
 # 事件处理器类型：同步或异步均可，不关心返回值
@@ -319,6 +324,24 @@ class BotWebSocketClient:
 
         return result
 
+    async def interaction_resolve(
+        self,
+        *,
+        interaction_id: str,
+        decision: str,
+    ) -> EngineInteractionResolveExchange:
+        """Resolve an interaction and return the exact validated RPC exchange."""
+        request = build_interaction_resolve_request(
+            request_id=self._next_request_id(),
+            interaction_id=interaction_id,
+            decision=decision,
+        )
+        response = await self._send_request_frame(request, timeout=30.0)
+        return EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response=response,
+        )
+
     async def chat_abort(
         self,
         session_key: str,
@@ -474,28 +497,34 @@ class BotWebSocketClient:
         if not self._connected or self._ws is None:
             raise RuntimeError("Not connected")
 
-        request_id = self._next_request_id()
         request_frame = {
             "type": "req",
-            "id": request_id,
+            "id": self._next_request_id(),
             "method": method,
             "params": params,
         }
+        return await self._send_request_frame(request_frame, timeout=timeout)
 
-        # 注册 Future 等待响应
+    async def _send_request_frame(
+        self,
+        request_frame: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> dict[str, Any]:
+        """Send an already-built request frame and await its matching response."""
+        if not self._connected or self._ws is None:
+            raise RuntimeError("Not connected")
+
+        request_id = request_frame["id"]
+        method = request_frame["method"]
         loop = asyncio.get_running_loop()
         future: asyncio.Future[dict[str, Any]] = loop.create_future()
         self._pending_requests[request_id] = future
-
         await self._ws.send(json.dumps(request_frame))
 
-        # 等待响应
         try:
-            result = await asyncio.wait_for(future, timeout=timeout)
+            return await asyncio.wait_for(future, timeout=timeout)
         except TimeoutError:
-            self._pending_requests.pop(request_id, None)
             raise TimeoutError(f"Request {method} timed out")
         finally:
             self._pending_requests.pop(request_id, None)
-
-        return result

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -530,6 +530,9 @@ class BotRunRequestExecutor:
                     stream_error = chunk.content or "stream error"
                     _write_chunk(chunk)
                     last_flush_ts = time.monotonic()
+                elif chunk.type == "interaction":
+                    _write_chunk(chunk)
+                    last_flush_ts = time.monotonic()
                 else:
                     logger.debug(
                         "[BotRequestWorker] ignore chunk type: %s, run_id: %s",

--- a/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 JsonObject = dict[str, object]
-InteractionEventName = Literal["interaction.requested", "interaction.resolve"]
+InteractionEventName = Literal["interaction.requested", "interaction.resolved"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,7 +54,7 @@ class EngineInteractionResolvedEvent:
         return cls(
             session_key=_required_identity(session_key, "sessionKey"),
             interaction_id=_interaction_id(payload),
-            envelope=_event_envelope("interaction.resolve", payload),
+            envelope=_event_envelope("interaction.resolved", payload),
         )
 
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
@@ -1,0 +1,178 @@
+"""Typed protocol boundary for engine human-interaction frames."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+JsonObject = dict[str, object]
+InteractionEventName = Literal["interaction.requested", "interaction.resolve"]
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionRequestedEvent:
+    """Validated engine request ready for persistence and SSE delivery."""
+
+    session_key: str
+    interaction_id: str
+    envelope: JsonObject
+    allowed_decisions: tuple[str, ...]
+    expires_at_ms: int | None
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        session_key: str,
+        payload: JsonObject,
+    ) -> EngineInteractionRequestedEvent:
+        return cls(
+            session_key=_required_identity(session_key, "sessionKey"),
+            interaction_id=_interaction_id(payload),
+            envelope=_event_envelope("interaction.requested", payload),
+            allowed_decisions=_allowed_decisions(payload),
+            expires_at_ms=_optional_int(payload, "expiresAtMs"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionResolvedEvent:
+    """Validated terminal engine event ready for persistence and SSE delivery."""
+
+    session_key: str
+    interaction_id: str
+    envelope: JsonObject
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        session_key: str,
+        payload: JsonObject,
+    ) -> EngineInteractionResolvedEvent:
+        return cls(
+            session_key=_required_identity(session_key, "sessionKey"),
+            interaction_id=_interaction_id(payload),
+            envelope=_event_envelope("interaction.resolve", payload),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionResolveExchange:
+    """Validated engine RPC request/response pair."""
+
+    request: JsonObject
+    response: JsonObject
+    accepted: bool
+    error_message: str | None
+
+    @classmethod
+    def from_frames(
+        cls,
+        *,
+        request: JsonObject,
+        response: JsonObject,
+    ) -> EngineInteractionResolveExchange:
+        request_id = _required_str(request, "id")
+        if response.get("type") != "res":
+            raise ValueError("interaction.resolve response type must be res")
+        if _required_str(response, "id") != request_id:
+            raise ValueError("interaction.resolve response id does not match request")
+        ok = response.get("ok")
+        if not isinstance(ok, bool):
+            raise ValueError("interaction.resolve response ok must be boolean")
+        return cls(
+            request=request,
+            response=response,
+            accepted=ok,
+            error_message=None if ok else _error_message(response.get("error")),
+        )
+
+
+def build_interaction_resolve_request(
+    *,
+    request_id: str,
+    interaction_id: str,
+    decision: str,
+) -> JsonObject:
+    """Build the exact engine request frame sent over websocket."""
+    return {
+        "type": "req",
+        "id": _required_identity(request_id, "request id"),
+        "method": "interaction.resolve",
+        "params": {
+            "interactionId": _required_identity(interaction_id, "interactionId"),
+            "decision": _required_identity(decision, "decision"),
+        },
+    }
+
+
+def _interaction_id(payload: JsonObject) -> str:
+    value = payload.get("interactionId")
+    if value is None:
+        value = payload.get("id")
+    if not isinstance(value, str) or not value:
+        raise ValueError("interaction event is missing interactionId")
+    return value
+
+
+def _event_envelope(event: InteractionEventName, payload: JsonObject) -> JsonObject:
+    envelope: JsonObject = {"type": "event", "event": event, "payload": payload}
+    if "seq" in payload:
+        envelope["seq"] = payload["seq"]
+    return envelope
+
+
+def _allowed_decisions(payload: JsonObject) -> tuple[str, ...]:
+    options = payload.get("options")
+    if options is None:
+        return ()
+    if not isinstance(options, list):
+        raise ValueError("interaction options must be an array")
+
+    decisions: list[str] = []
+    for option in options:
+        if not isinstance(option, dict):
+            raise ValueError("interaction option must be an object")
+        value = option.get("decision")
+        if value is None:
+            value = option.get("value")
+        if not isinstance(value, str) or not value:
+            raise ValueError("interaction option is missing decision")
+        if value not in decisions:
+            decisions.append(value)
+    return tuple(decisions)
+
+
+def _optional_int(payload: JsonObject, key: str) -> int | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"interaction {key} must be an integer")
+    return value
+
+
+def _required_str(value: JsonObject, key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"interaction frame is missing {key}")
+    return item
+
+
+def _required_identity(value: str, name: str) -> str:
+    if not value:
+        raise ValueError(f"interaction event is missing {name}")
+    return value
+
+
+def _error_message(value: object) -> str:
+    if isinstance(value, dict):
+        message = value.get("message")
+        if isinstance(message, str) and message:
+            return message
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, str) and value:
+        return value
+    return "engine rejected interaction.resolve"

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_key_matcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_key_matcher.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 from secbaas.community.logger import get_logger
 
-from ._session_state import _SessionState
+from ._session_state import SessionState
 
 logger = get_logger("core-bot-run")
 
@@ -36,7 +36,7 @@ class _MatchResult:
     """
 
     key: str
-    state: _SessionState
+    state: SessionState
     matched_by: str
 
 
@@ -69,7 +69,7 @@ class SessionKeyMatcher:
     """
 
     def __init__(
-        self, store: dict[str, _SessionState], ignore_case: bool = False
+        self, store: dict[str, SessionState], ignore_case: bool = False
     ) -> None:
         """初始化匹配器。
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
@@ -11,7 +11,7 @@ from typing import Any
 
 
 @dataclass
-class _SessionState:
+class SessionState:
     """Per-sessionKey 状态，用于多路复用场景下隔离不同会话的消息。"""
 
     content: str = ""

--- a/src/baas/src/secbaas/community/core/service/config/_constants.py
+++ b/src/baas/src/secbaas/community/core/service/config/_constants.py
@@ -49,6 +49,14 @@ class SystemConfigKey(StrEnum):
     SessionKeyMatcher performs case-insensitive contains matching.
     """
 
+    INTERACTION_PROCESS = "bot_run.interaction_process"
+    """Whether engine interaction events are persisted and forwarded to SSE.
+
+    Value: "true" or "false" (default: "false")
+    Usage: Read when a new pooled AsyncChatClient connection is created.
+    Existing pooled connections keep the value selected at creation time.
+    """
+
     # Add more system config keys here as needed
     # Example:
     # ARCA_DEFAULT_TIMEOUT = "arca.default_timeout"

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -9,7 +9,7 @@
   - chunk.type == "aborted"   → SSE event: chat (中止)
   - chunk.type == "agent"     → SSE event: agent (引擎事件)
   - chunk.type == "heartbeat" → SSE 注释帧: : heartbeat
-  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolve
+  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolved
   - chunk.type == "usage"     → 无独立事件（忽略）
 """
 
@@ -158,9 +158,7 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
 def _transform_interaction(chunk: StreamChunk) -> dict[str, Any] | None:
     metadata = chunk.metadata or {}
     event = metadata.get("event")
-    if event == "interaction.resolved":
-        event = "interaction.resolve"
-    if event not in {"interaction.requested", "interaction.resolve"}:
+    if event not in {"interaction.requested", "interaction.resolved"}:
         return None
     payload = metadata.get("payload")
     if not isinstance(payload, dict):

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -9,6 +9,7 @@
   - chunk.type == "aborted"   → SSE event: chat (中止)
   - chunk.type == "agent"     → SSE event: agent (引擎事件)
   - chunk.type == "heartbeat" → SSE 注释帧: : heartbeat
+  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolve
   - chunk.type == "usage"     → 无独立事件（忽略）
 """
 
@@ -144,11 +145,29 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
     if ctype == "agent":
         return _transform_agent(_agent_payload(chunk), engine)
 
+    if ctype == "interaction":
+        return _transform_interaction(chunk)
+
     if ctype == "heartbeat":
         return {"event": ": heartbeat", "data": {}}
 
     # usage / unknown: no standalone SSE event.
     return None
+
+
+def _transform_interaction(chunk: StreamChunk) -> dict[str, Any] | None:
+    metadata = chunk.metadata or {}
+    event = metadata.get("event")
+    if event == "interaction.resolved":
+        event = "interaction.resolve"
+    if event not in {"interaction.requested", "interaction.resolve"}:
+        return None
+    payload = metadata.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    # Payload is already the public protocol envelope. The generic builder will
+    # only set missing runId/ts and assign the SSE seq/id.
+    return {"event": event, "data": payload}
 
 
 def _transform_agent(payload: dict[str, Any], engine: str) -> dict[str, Any] | None:

--- a/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from secbaas.community.adapters.web.routers.open_api.message_router import (
     deliver_message,
@@ -979,3 +980,192 @@ class TestGetMessageResult:
                 bot_runner=self._make_runner(record),
             )
             mock_policy.assert_called_once_with(api_key, "bot-42:entity-7")
+
+
+class TestResolveMessageInteraction:
+    @pytest.mark.asyncio
+    async def test_returns_rpc_res_envelope(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+        from secbaas.community.core.service.bot_interaction import (
+            InteractionResolveResult,
+        )
+
+        service = MagicMock()
+        service.resolve.return_value = InteractionResolveResult(interaction_id="int-1")
+
+        response = await resolve_message_interaction(
+            request=InteractionResolveEnvelope(
+                type="req",
+                id="req-1",
+                method="interaction.resolve",
+                params={
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            ),
+            api_key_record=_make_api_key_record(),
+            interaction_service=service,
+        )
+
+        body = response.model_dump(by_alias=True)
+        assert body["type"] == "res"
+        assert body["id"] == "req-1"
+        assert body["ok"] is True
+        service.resolve.assert_called_once_with(
+            session_key="s-1",
+            interaction_id="int-1",
+            decision="allow-once",
+            request_envelope={
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_forbidden_app_type_raises_403(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve_message_interaction(
+                request=InteractionResolveEnvelope(
+                    type="req",
+                    id="req-1",
+                    method="interaction.resolve",
+                    params={
+                        "sessionKey": "s-1",
+                        "interactionId": "int-1",
+                        "decision": "allow-once",
+                    },
+                ),
+                api_key_record=_make_api_key_record(app_type="user"),
+                interaction_service=MagicMock(),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_domain_conflict_returns_typed_rpc_error(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+        from secbaas.community.core.service.bot_interaction import (
+            InteractionConflictError,
+        )
+
+        service = MagicMock()
+        service.resolve.side_effect = InteractionConflictError(
+            "interaction state is queued"
+        )
+        response = await resolve_message_interaction(
+            request=InteractionResolveEnvelope(
+                type="req",
+                id="req-1",
+                method="interaction.resolve",
+                params={
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            ),
+            api_key_record=_make_api_key_record(),
+            interaction_service=service,
+        )
+
+        assert response.model_dump(by_alias=True) == {
+            "type": "res",
+            "id": "req-1",
+            "ok": False,
+            "error": {
+                "code": "CONFLICT",
+                "message": "interaction state is queued",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_repository_failure_propagates(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        service = MagicMock()
+        service.resolve.side_effect = RuntimeError("db down")
+        with pytest.raises(RuntimeError, match="db down"):
+            await resolve_message_interaction(
+                request=InteractionResolveEnvelope(
+                    type="req",
+                    id="req-1",
+                    method="interaction.resolve",
+                    params={
+                        "sessionKey": "s-1",
+                        "interactionId": "int-1",
+                        "decision": "allow-once",
+                    },
+                ),
+                api_key_record=_make_api_key_record(),
+                interaction_service=service,
+            )
+
+    @pytest.mark.parametrize(
+        "request_body",
+        [
+            {
+                "type": "event",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+            {
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.answer",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+            {
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+        ],
+    )
+    def test_request_contract_rejects_invalid_envelopes(self, request_body):
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        with pytest.raises(ValidationError):
+            InteractionResolveEnvelope.model_validate(request_body)

--- a/src/baas/tests/unit/bootstrap/test_infra.py
+++ b/src/baas/tests/unit/bootstrap/test_infra.py
@@ -1,8 +1,8 @@
 """Tests for InfraContainer — standalone, no database needed.
 
 Config-based providers (bot_service_config, baas_bot_service_config) are
-testable with config.from_dict.  The chat_client_pool resolves without any
-dependencies.  Providers that require MOSN/Layotto (claw_bot_service,
+testable with config.from_dict. The chat_client_pool resolves with its repository
+dependencies overridden.  Providers that require MOSN/Layotto (claw_bot_service,
 baas_bot_service, etc.) are verified structurally — they exist and accept
 overrides.
 """
@@ -59,10 +59,11 @@ class TestInfraContainerStandalone:
         for attr in expected:
             assert hasattr(container, attr), f"Missing provider: {attr}"
 
-    def test_chat_client_pool_resolves_without_deps(self):
-        """AsyncChatClientPool resolves with system_config_repo mocked."""
+    def test_chat_client_pool_resolves_with_mocked_repositories(self):
+        """AsyncChatClientPool resolves with its repository dependencies mocked."""
         container = InfraContainer()
         container.system_config_repo.override(MagicMock())
+        container.bot_run_interaction_repository.override(MagicMock())
         pool = container.chat_client_pool()
         assert isinstance(pool, AsyncChatClientPool)
 
@@ -70,6 +71,7 @@ class TestInfraContainerStandalone:
         """AsyncChatClientPool is a singleton — same instance returned."""
         container = InfraContainer()
         container.system_config_repo.override(MagicMock())
+        container.bot_run_interaction_repository.override(MagicMock())
         pool1 = container.chat_client_pool()
         pool2 = container.chat_client_pool()
         assert pool1 is pool2
@@ -133,6 +135,7 @@ class TestInfraContainerStandalone:
         container.ac_bot_publish_repo.override(mock_repo)
         container.device_binding_repo.override(mock_repo)
         container.system_config_repo.override(mock_repo)
+        container.bot_run_interaction_repository.override(mock_repo)
 
         store = container.chat_client_pool()
         assert isinstance(store, AsyncChatClientPool)

--- a/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
+++ b/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
@@ -11,7 +11,7 @@ from secbaas.community.core.repository.bot_run_interaction import (
     BotRunInteractionPayloadPatch,
     OrmBotRunInteractionRepository,
 )
-from secbaas.community.plugins.database.stub.sqlite_orm import SqliteOrmPlugin
+from secbaas.community.plugins.database.sqlite.sqlite_orm import SqliteOrmPlugin
 
 
 @pytest.fixture

--- a/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
+++ b/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
@@ -1,0 +1,124 @@
+"""Real SQLite tests for interaction payload/state persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+import secbaas.community.core.repository.bot_run_interaction._orm_model  # noqa: F401
+from secbaas.community.core.database import DatabaseManager
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    OrmBotRunInteractionRepository,
+)
+from secbaas.community.plugins.database.stub.sqlite_orm import SqliteOrmPlugin
+
+
+@pytest.fixture
+def repository() -> OrmBotRunInteractionRepository:
+    plugin = SqliteOrmPlugin("sqlite:///:memory:")
+    plugin.create_all()
+    database = DatabaseManager()
+    database._sync_session_factory = plugin._sync_session_factory
+    database._sync_engine = plugin._sync_engine
+    return OrmBotRunInteractionRepository(database=database)
+
+
+def test_create_requested_is_idempotent(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    payload = BotRunInteractionPayload(
+        requested={"type": "event"},
+        allowed_decisions=("allow-once", "deny"),
+    )
+
+    first = repository.create_requested(
+        session_key="s-1", interaction_id="int-1", payload=payload
+    )
+    second = repository.create_requested(
+        session_key="s-1", interaction_id="int-1", payload=payload
+    )
+
+    assert first.created is True
+    assert second.created is False
+    assert second.record.id == first.record.id
+
+
+def test_transition_merges_typed_payload(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+
+    queued = repository.transition(
+        session_key="s-1",
+        interaction_id="int-1",
+        from_states=frozenset({"requested"}),
+        to_state="queued",
+        patch=BotRunInteractionPayloadPatch(
+            decision="allow-once",
+            client_req={"type": "req"},
+        ),
+    )
+
+    assert queued is not None
+    assert queued.state == "queued"
+    assert queued.payload.requested == {"type": "event"}
+    assert queued.payload.decision == "allow-once"
+    assert queued.payload.client_req == {"type": "req"}
+
+
+def test_late_payload_write_is_rejected_after_terminal_transition(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+    resolved = repository.transition(
+        session_key="s-1",
+        interaction_id="int-1",
+        from_states=frozenset({"requested"}),
+        to_state="resolved",
+        patch=BotRunInteractionPayloadPatch(resolved={"type": "event"}),
+    )
+    assert resolved is not None
+
+    late = repository.merge_payload(
+        session_key="s-1",
+        interaction_id="int-1",
+        allowed_states=frozenset({"dispatching"}),
+        patch=BotRunInteractionPayloadPatch(engine_res={"ok": True}),
+    )
+
+    assert late is None
+    stored = repository.get(session_key="s-1", interaction_id="int-1")
+    assert stored is not None
+    assert stored.payload.resolved == {"type": "event"}
+    assert stored.payload.engine_res is None
+
+
+def test_corrupt_payload_shape_is_not_silently_downgraded(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    created = repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+    with repository._database.orm_session() as session:
+        from secbaas.community.core.repository.bot_run_interaction import (
+            BotRunInteractionModel,
+        )
+
+        session.query(BotRunInteractionModel).filter(
+            BotRunInteractionModel.id == created.record.id
+        ).update({"payload": '{"requested":[],"decision":7}'})
+        session.commit()
+
+    with pytest.raises(ValueError, match="requested must be an object"):
+        repository.get(session_key="s-1", interaction_id="int-1")

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -21,9 +21,9 @@ _TEST_SESSION_KEY = "test-session-key"
 
 def _setup_session_state(client, session_key=_TEST_SESSION_KEY):
     """Helper: register a _SessionState for a given session_key."""
-    from secbaas.community.core.service.bot_run._async_chat_client import _SessionState
+    from secbaas.community.core.service.bot_run._async_chat_client import SessionState
 
-    return client._sessions.setdefault(session_key, _SessionState())
+    return client._sessions.setdefault(session_key, SessionState())
 
 
 @pytest.fixture
@@ -1589,7 +1589,7 @@ class TestChatRequestErrorStream:
         """send_message_stream sets chat_complete when ChatRequestError is raised."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
-            _SessionState,
+            SessionState,
         )
         from secbaas.community.core.service.bot_run._bot_websocket_client import (
             ChatRequestError,
@@ -1605,7 +1605,7 @@ class TestChatRequestErrorStream:
 
         # Pre-register a session state so we can inspect it after the error
         sk = "sk-err"
-        state = _SessionState()
+        state = SessionState()
         client._sessions[sk] = state
 
         mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
@@ -1801,7 +1801,7 @@ class TestBotSessionError:
         """send_message_stream sets chat_complete when ChatRequestError is raised."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
-            _SessionState,
+            SessionState,
         )
         from secbaas.community.core.service.bot_run._bot_websocket_client import (
             ChatRequestError,
@@ -1817,7 +1817,7 @@ class TestBotSessionError:
 
         # Pre-register a session state so we can inspect it after the error
         sk = "sk-err"
-        state = _SessionState()
+        state = SessionState()
         client._sessions[sk] = state
 
         mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -18,8 +18,8 @@ from secbaas.community.core.service.bot_run._async_chat_client import (
     AsyncChatClient,
     ConcurrentSessionError,
     NotConnectedError,
+    SessionState,
     _capture_trace_context,
-    _SessionState,
 )
 from secbaas.community.core.service.bot_run._interaction_protocol import (
     EngineInteractionResolveExchange,
@@ -29,7 +29,7 @@ _TEST_SESSION_KEY = "test-session-key"
 
 
 def _setup_session_state(client, session_key=_TEST_SESSION_KEY):
-    return client._sessions.setdefault(session_key, _SessionState())
+    return client._sessions.setdefault(session_key, SessionState())
 
 
 @pytest.fixture
@@ -269,7 +269,7 @@ class TestGetSession:
 class TestEmitStreamChunk:
     def test_put_chunk_when_queue_exists(self, mock_bot_ws):
         client = AsyncChatClient(uri="ws://host/ws")
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = asyncio.Queue()
         chunk = StreamChunk(type="delta", content="hello")
         AsyncChatClient._emit_stream_chunk(state, chunk)
@@ -278,7 +278,7 @@ class TestEmitStreamChunk:
 
     def test_no_queue_no_error(self, mock_bot_ws):
         client = AsyncChatClient(uri="ws://host/ws")
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = None
         # Should not raise
         AsyncChatClient._emit_stream_chunk(
@@ -291,13 +291,13 @@ class TestEmitStreamChunk:
 
 class TestHandleTerminalError:
     def test_sets_error_state_and_completes(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         AsyncChatClient._handle_terminal_error(state, "sk1", "boom", "agent")
         assert state.state == "error"
         assert state.chat_complete.is_set()
 
     def test_emits_error_chunk_to_queue(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = asyncio.Queue()
         AsyncChatClient._handle_terminal_error(state, "sk1", "boom", "agent")
         chunk = state.stream_queue.get_nowait()
@@ -305,7 +305,7 @@ class TestHandleTerminalError:
         assert chunk.content == "boom"
 
     def test_empty_error_msg_uses_source(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         AsyncChatClient._handle_terminal_error(state, "sk1", "", "agent")
         assert state.state == "error"
         assert state.chat_complete.is_set()
@@ -1198,6 +1198,31 @@ class TestCloseAdditional:
 
 
 class TestInteractionEvents:
+    def test_requested_is_ignored_when_interaction_processing_is_disabled(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws", max_retries=0)
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_interaction_requested(
+            {"sessionKey": "sk1", "interactionId": "int-1"}
+        )
+
+        assert state.stream_queue.empty()
+        assert client._interaction_tasks == {}
+
+    def test_resolved_is_ignored_when_interaction_processing_is_disabled(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws", max_retries=0)
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_interaction_resolved({"sessionKey": "sk1", "interactionId": "int-1"})
+
+        assert state.stream_queue.empty()
+
     @pytest.mark.asyncio
     async def test_requested_passes_validated_identity_and_emits_chunk(
         self, mock_bot_ws
@@ -1296,14 +1321,14 @@ class TestInteractionEvents:
             interaction_id="int-1",
             envelope={
                 "type": "event",
-                "event": "interaction.resolve",
+                "event": "interaction.resolved",
                 "payload": payload,
             },
         )
         chunk = state.stream_queue.get_nowait()
         assert chunk.type == "interaction"
-        assert chunk.metadata["event"] == "interaction.resolve"
-        assert chunk.metadata["payload"]["event"] == "interaction.resolve"
+        assert chunk.metadata["event"] == "interaction.resolved"
+        assert chunk.metadata["payload"]["event"] == "interaction.resolved"
 
     @pytest.mark.asyncio
     async def test_duplicate_resolved_does_not_emit_duplicate_chunk(self, mock_bot_ws):

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -13,12 +13,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from secbaas.community.api.sse import StreamChunk
+from secbaas.community.core.service.bot_interaction import InteractionDispatch
 from secbaas.community.core.service.bot_run._async_chat_client import (
     AsyncChatClient,
     ConcurrentSessionError,
     NotConnectedError,
     _capture_trace_context,
     _SessionState,
+)
+from secbaas.community.core.service.bot_run._interaction_protocol import (
+    EngineInteractionResolveExchange,
 )
 
 _TEST_SESSION_KEY = "test-session-key"
@@ -1191,3 +1195,173 @@ class TestCloseAdditional:
         await client.close()
         # Double close should not raise
         await client.close()
+
+
+class TestInteractionEvents:
+    @pytest.mark.asyncio
+    async def test_requested_passes_validated_identity_and_emits_chunk(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": "sk1",
+            "interactionId": "int-1",
+            "seq": 42,
+            "expiresAtMs": 123456,
+            "options": [{"decision": "allow-once"}],
+        }
+        client._on_interaction_requested(payload)
+
+        service.record_requested.assert_called_once_with(
+            session_key="sk1",
+            interaction_id="int-1",
+            envelope={
+                "type": "event",
+                "event": "interaction.requested",
+                "payload": payload,
+                "seq": 42,
+            },
+            allowed_decisions=("allow-once",),
+            expires_at_ms=123456,
+        )
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "interaction"
+        assert chunk.metadata["event"] == "interaction.requested"
+        assert chunk.metadata["payload"]["event"] == "interaction.requested"
+        assert chunk.metadata["payload"]["seq"] == 42
+
+    @pytest.mark.asyncio
+    async def test_duplicate_requested_does_not_emit_duplicate_chunk(self, mock_bot_ws):
+        service = MagicMock()
+        service.record_requested.side_effect = [True, False]
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        payload = {"sessionKey": "sk1", "interactionId": "int-1"}
+
+        client._on_interaction_requested(payload)
+        client._on_interaction_requested(payload)
+
+        assert state.stream_queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_requested_persistence_failure_is_not_silently_ignored(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.side_effect = RuntimeError("db unavailable")
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        with pytest.raises(RuntimeError, match="db unavailable"):
+            client._on_interaction_requested(
+                {"sessionKey": "sk1", "interactionId": "int-1"}
+            )
+
+        assert state.stream_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_resolved_uses_callback_identity_and_emits_public_chunk(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.mark_resolved.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": "sk1",
+            "interactionId": "int-1",
+            "decision": "allow-once",
+        }
+        client._on_interaction_resolved(payload)
+
+        service.mark_resolved.assert_called_once_with(
+            session_key="sk1",
+            interaction_id="int-1",
+            envelope={
+                "type": "event",
+                "event": "interaction.resolve",
+                "payload": payload,
+            },
+        )
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "interaction"
+        assert chunk.metadata["event"] == "interaction.resolve"
+        assert chunk.metadata["payload"]["event"] == "interaction.resolve"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_resolved_does_not_emit_duplicate_chunk(self, mock_bot_ws):
+        service = MagicMock()
+        service.mark_resolved.side_effect = [True, False]
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        payload = {"sessionKey": "sk1", "interactionId": "int-1"}
+
+        client._on_interaction_resolved(payload)
+        client._on_interaction_resolved(payload)
+
+        assert state.stream_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_interaction_dispatch_uses_typed_claim_command(mock_bot_ws):
+    service = MagicMock()
+    service.claim_for_dispatch.return_value = InteractionDispatch(
+        session_key="sk1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    engine_client = MagicMock()
+    engine_request = {
+        "type": "req",
+        "id": "engine-1",
+        "method": "interaction.resolve",
+        "params": {"interactionId": "int-1", "decision": "allow-once"},
+    }
+    engine_response = {"type": "res", "id": "engine-1", "ok": True}
+    engine_client.interaction_resolve = AsyncMock(
+        return_value=EngineInteractionResolveExchange.from_frames(
+            request=engine_request,
+            response=engine_response,
+        )
+    )
+    client = AsyncChatClient(
+        uri="ws://host/ws", max_retries=0, interaction_service=service
+    )
+    client._client = engine_client
+
+    await client._dispatch_interaction_answer(
+        session_key="sk1",
+        interaction_id="int-1",
+        deadline_ms=None,
+    )
+
+    engine_client.interaction_resolve.assert_awaited_once_with(
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    service.record_engine_exchange.assert_called_once_with(
+        session_key="sk1",
+        interaction_id="int-1",
+        engine_req=engine_request,
+        engine_res=engine_response,
+    )

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
@@ -110,6 +110,57 @@ class TestParamPassthrough:
 
         await pool.close_all()
 
+    @pytest.mark.asyncio
+    async def test_enabled_interaction_service_passed_to_new_client(
+        self, mock_chat_client_class
+    ):
+        mock_cls, _ = mock_chat_client_class
+
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        config_service = MagicMock()
+        config_service.get_config.side_effect = [
+            MagicMock(conf_value="false"),
+            MagicMock(conf_value="true"),
+        ]
+        interaction_service = MagicMock()
+        pool = AsyncChatClientPool(
+            system_config_service=config_service,
+            interaction_service=interaction_service,
+        )
+
+        await pool.get("sandbox-1", "ws://host/ws")
+
+        assert mock_cls.call_args.kwargs["interaction_service"] is interaction_service
+        await pool.close_all()
+
+    @pytest.mark.asyncio
+    async def test_disabled_interaction_service_not_passed_to_new_client(
+        self, mock_chat_client_class
+    ):
+        mock_cls, _ = mock_chat_client_class
+
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        config_service = MagicMock()
+        config_service.get_config.side_effect = [
+            MagicMock(conf_value="false"),
+            MagicMock(conf_value="false"),
+        ]
+        pool = AsyncChatClientPool(
+            system_config_service=config_service,
+            interaction_service=MagicMock(),
+        )
+
+        await pool.get("sandbox-1", "ws://host/ws")
+
+        assert mock_cls.call_args.kwargs["interaction_service"] is None
+        await pool.close_all()
+
 
 # ==================== reconnect awareness tests ====================
 
@@ -505,3 +556,57 @@ class TestReadIgnoreCase:
         svc.get_config.side_effect = RuntimeError("db error")
         result = AsyncChatClientPool._read_ignore_case(svc)
         assert result is False
+
+
+# ==================== interaction processing flag tests ====================
+
+
+class TestEnableProcessInteraction:
+    @pytest.mark.parametrize(
+        ("conf_value", "expected"),
+        [
+            ("true", True),
+            ("  True  ", True),
+            ("false", False),
+            ("invalid", False),
+            (None, False),
+        ],
+    )
+    def test_reads_boolean_value(self, conf_value, expected):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+        from secbaas.community.core.service.config import SystemConfigKey
+
+        service = MagicMock()
+        service.get_config.return_value = MagicMock(conf_value=conf_value)
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is expected
+        service.get_config.assert_called_once_with(SystemConfigKey.INTERACTION_PROCESS)
+
+    def test_none_service_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        assert AsyncChatClientPool._enable_process_interaction(None) is False
+
+    def test_missing_config_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        service = MagicMock()
+        service.get_config.return_value = None
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is False
+
+    def test_read_failure_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        service = MagicMock()
+        service.get_config.side_effect = RuntimeError("db unavailable")
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is False

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
@@ -105,6 +105,7 @@ class TestParamPassthrough:
             max_retries=3,
             retry_base_backoff=2.0,
             ignore_case=False,
+            interaction_service=None,
         )
 
         await pool.close_all()

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -71,7 +71,7 @@ def test_resolved_event_uses_explicit_session_identity() -> None:
     assert event.interaction_id == "int-1"
     assert event.envelope == {
         "type": "event",
-        "event": "interaction.resolve",
+        "event": "interaction.resolved",
         "payload": payload,
     }
 

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from secbaas.community.core.service.bot_run._interaction_protocol import (
+    EngineInteractionRequestedEvent,
+    EngineInteractionResolvedEvent,
+    EngineInteractionResolveExchange,
+    build_interaction_resolve_request,
+)
+
+
+def test_requested_event_is_parsed_once_into_explicit_fields() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-1",
+        "expiresAtMs": 123,
+        "options": [
+            {"decision": "allow-once"},
+            {"value": "deny"},
+            {"decision": "allow-once"},
+        ],
+        "seq": 9,
+    }
+
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-1"
+    assert event.allowed_decisions == ("allow-once", "deny")
+    assert event.expires_at_ms == 123
+    assert event.envelope["payload"] is payload
+    assert event.envelope["seq"] == 9
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({"interactionId": "int-1", "options": {}}, "options must be an array"),
+        (
+            {"interactionId": "int-1", "options": [{}]},
+            "option is missing decision",
+        ),
+        (
+            {"interactionId": "int-1", "expiresAtMs": "soon"},
+            "expiresAtMs must be an integer",
+        ),
+    ],
+)
+def test_requested_event_rejects_malformed_dispatch_metadata(payload, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        EngineInteractionRequestedEvent.from_payload(session_key="s-1", payload=payload)
+
+
+def test_resolved_event_uses_explicit_session_identity() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-1",
+        "decision": "allow-once",
+    }
+
+    event = EngineInteractionResolvedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-1"
+    assert event.envelope == {
+        "type": "event",
+        "event": "interaction.resolve",
+        "payload": payload,
+    }
+
+
+def test_engine_exchange_validates_and_preserves_exact_frames() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    response = {"type": "res", "id": "engine-1", "ok": True}
+
+    exchange = EngineInteractionResolveExchange.from_frames(
+        request=request,
+        response=response,
+    )
+
+    assert exchange.request is request
+    assert exchange.response is response
+    assert exchange.accepted is True
+    assert exchange.error_message is None
+
+
+def test_engine_exchange_rejects_mismatched_response_id() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        decision="deny",
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response={"type": "res", "id": "engine-2", "ok": True},
+        )

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -414,3 +414,43 @@ class TestEngineNameFallback:
             run_id="run-1",
         )
         assert event is not None
+
+
+class TestInteractionBranch:
+    def test_interaction_requested_passthrough_envelope(self):
+        converter = DefaultStreamConverter()
+        envelope = {
+            "type": "event",
+            "event": "interaction.requested",
+            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        }
+        event = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={"event": "interaction.requested", "payload": envelope},
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert event.event == "interaction.requested"
+        data = _data(event)
+        assert data["type"] == "event"
+        assert data["event"] == "interaction.requested"
+        assert data["payload"]["interactionId"] == "int-1"
+
+    def test_interaction_resolved_is_exposed_as_resolve(self):
+        converter = DefaultStreamConverter()
+        envelope = {
+            "type": "event",
+            "event": "interaction.resolve",
+            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        }
+        event = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={"event": "interaction.resolved", "payload": envelope},
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert event.event == "interaction.resolve"

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -438,11 +438,11 @@ class TestInteractionBranch:
         assert data["event"] == "interaction.requested"
         assert data["payload"]["interactionId"] == "int-1"
 
-    def test_interaction_resolved_is_exposed_as_resolve(self):
+    def test_interaction_resolved_is_preserved(self):
         converter = DefaultStreamConverter()
         envelope = {
             "type": "event",
-            "event": "interaction.resolve",
+            "event": "interaction.resolved",
             "payload": {"sessionKey": "s", "interactionId": "int-1"},
         }
         event = converter.convert(
@@ -453,4 +453,4 @@ class TestInteractionBranch:
             run_id="run-1",
         )
         assert event is not None
-        assert event.event == "interaction.resolve"
+        assert event.event == "interaction.resolved"

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+
+import pytest
+
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+)
+from secbaas.community.core.service.bot_interaction import (
+    BotInteractionService,
+    InteractionBadRequestError,
+    InteractionDispatch,
+)
+
+
+class FakeRepo:
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str], BotRunInteractionRecord] = {}
+        self.next_id = 1
+
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult:
+        key = (session_key, interaction_id)
+        existing = self.rows.get(key)
+        if existing is not None:
+            return BotRunInteractionCreateResult(existing, created=False)
+        record = BotRunInteractionRecord(
+            id=self.next_id,
+            session_key=session_key,
+            interaction_id=interaction_id,
+            state="requested",
+            payload=payload,
+        )
+        self.rows[key] = record
+        self.next_id += 1
+        return BotRunInteractionCreateResult(record, created=True)
+
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None:
+        return self.rows.get((session_key, interaction_id))
+
+    def transition(
+        self,
+        *,
+        session_key,
+        interaction_id,
+        from_states,
+        to_state,
+        patch,
+    ):
+        key = (session_key, interaction_id)
+        record = self.rows.get(key)
+        if record is None or record.state not in from_states:
+            return None
+        updated = replace(
+            record,
+            state=to_state,
+            payload=record.payload.merge(patch),
+        )
+        self.rows[key] = updated
+        return updated
+
+    def merge_payload(
+        self,
+        *,
+        session_key,
+        interaction_id,
+        allowed_states,
+        patch,
+    ):
+        key = (session_key, interaction_id)
+        record = self.rows.get(key)
+        if record is None or record.state not in allowed_states:
+            return None
+        updated = replace(record, payload=record.payload.merge(patch))
+        self.rows[key] = updated
+        return updated
+
+
+def _requested_envelope(*, session_key: str = "payload-session") -> dict:
+    return {
+        "type": "event",
+        "event": "interaction.requested",
+        "payload": {
+            "sessionKey": session_key,
+            "interactionId": "int-1",
+            "expiresAtMs": int(time.time() * 1000) + 60_000,
+            "options": [
+                {"decision": "allow-once", "label": "Allow once"},
+                {"decision": "deny", "label": "Deny"},
+            ],
+        },
+    }
+
+
+def _record_requested(repo: FakeRepo, service: BotInteractionService) -> None:
+    created = service.record_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        envelope=_requested_envelope(),
+        allowed_decisions=("allow-once", "deny"),
+        expires_at_ms=int(time.time() * 1000) + 60_000,
+    )
+    assert created is True
+
+
+def _resolve(service: BotInteractionService, *, decision: str = "allow-once"):
+    request = {
+        "type": "req",
+        "id": "client-1",
+        "method": "interaction.resolve",
+        "params": {
+            "sessionKey": "s-1",
+            "interactionId": "int-1",
+            "decision": decision,
+        },
+    }
+    return service.resolve(
+        session_key="s-1",
+        interaction_id="int-1",
+        decision=decision,
+        request_envelope=request,
+    )
+
+
+def test_record_requested_uses_explicit_identity_not_envelope_identity() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+
+    service.record_requested(
+        session_key="trusted-session",
+        interaction_id="trusted-interaction",
+        envelope=_requested_envelope(session_key="untrusted-payload-session"),
+        allowed_decisions=("allow-once",),
+        expires_at_ms=None,
+    )
+
+    assert (
+        repo.get(session_key="trusted-session", interaction_id="trusted-interaction")
+        is not None
+    )
+    assert (
+        repo.get(session_key="untrusted-payload-session", interaction_id="int-1")
+        is None
+    )
+
+
+def test_duplicate_requested_is_idempotent() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    kwargs = {
+        "session_key": "s-1",
+        "interaction_id": "int-1",
+        "envelope": _requested_envelope(),
+        "allowed_decisions": ("allow-once", "deny"),
+        "expires_at_ms": None,
+    }
+
+    assert service.record_requested(**kwargs) is True
+    assert service.record_requested(**kwargs) is False
+    assert len(repo.rows) == 1
+
+
+def test_http_resolve_moves_requested_to_queued() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+
+    result = _resolve(service)
+
+    assert result.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+    assert record.payload.decision == "allow-once"
+    assert record.payload.client_req is not None
+    assert record.payload.client_req["id"] == "client-1"
+
+
+def test_http_resolve_rejects_unknown_decision() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="always")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "requested"
+
+
+def test_claim_returns_typed_dispatch_without_exposing_payload_layout() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+
+    command = service.claim_for_dispatch(session_key="s-1", interaction_id="int-1")
+
+    assert command == InteractionDispatch(
+        session_key="s-1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "dispatching"
+
+
+def test_duplicate_resolved_transition_is_suppressed() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    envelope = {
+        "type": "event",
+        "event": "interaction.resolve",
+        "payload": {"interactionId": "different-id"},
+    }
+
+    assert (
+        service.mark_resolved(
+            session_key="s-1", interaction_id="int-1", envelope=envelope
+        )
+        is True
+    )
+    assert (
+        service.mark_resolved(
+            session_key="s-1", interaction_id="int-1", envelope=envelope
+        )
+        is False
+    )
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.payload.resolved == envelope
+
+
+def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+    assert (
+        service.claim_for_dispatch(session_key="s-1", interaction_id="int-1")
+        is not None
+    )
+    assert service.mark_resolved(
+        session_key="s-1",
+        interaction_id="int-1",
+        envelope={"type": "event", "event": "interaction.resolve", "payload": {}},
+    )
+
+    updated = service.record_engine_exchange(
+        session_key="s-1",
+        interaction_id="int-1",
+        engine_req={"type": "req"},
+        engine_res={"type": "res", "ok": True},
+    )
+
+    assert updated is False
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.payload.engine_req is None
+    assert record.payload.engine_res is None
+
+
+def test_expiry_can_close_a_queued_answer_before_dispatch() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+
+    assert service.mark_expired(session_key="s-1", interaction_id="int-1") is True
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "expired"
+    assert record.payload.expire_reason == "interaction deadline elapsed"
+    assert service.claim_for_dispatch(session_key="s-1", interaction_id="int-1") is None

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -225,7 +225,7 @@ def test_duplicate_resolved_transition_is_suppressed() -> None:
     _record_requested(repo, service)
     envelope = {
         "type": "event",
-        "event": "interaction.resolve",
+        "event": "interaction.resolved",
         "payload": {"interactionId": "different-id"},
     }
 
@@ -258,7 +258,7 @@ def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
     assert service.mark_resolved(
         session_key="s-1",
         interaction_id="int-1",
-        envelope={"type": "event", "event": "interaction.resolve", "payload": {}},
+        envelope={"type": "event", "event": "interaction.resolved", "payload": {}},
     )
 
     updated = service.record_engine_exchange(


### PR DESCRIPTION
## Problem

  `/openapi/v1/messages/stream` 使用 SSE 向客户端单向推送消息。当 Claude Code、Codex 等 Engine 在运行过程中产生 `AskUserQuestion`、命令执行审批、文件访问审批等交互请求时，客户端能够通过 SSE 收到请求，但无法在同一条 SSE 连接上发送回
  答。

  在分布式部署场景中，接收 HTTP 回答的 BaaS 实例也不一定是持有 Engine WebSocket 连接的实例，因此不能依赖进程内状态或本机 WebSocket 直接完成回答投递。

  ## Solution

  实现基于 **SSE 下行 + HTTP 上行 + Interaction DB 状态表** 的交互闭环。

  ### Protocol flow

  1. Engine 通过 WebSocket 向 BaaS 发送 `interaction.requested`。
  2. 持有 WebSocket 的 BaaS 实例校验协议并将 interaction 持久化。
  3. BaaS 通过原有 SSE 流向客户端推送 `interaction.requested`。
  4. Client 调用以下接口提交回答：

     ```text
     POST /openapi/v1/messages/interactions/resolve

  请求使用 interaction.resolve req envelope，并通过参数传递：

  - sessionKey
  - interactionId
  - decision

  5. HTTP 接口通过数据库状态迁移将回答写入 queued 状态，并直接返回对应的 res envelope。
  6. 持有 Engine WebSocket 的实例从数据库 claim 回答，将 interaction.resolve 请求发送给 Engine。
  7. Engine 完成处理后发送 interaction.resolved。
  8. BaaS 更新 interaction 终态，并通过同一条 SSE 流向客户端推送 interaction.resolved。

  ### Distributed dispatch

  新增 baas_bot_run_interaction 表，以：

  session_key + interaction_id

  作为 interaction 的业务唯一键。

  协议快照、客户端请求、Engine 请求与响应以及最终 resolved 事件统一存放在 payload JSON 中。数据库状态迁移负责处理多实例并发：

  requested -> queued -> dispatching -> resolved

  异常路径支持：

  expired
  failed

  只有成功完成 queued -> dispatching 原子迁移的 WebSocket owner 才能向 Engine 投递回答，从而避免多个实例重复发送。

  Core service 只处理 interaction 状态和协议数据，不依赖 HTTP、SSE 或 WebSocket transport；各 transport adapter 负责协议解析和转换。

  ### Protocol normalization

  统一事件命名：

  - Client → BaaS HTTP method：interaction.resolve
  - BaaS → Engine WebSocket method：interaction.resolve
  - Engine → BaaS WebSocket event：interaction.resolved
  - BaaS → Client SSE event：interaction.resolved

  移除了将 interaction.resolve 当作 Engine 下行事件处理的兼容逻辑。

  ### Feature flag

  新增系统配置：

  bot_run.interaction_process

  行为如下：

  - 仅配置值为 true 时启用 interaction 事件处理。
  - 配置不存在、读取失败或值非法时默认关闭。
  - 开关在创建新的池化 AsyncChatClient 连接时读取。
  - 已存在的池化连接保持创建时的配置，需要连接重建后才能应用新的开关值。
  - 开关关闭时不持久化 interaction 事件、不推送 interaction SSE，也不启动 answer dispatch task。

  保留 interaction event handler 注册，在开关关闭时执行轻量级跳过，避免事件落入 wildcard handler 并输出命令、文件路径等完整交互内容。

  ## Validation

  运行了本次变更涉及的 Router、Bootstrap、Repository、Interaction Service、WebSocket Client、Protocol 和 SSE Converter 单元测试：

  285 passed in 1.94s

  运行 Ruff 检查：

  All checks passed

  运行 Git diff 格式检查：

  git diff --check

  结果通过。

  未运行完整 BaaS 单元测试、changed-line coverage 和 Singlebox E2E；本次仅运行了直接受影响的聚焦测试集。

  ## Compatibility and risk

  ### API contract

  新增接口：

  POST /openapi/v1/messages/interactions/resolve

  HTTP 成功响应表示回答已经持久化并进入 queued 状态，不表示 Engine 已经执行完成。最终结果以 SSE interaction.resolved 事件为准。

  ### SSE contract

  客户端需要支持两个 interaction SSE event：

  interaction.requested
  interaction.resolved

  interaction.resolve 仅作为 Client/HTTP 和 BaaS/Engine 的请求 method，不再作为 SSE 下行事件名。

  ### Database migration

  部署前需要执行：

  sqls/migrate_baas_bot_run_interaction.sql

  新表使用以下时间字段：

  gmt_create
  gmt_modified

  应用代码部署前必须确保数据库表结构与 ORM 定义一致。

  ### Feature rollout

  interaction processing 默认关闭。部署后需要显式配置：

  bot_run.interaction_process=true

  并重建已有池化 WebSocket 连接后才会生效。

  如需回滚，可将配置改为 false 并重建连接；新增表可暂时保留，不影响关闭状态下的普通消息流。
