### PR TITLE
fix(backend): reject restart for teclaw bots instead of destroying them

### DIFF
--- a/src/backend/specs/2026-08-06-teclaw-restart-not-supported/plan.md
+++ b/src/backend/specs/2026-08-06-teclaw-restart-not-supported/plan.md
@@ -1,0 +1,185 @@
+# Plan: Teclaw Restart Is Not Supported
+
+## Approach
+Close the destructive path at its source with a single guard at the top of
+`BotService.restart_bot`, before any state is read or written.
+
+Three decisions shape the change:
+
+**1. Guard on the bot's engine, not the binding's `device_provider`.**
+`self.is_teclaw_bot(bot.get("active_engine"))` is the canonical teclaw
+definition, delegating to `TeclawProvisionService.is_teclaw`. Keying on it
+rather than the binding's provider column has three benefits: it works for a
+teclaw bot with no binding (a `FAILED` bot whose binding was lost), it needs no
+device-service round trip before the guard can fire, and it adds no new read of
+the `device_provider == "teclaw"` axis — a value that conflates lifecycle
+ownership with container flavor and is a known cleanup target. The two axes
+agree in practice: a bot's container type follows its engine.
+
+**2. Reuse `BotOperationNotAllowedError`.** Its docstring already states the
+exact semantics needed — *"The operation is not supported for this bot and never
+will be. Distinct from a transient failure: retrying cannot help, so delivery
+surfaces should report it as a client error rather than a server fault."* It is
+already the idiom for this shape of refusal (desktop bots use it in the OpenAPI
+v1 router), and every restart surface already handles it. No new exception type,
+no router changes.
+
+**3. Place the guard beside the existing desktop guard.** Both answer the same
+question — "is this bot's lifecycle managed by something other than the generic
+device path?" — and both must fire before the lifecycle-state checks, the
+restart lock, and any repository write. Sitting them together keeps the
+precondition block readable and makes the inertness obvious by position.
+
+The existing caller-side workarounds in `BotPublishService` and
+`CreateBotForOthersService` are deliberately **left in place**. Neither is purely
+a bug workaround: each expresses correct local behavior (skip a restart that is
+unnecessary; report a domain-specific 400). With the service-level guard they
+become defense in depth. Removing them would churn working code on a release
+branch for no behavioral gain.
+
+## Affected Components
+| Component | Change |
+| --- | --- |
+| `BotService.restart_bot` | New teclaw precondition guard (the entire fix) |
+| `bot_management` HTTP router | None — already maps the error on all three routes |
+| `openapi_v1` bots router | None — mapped via `responses.py` |
+| Web client (`useBot.ts`) | None — already surfaces a rejected restart correctly |
+| `BotPublishService` / `CreateBotForOthersService` | None — existing guards retained |
+| Tests | New coverage across service, surfaces, and internal callers |
+
+## Data Model Changes
+None. The guard performs no writes.
+
+## API / Interface Changes
+No signature changes. One behavioral change, surfaced through existing error
+mappings:
+
+| Surface | Before (teclaw) | After (teclaw) |
+| --- | --- | --- |
+| `POST /api/bots/{bot_id}/restart` | 200, container destroyed, bot → `FAILED` | 400, `"teclaw ..."`, nothing changed |
+| `POST /api/bots/{bot_id}/restart-for-others` | as above | 400 |
+| `POST /api/bots/restart-scheduler` | as above | 400 |
+| `POST /v1/bots/{bot_id}/restart` | as above | 409 (`responses.py:177`) |
+
+The OpenAPI v1 surface maps `BotOperationNotAllowedError` to **409**, not 400
+(`responses.py:177`: `(409, "Operation not supported for this bot")`). Both are
+client errors, satisfying the acceptance criterion; the asymmetry is pre-existing
+and is not changed here.
+
+Non-teclaw restart behavior is untouched on every surface.
+
+## Key Files & Functions
+
+### 1. The guard (`core/bot_management/services/bot_service.py`)
+`restart_bot` begins at `:3833`. It loads the bot, then rejects desktop bots at
+`:3870-3877`. Insert the teclaw guard immediately after that block — before the
+`bot_status` read at `:3879`, the restart lock at `:3996`, and `stop_bot` at
+`:4051`:
+
+```python
+if self.is_teclaw_bot(bot.get("active_engine")):
+    raise BotOperationNotAllowedError("teclaw 类型的 Bot 不支持重启")
+```
+
+Message wording matches the existing refusal in `CreateBotForOthersService` so
+users see one consistent string.
+
+`is_teclaw_bot` is at `:3689`; `BotOperationNotAllowedError` at `:149`. Both are
+already imported/defined in this module — no new imports.
+
+### 2. Surfaces (no production changes)
+Verified handlers on the current branch:
+- `adapters/http/bot_management/router.py:414` (`restart_bot_for_others`) → 400
+- `adapters/http/bot_management/router.py:501` (`restart_scheduler`) → 400
+- `adapters/http/bot_management/router.py:2685` (`restart_bot`) → 400
+- `adapters/http/openapi_v1/responses.py:177` → 409 envelope
+
+### 3. Internal callers (no production changes)
+- `bot_publish_service.py:1250` — already branches on `is_teclaw_bot` and skips
+  the restart; the guard is never reached from here.
+- `create_bot_for_others_service.py:307` — reachable for a teclaw bot when the
+  bot is not `ACTIVE` and no restart-wait applies. It will now receive
+  `BotOperationNotAllowedError` instead of silently destroying the container.
+  Confirm this surfaces as a client error rather than an unhandled 500.
+
+### 4. Tests
+- `tests/community/core/bot_management/services/` — service-level guard behavior
+  and inertness (new file).
+- `tests/community/api/bot_management/test_router.py` — surface mappings.
+- `tests/community/core/bot_management/services/test_create_bot_for_others_service.py`
+  — internal caller behavior.
+
+## Dependencies
+None. No new packages, no DI changes, no migrations.
+
+## Risks & Mitigations
+| Risk | Mitigation |
+| --- | --- |
+| A legitimate teclaw restart use case exists that we are now blocking | Confirmed with the teclaw owner that restart is not a supported teclaw operation. The prior behavior was destructive, so nothing usable is lost. |
+| `is_teclaw_bot` and the binding's `device_provider` disagree for some bot, so a teclaw-provider binding slips past an engine-keyed guard | The engine is the creation-time determinant of container type, and teclaw bindings are only ever minted for teclaw-engine bots (`TeclawProvisionService.provision`). A test asserts the guard fires for a teclaw bot regardless of binding state, including no binding at all. |
+| Guard placed too late and a partial mutation still occurs | Placement is above every read and write in the method; a test asserts no repository, device-service, or task-queue call is made. |
+| Callers relying on restart succeeding for teclaw now see an exception | Both internal callers audited: one never reaches it, the other is covered by a task. |
+| Users lose their only "fix my stuck bot" affordance | Real, and accepted: the affordance did not work — it destroyed the bot. Recovery path tracked in #869. |
+
+## Alternatives Considered
+**Restart teclaw in place via `update_teclaw_bot`.** Designed in full before
+being dropped. It would reuse the existing teclaw publish-poll machinery
+(`TeclawPublishTaskHandler` and `transition_teclaw_publish_terminal` work
+unchanged for a restart publish, provided `device_props["publish_id"]` is
+overwritten). Rejected because the teclaw owner confirmed there is no restart
+semantics for a teclaw container: `update_teclaw_bot` re-delivers configuration
+to an existing container, which is a different operation and does not recover a
+wedged one. Building it would have produced a restart that does not restart.
+Revisitable via #869 question 3.
+
+**Register `teclaw` as a `DeviceService` provider** so the generic
+`stop_bot` + `start_bot` path works. Rejected on two grounds: it entrenches
+`teclaw` on the lifecycle-provider axis we want to remove, and mechanically
+"working" would be semantically wrong — destroying a container and provisioning
+an empty one is a reset, not a restart, and would silently discard the user's
+workspace files.
+
+**Return a silent success (`success: True`, no-op).** Rejected. The client
+optimistically writes `PENDING` and begins polling on a successful response
+(`useBot.ts:746-751`), so a user with a stuck bot would be told it was
+restarting when nothing happened. Returning an error routes through
+`handleApiError` (`useBot.ts:740-744`), which surfaces the message and returns
+before the optimistic write — correct UX with no frontend change.
+
+**Guard at each delivery surface** instead of the service. Rejected: that is
+what the two existing caller-side workarounds already do, and it is why the bug
+survived — the surfaces nobody remembered still reach the destructive path.
+
+## Rollout
+Single PR onto `REL20260806`. No feature flag, no migration, no config. The
+change is inert for every non-teclaw bot and strictly removes a destructive
+operation for teclaw bots, so it can ship and be reverted freely.
+
+Bots already broken by the prior behavior have been recovered manually; no
+backfill is required.
+
+## Test Strategy
+**Service-level (primary).** The guard fires for a teclaw bot across `ACTIVE`,
+`FAILED`, and `PENDING`, with a live binding, a stale binding, and no binding.
+The strongest assertion is inertness: with mocked collaborators, assert the
+device service, binding repository, bot repository, restart-lock repository and
+task queue receive **no** calls — specifically no `release_device`, no
+`destroy_bot`, no status write, no lock acquisition.
+
+**Regression pin.** A test named for the original defect asserting that a teclaw
+restart never reaches `stop_bot` — the single behavior whose reintroduction
+would re-destroy containers.
+
+**Non-regression.** Existing restart tests
+(`test_bot_service_restart_idempotency.py`, `test_bot_service_restart_baas_envs.py`,
+`test_bot_service_aix_extra_envs_restart.py`, `test_bot_service_stop_start.py`)
+must pass unchanged, proving BaaS and arca paths are untouched.
+
+**Surfaces.** Each of the four restart endpoints returns its client error for a
+teclaw bot, asserted against the mapped status codes above.
+
+**Internal caller.** `CreateBotForOthersService` reports a client error for a
+teclaw bot reaching its restart call.
+
+Full module gates before push per `AGENTS.md` (`OCB_PRE_PUSH_RUN_CI=1`), with
+the merge target set to `REL20260806`.

--- a/src/backend/specs/2026-08-06-teclaw-restart-not-supported/spec.md
+++ b/src/backend/specs/2026-08-06-teclaw-restart-not-supported/spec.md
@@ -1,0 +1,119 @@
+# Teclaw Restart Is Not Supported
+
+## Summary
+Restarting a teclaw bot currently destroys its container and then fails, leaving
+the bot `FAILED` with a stale binding pointing at a container that no longer
+exists. Restart is not a recoverable operation for teclaw containers, so this
+change makes it an explicit, inert rejection: a teclaw restart request changes
+nothing and returns a clear "not supported" response.
+
+## Motivation
+`BotService.restart_bot` has two paths. BaaS-provider bots restart **in place**
+(BaaS `/update`, binding and container preserved). Everything else falls through
+to `stop_bot` + `start_bot` — release the device, then allocate a new one.
+
+Teclaw bindings take the second path, and both halves misbehave:
+
+- `stop_bot` → `release_device` routes by the binding's `device_provider`.
+  `"teclaw"` is not a registered provider, so the router silently falls back to
+  the BaaS device service, which destroys the container via `destroy_bot`.
+- `start_bot` → `apply_device(device_provider="teclaw")` is then refused
+  outright (`device_provider 'teclaw' is not registered; refuse to re-run create
+  rollout`). The async allocation thread catches it and marks the bot `FAILED`.
+
+The net effect is destructive: the container is gone, the bot is `FAILED`, and
+the binding still points at the destroyed container. Restart does not merely
+fail to work — it breaks a previously healthy bot.
+
+The delete-and-recreate shape cannot work for teclaw in the first place. A
+teclaw container is provisioned only inside `TeclawProvisionService.provision`,
+called only from `create_bot`. There is no "start a teclaw container" primitive
+outside bot creation, so the second half of delete-and-recreate has nothing to
+call.
+
+Restarting the container in place was considered and rejected: the teclaw side
+owns the container lifecycle, and there is no confirmed restart semantics for a
+teclaw container from the backend. Re-delivering config (`update_teclaw_bot`) is
+a different operation and does not answer "my bot is stuck".
+
+The policy this establishes is not new, and neither is the bug. Two callers
+already guard against it locally:
+
+- `BotPublishService.upgrade_bot_to_service` skips the restart entirely for
+  teclaw bots, with a comment describing this exact failure — *"一旦重启会
+  destroy 容器 + 重新分配失败,把 bot 打成无 binding 的坏状态,并丢掉个人阶段的
+  容器内文件"* — and a ticket reference (Dima 2026070100117117968).
+- `CreateBotForOthersService` refuses the operation outright, raising
+  `"teclaw 类型的 Bot 不支持重启"` with a 400.
+
+Both are workarounds at the call site. The destructive path itself was never
+closed, so every other entry point — the three `/api/bots` restart endpoints and
+the OpenAPI v1 one — still reaches it. This change closes it at the source, in
+the lifecycle service, where no future caller can miss it.
+
+## User Stories
+- As a teclaw bot owner, when I click restart, I want to be told plainly that
+  restart is not supported for my bot, so that I do not lose a working container
+  to an operation that was never going to succeed.
+- As a teclaw bot owner, I want a restart request to leave my bot exactly as it
+  was — same container, same binding, same status — so that a mistaken click
+  costs me nothing.
+- As an operator using the admin and scheduler restart endpoints, I want teclaw
+  bots rejected with a client error rather than a 500, so I can tell "not
+  applicable" apart from "something broke".
+- As an engineer, I want the rejection to sit at one place in the lifecycle
+  service rather than at each delivery surface, so no future entry point can
+  reach the destructive path by omission.
+
+## Acceptance Criteria
+- [ ] A restart request for a teclaw bot performs **no** writes: no device
+      release, no BaaS `destroy_bot`, no binding status change, no bot status
+      change, no restart-lock acquisition, no device allocation.
+- [ ] A restart request for a teclaw bot is rejected with
+      `BotOperationNotAllowedError` carrying a user-facing message stating that
+      teclaw bots do not support restart.
+- [ ] All four HTTP restart surfaces report that rejection as a client error
+      (400 / the OpenAPI envelope equivalent), not a 500:
+      `POST /api/bots/{bot_id}/restart`,
+      `POST /api/bots/{bot_id}/restart-for-others`,
+      `POST /api/bots/restart-scheduler`,
+      and the OpenAPI v1 `POST /v1/bots/{bot_id}/restart`.
+- [ ] A teclaw bot in any restart-eligible lifecycle state (`ACTIVE`, `FAILED`,
+      `PENDING`) is rejected identically — the guard does not depend on the bot
+      having a live binding.
+- [ ] Restart behavior for non-teclaw bots is unchanged: BaaS bots still restart
+      in place, arca bots still go through `stop_bot` + `start_bot`, and desktop
+      bots are still rejected by the existing guard.
+- [ ] The web client surfaces the rejection message and does not optimistically
+      show the bot as restarting.
+- [ ] The internal caller in `CreateBotForOthersService` continues to report a
+      client error for teclaw bots rather than propagating an unhandled
+      exception.
+
+## In Scope
+- A teclaw guard in `BotService.restart_bot`, placed before any state mutation.
+- Tests proving the guard is inert (no release, no destroy, no status writes)
+  and that it fires across lifecycle states.
+- Tests pinning the client-error mapping on all four HTTP restart surfaces.
+- Verification that the `CreateBotForOthersService` caller behaves correctly.
+
+## Out of Scope
+- **The recovery path for an unhealthy teclaw container** — tracked in #869.
+  This change removes a destructive operation; it does not add a replacement.
+- **Gating the restart affordance in the web client** — tracked in #869. The
+  existing client already surfaces a rejected restart correctly, so no frontend
+  change is required for the acceptance criteria above.
+- **Restarting a teclaw container in place** via `update_teclaw_bot`. Not
+  pursued; see #869 question 3 if this is revisited.
+- **Removing `"teclaw"` as a `device_provider` value.** The value conflates
+  "who owns the device lifecycle" (where teclaw does not belong) with "what
+  flavor of container this is" (where it is meaningful). Untangling it is a
+  separate refactor with a data migration; this change deliberately keys its
+  guard on the bot's engine instead, so it adds no new reads of the provider
+  axis.
+- Cleanup of bots broken by the previous behavior — already recovered manually.
+
+## Open Questions
+None blocking. The two questions raised during design — the recovery path for an
+unhealthy teclaw container, and whether `update_teclaw_bot` can cycle one — are
+captured in #869 and do not gate this change.

--- a/src/backend/specs/2026-08-06-teclaw-restart-not-supported/tasks.md
+++ b/src/backend/specs/2026-08-06-teclaw-restart-not-supported/tasks.md
@@ -1,0 +1,133 @@
+# Tasks: Teclaw Restart Is Not Supported
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: `[ ]` Reject teclaw restart in `BotService.restart_bot`
+
+- **Goal:** Close the destructive path at its source. A teclaw restart request
+  raises `BotOperationNotAllowedError` before any state is read or written.
+- **Files:**
+  `src/agentclaw/community/core/bot_management/services/bot_service.py`
+- **Done when:**
+  - [ ] Guard added immediately after the desktop guard (`:3870-3877`), before
+        the `bot_status` read at `:3879`:
+        `if self.is_teclaw_bot(bot.get("active_engine")): raise
+        BotOperationNotAllowedError("teclaw 类型的 Bot 不支持重启")`
+  - [ ] Message string matches the existing refusal in
+        `create_bot_for_others_service.py` so users see one consistent wording.
+  - [ ] No new imports required (`is_teclaw_bot` at `:3689`,
+        `BotOperationNotAllowedError` at `:149` both already in module).
+  - [ ] Docstring of `restart_bot` updated: notes teclaw is refused outright and
+        why (no teclaw restart primitive; the generic path would destroy the
+        container), referencing #869 for the recovery-path question.
+  - [ ] Nothing else in `restart_bot` changed — the BaaS branch at `:4047` and
+        the `stop_bot` + `start_bot` fall-through are untouched.
+- **Depends on:** —
+
+## Task 2: `[ ]` Prove the guard is inert, and that BaaS/arca are untouched
+
+- **Goal:** Pin the two properties that matter: a teclaw restart mutates
+  **nothing**, and no other provider's restart behavior moved.
+- **Files:**
+  `tests/community/core/bot_management/services/test_bot_service_restart_teclaw.py` (new)
+- **Done when:**
+  - [ ] Guard fires for a teclaw bot in each restart-eligible lifecycle state
+        (`ACTIVE`, `FAILED`, `PENDING`), asserting
+        `BotOperationNotAllowedError` and its message.
+  - [ ] Guard fires regardless of binding state: live binding, stale binding
+        (points at a destroyed container), and **no binding at all** — the case
+        an engine-keyed guard handles and a provider-keyed one could not.
+  - [ ] **Inertness assertions** (the core of this task): with mocked
+        collaborators, assert zero calls to the device service
+        (`release_device` / `apply_device` / `get_device`), the binding
+        repository, the bot repository, the restart-lock repository, and the
+        task queue.
+  - [ ] **Regression pin** named for the original defect: a teclaw restart never
+        reaches `stop_bot` — patch `stop_bot` and assert not called. This is the
+        single behavior whose reintroduction re-destroys containers.
+  - [ ] Non-regression: a BaaS-provider bot still takes `_restart_bot_baas`, and
+        an arca-provider bot still takes `stop_bot` + `start_bot`.
+  - [ ] `pytest tests/community/core/bot_management/services/` green — including
+        `test_bot_service_restart_idempotency.py`,
+        `test_bot_service_restart_baas_envs.py`,
+        `test_bot_service_aix_extra_envs_restart.py`,
+        `test_bot_service_stop_start.py` unchanged.
+- **Depends on:** Task 1
+
+## Task 3: `[ ]` Pin the client-error mapping on all four restart surfaces
+
+- **Goal:** Every restart entry point reports the refusal as a client error, not
+  a 500. No production code should need to change — this task proves it.
+- **Files:**
+  `tests/community/api/bot_management/test_router.py`,
+  `tests/community/adapters/http/openapi_v1/test_bots_endpoints.py`
+- **Done when:**
+  - [ ] `POST /api/bots/{bot_id}/restart` → `error_code 400` for a teclaw bot
+        (handler at `router.py:2685`).
+  - [ ] `POST /api/bots/{bot_id}/restart-for-others` → `error_code 400`
+        (handler at `router.py:414`).
+  - [ ] `POST /api/bots/restart-scheduler` → `error_code 400`
+        (handler at `router.py:501`).
+  - [ ] `POST /v1/bots/{bot_id}/restart` → **409** via
+        `openapi_v1/responses.py:177`. Assert 409, not 400 — the asymmetry with
+        the legacy surfaces is pre-existing and intentionally not changed here.
+  - [ ] Each asserts the response carries the teclaw message, so the user learns
+        why rather than seeing a bare status code.
+  - [ ] If any surface turns out **not** to map the error to a client status,
+        stop and report before changing router code — the plan asserts all four
+        already do, and a miss means the audit was wrong.
+- **Depends on:** Task 1
+
+## Task 4: `[ ]` Verify the `CreateBotForOthersService` caller
+
+- **Goal:** The one internal caller that can actually reach the guard degrades
+  to a client error rather than an unhandled exception.
+- **Files:**
+  `tests/community/core/bot_management/services/test_create_bot_for_others_service.py`,
+  `src/agentclaw/community/core/bot_management/services/create_bot_for_others_service.py` (only if the test proves a gap)
+- **Done when:**
+  - [ ] Confirmed by test: a teclaw bot that is not `ACTIVE` and has no
+        restart-wait reaches `_bot_service.restart_bot` (`:307`) and the raised
+        `BotOperationNotAllowedError` surfaces as a client error, not a 500.
+  - [ ] If it does not, convert it at the call site to `CreateBotForOthersError`
+        with `error_code=400` and the same teclaw message — matching the
+        existing refusal on the restart-wait branch. Change nothing else.
+  - [ ] The existing teclaw refusal on the restart-wait branch still passes
+        unchanged.
+  - [ ] `BotPublishService.upgrade_bot_to_service` confirmed unaffected: its
+        `is_teclaw_bot` branch at `:1250` skips the restart, so the guard is
+        never reached from there. Assert the skip still holds.
+- **Depends on:** Task 1
+
+## Task 5: `[ ]` Full-suite verification and spec acceptance
+
+- **Goal:** Every acceptance criterion in `spec.md` demonstrably holds, and the
+  module gates are green against the release branch.
+- **Files:** —
+- **Done when:**
+  - [ ] Each acceptance criterion in `spec.md` walked and checked off, with the
+        test or code reference that satisfies it.
+  - [ ] Backend module gates green:
+        `OCB_PRE_PUSH_RUN_CI=1` with
+        `AVERNET_PRE_PUSH_MERGE_TARGET=origin/REL20260806` per `AGENTS.md`.
+  - [ ] `grep` confirms no other call path reaches `stop_bot` for a teclaw bot.
+  - [ ] PR opened as draft against `REL20260806`, titled
+        `fix(backend): reject restart for teclaw bots instead of destroying them`,
+        body following `.github/pull_request_template.md`
+        (Problem / Solution / Validation) and linking #869.
+- **Depends on:** Tasks 2, 3, 4
+
+## Groups
+
+> Groups bundle tasks into end-to-end units. `implement` executes one group at
+> a time and runs code review on each group before moving on.
+
+- **Group A — The guard:** Tasks 1, 2
+  - Theme: the destructive path is closed at the source, and proven inert. This
+    group alone fixes the reported bug.
+- **Group B — Surfaces and callers:** Tasks 3, 4
+  - Theme: every entry point reports the refusal as a client error, and the one
+    internal caller that reaches it degrades cleanly. Expected to be
+    test-only — any production change here is a signal the audit was wrong.
+- **Group C — Verification:** Task 5
+  - Theme: spec acceptance walk, module gates, draft PR.


### PR DESCRIPTION
> **Draft — design only so far.** This PR currently contains the SDD artifacts
> (spec / plan / tasks) and no behavior change. The implementation lands on this
> same branch once the design is approved.

## Problem

Restarting a teclaw bot destroys its container and then fails, leaving the bot
`FAILED` with a stale binding pointing at a container that no longer exists.

`BotService.restart_bot` restarts BaaS-provider bots in place, and sends
everything else through `stop_bot` + `start_bot`. Teclaw bindings take the
second path, and both halves misbehave:

- `stop_bot` → `release_device` routes by the binding's `device_provider`.
  `"teclaw"` is not a registered provider, so the router silently falls back to
  the BaaS device service, which destroys the container via `destroy_bot`.
- `start_bot` → `apply_device(device_provider="teclaw")` is then refused
  (`device_provider 'teclaw' is not registered; refuse to re-run create
  rollout`). The async allocation thread catches it and marks the bot `FAILED`.

Delete-and-recreate cannot work for teclaw in the first place: a teclaw
container is provisioned only inside `TeclawProvisionService.provision`, called
only from `create_bot`. There is no "start a teclaw container" primitive outside
bot creation, so the second half has nothing to call.

The defect is already known and worked around at two call sites —
`BotPublishService.upgrade_bot_to_service` skips the restart for teclaw bots
(with a comment describing this exact failure and ticket Dima
2026070100117117968), and `CreateBotForOthersService` refuses it with a 400. The
destructive path itself was never closed, so every other entry point still
reaches it.

## Solution

Close it at the source: one guard at the top of `BotService.restart_bot`, beside
the existing desktop guard and before any state is read or written.

```python
if self.is_teclaw_bot(bot.get("active_engine")):
    raise BotOperationNotAllowedError("teclaw 类型的 Bot 不支持重启")
```

Everything else is tests. All four restart surfaces already map that error to a
client status, and the web client already surfaces a rejected restart correctly.

Notable choices:

- **Guard on the bot's engine, not the binding's `device_provider`.** Works for a
  teclaw bot with no binding (a `FAILED` bot whose binding was lost), and adds no
  new read of the `device_provider == "teclaw"` axis, which conflates lifecycle
  ownership with container flavor and is a known cleanup target.
- **An error, not a silent success.** The client optimistically writes `PENDING`
  and starts polling on a successful response, so a silent no-op would tell a
  user with a stuck bot that it was restarting. An error routes through
  `handleApiError`, which surfaces the message and returns before the optimistic
  write — correct UX with no frontend change.
- **Rejected: restarting teclaw in place via `update_teclaw_bot`.** Designed in
  full, then dropped — there is no restart semantics for a teclaw container.
  `update_teclaw_bot` re-delivers configuration to an existing container, a
  different operation that does not recover a wedged one.
- **Rejected: registering `teclaw` as a `DeviceService` provider** so the generic
  path works. Entrenches the axis we want to remove, and "working" would be
  semantically wrong — destroying a container and provisioning an empty one is a
  reset, not a restart, and would discard the user's workspace files.
- **Both existing caller-side workarounds are retained.** Each expresses correct
  local behavior rather than pure bug avoidance; with the service guard they
  become defense in depth.

## Validation

Not yet run — no implementation in this PR. Planned per `tasks.md`:

- Service-level: the guard fires across `ACTIVE` / `FAILED` / `PENDING` and with
  a live binding, a stale binding, and no binding; **inertness assertions** that
  the device service, repositories, restart-lock repo and task queue receive no
  calls at all.
- Regression pin: a teclaw restart never reaches `stop_bot` — the single
  behavior whose reintroduction re-destroys containers.
- Non-regression: existing BaaS and arca restart suites pass unchanged.
- Surfaces: all four restart endpoints return their client error for a teclaw
  bot.
- Backend module gates with `OCB_PRE_PUSH_RUN_CI=1` against `REL20260806`.

## Compatibility and risk

No schema, config, or migration impact. The change is inert for every
non-teclaw bot and strictly removes a destructive operation for teclaw bots, so
it can ship and be reverted freely. Bots already broken by the prior behavior
have been recovered manually; no backfill required.

Behavioral change, surfaced through existing error mappings: the three
`/api/bots` restart routes return 400 for teclaw bots, and the OpenAPI v1 route
returns 409 (`responses.py:177`). That asymmetry is pre-existing and is pinned
by tests rather than changed here.

## Spec

`src/backend/specs/2026-08-06-teclaw-restart-not-supported/` — `spec.md`,
`plan.md`, `tasks.md`.

## Related issues

Relates to #869 — the recovery path for an unhealthy teclaw container, and
whether the restart affordance should be hidden in the web client. This PR
removes a destructive operation; it does not add a replacement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbY9w8Rug6zF6KEXm5pNgh)_