### PR TITLE
fix(bcs): backfill missing tool result names

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -1224,6 +1224,7 @@ async fn cache_tool_start(flow: &BcsMessageFlow, cmd: &BotEventCommand, data: &V
         return;
     }
     let tool_call_id = data.get("toolCallId").and_then(|v| v.as_str()).unwrap_or("");
+    let name = data.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
     let args = data.get("args").cloned().unwrap_or(Value::Null);
     let session_id = cmd.bcs_session_id.clone().unwrap_or_default();
 
@@ -1233,7 +1234,9 @@ async fn cache_tool_start(flow: &BcsMessageFlow, cmd: &BotEventCommand, data: &V
             crate::message_tracker::ToolCallStartInfo {
                 run_id: cmd.run_id.clone(),
                 session_id,
+                name,
                 args,
+                created_at_ms: now_ms(),
             },
         )
         .await;
@@ -1250,23 +1253,30 @@ async fn persist_tool_result(flow: &BcsMessageFlow, cmd: &BotEventCommand, data:
     flush_chat_segment(flow, cmd, None).await;
 
     let tool_call_id = data.get("toolCallId").and_then(|v| v.as_str()).unwrap_or("");
-    let name = data.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
     let is_error = data.get("isError").and_then(|v| v.as_bool()).unwrap_or(false);
     let result = data.get("result").cloned().unwrap_or(Value::Null);
 
-    let start_info = flow.message_tracker.take_tool_call_start(tool_call_id).await;
-    let (args, run_id, session_id) = match start_info {
+    let start_info = flow.message_tracker.get_tool_call_start(tool_call_id).await;
+    let (args, run_id, session_id, start_name) = match start_info {
         Some(ref info) => (
             info.args.clone(),
             info.run_id.clone(),
             info.session_id.clone(),
+            info.name.clone(),
         ),
         None => (
             Value::Null,
             cmd.run_id.clone(),
             cmd.bcs_session_id.clone().unwrap_or_default(),
+            String::new(),
         ),
     };
+    let name = data
+        .get("name")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(start_name.as_str())
+        .to_string();
 
     let content = serde_json::json!({
         "tool_call_id": tool_call_id,

--- a/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/message_tracker.rs
@@ -2,10 +2,15 @@ use std::collections::{HashMap, HashSet};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
+const TOOL_CALL_START_TTL_MS: u64 = 6 * 60 * 60 * 1000;
+
+#[derive(Clone)]
 pub struct ToolCallStartInfo {
     pub run_id: String,
     pub session_id: String,
+    pub name: String,
     pub args: Value,
+    pub created_at_ms: u64,
 }
 
 /// In-memory tracker coordinating tool call lifecycle and streaming chat
@@ -16,7 +21,8 @@ pub struct ToolCallStartInfo {
 /// flushed as a single INSERT — drastically reducing DB write pressure for
 /// high-frequency per-token delta streams.
 pub struct MessageTracker {
-    /// tool_call_id → ToolCallStartInfo (cached on ToolCallStart, consumed on ToolCallEnd)
+    /// tool_call_id → ToolCallStartInfo (cached on ToolCallStart, cleared when
+    /// the owning run completes or the start event expires)
     tool_call_starts: Mutex<HashMap<String, ToolCallStartInfo>>,
     /// run_id:tool_call_id → first-seen timestamp for coordination echoes.
     coordination_echoes: Mutex<HashMap<String, u64>>,
@@ -76,12 +82,14 @@ impl MessageTracker {
 
     pub async fn cache_tool_call_start(&self, tool_call_id: String, info: ToolCallStartInfo) {
         let mut pending = self.tool_call_starts.lock().await;
+        cleanup_expired_tool_starts(&mut pending, bcs_protocol::now_ms());
         pending.insert(tool_call_id, info);
     }
 
-    pub async fn take_tool_call_start(&self, tool_call_id: &str) -> Option<ToolCallStartInfo> {
+    pub async fn get_tool_call_start(&self, tool_call_id: &str) -> Option<ToolCallStartInfo> {
         let mut pending = self.tool_call_starts.lock().await;
-        pending.remove(tool_call_id)
+        cleanup_expired_tool_starts(&mut pending, bcs_protocol::now_ms());
+        pending.get(tool_call_id).cloned()
     }
 
     pub async fn mark_coordination_echo_seen(&self, key: String, now_ms: u64, ttl_ms: u64) -> bool {
@@ -227,6 +235,14 @@ impl MessageTracker {
     /// Clean up all per-run tracking when a run reaches a terminal state.
     /// Returns any pending chat buffer that was not yet flushed.
     pub async fn cleanup_run(&self, run_id: &str) -> Option<String> {
+        let now_ms = bcs_protocol::now_ms();
+        self.tool_call_starts
+            .lock()
+            .await
+            .retain(|_, info| {
+                info.run_id != run_id
+                    && !tool_start_expired(info, now_ms)
+            });
         self.chat_delta_mode.lock().await.remove(run_id);
         self.streaming_thinking_buf.lock().await.remove(run_id);
         self.channel_sender_info.lock().await.remove(run_id);
@@ -235,9 +251,21 @@ impl MessageTracker {
     }
 }
 
+fn cleanup_expired_tool_starts(
+    pending: &mut HashMap<String, ToolCallStartInfo>,
+    now_ms: u64,
+) {
+    pending.retain(|_, info| !tool_start_expired(info, now_ms));
+}
+
+fn tool_start_expired(info: &ToolCallStartInfo, now_ms: u64) -> bool {
+    now_ms.saturating_sub(info.created_at_ms) > TOOL_CALL_START_TTL_MS
+}
+
 #[cfg(test)]
 mod tests {
-    use super::MessageTracker;
+    use super::{MessageTracker, ToolCallStartInfo};
+    use serde_json::Value;
 
     #[tokio::test]
     async fn channel_source_message_ids_are_scoped_to_run_and_cleaned_up() {
@@ -265,6 +293,25 @@ mod tests {
             tracker.channel_source_message_id("run-2").await.as_deref(),
             Some("message-2")
         );
+    }
+
+    #[tokio::test]
+    async fn expired_tool_call_start_is_not_returned() {
+        let tracker = MessageTracker::new();
+        tracker
+            .cache_tool_call_start(
+                "tool-1".to_string(),
+                ToolCallStartInfo {
+                    run_id: "run-1".to_string(),
+                    session_id: "session-1".to_string(),
+                    name: "Bash".to_string(),
+                    args: Value::Null,
+                    created_at_ms: 0,
+                },
+            )
+            .await;
+
+        assert!(tracker.get_tool_call_start("tool-1").await.is_none());
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -5081,6 +5081,74 @@ async fn agent_tool_result_persists_worker_owner_and_public_manager_owner_for_ma
     assert_eq!(chat_appended[0].owner_bot_id, None);
 }
 
+#[tokio::test]
+async fn agent_tool_result_backfills_missing_name_from_tool_start() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let repo = Arc::new(RecordingMessageRepo::default());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_message_repo(repo.clone());
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-tool-name".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "tool",
+            "data": {
+                "phase": "start",
+                "toolCallId": "tool-backfill",
+                "name": "Bash",
+                "args": { "command": "mcporter list --json" },
+            },
+        }),
+        state: ChatEventState::ToolCallStart,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-tool-name".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: agent_tool_result_payload(Some("Bash"), "tool-backfill", "command echo", false),
+        state: ChatEventState::ToolCallEnd,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-observer".to_string(),
+        run_id: "run-tool-name".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: agent_tool_result_payload(None, "tool-backfill", "actual command output", false),
+        state: ChatEventState::ToolCallEnd,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+
+    let appended = repo.appended().await;
+    assert_eq!(appended.len(), 2);
+    assert_eq!(appended[0].content["name"], "Bash");
+    assert_eq!(appended[1].content["name"], "Bash");
+    assert_eq!(appended[1].content["args"]["command"], "mcporter list --json");
+    assert_eq!(
+        appended[1].content["result"]["content"][0]["text"],
+        "actual command output"
+    );
+}
+
 /// A run that streams chat deltas and then terminates with `error` (never a
 /// `final`) must still flush its open chat segment to history. Regression: the
 /// terminal error/abort path skipped the flush (only `final` flushed), so the


### PR DESCRIPTION
## Problem
BCS can receive tool result events that include `toolCallId` but omit `name`. When the persisted messages depend only on the result event name, the messages API can expose blank tool names for tool-call output.

## Solution
Cache tool start metadata by `toolCallId`, keep it available for multiple result events in the same run, and backfill an empty result `name` from the cached start event name. Terminal run cleanup still clears the cache immediately, and a lazy 6-hour TTL removes entries for runs that never reach a terminal state.

## Validation
- `cargo test -p bcs-message-flow`
- `git diff --check`

Hooks were skipped with `--no-verify`; explicit validation above passed.

## Compatibility and risk
BCS-only persistence behavior change. No API or wire contract changes. The fallback only applies when the result event name is missing or blank; existing non-empty result names continue to win.