### PR TITLE
fix(backend): preserve service Skills snapshot compatibility

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -196,6 +196,8 @@ class BotBuildService:
         self,
         bot: Dict[str, Any],
         version: int = 1,
+        *,
+        active_skills_snapshot_required: bool = False,
     ) -> Dict[str, Any]:
         """执行 Bot 构建迁移。
 
@@ -206,6 +208,8 @@ class BotBuildService:
         Args:
             bot: Bot 信息字典，包含: bot_id, entity_id, entity_type, device_id, bot_name, bot_desc
             version: 迁移版本号（整数），默认 1
+            active_skills_snapshot_required: active Skills 快照失败时是否阻断构建；
+                Pool 发布传 True，Legacy 和历史直接构建保持 best-effort
 
         Returns:
             dict: 构建结果信息
@@ -260,6 +264,13 @@ class BotBuildService:
                 bot_id=bot_id,
                 entity_type=entity_type,
             ) / version_str / build_plan.migration_subpath
+            migration_path_base = self._get_migration_path_base(
+                owner_id=entity_id,
+                bot_id=bot_id,
+            )
+            runtime_artifact_root = (
+                f"{migration_path_base}/{version_str}/{build_plan.migration_subpath}"
+            )
 
             logger.info(
                 f"[BotBuildService.build] Step 1: "
@@ -280,6 +291,15 @@ class BotBuildService:
                 build_plan=build_plan,
                 provider=provider,
             )
+
+            if migration_success:
+                self._sync_skill_links(
+                    device_id=device_id,
+                    runtime_artifact_root=runtime_artifact_root,
+                    build_plan=build_plan,
+                    provider=provider,
+                    required=active_skills_snapshot_required,
+                )
 
             # 2.2 生成 MCP 配置（使用 bot 的 device_id）
             mcp_success = True
@@ -308,17 +328,13 @@ class BotBuildService:
 
             # 构建结果
             success = migration_success and mcp_success and openclaw_configs_success
-            migration_path_base = self._get_migration_path_base(
-                owner_id=entity_id,
-                bot_id=bot_id,
-            )
             result = {
                 "success": success,
                 "bot_id": bot_id,
                 "entity_id": entity_id,
                 "entity_type": entity_type,
                 "version": version_str,
-                "migration_path": f"{migration_path_base}/{version_str}/{build_plan.migration_subpath}",
+                "migration_path": runtime_artifact_root,
                 "build_target_path": str(target_dir),
                 "mcp_success": mcp_success,
                 "openclaw_configs_success": openclaw_configs_success,
@@ -630,17 +646,19 @@ class BotBuildService:
     def _sync_skill_links(
         self,
         device_id: str,
-        version: str,
+        runtime_artifact_root: str,
         build_plan: EngineBuildPlan,
         provider: EngineSandboxProvider,
+        required: bool,
     ) -> None:
         """同步 skill 软链到目标目录。
 
         Args:
             device_id: 设备 ID，用于执行远程命令
-            version: 版本号，用于拼接目标路径
+            runtime_artifact_root: 当前容器视角下的版本化发布制品根目录
             build_plan: 引擎构建计划
             provider: 当前引擎 provider
+            required: 失败时是否阻断构建
 
         Raises:
             BotBuildMigrationError: 同步失败
@@ -649,11 +667,12 @@ class BotBuildService:
             source_base_path = provider.get_base_path().rstrip('/')
             source_skill_path = f"{source_base_path}/{build_plan.skill_source_relpath.strip('/')}"
             target_skill_path = (
-                f"/home/admin/nfs/bot-data/{version}/"
-                f"{build_plan.migration_subpath}/{build_plan.skill_target_relpath.strip('/')}"
+                f"{runtime_artifact_root.rstrip('/')}/"
+                f"{build_plan.skill_target_relpath.strip('/')}"
             )
             skill_cmd = (
-                "rsync -av --exclude='skills-repo' --exclude='.skills-repo*' "
+                "rsync -av --delete --delete-excluded "
+                "--exclude='skills-repo' --exclude='.skills-repo*' "
                 f"{source_skill_path}/ {target_skill_path}/"
             )
 
@@ -668,16 +687,20 @@ class BotBuildService:
             )
 
             if result.exit_code != 0:
-                logger.error(
-                    "[BotBuildService._sync_skill_links] "
-                    "Active Skills mapping snapshot failed: "
-                    f"device_id={device_id}, exit_code={result.exit_code}, "
-                    f"stderr={result.stderr}"
-                )
-                raise BotBuildMigrationError(
+                message = (
                     "active Skills mapping snapshot failed: "
                     f"exit_code={result.exit_code}, stderr={result.stderr}"
                 )
+                log = logger.error if required else logger.warning
+                log(
+                    "[BotBuildService._sync_skill_links] "
+                    f"Active Skills mapping snapshot failed: device_id={device_id}, "
+                    f"required={required}, exit_code={result.exit_code}, "
+                    f"stderr={result.stderr}"
+                )
+                if required:
+                    raise BotBuildMigrationError(message)
+                return
 
             logger.info(
                 "[BotBuildService._sync_skill_links] "
@@ -686,13 +709,16 @@ class BotBuildService:
         except BotBuildMigrationError:
             raise
         except Exception as e:
-            logger.error(
+            log = logger.error if required else logger.warning
+            log(
                 f"[BotBuildService._sync_skill_links] "
-                f"Active Skills mapping snapshot failed: {device_id}, {e}"
+                f"Active Skills mapping snapshot failed: device_id={device_id}, "
+                f"required={required}, error={e}"
             )
-            raise BotBuildMigrationError(
-                f"active Skills mapping snapshot failed: {e}"
-            ) from e
+            if required:
+                raise BotBuildMigrationError(
+                    f"active Skills mapping snapshot failed: {e}"
+                ) from e
 
     def _run_local_command(
         self,
@@ -873,10 +899,6 @@ class BotBuildService:
                     command_name="rsync (extra)",
                     error_message="rsync extra sync failed",
                 )
-
-            # 同步 skill 软链到目标目录
-            if build_plan and provider:
-                self._sync_skill_links(device_id, version_str, build_plan, provider)
 
             logger.info(
                 f"[BotBuildService._migrate_bot_instance] "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/arca_snapshot_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/arca_snapshot_producer.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.service_bot.services.deploy.producer import (
 from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
     ServiceSkillsManifestBuilder,
 )
+from agentclaw.community.core.skills_pool.types import SkillLayout
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
@@ -50,7 +51,20 @@ class ArcaSnapshotProducer(DeployArtifactProducer):
         return type changes.
         """
         captured_layout = self._skills_manifest_builder.capture(bot=bot)
-        result = self._build_service.build(bot=bot, version=version)
+        build_kwargs: dict[str, Any] = {}
+        if captured_layout is not None:
+            # Pool artifacts must not be published without an exact active
+            # Skills mapping snapshot. Legacy keeps the pre-Pool best-effort
+            # failure semantics so an unopened rollout cannot block existing
+            # service publication.
+            build_kwargs["active_skills_snapshot_required"] = (
+                captured_layout.active_layout is SkillLayout.POOL
+            )
+        result = self._build_service.build(
+            bot=bot,
+            version=version,
+            **build_kwargs,
+        )
 
         success = bool(result.get("success"))
         ext: dict[str, Any] = {}

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
@@ -30,9 +30,17 @@ class _RecordingBuild:
     def __init__(self, result: dict[str, Any]) -> None:
         self.result = result
         self.calls: list[tuple[dict[str, Any], int]] = []
+        self.snapshot_requirements: list[bool] = []
 
-    def build(self, bot: dict[str, Any], version: int = 1) -> dict[str, Any]:
+    def build(
+        self,
+        bot: dict[str, Any],
+        version: int = 1,
+        *,
+        active_skills_snapshot_required: bool = False,
+    ) -> dict[str, Any]:
         self.calls.append((bot, version))
+        self.snapshot_requirements.append(active_skills_snapshot_required)
         return self.result
 
 
@@ -144,6 +152,7 @@ def test_pool_build_freezes_the_draft_layout_into_one_versioned_artifact(
         "active_layout": "pool",
         "layout_contract_version": "skills-pool-p3-v1",
     }
+    assert stub.snapshot_requirements == [True]
     assert layout_repository.scopes == [
         BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1"),
         BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1"),
@@ -178,9 +187,19 @@ def test_layout_is_captured_before_physical_build_starts(tmp_path) -> None:
     )
 
     class _StateChangingBuild(_RecordingBuild):
-        def build(self, bot, version=1):
+        def build(
+            self,
+            bot,
+            version=1,
+            *,
+            active_skills_snapshot_required=False,
+        ):
             repository.state = pool_state
-            return super().build(bot, version)
+            return super().build(
+                bot,
+                version,
+                active_skills_snapshot_required=active_skills_snapshot_required,
+            )
 
     producer = ArcaSnapshotProducer(
         _StateChangingBuild(
@@ -276,13 +295,23 @@ def test_build_rejects_phase_or_generation_drift_after_physical_snapshot(
     repository = _LayoutRepository(initial)
 
     class _StateChangingBuild(_RecordingBuild):
-        def build(self, bot, version=1):
+        def build(
+            self,
+            bot,
+            version=1,
+            *,
+            active_skills_snapshot_required=False,
+        ):
             repository.state = replace(
                 initial,
                 phase=SkillLayoutPhase.NEEDS_MANUAL_REPAIR,
                 migration_generation="generation-2",
             )
-            return super().build(bot, version)
+            return super().build(
+                bot,
+                version,
+                active_skills_snapshot_required=active_skills_snapshot_required,
+            )
 
     producer = ArcaSnapshotProducer(
         _StateChangingBuild(
@@ -328,12 +357,22 @@ def test_legacy_build_rejects_contract_drift_after_physical_snapshot(
     repository = _LayoutRepository(initial)
 
     class _StateChangingBuild(_RecordingBuild):
-        def build(self, bot, version=1):
+        def build(
+            self,
+            bot,
+            version=1,
+            *,
+            active_skills_snapshot_required=False,
+        ):
             repository.state = replace(
                 initial,
                 layout_contract_version="skills-pool-p3-v1",
             )
-            return super().build(bot, version)
+            return super().build(
+                bot,
+                version,
+                active_skills_snapshot_required=active_skills_snapshot_required,
+            )
 
     producer = ArcaSnapshotProducer(
         _StateChangingBuild(
@@ -419,14 +458,15 @@ def test_legacy_draft_builds_a_legacy_artifact_without_pool_contract(
     (target / "workspace" / "skills" / "skills-local").mkdir(parents=True)
     (target / "workspace" / "skills").mkdir(parents=True, exist_ok=True)
     scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="legacy-bot")
+    build = _RecordingBuild(
+        {
+            "success": True,
+            "migration_path": "/snapshot/1/openclaw",
+            "build_target_path": str(target),
+        }
+    )
     producer = ArcaSnapshotProducer(
-        _RecordingBuild(
-            {
-                "success": True,
-                "migration_path": "/snapshot/1/openclaw",
-                "build_target_path": str(target),
-            }
-        ),
+        build,
         ServiceSkillsManifestBuilder(
             _LayoutRepository(BotSkillLayoutState.legacy_default(scope))
         ),
@@ -449,6 +489,7 @@ def test_legacy_draft_builds_a_legacy_artifact_without_pool_contract(
         "active_layout": "legacy",
         "layout_contract_version": None,
     }
+    assert build.snapshot_requirements == [False]
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_mapping_snapshot.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_mapping_snapshot.py
@@ -43,11 +43,15 @@ class _TestSandboxProvider:
         )
 
 
-def _make_service(device_service: MagicMock) -> BotBuildService:
+def _make_service(
+    device_service: MagicMock,
+    *,
+    mount_home_dir_storage: bool = False,
+) -> BotBuildService:
     registry = EngineSandboxRegistry()
     registry.register(_TestSandboxProvider())
     whitelist_service = MagicMock()
-    whitelist_service.is_bot_feature_enabled.return_value = False
+    whitelist_service.is_bot_feature_enabled.return_value = mount_home_dir_storage
     return BotBuildService(
         device_service=device_service,
         baas_service=MagicMock(),
@@ -60,6 +64,57 @@ def _make_service(device_service: MagicMock) -> BotBuildService:
         common_whitelist_service=whitelist_service,
         baas_template_resolver=MagicMock(),
         teclaw_template_uuid="",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mount_home_dir_storage", "expected_root"),
+    [
+        (True, "/opt/nfs/bot-data"),
+        (False, "/home/admin/nfs/bot-data"),
+    ],
+)
+def test_build_snapshots_active_skills_into_the_resolved_mount(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mount_home_dir_storage: bool,
+    expected_root: str,
+):
+    """The snapshot and deploy pointer share the selected container mount."""
+    _arrange_build_paths(monkeypatch, tmp_path)
+    device_service = MagicMock()
+    device_service.exec_shell_new.side_effect = [
+        CommandResult(exit_code=0),
+        CommandResult(stdout='{"mcpServers": {}}', exit_code=0),
+    ]
+    service = _make_service(
+        device_service,
+        mount_home_dir_storage=mount_home_dir_storage,
+    )
+
+    result = service.build(
+        bot={
+            "bot_id": "bot-1",
+            "entity_id": "owner-1",
+            "entity_type": "staff",
+            "device_id": "device-1",
+            "active_engine": "test-engine",
+        },
+        version=7,
+    )
+
+    snapshot_command = device_service.exec_shell_new.call_args_list[0].kwargs[
+        "shell_cmd"
+    ]
+    assert result["migration_path"] == f"{expected_root}/7/test-engine"
+    assert snapshot_command.startswith(
+        "rsync -av --delete --delete-excluded "
+        "--exclude='skills-repo' --exclude='.skills-repo*' "
+    )
+    assert snapshot_command.endswith(
+        "/home/admin/.test-engine/workspace/skills/ "
+        f"{expected_root}/7/test-engine/workspace/skills/"
     )
 
 
@@ -107,6 +162,7 @@ def test_build_fails_when_active_skill_mapping_snapshot_raises(
                 "active_engine": "test-engine",
             },
             version=7,
+            active_skills_snapshot_required=True,
         )
 
 
@@ -136,4 +192,35 @@ def test_build_fails_when_active_skill_mapping_snapshot_returns_nonzero(
                 "active_engine": "test-engine",
             },
             version=7,
+            active_skills_snapshot_required=True,
         )
+
+
+@pytest.mark.unit
+def test_legacy_build_keeps_snapshot_failure_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Legacy publication keeps the pre-Pool failure semantics."""
+    _arrange_build_paths(monkeypatch, tmp_path)
+    device_service = MagicMock()
+    device_service.exec_shell_new.side_effect = [
+        CommandResult(stderr="rsync failed", exit_code=23, status="error"),
+        CommandResult(stdout='{"mcpServers": {}}', exit_code=0),
+    ]
+    service = _make_service(device_service)
+
+    result = service.build(
+        bot={
+            "bot_id": "legacy-bot",
+            "entity_id": "owner-1",
+            "entity_type": "staff",
+            "device_id": "device-1",
+            "active_engine": "test-engine",
+        },
+        version=7,
+        active_skills_snapshot_required=False,
+    )
+
+    assert result["success"] is True
+    assert device_service.exec_shell_new.call_count == 2


### PR DESCRIPTION
## Problem

Service Bot 发布在同步 active Skills mapping 时固定写入 `/home/admin/nfs/bot-data`。启用 home-dir storage mount 的容器实际发布制品根目录是 `/opt/nfs/bot-data`，因此即使 Skills Pool 尚未切流，Legacy Bot 也会因源路径/目标挂载不一致而发布失败。

同时，Pool 改造把 mapping snapshot 失败统一改成 fail-closed，意外改变了尚未切流的 Legacy 发布语义。Pool 制品必须具备精确 snapshot，但 Legacy 应继续保持原有 best-effort 行为。

复现场景：预发 Service Bot `20260806_dr2mi4jm`，publish `7288`。

## Solution

- 构建时只解析一次容器视角的 runtime artifact root，并同时用于 `migration_path` 和 active Skills snapshot 目标路径。
- 覆盖 `/opt/nfs/bot-data` 与 `/home/admin/nfs/bot-data` 两种合法挂载。
- Pool layout 的 snapshot 失败继续 fail-closed；Legacy layout 与历史直接构建保持 best-effort，避免未开启的切流影响存量发布。
- snapshot 使用 `rsync --delete --delete-excluded`，使重试结果精确，并清理不应进入发布制品的完整 Skills 仓库 bridge。

## Compatibility and risk

- 不修改 Runtime Pin、镜像选择、数据库 schema 或开关配置。
- 不触发 Skills Pool cutover；只根据发布时已捕获的 layout 决定 snapshot 是否为强制条件。
- Pool 的安全门禁保持严格；Legacy 恢复上线前兼容行为。

## Validation

- Backend 全量：`10798 passed`
- Service Bot services：`810 passed`
- Skills Pool：`272 passed`
- rebase 最新 `REL20260806` 后定向回归：`29 passed`
- Ruff：通过
- `git diff --check`：通过
