### PR TITLE
fix(service-bot): gate image policy on valid config

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -73,8 +73,10 @@ from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     apply_default_image_to_ext,
+    clear_image_policy_from_ext,
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
+    resolve_current_arca_image,
 )
 from agentclaw.community.utils.avernet_tenant import (
     bind_current_avernet_tenant,
@@ -372,17 +374,30 @@ class BotService:
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
 
+    def _service_bot_image_policy_enabled(self) -> bool:
+        """Whether draft create/restart should opt into image policy."""
+        return (
+            resolve_current_arca_image(
+                self._common_config_service,
+                env=get_current_env(),
+            )
+            is not None
+        )
+
     def _mark_service_bot_default_image(
         self,
         bot: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Mark a draft ARCA bot to follow the provider default image."""
+        """Apply the draft ARCA image policy only when fully configured."""
         if bot.get("bot_type") != "service" or self.is_teclaw_bot(
             bot.get("active_engine")
         ):
             return bot
         updated_bot = dict(bot)
-        updated_bot["ext"] = apply_default_image_to_ext(bot.get("ext"))
+        if self._service_bot_image_policy_enabled():
+            updated_bot["ext"] = apply_default_image_to_ext(bot.get("ext"))
+        else:
+            updated_bot["ext"] = clear_image_policy_from_ext(bot.get("ext"))
         return updated_bot
 
     def _persist_service_bot_default_image(
@@ -392,8 +407,10 @@ class BotService:
         user_id: str,
     ) -> None:
         """Persist an accepted draft restart's default policy to Bot and Draft."""
-        if bot.get("bot_type") != "service" or self.is_teclaw_bot(
-            bot.get("active_engine")
+        if (
+            bot.get("bot_type") != "service"
+            or self.is_teclaw_bot(bot.get("active_engine"))
+            or not self._service_bot_image_policy_enabled()
         ):
             return
 
@@ -403,6 +420,7 @@ class BotService:
             bot_id=str(bot["bot_id"]),
             owner_id=user_id,
             env=get_current_env(),
+            common_config_service=self._common_config_service,
         )
 
     def _build_engine_extra_envs(
@@ -1304,10 +1322,13 @@ class BotService:
         if resolved_bot_type == "service" and not self.is_teclaw_bot(
             resolved_active_engine
         ):
-            # New ARCA service bots intentionally follow the provider default.
-            # Persist an explicit marker so their future publish records are not
-            # mistaken for legacy records that require Pin compatibility.
-            ext = apply_default_image_to_ext(ext)
+            # The CommonConfig record is the master switch. Missing, disabled,
+            # or lacking a valid image preserves the pre-feature behavior and
+            # removes any caller-supplied image-policy fields.
+            if self._service_bot_image_policy_enabled():
+                ext = apply_default_image_to_ext(ext)
+            else:
+                ext = clear_image_policy_from_ext(ext)
 
         # Resolve bot name according to naming rules
         resolved_bot_name = self._resolve_bot_name(bot_name, bot_id, user_id, nick_name)
@@ -4087,6 +4108,7 @@ class BotService:
                     bot.get("ext")
                     if bot.get("bot_type") == "service"
                     and not self.is_teclaw_bot(bot.get("active_engine"))
+                    and (bot.get("ext") or {}).get("sbot_use_default_image") is True
                     else None
                 ),
             )

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -378,7 +378,7 @@ class BotService:
         """Whether draft create/restart should opt into image policy."""
         return (
             resolve_current_arca_image(
-                self._common_config_service,
+                getattr(self, "_common_config_service", None),
                 env=get_current_env(),
             )
             is not None

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_image_policy_listener.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from injector import inject
 
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.bot_management.services.teclaw_provision_service import (
     DEFAULT_TECLAW_ENGINE_TYPES,
 )
@@ -36,10 +37,12 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
         bot_repository: BotRepository,
         publish_repository: BotPublishRepositoryProtocol,
         binding_repository: DeviceBindingRepository,
+        common_config_service: CommonConfigService,
     ) -> None:
         self._bot_repository = bot_repository
         self._publish_repository = publish_repository
         self._binding_repository = binding_repository
+        self._common_config_service = common_config_service
 
     async def startup(self) -> None:
         from agentclaw.community.core.events.bus import get_event_bus
@@ -89,6 +92,7 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
             bot_id=bot_id,
             owner_id=owner_id,
             env=str(getattr(binding, "env", None) or ""),
+            common_config_service=self._common_config_service,
         )
         # Clear only after both Bot and Draft have accepted DEFAULT. A failed
         # persistence leaves the intent durable for diagnosis/retry.
@@ -97,7 +101,7 @@ class DefaultImagePolicyActivationListener(LifecycleBase):
             props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
         )
         logger.info(
-            "[default_image_policy_listener] persisted DEFAULT before activation: "
+            "[default_image_policy_listener] finalized DEFAULT intent before activation: "
             "bot_id=%s binding_id=%s",
             bot_id,
             event.binding_id,

--- a/src/backend/src/agentclaw/community/core/devices/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/README.md
@@ -24,6 +24,7 @@ internal_dependencies:
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.bot_collaborator
   - agentclaw.community.core.config
+  - agentclaw.community.core.common_config
   - agentclaw.community.core.config_compose    # teclaw_paths — namespaces/mappers used by the device-fs dispatcher (B6)
   - agentclaw.community.core.events
   - agentclaw.community.core.service_bot

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from typing import Any, Callable, Optional
 
 from agentclaw.community.core.bot_management.engines import resolve_provisioning
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.bot_management.utils import clear_baas_publish_failure_ext
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.events.bus import get_event_bus
@@ -347,6 +348,7 @@ class BaasRestartPublishPollHandler:
         baas_device_service: Any | None = None,
         bot_repository: Any | None = None,
         publish_repository: Any | None = None,
+        common_config_service: CommonConfigService | None = None,
         template_service: Any | None = None,
         poll_delay_seconds: float = 10.0,
         clock: Callable[[], float] = time.time,
@@ -356,6 +358,7 @@ class BaasRestartPublishPollHandler:
         self._baas_device_service = baas_device_service or baas_service
         self._bot_repository = bot_repository
         self._publish_repository = publish_repository
+        self._common_config_service = common_config_service
         self._template_service = template_service
         self._poll_delay_seconds = poll_delay_seconds
         self._clock = clock
@@ -711,6 +714,7 @@ class BaasRestartPublishPollHandler:
                     bot_id=bot_id,
                     owner_id=owner_id,
                     env=get_current_env(),
+                    common_config_service=self._common_config_service,
                 )
             except Exception as exc:
                 logger.warning(
@@ -890,6 +894,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
         baas_device_service: Any,
         bot_repository: Any,
         publish_repository: Any | None = None,
+        common_config_service: CommonConfigService | None = None,
         template_service: Any = None,
     ) -> None:
         self._registry = registry
@@ -899,6 +904,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
         self._baas_device_service = baas_device_service
         self._bot_repository = bot_repository
         self._publish_repository = publish_repository
+        self._common_config_service = common_config_service
         self._template_service = template_service
 
     async def bootstrap(self) -> None:
@@ -923,6 +929,7 @@ class BaasPublishTaskLifecycle(LifecycleBase):
                 baas_device_service=self._baas_device_service,
                 bot_repository=self._bot_repository,
                 publish_repository=self._publish_repository,
+                common_config_service=self._common_config_service,
                 template_service=self._template_service,
             )
         )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
@@ -72,8 +72,8 @@ def resolve_current_arca_image(
 ) -> str | None:
     """Return the enabled legacy-protection image.
 
-    Missing/disabled means the feature is not active and preserves the historical
-    platform-default behavior. An enabled but malformed value fails closed.
+    Missing, disabled, or lacking a valid image means the feature is inactive
+    and preserves the historical platform-default behavior.
     """
     if common_config_service is None:
         return None
@@ -89,9 +89,7 @@ def resolve_current_arca_image(
     image = value.get("image") if isinstance(value, dict) else None
     if isinstance(image, str) and image.strip():
         return image.strip()
-    raise ImagePinConfigError(
-        f"Enabled {IMAGE_PIN_PARAM_CODE} config has no valid image: env={env}"
-    )
+    return None
 
 
 def runtime_kind_from_provider(device_provider: str | None) -> str | None:
@@ -163,6 +161,16 @@ def apply_default_image_to_ext(ext: dict[str, Any] | None) -> dict[str, Any]:
     updated.pop(IMAGE_PIN_VALUE_KEY, None)
     updated[IMAGE_DEFAULT_KEY] = True
     return updated
+
+
+def clear_image_policy_from_ext(
+    ext: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Remove all image-policy fields while preserving unrelated ext fields."""
+    updated = dict(ext or {})
+    for key in IMAGE_POLICY_KEYS:
+        updated.pop(key, None)
+    return updated or None
 
 
 def apply_image_pin_to_ext(
@@ -265,9 +273,25 @@ def persist_default_image_policy(
     bot_id: str,
     owner_id: str,
     env: str,
+    common_config_service: CommonConfigService | None,
     max_cas_attempts: int = 3,
-) -> None:
-    """Idempotently persist DEFAULT to the current Bot and Draft after success."""
+) -> bool:
+    """Persist DEFAULT only while the fully configured master switch is active.
+
+    The restart intent can outlive the request that created it. Re-checking the
+    CommonConfig here prevents an asynchronous completion from adding image
+    policy fields after the switch was disabled, deleted, or lost its image.
+    Existing Bot/Draft markers are ignored but left untouched.
+    """
+    if resolve_current_arca_image(common_config_service, env=env) is None:
+        logger.info(
+            "[arca_image_pin] skipped default-image policy because it is "
+            "inactive: bot_id=%s env=%s",
+            bot_id,
+            env,
+        )
+        return False
+
     updated_bot_ext: dict[str, Any] | None = None
     for _attempt in range(max_cas_attempts):
         bot = bot_repository.get_by_id_and_owner(bot_id, owner_id)
@@ -299,15 +323,15 @@ def persist_default_image_policy(
             publish_bot_id=bot_id, env=env
         )
         if draft is None:
-            return
+            return True
         draft_ext = copy_image_policy_to_ext(updated_bot_ext, draft.ext) or {}
         if draft_ext == (draft.ext or {}):
-            return
+            return True
         updated = publish_repository.compare_and_set_ext(
             publish_id=draft.id, expected_ext=draft.ext, ext=draft_ext
         )
         if updated is not None:
-            return
+            return True
     raise ImagePinPersistenceError(
         f"Draft image policy CAS conflicted repeatedly: bot_id={bot_id}"
     )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -28,6 +28,7 @@ from agentclaw.community.core.service_bot.services.publish_exceptions import (
 from agentclaw.community.core.service_bot.services.publish_rollback_mixin import PublishRollbackMixin
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     apply_image_pin_to_ext,
+    clear_image_policy_from_ext,
     copy_image_policy_to_ext,
     has_explicit_image_policy,
     resolve_current_arca_image,
@@ -237,6 +238,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             source_bot.get("ext") if isinstance(source_bot, dict) else None
         )
         ext = copy_image_policy_to_ext(source_bot_ext, ext)
+        image_policy_image: str | None = None
         if isinstance(source_bot, dict) and source_bot.get("bot_type") == "service":
             runtime_kind = None
             binding_id = source_bot.get("binding_id")
@@ -252,6 +254,12 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                     else RUNTIME_KIND_ARCA
                 )
             ext = apply_runtime_kind_to_ext(ext, runtime_kind)
+            if runtime_kind == RUNTIME_KIND_ARCA:
+                image_policy_image = resolve_current_arca_image(
+                    self._common_config_service, env=self._env
+                )
+            if image_policy_image is None:
+                ext = clear_image_policy_from_ext(ext)
 
         # A new/default Bot carries an explicit marker and never consumes the
         # legacy Pin switch. A pre-feature ARCA Bot has no policy marker; when
@@ -263,12 +271,8 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             and not self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
             and not has_explicit_image_policy(source_bot_ext)
         )
-        if is_legacy_arca_service:
-            legacy_image = resolve_current_arca_image(
-                self._common_config_service, env=self._env
-            )
-            if legacy_image:
-                ext = apply_image_pin_to_ext(ext, legacy_image)
+        if is_legacy_arca_service and image_policy_image:
+            ext = apply_image_pin_to_ext(ext, image_policy_image)
 
         record = self._repo.insert({
             "source_bot_pk": source_bot_pk,

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -43,6 +43,7 @@ from agentclaw.community.api.oss_to_nas_switch_service import OssToNasSwitchServ
 from agentclaw.community.core.bot_management.token_vault import TokenVault
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.bot_management.services.default_image_policy_listener import (
     DefaultImagePolicyActivationListener,
 )
@@ -272,6 +273,7 @@ class DevicesModule(Module):
         baas_device_service: BaasDeviceService,
         bot_repository: BotRepository,
         publish_repository: BotPublishRepositoryProtocol,
+        common_config_service: CommonConfigService,
         template_service: TemplateService,
     ) -> BaasPublishTaskLifecycle:
         return BaasPublishTaskLifecycle(
@@ -282,6 +284,7 @@ class DevicesModule(Module):
             baas_device_service=baas_device_service,
             bot_repository=bot_repository,
             publish_repository=publish_repository,
+            common_config_service=common_config_service,
             template_service=template_service,
         )
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -188,7 +188,41 @@ class TestCreateBotBcnRegister:
             "envs": {"A": "1"},
         }
         assert template_config["image"] == "registry/arca:v1"
-        common_config.get_value.assert_not_called()
+        common_config.get_value.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "config_value",
+        [None, {}, {"image": ""}],
+        ids=["missing-or-disabled", "missing-image", "empty-image"],
+    )
+    def test_service_bot_create_without_active_image_policy_has_no_markers(
+        self, config_value
+    ):
+        svc = _make_service()
+        _attach_device_service(svc)
+        common_config = MagicMock()
+        common_config.get_value.return_value = config_value
+        svc._common_config_service = common_config
+
+        svc.create_bot(
+            user_id="u1",
+            nick_name="nick",
+            bot_name="legacy-service-bot",
+            bot_id="service-legacy-1",
+            engine_type="openclaw",
+            bot_type="service",
+            template_type="service",
+            ext={
+                "service_bot_config": {"device_count": 3},
+                "sbot_use_default_image": True,
+                "sbot_pin_image": True,
+                "sbot_docker_image": "stale:v1",
+            },
+        )
+
+        inserted_ext = svc._repository.insert.call_args.args[0]["ext"]
+        assert inserted_ext == {"service_bot_config": {"device_count": 3}}
+        common_config.get_value.assert_called_once()
 
     def test_claude_code_application_coding_does_not_trigger_bcn_register(self):
         """claude_code + applicationCoding 创建时不应触发 BCN 注册。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -183,6 +183,15 @@ def _stateful_bot_repository(bot: dict) -> tuple[MagicMock, dict]:
         return dict(state)
 
     repository.update_by_owner.side_effect = update_bot
+
+    def compare_and_set_ext(*, bot_id, owner_id, expected_ext, ext):
+        del bot_id, owner_id
+        if state.get("ext") != expected_ext:
+            return None
+        state["ext"] = ext
+        return dict(state)
+
+    repository.compare_and_set_ext.side_effect = compare_and_set_ext
     return repository, state
 
 
@@ -973,7 +982,7 @@ class TestRestartGuardOrchestration:
         with patch.object(svc, "stop_bot"), patch.object(svc, "start_bot"):
             svc.restart_bot(bot_id="bot001", user_id="user001")
 
-        common_config.get_value.assert_not_called()
+        common_config.get_value.assert_called_once()
         assert state["ext"]["service_bot_config"] == {"device_count": 3}
         assert "sbot_use_default_image" not in state["ext"]
         payload = svc._task_queue_service.enqueue.call_args.args[1]
@@ -983,6 +992,93 @@ class TestRestartGuardOrchestration:
             "image": "registry/arca:v1",
             "envs": {"A": "1"},
         }
+
+    @pytest.mark.parametrize(
+        "config_value",
+        [None, {}, {"image": ""}],
+        ids=["missing-or-disabled", "missing-image", "empty-image"],
+    )
+    def test_restart_baas_without_active_image_policy_has_no_marker_intent(
+        self, config_value
+    ):
+        repo = FakeRestartLockRepo()
+        common_config = MagicMock()
+        common_config.get_value.return_value = config_value
+        bot = {
+            **_make_bot(status="ACTIVE", binding_id=42, bot_type="service"),
+            "ext": {
+                "service_bot_config": {"device_count": 3},
+                "sbot_use_default_image": True,
+                "sbot_pin_image": True,
+                "sbot_docker_image": "stale:v1",
+            },
+        }
+        bot_repository, state = _stateful_bot_repository(bot)
+        svc = _make_service(
+            repo,
+            bot_repository=bot_repository,
+            common_config_service=common_config,
+            task_queue_service=MagicMock(),
+        )
+        svc._template_service.get_template_config.return_value = {
+            "image": "registry/arca:v1",
+            "envs": {"A": "1"},
+        }
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="baas", device_id="BOT-uuid-9",
+        )
+        svc._device_service_provider = lambda: device_service
+        baas = MagicMock()
+        baas.upgrade_bot.return_value = {"publish_id": 101}
+        svc._baas_service_provider = lambda: baas
+
+        with patch.object(svc, "stop_bot"), patch.object(svc, "start_bot"):
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert state["ext"] == {
+            "service_bot_config": {"device_count": 3},
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        }
+        payload = svc._task_queue_service.enqueue.call_args.args[1]
+        assert "image_policy_on_success" not in payload
+        assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
+            "image": "registry/arca:v1",
+            "envs": {"A": "1"},
+        }
+        common_config.get_value.assert_called_once()
+
+    def test_restart_arca_without_active_image_policy_has_no_marker_override(self):
+        repo = FakeRestartLockRepo()
+        common_config = MagicMock()
+        common_config.get_value.return_value = None
+        svc = _make_service(repo, common_config_service=common_config)
+        bot = {
+            **_make_bot(status="ACTIVE", binding_id=42, bot_type="service"),
+            "ext": {
+                "service_bot_config": {"device_count": 3},
+                "sbot_use_default_image": True,
+                "sbot_pin_image": True,
+                "sbot_docker_image": "stale:v1",
+            },
+        }
+        svc._repository.get_by_id_and_owner.return_value = bot
+        device_service = MagicMock()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42, device_provider="arca"
+        )
+        svc._device_service_provider = lambda: device_service
+
+        with patch.object(svc, "stop_bot", return_value=True), patch.object(
+            svc, "start_bot", return_value=bot
+        ) as start:
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert start.call_args.kwargs["bot_ext_override"] is None
+        svc._repository.compare_and_set_ext.assert_not_called()
+        common_config.get_value.assert_called_once()
 
     def test_restart_baas_service_ignores_existing_publish_migration_path(self):
         """普通 restart 只重启当前 bot；历史发布记录里的 migration_path 不参与。"""

--- a/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
+++ b/src/backend/tests/community/core/bot_management/services/test_default_image_policy_listener.py
@@ -30,7 +30,17 @@ def _listener(*, marker=DEFAULT_IMAGE_POLICY_VALUE, active_engine="openclaw"):
         "bot_type": "service",
         "active_engine": active_engine,
     }
+    bot_repo.get_by_id_and_owner.return_value = {
+        "ext": {
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        }
+    }
     publish_repo = MagicMock()
+    publish_repo.get_draft_by_publish_bot_id.return_value = None
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arca:default"}
     binding_repo = MagicMock()
     binding_repo.get_by_id.return_value = SimpleNamespace(
         id=7,
@@ -42,6 +52,7 @@ def _listener(*, marker=DEFAULT_IMAGE_POLICY_VALUE, active_engine="openclaw"):
             bot_repository=bot_repo,
             publish_repository=publish_repo,
             binding_repository=binding_repo,
+            common_config_service=common_config,
         ),
         bot_repo,
         publish_repo,
@@ -78,7 +89,23 @@ def test_activation_persists_default_then_clears_intent():
         bot_id="bot-1",
         owner_id="u1",
         env="pre",
+        common_config_service=listener._common_config_service,
     )
+    binding_repo.update_device_props.assert_called_once_with(
+        binding_id=7,
+        props={IMAGE_POLICY_ON_ACTIVE_KEY: None},
+    )
+
+
+@pytest.mark.parametrize("config_value", [None, {}, {"image": ""}])
+def test_activation_ignores_existing_markers_when_policy_inactive(config_value):
+    listener, bot_repo, publish_repo, binding_repo = _listener()
+    listener._common_config_service.get_value.return_value = config_value
+
+    listener.handle(_event())
+
+    bot_repo.compare_and_set_ext.assert_not_called()
+    publish_repo.compare_and_set_ext.assert_not_called()
     binding_repo.update_device_props.assert_called_once_with(
         binding_id=7,
         props={IMAGE_POLICY_ON_ACTIVE_KEY: None},

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -76,13 +76,20 @@ def _make_restart_handler(
     publish_repository: MagicMock | None = None,
     template_service: MagicMock | None = None,
     baas_service: MagicMock | None = None,
+    common_config_service: MagicMock | None = None,
     clock=lambda: 200.0,
 ) -> tuple[BaasRestartPublishPollHandler, MagicMock]:
+    if common_config_service is None:
+        common_config_service = MagicMock()
+        common_config_service.get_value.return_value = {
+            "image": "registry/arca:default"
+        }
     handler = BaasRestartPublishPollHandler(
         binding_repository=repo,
         baas_service=baas_service,
         bot_repository=bot_repository,
         publish_repository=publish_repository or MagicMock(),
+        common_config_service=common_config_service,
         baas_device_service=baas_device_service,
         template_service=template_service or MagicMock(),
         poll_delay_seconds=10.0,
@@ -1536,6 +1543,7 @@ def test_baas_publish_task_lifecycle_registers_all_handlers():
         task_queue_service=MagicMock(),
         baas_device_service=MagicMock(),
         bot_repository=MagicMock(),
+        common_config_service=MagicMock(),
         template_service=MagicMock(),
     )
 
@@ -1845,6 +1853,7 @@ def test_restart_default_policy_is_persisted_only_after_active():
             bot_id="bot-001",
             owner_id="owner-001",
             env="dev",
+            common_config_service=handler._common_config_service,
         )
         repo.update_device_props.assert_called_once_with(
             binding_id=42,
@@ -1858,6 +1867,84 @@ def test_restart_default_policy_is_persisted_only_after_active():
         assert received[0].publish_kind == "restart"
     finally:
         reset_event_bus()
+
+
+@pytest.mark.parametrize("config_value", [None, {}, {"image": ""}])
+def test_restart_success_does_not_persist_default_policy_when_switch_is_inactive(
+    config_value,
+):
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.PENDING.value,
+        device_props={
+            "restart_publish_id": 1002,
+            "restart_image_policy_on_success": "default",
+        },
+    )
+    bot_repository = MagicMock()
+    bot_repository.get_by_binding_id.return_value = {
+        "bot_id": "bot-001",
+        "owner_id": "owner-001",
+        "status": DeviceBindingStatus.PENDING.value,
+    }
+    bot_repository.get_by_id_and_owner.return_value = {
+        "ext": {
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        }
+    }
+    publish_repository = MagicMock()
+    publish_repository.get_draft_by_publish_bot_id.return_value = None
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = DeviceBindingStatus.ACTIVE.value
+    baas_device_service.refresh_codefuse_token_on_publish_success.return_value = None
+    common_config = MagicMock()
+    common_config.get_value.return_value = config_value
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=bot_repository,
+        publish_repository=publish_repository,
+        baas_device_service=baas_device_service,
+        common_config_service=common_config,
+    )
+
+    outcome = handler.handle(
+        build_restart_publish_poll_payload(
+            binding_id=42,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            publish_id=1002,
+            started_at_epoch_s=190.0,
+            bot_uuid="baas-bot-1",
+        )
+    )
+
+    assert outcome == Complete()
+    bot_repository.compare_and_set_ext.assert_called_once_with(
+        bot_id="bot-001",
+        owner_id="owner-001",
+        expected_ext={
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        },
+        ext={
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+            "restart_publish_id": "1002",
+        },
+    )
+    publish_repository.compare_and_set_ext.assert_not_called()
+    repo.update_device_props.assert_called_once_with(
+        binding_id=42,
+        props={
+            "restart_request_id": None,
+            "restart_workflow_baseline": None,
+            "restart_image_policy_on_success": None,
+        },
+    )
 
 
 def test_restart_failed_publish_does_not_persist_default_policy():

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -1010,10 +1010,13 @@ class TestReportDeviceAlive:
             },
         ]
         publish_repo = MagicMock()
+        common_config = MagicMock()
+        common_config.get_value.return_value = {"image": "registry/arca:default"}
         listener = DefaultImagePolicyActivationListener(
             bot_repository=policy_bot_repo,
             publish_repository=publish_repo,
             binding_repository=repo,
+            common_config_service=common_config,
         )
         get_event_bus().subscribe(DeviceAliveEvent, listener.handle, required=True)
 
@@ -1043,6 +1046,7 @@ class TestReportDeviceAlive:
             bot_id="bot-1",
             owner_id="u001",
             env="dev",
+            common_config_service=common_config,
         )
         repo.update_device_props.assert_called_once_with(
             binding_id=record.id,

--- a/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
     RUNTIME_KIND_TECLAW,
     apply_default_image_to_ext,
     apply_image_pin_to_ext,
+    clear_image_policy_from_ext,
     apply_runtime_kind_to_ext,
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
@@ -65,12 +66,11 @@ def test_resolve_current_image_returns_none_for_disabled_or_missing_config():
 
 
 @pytest.mark.parametrize("value", [{}, {"image": ""}, "registry/arca:v2"])
-def test_resolve_current_image_rejects_enabled_malformed_config(value):
+def test_resolve_current_image_returns_none_without_valid_image(value):
     service = MagicMock()
     service.get_value.return_value = value
 
-    with pytest.raises(ImagePinConfigError, match="has no valid image"):
-        resolve_current_arca_image(service, env="pre")
+    assert resolve_current_arca_image(service, env="pre") is None
 
 
 def test_apply_pin_preserves_service_bot_config_and_clears_stale_pin():
@@ -101,6 +101,17 @@ def test_apply_default_preserves_unrelated_fields_and_clears_stale_pin():
         "service_bot_config": {"device_count": 3},
         "sbot_use_default_image": True,
     }
+
+
+def test_clear_policy_preserves_unrelated_fields_and_removes_all_markers():
+    assert clear_image_policy_from_ext(
+        {
+            "service_bot_config": {"device_count": 3},
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "old:v1",
+        }
+    ) == {"service_bot_config": {"device_count": 3}}
 
 
 def test_publish_copy_is_whitelisted_and_template_overlay_is_non_mutating():
@@ -389,12 +400,16 @@ def test_default_policy_retries_bot_cas_without_losing_concurrent_ext():
     publish_repo = MagicMock()
     publish_repo.get_draft_by_publish_bot_id.return_value = None
 
+    common_config = MagicMock()
+    common_config.get_value.return_value = {"image": "registry/arca:default"}
+
     persist_default_image_policy(
         bot_repository=bot_repo,
         publish_repository=publish_repo,
         bot_id="bot-1",
         owner_id="u1",
         env="pre",
+        common_config_service=common_config,
     )
 
     assert bot_repo.compare_and_set_ext.call_count == 2
@@ -405,3 +420,43 @@ def test_default_policy_retries_bot_cas_without_losing_concurrent_ext():
         "concurrent": True,
         "sbot_use_default_image": True,
     }
+
+
+@pytest.mark.parametrize("config_value", [None, {}, {"image": ""}])
+def test_default_policy_persistence_ignores_markers_when_policy_inactive(config_value):
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = {
+        "ext": {
+            "keep": "bot",
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        }
+    }
+    bot_repo.compare_and_set_ext.return_value = {"ext": {"keep": "bot"}}
+    publish_repo = MagicMock()
+    publish_repo.get_draft_by_publish_bot_id.return_value = SimpleNamespace(
+        id=9,
+        ext={
+            "keep": "draft",
+            "sbot_use_default_image": True,
+            "sbot_pin_image": True,
+            "sbot_docker_image": "stale:v1",
+        },
+    )
+    publish_repo.compare_and_set_ext.return_value = SimpleNamespace(id=9)
+    common_config = MagicMock()
+    common_config.get_value.return_value = config_value
+
+    persisted = persist_default_image_policy(
+        bot_repository=bot_repo,
+        publish_repository=publish_repo,
+        bot_id="bot-1",
+        owner_id="u1",
+        env="pre",
+        common_config_service=common_config,
+    )
+
+    assert persisted is False
+    bot_repo.compare_and_set_ext.assert_not_called()
+    publish_repo.compare_and_set_ext.assert_not_called()

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -132,7 +132,7 @@ class TestCreatePublishImagePolicy:
         )
         return publish_repo.insert.call_args.args[0]["ext"], common_config
 
-    def test_default_bot_copies_marker_without_reading_common_config(self):
+    def test_default_bot_copies_marker_when_switch_has_valid_image(self):
         ext, common_config = self._create(
             source_bot={
                 "bot_type": "service",
@@ -147,7 +147,34 @@ class TestCreatePublishImagePolicy:
             "sbot_use_default_image": True,
             "sbot_runtime_kind": "arca",
         }
-        common_config.get_value.assert_not_called()
+        common_config.get_value.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "config_value",
+        [None, {}, {"image": ""}],
+        ids=["missing-or-disabled", "missing-image", "empty-image"],
+    )
+    def test_existing_policy_is_not_copied_when_switch_is_inactive(
+        self, config_value
+    ):
+        ext, common_config = self._create(
+            source_bot={
+                "bot_type": "service",
+                "active_engine": "openclaw",
+                "ext": {
+                    "sbot_use_default_image": True,
+                    "sbot_pin_image": True,
+                    "sbot_docker_image": "stale:v1",
+                },
+            },
+            common_config_value=config_value,
+        )
+
+        assert ext == {
+            "migration_path": "/build/v1",
+            "sbot_runtime_kind": "arca",
+        }
+        common_config.get_value.assert_called_once()
 
     def test_legacy_arca_bot_snapshots_enabled_common_config_image(self):
         ext, common_config = self._create(


### PR DESCRIPTION
## Problem

Service Bot create and restart flows could apply default-image markers whenever the image-policy path was present, even when the `sbot_pin_image` configuration was disabled, missing, or had no valid image. Asynchronous restart completion could also persist a marker after the configuration became inactive.

## Solution

- Treat disabled, missing, and empty-image configurations as an inactive image policy.
- Do not add default-image intent during ARCA/BaaS create or restart when the policy is inactive.
- Re-check the configuration before asynchronous restart completion persists the default marker.
- Ignore existing Bot/Draft image-policy markers for the current operation when the switch is inactive, without rewriting or clearing stored records.
- Keep new publish records free of image-policy markers when the policy is inactive, while preserving historical published contracts.
- Declare the new devices-to-common-config module dependency.

## Validation

- `401 passed, 17 warnings` across the affected Service Bot, device, image-policy, publish-flow, and module-boundary tests.
- Ruff checks passed for all changed Python files.
- `git diff --check` passed.

## Compatibility and risk

When the configuration is inactive, behavior falls back to the existing provider-default image flow. Existing stored image-policy fields are not migrated or deleted. Historical published records continue to use their frozen runtime/image contract.