### PR TITLE
fix(backend): serve the connection endpoint for ARCA-provider bots

### DIFF
--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/plan.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/plan.md
@@ -1,0 +1,363 @@
+# Plan: Connection Endpoint — Serving Bots on the ARCA Provider
+
+## Approach
+
+`EngineConnectionService._socket_url` currently recognises two provider shapes
+and treats everything else as the second one:
+
+1. `type == "local"` → compose `ws://{target}{path}` directly.
+2. everything else → `_readdress_onto_gateway`, which **requires** a finished
+   `/proxypass/…` URL in `info.url`.
+
+The ARCA provider is neither. It returns `type="proxy"`, a bare routing target, a
+signed credential, and `url=""`, so it lands in branch 2 and is refused.
+
+Add a third branch: a provider whose connection kind says "bare routing target"
+gets its URL composed here, from `target` + the engine's socket path + `token`.
+
+The composition is not new code so much as a second entry point into code that
+already exists. `_readdress_onto_gateway` today does two separable things: it
+*extracts* `tail` and `query` from the provider's URL, then *builds* the gateway
+URL from `tail`, `query` and `token`. Only the extraction is BaaS-specific. Split
+the build out as `_gateway_url(tail, query, token)`, and the new branch becomes:
+produce a `tail` from the target and path, pass an empty query, call the same
+builder. Byte-identical output by construction, not by two implementations
+agreeing.
+
+### Why no ARCA-side or configuration change is needed
+
+The corp provider gives us both facts we need, and the gateway already routes
+what we would build:
+
+- `ArcaDeviceService._compose_device_conn_info` calls
+  `sandbox_client.build_proxy_connection(sandbox_id=…, ttl_seconds=…)`, which
+  returns a `ProxyConnection(target, token)` — `kernel/device_dto.py:155`. The
+  target is the runtime's own routing string; the token is a JWT signed over
+  exactly that string.
+- The gateway's `bots-messages-ws` domain (`src/gateway/configs/application.yaml:276`)
+  matches `/openapi/v1/bots/messages/ws/**`, rewrites that prefix to `/proxypass`,
+  and forwards to the `engine_proxy` server — the same proxy the target is for.
+
+So the endpoint holds everything required. The one thing it must *not* do is
+reach for `sandbox_client.proxy_base_url()`: `_readdress_onto_gateway` discards
+the provider's origin and substitutes the gateway's, so a proxy base URL would be
+fetched only to be thrown away.
+
+## Worked trace — every value, every step
+
+One bot throughout: `bot_id=b_01k2f9`, owner `staff-9931`, `active_engine=openclaw`,
+`bot_type=personal`, unshared. Gateway configured as
+`https://gateway.example.com`.
+
+### Step 0 — what `build` resolves before touching a device
+
+| name | value | source |
+| --- | --- | --- |
+| `engine` | `openclaw` | `bot["active_engine"]` |
+| `binding_id` | `4471` | `binding_repository.get_active_by_bot_and_owner("b_01k2f9", "staff-9931")` |
+| `chat_path` | `/api/openclaw/ws` | `_chat_path("openclaw")` → `_CHAT_WS_PATHS` |
+| `operator` | `OperatorContext(staff_id="staff-9931", …)` | the authenticated principal |
+
+For a `claude_code` bot `chat_path` is `/api/claude_code/ws`; for an engine with
+no dedicated entry, `/api/{engine}/ws`.
+
+### Step 1 — what the provider returns
+
+`_get_connection` calls
+`device_service.get_device_connection(binding_id=4471, operator=…, ttl=7200,
+ws_conn_mode="relay", path="/api/openclaw/ws")`. The router dispatches on
+`binding.device_provider`.
+
+**`device_provider="baas"`** → `BaasDeviceService.get_device_connection`
+(`baas_device_service.py:751`), which calls BaaS `GET /api/v1/bots/{bot_uuid}/ws-info`
+and returns:
+
+```python
+DeviceConnectionInfo(
+    type="baas",
+    target="ARCA_ARCA-SANDBOX-abc123@0:20003",
+    token="eyJhbGciOiJIUzI1NiIs…",
+    engine_type="openclaw",
+    url="wss://agentclawproxy-prod.example.com/proxypass/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws",
+    expires_at="2026-08-06T12:02:00Z",
+    baas_base_url="http://baas.example.com:8890",
+    bot_uuid="b_01k2f9",
+    tenant="default",
+    engine_port=20003,
+    available=True,
+)
+```
+
+`url` is populated **only** because `ws_conn_mode == "relay"`
+(`baas_device_service.py:818`); `path` is what BaaS concatenated onto the target
+with no separator of its own.
+
+**`device_provider="arca"`** → the corp `ArcaDeviceService`. Both `ws_conn_mode`
+and `path` are ignored — `path` never even reaches it, because the base
+`get_device_connection` does not forward it to `_compose_device_conn_info`
+(`device_service.py:1031`). It returns:
+
+```python
+DeviceConnectionInfo(
+    type="proxy",
+    target="ARCA_ARCA-SANDBOX-abc123@0:20003",
+    token="eyJhbGciOiJIUzI1NiIs…",
+    engine_type="openclaw",
+    url="",              # every other field at its default
+    expires_at="",
+    available=True,
+)
+```
+
+The target's `@0` comes from the `@alt`-suffixed sandbox id, which
+`build_proxy_connection` uses verbatim (`plugin_api/sandbox_runtime.py:94-98`).
+A device with no alt suffix yields `ARCA_ARCA-SANDBOX-abc123:20003` — same
+grammar, one fewer component. **The endpoint must not parse either form.**
+
+**`device_provider="local"`** (test/singlebox composition roots):
+
+```python
+DeviceConnectionInfo(type="local", target="127.0.0.1:20003", token="", …)
+```
+
+### Step 2 — `token` selection, unchanged
+
+`connection.py:246` — `ws_token or token or ""`:
+
+| provider | `ws_token` | `token` | selected |
+| --- | --- | --- | --- |
+| baas | `""` | `eyJhbGciOiJIUzI1NiIs…` | `eyJhbGciOiJIUzI1NiIs…` |
+| arca | `""` | `eyJhbGciOiJIUzI1NiIs…` | `eyJhbGciOiJIUzI1NiIs…` |
+| local | ws-info's token | http-info's token | ws-info's |
+
+### Step 3 — `target` selection, unchanged
+
+`_socket_url` reads `ws_target or target or ""` and refuses an empty result with
+`"device connection carries no routing target"`. ARCA sets `ws_target=""`, so the
+value used is `ARCA_ARCA-SANDBOX-abc123@0:20003`.
+
+### Step 4 — the branch (this is the change)
+
+| `info.type` | branch | tail fed to the builder |
+| --- | --- | --- |
+| `local` | compose direct, no gateway, no credential | — |
+| `proxy` | **new** — compose onto gateway | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| `baas`, `desktop` | re-address the provider's URL | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| anything else, `url` empty | **new** — named error | — |
+| anything else, `url` present | re-address, or refuse the shape | — |
+
+The two tails are identical, which is the whole point. On the BaaS path the tail
+is what remains after cutting `/proxypass/` off `parts.path`; on the ARCA path it
+is `quote(target) + quote(socket_path)`.
+
+### Step 5 — the shared builder
+
+`_gateway_url(tail="ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws", query="", token="eyJ…")`:
+
+| sub-step | value |
+| --- | --- |
+| credential percent-encoded | `eyJhbGciOiJIUzI1NiIs…` (a JWT is already URL-safe; a `+` or `/` in another credential would become `%2B` / `%2F`) |
+| query after appending | `x-proxypass-token=eyJhbGciOiJIUzI1NiIs…` |
+| `_gateway_ws_base()` | `wss://gateway.example.com` |
+| `+ _ENGINE_PREFIX` | `wss://gateway.example.com/openapi/v1/bots/messages/ws` |
+| `+ "/" + tail` | `wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| `+ "?" + query` | **final** (below) |
+
+```
+wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…
+```
+
+Where a provider's URL carried a query of its own, it is preserved and the
+credential appended with `&` — unchanged behaviour, and the reason `query` is a
+parameter of the builder rather than something it invents.
+
+### Step 6 — what the gateway does with it
+
+| hop | value |
+| --- | --- |
+| tenant's browser opens | `wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJ…` |
+| gateway rewrites prefix | `/proxypass/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJ…` |
+| forwarded to `engine_proxy` | proxy validates the JWT's target claim against `ARCA_ARCA-SANDBOX-abc123@0:20003` |
+| proxy routes to | the sandbox's engine adapter on `:20003`, path `/api/openclaw/ws` |
+
+The claim check is why the target must survive byte-for-byte: `arca_utils._get_proxypass_token`
+records that a token target disagreeing with the URL target is rejected by the
+proxy.
+
+### Step 7 — `expires_at`
+
+| provider | reported | published |
+| --- | --- | --- |
+| baas | `2026-08-06T12:02:00Z` | `2026-08-06T12:02:00+00:00` (normalised) |
+| arca | *(empty)* | `now + 7200s`, computed |
+
+Unchanged code. Worth recording that the computed fallback is *exact* on the ARCA
+path rather than a guess: `_get_connection` passes `ttl=CONNECTION_TTL_SECONDS`
+(7200), and the corp provider signs for precisely that (`resolved_ttl`, capped at
+7 days). On the BaaS path the TTL is advisory, which is why the provider's own
+value is preferred.
+
+## Affected Components
+
+| component | change |
+| --- | --- |
+| `core/engine_runtime/connection.py` | the only production file that changes |
+| `core/devices/**` | none — the ARCA provider is corp-side and untouched |
+| `adapters/http/openapi_v1/**` | none — same response model, same error mapping |
+| `di/**` | none — no new dependency is injected |
+| `src/gateway/**` | none — the route already exists |
+
+## Key Files & Functions
+
+`src/backend/src/agentclaw/community/core/engine_runtime/connection.py`
+
+| location | change |
+| --- | --- |
+| module constants, near `_PROXYPASS_PREFIX` (`:84`) | **add** `_PROXY_TARGET_TYPES` |
+| `_socket_url` (`:321`) | **modify** — read `type` once, add the proxy-target branch and the unrecognised-shape guard |
+| `_compose_onto_gateway` | **add** — target + path → `_gateway_url` |
+| `_gateway_url` | **add** — extracted from the tail of `_readdress_onto_gateway` |
+| `_readdress_onto_gateway` (`:360`) | **modify** — its last five lines become a call to `_gateway_url`; extraction and guards unchanged |
+| `_get_connection` (`:285`) | **comment only** — the note claiming an unset `ws_conn_mode` is what makes a provider return a bare target is wrong for ARCA, which returns one either way, and drops `path` besides |
+
+`src/backend/tests/community/core/engine_runtime/test_connection.py` — new cases
+alongside the existing `_Devices(type="local", …)` ones.
+
+## API / Interface Changes
+
+None. `ConnectionResult`, `SocketInfo`, the `Connection`/`Socket` response models,
+and the `EngineUpstreamError → 502 "Engine service error"` mapping
+(`responses.py:260`) are all unchanged. A previously-failing request starts
+succeeding; no field is added, removed, or retyped.
+
+## Implementation Detail
+
+### Naming the shape
+
+```python
+#: Connection kinds whose provider returns a *bare* proxypass routing target and
+#: a signed proxypass credential, leaving the URL for the caller to assemble. The
+#: corp ``ArcaDeviceService`` answers ``"proxy"``; ``"arca"`` is accepted beside
+#: it because that is the provider key the same device carries everywhere else
+#: (``ARCA_DEVICE_PROVIDER``), and a provider spelling one where the other is
+#: meant should not be the difference between a socket and a 502.
+#:
+#: Assembling here rather than in the provider is the platform's normal case, not
+#: a special case: ``get_device_connection_v2`` (``device_service.py:1776``) and
+#: the console frontend (``connectionStore.ts:177``) each build
+#: ``/proxypass/{target}{path}`` for themselves from the same two values.
+_PROXY_TARGET_TYPES = frozenset({"proxy", "arca"})
+```
+
+### The branch
+
+```python
+conn_type = str(getattr(info, "type", "") or "")
+
+if conn_type == "local":
+    ...unchanged...
+
+if conn_type in _PROXY_TARGET_TYPES:
+    return self._compose_onto_gateway(target, socket_path, token)
+
+return self._readdress_onto_gateway(info, token)
+```
+
+`_readdress_onto_gateway` gains one guard at its top, before the URL is parsed, so
+that an unrecognised kind carrying no URL is named as such instead of borrowing
+the wrong-shape message:
+
+```python
+if not url:
+    raise EngineUpstreamError(
+        f"device connection of kind {conn_type!r} carries no relay url and is "
+        f"not a kind this endpoint can compose one for"
+    )
+```
+
+The kind is safe to name here: `@envelope_errors` publishes the fixed string
+`"Engine service error"` and the exception's own message reaches logs only.
+
+### Encoding
+
+| part | `safe` | why |
+| --- | --- | --- |
+| routing target | `@:[]` | the target is an *authority-like* segment: `ARCA_…@0:20003` must keep `@` and `:`, and the local branch's `[::1]` must keep its brackets. Same set the local branch already uses. |
+| socket path | `/` | separators survive; anything else is escaped so it cannot end the path early |
+| credential | `""` (nothing safe) | a credential is opaque; every reserved character is encoded |
+
+All three go through `_quote_or_reject`, so a lone surrogate in a provider value
+is named rather than becoming a 500 at serialisation.
+
+The re-addressed BaaS path is **not** re-encoded — the provider already encoded
+it. Only the composed path encodes, because it is building from raw values. This
+asymmetry is deliberate and already present for the local branch.
+
+## Risks & Mitigations
+
+| risk | mitigation |
+| --- | --- |
+| The corp provider's `type` string is `"proxy"` today; a corp-side rename would silently revert ARCA to a 502. | The set holds both plausible spellings, and the unrecognised-kind error names the value it saw, so the log line says exactly which string to add. |
+| Percent-encoding the target could break the proxy's claim check. | `safe="@:[]"` leaves every character of the real grammar untouched; a test asserts the target segment survives verbatim. |
+| The gateway might not front the same proxy that serves ARCA targets. | It does — `application.yaml:276` forwards to `engine_proxy`, and the BaaS path already publishes `ARCA_…` targets through this same route in production. |
+| Composing a URL for a stopped sandbox. | Pre-existing and out of scope: ARCA does not report liveness, and `available` defaults to `True`. The handshake fails, as it does for every other ARCA caller today. |
+| The refactor changes the BaaS output. | The builder is called with exactly the values the old inline code used; a test asserts the two branches agree byte-for-byte for the same inputs. |
+
+## Alternatives Considered
+
+**Make the ARCA provider fill `url` in relay mode.** Rejected — see spec Resolved
+Question 1. Corp-side, and it would need `path` threaded through
+`_compose_device_conn_info`, whose signature does not carry it, to build a URL
+whose origin this endpoint discards anyway.
+
+**Infer the shape from `url == ""`.** Rejected — see spec Resolved Question 2. It
+would compose a plausible-looking URL for a provider that failed to fill a field
+it was supposed to fill.
+
+**Inject `SandboxRuntimeClient` and build `{proxy_base}/proxypass/{target}{path}`,
+then re-address it.** Rejected: a new dependency on this service, a network-facing
+config lookup, and an origin computed only to be replaced one line later.
+
+**Normalise `"proxy"` to `"baas"` at the router.** Rejected: the router's job is
+dispatch, and the two kinds genuinely differ in what they return. Flattening them
+would leave `url` empty on a kind that promises one.
+
+## Test Strategy
+
+All in `tests/community/core/engine_runtime/test_connection.py`, reusing the
+existing `_Devices` fake, which already takes `type`/`target`/`token`.
+
+**New:**
+1. `type="proxy"` publishes `wss://gw.example/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=…`.
+2. The published URL never names the engine proxy and never contains `/proxypass/`.
+3. `@` and `:` survive in the target segment; a bracketed IPv6-style target keeps its brackets.
+4. The engine's path is used — `claude_code` yields `/api/claude_code/ws`.
+5. A `proxy` device with no token publishes no query string.
+6. The credential is percent-encoded.
+7. Composed and re-addressed branches agree byte-for-byte for the same target, path and token.
+8. An unrecognised kind with `url=""` raises the new named error, and the message does not carry the credential.
+9. `expires_at` for a `proxy` device falls back to `now + CONNECTION_TTL_SECONDS`.
+10. A `proxy` device with an empty target still raises `"carries no routing target"`.
+
+**Unchanged and must stay green:** the whole existing file, in particular the
+local-branch cases, the `/wsrelay/` wrong-shape refusal, the fragment refusal, the
+provider-query-preserved case, and the gateway-base validation cases.
+
+## Rollout
+
+Single commit on `claude/backend-openapi-connection-f7j47u`, cut from and merged
+into `REL20260806`. No migration, no config, no feature flag: the change converts
+a hard failure into a success on one provider and is a no-op on the others. Nothing
+to roll back beyond reverting the commit.
+
+## Decisions Taken
+
+1. Compose at the point of publication, not in the provider.
+2. Branch on the declared connection kind, not on an absent URL.
+3. One builder shared by both gateway branches, so they cannot drift.
+4. Accept both `"proxy"` and `"arca"` as the bare-target kind.
+5. Name the unrecognised kind in the error; the HTTP body stays the fixed
+   `"Engine service error"`.
+6. Leave `ws_conn_mode="relay"` and `path=…` on the provider call, even though
+   ARCA ignores both — they are correct for BaaS, and removing them would break
+   it.

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/plan.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/plan.md
@@ -138,17 +138,32 @@ value used is `ARCA_ARCA-SANDBOX-abc123@0:20003`.
 
 ### Step 4 — the branch (this is the change)
 
-| `info.type` | branch | tail fed to the builder |
-| --- | --- | --- |
-| `local` | compose direct, no gateway, no credential | — |
-| `proxy` | **new** — compose onto gateway | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
-| `baas`, `desktop` | re-address the provider's URL | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
-| anything else, `url` empty | **new** — named error | — |
-| anything else, `url` present | re-address, or refuse the shape | — |
+Four cases, **tested in this order**:
 
-The two tails are identical, which is the whole point. On the BaaS path the tail
-is what remains after cutting `/proxypass/` off `parts.path`; on the ARCA path it
-is `quote(target) + quote(socket_path)`.
+| # | condition | branch | tail fed to the builder |
+| --- | --- | --- | --- |
+| 1 | `type == "local"` | compose direct — no gateway, no credential | — |
+| 2 | `url` non-empty | re-address the provider's URL (existing guards) | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| 3 | `type in _PROXY_TARGET_TYPES` | **new** — compose onto gateway | `ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| 4 | otherwise | **new** — named error | — |
+
+Worked through the three providers: `baas` takes case 2, `proxy` takes case 3,
+`local` takes case 1. The tails in cases 2 and 3 are identical — that is the
+whole point. On the BaaS path the tail is what remains after cutting
+`/proxypass/` off `parts.path`; on the ARCA path it is
+`quote(target) + quote(socket_path)`.
+
+**Why the URL is tested before the kind.** A URL the provider issued describes a
+routing decision it made; composing over the top would override that decision
+silently. Concretely, this is what makes spec Resolved Question 1 reversible: if
+the ARCA provider ever grows a relay mode, it starts taking case 2 and case 3
+stops being reached, with no change here and no window in which both could apply.
+Ordering it the other way would pin `proxy` to the composed path forever.
+
+This is not the rejected "infer the shape from an absent URL" (spec Resolved
+Question 2). That would have made case 3 the *fallback for everything*, so a
+provider which was supposed to fill `url` and failed would get a plausible URL
+composed for it. Here an unrecognised kind with no URL still falls to case 4.
 
 ### Step 5 — the shared builder
 
@@ -257,26 +272,31 @@ conn_type = str(getattr(info, "type", "") or "")
 if conn_type == "local":
     ...unchanged...
 
+# Preferred over composing whenever the provider issued one: the URL records a
+# routing decision the provider made and we did not.
+if str(getattr(info, "url", "") or ""):
+    return self._readdress_onto_gateway(info, token)
+
 if conn_type in _PROXY_TARGET_TYPES:
     return self._compose_onto_gateway(target, socket_path, token)
 
-return self._readdress_onto_gateway(info, token)
+raise EngineUpstreamError(
+    f"device connection of kind {conn_type!r} carries no relay url and is not a "
+    f"kind this endpoint can compose one for"
+)
 ```
 
-`_readdress_onto_gateway` gains one guard at its top, before the URL is parsed, so
-that an unrecognised kind carrying no URL is named as such instead of borrowing
-the wrong-shape message:
+Reading `url` in `_socket_url` to decide, and again inside
+`_readdress_onto_gateway` to parse, is deliberate: the second read is that
+method's own precondition, and it keeps the method callable on its own terms
+rather than depending on its one caller having checked first. Its existing
+`not parts.path.startswith(_PROXYPASS_PREFIX)` guard therefore now covers only
+URLs that are *present and wrong-shaped* — `wss://host/wsrelay/6f2a…` — which is
+what its message has always described.
 
-```python
-if not url:
-    raise EngineUpstreamError(
-        f"device connection of kind {conn_type!r} carries no relay url and is "
-        f"not a kind this endpoint can compose one for"
-    )
-```
-
-The kind is safe to name here: `@envelope_errors` publishes the fixed string
-`"Engine service error"` and the exception's own message reaches logs only.
+The kind is safe to name in the error: `@envelope_errors` publishes the fixed
+string `"Engine service error"` (`responses.py:260`) and the exception's own
+message reaches logs only.
 
 ### Encoding
 
@@ -305,14 +325,26 @@ asymmetry is deliberate and already present for the local branch.
 
 ## Alternatives Considered
 
-**Make the ARCA provider fill `url` in relay mode.** Rejected — see spec Resolved
-Question 1. Corp-side, and it would need `path` threaded through
-`_compose_device_conn_info`, whose signature does not carry it, to build a URL
-whose origin this endpoint discards anyway.
+**Give the ARCA provider a relay mode, so it returns a finished URL like BaaS.**
+Rejected — see spec Resolved Question 1 for the full reasoning. In short: a relay
+mode is not one contract (BaaS itself issues two incompatible relay shapes, so
+the guard stays either way); the provider would format a URL whose origin and
+routing prefix this endpoint immediately strips to recover values it already
+held; and it lands in a repository where this endpoint's tests cannot verify it,
+leaving bots unserved until a second repo ships. Not permanently excluded — the
+branch ordering above means a relay mode added later is preferred automatically.
 
-**Infer the shape from `url == ""`.** Rejected — see spec Resolved Question 2. It
-would compose a plausible-looking URL for a provider that failed to fill a field
-it was supposed to fill.
+*Correction to an earlier draft of this plan:* this alternative was also argued
+against on the grounds that `path` could not reach the provider without changing
+`_compose_device_conn_info`'s signature. It can — the provider could override
+`get_device_connection` outright, as `BaasDeviceService` does. That argument is
+withdrawn; the three above stand on their own.
+
+**Infer the shape from `url == ""` alone.** Rejected — see spec Resolved
+Question 2. Note this is *not* what the ordering above does: an absent URL sends
+a recognised bare-target kind to the composer, but an unrecognised kind still
+raises. Inferring would have made composition the fallback for everything,
+including a provider that was supposed to fill `url` and failed.
 
 **Inject `SandboxRuntimeClient` and build `{proxy_base}/proxypass/{target}{path}`,
 then re-address it.** Rejected: a new dependency on this service, a network-facing
@@ -338,6 +370,8 @@ existing `_Devices` fake, which already takes `type`/`target`/`token`.
 8. An unrecognised kind with `url=""` raises the new named error, and the message does not carry the credential.
 9. `expires_at` for a `proxy` device falls back to `now + CONNECTION_TTL_SECONDS`.
 10. A `proxy` device with an empty target still raises `"carries no routing target"`.
+11. **Ordering:** a `proxy` device that *does* carry a `/proxypass/…` URL is re-addressed, not composed — the provider's URL wins. Pinned with a URL whose tail differs from `target + path` (e.g. a different port) so the two branches are distinguishable in the assertion.
+12. **Ordering:** a `proxy` device carrying a wrong-shaped URL (`wss://host/wsrelay/6f2a…`) is refused with the wrong-shape message, not quietly composed around.
 
 **Unchanged and must stay green:** the whole existing file, in particular the
 local-branch cases, the `/wsrelay/` wrong-shape refusal, the fragment refusal, the
@@ -353,7 +387,9 @@ to roll back beyond reverting the commit.
 ## Decisions Taken
 
 1. Compose at the point of publication, not in the provider.
-2. Branch on the declared connection kind, not on an absent URL.
+2. Branch on the declared connection kind, not on an absent URL — but test for a
+   provider-supplied URL *first*, so a provider that later starts issuing one is
+   preferred without a change here.
 3. One builder shared by both gateway branches, so they cannot drift.
 4. Accept both `"proxy"` and `"arca"` as the bare-target kind.
 5. Name the unrecognised kind in the error; the HTTP body stays the fixed

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
@@ -159,6 +159,8 @@ URL is assembled.
       proxy already accepts, and is percent-encoded.
 - [ ] The published URL addresses the active engine's own socket path.
 - [ ] The published expiry bounds the credential the response actually carries.
+- [ ] Where a provider supplies a URL of its own, that URL is used — composing
+      happens only where none was supplied.
 - [ ] A provider shape the endpoint still cannot serve fails with a named error
       that says the provider's connection kind was not recognised, rather than
       describing a missing URL.
@@ -197,16 +199,37 @@ URL is assembled.
 
 ## Resolved Questions
 
-1. **Should the fix live in the ARCA provider instead — make it issue a finished
-   URL like BaaS does?** *Resolved 2026-08-06: no.* Three reasons. The provider is
-   in a separate repository, so the fix would land where this endpoint's tests
-   cannot see it. The URL it produced would name the engine proxy, whose origin
-   this endpoint discards and replaces with the gateway's — so the provider would
-   be doing work purely to have it thrown away. And the in-device path, which the
-   URL has to embed, is not something the provider is given: it would need a new
-   parameter threaded through a shared base method that currently drops it.
-   Assembling at the point of publication is both smaller and closer to where the
-   knowledge already is.
+1. **Should the fix live in the ARCA provider instead — give it a relay mode that
+   issues a finished URL like BaaS does?** *Resolved 2026-08-06: no.* Three
+   reasons.
+
+   *A relay mode is not one contract.* BaaS already issues two different relay
+   shapes — a routing-target URL for a sandbox-backed device, and a
+   session-keyed one for its LOCAL platform, which cannot be re-addressed onto
+   the gateway at all. Teaching a second provider to issue relay URLs adds a
+   third producer of a shape this endpoint has to guard anyway. It moves the
+   branching rather than removing it.
+
+   *The information would travel backwards.* The provider would look up the
+   engine proxy's address and format a URL around it; this endpoint would then
+   discard that origin, strip the proxy's routing prefix, and recover the
+   routing target and in-device path it already held. Formatting a string purely
+   so the other side can take it apart again is not a contract, it is a round
+   trip.
+
+   *It would land where this endpoint cannot be tested.* The provider is in a
+   separate repository. The fix would be verified by hand in a deployed
+   environment rather than by the tests that cover this endpoint, and bots stay
+   unserved until a second repository ships.
+
+   *Withdrawn from this reasoning:* an earlier draft argued the provider could
+   not receive the in-device path without a change to a shared base method's
+   signature. That is avoidable — the provider could override the connection
+   method outright, as the BaaS provider already does, and receive the path
+   directly. The objection does not hold and is not part of this decision.
+
+   *Not mutually exclusive.* See Resolved Question 4: the ordering chosen means a
+   relay mode added later needs no change here.
 
 2. **Should the endpoint identify the ARCA shape by the connection kind the
    provider declares, or by noticing that no URL was returned?** *Resolved
@@ -222,6 +245,15 @@ URL is assembled.
    feature covers a case that question did not consider: a provider that returns
    **no URL at all**, by design, because assembling one was never its job. The
    guard on wrong-shaped URLs is unchanged.
+
+4. **If a provider of the bare-target kind ever does supply a URL, which wins?**
+   *Resolved 2026-08-06: the provider's URL.* A URL the provider took the trouble
+   to issue describes a routing decision it made and we did not; composing our own
+   over the top would override that decision silently. Deciding it now, rather
+   than when it happens, is what makes Resolved Question 1 reversible at no cost:
+   should the ARCA provider grow a relay mode later, its URL is preferred
+   automatically and the composed path simply stops being reached — no change to
+   this endpoint, and no window in which both could apply.
 
 ## Open Questions
 

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
@@ -145,28 +145,28 @@ URL is assembled.
 
 ## Acceptance Criteria
 
-- [ ] A bot whose device is owned by the ARCA provider gets a published socket
+- [x] A bot whose device is owned by the ARCA provider gets a published socket
       URL instead of an upstream error.
-- [ ] For the same routing target, engine path and credential, the URL published
+- [x] For the same routing target, engine path and credential, the URL published
       for an ARCA-provider bot is byte-for-byte the URL published for a
       BaaS-provider bot.
-- [ ] The published URL addresses the gateway. It does not name the engine proxy,
+- [x] The published URL addresses the gateway. It does not name the engine proxy,
       and does not carry the proxy's own routing prefix.
-- [ ] The routing target reaches the published URL unchanged, including the `@`
+- [x] The routing target reaches the published URL unchanged, including the `@`
       and `:` its format uses, so that the credential's claim over that target
       still matches.
-- [ ] The credential is carried as a query parameter under the parameter name the
+- [x] The credential is carried as a query parameter under the parameter name the
       proxy already accepts, and is percent-encoded.
-- [ ] The published URL addresses the active engine's own socket path.
-- [ ] The published expiry bounds the credential the response actually carries.
-- [ ] Where a provider supplies a URL of its own, that URL is used — composing
+- [x] The published URL addresses the active engine's own socket path.
+- [x] The published expiry bounds the credential the response actually carries.
+- [x] Where a provider supplies a URL of its own, that URL is used — composing
       happens only where none was supplied.
-- [ ] A provider shape the endpoint still cannot serve fails with a named error
+- [x] A provider shape the endpoint still cannot serve fails with a named error
       that says the provider's connection kind was not recognised, rather than
       describing a missing URL.
-- [ ] The BaaS and local paths are unchanged: same published URL, same errors, for
+- [x] The BaaS and local paths are unchanged: same published URL, same errors, for
       every input that reaches them today.
-- [ ] A device the provider reports as unavailable, a bot of an unsupported type,
+- [x] A device the provider reports as unavailable, a bot of an unsupported type,
       and a shared bot are all refused exactly as they are today, on every
       provider.
 

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/spec.md
@@ -1,0 +1,229 @@
+# Connection Endpoint — Serving Bots on the ARCA Provider
+
+## Summary
+
+The public connection endpoint hands a tenant a finished chat-socket URL for one
+of their bots. It works for bots whose device is owned by the BaaS provider and
+fails for every bot whose device is owned by the ARCA provider — not
+occasionally, but on every request, because the endpoint was built against one
+provider's way of describing a connection and ARCA describes it a different way.
+
+The two providers agree on the two facts that matter — *which device to route to*
+and *what credential opens it* — and disagree only on who assembles those into a
+URL. BaaS assembles one server-side and hands it over finished. ARCA hands over
+the parts and expects the caller to assemble them, which is what every other
+caller in the platform already does. This feature teaches the endpoint the second
+shape, so that the socket it publishes is the same socket regardless of which
+provider owns the device behind it.
+
+## Motivation
+
+**Half the fleet cannot use the endpoint at all.** Which provider owns a bot's
+device is decided when the bot is created, by a rollout policy that is being
+migrated provider by provider. A tenant cannot see that decision, cannot
+influence it, and has no way to tell from the outside why the same API call
+succeeds for one of their bots and fails for another. What they observe is an
+upstream error on a bot that is running and healthy.
+
+**The failure is silent about its cause.** The endpoint refuses to publish an
+address it cannot re-address onto the gateway, which is the right instinct — but
+the resulting message describes the *symptom* (there was no relay URL to work
+with) rather than the situation (this provider does not issue one, by design).
+Nothing in the response, and nothing short of reading the provider's source,
+tells an operator that the bot is on a provider the endpoint never learned to
+serve.
+
+**The missing piece is already the platform's normal case.** Assembling
+`/proxypass/{target}{path}` from a routing target is not a new behaviour to
+invent. The internal console frontend does it, the shared connection helper does
+it, and the BaaS layer itself does it server-side. The endpoint is the odd one
+out for expecting the URL pre-built, and the gateway that fronts it already
+routes exactly the targets ARCA produces.
+
+**The two shapes converge anyway.** In production today, a BaaS-provider device
+is very often an ARCA sandbox underneath: the URL BaaS returns carries an
+`ARCA_…`-prefixed routing target, and after the endpoint re-addresses that URL
+onto the gateway, the published result is the same grammar the ARCA provider
+would have produced from its own target. The endpoint is already publishing ARCA
+targets successfully; it just cannot do so when ARCA is the provider rather than
+BaaS's backend.
+
+## Worked examples
+
+Every example below uses one bot: `bot_id=b_01k2f9`, owner `staff-9931`, active
+engine `openclaw`, device on port `20003`, sandbox `ARCA-SANDBOX-abc123` with
+tenant-alt suffix `@0`.
+
+### What the provider gives the endpoint
+
+**BaaS provider — works today.** BaaS builds the URL server-side and returns it
+whole:
+
+| field | value |
+| --- | --- |
+| `type` | `baas` |
+| `target` | `ARCA_ARCA-SANDBOX-abc123@0:20003` |
+| `token` | `eyJhbGciOiJIUzI1NiIs…` |
+| `url` | `wss://agentclawproxy-prod.example.com/proxypass/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws` |
+| `engine_type` | `openclaw` |
+| `expires_at` | `2026-08-06T12:02:00Z` |
+
+**ARCA provider — fails today.** ARCA returns the parts and no URL:
+
+| field | value |
+| --- | --- |
+| `type` | `proxy` |
+| `target` | `ARCA_ARCA-SANDBOX-abc123@0:20003` |
+| `token` | `eyJhbGciOiJIUzI1NiIs…` |
+| `url` | *(empty)* |
+| `engine_type` | `openclaw` |
+| `expires_at` | *(empty)* |
+
+**Local provider — works today.** A device on the caller's own machine, reached
+directly with no credential:
+
+| field | value |
+| --- | --- |
+| `type` | `local` |
+| `target` | `127.0.0.1:20003` |
+| `token` | *(empty)* |
+| `url` | *(not consulted)* |
+
+### What the endpoint must publish
+
+For the BaaS row, today and unchanged:
+
+```
+wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…
+```
+
+For the ARCA row, the same string — this feature's whole outcome:
+
+```
+wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…
+```
+
+For the local row, today and unchanged:
+
+```
+ws://127.0.0.1:20003/api/openclaw/ws
+```
+
+The BaaS and ARCA results being identical is the point: the same bot, moved
+between providers, must present the tenant with the same socket.
+
+### The same bot on a `claude_code` engine
+
+The engine decides the in-device path, so on ARCA the published URL becomes:
+
+```
+wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/claude_code/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…
+```
+
+This matters because the engine closes a socket whose pinned engine is not the
+active one. On the BaaS path the provider is told which path to bake in; on the
+ARCA path it is not told, and cannot be, so the path has to be applied where the
+URL is assembled.
+
+## User Stories
+
+- As an external tenant, I want the connection endpoint to answer for every bot I
+  own, so that which internal provider happens to host a bot is not something I
+  can observe or have to work around.
+- As an external tenant, I want the socket URL for a given bot to be the same
+  shape whichever provider hosts it, so that my integration does not branch on a
+  fact we never published to it.
+- As an external tenant on a non-default engine, I want the URL I am given to
+  address my bot's own engine socket, so that the connection is not closed
+  immediately after it opens.
+- As an operator, I want a bot on a provider this endpoint cannot serve to fail
+  with a message naming that situation, so that I am not left reading provider
+  source to explain an upstream error on a healthy bot.
+- As the team operating the platform, I want the credential and routing target to
+  reach the published URL exactly as the provider issued them, so that the proxy's
+  check that the two agree cannot fail on a value we reshaped in transit.
+
+## Acceptance Criteria
+
+- [ ] A bot whose device is owned by the ARCA provider gets a published socket
+      URL instead of an upstream error.
+- [ ] For the same routing target, engine path and credential, the URL published
+      for an ARCA-provider bot is byte-for-byte the URL published for a
+      BaaS-provider bot.
+- [ ] The published URL addresses the gateway. It does not name the engine proxy,
+      and does not carry the proxy's own routing prefix.
+- [ ] The routing target reaches the published URL unchanged, including the `@`
+      and `:` its format uses, so that the credential's claim over that target
+      still matches.
+- [ ] The credential is carried as a query parameter under the parameter name the
+      proxy already accepts, and is percent-encoded.
+- [ ] The published URL addresses the active engine's own socket path.
+- [ ] The published expiry bounds the credential the response actually carries.
+- [ ] A provider shape the endpoint still cannot serve fails with a named error
+      that says the provider's connection kind was not recognised, rather than
+      describing a missing URL.
+- [ ] The BaaS and local paths are unchanged: same published URL, same errors, for
+      every input that reaches them today.
+- [ ] A device the provider reports as unavailable, a bot of an unsupported type,
+      and a shared bot are all refused exactly as they are today, on every
+      provider.
+
+## In Scope
+
+- The socket URL the public connection endpoint publishes for a bot whose device
+  is owned by the ARCA provider.
+- The error raised for a provider connection shape the endpoint does not
+  recognise.
+
+## Out of Scope
+
+- **The ARCA provider itself.** It already returns everything needed. It gains no
+  awareness of this endpoint, no relay mode, and no URL-building duty. The
+  provider lives outside this repository and this feature must not require a
+  change there.
+- **The BaaS and local paths.** Both work; neither changes behaviour.
+- **The gateway's routing.** The gateway already serves these targets under the
+  published prefix. No gateway configuration changes.
+- **The credential.** Its issuer, signature, lifetime, and the fact that it is
+  checked once at handshake are all unchanged.
+- **Device liveness on the ARCA path.** ARCA does not report whether the sandbox
+  is reachable, so a URL for a stopped device will fail at handshake rather than
+  being refused up front. That is today's behaviour for every other ARCA caller
+  and is not repaired here.
+- **The internal console, and every other caller that assembles its own proxy
+  URL.** Untouched.
+- **The multi-instance, service-bot, and shared-bot surfaces.** This endpoint
+  serves private personal bots only, and that gate is unchanged.
+
+## Resolved Questions
+
+1. **Should the fix live in the ARCA provider instead — make it issue a finished
+   URL like BaaS does?** *Resolved 2026-08-06: no.* Three reasons. The provider is
+   in a separate repository, so the fix would land where this endpoint's tests
+   cannot see it. The URL it produced would name the engine proxy, whose origin
+   this endpoint discards and replaces with the gateway's — so the provider would
+   be doing work purely to have it thrown away. And the in-device path, which the
+   URL has to embed, is not something the provider is given: it would need a new
+   parameter threaded through a shared base method that currently drops it.
+   Assembling at the point of publication is both smaller and closer to where the
+   knowledge already is.
+
+2. **Should the endpoint identify the ARCA shape by the connection kind the
+   provider declares, or by noticing that no URL was returned?** *Resolved
+   2026-08-06: by the declared kind.* Inferring from an absent URL would silently
+   assemble something for any provider that fails to fill the field, including one
+   that was supposed to and did not — turning a bug into a plausible-looking URL
+   that fails at handshake. Naming the shape keeps the unrecognised case loud.
+
+3. **Does this reopen the earlier decision that a provider URL the endpoint cannot
+   re-address is refused?** *Resolved 2026-08-06: no — it amends its scope.* The
+   2026-07-31 spec's Resolved Question 3 asked whether a provider might return a
+   *differently shaped URL*, and the answer — refuse it — still stands. This
+   feature covers a case that question did not consider: a provider that returns
+   **no URL at all**, by design, because assembling one was never its job. The
+   guard on wrong-shaped URLs is unchanged.
+
+## Open Questions
+
+None. The provider's return shape is known, the gateway route already exists, and
+the target grammar is already published through the BaaS path.

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
@@ -68,15 +68,23 @@ lossless.
   byte-identical to what `_readdress_onto_gateway` produces for the same target
   and path, because the origin is discarded there either way.
 - In `_socket_url` (`connection.py:341-358`): read the connection kind once into
-  `conn_type`, keep the `local` branch exactly as it is, and add
-  `if conn_type in _PROXY_TARGET_TYPES: return self._compose_onto_gateway(target, socket_path, token)`
-  before the fall-through to `_readdress_onto_gateway`.
-- Extend the method's docstring from two shapes to three, naming which provider
-  produces each.
+  `conn_type`, keep the `local` branch exactly as it is, then order the remaining
+  cases as `plan.md` "Step 4" specifies —
+  **(2)** a non-empty `info.url` → `_readdress_onto_gateway`;
+  **(3)** `conn_type in _PROXY_TARGET_TYPES` → `_compose_onto_gateway`;
+  **(4)** anything else → the named error (Task 4).
+- Record in a comment why case 2 precedes case 3: a URL the provider issued
+  records a routing decision it made, and this ordering is what lets a
+  provider-side relay mode added later take over with no change here.
+- Extend the method's docstring from two shapes to four cases, naming which
+  provider takes each.
 
 **Worked check.** `_Devices(type="proxy", target="ARCA_ARCA-SANDBOX-abc123@0:20003", token="eyJ…")`
 on an `openclaw` bot yields the expected URL above. The same fake on a
-`claude_code` bot yields the same URL with `/api/claude_code/ws`.
+`claude_code` bot yields the same URL with `/api/claude_code/ws`. The same fake
+with `url="wss://agentclawproxy-prod.example.com/proxypass/ARCA_OTHER@0:20099/api/openclaw/ws"`
+yields the **provider's** target (`ARCA_OTHER@0:20099`), not the composed one —
+that is case 2 winning.
 
 **Verify.** `pytest tests/community/core/engine_runtime/test_connection.py` still
 green (no existing case uses `type="proxy"`).
@@ -85,14 +93,16 @@ green (no existing case uses `type="proxy"`).
 
 ## Task 4: Name the unrecognised connection kind  `[ ]`
 
-- At the top of `_readdress_onto_gateway`, after reading `url` and before parsing
-  it, refuse an empty `url` with a message naming the kind:
-  `f"device connection of kind {conn_type!r} carries no relay url and is not a kind this endpoint can compose one for"`.
-  Pass the kind in, or re-read it from `info` — whichever keeps the method's
-  signature honest about what it needs.
-- Leave the wrong-shape message (`"…no relay url this endpoint can re-address…"`)
-  for a URL that is present but not `/proxypass/`-shaped, e.g. BaaS LOCAL's
-  `wss://host/wsrelay/6f2a…`. The two situations now read differently in a log.
+- Add case 4 of `_socket_url` as the method's final statement: raise
+  `EngineUpstreamError(f"device connection of kind {conn_type!r} carries no relay url and is not a kind this endpoint can compose one for")`.
+  It is reached only when the kind is not `local`, not a bare-target kind, and no
+  URL was supplied.
+- Leave `_readdress_onto_gateway` and its guards alone. Its wrong-shape message
+  (`"…no relay url this endpoint can re-address…"`) now describes only URLs that
+  are *present and unmappable* — e.g. BaaS LOCAL's `wss://host/wsrelay/6f2a…` —
+  which is what it always meant. Its own empty-`url` path stays reachable in
+  principle, so do not delete that guard; the two situations simply read
+  differently in a log now.
 - Do not touch the `responses.py` mapping: the published body stays
   `502 "Engine service error"`, and the kind reaches logs only.
 
@@ -136,6 +146,12 @@ existing local-branch cases, using the reference values above.
       publish the identical string.
 - [ ] An unrecognised kind with `url=""` raises the new named error; the message
       carries the kind and not the credential.
+- [ ] **Ordering:** a `proxy` device that *also* carries a `/proxypass/…` URL is
+      re-addressed, not composed. Give the URL a tail that differs from
+      `target + socket_path` (a different port, say `ARCA_OTHER@0:20099`) so the
+      assertion can tell the two branches apart.
+- [ ] **Ordering:** a `proxy` device carrying `wss://host/wsrelay/6f2a…` is
+      refused with the wrong-shape message rather than quietly composed around.
 - [ ] `expires_at` on a `proxy` device (which reports none) is `now + 7200s`.
 - [ ] A `proxy` device with an empty target still raises
       `"device connection carries no routing target"`.

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
@@ -128,34 +128,34 @@ would break it.
 
 ---
 
-## Task 6: Tests  `[ ]`
+## Task 6: Tests  `[x]`
 
 Add to `tests/community/core/engine_runtime/test_connection.py`, beside the
 existing local-branch cases, using the reference values above.
 
-- [ ] A `proxy` device publishes the expected gateway URL, in full.
-- [ ] The published URL contains neither the engine proxy's host nor `/proxypass/`.
-- [ ] The target segment survives verbatim: `@` and `:` are not percent-encoded.
-- [ ] A bracketed target keeps its brackets.
-- [ ] The engine's own path is used — `claude_code` → `/api/claude_code/ws`.
-- [ ] A `proxy` device with an empty token publishes no query string.
-- [ ] A credential containing reserved characters is percent-encoded.
-- [ ] Composed and re-addressed branches agree byte-for-byte: a `proxy` device and
+- [x] A `proxy` device publishes the expected gateway URL, in full.
+- [x] The published URL contains neither the engine proxy's host nor `/proxypass/`.
+- [x] The target segment survives verbatim: `@` and `:` are not percent-encoded.
+- [x] A bracketed target keeps its brackets.
+- [x] The engine's own path is used — `claude_code` → `/api/claude_code/ws`.
+- [x] A `proxy` device with an empty token publishes no query string.
+- [x] A credential containing reserved characters is percent-encoded.
+- [x] Composed and re-addressed branches agree byte-for-byte: a `proxy` device and
       a `baas` device whose `url` is
       `wss://agentclawproxy-prod.example.com/proxypass/{same target}{same path}`
       publish the identical string.
-- [ ] An unrecognised kind with `url=""` raises the new named error; the message
+- [x] An unrecognised kind with `url=""` raises the new named error; the message
       carries the kind and not the credential.
-- [ ] **Ordering:** a `proxy` device that *also* carries a `/proxypass/…` URL is
+- [x] **Ordering:** a `proxy` device that *also* carries a `/proxypass/…` URL is
       re-addressed, not composed. Give the URL a tail that differs from
       `target + socket_path` (a different port, say `ARCA_OTHER@0:20099`) so the
       assertion can tell the two branches apart.
-- [ ] **Ordering:** a `proxy` device carrying `wss://host/wsrelay/6f2a…` is
+- [x] **Ordering:** a `proxy` device carrying `wss://host/wsrelay/6f2a…` is
       refused with the wrong-shape message rather than quietly composed around.
-- [ ] `expires_at` on a `proxy` device (which reports none) is `now + 7200s`.
-- [ ] A `proxy` device with an empty target still raises
+- [x] `expires_at` on a `proxy` device (which reports none) is `now + 7200s`.
+- [x] A `proxy` device with an empty target still raises
       `"device connection carries no routing target"`.
-- [ ] An unencodable (lone-surrogate) target on a `proxy` device is named, not a
+- [x] An unencodable (lone-surrogate) target on a `proxy` device is named, not a
       500 — extend the existing parametrised case rather than writing a new one.
 
 **Verify.** `pytest tests/community/core/engine_runtime/test_connection.py` and

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
@@ -1,0 +1,179 @@
+# Tasks: Connection Endpoint — Serving Bots on the ARCA Provider
+
+Spec: `spec.md` · Plan: `plan.md`
+
+Every task below touches exactly two files:
+
+- `src/backend/src/agentclaw/community/core/engine_runtime/connection.py`
+- `src/backend/tests/community/core/engine_runtime/test_connection.py`
+
+Reference values used throughout (from `plan.md`, "Worked trace"):
+
+| name | value |
+| --- | --- |
+| target | `ARCA_ARCA-SANDBOX-abc123@0:20003` |
+| credential | `eyJhbGciOiJIUzI1NiIs…` |
+| socket path | `/api/openclaw/ws` |
+| gateway base | `https://gateway.example.com` |
+| expected URL | `wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…` |
+
+---
+
+## Task 1: Extract the shared gateway-URL builder  `[ ]`
+
+Pure refactor. No behaviour change, no new branch yet.
+
+- Add `_gateway_url(self, tail: str, query: str, token: str) -> str` holding the
+  last five lines of `_readdress_onto_gateway` (`connection.py:415-424`): append
+  the percent-encoded credential to `query`, prefix `_gateway_ws_base()` +
+  `_ENGINE_PREFIX` + `/` onto `tail`, join with `?` only when there is a query.
+- Replace those lines in `_readdress_onto_gateway` with
+  `return self._gateway_url(parts.path[len(_PROXYPASS_PREFIX):], parts.query, token)`.
+- Carry the existing comments with the code they explain — in particular why the
+  credential is *appended* to a provider query rather than assigned, and why an
+  absent credential publishes no empty parameter.
+
+**Worked check.** With `tail="ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws"`,
+`query=""`, `token="eyJhbGciOiJIUzI1NiIs…"` the builder returns the expected URL
+above. With `query="mode=chat"` it returns
+`…/api/openclaw/ws?mode=chat&x-proxypass-token=eyJ…`. With `token=""` it returns
+the URL with no `?` at all.
+
+**Verify.** `pytest tests/community/core/engine_runtime/test_connection.py` — the
+whole existing file passes untouched. This is the guard that the extraction was
+lossless.
+
+---
+
+## Task 2: Name the bare-target connection kinds  `[ ]`
+
+- Add `_PROXY_TARGET_TYPES = frozenset({"proxy", "arca"})` beside
+  `_PROXYPASS_PREFIX` (`connection.py:84`).
+- Document, in the constant's comment: that the corp `ArcaDeviceService` answers
+  `"proxy"`; that these providers return a bare routing target plus a signed
+  credential and no URL; that `get_device_connection_v2` (`device_service.py:1776`)
+  and `connectionStore.ts:177` already assemble `/proxypass/{target}{path}` from
+  the same two values; and why both spellings are accepted.
+
+**Verify.** Nothing to run — the constant is unused until Task 3. Lint clean.
+
+---
+
+## Task 3: Compose the gateway URL for a bare routing target  `[ ]`
+
+- Add `_compose_onto_gateway(self, target: str, socket_path: str, token: str) -> str`:
+  `_quote_or_reject(target, safe="@:[]", what="routing target")` +
+  `_quote_or_reject(socket_path, safe="/", what="socket path")` as the tail, an
+  empty query, then `_gateway_url`. State in the docstring that the result is
+  byte-identical to what `_readdress_onto_gateway` produces for the same target
+  and path, because the origin is discarded there either way.
+- In `_socket_url` (`connection.py:341-358`): read the connection kind once into
+  `conn_type`, keep the `local` branch exactly as it is, and add
+  `if conn_type in _PROXY_TARGET_TYPES: return self._compose_onto_gateway(target, socket_path, token)`
+  before the fall-through to `_readdress_onto_gateway`.
+- Extend the method's docstring from two shapes to three, naming which provider
+  produces each.
+
+**Worked check.** `_Devices(type="proxy", target="ARCA_ARCA-SANDBOX-abc123@0:20003", token="eyJ…")`
+on an `openclaw` bot yields the expected URL above. The same fake on a
+`claude_code` bot yields the same URL with `/api/claude_code/ws`.
+
+**Verify.** `pytest tests/community/core/engine_runtime/test_connection.py` still
+green (no existing case uses `type="proxy"`).
+
+---
+
+## Task 4: Name the unrecognised connection kind  `[ ]`
+
+- At the top of `_readdress_onto_gateway`, after reading `url` and before parsing
+  it, refuse an empty `url` with a message naming the kind:
+  `f"device connection of kind {conn_type!r} carries no relay url and is not a kind this endpoint can compose one for"`.
+  Pass the kind in, or re-read it from `info` — whichever keeps the method's
+  signature honest about what it needs.
+- Leave the wrong-shape message (`"…no relay url this endpoint can re-address…"`)
+  for a URL that is present but not `/proxypass/`-shaped, e.g. BaaS LOCAL's
+  `wss://host/wsrelay/6f2a…`. The two situations now read differently in a log.
+- Do not touch the `responses.py` mapping: the published body stays
+  `502 "Engine service error"`, and the kind reaches logs only.
+
+**Verify.** Existing wrong-shape cases (`/wsrelay/`, unparseable URL, fragment)
+still raise their original messages.
+
+---
+
+## Task 5: Correct the stale comment on the provider call  `[ ]`
+
+`_get_connection` (`connection.py:285-308`) claims that leaving `ws_conn_mode`
+unset is what makes a provider hand back a bare routing target, and that `path` is
+baked into the URL by the provider. Both are BaaS-only facts. Amend to record:
+ARCA returns a bare target regardless of the mode, and never sees `path` at all —
+the base `get_device_connection` does not forward it to `_compose_device_conn_info`
+(`device_service.py:1031`) — which is why the composed branch appends the engine
+path itself.
+
+Keep both arguments on the call: they are correct for BaaS and removing either
+would break it.
+
+**Verify.** Comment-only. Full test file green.
+
+---
+
+## Task 6: Tests  `[ ]`
+
+Add to `tests/community/core/engine_runtime/test_connection.py`, beside the
+existing local-branch cases, using the reference values above.
+
+- [ ] A `proxy` device publishes the expected gateway URL, in full.
+- [ ] The published URL contains neither the engine proxy's host nor `/proxypass/`.
+- [ ] The target segment survives verbatim: `@` and `:` are not percent-encoded.
+- [ ] A bracketed target keeps its brackets.
+- [ ] The engine's own path is used — `claude_code` → `/api/claude_code/ws`.
+- [ ] A `proxy` device with an empty token publishes no query string.
+- [ ] A credential containing reserved characters is percent-encoded.
+- [ ] Composed and re-addressed branches agree byte-for-byte: a `proxy` device and
+      a `baas` device whose `url` is
+      `wss://agentclawproxy-prod.example.com/proxypass/{same target}{same path}`
+      publish the identical string.
+- [ ] An unrecognised kind with `url=""` raises the new named error; the message
+      carries the kind and not the credential.
+- [ ] `expires_at` on a `proxy` device (which reports none) is `now + 7200s`.
+- [ ] A `proxy` device with an empty target still raises
+      `"device connection carries no routing target"`.
+- [ ] An unencodable (lone-surrogate) target on a `proxy` device is named, not a
+      500 — extend the existing parametrised case rather than writing a new one.
+
+**Verify.** `pytest tests/community/core/engine_runtime/test_connection.py` and
+`pytest tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py`
+both green.
+
+---
+
+## Task 7: Verification against the spec  `[ ]`
+
+- Walk each acceptance criterion in `spec.md` and tick it, or record why not.
+- Run the module gates the pre-push contract requires
+  (`AGENTS.md` → `Pre-push Module Selection`; `OCB_PRE_PUSH_RUN_CI=1` for the full
+  set), with `REL20260806` as the merge target.
+- Confirm nothing outside `connection.py` and its test file changed:
+  `git diff --stat origin/REL20260806`.
+
+---
+
+## Groups
+
+| group | tasks | why together |
+| --- | --- | --- |
+| A — refactor | 1 | Lossless extraction, proved by the untouched suite. Lands green on its own. |
+| B — the fix | 2, 3, 4, 5 | The new branch, its constant, its error, and the comment that described the old two-shape world. Meaningless apart. |
+| C — proof | 6, 7 | Tests and spec verification. |
+
+## Notes for the implementer
+
+- **Do not** inject `SandboxRuntimeClient`. The proxy base URL would be fetched
+  only to be discarded — see `plan.md`, "Why no ARCA-side or configuration change
+  is needed".
+- **Do not** re-encode the BaaS path. Only the composed branch encodes, because
+  only it builds from raw values.
+- **Do not** parse the target. `ARCA_{id}@{alt}:{port}` and `ARCA_{id}:{port}` are
+  both valid and both opaque to this service; the proxy checks the credential's
+  claim against the whole string.

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
@@ -164,7 +164,7 @@ both green.
 
 ---
 
-## Task 7: Verification against the spec  `[ ]`
+## Task 7: Verification against the spec  `[x]`
 
 - Walk each acceptance criterion in `spec.md` and tick it, or record why not.
 - Run the module gates the pre-push contract requires
@@ -193,3 +193,38 @@ both green.
 - **Do not** parse the target. `ARCA_{id}@{alt}:{port}` and `ARCA_{id}:{port}` are
   both valid and both opaque to this service; the proxy checks the credential's
   claim against the whole string.
+
+---
+
+## Verification record (Task 7)
+
+**Acceptance criteria** — all ten hold, each pinned by a named test in
+`tests/community/core/engine_runtime/test_connection.py`:
+
+| criterion | test |
+| --- | --- |
+| ARCA bot gets a URL, not a 502 | `test_a_bare_target_provider_gets_a_composed_gateway_url` |
+| byte-identical to the BaaS path | `test_composing_and_readdressing_agree_byte_for_byte` |
+| addresses the gateway, names no proxy | `test_a_composed_url_never_names_the_hop_behind_the_gateway` |
+| target survives unchanged | `test_a_composed_target_segment_survives_verbatim` |
+| credential as an encoded query param | `test_a_composed_credential_is_percent_encoded` |
+| the active engine's path | `test_a_composed_url_addresses_the_bots_own_engine` |
+| expiry bounds the published credential | `test_a_composed_expiry_falls_back_to_the_requested_ttl` |
+| a provider url wins over composing | `test_a_provider_url_wins_over_composing_one` |
+| unrecognised kind named, not misdescribed | `test_an_unrecognised_connection_kind_is_named` |
+| BaaS / local / gating unchanged | the 59 pre-existing cases, untouched |
+
+**Runs.** `test_connection.py` 76 passed. `core/engine_runtime` +
+`adapters/http/openapi_v1` + `architecture` + `core/devices` 1358 passed.
+`ruff check` clean on both changed files. The pre-push contract's
+`python_sast_local.sh` gate passed against `origin/REL20260806`.
+
+**Not run here.** `scripts/ci_test.sh` runs all 10 836 `tests/community` cases
+under `--cov` over the whole source tree. In this sandbox that does not finish:
+collection alone takes ~37 s uninstrumented and over 20 minutes under coverage,
+and unrelated suites stall on network egress through the agent proxy. The
+change touches one file whose only consumers are the connection router and this
+test module, so the blast radius above is covered; the full gate runs on CI.
+
+**Diff scope.** `git diff --stat origin/REL20260806` — `connection.py`,
+`test_connection.py`, and this feature's three artifacts. Nothing else.

--- a/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
+++ b/src/backend/specs/2026-08-06-connection-endpoint-arca-provider/tasks.md
@@ -19,7 +19,7 @@ Reference values used throughout (from `plan.md`, "Worked trace"):
 
 ---
 
-## Task 1: Extract the shared gateway-URL builder  `[ ]`
+## Task 1: Extract the shared gateway-URL builder  `[x]`
 
 Pure refactor. No behaviour change, no new branch yet.
 
@@ -45,7 +45,7 @@ lossless.
 
 ---
 
-## Task 2: Name the bare-target connection kinds  `[ ]`
+## Task 2: Name the bare-target connection kinds  `[x]`
 
 - Add `_PROXY_TARGET_TYPES = frozenset({"proxy", "arca"})` beside
   `_PROXYPASS_PREFIX` (`connection.py:84`).
@@ -59,7 +59,7 @@ lossless.
 
 ---
 
-## Task 3: Compose the gateway URL for a bare routing target  `[ ]`
+## Task 3: Compose the gateway URL for a bare routing target  `[x]`
 
 - Add `_compose_onto_gateway(self, target: str, socket_path: str, token: str) -> str`:
   `_quote_or_reject(target, safe="@:[]", what="routing target")` +
@@ -91,7 +91,7 @@ green (no existing case uses `type="proxy"`).
 
 ---
 
-## Task 4: Name the unrecognised connection kind  `[ ]`
+## Task 4: Name the unrecognised connection kind  `[x]`
 
 - Add case 4 of `_socket_url` as the method's final statement: raise
   `EngineUpstreamError(f"device connection of kind {conn_type!r} carries no relay url and is not a kind this endpoint can compose one for")`.
@@ -111,7 +111,7 @@ still raise their original messages.
 
 ---
 
-## Task 5: Correct the stale comment on the provider call  `[ ]`
+## Task 5: Correct the stale comment on the provider call  `[x]`
 
 `_get_connection` (`connection.py:285-308`) claims that leaving `ws_conn_mode`
 unset is what makes a provider hand back a bare routing target, and that `path` is

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -83,6 +83,23 @@ _ENGINE_PREFIX = "/openapi/v1/bots/messages/ws"
 #: for :data:`_ENGINE_PREFIX` — see :meth:`_readdress_onto_gateway`.
 _PROXYPASS_PREFIX = "/proxypass/"
 
+#: Connection kinds whose provider returns a *bare* routing target and a signed
+#: proxypass credential, and leaves the URL for the caller to assemble.
+#:
+#: The ARCA provider answers ``"proxy"``: it composes no URL in any mode, and is
+#: never handed the in-device path to bake into one (the base
+#: ``get_device_connection`` does not forward ``path`` to
+#: ``_compose_device_conn_info``). ``"arca"`` is accepted beside it because that
+#: is the ``device_provider`` key the same device carries everywhere else, and a
+#: provider spelling one where the other was meant should not be the difference
+#: between a socket and a 502.
+#:
+#: Assembling here is the platform's normal case rather than a special one:
+#: ``DeviceService.get_device_connection_v2`` and the internal console's frontend
+#: each build ``/proxypass/{target}{path}`` for themselves out of exactly these
+#: two values. This surface builds the same thing addressed to the gateway.
+_PROXY_TARGET_TYPES = frozenset({"proxy", "arca"})
+
 #: WebSocket scheme for each scheme a gateway base url may be configured with.
 #: ``ws``/``wss`` are accepted so a deployment that spells the base out as a
 #: socket origin is not rejected for being explicit.
@@ -290,18 +307,28 @@ class EngineConnectionService:
             binding_id=binding_id,
             operator=operator,
             ttl=CONNECTION_TTL_SECONDS,
-            # Relay is the mode that yields a *finished* WebSocket URL, which is
-            # what this endpoint re-addresses onto the gateway. Leaving the mode
-            # unset makes the provider hand back a bare routing target instead,
-            # and there would be nothing to re-address. Asking once also keeps
-            # the URL and the credential describing the same mode.
+            # Both arguments below are meaningful to the BaaS provider and inert
+            # elsewhere. They are passed unconditionally because this call site
+            # does not know which provider answers it, and because getting them
+            # to BaaS is what makes its answer re-addressable at all.
+            #
+            # Relay is the mode in which BaaS yields a *finished* WebSocket URL.
+            # Left unset, it hands back a bare routing target and there would be
+            # nothing to re-address. Asking once also keeps the URL and the
+            # credential describing the same mode. A bare-target provider returns
+            # a bare target either way — the mode does not reach its decision.
             ws_conn_mode=_RELAY_MODE,
-            # The provider bakes this path *into* the relay URL, and that URL is
-            # what a caller ends up connecting to, so it has to be the bot's own
-            # engine path. The provider default is openclaw's, and the engine
-            # closes a socket whose pinned engine is not the active one (code
-            # 4001) — a claude_code bot handed the default would be rejected on
-            # connect.
+            # BaaS bakes this path *into* the relay URL, and that URL is what a
+            # caller ends up connecting to, so it has to be the bot's own engine
+            # path. Its default is openclaw's, and the engine closes a socket
+            # whose pinned engine is not the active one (code 4001) — a
+            # claude_code bot handed the default would be rejected on connect.
+            #
+            # A bare-target provider never sees this: the base
+            # ``get_device_connection`` does not forward ``path`` to
+            # ``_compose_device_conn_info``. That is why ``_compose_onto_gateway``
+            # appends the engine path itself rather than trusting the provider to
+            # have applied it.
             path=chat_path,
         )
 
@@ -321,14 +348,16 @@ class EngineConnectionService:
     def _socket_url(self, info: object, socket_path: str, token: str) -> str:
         """The finished URL for ``socket_path``.
 
-        The provider builds a finished relay URL around the engine path we ask
-        it for. That URL addresses the hop *behind* the gateway, so we re-address
-        it — swapping the origin and the routing prefix — rather than rebuilding
-        it from parts. Rebuilding would mean asserting our own grammar for a URL
-        the provider owns, and silently dropping anything it put there that we
-        did not anticipate.
+        Providers describe a connection in one of two ways, and both end at the
+        same published URL. Some build a finished relay URL around the engine
+        path we ask them for; that URL addresses the hop *behind* the gateway, so
+        we re-address it rather than rebuilding it from parts — rebuilding would
+        assert our own grammar for a URL the provider owns and silently drop
+        anything it put there that we did not anticipate. Others hand back the
+        routing target and the credential and leave the assembly to the caller,
+        which is what every other caller of those providers already does.
 
-        Two shapes:
+        Four cases, in the order they are tested:
 
         1. A local device — reached directly, with no credential. The gateway
            routes to the hop behind it, which has no path to a device on the
@@ -336,7 +365,21 @@ class EngineConnectionService:
            ``url`` is not consulted at all: the local provider fills that field
            from *http*-info (``local_device_service.py``), which was never a
            relay URL and was never published here either.
-        2. Otherwise the gateway, re-addressed from the provider's relay URL.
+        2. A provider that supplied a ``url`` — re-addressed onto the gateway.
+           Tested before the connection kind on purpose: a URL the provider went
+           to the trouble of issuing records a routing decision it made and we
+           did not, so composing our own over the top would override it in
+           silence. It is also what keeps this method's shape from being a
+           one-way door — should a bare-target provider ever start issuing relay
+           URLs, they win here with no change, and case 3 simply stops being
+           reached.
+        3. A provider of a bare-target kind (:data:`_PROXY_TARGET_TYPES`) —
+           composed onto the gateway from the target, the engine path and the
+           credential.
+        4. Anything else — refused by name. Deliberately *not* folded into case 3
+           as a catch-all: a provider that was supposed to supply a ``url`` and
+           did not has a bug, and composing a plausible-looking URL for it would
+           bury that bug in a socket that fails at handshake instead.
         """
         target = str(
             getattr(info, "ws_target", "")
@@ -346,7 +389,9 @@ class EngineConnectionService:
         if not target:
             raise EngineUpstreamError("device connection carries no routing target")
 
-        if str(getattr(info, "type", "") or "") == "local":
+        conn_type = str(getattr(info, "type", "") or "")
+
+        if conn_type == "local":
             # Composed, because there is no relay URL to re-address. This target
             # is an *authority*, so ``@``, ``:`` and the brackets of an IPv6 host
             # all have to survive — singlebox reclassifies a ``::1`` binding as
@@ -355,7 +400,36 @@ class EngineConnectionService:
             segment = _quote_or_reject(target, safe="@:[]", what="routing target")
             return f"ws://{segment}{_quote_or_reject(socket_path, safe='/', what='socket path')}"
 
-        return self._readdress_onto_gateway(info, token)
+        if str(getattr(info, "url", "") or ""):
+            return self._readdress_onto_gateway(info, token)
+
+        if conn_type in _PROXY_TARGET_TYPES:
+            return self._compose_onto_gateway(target, socket_path, token)
+
+        raise EngineUpstreamError(
+            f"device connection of kind {conn_type!r} carries no relay url and "
+            f"is not a kind this endpoint can compose one for"
+        )
+
+    def _compose_onto_gateway(
+        self, target: str, socket_path: str, token: str
+    ) -> str:
+        """The gateway URL for a provider that hands back a bare routing target.
+
+        Byte-for-byte what :meth:`_readdress_onto_gateway` produces for the same
+        target, path and credential — the provider's origin and routing prefix
+        are discarded there anyway, so the two branches differ only in where the
+        tail came from, never in what is published.
+
+        Encoded here, unlike the re-addressed branch, because these are raw
+        provider values rather than a URL something already encoded. The target
+        keeps ``@``, ``:`` and brackets: it is an authority-like segment
+        (``ARCA_{sandbox_id}@{alt}:{port}``), and the credential is a signature
+        over that exact string, so a reshaped target is a rejected handshake.
+        """
+        segment = _quote_or_reject(target, safe="@:[]", what="routing target")
+        path = _quote_or_reject(socket_path, safe="/", what="socket path")
+        return self._gateway_url(f"{segment}{path}", "", token)
 
     def _readdress_onto_gateway(self, info: object, token: str) -> str:
         """The provider's relay URL, re-pointed at the gateway.
@@ -410,8 +484,22 @@ class EngineConnectionService:
         # cannot end the path early no matter what it holds. The fragment is
         # dropped rather than carried: a browser never sends one, so keeping it
         # would publish a component that cannot reach the upstream.
-        tail = parts.path[len(_PROXYPASS_PREFIX) :]
-        query = parts.query
+        return self._gateway_url(
+            parts.path[len(_PROXYPASS_PREFIX) :], parts.query, token
+        )
+
+    def _gateway_url(self, tail: str, query: str, token: str) -> str:
+        """The gateway URL addressing ``tail``, carrying ``token`` in its query.
+
+        The one place a published socket URL is spelled out, so the callers that
+        arrive at a ``tail`` by different routes — re-addressing a provider's
+        relay URL, or composing from a bare routing target — cannot drift into
+        publishing two different grammars for the same device.
+
+        ``tail`` is everything the gateway forwards: the routing target and the
+        in-device path, already encoded by whoever produced it. ``query`` is the
+        provider's own, or empty.
+        """
         if token:
             # Appended, not assigned — a provider query would otherwise be lost,
             # and the socket would fail with nothing pointing at why. Absent

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -850,3 +850,13 @@ def test_a_composed_expiry_falls_back_to_the_requested_ttl():
     expires = datetime.fromisoformat(result.expires_at)
     expected = datetime.now(timezone.utc) + timedelta(seconds=CONNECTION_TTL_SECONDS)
     assert abs((expires - expected).total_seconds()) < 60
+
+
+def test_a_bare_target_provider_reporting_unavailable_is_not_ready():
+    """The availability gate sits in ``build``, before any URL is composed, so it
+    covers this branch by construction rather than by repetition. Pinned because
+    "refused exactly as today, on every provider" is a spec criterion, and a
+    future reordering could quietly compose a URL for a stopped sandbox."""
+    devices = _arca(available=False, message="sandbox stopped")
+    with pytest.raises(EngineDeviceNotReadyError):
+        _build(_svc(devices=devices))

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -109,6 +109,42 @@ class _Devices:
         return self.info
 
 
+#: A routing target as the ARCA provider spells one: ``ARCA_`` + the
+#: ``@alt``-suffixed sandbox id + the engine adapter's port.
+ARCA_TARGET = "ARCA_ARCA-SANDBOX-abc123@0:20003"
+ARCA_TOKEN = "eyJhbGciOiJIUzI1NiIs"
+
+#: What the endpoint must publish for :data:`ARCA_TARGET` on an openclaw bot.
+#: Spelled out in full rather than assembled from parts, so a change to any of
+#: the four pieces — gateway origin, published prefix, target, credential
+#: parameter — has to be restated here deliberately.
+ARCA_URL = (
+    "wss://gw.example/openapi/v1/bots/messages/ws/"
+    "ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws"
+    f"?x-proxypass-token={ARCA_TOKEN}"
+)
+
+
+def _arca(**overrides):
+    """The ARCA provider's shape: a bare routing target, a signed credential,
+    and **no url** — it composes none in any mode and is never handed the
+    in-device path that would have to go into one.
+
+    ``url=""`` is the load-bearing part: ``_Devices`` otherwise synthesises a
+    BaaS-style relay URL, which would send these cases down the re-addressing
+    branch and quietly stop testing the composed one.
+    """
+    return _Devices(
+        **{
+            "type": "proxy",
+            "target": ARCA_TARGET,
+            "token": ARCA_TOKEN,
+            "url": "",
+            **overrides,
+        }
+    )
+
+
 def _gateway(base="https://gw.example"):
     """The endpoint the composition root resolved for this environment.
 
@@ -654,3 +690,163 @@ def test_the_provider_is_asked_exactly_once():
     # ...leaving the relay-mode lookup as the only provider round trip.
     assert devices.kwargs is not None
     assert devices.kwargs["binding_id"] == 42
+
+
+# ── providers that hand back a bare routing target (ARCA) ─────────────────────
+
+
+def test_a_bare_target_provider_gets_a_composed_gateway_url():
+    """The ARCA provider returns a target and a credential and no url. Composing
+    one here is what makes the endpoint answer for those bots at all — before
+    this branch existed every one of them was a 502."""
+    assert _build(_svc(devices=_arca())).sockets[0].url == ARCA_URL
+
+
+def test_a_composed_url_never_names_the_hop_behind_the_gateway():
+    """The reason this endpoint exists. Composing must not become the way the
+    engine proxy's address leaks out after re-addressing stopped leaking it."""
+    url = _build(_svc(devices=_arca())).sockets[0].url
+    # The *routing prefix*, with its slash — bare ``proxypass`` also matches the
+    # credential parameter, which is named ``x-proxypass-token`` and belongs here.
+    assert "proxypass/" not in url
+    assert "agentclawproxy" not in url
+
+
+def test_a_composed_target_segment_survives_verbatim():
+    """The credential is a signature over the target string, and the proxy
+    rejects a handshake whose url target disagrees with the claim — so
+    percent-encoding ``@`` or ``:`` here would break every ARCA connection."""
+    url = _build(_svc(devices=_arca())).sockets[0].url
+    assert f"/openapi/v1/bots/messages/ws/{ARCA_TARGET}/api/openclaw/ws" in url
+    assert "%40" not in url and "%3A" not in url
+
+
+def test_a_composed_bracketed_target_keeps_its_brackets():
+    """Same ``safe`` set as the local branch, so a target that is authority-like
+    rather than a plain segment survives either way in."""
+    devices = _arca(target="[::1]:20003")
+    url = _build(_svc(devices=devices)).sockets[0].url
+    assert url.startswith(
+        "wss://gw.example/openapi/v1/bots/messages/ws/[::1]:20003/api/openclaw/ws"
+    )
+
+
+def test_a_composed_url_addresses_the_bots_own_engine():
+    """The provider never sees ``path`` — the base ``get_device_connection`` does
+    not forward it — so the engine path is this branch's to apply. Getting it
+    wrong is not a 404 but a socket the engine closes with 4001."""
+    devices = _arca()
+    url = _build(_svc(bots=_Bots(engine="claude_code"), devices=devices)).sockets[0].url
+    assert url.endswith(
+        f"/{ARCA_TARGET}/api/claude_code/ws?x-proxypass-token={ARCA_TOKEN}"
+    )
+
+
+def test_a_composed_url_with_no_credential_publishes_no_query_string():
+    devices = _arca(token="")
+    url = _build(_svc(devices=devices)).sockets[0].url
+    assert url == (
+        "wss://gw.example/openapi/v1/bots/messages/ws/"
+        f"{ARCA_TARGET}/api/openclaw/ws"
+    )
+    assert "?" not in url
+
+
+def test_a_composed_credential_is_percent_encoded():
+    devices = _arca(token="a b&c=d")
+    url = _build(_svc(devices=devices)).sockets[0].url
+    assert url.endswith("?x-proxypass-token=a%20b%26c%3Dd")
+
+
+def test_composing_and_readdressing_agree_byte_for_byte():
+    """The two branches reach the same published URL by different routes: one
+    cuts the tail out of a provider's url, the other builds it from the target
+    and path. They share a builder precisely so they cannot drift — this pins
+    that they have not."""
+    composed = _build(_svc(devices=_arca())).sockets[0].url
+    readdressed = _build(
+        _svc(
+            devices=_Devices(
+                type="baas",
+                target=ARCA_TARGET,
+                token=ARCA_TOKEN,
+                url=(
+                    "wss://agentclawproxy-prod.example.com/proxypass/"
+                    f"{ARCA_TARGET}/api/openclaw/ws"
+                ),
+            )
+        )
+    ).sockets[0].url
+    assert composed == readdressed == ARCA_URL
+
+
+def test_a_provider_url_wins_over_composing_one():
+    """Ordering, and the reason this fix is not a one-way door: a url the
+    provider issued records a routing decision it made and we did not. Should a
+    bare-target provider ever grow a relay mode, it is preferred here with no
+    change — the composed branch simply stops being reached.
+
+    The url deliberately points somewhere the composed branch never would, so
+    the assertion can tell which branch answered.
+    """
+    devices = _arca(
+        url="wss://agentclawproxy-prod.example.com/proxypass/ARCA_OTHER@1:20099/api/openclaw/ws"
+    )
+    url = _build(_svc(devices=devices)).sockets[0].url
+    assert url == (
+        "wss://gw.example/openapi/v1/bots/messages/ws/"
+        f"ARCA_OTHER@1:20099/api/openclaw/ws?x-proxypass-token={ARCA_TOKEN}"
+    )
+
+
+def test_a_bare_target_provider_url_of_an_unknown_shape_is_still_refused():
+    """The composed branch is not a fallback for a url that failed to parse.
+    A provider that issued a shape we cannot re-address is a fault to name, not
+    something to quietly route around by building our own."""
+    devices = _arca(url="wss://relay.example/wsrelay/6f2a")
+    with pytest.raises(EngineUpstreamError):
+        _build(_svc(devices=devices))
+
+
+def test_an_unrecognised_connection_kind_is_named():
+    """Not folded into the composed branch as a catch-all: a provider that was
+    supposed to supply a url and did not has a bug, and composing something
+    plausible for it would bury that bug in a handshake failure."""
+    devices = _Devices(type="teclaw", target="TECLAW_x@4:20003", token="tok", url="")
+    with pytest.raises(EngineUpstreamError) as excinfo:
+        _build(_svc(devices=devices))
+    assert "teclaw" in str(excinfo.value)
+
+
+def test_the_unrecognised_kind_message_does_not_carry_the_credential():
+    devices = _Devices(type="teclaw", target="t", token="secret-tok", url="")
+    with pytest.raises(EngineUpstreamError) as excinfo:
+        _build(_svc(devices=devices))
+    assert "secret-tok" not in str(excinfo.value)
+
+
+def test_a_composed_url_still_needs_a_routing_target():
+    """The target guard runs before any branching, so it covers this branch too
+    — and here it is the only thing standing between an empty target and
+    ``…/bots/messages/ws//api/openclaw/ws``."""
+    with pytest.raises(EngineUpstreamError):
+        _build(_svc(devices=_arca(target="")))
+
+
+def test_an_unencodable_composed_target_is_named_rather_than_a_500():
+    """A lone surrogate survives ``json.loads``, so a provider's response can
+    carry one into this branch as easily as into the local one."""
+    with pytest.raises(EngineUpstreamError):
+        _build(_svc(devices=_arca(target="ARCA_x\ud800@0:20003")))
+
+
+def test_a_composed_expiry_falls_back_to_the_requested_ttl():
+    """ARCA reports no expiry, so the computed bound is what is published — and
+    unusually it is exact rather than a guess: this endpoint asks for
+    ``CONNECTION_TTL_SECONDS`` and the provider signs for precisely that."""
+    from datetime import datetime, timedelta, timezone
+
+    result = _build(_svc(devices=_arca(expires_at="")))
+    expires = datetime.fromisoformat(result.expires_at)
+    expected = datetime.now(timezone.utc) + timedelta(seconds=CONNECTION_TTL_SECONDS)
+    assert abs((expires - expected).total_seconds()) < 60

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -695,11 +695,19 @@ def test_the_provider_is_asked_exactly_once():
 # ── providers that hand back a bare routing target (ARCA) ─────────────────────
 
 
-def test_a_bare_target_provider_gets_a_composed_gateway_url():
+@pytest.mark.parametrize("kind", ["proxy", "arca"])
+def test_a_bare_target_provider_gets_a_composed_gateway_url(kind):
     """The ARCA provider returns a target and a credential and no url. Composing
     one here is what makes the endpoint answer for those bots at all — before
-    this branch existed every one of them was a 502."""
-    assert _build(_svc(devices=_arca())).sockets[0].url == ARCA_URL
+    this branch existed every one of them was a 502.
+
+    Both members of ``_PROXY_TARGET_TYPES`` are exercised, and against the same
+    expected URL: the kind selects the branch and must not reach the output. The
+    provider answers ``"proxy"`` today and ``"arca"`` is the ``device_provider``
+    key the same device carries elsewhere, so a transposition in either literal
+    is a silent 502 for a whole provider — this is what fails first if one is
+    mistyped."""
+    assert _build(_svc(devices=_arca(type=kind))).sockets[0].url == ARCA_URL
 
 
 def test_a_composed_url_never_names_the_hop_behind_the_gateway():


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/connection/{bot_id}` answers `502` for every bot whose device is owned by the **ARCA** provider — not intermittently, on every request, while the bot itself is healthy.

`EngineConnectionService._socket_url` recognised two provider shapes and treated everything else as the second:

1. `type == "local"` → compose `ws://{target}{path}` directly.
2. everything else → `_readdress_onto_gateway`, which **requires** a finished `/proxypass/…` URL in `DeviceConnectionInfo.url`.

The ARCA provider is neither. It returns a bare routing target, a signed proxypass credential, and no URL:

| field | BaaS (works) | ARCA (502s) |
| --- | --- | --- |
| `type` | `baas` | `proxy` |
| `target` | `ARCA_ARCA-SANDBOX-abc123@0:20003` | `ARCA_ARCA-SANDBOX-abc123@0:20003` |
| `token` | `eyJhbGciOiJIUzI1NiIs…` | `eyJhbGciOiJIUzI1NiIs…` |
| `url` | `wss://agentclawproxy-prod…/proxypass/ARCA_…@0:20003/api/openclaw/ws` | *(empty)* |

So it fell into branch 2 and raised `EngineUpstreamError`. Which provider owns a bot is decided at creation by a rollout policy a tenant cannot see or influence, so what they observe is the same API call succeeding for one of their bots and failing for another.

The error also misdescribed the situation: it reported "no relay url to re-address" (a symptom) rather than "this provider does not issue one, by design".

## Solution

Compose the gateway URL for those providers, from the routing target, the bot's engine path, and the credential. That is the platform's normal case rather than a special one — `get_device_connection_v2` and the internal console frontend each build `/proxypass/{target}{path}` out of exactly these two values.

`_socket_url` now tests four cases **in order**:

| # | condition | branch |
| --- | --- | --- |
| 1 | `type == "local"` | compose direct — no gateway, no credential |
| 2 | `url` non-empty | re-address the provider's URL (existing guards) |
| 3 | `type in _PROXY_TARGET_TYPES` | **new** — compose onto the gateway |
| 4 | otherwise | **new** — refuse, naming the kind |

Both ARCA and BaaS now publish the identical string:

```
wss://gateway.example.com/openapi/v1/bots/messages/ws/ARCA_ARCA-SANDBOX-abc123@0:20003/api/openclaw/ws?x-proxypass-token=eyJhbGciOiJIUzI1NiIs…
```

Three things worth a reviewer's attention:

- **The URL is tested before the kind.** A URL the provider issued records a routing decision it made and we did not, so composing over the top would override it silently. It also keeps this from being a one-way door: should the ARCA provider ever grow a relay mode, it takes case 2 automatically and case 3 stops being reached — no change here.
- **The tail of `_readdress_onto_gateway` became `_gateway_url`,** shared by both gateway branches so they cannot drift into publishing two grammars for the same device. Composed and re-addressed output is byte-for-byte identical for the same inputs — pinned by a test.
- **Nothing outside this repo changes.** No corp-side provider change, no gateway config, no DI change, no injected `SandboxRuntimeClient` — `_readdress_onto_gateway` discards the provider's origin anyway, so a proxy base URL would be fetched only to be thrown away.

Case 4 replaces the misleading message; the published body is unchanged (`502 "Engine service error"`) and the kind reaches logs only.

Spec, plan and tasks: `src/backend/specs/2026-08-06-connection-endpoint-arca-provider/`.

## Validation

- `tests/community/core/engine_runtime/test_connection.py` — **76 passed** (17 new cases for this branch)
- `core/engine_runtime` + `adapters/http/openapi_v1` + `architecture` + `core/devices` — **1358 passed**
- `ruff check` clean on both changed files
- The pre-push contract's `python_sast_local.sh` gate passed against `origin/REL20260806`

New tests cover: the published URL in full; the target segment surviving verbatim (the credential is a signature over that exact string, so percent-encoding `@` or `:` would break every handshake); the bot's own engine path; absent credential publishing no query; encoding; the target, surrogate and availability guards reaching this branch; composed and re-addressed agreeing byte-for-byte; and both ordering properties — a provider URL winning over composing, and an unmappable provider URL still being refused rather than composed around.

**Not run here:** `scripts/ci_test.sh` executes all 10 836 `tests/community` cases under `--cov` over the whole source tree. In this sandbox that does not finish — collection alone goes from ~37s uninstrumented to over 20 minutes under coverage, and unrelated suites stall on network egress through the agent proxy. The change touches one file whose only consumers are the connection router and its test module, so the suites above cover its blast radius; the full gate runs here on CI.