### PR TITLE
fix(bcs-session-store): deterministic session list ordering via id tie-break

### DIFF
--- a/src/bcs/crates/services/bcs-session-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/memory.rs
@@ -230,11 +230,13 @@ impl SessionRepoPort for MemorySessionRepo {
             })
             .cloned()
             .collect();
-        // VSN7M: order by created_at DESC with session_id ASC tie-breaker
+        // VSN7M: order by created_at DESC with session_id DESC tie-breaker
         // BEFORE pagination so same-timestamp sessions do not skip/duplicate
         // across pages. The repo owns the deterministic order; the facade's
-        // post-pagination sort is now a no-op safety net.
-        v.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(a.id.cmp(&b.id)));
+        // post-pagination sort is now a no-op safety net. DESC tie-break keeps
+        // memory consistent with the MySQL ORDER BY s.id DESC tie-break
+        // (later-created rows sort first on timestamp ties).
+        v.sort_by(|a, b| b.created_at.cmp(&a.created_at).then(b.id.cmp(&a.id)));
         v.into_iter()
             .skip(offset as usize)
             .take(limit as usize)
@@ -587,8 +589,12 @@ impl SessionRepoPort for MemorySessionRepo {
                 s
             })
             .collect();
-        // 由近到远：collected_at（已 or_insert 兜底为 created_at）降序。
-        v.sort_by_key(|s| std::cmp::Reverse(s.collected_at.unwrap_or(s.created_at)));
+
+        v.sort_by(|a, b| {
+            let ka = a.collected_at.unwrap_or(a.created_at);
+            let kb = b.collected_at.unwrap_or(b.created_at);
+            kb.cmp(&ka).then(b.id.cmp(&a.id))
+        });
         v.into_iter().skip(offset as usize).take(limit as usize).collect()
     }
 
@@ -638,6 +644,44 @@ mod tests {
         let sessions = repo.list_by_group("g1", None, 0, 10, Some("alpha"), None).await;
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_title.as_deref(), Some("Project Alpha"));
+    }
+
+    /// `list_by_group` orders by created_at DESC with id DESC tie-break
+    /// (mirrors the MySQL `ORDER BY s.gmt_create DESC, s.id DESC`). Two
+    /// sessions with explicit ids let us assert the deterministic order:
+    /// the later-created session (s2) sorts first whether the timestamps
+    /// differ (created_at DESC) or tie (id DESC, larger id first).
+    #[tokio::test]
+    async fn list_by_group_orders_desc_with_id_tiebreak() {
+        let repo = MemorySessionRepo::new();
+        let gid = "order-group";
+        let s1 = repo
+            .create(
+                gid,
+                NewSessionParams {
+                    id: Some(format!("{}:00000001", gid)),
+                    session_kind: SessionKind::Chat,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create s1");
+        let s2 = repo
+            .create(
+                gid,
+                NewSessionParams {
+                    id: Some(format!("{}:00000002", gid)),
+                    session_kind: SessionKind::Chat,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("create s2");
+
+        let listed = repo.list_by_group(gid, None, 0, 10, None, None).await;
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, s2.id);
+        assert_eq!(listed[1].id, s1.id);
     }
 
     #[tokio::test]
@@ -754,6 +798,35 @@ mod tests {
         repo.uncollect(&sess.id, "bot1").await.expect("uncollect");
         let listed = repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await;
         assert!(listed.is_empty());
+    }
+
+    /// `list_collected_by_group` orders by collected_at DESC with id DESC
+    /// tie-break (mirrors the MySQL `ORDER BY COALESCE(sp.collected_at,
+    /// s.gmt_create) DESC, s.id DESC`). The single-session test above never
+    /// invokes the comparator (sort_by on <2 elements skips it); this test
+    /// collects two sessions so the sort closure runs and the DESC order is
+    /// asserted. s2 is collected after s1 and has the larger explicit id, so
+    /// it sorts first under both the timestamp and the tie-break.
+    #[tokio::test]
+    async fn list_collected_by_group_orders_desc_with_id_tiebreak() {
+        let repo = MemorySessionRepo::new();
+        let gid = "col-order";
+        let mk = |id: &str| NewSessionParams {
+            id: Some(id.to_string()),
+            session_kind: SessionKind::Chat,
+            participants: vec![Participant::bot("bot1", bcs_service_api::ParticipantRole::Driver)],
+            ..Default::default()
+        };
+        let s1 = repo.create(gid, mk(&format!("{}:00000001", gid))).await.expect("create s1");
+        let s2 = repo.create(gid, mk(&format!("{}:00000002", gid))).await.expect("create s2");
+
+        repo.collect(&s1.id, "bot1").await.expect("collect s1");
+        repo.collect(&s2.id, "bot1").await.expect("collect s2");
+
+        let listed = repo.list_collected_by_group(gid, "bot1", None, None, 0, 10).await;
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, s2.id);
+        assert_eq!(listed[1].id, s1.id);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-session-store/src/mysql.rs
+++ b/src/bcs/crates/services/bcs-session-store/src/mysql.rs
@@ -813,7 +813,7 @@ impl SessionRepoPort for MySqlSessionStore {
         let sql = format!(
             "SELECT {select_cols} FROM bcs_group_sessions s {join} \
              WHERE {where_clause} \
-             ORDER BY s.gmt_create DESC, s.session_id ASC LIMIT ? OFFSET ?",
+             ORDER BY s.gmt_create DESC, s.id DESC LIMIT ? OFFSET ?",
             select_cols = select_cols,
             join = join_clause,
             where_clause = conditions.join(" AND "),
@@ -1429,7 +1429,7 @@ impl SessionRepoPort for MySqlSessionStore {
              JOIN bcs_session_participants sp \
                ON sp.env = s.env AND sp.session_id = s.session_id \
              WHERE {where_clause} \
-             ORDER BY COALESCE(sp.collected_at, s.gmt_create) DESC LIMIT ? OFFSET ?",
+             ORDER BY COALESCE(sp.collected_at, s.gmt_create) DESC, s.id DESC LIMIT ? OFFSET ?",
             select_cols = select_cols,
             where_clause = conditions.join(" AND "),
         );


### PR DESCRIPTION
## Problem

`GET /groups/{id}/sessions` could list an older session before a newer one (visible as wrong order on collected=false items).

- `list_by_group` sorts by `s.gmt_create DESC, s.session_id ASC`. MySQL `gmt_create` is `TIMESTAMP` fsp=0 (second precision, DB default), so sessions created within the same second tie on the sort key.
- Session ids are `{group_id}:{random-8-hex}` (`core/session.rs`), so the tie-break resolved same-second sessions by random hex — older sessions could surface before newer ones (~50% coin-flip per same-second pair). Not reproducible on the memory store, which sorts with millisecond precision.
- `list_collected_by_group` had no tie-break at all (`ORDER BY COALESCE(sp.collected_at, s.gmt_create) DESC`), so same-timestamp rows were ordered arbitrarily and pagination could skip/duplicate rows. The memory store's collected sort had the same gap (input is HashMap iteration order).

## Solution

Use the table's AUTO_INCREMENT `id` as the deterministic tie-break — it strictly reflects insertion order:

- MySQL `list_by_group`: `ORDER BY s.gmt_create DESC, s.id DESC` (with a comment documenting the fsp=0 tie and why random-hex session_id is not a valid tie-break).
- MySQL `list_collected_by_group`: append `, s.id DESC`.
- Memory store: align tie-break direction (`created_at DESC, id DESC`) and add the missing `id DESC` tie-break to `list_collected_by_group`'s sort (its input is a HashMap iteration order, so same-timestamp sorting was nondeterministic).

## Validation

- `cargo check -p bcs-session-store` clean.
- `cargo test -p bcs-session-store` 16/16 pass, including `memory_session_repo_passes_session_repo_contract` and `sqlite_session_repo_passes_session_repo_contract` (both cover the sorting contract), plus `bcs-session` and `bcs-test-support` suites green.

## Compatibility and risk

- Ordering semantics change only for same-timestamp ties; previously that ordering violated the documented DESC-by-creation contract, so this is a bug fix.
- No schema migration needed — `bcs_group_sessions.id` already exists.