### PR TITLE
fix(backend): finalize service artifacts for runtime access

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -83,9 +83,9 @@ _DRAFT_RESTORE_TIMEOUT_SECONDS = 30 * 60
 # same ownership contract below.  A versioned artifact is not publishable until
 # this identity can traverse and read it.
 _PUBLISHED_RUNTIME_OWNER = "1000:1000"
-_PUBLISHED_RUNTIME_UID = "#1000"
-_RUNTIME_ARTIFACT_READABILITY_PROBE = (
-    "import os, sys\n"
+_PUBLISHED_RUNTIME_UID = 1000
+_PUBLISHED_RUNTIME_GID = 1000
+_RUNTIME_ARTIFACT_TREE_READ_PROBE = (
     "def check(path):\n"
     "    with os.scandir(path) as entries:\n"
     "        for entry in entries:\n"
@@ -98,7 +98,25 @@ _RUNTIME_ARTIFACT_READABILITY_PROBE = (
     "                    pass\n"
     "            else:\n"
     "                os.lstat(entry.path)\n"
-    "check(sys.argv[1])\n"
+)
+_RUNTIME_ARTIFACT_READABILITY_PROBE = (
+    "import os, sys\n"
+    + _RUNTIME_ARTIFACT_TREE_READ_PROBE
+    + "check(sys.argv[1])\n"
+)
+_NUMERIC_RUNTIME_ARTIFACT_READABILITY_PROBE = (
+    "import os, sys\n"
+    "runtime_uid = int(sys.argv[1])\n"
+    "runtime_gid = int(sys.argv[2])\n"
+    "artifact_path = sys.argv[3]\n"
+    # Do not ask sudo to resolve uid 1000 through the Backend host's NSS
+    # database.  The identity belongs to the separate DaaS runtime image and
+    # may deliberately be unknown on the build host.
+    "os.setgroups([])\n"
+    "os.setgid(runtime_gid)\n"
+    "os.setuid(runtime_uid)\n"
+    + _RUNTIME_ARTIFACT_TREE_READ_PROBE
+    + "check(artifact_path)\n"
 )
 
 
@@ -774,12 +792,12 @@ class BotBuildService:
         self._run_local_command(
             cmd=[
                 "sudo",
-                "-u",
-                _PUBLISHED_RUNTIME_UID,
                 sys.executable,
                 "-I",
                 "-c",
-                _RUNTIME_ARTIFACT_READABILITY_PROBE,
+                _NUMERIC_RUNTIME_ARTIFACT_READABILITY_PROBE,
+                str(_PUBLISHED_RUNTIME_UID),
+                str(_PUBLISHED_RUNTIME_GID),
                 str(target_dir),
             ],
             command_name="verify artifact runtime readability",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -16,6 +16,7 @@ import copy
 import hashlib
 import json
 import subprocess
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -76,6 +77,29 @@ _BOT_GONE_ERROR_CODES = frozenset({"BOT_NOT_FOUND", "DEVICE_NOT_FOUND"})
 # Draft restoration copies a potentially large historical workspace. Bound the
 # whole operation, rather than granting each individual command a fresh timeout.
 _DRAFT_RESTORE_TIMEOUT_SECONDS = 30 * 60
+
+# ARCA/DaaS starts service-bot hooks as ``admin``.  The current image contract
+# fixes that runtime identity at uid/gid 1000; draft restore already uses the
+# same ownership contract below.  A versioned artifact is not publishable until
+# this identity can traverse and read it.
+_PUBLISHED_RUNTIME_OWNER = "1000:1000"
+_PUBLISHED_RUNTIME_UID = "#1000"
+_RUNTIME_ARTIFACT_READABILITY_PROBE = (
+    "import os, sys\n"
+    "def check(path):\n"
+    "    with os.scandir(path) as entries:\n"
+    "        for entry in entries:\n"
+    "            if entry.is_symlink():\n"
+    "                os.readlink(entry.path)\n"
+    "            elif entry.is_dir(follow_symlinks=False):\n"
+    "                check(entry.path)\n"
+    "            elif entry.is_file(follow_symlinks=False):\n"
+    "                with open(entry.path, \"rb\"):\n"
+    "                    pass\n"
+    "            else:\n"
+    "                os.lstat(entry.path)\n"
+    "check(sys.argv[1])\n"
+)
 
 
 class BotBuildServiceError(Exception):
@@ -312,6 +336,17 @@ class BotBuildService:
                     target_dir=target_dir,
                 )
 
+            # All artifact writers must finish before ownership is normalized.
+            # In particular, MCP and OpenClaw stage configs are generated after
+            # rsync and would be missed by an rsync-only --chown fix.
+            artifact_writes_success = (
+                migration_success
+                and mcp_success
+                and openclaw_configs_success
+            )
+            if artifact_writes_success:
+                self._finalize_runtime_artifact(target_dir)
+
             logger.info(
                 f"[BotBuildService.build] Step 2 completed: "
                 f"migration_success={migration_success}, "
@@ -320,7 +355,7 @@ class BotBuildService:
             )
 
             # 构建结果
-            success = migration_success and mcp_success and openclaw_configs_success
+            success = artifact_writes_success
             result = {
                 "success": success,
                 "bot_id": bot_id,
@@ -699,6 +734,57 @@ class BotBuildService:
             )
 
         return result
+
+    def _finalize_runtime_artifact(self, target_dir: Path) -> None:
+        """Make a completed artifact readable by the Published Runtime.
+
+        Backend is the sole writer of the versioned artifact, but ``rsync -a``
+        deliberately preserves the Draft NAS ownership and modes.  Those
+        identities are not guaranteed to match the ``admin`` user used by
+        DaaS ``start_service.sh``.  Normalize only the constructed artifact
+        root, without following active-Skill symlinks, then perform the same
+        recursive read that the Published startup path requires.
+
+        Any failure is fatal at build time.  Deferring it to the BaaS start hook
+        leaves a publish in VALIDATE_PUB with a sandbox that can see the mount
+        but cannot install its contents.
+        """
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chown",
+                "-hR",
+                _PUBLISHED_RUNTIME_OWNER,
+                str(target_dir),
+            ],
+            command_name="normalize artifact owner",
+            error_message="normalize artifact owner failed",
+        )
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chmod",
+                "-R",
+                "u+rwX",
+                str(target_dir),
+            ],
+            command_name="normalize artifact mode",
+            error_message="normalize artifact mode failed",
+        )
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "-u",
+                _PUBLISHED_RUNTIME_UID,
+                sys.executable,
+                "-I",
+                "-c",
+                _RUNTIME_ARTIFACT_READABILITY_PROBE,
+                str(target_dir),
+            ],
+            command_name="verify artifact runtime readability",
+            error_message="artifact is not readable by published runtime",
+        )
 
     def _migrate_bot_instance(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -132,6 +132,24 @@ _NUMERIC_RUNTIME_ARTIFACT_READABILITY_PROBE = (
     "    raise PermissionError(\n"
     "        'artifact unexpectedly writable by published runtime'\n"
     "    )\n"
+    "def assert_not_replaceable(path, message):\n"
+    "    sibling = f\"{path}.runtime-rename-probe-{os.getpid()}\"\n"
+    "    try:\n"
+    "        os.rename(path, sibling)\n"
+    "    except OSError as exc:\n"
+    "        if exc.errno not in (errno.EACCES, errno.EPERM, errno.EROFS):\n"
+    "            raise\n"
+    "    else:\n"
+    "        os.rename(sibling, path)\n"
+    "        raise PermissionError(message)\n"
+    "assert_not_replaceable(\n"
+    "    artifact_path,\n"
+    "    'artifact path unexpectedly replaceable by published runtime',\n"
+    ")\n"
+    "assert_not_replaceable(\n"
+    "    os.path.dirname(artifact_path),\n"
+    "    'version path unexpectedly replaceable by published runtime',\n"
+    ")\n"
 )
 
 
@@ -335,8 +353,7 @@ class BotBuildService:
             # A previous attempt for this version may already have sealed the
             # target read-only. Re-open it only for the Backend writer before
             # retrying; a successful build seals it again below.
-            if target_dir.exists() and source_dir.exists():
-                self._prepare_artifact_for_build(target_dir)
+            self._prepare_artifact_for_build(target_dir)
 
             # 2.1 执行 rsync 迁移
             migration_success = self._migrate_bot_instance(
@@ -841,6 +858,57 @@ class BotBuildService:
             ],
             command_name="seal artifact mode",
             error_message="seal artifact mode failed",
+        )
+        version_dir = target_dir.parent
+        artifact_store = version_dir.parent
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chown",
+                _PUBLISHED_ARTIFACT_OWNER,
+                str(version_dir),
+            ],
+            command_name="seal artifact version owner",
+            error_message="seal artifact version owner failed",
+        )
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chmod",
+                _PUBLISHED_ARTIFACT_MODE,
+                str(version_dir),
+            ],
+            command_name="seal artifact version mode",
+            error_message="seal artifact version mode failed",
+        )
+        # The bot-data mount remains writable because the active engine lives
+        # beside versioned artifacts. Make root the directory owner and use
+        # sticky-directory semantics so runtime gid 1000 can manage its own
+        # active entries but cannot rename a root-owned version directory.
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chown",
+                _PUBLISHED_ARTIFACT_OWNER,
+                str(artifact_store),
+            ],
+            command_name="protect artifact store owner",
+            error_message="protect artifact store owner failed",
+        )
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chmod",
+                "u=rwx,g=rwx,o=",
+                str(artifact_store),
+            ],
+            command_name="protect artifact store mode",
+            error_message="protect artifact store mode failed",
+        )
+        self._run_local_command(
+            cmd=["sudo", "chmod", "+t", str(artifact_store)],
+            command_name="protect artifact version entry",
+            error_message="protect artifact version entry failed",
         )
         self._run_local_command(
             cmd=[

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -79,10 +79,11 @@ _BOT_GONE_ERROR_CODES = frozenset({"BOT_NOT_FOUND", "DEVICE_NOT_FOUND"})
 _DRAFT_RESTORE_TIMEOUT_SECONDS = 30 * 60
 
 # ARCA/DaaS starts service-bot hooks as ``admin``.  The current image contract
-# fixes that runtime identity at uid/gid 1000; draft restore already uses the
-# same ownership contract below.  A versioned artifact is not publishable until
-# this identity can traverse and read it.
-_PUBLISHED_RUNTIME_OWNER = "1000:1000"
+# fixes that runtime identity at uid/gid 1000. A versioned artifact is not
+# publishable until this identity can traverse and read it, but it must remain
+# immutable to that runtime because rollback reuses the same version path.
+_PUBLISHED_ARTIFACT_OWNER = "0:1000"
+_PUBLISHED_ARTIFACT_MODE = "u=rwX,g=rX,o="
 _PUBLISHED_RUNTIME_UID = 1000
 _PUBLISHED_RUNTIME_GID = 1000
 _RUNTIME_ARTIFACT_TREE_READ_PROBE = (
@@ -757,11 +758,11 @@ class BotBuildService:
         """Make a completed artifact readable by the Published Runtime.
 
         Backend is the sole writer of the versioned artifact, but ``rsync -a``
-        deliberately preserves the Draft NAS ownership and modes.  Those
-        identities are not guaranteed to match the ``admin`` user used by
-        DaaS ``start_service.sh``.  Normalize only the constructed artifact
-        root, without following active-Skill symlinks, then perform the same
-        recursive read that the Published startup path requires.
+        deliberately preserves the Draft NAS ownership and modes. Normalize
+        only the constructed artifact root to root ownership with the runtime
+        group granted read/traverse access, without following active-Skill
+        symlinks, then perform the same recursive read that Published startup
+        requires.
 
         Any failure is fatal at build time.  Deferring it to the BaaS start hook
         leaves a publish in VALIDATE_PUB with a sandbox that can see the mount
@@ -772,7 +773,7 @@ class BotBuildService:
                 "sudo",
                 "chown",
                 "-hR",
-                _PUBLISHED_RUNTIME_OWNER,
+                _PUBLISHED_ARTIFACT_OWNER,
                 str(target_dir),
             ],
             command_name="normalize artifact owner",
@@ -783,7 +784,7 @@ class BotBuildService:
                 "sudo",
                 "chmod",
                 "-R",
-                "u+rwX",
+                _PUBLISHED_ARTIFACT_MODE,
                 str(target_dir),
             ],
             command_name="normalize artifact mode",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -84,7 +84,9 @@ _DRAFT_RESTORE_TIMEOUT_SECONDS = 30 * 60
 # publishable until this identity can traverse and read it, but it must remain
 # immutable to that runtime because rollback reuses the same version path.
 _PUBLISHED_ARTIFACT_OWNER = "0:1000"
-_PUBLISHED_ARTIFACT_MODE = "u=rwX,g=rX,o="
+# Unknown Backend host identities may still need to stat or reopen an artifact.
+# ``o=X`` grants directory traversal only; regular files remain inaccessible.
+_PUBLISHED_ARTIFACT_MODE = "u=rwX,g=rX,o=X"
 _PUBLISHED_RUNTIME_UID = 1000
 _PUBLISHED_RUNTIME_GID = 1000
 _RUNTIME_ARTIFACT_TREE_READ_PROBE = (
@@ -899,7 +901,7 @@ class BotBuildService:
             cmd=[
                 "sudo",
                 "chmod",
-                "u=rwx,g=rwx,o=",
+                "u=rwx,g=rwx,o=x",
                 str(artifact_store),
             ],
             command_name="protect artifact store mode",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -15,6 +15,7 @@ import asyncio
 import copy
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import time
@@ -106,7 +107,7 @@ _RUNTIME_ARTIFACT_READABILITY_PROBE = (
     + "check(sys.argv[1])\n"
 )
 _NUMERIC_RUNTIME_ARTIFACT_READABILITY_PROBE = (
-    "import os, sys\n"
+    "import errno, os, sys\n"
     "runtime_uid = int(sys.argv[1])\n"
     "runtime_gid = int(sys.argv[2])\n"
     "artifact_path = sys.argv[3]\n"
@@ -118,6 +119,19 @@ _NUMERIC_RUNTIME_ARTIFACT_READABILITY_PROBE = (
     "os.setuid(runtime_uid)\n"
     + _RUNTIME_ARTIFACT_TREE_READ_PROBE
     + "check(artifact_path)\n"
+    "write_probe = os.path.join(artifact_path, "
+    "f\".runtime-write-probe-{os.getpid()}\")\n"
+    "try:\n"
+    "    fd = os.open(write_probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)\n"
+    "except OSError as exc:\n"
+    "    if exc.errno not in (errno.EACCES, errno.EPERM, errno.EROFS):\n"
+    "        raise\n"
+    "else:\n"
+    "    os.close(fd)\n"
+    "    os.unlink(write_probe)\n"
+    "    raise PermissionError(\n"
+    "        'artifact unexpectedly writable by published runtime'\n"
+    "    )\n"
 )
 
 
@@ -318,6 +332,12 @@ class BotBuildService:
             # ============================================================
             # Step 2: Bot 实例迁移
             # ============================================================
+            # A previous attempt for this version may already have sealed the
+            # target read-only. Re-open it only for the Backend writer before
+            # retrying; a successful build seals it again below.
+            if target_dir.exists() and source_dir.exists():
+                self._prepare_artifact_for_build(target_dir)
+
             # 2.1 执行 rsync 迁移
             migration_success = self._migrate_bot_instance(
                 device_id=device_id,
@@ -329,6 +349,11 @@ class BotBuildService:
                 build_plan=build_plan,
                 provider=provider,
             )
+            if migration_success:
+                # ``rsync -a`` preserves Draft ownership and modes. Normalize
+                # them to the Backend writer before the remaining host-side
+                # config generators append to the artifact.
+                self._prepare_artifact_for_build(target_dir)
 
             # The host-side engine-root rsync is the sole writer of the
             # versioned artifact. It preserves active symlinks and local Skill
@@ -754,6 +779,31 @@ class BotBuildService:
 
         return result
 
+    def _prepare_artifact_for_build(self, target_dir: Path) -> None:
+        """Restore Backend writer access before building or retrying a version."""
+        writer_owner = f"{os.geteuid()}:{os.getegid()}"
+        self._run_local_command(
+            cmd=["sudo", "mkdir", "-p", str(target_dir)],
+            command_name="prepare artifact directory",
+            error_message="prepare artifact directory failed",
+        )
+        self._run_local_command(
+            cmd=[
+                "sudo",
+                "chown",
+                "-hR",
+                writer_owner,
+                str(target_dir),
+            ],
+            command_name="prepare artifact owner",
+            error_message="prepare artifact owner failed",
+        )
+        self._run_local_command(
+            cmd=["sudo", "chmod", "-R", "u+rwX", str(target_dir)],
+            command_name="prepare artifact mode",
+            error_message="prepare artifact mode failed",
+        )
+
     def _finalize_runtime_artifact(self, target_dir: Path) -> None:
         """Make a completed artifact readable by the Published Runtime.
 
@@ -762,7 +812,9 @@ class BotBuildService:
         only the constructed artifact root to root ownership with the runtime
         group granted read/traverse access, without following active-Skill
         symlinks, then perform the same recursive read that Published startup
-        requires.
+        requires. Because the Runtime is not the owner and receives no group
+        write bit, it cannot chmod, replace, or delete the source later reused
+        by restart and rollback.
 
         Any failure is fatal at build time.  Deferring it to the BaaS start hook
         leaves a publish in VALIDATE_PUB with a sandbox that can see the mount
@@ -776,8 +828,8 @@ class BotBuildService:
                 _PUBLISHED_ARTIFACT_OWNER,
                 str(target_dir),
             ],
-            command_name="normalize artifact owner",
-            error_message="normalize artifact owner failed",
+            command_name="seal artifact owner",
+            error_message="seal artifact owner failed",
         )
         self._run_local_command(
             cmd=[
@@ -787,8 +839,8 @@ class BotBuildService:
                 _PUBLISHED_ARTIFACT_MODE,
                 str(target_dir),
             ],
-            command_name="normalize artifact mode",
-            error_message="normalize artifact mode failed",
+            command_name="seal artifact mode",
+            error_message="seal artifact mode failed",
         )
         self._run_local_command(
             cmd=[

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -70,8 +70,11 @@ def _registry() -> EngineSandboxRegistry:
 @pytest.mark.parametrize(
     ("engine", "expected_events"),
     [
-        ("openclaw", ["migrate", "mcp", "stage-configs", "finalize"]),
-        ("claude_code", ["migrate", "mcp", "finalize"]),
+        (
+            "openclaw",
+            ["migrate", "prepare", "mcp", "stage-configs", "finalize"],
+        ),
+        ("claude_code", ["migrate", "prepare", "mcp", "finalize"]),
     ],
 )
 def test_build_finalizes_complete_artifact_after_all_writers(
@@ -115,7 +118,12 @@ def test_build_finalizes_complete_artifact_after_all_writers(
             assert (target_dir / "openclaw_verify.json").is_file()
         events.append("finalize")
 
+    def prepare(target_dir: Path) -> None:
+        assert target_dir.is_dir()
+        events.append("prepare")
+
     service._migrate_bot_instance = MagicMock(side_effect=migrate)
+    service._prepare_artifact_for_build = MagicMock(side_effect=prepare)
     service._generate_mcp_config = MagicMock(side_effect=generate_mcp)
     service._generate_openclaw_stage_configs = MagicMock(
         side_effect=generate_stage_configs
@@ -151,8 +159,8 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
 
     calls = service._run_local_command.call_args_list
     assert [call.kwargs["command_name"] for call in calls] == [
-        "normalize artifact owner",
-        "normalize artifact mode",
+        "seal artifact owner",
+        "seal artifact mode",
         "verify artifact runtime readability",
     ]
     assert calls[0].kwargs["cmd"] == [
@@ -179,7 +187,30 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     assert "os.setuid(runtime_uid)" in probe_cmd[4]
     assert "follow_symlinks=False" in probe_cmd[4]
     assert 'open(entry.path, "rb")' in probe_cmd[4]
+    assert "artifact unexpectedly writable by published runtime" in probe_cmd[4]
     assert probe_cmd[5:] == ["1000", "1000", str(target_dir)]
+
+
+@pytest.mark.unit
+def test_artifact_prepare_restores_backend_writer_access_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """重试已封存版本前，应先用纯数字宿主身份恢复 Backend 写权限。"""
+    monkeypatch.setattr(module.os, "geteuid", lambda: 43210)
+    monkeypatch.setattr(module.os, "getegid", lambda: 43211)
+    service = BotBuildService.__new__(BotBuildService)
+    service._run_local_command = MagicMock()
+    target_dir = tmp_path / "artifact"
+
+    service._prepare_artifact_for_build(target_dir)
+
+    calls = service._run_local_command.call_args_list
+    assert [call.kwargs["cmd"] for call in calls] == [
+        ["sudo", "mkdir", "-p", str(target_dir)],
+        ["sudo", "chown", "-hR", "43210:43211", str(target_dir)],
+        ["sudo", "chmod", "-R", "u+rwX", str(target_dir)],
+    ]
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -170,16 +170,16 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
         str(target_dir),
     ]
     probe_cmd = calls[2].kwargs["cmd"]
-    assert probe_cmd[:3] == [
-        "sudo",
-        "-u",
-        "#1000",
-    ]
-    assert Path(probe_cmd[3]).name.startswith("python")
-    assert probe_cmd[4:6] == ["-I", "-c"]
-    assert "follow_symlinks=False" in probe_cmd[6]
-    assert 'open(entry.path, "rb")' in probe_cmd[6]
-    assert probe_cmd[7] == str(target_dir)
+    assert probe_cmd[0] == "sudo"
+    assert "-u" not in probe_cmd
+    assert Path(probe_cmd[1]).name.startswith("python")
+    assert probe_cmd[2:4] == ["-I", "-c"]
+    assert "os.setgroups([])" in probe_cmd[4]
+    assert "os.setgid(runtime_gid)" in probe_cmd[4]
+    assert "os.setuid(runtime_uid)" in probe_cmd[4]
+    assert "follow_symlinks=False" in probe_cmd[4]
+    assert 'open(entry.path, "rb")' in probe_cmd[4]
+    assert probe_cmd[5:] == ["1000", "1000", str(target_dir)]
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -72,9 +72,19 @@ def _registry() -> EngineSandboxRegistry:
     [
         (
             "openclaw",
-            ["migrate", "prepare", "mcp", "stage-configs", "finalize"],
+            [
+                "prepare",
+                "migrate",
+                "prepare",
+                "mcp",
+                "stage-configs",
+                "finalize",
+            ],
         ),
-        ("claude_code", ["migrate", "prepare", "mcp", "finalize"]),
+        (
+            "claude_code",
+            ["prepare", "migrate", "prepare", "mcp", "finalize"],
+        ),
     ],
 )
 def test_build_finalizes_complete_artifact_after_all_writers(
@@ -95,7 +105,7 @@ def test_build_finalizes_complete_artifact_after_all_writers(
 
     def migrate(**kwargs: object) -> bool:
         events.append("migrate")
-        Path(kwargs["target_dir"]).mkdir(parents=True)
+        Path(kwargs["target_dir"]).mkdir(parents=True, exist_ok=True)
         return True
 
     def generate_mcp(**kwargs: object) -> bool:
@@ -119,7 +129,7 @@ def test_build_finalizes_complete_artifact_after_all_writers(
         events.append("finalize")
 
     def prepare(target_dir: Path) -> None:
-        assert target_dir.is_dir()
+        target_dir.mkdir(parents=True, exist_ok=True)
         events.append("prepare")
 
     service._migrate_bot_instance = MagicMock(side_effect=migrate)
@@ -161,6 +171,11 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     assert [call.kwargs["command_name"] for call in calls] == [
         "seal artifact owner",
         "seal artifact mode",
+        "seal artifact version owner",
+        "seal artifact version mode",
+        "protect artifact store owner",
+        "protect artifact store mode",
+        "protect artifact version entry",
         "verify artifact runtime readability",
     ]
     assert calls[0].kwargs["cmd"] == [
@@ -177,7 +192,37 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
         "u=rwX,g=rX,o=",
         str(target_dir),
     ]
-    probe_cmd = calls[2].kwargs["cmd"]
+    assert calls[2].kwargs["cmd"] == [
+        "sudo",
+        "chown",
+        "0:1000",
+        str(target_dir.parent),
+    ]
+    assert calls[3].kwargs["cmd"] == [
+        "sudo",
+        "chmod",
+        "u=rwX,g=rX,o=",
+        str(target_dir.parent),
+    ]
+    assert calls[4].kwargs["cmd"] == [
+        "sudo",
+        "chown",
+        "0:1000",
+        str(target_dir.parent.parent),
+    ]
+    assert calls[5].kwargs["cmd"] == [
+        "sudo",
+        "chmod",
+        "u=rwx,g=rwx,o=",
+        str(target_dir.parent.parent),
+    ]
+    assert calls[6].kwargs["cmd"] == [
+        "sudo",
+        "chmod",
+        "+t",
+        str(target_dir.parent.parent),
+    ]
+    probe_cmd = calls[7].kwargs["cmd"]
     assert probe_cmd[0] == "sudo"
     assert "-u" not in probe_cmd
     assert Path(probe_cmd[1]).name.startswith("python")
@@ -188,6 +233,8 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     assert "follow_symlinks=False" in probe_cmd[4]
     assert 'open(entry.path, "rb")' in probe_cmd[4]
     assert "artifact unexpectedly writable by published runtime" in probe_cmd[4]
+    assert "artifact path unexpectedly replaceable by published runtime" in probe_cmd[4]
+    assert "version path unexpectedly replaceable by published runtime" in probe_cmd[4]
     assert probe_cmd[5:] == ["1000", "1000", str(target_dir)]
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -1,0 +1,265 @@
+"""Service Bot 版本化制品与 Published Runtime 的权限契约。"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services import bot_build_service as module
+from agentclaw.community.core.service_bot.services.bot_build_service import (
+    BotBuildMigrationError,
+    BotBuildService,
+)
+from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.engines.claude_code import (
+    ClaudeCodeSandboxProvider,
+)
+from agentclaw.community.core.workspace.engines.openclaw import (
+    OpenClawSandboxProvider,
+)
+from agentclaw.community.di.config import WorkspaceConfig
+from agentclaw.community.kernel.device_dto import CommandResult
+
+
+def _make_service(*, registry: EngineSandboxRegistry) -> BotBuildService:
+    whitelist_service = MagicMock()
+    whitelist_service.is_bot_feature_enabled.return_value = False
+    device_service = MagicMock()
+    device_service.exec_shell_new.return_value = CommandResult(
+        stdout='{"mcpServers": {}}',
+        exit_code=0,
+    )
+    channel_service = MagicMock()
+    channel_service.generate_openclaw_configs = AsyncMock(
+        return_value=SimpleNamespace(verify="{}", online="{}")
+    )
+    return BotBuildService(
+        device_service=device_service,
+        baas_service=MagicMock(),
+        path_factory=MagicMock(),
+        passport_plugin=MagicMock(),
+        device_binding_repo=MagicMock(),
+        sandbox_registry=registry,
+        channel_service=channel_service,
+        bot_repository=MagicMock(),
+        common_whitelist_service=whitelist_service,
+        baas_template_resolver=MagicMock(),
+        teclaw_template_uuid="",
+    )
+
+
+def _registry() -> EngineSandboxRegistry:
+    workspace = WorkspaceConfig(
+        openclaw_root="/home/admin/.openclaw",
+        claude_code_root="/home/admin/.claude_code",
+        claude_code_session_root="/home/admin/.claude",
+    )
+    registry = EngineSandboxRegistry()
+    registry.register(OpenClawSandboxProvider(workspace=workspace))
+    registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
+    return registry
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("engine", "expected_events"),
+    [
+        ("openclaw", ["migrate", "mcp", "stage-configs", "finalize"]),
+        ("claude_code", ["migrate", "mcp", "finalize"]),
+    ],
+)
+def test_build_finalizes_complete_artifact_after_all_writers(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    engine: str,
+    expected_events: list[str],
+) -> None:
+    """build() 交付前必须在所有制品写入者之后统一收口。"""
+    nas_root = tmp_path / "nas"
+    artifact_root = tmp_path / "artifacts"
+    nas_root.mkdir()
+    monkeypatch.setattr(module, "get_bot_nas_dir", lambda **_: nas_root)
+    monkeypatch.setattr(module, "get_bot_dir", lambda **_: artifact_root)
+
+    service = _make_service(registry=_registry())
+    events: list[str] = []
+
+    def migrate(**kwargs: object) -> bool:
+        events.append("migrate")
+        Path(kwargs["target_dir"]).mkdir(parents=True)
+        return True
+
+    def generate_mcp(**kwargs: object) -> bool:
+        events.append("mcp")
+        target_dir = Path(kwargs["target_dir"])
+        config = target_dir / "workspace" / "config" / "mcporter.json"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text("{}", encoding="utf-8")
+        return True
+
+    def generate_stage_configs(**kwargs: object) -> bool:
+        events.append("stage-configs")
+        target_dir = Path(kwargs["target_dir"])
+        (target_dir / "openclaw_verify.json").write_text("{}", encoding="utf-8")
+        return True
+
+    def finalize(target_dir: Path) -> None:
+        assert (target_dir / "workspace" / "config" / "mcporter.json").is_file()
+        if engine == "openclaw":
+            assert (target_dir / "openclaw_verify.json").is_file()
+        events.append("finalize")
+
+    service._migrate_bot_instance = MagicMock(side_effect=migrate)
+    service._generate_mcp_config = MagicMock(side_effect=generate_mcp)
+    service._generate_openclaw_stage_configs = MagicMock(
+        side_effect=generate_stage_configs
+    )
+    service._finalize_runtime_artifact = MagicMock(side_effect=finalize)
+
+    result = service.build(
+        bot={
+            "bot_id": "service-bot",
+            "entity_id": "168944",
+            "entity_type": "staff",
+            "device_id": "device-1",
+            "active_engine": engine,
+        },
+        version=1,
+    )
+
+    assert result["success"] is True
+    assert events == expected_events
+
+
+@pytest.mark.unit
+def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
+    tmp_path: Path,
+) -> None:
+    """Finalizer 不得跟随 Pool 软链，且必须用 Runtime UID 验读。"""
+    service = BotBuildService.__new__(BotBuildService)
+    service._run_local_command = MagicMock()
+    target_dir = tmp_path / "artifact" / "openclaw"
+    target_dir.mkdir(parents=True)
+
+    service._finalize_runtime_artifact(target_dir)
+
+    calls = service._run_local_command.call_args_list
+    assert [call.kwargs["command_name"] for call in calls] == [
+        "normalize artifact owner",
+        "normalize artifact mode",
+        "verify artifact runtime readability",
+    ]
+    assert calls[0].kwargs["cmd"] == [
+        "sudo",
+        "chown",
+        "-hR",
+        "1000:1000",
+        str(target_dir),
+    ]
+    assert calls[1].kwargs["cmd"] == [
+        "sudo",
+        "chmod",
+        "-R",
+        "u+rwX",
+        str(target_dir),
+    ]
+    probe_cmd = calls[2].kwargs["cmd"]
+    assert probe_cmd[:3] == [
+        "sudo",
+        "-u",
+        "#1000",
+    ]
+    assert Path(probe_cmd[3]).name.startswith("python")
+    assert probe_cmd[4:6] == ["-I", "-c"]
+    assert "follow_symlinks=False" in probe_cmd[6]
+    assert 'open(entry.path, "rb")' in probe_cmd[6]
+    assert probe_cmd[7] == str(target_dir)
+
+
+@pytest.mark.unit
+def test_artifact_finalizer_fails_closed_when_runtime_admin_cannot_read(
+    tmp_path: Path,
+) -> None:
+    """admin 等价读取失败必须阻断 build，不能延迟到 BaaS hook。"""
+    service = BotBuildService.__new__(BotBuildService)
+
+    def run_command(**kwargs: object) -> None:
+        if kwargs["command_name"] == "verify artifact runtime readability":
+            raise BotBuildMigrationError(
+                "artifact is not readable by published runtime: Operation not permitted"
+            )
+
+    service._run_local_command = MagicMock(side_effect=run_command)
+    target_dir = tmp_path / "artifact"
+    target_dir.mkdir()
+
+    with pytest.raises(
+        BotBuildMigrationError,
+        match="artifact is not readable by published runtime",
+    ):
+        service._finalize_runtime_artifact(target_dir)
+
+
+@pytest.mark.unit
+def test_runtime_readability_probe_opens_files_without_following_pool_links(
+    tmp_path: Path,
+) -> None:
+    """探测应验读普通文件，但绝不能进入 active Skill 的外部目标。"""
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    (artifact / "settings.json").write_text("{}", encoding="utf-8")
+    (artifact / "active-skill").symlink_to(
+        "/home/admin/.openclaw/workspace/skills-pool/skills-repo/active-skill",
+        target_is_directory=True,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            module._RUNTIME_ARTIFACT_READABILITY_PROBE,
+            str(artifact),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses Unix read permission bits")
+def test_runtime_readability_probe_detects_unreadable_regular_file(
+    tmp_path: Path,
+) -> None:
+    """本地回放 Published admin 遇到不可读制品时的 PermissionError。"""
+    artifact = tmp_path / "artifact"
+    artifact.mkdir()
+    unreadable = artifact / "settings.json"
+    unreadable.write_text("{}", encoding="utf-8")
+    unreadable.chmod(0)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                module._RUNTIME_ARTIFACT_READABILITY_PROBE,
+                str(artifact),
+            ],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        unreadable.chmod(0o600)
+
+    assert result.returncode != 0
+    assert "PermissionError" in result.stderr

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -141,7 +141,7 @@ def test_build_finalizes_complete_artifact_after_all_writers(
 def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     tmp_path: Path,
 ) -> None:
-    """Finalizer 不得跟随 Pool 软链，且必须用 Runtime UID 验读。"""
+    """Finalizer 不得跟随 Pool 软链，且 Published Runtime 只能读制品。"""
     service = BotBuildService.__new__(BotBuildService)
     service._run_local_command = MagicMock()
     target_dir = tmp_path / "artifact" / "openclaw"
@@ -159,14 +159,14 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
         "sudo",
         "chown",
         "-hR",
-        "1000:1000",
+        "0:1000",
         str(target_dir),
     ]
     assert calls[1].kwargs["cmd"] == [
         "sudo",
         "chmod",
         "-R",
-        "u+rwX",
+        "u=rwX,g=rX,o=",
         str(target_dir),
     ]
     probe_cmd = calls[2].kwargs["cmd"]

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_artifact_permissions.py
@@ -189,7 +189,7 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
         "sudo",
         "chmod",
         "-R",
-        "u=rwX,g=rX,o=",
+        "u=rwX,g=rX,o=X",
         str(target_dir),
     ]
     assert calls[2].kwargs["cmd"] == [
@@ -201,7 +201,7 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     assert calls[3].kwargs["cmd"] == [
         "sudo",
         "chmod",
-        "u=rwX,g=rX,o=",
+        "u=rwX,g=rX,o=X",
         str(target_dir.parent),
     ]
     assert calls[4].kwargs["cmd"] == [
@@ -213,7 +213,7 @@ def test_artifact_finalizer_is_symlink_safe_and_probes_as_runtime_admin(
     assert calls[5].kwargs["cmd"] == [
         "sudo",
         "chmod",
-        "u=rwx,g=rwx,o=",
+        "u=rwx,g=rwx,o=x",
         str(target_dir.parent.parent),
     ]
     assert calls[6].kwargs["cmd"] == [

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
@@ -23,6 +23,7 @@ def _make_service(channel_service: object = _UNSET) -> BotBuildService:
     service._common_whitelist_service = MagicMock()
     # build() tests in this module isolate stage-config and path selection;
     # artifact permission finalization has its own command-contract coverage.
+    service._prepare_artifact_for_build = MagicMock()
     service._finalize_runtime_artifact = MagicMock()
     return service
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
@@ -21,6 +21,9 @@ def _make_service(channel_service: object = _UNSET) -> BotBuildService:
     service = BotBuildService.__new__(BotBuildService)
     service._channel_service = MagicMock() if channel_service is _UNSET else channel_service
     service._common_whitelist_service = MagicMock()
+    # build() tests in this module isolate stage-config and path selection;
+    # artifact permission finalization has its own command-contract coverage.
+    service._finalize_runtime_artifact = MagicMock()
     return service
 
 
@@ -197,6 +200,7 @@ class TestGenerateOpenClawStageConfigs:
             owner_id="owner-1",
             target_dir=target_dir,
         )
+        service._finalize_runtime_artifact.assert_called_once_with(target_dir)
 
     def test_build_marks_failure_when_openclaw_config_generation_fails(self, tmp_path: Path):
         @dataclass
@@ -247,6 +251,7 @@ class TestGenerateOpenClawStageConfigs:
 
         assert result["success"] is False
         assert result["openclaw_configs_success"] is False
+        service._finalize_runtime_artifact.assert_not_called()
 
     def test_build_skips_openclaw_config_generation_for_non_openclaw_engine(
         self, tmp_path: Path
@@ -301,6 +306,9 @@ class TestGenerateOpenClawStageConfigs:
         assert result["openclaw_configs_success"] is True
         service._generate_mcp_config.assert_called_once()
         service._generate_openclaw_stage_configs.assert_not_called()
+        service._finalize_runtime_artifact.assert_called_once_with(
+            tmp_path / "target-root" / "3" / "claude_code"
+        )
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
@@ -56,7 +56,13 @@ def _install_passthrough_sudo(
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     sudo = bin_dir / "sudo"
-    sudo.write_text("#!/bin/sh\nexec \"$@\"\n", encoding="utf-8")
+    sudo.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = chown ]; then exit 0; fi\n"
+        "if [ \"$1\" = -u ]; then shift 2; fi\n"
+        "exec \"$@\"\n",
+        encoding="utf-8",
+    )
     sudo.chmod(0o755)
     monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
@@ -167,6 +167,7 @@ def test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_w
         registry=registry,
         channel_service=channel_service,
     )
+    service._finalize_runtime_artifact = MagicMock()
 
     result = service.build(
         bot={
@@ -187,6 +188,7 @@ def test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_w
     assert (artifact_pool_root / "skills-local" / "local-skill" / "SKILL.md").is_file()
     assert not stale_active_corpus.exists()
     assert not stale_pool_corpus.exists()
+    service._finalize_runtime_artifact.assert_called_once_with(artifact_engine_root)
     assert all(
         not call.kwargs["shell_cmd"].startswith("rsync ")
         for call in device_service.exec_shell_new.call_args_list

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py
@@ -167,6 +167,7 @@ def test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_w
         registry=registry,
         channel_service=channel_service,
     )
+    service._prepare_artifact_for_build = MagicMock()
     service._finalize_runtime_artifact = MagicMock()
 
     result = service.build(
@@ -188,6 +189,11 @@ def test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_w
     assert (artifact_pool_root / "skills-local" / "local-skill" / "SKILL.md").is_file()
     assert not stale_active_corpus.exists()
     assert not stale_pool_corpus.exists()
+    assert service._prepare_artifact_for_build.call_count == 2
+    assert all(
+        call.args == (artifact_engine_root,)
+        for call in service._prepare_artifact_for_build.call_args_list
+    )
     service._finalize_runtime_artifact.assert_called_once_with(artifact_engine_root)
     assert all(
         not call.kwargs["shell_cmd"].startswith("rsync ")


### PR DESCRIPTION
## Problem

After #860 moved Service Bot Pool artifact construction to the Backend host, both OpenClaw publish 7369 and Claude Code publish 7370 completed BUILD but failed in the BaaS start hook. The versioned artifact retained Draft NAS ownership/modes from `rsync -a`, while DaaS installs it as runtime user `admin` (uid/gid 1000), producing `Operation not permitted` during `stat`, `readlink`, and `cp`.

The previous build path had no explicit postcondition that a completed artifact was readable by the Published Runtime, so the failure surfaced late in `VALIDATE_PUB` after a sandbox had already been created.

## Solution

- Keep Backend as the sole writer of the versioned artifact.
- After main rsync, Claude Code extra sync, MCP generation, and OpenClaw stage-config generation all finish, normalize the complete artifact to uid/gid `1000:1000`.
- Add owner read/write/traverse permissions without making the artifact world-writable.
- Use symlink-safe ownership handling (`chown -hR`) and a non-following recursive probe.
- Run the probe as uid 1000; it opens every regular file without reading contents and only reads symlink metadata, so it catches permission failures without re-reading the full artifact or following Pool links.
- Fail the BUILD immediately if finalization or the runtime-identity probe fails.

## Validation

- Focused artifact/build matrix: 19 passed.
- Service Bot service suite: 814 passed.
- Full Backend suite: 10,826 passed.
- Backend CI gate: 100% case pass rate, 85.22% line coverage, 100% changed-line coverage.
- Ruff and blocking Python SAST rules passed for changed files.
- Local regression reproduces an unreadable artifact with Unix mode `000` and verifies the probe returns `PermissionError`.
- Pool absolute symlinks are verified without following their external targets.
- OpenClaw and Claude Code are both covered; the finalizer is layout-agnostic and therefore preserves Legacy behavior as well.

## Compatibility and risk

No API, schema, manifest, DaaS, or BaaS payload contract changes. Existing Legacy and Pool builds gain the same artifact-readability postcondition. The only intentional behavior change is fail-early: an unreadable artifact now fails during BUILD instead of creating a Published sandbox and failing in its start hook.

Related: #860
