### PR TITLE
  Title: fix(harness): batch D-TOOLS-002 MCP prompt into bounded concurrent LLM calls

### DIFF
--- a/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
+++ b/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
@@ -3,6 +3,7 @@
 针对用户配置的 MCP 进行独立检查，判断是否声明了具体 MCP 的调用规范，
 对应文档中"三、场景与工具映射速查"和"四、高频 MCP 调用规范"。
 """
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -13,6 +14,12 @@ import requests
 from agentclaw.community.core.harness.diagnostics.base import Diagnostic, DiagnosticContext
 from agentclaw.community.core.harness.models import Finding, Severity, score_to_result
 from agentclaw.community.core.harness.services.llm import DIAGNOSTIC_MAX_TOKENS
+from agentclaw.community.core.harness.services.llm_response_parser import (
+    _LLM_DISABLED_MARKER,
+    _NO_ISSUE_MARKERS,
+    _extract_score,
+    _extract_summary_and_message,
+)
 
 if TYPE_CHECKING:
     from agentclaw.community.di.config import KbConfig
@@ -309,6 +316,152 @@ def _format_mcp_block(mcp: dict, *, include_guide: bool) -> str:
     return "\n".join(lines)
 
 
+# ── batched prompt mode ───────────────────────────────────────
+# Even with the compact rendering above, one LLM call carrying *every*
+# configured MCP grows with bot complexity, while antchat's gateway kills any
+# request it can't answer inside ~90s (88-tool bot: 5×90s
+# ``RemoteProtocolError`` on a ~19k-char prompt, while D-TOOLS-001-scale
+# prompts of a few KB succeed). Batching decouples prompt size from MCP
+# count: each call carries at most ``_BATCH_MAX_MCPS`` MCPs /
+# ``_BATCH_CHAR_BUDGET`` chars of MCP data. Single-batch bots keep the
+# pre-batching prompt byte-for-byte. Batches run concurrently — llm.py's own
+# semaphore allows 10, so ``_BATCH_CONCURRENCY`` is the only limiter; 3 is
+# the safe default until antchat's rate limit is known (bump to 5 if clean).
+_BATCH_MAX_MCPS = 3
+_BATCH_CHAR_BUDGET = 4000
+_BATCH_CONCURRENCY = 3
+
+_BUCKET_ORDER = ("verified", "schema", "unreachable")
+_BUCKET_HEADERS = {
+    "verified": "✅ 已验证 MCP（verified_guide 不为空，引用原文生成调用规范）",
+    "schema": "🛠 可据参数表转录 MCP（无 verified_guide，但工具含 params 参数表：可据参数表转录调用规范，禁止编造示例/命令）",
+    "unreachable": "⛔ 无 schema MCP（既无 verified_guide 又无 inputSchema，仅写入映射表，禁止生成调用规范/示例）",
+}
+
+
+def _render_bucketed_blocks(mcp_details: list[dict]) -> list[tuple[str, str, dict]]:
+    """Render each enriched MCP as ``(bucket, block_text, mcp_detail)``.
+
+    Bucketing is unchanged from #717: verified → guide verbatim; schema →
+    transcribe from params; unreachable → mapping-table row only.
+    """
+    rendered: list[tuple[str, str, dict]] = []
+    for mcp in mcp_details:
+        tools = mcp.get("tools") or []
+        has_schema = any(
+            isinstance(t, dict) and t.get("inputSchema")
+            for t in (tools if isinstance(tools, list) else [])
+        )
+        if mcp.get("verified_guide"):
+            rendered.append(("verified", _format_mcp_block(mcp, include_guide=True), mcp))
+        elif has_schema:
+            rendered.append(("schema", _format_mcp_block(mcp, include_guide=False), mcp))
+        else:
+            # Unreachable: mapping-table row only (no tools, no schema).
+            server_code = mcp["server_code"]
+            name = mcp.get("name", "")
+            desc = (mcp.get("description") or "").strip().split("\n", 1)[0]
+            header = f"## {server_code} ({name}): {desc}" if desc else f"## {server_code} ({name})"
+            rendered.append((
+                "unreachable",
+                header + "\n注意: 该 MCP 既无人工校验调用规范也无工具 inputSchema，"
+                "只能在「场景与工具映射速查」表格中列出，注意事项写「调用规范由平台补全中」；"
+                "禁止为其生成「MCP 调用规范」子章节或 mcporter call 示例",
+                mcp,
+            ))
+    return rendered
+
+
+def _pack_mcp_batches(items: list[tuple[str, str, dict]]) -> list[list[tuple[str, str, dict]]]:
+    """Greedy-pack rendered MCP blocks into LLM-call batches.
+
+    A batch closes when it already holds an item and adding the next would
+    exceed ``_BATCH_MAX_MCPS`` or ``_BATCH_CHAR_BUDGET``; a block larger than
+    the budget gets a batch to itself.
+    """
+    batches: list[list[tuple[str, str, dict]]] = []
+    current: list[tuple[str, str, dict]] = []
+    current_chars = 0
+    for item in items:
+        if current and (len(current) >= _BATCH_MAX_MCPS or current_chars + len(item[1]) > _BATCH_CHAR_BUDGET):
+            batches.append(current)
+            current, current_chars = [], 0
+        current.append(item)
+        current_chars += len(item[1])
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _render_mcp_sections(batch: list[tuple[str, str, dict]]) -> str:
+    """Render one batch's blocks under their bucket section headers (fixed order)."""
+    out = ""
+    for kind in _BUCKET_ORDER:
+        blocks = [block for bucket, block, _ in batch if bucket == kind]
+        if blocks:
+            out += f"\n--- {_BUCKET_HEADERS[kind]} ---\n" + "\n\n".join(blocks) + "\n"
+    return out
+
+
+def _fetch_kb_quiet(mcp_details: list[dict], kb_config: "KbConfig | None", bot_id: str) -> str:
+    """KB context for the given MCPs; ``""`` when unconfigured or on failure."""
+    try:
+        return _fetch_kb_context_for_mcps(mcp_details, kb_config) or ""
+    except Exception:
+        logger.warning("[D-TOOLS-002] KB context fetch failed for bot=%s", bot_id, exc_info=True)
+        return ""
+
+
+def _synthesize_batch_responses(results: list[tuple[str | None, list[str]]]) -> str:
+    """Merge per-batch LLM responses into one response text for the parser.
+
+    ``results`` holds ``(response_or_None, server_codes)`` per batch; ``None``
+    marks a batch whose LLM call raised. Behaviour:
+
+    - every batch failed (raise / empty / sentinel) → return the sentinel so
+      the run degrades to the usual LLM01 finding, as an oversized single
+      call did before batching;
+    - all healthy batches answered no-issue (and nothing failed) → ``无问题``;
+    - otherwise: distinct batch summaries joined by "；", drafts concatenated,
+      failed batches' server_codes noted as undiagnosed, and an aggregate
+      ``max(10, 100 − Σ(100 − batch_score))``. The aggregate re-counts the
+      rubric's global section-missing deductions once per batch — biased low
+      (conservative for a health check), never inventing a pass.
+    """
+
+    def _usable(resp: str | None) -> bool:
+        return bool(resp and resp.strip()) and resp.strip() != _LLM_DISABLED_MARKER
+
+    failed_codes = [c for resp, codes in results if not _usable(resp) for c in codes]
+    ok_resps = [resp.strip() for resp, _ in results if _usable(resp)]
+    if not ok_resps:
+        return _LLM_DISABLED_MARKER
+
+    summaries: list[str] = []
+    drafts: list[str] = []
+    deductions = 0
+    for resp in ok_resps:
+        if resp.lower() in _NO_ISSUE_MARKERS:
+            continue
+        score, body = _extract_score(resp)
+        summary, message = _extract_summary_and_message(body)
+        deductions += 100 - score
+        if summary and summary not in summaries:
+            summaries.append(summary)
+        if message:
+            drafts.append(message)
+
+    if failed_codes:
+        drafts.append("（以下 MCP 本次未完成诊断（LLM 调用失败），请稍后重试：" + "、".join(failed_codes) + "）")
+    if not summaries and not drafts:
+        return "无问题"
+    if not summaries:
+        # Only failures, nothing diagnosed — surface as check-failed, not pass.
+        return "\n".join(["部分 MCP 诊断失败", "\n\n".join(drafts), "[SCORE:0]"])
+    total = max(10, 100 - deductions)
+    return "\n".join(["；".join(summaries), "\n\n".join(drafts), f"[SCORE:{total}]"])
+
+
 class ToolsMcpFormatDiagnostic(Diagnostic):
     id = "D-TOOLS-002"
     name = "各项 MCP 调用规范诊断"
@@ -559,75 +712,37 @@ XX 为 0-100 的整数
                     ctx.bot_id, len(mcp_details),
                 )
 
-        user_msg = (
+        intro_msg = (
             "请检查下面的 TOOLS.md 是否已经为已配置 MCP 提供了充分的调用规范。"
             "如果缺失或不完整，请输出诊断结论，并优先给出可直接补充到 TOOLS.md 中的"
             "`## 场景与工具映射速查` 和 `##  MCP 调用规范` 草案。\n\n"
             f"--- TOOLS.md MCP 调用规范诊断 ---\n{content}\n"
         )
-        kb_included = False
-        if mcp_details:
-            # Bucket each MCP by what call-spec source is available (unchanged
-            # from #717): verified → verified_guide verbatim; schema → no guide
-            # but tools expose inputSchema (transcribe params); unreachable →
-            # neither. Only the *rendering* changes: instead of json.dumps of
-            # the dict (nested inputSchema + indent = tens of KB), each MCP is
-            # rendered as a compact text block (_format_mcp_block) — same param
-            # name/type/required info, a fraction of the size.
-            verified_blocks: list[str] = []
-            schema_blocks: list[str] = []
-            unreachable_blocks: list[str] = []
-            for mcp in mcp_details:
-                tools = mcp.get("tools") or []
-                has_schema = any(
-                    isinstance(t, dict) and t.get("inputSchema")
-                    for t in (tools if isinstance(tools, list) else [])
+        if not mcp_details:
+            response = await ctx.llm.chat(
+                system=self.system_prompt, user=intro_msg + "--- end ---",
+                max_tokens=DIAGNOSTIC_MAX_TOKENS,
+            )
+            logger.info("[D-TOOLS-002] LLM response received: bot=%s response_len=%d", ctx.bot_id, len(response))
+        else:
+            batches = _pack_mcp_batches(_render_bucketed_blocks(mcp_details))
+            if len(batches) == 1:
+                # Single batch → prompt identical to the pre-batching path.
+                user_msg = intro_msg + _render_mcp_sections(batches[0])
+                kb_context = _fetch_kb_quiet(mcp_details, ctx.kb_config, ctx.bot_id)
+                logger.info(
+                    "[D-TOOLS-002] KB context fetched: bot=%s kb_included=%s",
+                    ctx.bot_id, bool(kb_context),
                 )
-                if mcp.get("verified_guide"):
-                    verified_blocks.append(_format_mcp_block(mcp, include_guide=True))
-                elif has_schema:
-                    schema_blocks.append(_format_mcp_block(mcp, include_guide=False))
-                else:
-                    # Unreachable: mapping-table row only (no tools, no schema).
-                    server_code = mcp["server_code"]
-                    name = mcp.get("name", "")
-                    desc = (mcp.get("description") or "").strip().split("\n", 1)[0]
-                    header = f"## {server_code} ({name}): {desc}" if desc else f"## {server_code} ({name})"
-                    unreachable_blocks.append(
-                        header + "\n注意: 该 MCP 既无人工校验调用规范也无工具 inputSchema，"
-                        "只能在「场景与工具映射速查」表格中列出，注意事项写「调用规范由平台补全中」；"
-                        "禁止为其生成「MCP 调用规范」子章节或 mcporter call 示例"
-                    )
-
-            if verified_blocks:
-                user_msg += (
-                    "\n--- ✅ 已验证 MCP（verified_guide 不为空，引用原文生成调用规范） ---\n"
-                    + "\n\n".join(verified_blocks) + "\n"
-                )
-            if schema_blocks:
-                user_msg += (
-                    "\n--- 🛠 可据参数表转录 MCP（无 verified_guide，但工具含 params 参数表：可据参数表转录调用规范，禁止编造示例/命令） ---\n"
-                    + "\n\n".join(schema_blocks) + "\n"
-                )
-            if unreachable_blocks:
-                user_msg += (
-                    "\n--- ⛔ 无 schema MCP（既无 verified_guide 又无 inputSchema，仅写入映射表，禁止生成调用规范/示例） ---\n"
-                    + "\n\n".join(unreachable_blocks) + "\n"
-                )
-
-            # 查询内网知识库补充 MCP 上下文
-            try:
-                kb_context = _fetch_kb_context_for_mcps(mcp_details, ctx.kb_config)
                 if kb_context:
                     user_msg += f"\n{kb_context}"
-                    kb_included = True
-                logger.info("[D-TOOLS-002] KB context fetched: bot=%s kb_included=%s", ctx.bot_id, kb_included)
-            except Exception:
-                logger.warning("[D-TOOLS-002] KB context fetch failed for bot=%s", ctx.bot_id, exc_info=True)
-        user_msg += "--- end ---"
-
-        response = await ctx.llm.chat(system=self.system_prompt, user=user_msg, max_tokens=DIAGNOSTIC_MAX_TOKENS)
-        logger.info("[D-TOOLS-002] LLM response received: bot=%s response_len=%d", ctx.bot_id, len(response))
+                user_msg += "--- end ---"
+                response = await ctx.llm.chat(
+                    system=self.system_prompt, user=user_msg, max_tokens=DIAGNOSTIC_MAX_TOKENS,
+                )
+                logger.info("[D-TOOLS-002] LLM response received: bot=%s response_len=%d", ctx.bot_id, len(response))
+            else:
+                response = await self._chat_in_batches(ctx, intro_msg, batches)
         findings = self._analyze_response(response, ctx.bot_id)
 
         # Decide whether this run produced any concrete, patchable call-spec
@@ -662,3 +777,56 @@ XX 为 0-100 的整数
                     )
 
         return findings
+
+    async def _chat_in_batches(
+        self,
+        ctx: DiagnosticContext,
+        intro_msg: str,
+        batches: list[list[tuple[str, str, dict]]],
+    ) -> str:
+        """Run one bounded-size LLM call per MCP batch, concurrently, and merge.
+
+        Each batch call carries only its own MCPs' blocks plus the batch note,
+        so prompt size is decoupled from the bot's total MCP count. At most
+        ``_BATCH_CONCURRENCY`` calls run at once. A batch whose call raises is
+        reported as undiagnosed in the merged response instead of failing the
+        whole scan.
+        """
+        total = len(batches)
+        sem = asyncio.Semaphore(_BATCH_CONCURRENCY)
+        logger.info(
+            "[D-TOOLS-002] batched prompt: bot=%s batches=%d max_mcps=%d char_budget=%d concurrency=%d",
+            ctx.bot_id, total, _BATCH_MAX_MCPS, _BATCH_CHAR_BUDGET, _BATCH_CONCURRENCY,
+        )
+
+        async def run_one(idx: int, batch: list[tuple[str, str, dict]]) -> tuple[str | None, list[str]]:
+            async with sem:
+                codes = [d.get("server_code", "") for _, _, d in batch]
+                note = (
+                    f"注意：本次仅诊断已配置 MCP 的一部分（第 {idx + 1}/{total} 批，"
+                    f"本批 {len(batch)} 个 MCP）；请只评估本批 MCP 的覆盖与质量，"
+                    "草案与评分仅针对本批。\n\n"
+                )
+                msg = note + intro_msg + _render_mcp_sections(batch)
+                kb_context = _fetch_kb_quiet([d for _, _, d in batch], ctx.kb_config, ctx.bot_id)
+                if kb_context:
+                    msg += f"\n{kb_context}"
+                msg += "--- end ---"
+                try:
+                    resp = await ctx.llm.chat(
+                        system=self.system_prompt, user=msg, max_tokens=DIAGNOSTIC_MAX_TOKENS,
+                    )
+                except Exception:
+                    logger.warning(
+                        "[D-TOOLS-002] batch %d/%d chat raised: bot=%s",
+                        idx + 1, total, ctx.bot_id, exc_info=True,
+                    )
+                    return None, codes
+                logger.info(
+                    "[D-TOOLS-002] batch %d/%d LLM response received: bot=%s response_len=%d",
+                    idx + 1, total, ctx.bot_id, len(resp or ""),
+                )
+                return resp, codes
+
+        results = await asyncio.gather(*(run_one(i, b) for i, b in enumerate(batches)))
+        return _synthesize_batch_responses(results)

--- a/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
+++ b/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
@@ -10,8 +10,12 @@ from agentclaw.community.core.harness.diagnostics.agents.behavior_boundaries imp
 from agentclaw.community.core.harness.diagnostics.tools.declaration import ToolsDeclarationDiagnostic
 from agentclaw.community.core.harness.diagnostics.tools.mcp_format import (
     ToolsMcpFormatDiagnostic,
+    _BATCH_CHAR_BUDGET,
+    _BATCH_MAX_MCPS,
     _compact_tool_for_prompt,
     _MAX_TOOLS_PER_MCP_IN_PROMPT,
+    _pack_mcp_batches,
+    _synthesize_batch_responses,
 )
 from agentclaw.community.core.harness.diagnostics.config.soul import SoulPersonaDiagnostic
 from agentclaw.community.core.harness.models import Severity
@@ -1186,3 +1190,123 @@ class TestDiagnosticContextNoCache:
 
         result = await ctx.read_file("NONEXISTENT.md")
         assert result == ""
+
+
+class TestToolsMcpFormatBatching:
+    """D-TOOLS-002 batched prompt mode: prompt size decoupled from MCP count."""
+
+    def test_pack_splits_on_count(self):
+        items = [("schema", f"block-{i}", {"server_code": f"mcp.{i}"}) for i in range(7)]
+        batches = _pack_mcp_batches(items)
+        assert [len(b) for b in batches] == [_BATCH_MAX_MCPS, _BATCH_MAX_MCPS, 1]
+
+    def test_pack_splits_on_chars(self):
+        big = "x" * (_BATCH_CHAR_BUDGET - 100)
+        items = [
+            ("schema", big, {"server_code": "mcp.a"}),
+            ("schema", big, {"server_code": "mcp.b"}),
+        ]
+        batches = _pack_mcp_batches(items)
+        assert [[d["server_code"] for _, _, d in b] for b in batches] == [["mcp.a"], ["mcp.b"]]
+
+    def test_pack_single_when_small(self):
+        items = [("schema", "tiny", {"server_code": "mcp.a"})]
+        assert len(_pack_mcp_batches(items)) == 1
+
+    def test_pack_oversized_block_gets_own_batch(self):
+        huge = "y" * (_BATCH_CHAR_BUDGET * 2)
+        items = [
+            ("schema", "a", {"server_code": "mcp.a"}),
+            ("schema", huge, {"server_code": "mcp.b"}),
+            ("schema", "c", {"server_code": "mcp.c"}),
+        ]
+        batches = _pack_mcp_batches(items)
+        assert [[d["server_code"] for _, _, d in b] for b in batches] == [["mcp.a"], ["mcp.b"], ["mcp.c"]]
+
+    def test_synthesize_all_no_issue(self):
+        out = _synthesize_batch_responses([("无问题", ["mcp.a"]), ("无问题", ["mcp.b"])])
+        assert out == "无问题"
+
+    def test_synthesize_all_failed_returns_sentinel(self):
+        out = _synthesize_batch_responses([(None, ["mcp.a"]), ("[llm disabled]", ["mcp.b"])])
+        assert out == "[llm disabled]"
+
+    def test_synthesize_aggregates_scores_and_summaries(self):
+        out = _synthesize_batch_responses([
+            ("映射表缺失\n缺 a 的映射\n[SCORE:70]", ["mcp.a"]),
+            ("规范不全\n缺 b 的规范\n[SCORE:80]", ["mcp.b"]),
+        ])
+        assert out.startswith("映射表缺失；规范不全")
+        assert "缺 a 的映射" in out and "缺 b 的规范" in out
+        assert "[SCORE:50]" in out  # 100 - (30 + 20)
+
+    def test_synthesize_partial_failure_noted(self):
+        out = _synthesize_batch_responses([
+            ("映射表缺失\n缺 a\n[SCORE:70]", ["mcp.a"]),
+            (None, ["mcp.b"]),
+        ])
+        assert "未完成诊断" in out and "mcp.b" in out
+        assert "[SCORE:70]" in out
+
+    def test_synthesize_only_failures_is_check_failed_not_pass(self):
+        out = _synthesize_batch_responses([
+            ("无问题", ["mcp.a"]),
+            (None, ["mcp.b"]),
+        ])
+        assert "部分 MCP 诊断失败" in out
+        assert "[SCORE:0]" in out
+
+    @pytest.mark.asyncio
+    async def test_analyze_splits_into_batches_and_aggregates(self):
+        diag = ToolsMcpFormatDiagnostic()
+        mcps = [{"server_code": f"mcp.{c}", "name": c} for c in "abcde"]
+        ctx = _make_ctx({"TOOLS.md": "# Tools\n\n- some tools"}, activated_mcps=mcps)
+        ctx.mcp_center = _MockMCPCenter({
+            f"mcp.{c}": {
+                "name": c,
+                "description": f"desc {c}",
+                "tools": [{
+                    "name": "t1",
+                    "inputSchema": {"type": "object", "properties": {"p": {"type": "string"}}},
+                }],
+            }
+            for c in "abcde"
+        })
+
+        captured: list[str] = []
+
+        async def fake_chat(system, user, **kwargs):
+            captured.append(user)
+            if "mcp.a" in user:
+                return "规范缺失\n缺 a 规范\n[SCORE:70]"
+            return "无问题"
+
+        ctx.llm.chat = fake_chat
+        findings = await diag.analyze(ctx)
+
+        assert len(captured) == 2  # 5 MCPs / _BATCH_MAX_MCPS per batch
+        assert "第 1/2 批" in captured[0] and "第 2/2 批" in captured[1]
+        assert "mcp.a" in captured[0] and "mcp.d" not in captured[0]
+        assert "mcp.e" in captured[1] and "mcp.a" not in captured[1]
+        assert len(findings) == 1
+        assert findings[0].score == 70
+        assert findings[0].short_summary == "规范缺失"
+
+    @pytest.mark.asyncio
+    async def test_analyze_all_batches_failed_yields_llm01(self):
+        diag = ToolsMcpFormatDiagnostic()
+        mcps = [{"server_code": f"mcp.{c}", "name": c} for c in "abcde"]
+        ctx = _make_ctx({"TOOLS.md": "# Tools\n\n- some tools"}, activated_mcps=mcps)
+        ctx.mcp_center = _MockMCPCenter({
+            f"mcp.{c}": {"name": c, "description": f"desc {c}", "tools": []}
+            for c in "abcde"
+        })
+
+        async def dead_chat(system, user, **kwargs):
+            return "[llm disabled]"
+
+        ctx.llm.chat = dead_chat
+        findings = await diag.analyze(ctx)
+
+        assert len(findings) == 1
+        assert findings[0].rule_id == "LLM01"


### PR DESCRIPTION
Problem

  #840 shrank the D-TOOLS-002 prompt by ~78%, but MCP-heavy bots still fail: one LLM call carries every configured MCP, and antchat's gateway kills any request it can't answer within ~90s. Prepub logs (88-tool bot) show every
  attempt — even at max_tokens=8192 — dying with RemoteProtocolError at ~90s, retries exhausted after ~280s, response_len=14 → spurious "LLM执行异常（请重试）". Small prompts (D-TOOLS-001-scale) succeed on the same gateway. A single
  call whose size grows with MCP count can never be safe against a fixed gateway window.
  
  Solution

  Split the rendered MCP payload into bounded batches (≤3 MCPs / ≤4000 chars of MCP data per call) and run the calls concurrently (3 at a time; llm.py's own semaphore allows 10, so the batch semaphore is the only limiter). Per-batch
  responses are merged in code: distinct summaries joined, drafts concatenated, scores aggregated as max(10, 100 − Σ per-batch deductions) (conservative: global rubric deductions are re-counted per batch). A batch whose call fails
  is reported as undiagnosed in the merged draft instead of failing the whole scan; if every batch fails, the run degrades to the same LLM01 sentinel as before.
  
  Bots whose MCP data fits one batch get the pre-batching prompt byte-for-byte; system_prompt, bucketing, and scoring rules are untouched.

  Validation

  - 61/61 diagnostic unit tests pass (11 new: packing, synthesis, score aggregation, partial failure, multi-batch analyze)
  - Harness acceptance 8/8 against a real local singlebox stack; backend logs show a 13-MCP scan executing as 5 concurrent batches
  - Knobs (_BATCH_MAX_MCPS / _BATCH_CHAR_BUDGET / _BATCH_CONCURRENCY) are module constants — concurrency can go to 5 once antchat's rate limit is known

  Known limitation: concatenated drafts may repeat section headers across batches (merged downstream by patch_planner).
