### PR TITLE
fix(backend): keep the ws-info socket path's leading slash

### DIFF
--- a/src/backend/src/agentclaw/community/api/baas_service.py
+++ b/src/backend/src/agentclaw/community/api/baas_service.py
@@ -116,13 +116,18 @@ class BaasServiceProtocol(Protocol):
         self,
         bind_id: int,
         port: int = 20003,
-        path: str = "api/openclaw/ws",
+        path: str = "/api/openclaw/ws",
         tenant: str = "",
         device_affinity: Optional[str] = None,
         device_uuid: Optional[str] = None,
         ws_conn_mode: Optional[str] = None,
     ) -> BotWsConnectionInfoResponse:
         """Resolve WebSocket / proxypass info for a device binding.
+
+        ``path`` carries its own leading slash. BaaS appends it to the routing
+        target verbatim — ``build_proxypass_url`` is
+        ``f"{scheme}://{host}/proxypass/{target}{path}"`` — so a value without
+        one yields ``…@0:20003api/openclaw/ws``, a URL no socket can open.
 
         ``device_uuid`` (optional) locks a specific instance in a multi-instance
         service bot; omitted → BaaS auto-selects an active instance.

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
@@ -770,8 +770,9 @@ class BaasDeviceService(DeviceService):
             ttl: TTL（BaaS 层忽略，由服务端决定）
             device_uuid: 多实例场景锁定特定实例（可选）；不传则 BaaS 自动选活跃实例
             ws_conn_mode: WebSocket 连接模式透传（可选）；不传则不覆盖
-            path: 目标 in-device 路径（可选）；BaaS 用它拼 ``ws_url``，故 relay 下它
-                决定 URL 指向哪个引擎 socket，不传落到默认 ``api/openclaw/ws``
+            path: 目标 in-device 路径（可选，自带前导斜杠）；BaaS 用它拼 ``ws_url``，
+                故 relay 下它决定 URL 指向哪个引擎 socket，不传落到默认
+                ``/api/openclaw/ws``
 
         Returns:
             DeviceConnectionInfo: 设备连接信息
@@ -791,8 +792,13 @@ class BaasDeviceService(DeviceService):
                 device_affinity=operator.staff_id,
                 device_uuid=device_uuid,
                 ws_conn_mode=ws_conn_mode,
+                # Verbatim, leading slash included. BaaS appends this to the
+                # routing target with no separator of its own
+                # (``build_proxypass_url`` → ``…/proxypass/{target}{path}``), so
+                # stripping the slash published ``…@0:20003api/openclaw/ws`` — a
+                # URL whose handshake cannot reach the engine.
                 # Only override when asked; None would blank get_ws_info's default.
-                **({"path": path.lstrip("/")} if path else {}),
+                **({"path": path} if path else {}),
             )
         except BaasServiceError as e:
             logger.error(f"[BaasDeviceService.get_device_connection] BaaS error: {e}")

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -1742,7 +1742,7 @@ class BaasService:  # pragma: no cover
         self,
         bind_id: int,
         port: int = 20003,
-        path: str = "api/openclaw/ws",
+        path: str = "/api/openclaw/ws",
         tenant: str = "",
         device_affinity: Optional[str] = None,
         device_uuid: Optional[str] = None,
@@ -1755,7 +1755,10 @@ class BaasService:  # pragma: no cover
         Args:
             bind_id: 设备绑定 ID
             port: 目标端口，默认 20003
-            path: WebSocket 路径，默认 api/openclaw/ws
+            path: WebSocket 路径，必须自带前导斜杠，默认 /api/openclaw/ws。
+                BaaS 侧 ``build_proxypass_url`` 是
+                ``f"{scheme}://{host}/proxypass/{target}{path}"`` 直接拼接，
+                不补分隔符；缺斜杠会拼出 ``…@0:20003api/openclaw/ws``。
             tenant: 租户名称；空则回落到 self._tenant（BaasConfig.tenant，各部署配置）
             device_affinity: 设备亲和性标识，用于指定目标设备（可选）
             device_uuid: 多实例场景锁定特定实例（可选）；不传则 BaaS 自动选活跃实例
@@ -1786,7 +1789,7 @@ class BaasService:  # pragma: no cover
         self,
         bot_uuid: str,
         port: int = 20003,
-        path: str = "api/openclaw/ws",
+        path: str = "/api/openclaw/ws",
         tenant: str = "",
         device_affinity: Optional[str] = None,
         device_uuid: Optional[str] = None,
@@ -1799,7 +1802,8 @@ class BaasService:  # pragma: no cover
         Args:
             bot_uuid: Bot UUID（= device_id）
             port: 目标端口，默认 20003
-            path: WebSocket 路径，默认 api/openclaw/ws
+            path: WebSocket 路径，必须自带前导斜杠，默认 /api/openclaw/ws
+                （拼接契约见 :meth:`get_ws_info`）
             tenant: 租户名称；空则回落到 self._tenant（BaasConfig.tenant，各部署配置）
             device_affinity: 设备亲和性标识，用于指定目标设备（可选）
             device_uuid: 多实例场景锁定特定实例（可选）；不传则 BaaS 自动选活跃实例

--- a/src/backend/src/agentclaw/community/testing/baas_mock.py
+++ b/src/backend/src/agentclaw/community/testing/baas_mock.py
@@ -35,19 +35,29 @@ def mock_baas_calls() -> Iterator[Any]:
         r.route(url__regex=r"^(?!http://localhost:8890).*").pass_through()
 
         # ws-info: LocalDeviceService._compose_device_conn_info 必调
-        r.get(url__regex=r"http://localhost:8890/api/v1/bots/.*/ws-info").mock(
-            return_value=httpx.Response(
+        #
+        # ``ws_url`` 按 BaaS 的拼法回显请求参数，而不是写死一个规范 URL：BaaS
+        # 侧 ``build_proxypass_url`` 是 ``…/proxypass/{target}{path}`` 直接拼接，
+        # 不补分隔符，所以 caller 少给前导斜杠时这里就该拼出坏 URL。写死规范值
+        # 会把这类 caller 侧的拼接错误一路放到线上才暴露。
+        def _ws_info_response(request: httpx.Request) -> httpx.Response:
+            port = request.url.params.get("port", "20003")
+            path = request.url.params.get("path", "/api/openclaw/ws")
+            return httpx.Response(
                 200,
                 json={
                     "code": 0,
                     "data": {
-                        "ws_url": "ws://localhost:20003/api/openclaw/ws",
+                        "ws_url": f"ws://localhost:{port}{path}",
                         "token": "test_token",
-                        "target": "localhost:20003",
+                        "target": f"localhost:{port}",
                         "expires_at": "2099-12-31T00:00:00Z",
                     },
                 },
             )
+
+        r.get(url__regex=r"http://localhost:8890/api/v1/bots/.*/ws-info").mock(
+            side_effect=_ws_info_response
         )
 
         # create_bot

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -358,7 +358,23 @@ class TestGetDeviceConnection:
             binding_id=7, operator=_operator("u001"), path="/api/claude_code/ws"
         )
 
-        assert baas.get_ws_info.call_args.kwargs["path"] == "api/claude_code/ws"
+        assert baas.get_ws_info.call_args.kwargs["path"] == "/api/claude_code/ws"
+
+    def test_the_socket_paths_leading_slash_is_not_stripped(self):
+        """BaaS joins target and path with no separator of its own
+        (``build_proxypass_url`` → ``…/proxypass/{target}{path}``), so a path
+        sent without its slash comes back as ``…@0:20003api/openclaw/ws`` — a
+        URL that reaches no engine. Pinned separately from the path-forwarding
+        test above because the shape, not the forwarding, is what broke."""
+        baas = MagicMock()
+        baas.get_ws_info.return_value = self._ws_info()
+        svc = _make_service(baas_service=baas)
+
+        svc.get_device_connection(
+            binding_id=7, operator=_operator("u001"), path="/api/openclaw/ws"
+        )
+
+        assert baas.get_ws_info.call_args.kwargs["path"].startswith("/")
 
     def test_no_path_leaves_the_provider_default_alone(self):
         """Passing None would blank the default rather than keep it."""

--- a/src/backend/tests/community/utils/test_baas_mock_ws_info.py
+++ b/src/backend/tests/community/utils/test_baas_mock_ws_info.py
@@ -1,0 +1,68 @@
+"""The BaaS ws-info mock composes ``ws_url`` the way BaaS itself does.
+
+The mock stands in for an upstream this suite cannot call, so what it is
+allowed to *invent* is the whole question. A hardcoded well-formed ``ws_url``
+answers every request identically — including one whose ``path`` the caller
+mangled — which is how a client that stripped the socket path's leading slash
+shipped: BaaS joins target and path with no separator of its own
+(``build_proxypass_url`` → ``…/proxypass/{target}{path}``), so the real
+deployment published ``…@0:20003api/openclaw/ws`` while every test stayed green.
+
+These tests pin the echo instead: the mock's URL is a function of the request,
+so a caller that sends a bad path gets a bad URL back, here rather than in
+production.
+"""
+from __future__ import annotations
+
+import httpx
+
+WS_INFO_URL = "http://localhost:8890/api/v1/bots/BOT-1/ws-info"
+
+
+def _ws_url(**params: str) -> str:
+    """``ws_url`` the mocked ws-info endpoint answers for ``params``.
+
+    Goes over httpx on purpose: the autouse ``_no_real_baas_calls`` fixture
+    installs the mock as a *transport* route, so calling the composing function
+    directly would test something no caller reaches.
+    """
+    response = httpx.get(WS_INFO_URL, params=params)
+    response.raise_for_status()
+    return response.json()["data"]["ws_url"]
+
+
+def test_the_requested_path_is_appended_to_the_target():
+    assert (
+        _ws_url(port="20003", path="/api/openclaw/ws")
+        == "ws://localhost:20003/api/openclaw/ws"
+    )
+
+
+def test_the_requested_engine_path_is_honoured_not_a_fixed_one():
+    """A relay caller asks for its own engine's socket. A mock that answered
+    openclaw's regardless would hide a client that dropped the parameter."""
+    assert _ws_url(port="20003", path="/api/claude_code/ws").endswith(
+        "/api/claude_code/ws"
+    )
+
+
+def test_a_path_without_its_leading_slash_produces_the_broken_url():
+    """The failure mode this mock exists to surface. BaaS inserts no separator,
+    so the slash is the caller's to send — and its absence has to be visible
+    here, not in a published socket URL."""
+    assert _ws_url(port="20003", path="api/openclaw/ws") == (
+        "ws://localhost:20003api/openclaw/ws"
+    )
+
+
+def test_the_requested_port_is_honoured():
+    assert _ws_url(port="20010", path="/api/openclaw/ws").startswith(
+        "ws://localhost:20010/"
+    )
+
+
+def test_an_omitted_path_falls_back_to_the_engine_default():
+    """``path`` is always sent by this repo's client, but the mock is shared —
+    a caller that omits it gets the openclaw socket rather than a URL with no
+    path at all."""
+    assert _ws_url(port="20003") == "ws://localhost:20003/api/openclaw/ws"


### PR DESCRIPTION
## Problem

The relay URL published for a bot's chat socket is missing a separator between the routing target and the engine path:

```
wss://<gateway>/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-…@0:20003api/openclaw/ws?x-proxypass-token=…
```

`baas_device_service.py:794` stripped the leading slash off the ws-info `path` parameter before sending it to BaaS. BaaS appends that parameter to the routing target with no separator of its own — `build_proxypass_url` is `f"{scheme}://{host}/proxypass/{target}{path}"` (`src/baas/src/secbaas/community/core/utils/proxypass_utils.py:44`), and every other implementation does the same (`plugins/sandbox/arca/_stub.py:172`, `arca/local_docker/_sandbox_plugin.py:166`, `core/service/paas/_local_paas_service.py:734`). Its API documents the parameter as carrying the slash: *"WebSocket path on device (e.g., `/api/openclaw/ws`)"* (`adapters/web/routers/bot_service/wss_router.py:80`), and its own router tests pass `path=/p`.

One BaaS implementation repairs a slashless path — `plugins/sandbox/arca/local_proc/_sandbox_plugin.py:471`, whose comment names this exact symptom (*"规范化 path：补前导斜杠，避免拼成 `localhost:20018api/...` 缺斜杠"*). That is the plugin singlebox and dev run, which is why the malformed URL only appears against a real deployment.

The three ws-info client signatures also defaulted to a slashless `"api/openclaw/ws"`, and `path` is always placed into the request params (`baas_service.py:1826`), so callers that pass no path were affected identically — including `LocalDeviceService._compose_device_conn_info`.

## Solution

Pass `path` verbatim, leading slash included, and default the three ws-info signatures (`api/baas_service.py:119`, `baas_service.py:1744`, `:1789`) to `/api/openclaw/ws`. The docstrings now state the joining contract and why the slash is load-bearing, so the next reader does not re-derive it from a broken URL.

On the wire the change is one `%2F`: httpx percent-encodes the whole query value, so the request goes from `path=api%2Fopenclaw%2Fws` to `path=%2Fapi%2Fopenclaw%2Fws`, and Starlette decodes it back to the literal string BaaS then interpolates. The slash is in the query, never in the request path, so nothing about routing or normalisation is involved.

No double-slash risk: `local_proc` only adds a slash when one is missing, and every other implementation concatenates verbatim, so the slash-prefixed form is correct on all of them.

The BaaS test mock (`testing/baas_mock.py`) now echoes the requested `port` and `path` the way BaaS composes them, instead of returning a hardcoded well-formed `ws_url` regardless of input. That hardcoded response is why no test caught this — a caller could mangle the path and the mock would still hand back a valid URL. The second commit covers that echo with tests driven over httpx, which is how the mock is reached (it is installed as a transport route by the autouse fixture).

## Validation

CI on this head: Backend, BaaS, BCS, Gateway and Engine unit tests, BCS e2e, and Singlebox coverage all green.

Locally, from `src/backend` with `uv run pytest` (deps resolved from public PyPI; the configured mirror is unreachable from that environment): `tests/community/core/devices`, `tests/community/core/service_bot`, `tests/community/core/engine_runtime` — 1528 passed.

`test_the_requested_socket_path_reaches_ws_info` now expects the slash-prefixed path, and a new `test_the_socket_paths_leading_slash_is_not_stripped` pins the shape separately from the forwarding, since the shape is what broke. `tests/community/utils/test_baas_mock_ws_info.py` pins the mock's own contract, including that a slashless path yields the broken URL BaaS would build.

## Compatibility and risk

No contract, schema, config, or migration change. The wire change is one character in a query parameter this backend sends to BaaS; nothing in the published API surface changes.

Ten call sites reach `get_ws_info` / `get_ws_info_by_bot_uuid`. One passes `path` explicitly (`baas_device_service.py:790`, forwarding what `get_device_connection` was given); the other seven take the default. Of everything that reads the returned `ws_url`, only `baas_device_service.py:820` reaches a caller, and only in relay mode — that is the socket this fixes. `baas_conn_info.py:61`'s `_to_http_base` result is overwritten by `build_baas_conn_info_for_http` in both of its branches (`:169`, `:177`), and plain `build_baas_conn_info` has no production caller of its own, so that value is discarded either way. `expert_chat_instance_service.py:577` carries `ws_url` in a dict nothing reads back. The remaining callers read `target` / `token` / `baas_base_url` / `engine_port` only.

Callers that pass an explicit path already passed it slash-prefixed (`local_device_filesystem.py:272`, `local_device_accessor.py:96`, `health_probe.py:116`) — this stops the ws-info path from being the one place that strips it.

Rollback: revert either commit; the second is tests only.
