### PR TITLE
feat(baas): support multi-group template override mappings

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -463,7 +463,11 @@ class SystemConfigBaasTemplateResolver:
         env: str,
         user_id: str | None,
     ) -> str | None:
-        """如果 user_id 命中白名单，返回覆盖的 template_uuid，否则返回 None。"""
+        """如果 user_id 命中白名单，返回覆盖的 template_uuid。
+
+        同时支持历史单组 ``staff_ids/template_uuid`` 和新的
+        ``mappings`` 多组格式；未命中或配置不可唯一解析时返回 None。
+        """
         if not user_id:
             return None
 
@@ -486,30 +490,71 @@ class SystemConfigBaasTemplateResolver:
         if not isinstance(whitelist_config, dict):
             return None
 
-        staff_ids = whitelist_config.get("staff_ids")
-        if not isinstance(staff_ids, list) or not staff_ids:
-            return None
-
-        template_uuid = whitelist_config.get("template_uuid")
-        if not isinstance(template_uuid, str) or not template_uuid.strip():
-            return None
-
-        template_uuid = template_uuid.strip()
-        # 防止错误配置的 UUID 不经格式校验直接传给 BaaS，产生难以排查的下游错误。
-        if not template_uuid.startswith("TEMPLATE-"):
+        configured_mappings = whitelist_config.get("mappings")
+        if configured_mappings is None:
+            # 兼容已上线的单组格式，避免配置迁移期影响已有用户。
+            mappings = [whitelist_config]
+        elif not isinstance(configured_mappings, list):
             logger.warning(
-                "[template.whitelist] invalid template_uuid format in whitelist config: "
-                "env=%s config_key=%s template_uuid=%s",
+                "[template.whitelist] invalid mappings in whitelist config: "
+                "env=%s config_key=%s mappings_type=%s",
                 env,
                 PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
-                template_uuid,
+                type(configured_mappings).__name__,
+            )
+            return None
+        else:
+            mappings = configured_mappings
+
+        matched_template_uuids: set[str] = set()
+        normalized_user_id = str(user_id)
+        for mapping in mappings:
+            if not isinstance(mapping, dict):
+                continue
+
+            staff_ids = mapping.get("staff_ids")
+            if not isinstance(staff_ids, list) or normalized_user_id not in {
+                str(staff_id) for staff_id in staff_ids
+            }:
+                continue
+
+            template_uuid = mapping.get("template_uuid")
+            if not isinstance(template_uuid, str) or not template_uuid.strip():
+                logger.warning(
+                    "[template.whitelist] missing template_uuid for matched user: "
+                    "env=%s config_key=%s user_id=%s",
+                    env,
+                    PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
+                    user_id,
+                )
+                return None
+
+            template_uuid = template_uuid.strip()
+            # 防止错误配置的 UUID 不经格式校验直接传给 BaaS，产生难以排查的下游错误。
+            if not template_uuid.startswith("TEMPLATE-"):
+                logger.warning(
+                    "[template.whitelist] invalid template_uuid format in whitelist config: "
+                    "env=%s config_key=%s template_uuid=%s user_id=%s",
+                    env,
+                    PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
+                    template_uuid,
+                    user_id,
+                )
+                return None
+            matched_template_uuids.add(template_uuid)
+
+        if len(matched_template_uuids) > 1:
+            logger.warning(
+                "[template.whitelist] ambiguous template mappings for user: "
+                "env=%s config_key=%s user_id=%s template_uuids=%s",
+                env,
+                PERSONAL_BOT_TEST_TEMPLATE_WHITELIST_CONFIG_KEY,
+                user_id,
+                sorted(matched_template_uuids),
             )
             return None
 
-        if str(user_id) in {str(staff_id) for staff_id in staff_ids}:
-            return template_uuid
-
-        return None
+        return next(iter(matched_template_uuids), None)
 
     def _read_mapping(self, *, env: str) -> dict[str, Any]:
         """读取当前环境的 BaaS template 路由配置。"""

--- a/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
@@ -1013,3 +1013,118 @@ def test_whitelist_staff_ids_type_coercion():
 
     assert result.template_uuid == "TEMPLATE-override-test"
     assert result.source == "whitelist"
+
+
+@pytest.mark.parametrize(
+    ("user_id", "expected_template_uuid"),
+    [
+        ("405935", "TEMPLATE-group-a"),
+        ("168944", "TEMPLATE-group-b"),
+        ("999999", "TEMPLATE-default"),
+    ],
+)
+def test_multi_group_whitelist_selects_template_for_each_group(
+    user_id,
+    expected_template_uuid,
+):
+    """Each staff group can select an independent BaaS template."""
+    mapping = {
+        "selectors": [{"engine": "openclaw", "template_uid": "default_template"}],
+        "templates": {"default_template": {"template_uuid": "TEMPLATE-default"}},
+    }
+    whitelist_config = {
+        "mappings": [
+            {"staff_ids": [405935], "template_uuid": "TEMPLATE-group-a"},
+            {"staff_ids": ["168944"], "template_uuid": "TEMPLATE-group-b"},
+        ]
+    }
+    system_config = MagicMock()
+    system_config.get_config.side_effect = lambda *, category, config_key, env: (
+        mapping
+        if config_key == BAAS_TEMPLATE_UID_ROUTING_CONFIG_KEY
+        else whitelist_config
+    )
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template(
+        bot_id="bot001",
+        user_id=user_id,
+        env="pre",
+        bot_type="personal",
+        engine_type="openclaw",
+        template_type=None,
+        template_config=None,
+    )
+
+    assert result.template_uuid == expected_template_uuid
+    assert result.source == (
+        "system_config" if expected_template_uuid == "TEMPLATE-default" else "whitelist"
+    )
+
+
+def test_multi_group_whitelist_allows_duplicate_user_with_same_template():
+    """Repeated membership is harmless when every group selects the same template."""
+    system_config = MagicMock()
+    system_config.get_config.return_value = {
+        "mappings": [
+            {"staff_ids": ["405935"], "template_uuid": "TEMPLATE-shared"},
+            {"staff_ids": [405935], "template_uuid": " TEMPLATE-shared "},
+        ]
+    }
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template_override(
+        env="pre",
+        user_id="405935",
+        bot_type="service",
+    )
+
+    assert result == "TEMPLATE-shared"
+
+
+def test_multi_group_whitelist_rejects_ambiguous_user_mapping():
+    """A user mapped to different templates falls back instead of depending on order."""
+    system_config = MagicMock()
+    system_config.get_config.return_value = {
+        "mappings": [
+            {"staff_ids": ["405935"], "template_uuid": "TEMPLATE-group-a"},
+            {"staff_ids": ["405935"], "template_uuid": "TEMPLATE-group-b"},
+        ]
+    }
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template_override(
+        env="pre",
+        user_id="405935",
+        bot_type="personal",
+    )
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "whitelist_config",
+    [
+        {"mappings": "not-a-list"},
+        {
+            "mappings": [
+                "not-an-object",
+                {"staff_ids": ["405935"], "template_uuid": "invalid-template"},
+            ]
+        },
+        {"mappings": [{"staff_ids": ["405935"]}]},
+    ],
+)
+def test_multi_group_whitelist_invalid_config_falls_through(whitelist_config):
+    """Malformed multi-group config preserves the existing routing fallback."""
+    system_config = MagicMock()
+    system_config.get_config.return_value = whitelist_config
+    resolver = SystemConfigBaasTemplateResolver(system_config)
+
+    result = resolver.resolve_template_override(
+        env="pre",
+        user_id="405935",
+        bot_type="personal",
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary

- extend `personal_bot_test_template_whitelist` to support multiple staff groups with independent BaaS templates
- preserve the existing single-group `staff_ids` / `template_uuid` format without requiring an immediate config migration
- fall back to the existing template routing behavior for non-matching users or malformed mappings
- reject ambiguous mappings when one staff ID points to different templates, avoiding order-dependent selection

## Configuration

```json
{
  "mappings": [
    {
      "staff_ids": ["165137", "272471"],
      "template_uuid": "TEMPLATE-group-a"
    },
    {
      "staff_ids": ["100001", "100002"],
      "template_uuid": "TEMPLATE-group-b"
    }
  ]
}
```

The existing format remains supported:

```json
{
  "staff_ids": ["165137", "272471"],
  "template_uuid": "TEMPLATE-group-a"
}
```

## Compatibility

- only personal and service Bot template override resolution is changed
- users outside the configured groups continue through the existing selector-based routing
- creation and restart use the same system config and resolution path

## Testing

- `ruff check` passed
- 159 focused creation, restart, BaaS device, service Bot, and resolver tests passed
- changed-line coverage: 100%
- resolver file coverage: 99% (the only uncovered line is a pre-existing empty-user guard)
