### PR TITLE
feat(bcs): add provider HTTP bypass headers

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/admin_invocations.rs
@@ -189,6 +189,7 @@ pub async fn create_admin_run(
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: request.detach.then(|| "detached".to_string()),
             organization_code: Some(organization_code.clone()),
+            provider_bypass_headers: Vec::new(),
         })
         .await;
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bot_chat.rs
@@ -230,6 +230,7 @@ pub async fn bot_chat(
             tags,
             response_mode: req.response_mode,
             organization_code,
+            provider_bypass_headers: state.provider_bypass_headers_from(&headers),
         })
         .await
         .map_err(map_service_error)
@@ -383,6 +384,7 @@ pub async fn bot_chat_async(
             response_mode: req.response_mode,
             caller_wait_mode,
             organization_code,
+            provider_bypass_headers: state.provider_bypass_headers_from(&headers),
         })
         .await;
     let accepted = match accepted_result {

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/group_messages.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/group_messages.rs
@@ -127,6 +127,7 @@ pub async fn group_chat(
             requested_sender_id: req.from,
             message: req.message,
             session_id: req.session_id,
+            provider_bypass_headers: state.provider_bypass_headers_from(&headers),
         })
         .await
         .map_err(service_error_to_legacy)?;

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -1718,6 +1718,7 @@ pub async fn session_chat(
         requested_sender_id,
         message: body.message,
         session_id: Some(sid.clone()),
+        provider_bypass_headers: state.provider_bypass_headers_from(&headers),
     };
 
     match state.services.message_flow.handle_group_chat(cmd).await {

--- a/src/bcs/crates/adapters/http/bcs-http/src/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/state.rs
@@ -4,6 +4,7 @@ use bcs_channel_api::ChannelHttpIngressRegistry;
 use bcs_config_api::ManifestConfig;
 use bcs_domain::BotCapabilities;
 use bcs_route_security::OutboundUrlGuard;
+use axum::http::{HeaderMap, HeaderName};
 pub use bcs_service_api::{ChatRunCleanupPort, ChatRunEventPort};
 use bcs_service_api::{ProviderCredentialRepoPort, ProviderStreamGrayList};
 use bcs_services_container::Services;
@@ -40,7 +41,7 @@ pub struct HttpUserIdentity {
 pub trait UserIdentityPort: Send + Sync {
     async fn extract(
         &self,
-        headers: &axum::http::HeaderMap,
+        headers: &HeaderMap,
         uri: &axum::http::Uri,
     ) -> Option<HttpUserIdentity>;
 
@@ -103,7 +104,7 @@ impl ChainUserIdentityPort {
 impl UserIdentityPort for ChainUserIdentityPort {
     async fn extract(
         &self,
-        headers: &axum::http::HeaderMap,
+        headers: &HeaderMap,
         _uri: &axum::http::Uri,
     ) -> Option<HttpUserIdentity> {
         let result = self.chain.authenticate(headers).await.ok()?;
@@ -463,6 +464,7 @@ pub struct HttpAppState {
     pub manifest: ManifestConfig,
     pub allowed_switch_provider_ids: Arc<Vec<String>>,
     pub provider_stream_gray_list: Arc<ProviderStreamGrayList>,
+    pub provider_bypass_header_names: Arc<Vec<HeaderName>>,
     pub judge_enabled: bool,
     pub channel_http_ingress: Option<Arc<ChannelHttpIngressRegistry>>,
     pub auth_chain: Option<Arc<bcs_auth_api::AuthPluginChain>>,
@@ -511,6 +513,7 @@ impl HttpAppState {
             manifest: ManifestConfig::default(),
             allowed_switch_provider_ids: Arc::new(Vec::new()),
             provider_stream_gray_list: Arc::new(ProviderStreamGrayList::default()),
+            provider_bypass_header_names: Arc::new(Vec::new()),
             judge_enabled: false,
             channel_http_ingress: None,
             auth_chain: None,
@@ -674,6 +677,23 @@ impl HttpAppState {
         self
     }
 
+    pub fn with_provider_bypass_header_names(mut self, names: Vec<HeaderName>) -> Self {
+        self.provider_bypass_header_names = Arc::new(names);
+        self
+    }
+
+    pub fn provider_bypass_headers_from(&self, headers: &HeaderMap) -> Vec<(String, String)> {
+        self.provider_bypass_header_names
+            .iter()
+            .filter_map(|name| {
+                headers
+                    .get(name)
+                    .and_then(|value| value.to_str().ok())
+                    .map(|value| (name.as_str().to_string(), value.to_string()))
+            })
+            .collect()
+    }
+
     pub fn with_channel_http_ingress(
         mut self,
         ingress: Option<Arc<ChannelHttpIngressRegistry>>,
@@ -713,7 +733,7 @@ impl HttpAppState {
     /// default to `["local"]`), resolve a non-JWT session token directly via the
     /// registry — mirroring the legacy `SessionTokenPlugin` non-JWT branch. JWT
     /// tokens without a chain are not resolvable (production always has a chain).
-    pub async fn bot_uuid_from_headers(&self, headers: &axum::http::HeaderMap) -> Option<String> {
+    pub async fn bot_uuid_from_headers(&self, headers: &HeaderMap) -> Option<String> {
         if let Some(chain) = self.auth_chain.as_ref() {
             if let Ok(result) = chain.authenticate(headers).await {
                 if let Some(bot_uuid) = result.principal.and_then(|p| p.bot_uuid) {
@@ -735,7 +755,7 @@ impl HttpAppState {
 /// [`crate::headers::extract_bearer_token`]; kept private to `state` only to
 /// preserve the `X-BCS-Bot-Token` precedence and mirror
 /// `routes::caller::bot_token_from_headers`.
-fn bot_token_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+fn bot_token_from_headers(headers: &HeaderMap) -> Option<String> {
     if let Some(token) = headers
         .get("X-BCS-Bot-Token")
         .and_then(|value| value.to_str().ok())

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{Body, to_bytes},
-    http::{Request, StatusCode},
+    http::{HeaderName, Request, StatusCode},
 };
 use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
@@ -223,6 +223,7 @@ impl A2aChatRunService for RecordingA2aChat {
             response_mode: cmd.response_mode,
             caller_wait_mode: None,
             organization_code: cmd.organization_code,
+            provider_bypass_headers: cmd.provider_bypass_headers,
         });
         self.run_channel_froms
             .lock()
@@ -278,6 +279,7 @@ impl A2aChatRunService for RecordingA2aChat {
             response_mode: cmd.response_mode,
             caller_wait_mode: cmd.caller_wait_mode,
             organization_code: cmd.organization_code,
+            provider_bypass_headers: cmd.provider_bypass_headers,
         });
         self.run_channel_froms
             .lock()
@@ -406,6 +408,18 @@ async fn build_chat_app_with_events(
     Arc<RecordingA2aChat>,
     Arc<RecordingChatRunEvents>,
 ) {
+    build_chat_app_with_events_and_bypass(events, keep_open_after_send, Vec::new()).await
+}
+
+async fn build_chat_app_with_events_and_bypass(
+    events: Vec<String>,
+    keep_open_after_send: bool,
+    provider_bypass_header_names: Vec<HeaderName>,
+) -> (
+    axum::Router,
+    Arc<RecordingA2aChat>,
+    Arc<RecordingChatRunEvents>,
+) {
     let temp_dir = TempDir::new().unwrap();
     let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
     for bot_id in ["caller-bot", "target-bot"] {
@@ -456,7 +470,8 @@ async fn build_chat_app_with_events(
     let app = build_router(
         HttpAppState::new(services)
             .with_user_identity(Arc::new(ChainUserIdentityPort::new(chain)))
-            .with_chat_run_events(run_events.clone()),
+            .with_chat_run_events(run_events.clone())
+            .with_provider_bypass_header_names(provider_bypass_header_names),
     );
     (app, a2a, run_events)
 }
@@ -572,6 +587,47 @@ async fn bot_chat_waits_for_final_event_and_preserves_response_shape() {
     assert_eq!(
         a2a.run_channel_froms.lock().await.as_slice(),
         &[Some("human_123".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn bot_chat_forwards_only_configured_provider_bypass_headers() {
+    let (app, a2a, _run_events) = build_chat_app_with_events_and_bypass(
+        vec![final_event("pong")],
+        false,
+        vec![HeaderName::from_static("x-sandbox-bypass")],
+    )
+    .await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/bots/target-bot/chat")
+                .header("authorization", "Bearer caller-token")
+                .header("content-type", "application/json")
+                .header("X-Sandbox-Bypass", "sandbox-route-1")
+                .header("X-Unconfigured-Bypass", "must-not-pass")
+                .body(Body::from(
+                    serde_json::json!({
+                        "message": "ping",
+                        "from": "human_123",
+                        "session_id": "stable-session"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let commands = a2a.commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].provider_bypass_headers,
+        vec![("x-sandbox-bypass".to_string(), "sandbox-route-1".to_string())]
     );
 }
 

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -713,7 +713,13 @@ fn is_safe_provider_bypass_header(name: &str) -> bool {
     let lower = trimmed.to_ascii_lowercase();
     !matches!(
         lower.as_str(),
-        "authorization" | "cookie" | "host" | "content-length" | "content-type"
+        "authorization"
+            | "cookie"
+            | "host"
+            | "content-length"
+            | "content-type"
+            | "x-bcs-bot-token"
+            | "x-bcs-service-key"
     ) && lower != "bcn"
         && !lower.starts_with("bcn-")
         && !lower.starts_with("x-bcn-")

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -237,7 +237,7 @@ impl BotDeliveryPort for HttpProviderTransport {
             ) && method == "chat.send";
             let client = if wants_sse { &self.sse_client } else { &self.client };
             let resp =
-                send_provider_request(client, &self.url_guard, &cmd.target, &body, wants_sse)
+                send_provider_request(client, &self.url_guard, &cmd.target, &body, wants_sse, &cmd.provider_bypass_headers)
                     .await?;
             let ctype = resp
                 .headers()
@@ -351,7 +351,7 @@ impl BotDeliveryPort for HttpProviderTransport {
 
         let started = Instant::now();
         let ack_result: ServiceResult<ProviderAckResponse> =
-            post_provider(&self.client, &self.url_guard, &cmd.target, &body).await;
+            post_provider(&self.client, &self.url_guard, &cmd.target, &body, &cmd.provider_bypass_headers).await;
         let elapsed_ms = started.elapsed().as_millis();
         let ack = match ack_result {
             Ok(ack) => ack,
@@ -419,7 +419,7 @@ impl GroupHistoryBotRequestPort for HttpProviderTransport {
             .map_err(|error| error.to_string())?;
         let target_bot_id = target.bot_id().to_string();
         let response: ProviderHistoryResponse =
-            post_provider(&self.client, &self.url_guard, &target, &body)
+            post_provider(&self.client, &self.url_guard, &target, &body, &[])
                 .await
                 .map_err(|error| error.to_string())?;
         let history_body = provider_history_log(&response);
@@ -661,8 +661,9 @@ async fn post_provider<T: DeserializeOwned>(
     url_guard: &OutboundUrlGuard,
     target: &BotDeliveryTarget,
     body: &ProviderWebhookRequest,
+    provider_bypass_headers: &[(String, String)],
 ) -> ServiceResult<T> {
-    let response = send_provider_request(client, url_guard, target, body, false).await?;
+    let response = send_provider_request(client, url_guard, target, body, false, provider_bypass_headers).await?;
     let status = response.status();
     let method = body.method.clone();
     let frame_id = body.id.clone();
@@ -690,6 +691,7 @@ async fn send_provider_request(
     target: &BotDeliveryTarget,
     body: &ProviderWebhookRequest,
     accept_sse: bool,
+    provider_bypass_headers: &[(String, String)],
 ) -> ServiceResult<reqwest::Response> {
     send_provider_request_with_policy(
         client,
@@ -697,9 +699,24 @@ async fn send_provider_request(
         target,
         body,
         accept_sse,
+        provider_bypass_headers,
         ProviderClientPolicy::for_request(accept_sse),
     )
     .await
+}
+
+fn is_safe_provider_bypass_header(name: &str) -> bool {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || reqwest::header::HeaderName::try_from(trimmed).is_err() {
+        return false;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    !matches!(
+        lower.as_str(),
+        "authorization" | "cookie" | "host" | "content-length" | "content-type"
+    ) && lower != "bcn"
+        && !lower.starts_with("bcn-")
+        && !lower.starts_with("x-bcn-")
 }
 
 async fn send_provider_request_with_policy(
@@ -708,6 +725,7 @@ async fn send_provider_request_with_policy(
     target: &BotDeliveryTarget,
     body: &ProviderWebhookRequest,
     accept_sse: bool,
+    provider_bypass_headers: &[(String, String)],
     client_policy: ProviderClientPolicy,
 ) -> ServiceResult<reqwest::Response> {
     let BotDeliveryTarget::HttpProvider {
@@ -799,6 +817,11 @@ async fn send_provider_request_with_policy(
         .header(BCN_PROTOCOL_VERSION_HEADER, protocol_version)
         .header(BCN_MESSAGE_ID_HEADER, &message_id)
         .header(BCN_TIMESTAMP_HEADER, bcs_protocol::now_ms().to_string());
+    for (name, value) in provider_bypass_headers {
+        if is_safe_provider_bypass_header(name) {
+            request = request.header(name.as_str(), value.as_str());
+        }
+    }
     if protocol_version == "2.0" {
         request = request.header(BCN_TRANSPORT_HEADER, transport);
     }
@@ -1716,6 +1739,7 @@ Connection: keep-alive\r\n\
             &target,
             &body,
             true,
+            &[],
             policy,
         )
         .await

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -42,6 +42,7 @@ struct CapturedRequest {
     message_id: Option<String>,
     timestamp: Option<String>,
     legacy_protocol_version: Option<String>,
+    sandbox_bypass: Option<String>,
     body: Value,
 }
 
@@ -88,6 +89,7 @@ async fn provider_delivery_injects_current_gateway_span_context() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .instrument(span)
         .await
@@ -99,6 +101,84 @@ async fn provider_delivery_injects_current_gateway_span_context() {
     assert_eq!(fields[0], "00");
     assert_eq!(fields[1], expected_trace_id);
     assert_eq!(fields[2], expected_parent_span_id);
+    server.abort();
+}
+
+#[tokio::test]
+async fn provider_delivery_applies_configured_bypass_headers() {
+    let captured: CapturedState = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/webhook", post(capture_ack))
+        .with_state(captured.clone());
+    let (webhook_url, server) = spawn_server(app).await;
+
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let result = transport
+        .deliver(BotDeliveryCommand {
+            target: provider_target(webhook_url),
+            run_id: "run-bypass".to_string(),
+            frame: BcsFrame::Request(RequestFrame::new(
+                "run-bypass",
+                "chat.send",
+                Some(json!({
+                    "session_key": "group:bypass",
+                    "message": { "text": "hello" }
+                })),
+            )),
+            delivery_kind: BotDeliveryKind::Send,
+            provider_transport: Default::default(),
+            provider_bypass_headers: vec![(
+                "x-sandbox-bypass".to_string(),
+                "sandbox-route-1".to_string(),
+            )],
+        })
+        .await
+        .unwrap();
+
+    assert!(result.delivered);
+    let request = captured.lock().await.clone().unwrap();
+    assert_eq!(request.sandbox_bypass.as_deref(), Some("sandbox-route-1"));
+    assert_eq!(request.authorization.as_deref(), Some("Bearer secret-b2p"));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn provider_delivery_ignores_reserved_bypass_headers() {
+    let captured: CapturedState = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/webhook", post(capture_ack))
+        .with_state(captured.clone());
+    let (webhook_url, server) = spawn_server(app).await;
+
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let result = transport
+        .deliver(BotDeliveryCommand {
+            target: provider_target(webhook_url),
+            run_id: "run-reserved-bypass".to_string(),
+            frame: BcsFrame::Request(RequestFrame::new(
+                "run-reserved-bypass",
+                "chat.send",
+                Some(json!({
+                    "session_key": "group:reserved",
+                    "message": { "text": "hello" }
+                })),
+            )),
+            delivery_kind: BotDeliveryKind::Send,
+            provider_transport: Default::default(),
+            provider_bypass_headers: vec![
+                ("authorization".to_string(), "Bearer attacker".to_string()),
+                ("bcn-message-id".to_string(), "attacker-message-id".to_string()),
+            ],
+        })
+        .await
+        .unwrap();
+
+    assert!(result.delivered);
+    let request = captured.lock().await.clone().unwrap();
+    assert_eq!(request.authorization.as_deref(), Some("Bearer secret-b2p"));
+    assert_ne!(request.message_id.as_deref(), Some("attacker-message-id"));
+
     server.abort();
 }
 
@@ -233,6 +313,7 @@ async fn provider_delivery_posts_bearer_token_and_chat_send_body() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -301,6 +382,7 @@ async fn provider_delivery_forwards_extensions_when_present() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -333,6 +415,7 @@ async fn provider_delivery_rejects_private_webhook_url_before_request() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect_err("private webhook URL should be rejected before request");
@@ -357,6 +440,7 @@ async fn provider_delivery_logs_policy_rejection_with_provider_url_ip_and_reason
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect_err("private webhook URL should be rejected before request");
@@ -419,6 +503,7 @@ async fn provider_delivery_protocol2_sse_ingests_events() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: ProviderTransportPreference::CallbackSse,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -498,6 +583,7 @@ async fn provider_delivery_protocol2_task_kinds_sse_ingest_events() {
                 )),
                 delivery_kind,
                 provider_transport: ProviderTransportPreference::CallbackSse,
+                provider_bypass_headers: Vec::new(),
             })
             .await
             .unwrap();
@@ -566,6 +652,7 @@ async fn provider_delivery_falls_back_to_actor_id_for_sender_name() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -773,6 +860,7 @@ async fn provider_delivery_posts_chat_inject_body_with_bcn_group_id() {
             )),
             delivery_kind: BotDeliveryKind::Inject,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -817,6 +905,7 @@ async fn provider_delivery_rejects_chat_send_when_frame_id_differs_from_run_id()
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect_err("chat.send frame id must match run_id");
@@ -909,6 +998,10 @@ async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
         .get("x-bcs-protocol-version")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let sandbox_bypass = headers
+        .get("x-sandbox-bypass")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     *captured.lock().await = Some(CapturedRequest {
         traceparent,
         authorization,
@@ -918,6 +1011,7 @@ async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
         message_id,
         timestamp,
         legacy_protocol_version,
+        sandbox_bypass,
         body,
     });
 }
@@ -1089,6 +1183,7 @@ async fn provider_delivery_2_0_inject_accepts_json_ack() {
             )),
             delivery_kind: BotDeliveryKind::Inject,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect("2.0 inject JSON ack must be accepted, not InternalError");
@@ -1128,6 +1223,7 @@ async fn provider_delivery_2_0_chat_send_with_sse_preference_advertises_sse() {
             )),
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: ProviderTransportPreference::CallbackSse,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect("2.0 send JSON ack should be accepted while advertising SSE");
@@ -1175,6 +1271,7 @@ async fn provider_delivery_2_0_task_kinds_accept_json_callback_fallback() {
                 )),
                 delivery_kind,
                 provider_transport: ProviderTransportPreference::CallbackSse,
+                provider_bypass_headers: Vec::new(),
             })
             .await
             .expect("2.0 task JSON ack should fall back to callbacks");
@@ -1219,6 +1316,7 @@ async fn provider_delivery_2_0_inject_propagates_json_rejection() {
             )),
             delivery_kind: BotDeliveryKind::Inject,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .expect("rejection is a normal ack, not a transport error");

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -43,6 +43,8 @@ struct CapturedRequest {
     timestamp: Option<String>,
     legacy_protocol_version: Option<String>,
     sandbox_bypass: Option<String>,
+    bcs_bot_token: Option<String>,
+    bcs_service_key: Option<String>,
     body: Value,
 }
 
@@ -169,6 +171,8 @@ async fn provider_delivery_ignores_reserved_bypass_headers() {
             provider_bypass_headers: vec![
                 ("authorization".to_string(), "Bearer attacker".to_string()),
                 ("bcn-message-id".to_string(), "attacker-message-id".to_string()),
+                ("x-bcs-bot-token".to_string(), "bot-token-secret".to_string()),
+                ("x-bcs-service-key".to_string(), "service-key-secret".to_string()),
             ],
         })
         .await
@@ -178,6 +182,8 @@ async fn provider_delivery_ignores_reserved_bypass_headers() {
     let request = captured.lock().await.clone().unwrap();
     assert_eq!(request.authorization.as_deref(), Some("Bearer secret-b2p"));
     assert_ne!(request.message_id.as_deref(), Some("attacker-message-id"));
+    assert_eq!(request.bcs_bot_token, None);
+    assert_eq!(request.bcs_service_key, None);
 
     server.abort();
 }
@@ -1002,6 +1008,14 @@ async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
         .get("x-sandbox-bypass")
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let bcs_bot_token = headers
+        .get("x-bcs-bot-token")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let bcs_service_key = headers
+        .get("x-bcs-service-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
     *captured.lock().await = Some(CapturedRequest {
         traceparent,
         authorization,
@@ -1012,6 +1026,8 @@ async fn capture(captured: CapturedState, headers: HeaderMap, body: Value) {
         timestamp,
         legacy_protocol_version,
         sandbox_bypass,
+        bcs_bot_token,
+        bcs_service_key,
         body,
     });
 }

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -573,6 +573,7 @@ async fn handle_chat_send(
             idempotency_key: params.idempotency_key,
             source_im_message_id: None,
             sender_conn_id,
+            provider_bypass_headers: Vec::new(),
         })
         .await?;
     info!(

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/bot_delivery_port.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/bot_delivery_port.rs
@@ -21,6 +21,7 @@ async fn bot_registry_delivers_frame_to_connected_bot() {
             frame,
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -47,6 +48,7 @@ async fn bot_registry_returns_not_delivered_when_bot_disconnected() {
             frame,
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -152,6 +152,47 @@ fn default_history_attachment_ttl() -> u64 {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
+pub struct ProviderHttpConfig {
+    /// Inbound HTTP header names that BCS may forward to HTTP provider webhooks.
+    /// Empty by default; matching is case-insensitive.
+    #[serde(default)]
+    pub bypass_headers: Vec<String>,
+}
+
+impl ProviderHttpConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        for raw_name in &self.bypass_headers {
+            let name = raw_name.trim();
+            if name.is_empty() {
+                return Err(
+                    "provider_http.bypass_headers must not contain empty header names".to_string(),
+                );
+            }
+            axum::http::HeaderName::try_from(name).map_err(|_| {
+                format!("provider_http.bypass_headers contains invalid header name '{raw_name}'")
+            })?;
+            if is_reserved_provider_bypass_header(name) {
+                return Err(format!(
+                    "provider_http.bypass_headers contains reserved header name '{raw_name}'"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_reserved_provider_bypass_header(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "authorization" | "cookie" | "host" | "content-length" | "content-type"
+    ) || lower == "bcn"
+        || lower.starts_with("bcn-")
+        || lower.starts_with("x-bcn-")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CorsConfig {
     #[serde(default)]
     pub allowed_origins: Vec<String>,
@@ -463,6 +504,10 @@ pub struct BcsConfig {
     /// Channel(IM bridge) configuration.
     #[serde(default)]
     pub channels: ChannelConfigSection,
+
+    /// HTTP provider webhook adapter configuration.
+    #[serde(default)]
+    pub provider_http: ProviderHttpConfig,
 
     /// Structured collaboration authoring-template configuration.
     #[serde(default)]
@@ -883,6 +928,7 @@ impl Default for BcsConfig {
             database: DatabaseConfig::default(),
             secret: SecretConfig::default(),
             channels: ChannelConfigSection::default(),
+            provider_http: ProviderHttpConfig::default(),
             collaboration: CollaborationConfig::default(),
             max_groups_as_driver: default_max_groups_as_driver(),
             max_group_members: default_max_group_members(),
@@ -1312,6 +1358,10 @@ fn validate_loaded_config(config: &BcsConfig) -> Result<(), Box<dyn std::error::
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
     })?;
+    config.provider_http.validate().map_err(|e| {
+        Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            as Box<dyn std::error::Error>
+    })?;
     config.validate_metrics().map_err(|e| {
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
@@ -1402,6 +1452,48 @@ mod tests {
             .expect_err("blank group-session WebSocket secret name rejected");
 
         assert!(err.contains("group_session_ws.signing_key_secret must not be blank"));
+    }
+
+    #[test]
+    fn provider_http_bypass_headers_parse_and_default() {
+        let default_config = BcsConfig::default();
+        assert!(default_config.provider_http.bypass_headers.is_empty());
+
+        let toml = r#"
+            bots_base_dir = "/bots"
+
+            [provider_http]
+            bypass_headers = ["X-Sandbox-Bypass"]
+        "#;
+        let config: BcsConfig = toml::from_str(toml).expect("parse [provider_http]");
+        assert_eq!(
+            config.provider_http.bypass_headers,
+            vec!["X-Sandbox-Bypass".to_string()]
+        );
+        config.provider_http.validate().expect("valid bypass header");
+    }
+
+    #[test]
+    fn provider_http_bypass_headers_reject_invalid_and_reserved_names() {
+        for name in [
+            "",
+            "bad header",
+            "Authorization",
+            "Cookie",
+            "Host",
+            "Content-Length",
+            "Content-Type",
+            "bcn-message-id",
+            "x-bcn-protocol-version",
+        ] {
+            let config = ProviderHttpConfig {
+                bypass_headers: vec![name.to_string()],
+            };
+            assert!(
+                config.validate().is_err(),
+                "header name {name:?} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -185,7 +185,13 @@ fn is_reserved_provider_bypass_header(name: &str) -> bool {
     let lower = name.to_ascii_lowercase();
     matches!(
         lower.as_str(),
-        "authorization" | "cookie" | "host" | "content-length" | "content-type"
+        "authorization"
+            | "cookie"
+            | "host"
+            | "content-length"
+            | "content-type"
+            | "x-bcs-bot-token"
+            | "x-bcs-service-key"
     ) || lower == "bcn"
         || lower.starts_with("bcn-")
         || lower.starts_with("x-bcn-")
@@ -1483,6 +1489,8 @@ mod tests {
             "Host",
             "Content-Length",
             "Content-Type",
+            "X-BCS-Bot-Token",
+            "X-BCS-Service-Key",
             "bcn-message-id",
             "x-bcn-protocol-version",
         ] {

--- a/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
+use axum::http::HeaderName;
 use bcs_fuse_client::FuseClient;
 pub use bcs_http::state::BotRuntimeTokenResolverPort;
 use bcs_http::state::{
@@ -79,6 +80,12 @@ pub(crate) async fn build_http_app_state(state: Arc<BcsServerState>) -> HttpAppS
                 .with_credentials(state.provider_credentials.clone()),
         ),
     );
+    let provider_bypass_header_names = config
+        .provider_http
+        .bypass_headers
+        .iter()
+        .filter_map(|name| HeaderName::try_from(name.trim()).ok())
+        .collect();
 
     HttpAppState::new(services_with_secret)
         .with_bot_runtime_token_resolver(runtime_token_resolver)
@@ -137,6 +144,7 @@ pub(crate) async fn build_http_app_state(state: Arc<BcsServerState>) -> HttpAppS
         )
         .with_allowed_switch_provider_ids(config.allowed_switch_provider_ids.clone())
         .with_provider_stream_gray_list(state.provider_stream_gray_list.clone())
+        .with_provider_bypass_header_names(provider_bypass_header_names)
         .with_judge_enabled(config.llm.is_enabled())
         .with_channel_http_ingress(state.channel_http_ingress.clone())
         .with_auth_chain(state.auth_chain.clone(), state.auth_config.clone())

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -461,6 +461,7 @@ impl StateMachineResultPublisherPort for MessageFlowStateMachineResultPublisher 
                 idempotency_key: Some(idempotency_key),
                 source_im_message_id: None,
                 sender_conn_id: None,
+                provider_bypass_headers: Vec::new(),
             })
             .await?;
         Ok(())

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -567,6 +567,7 @@ fn web_send_cmd() -> WebSendCommand {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 
@@ -577,6 +578,7 @@ fn group_chat_cmd() -> GroupChatCommand {
         requested_sender_id: None,
         message: "hello".to_string(),
         session_id: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 
@@ -658,6 +660,7 @@ fn blocking_chat_cmd() -> BlockingA2aChatCommand {
         client: None,
         response_mode: ChatResponseMode::Full,
         organization_code: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 
@@ -670,6 +673,7 @@ fn bot_delivery_cmd(delivery_kind: BotDeliveryKind) -> BotDeliveryCommand {
         frame: BcsFrame::Request(RequestFrame::new("run-wrapper", "chat.send", None)),
         delivery_kind,
         provider_transport: Default::default(),
+        provider_bypass_headers: Vec::new(),
     }
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/a2a_chat.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/a2a_chat.rs
@@ -43,6 +43,7 @@ pub struct A2aChatCommand {
     pub response_mode: ChatResponseMode,
     pub caller_wait_mode: Option<String>,
     pub organization_code: Option<String>,
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -70,6 +71,7 @@ pub struct BlockingA2aChatCommand {
     pub tags: Vec<String>,
     pub response_mode: ChatResponseMode,
     pub organization_code: Option<String>,
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -99,6 +101,7 @@ pub struct AsyncA2aChatCommand {
     pub response_mode: ChatResponseMode,
     pub caller_wait_mode: Option<String>,
     pub organization_code: Option<String>,
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -37,6 +37,7 @@ pub struct WebSendCommand {
     /// Original IM message id when this command came from a channel ingress.
     pub source_im_message_id: Option<String>,
     pub sender_conn_id: Option<u64>,
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug)]
@@ -60,6 +61,7 @@ pub struct GroupChatCommand {
     pub requested_sender_id: Option<String>,
     pub message: String,
     pub session_id: Option<String>,
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 #[derive(Debug)]

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/delivery.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/delivery.rs
@@ -25,6 +25,9 @@ pub struct BotDeliveryCommand {
     pub frame: BcsFrame,
     pub delivery_kind: BotDeliveryKind,
     pub provider_transport: ProviderTransportPreference,
+    /// Opaque inbound HTTP headers explicitly allowlisted by BCS configuration
+    /// for forwarding to HTTP provider webhooks. Empty for non-HTTP ingress.
+    pub provider_bypass_headers: Vec<(String, String)>,
 }
 
 impl BotDeliveryCommand {

--- a/src/bcs/crates/service-api/bcs-service-api/tests/message_flow_contracts.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/message_flow_contracts.rs
@@ -76,6 +76,7 @@ async fn delivery_ports_are_transport_free_contracts() {
             frame,
             delivery_kind: BotDeliveryKind::Send,
             provider_transport: Default::default(),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -145,6 +146,7 @@ fn group_chat_command() -> GroupChatCommand {
         requested_sender_id: None,
         message: "hello".to_string(),
         session_id: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -1160,6 +1160,7 @@ impl ChannelService for BcsChannelService {
                     idempotency_key: Some(dispatch_msg_id.clone()),
                     source_im_message_id: Some(dispatch_msg_id.clone()),
                     sender_conn_id: None,
+                    provider_bypass_headers: Vec::new(),
                 })
                 .await
                 .map_err(|error| {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -628,6 +628,7 @@ impl CollaborationRuntime {
                 frame,
                 delivery_kind: BotDeliveryKind::TaskDispatch,
                 provider_transport: Default::default(),
+                provider_bypass_headers: Vec::new(),
             })
             .await
         {

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -308,6 +308,7 @@ impl A2aChatRunService for A2aChat {
                 response_mode: cmd.response_mode,
                 caller_wait_mode: None,
                 organization_code: cmd.organization_code,
+                provider_bypass_headers: cmd.provider_bypass_headers,
             })
             .await;
 
@@ -361,6 +362,7 @@ impl A2aChatRunService for A2aChat {
                 response_mode: cmd.response_mode,
                 caller_wait_mode: cmd.caller_wait_mode,
                 organization_code: cmd.organization_code,
+                provider_bypass_headers: cmd.provider_bypass_headers,
             })
             .await;
 
@@ -628,6 +630,7 @@ impl A2aChatService for A2aChat {
                 frame,
                 delivery_kind: BotDeliveryKind::Send,
                 provider_transport: Default::default(),
+                provider_bypass_headers: cmd.provider_bypass_headers.clone(),
             })
             .await
         {

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -727,6 +727,7 @@ async fn relay_final_chat_event(
                 frame,
                 delivery_kind,
                 provider_transport,
+                provider_bypass_headers: Vec::new(),
             })
             .await;
         match delivery {
@@ -864,6 +865,7 @@ async fn handle_task_bot_event(
             frame,
             delivery_kind,
             provider_transport,
+            provider_bypass_headers: Vec::new(),
         })
         .await?;
     if !result.delivered {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -648,6 +648,7 @@ pub async fn handle_web_send(
                 frame,
                 delivery_kind,
                 provider_transport,
+                provider_bypass_headers: cmd.provider_bypass_headers.clone(),
             })
             .await;
 
@@ -928,6 +929,7 @@ pub async fn handle_group_chat(
             idempotency_key: None,
             source_im_message_id: None,
             sender_conn_id: None,
+            provider_bypass_headers: cmd.provider_bypass_headers,
         },
     )
     .await?;
@@ -1050,6 +1052,7 @@ pub async fn handle_persistent_group_send(
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     };
     for target in &decision.targets {
         let outbound = match apply_outbound_interceptors(flow, &cmd.group_id, &message, target).await
@@ -1106,6 +1109,7 @@ pub async fn handle_persistent_group_send(
                 frame,
                 delivery_kind,
                 provider_transport,
+                provider_bypass_headers: Vec::new(),
             })
             .await;
         match result {
@@ -1423,6 +1427,7 @@ pub async fn handle_group_callback(
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     };
 
     for target in &decision.targets {
@@ -1517,6 +1522,7 @@ pub async fn handle_group_callback(
                 frame,
                 delivery_kind,
                 provider_transport,
+                provider_bypass_headers: Vec::new(),
             })
             .await;
 
@@ -1644,6 +1650,7 @@ pub async fn handle_chat_abort(
                 frame: build_chat_abort_frame(&session_key, cmd.run_id.as_deref()),
                 delivery_kind: BotDeliveryKind::Abort,
                 provider_transport: Default::default(),
+                provider_bypass_headers: Vec::new(),
             })
             .await;
 

--- a/src/bcs/crates/services/bcs-message-flow/src/task_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/task_flow.rs
@@ -208,6 +208,7 @@ pub async fn handle_task_dispatch(
             frame,
             delivery_kind,
             provider_transport,
+            provider_bypass_headers: Vec::new(),
         })
         .await
     {
@@ -555,6 +556,7 @@ pub async fn handle_task_message(
             frame,
             delivery_kind,
             provider_transport,
+            provider_bypass_headers: Vec::new(),
         })
         .await?;
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
@@ -40,6 +40,7 @@ fn chat_command(target_bot_id: &str) -> A2aChatCommand {
         response_mode: ChatResponseMode::Full,
         caller_wait_mode: None,
         organization_code: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 
@@ -210,6 +211,7 @@ async fn direct_chat_run_snapshot_maps_http_client_kinds() {
             client: None,
             response_mode: ChatResponseMode::Full,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -231,6 +233,7 @@ async fn direct_chat_run_snapshot_maps_http_client_kinds() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -284,6 +287,7 @@ async fn async_chat_creates_run_and_delivers_chat_send_frame() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: Some("detached".to_string()),
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -352,6 +356,7 @@ async fn blocking_run_service_records_final_event_and_unregisters_run() {
             client: Some("contract-test".to_string()),
             response_mode: ChatResponseMode::Full,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -411,6 +416,7 @@ async fn detached_provider_async_run_submits_after_downlink_ack_then_runs_on_cal
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: Some("detached".to_string()),
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -494,6 +500,7 @@ async fn blocking_run_service_unregisters_when_recording_event_fails() {
                     client: None,
                     response_mode: ChatResponseMode::Full,
                     organization_code: None,
+                    provider_bypass_headers: Vec::new(),
                 })
                 .await
         })
@@ -537,6 +544,7 @@ async fn run_service_preserves_omitted_from_as_run_channel_metadata_none() {
             client: None,
             response_mode: ChatResponseMode::Full,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -575,6 +583,7 @@ async fn async_run_service_accepts_and_drains_events_until_final() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -642,6 +651,7 @@ async fn async_run_after_last_tool_call_mode_returns_only_followup_text() {
             response_mode: ChatResponseMode::AfterLastToolCall,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -703,6 +713,7 @@ async fn async_run_after_last_tool_call_mode_uses_agent_tool_boundary() {
             response_mode: ChatResponseMode::AfterLastToolCall,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -763,6 +774,7 @@ async fn async_run_after_last_tool_call_mode_uses_final_when_agent_tool_has_no_f
             response_mode: ChatResponseMode::AfterLastToolCall,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -816,6 +828,7 @@ async fn async_run_service_marks_failed_on_chat_event_error() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -868,6 +881,7 @@ async fn async_run_service_times_out_and_unregisters_when_no_terminal_event_arri
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -920,6 +934,7 @@ async fn cancel_run_service_cancels_underlying_run_and_unregisters_channel() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -984,6 +999,7 @@ async fn cancel_run_marks_running_run_cancelled() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1039,6 +1055,7 @@ async fn run_events_update_status_and_wake_waiters() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -2117,6 +2134,7 @@ async fn a2a_chat_blocking_interceptor_prevents_bot_delivery() {
             response_mode: ChatResponseMode::Full,
             caller_wait_mode: None,
             organization_code: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await;
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -1201,7 +1201,8 @@ async fn web_send_resets_message_count_routes_and_delivers() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
-        sender_conn_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1266,6 +1267,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1304,6 +1306,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
             idempotency_key: None,
             source_im_message_id: None,
             sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1344,6 +1347,7 @@ async fn accepted_chat_send_records_run_context_for_callback() {
             idempotency_key: Some("idempotency-1".to_string()),
             source_im_message_id: Some("source-msg-1".to_string()),
             sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1431,6 +1435,7 @@ async fn web_send_delivers_to_registered_provider_target_without_ws_connection()
             idempotency_key: None,
             source_im_message_id: None,
             sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1472,6 +1477,7 @@ async fn provider_stream_gray_created_by_enables_sse_for_provider_chat_send() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1513,6 +1519,7 @@ async fn provider_stream_gray_created_by_miss_keeps_provider_callback() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1554,6 +1561,7 @@ async fn provider_stream_gray_mode_disabled_sends_provider_chat_send_over_sse() 
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1613,6 +1621,7 @@ async fn provider_stream_gray_created_by_still_keeps_inject_on_callback() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1733,6 +1742,7 @@ async fn web_send_explicit_mentions_do_not_inject_manager_worker_workers() {
             idempotency_key: None,
             source_im_message_id: None,
             sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1777,7 +1787,8 @@ async fn web_send_in_human_bot_dm_uses_dm_routing_and_keeps_frontend_echo() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
-        sender_conn_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1828,6 +1839,7 @@ async fn web_send_in_human_bot_dm_omits_group_context_by_default() -> ServiceRes
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await?;
 
@@ -1880,7 +1892,8 @@ async fn web_send_blocking_interceptor_prevents_bot_delivery() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
-        sender_conn_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -1922,7 +1935,8 @@ async fn web_send_delivery_frame_contains_recipient_group_context() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
-    sender_conn_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -1992,7 +2006,8 @@ async fn web_send_with_session_id_routes_v2_by_substituting_wire_group_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
-    sender_conn_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2060,6 +2075,7 @@ async fn web_send_with_legacy_session_id_routes_v2_with_group_wire_id() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2116,7 +2132,8 @@ async fn web_send_with_session_id_routes_v3_with_explicit_bcs_session_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
-    sender_conn_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2180,6 +2197,7 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2245,6 +2263,7 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
         idempotency_key: None,
         source_im_message_id: None,
         sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await?;
 
@@ -2304,7 +2323,8 @@ async fn web_send_prefers_human_from_name_in_delivered_frame() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
-    sender_conn_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2356,7 +2376,8 @@ async fn web_send_inject_delivery_uses_event_frame() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
-    sender_conn_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();
@@ -2410,7 +2431,8 @@ async fn web_send_delivers_to_private_group_targets() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
-        sender_conn_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -2457,7 +2479,8 @@ async fn web_send_partial_delivery_failure_is_represented_in_outcome() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
-        sender_conn_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -2498,6 +2521,7 @@ async fn group_chat_validates_sender_and_returns_legacy_delivery_projection() {
             requested_sender_id: Some("bot-driver".to_string()),
             message: "hello as my bot".to_string(),
             session_id: Some("session-1".to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -2549,6 +2573,7 @@ async fn group_chat_uses_session_participants_for_human_sender_validation() {
             requested_sender_id: Some("human_2".to_string()),
             message: "hello from the session Human".to_string(),
             session_id: Some(session_id.to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap();
@@ -2597,6 +2622,7 @@ async fn group_chat_rejects_bot_that_is_not_a_session_participant() {
             requested_sender_id: Some("bot-observer".to_string()),
             message: "should not be delivered".to_string(),
             session_id: Some(session_id.to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap_err();
@@ -2637,6 +2663,7 @@ async fn group_chat_rejects_session_from_another_group() {
             requested_sender_id: Some("bot-driver".to_string()),
             message: "should not be delivered".to_string(),
             session_id: Some(session_id.to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap_err();
@@ -2672,6 +2699,7 @@ async fn group_chat_rejects_session_without_participants() {
             requested_sender_id: Some("bot-driver".to_string()),
             message: "should not be delivered".to_string(),
             session_id: Some(session_id.to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap_err();
@@ -2710,6 +2738,7 @@ async fn group_chat_treats_requested_sender_id_literally_without_trimming() {
             requested_sender_id: Some(" bot-driver ".to_string()),
             message: "hello as my bot".to_string(),
             session_id: Some("session-1".to_string()),
+            provider_bypass_headers: Vec::new(),
         })
         .await
         .unwrap_err();
@@ -2744,6 +2773,7 @@ async fn group_chat_uses_human_staff_number_as_display_name_when_speaking_as_own
         requested_sender_id: Some("bot-driver".to_string()),
         message: "hello as my bot".to_string(),
         session_id: Some("session-1".to_string()),
+        provider_bypass_headers: Vec::new(),
     })
     .await
     .unwrap();

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -318,6 +318,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                         frame,
                         delivery_kind,
                         provider_transport,
+                        provider_bypass_headers: Vec::new(),
                     },
                 });
             }

--- a/src/bcs/docs/plans/2026-08-06-provider-http-bypass-headers.md
+++ b/src/bcs/docs/plans/2026-08-06-provider-http-bypass-headers.md
@@ -1,0 +1,60 @@
+# Provider HTTP Bypass Headers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let BCS forward only configured inbound HTTP headers from bcs-cli requests to HTTP provider webhooks.
+
+**Architecture:** BCS config owns the allowlist. HTTP delivery adapters extract allowlisted inbound headers into request context / delivery commands; core remains transport-agnostic. The provider HTTP delivery adapter applies those opaque headers when posting provider webhooks, while reserved/auth/protocol headers stay controlled by BCS.
+
+**Tech Stack:** Rust, axum HeaderMap, reqwest, serde TOML config, cargo test.
+
+---
+
+### Task 1: Lock provider transport behavior with a failing test
+
+**Files:**
+- Modify: `crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+**Step 1:** Add a unit/integration-style test near existing provider request tests that starts a local HTTP server, sends a provider request with passthrough headers, and asserts the provider receives the allowlisted header but not reserved ones.
+
+**Step 2:** Run `cargo test --package bcs-provider-http provider_request_applies_passthrough_headers -- --nocapture`.
+Expected: FAIL because the provider transport has no passthrough header input yet.
+
+### Task 2: Add config schema and validation
+
+**Files:**
+- Modify: `crates/bootstrap/bcs/src/config.rs`
+- Modify as needed: `crates/bootstrap/bcs/src/config_loader.rs`
+
+**Step 1:** Add failing config tests for `[provider_http] bypass_headers = [...]` parsing and invalid reserved/invalid header names.
+
+**Step 2:** Implement `ProviderHttpConfig { bypass_headers: Vec<String> }`, default empty, deny unknown fields, validation via `HeaderName`, and reserved header rejection.
+
+**Step 3:** Run targeted config tests.
+
+### Task 3: Capture inbound allowlisted headers at HTTP boundary
+
+**Files:**
+- Modify HTTP route/state files under `crates/bootstrap/bcs/src/server.rs` and/or `crates/adapters/http/bcs-http/` where chat/group/service requests create delivery requests.
+
+**Step 1:** Add a failing test that sends an inbound request with a configured bypass header and observes it on the provider webhook.
+
+**Step 2:** Extract only configured header names from the inbound `HeaderMap` in delivery adapter code and carry them through a transport-agnostic field.
+
+### Task 4: Carry headers through service/delivery command contract
+
+**Files:**
+- Modify `crates/service-api/bcs-service-api/src/...` containing `BotDeliveryCommand`.
+- Modify constructors/call sites compiling against it.
+
+**Step 1:** Add `provider_bypass_headers` or equivalent to `BotDeliveryCommand` with default empty value for existing constructors.
+
+**Step 2:** Ensure WebSocket delivery ignores it; HTTP provider delivery consumes it.
+
+### Task 5: Verify
+
+**Commands:**
+- `cargo test --package bcs-provider-http provider_request_applies_passthrough_headers -- --nocapture`
+- `cargo test --package bcs config:: -- --nocapture` or targeted config tests
+- Targeted integration test for inbound request to provider webhook if available.
+


### PR DESCRIPTION
## Problem
BCS receives HTTP requests from bcs-cli/BCN paths where the sandbox may inject request-scoped headers, but HTTP provider webhook calls had no BCS-side allowlist mechanism to forward those headers. This made sandbox/provider coordination impossible without changing the CLI or forwarding unsafe headers broadly.

## Solution
Added a BCS-only provider HTTP bypass header configuration:

```toml
[provider_http]
bypass_headers = ["X-Sandbox-Trace", "X-Whatever"]
```

The implementation:
- defaults to no header passthrough unless explicitly configured;
- validates configured header names during config loading;
- rejects reserved or dangerous headers such as authorization, cookie, host, content-length, content-type, bcn, bcn-*, and x-bcn-*;
- extracts only configured inbound HTTP headers from bot chat, async bot chat, group chat, and session chat routes;
- keeps non-HTTP ingress and internal flows empty by default;
- forwards the allowlisted opaque headers through the message-flow command path to the provider HTTP transport;
- defensively filters invalid/reserved header names again before sending provider webhook requests.

## Validation
Per request, no additional verification was run during commit/PR creation.

Earlier local checks run before this commit included:
- `cargo test --package bcs-http bot_chat_forwards_only_configured_provider_bypass_headers -- --nocapture`
- `cargo test --package bcs-provider-http bypass -- --nocapture`
- `cargo test --package bcs-message-flow --no-run`
- `cargo test --package bcs-service-api --no-run`
- `cargo test --package bcs provider_http_bypass -- --nocapture`
- `git diff --check`

## Compatibility and risk
- Backward compatible by default: empty `provider_http.bypass_headers` means no passthrough behavior change.
- No bcs-cli changes are required.
- New config is additive and uses serde defaults.
- Risk is limited to explicitly allowlisted provider HTTP headers; reserved protocol/auth headers are rejected at config validation and filtered again at transport time.
