### PR TITLE
fix(backend): accept legacy BaaS restart intent

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4150,21 +4150,47 @@ class BotService:
         if not bot_uuid:
             raise BotServiceError(f"Bot {bot_id} binding {binding_id} missing bot_uuid; cannot baas restart")
 
+        from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
+            RESTART_IMAGE_POLICY_ON_SUCCESS_KEY,
+            RESTART_REQUEST_ID_KEY,
+            RESTART_WORKFLOW_BASELINE_KEY,
+        )
+
         raw_binding_props = (
             binding.get("device_props", {})
             if isinstance(binding, dict)
             else (getattr(binding, "device_props", None) or {})
         )
         binding_props = raw_binding_props if isinstance(raw_binding_props, dict) else {}
-        if binding_props.get("restart_request_id"):
+        restart_request_id = binding_props.get(RESTART_REQUEST_ID_KEY)
+        restart_workflow_baseline = binding_props.get(RESTART_WORKFLOW_BASELINE_KEY)
+        has_durable_recovery_intent = (
+            isinstance(restart_request_id, str)
+            and bool(restart_request_id)
+            and isinstance(restart_workflow_baseline, int)
+            and not isinstance(restart_workflow_baseline, bool)
+            and restart_workflow_baseline >= 0
+        )
+        if has_durable_recovery_intent:
             logger.info(
                 "[bot_service._restart_bot_baas] restart already has a durable "
-                "recovery intent: bot_id=%s binding_id=%s request_id=%s",
+                "recovery intent: bot_id=%s binding_id=%s request_id=%s baseline=%s",
                 bot_id,
                 binding_id,
-                binding_props["restart_request_id"],
+                restart_request_id,
+                restart_workflow_baseline,
             )
             return dict(self._repository.get_by_id_and_owner(bot_id, user_id) or bot)
+        if restart_request_id:
+            logger.warning(
+                "[bot_service._restart_bot_baas] ignoring legacy restart intent "
+                "without a valid workflow baseline: bot_id=%s binding_id=%s "
+                "request_id=%s baseline=%r",
+                bot_id,
+                binding_id,
+                restart_request_id,
+                restart_workflow_baseline,
+            )
 
         active_engine = (bot.get("active_engine") or "").strip()
         bot_type = bot.get("bot_type") or "personal"
@@ -4304,9 +4330,6 @@ class BotService:
 
         from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
             BAAS_RESTART_PUBLISH_POLL_TASK,
-            RESTART_IMAGE_POLICY_ON_SUCCESS_KEY,
-            RESTART_REQUEST_ID_KEY,
-            RESTART_WORKFLOW_BASELINE_KEY,
             build_restart_publish_poll_payload,
         )
 
@@ -4370,7 +4393,11 @@ class BotService:
             try:
                 self._device_binding_repo.update_device_props(
                     binding_id=binding_id,
-                    props={RESTART_REQUEST_ID_KEY: None},
+                    props={
+                        RESTART_REQUEST_ID_KEY: None,
+                        RESTART_WORKFLOW_BASELINE_KEY: None,
+                        RESTART_IMAGE_POLICY_ON_SUCCESS_KEY: None,
+                    },
                 )
                 self._device_binding_repo.update_status(
                     binding_id=binding_id,

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -669,6 +669,7 @@ class BaasRestartPublishPollHandler:
                     binding_id=binding_id,
                     publish_id=publish_id,
                 )
+                self._clear_restart_recovery_intent(binding_id=binding_id)
                 return Complete()
             self._persist_restart_status(
                 bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_publish_task_handlers.py
@@ -446,6 +446,7 @@ class BaasRestartPublishPollHandler:
         )
         preflight = self._preflight(
             binding=binding,
+            binding_id=binding_id,
             publish_id=publish_id,
             request_id=request_id,
         )
@@ -610,9 +611,13 @@ class BaasRestartPublishPollHandler:
                 return value if isinstance(value, str) else None
         return payload_value
 
-    @staticmethod
     def _preflight(
-        *, binding: Any, publish_id: int, request_id: str | None
+        self,
+        *,
+        binding: Any,
+        binding_id: int,
+        publish_id: int,
+        request_id: str | None,
     ) -> TaskOutcome | None:
         if binding is None:
             return Complete()
@@ -632,6 +637,12 @@ class BaasRestartPublishPollHandler:
         # matching restart tasks must still poll that publish. FAILED remains a
         # terminal persisted result for the current binding.
         if getattr(binding, "status", None) == DeviceBindingStatus.FAILED.value:
+            if request_matches:
+                # A previous attempt may have persisted FAILED and then lost a
+                # transient race while clearing the durable intent. Retry that
+                # cleanup before completing the task; an exception here keeps
+                # TaskWorker retrying instead of permanently blocking restart.
+                self._clear_restart_recovery_intent(binding_id=binding_id)
             return Complete()
         return None
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -1909,6 +1909,109 @@ class TestAsyncReleasesLock:
 
 
 class TestRestartBaasPendingAndQueue:
+    @pytest.mark.parametrize("bot_type", ["personal", "service"])
+    def test_baas_restart_ignores_legacy_request_id_without_baseline(
+        self,
+        bot_type,
+    ):
+        """旧协议只留下 request_id 时，不得把历史记录当作进行中重启。"""
+        baas = MagicMock()
+        baas.list_bot_publishes.return_value = [
+            {"id": 32272, "publish_type": "UPDATE"}
+        ]
+        baas.upgrade_bot.return_value = {
+            "publish_id": 32273,
+            "bot_uuid": "BOT-x",
+        }
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = {
+            "device_id": "BOT-x",
+            "status": DeviceBindingStatus.ACTIVE.value,
+            "device_props": {
+                "restart_request_id": "legacy-request-id",
+                "restart_publish_id": "32272",
+            },
+        }
+        bot = {
+            "bot_id": "bot-1",
+            "owner_id": "u1",
+            "binding_id": 42,
+            "bot_type": bot_type,
+            "entity_id": "u1",
+        }
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = bot
+        bind_repo = MagicMock()
+        task_queue_service = MagicMock()
+        svc = _make_service(
+            bot_repository=bot_repo,
+            device_binding_repo=bind_repo,
+            device_provider=device_provider,
+            baas_service_provider=lambda: baas,
+            task_queue_service=task_queue_service,
+        )
+        svc._template_service.get_template_config.return_value = None
+
+        svc._restart_bot_baas(
+            bot_id="bot-1",
+            user_id="u1",
+            binding_id=42,
+            bot=bot,
+        )
+
+        baas.upgrade_bot.assert_called_once()
+        new_request_id = baas.upgrade_bot.call_args.kwargs["request_id"]
+        assert new_request_id != "legacy-request-id"
+        assert bind_repo.update_device_props.call_args_list[0].kwargs["props"] == {
+            "restart_request_id": new_request_id,
+            "restart_workflow_baseline": 32272,
+            "restart_publish_id": None,
+            "restart_image_policy_on_success": None,
+        }
+
+    @pytest.mark.parametrize("baseline", [0, 32272])
+    def test_baas_restart_suppresses_complete_durable_intent(self, baseline):
+        """只有 request_id 与合法 baseline 同时存在时才抑制重复重启。"""
+        baas = MagicMock()
+        device_provider = MagicMock()
+        device_provider.get_device.return_value = {
+            "device_id": "BOT-x",
+            "status": DeviceBindingStatus.PENDING.value,
+            "device_props": {
+                "restart_request_id": "current-request-id",
+                "restart_workflow_baseline": baseline,
+                "restart_publish_id": None,
+            },
+        }
+        bot = {
+            "bot_id": "bot-1",
+            "owner_id": "u1",
+            "binding_id": 42,
+            "bot_type": "personal",
+            "entity_id": "u1",
+        }
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = bot
+        task_queue_service = MagicMock()
+        svc = _make_service(
+            bot_repository=bot_repo,
+            device_provider=device_provider,
+            baas_service_provider=lambda: baas,
+            task_queue_service=task_queue_service,
+        )
+
+        result = svc._restart_bot_baas(
+            bot_id="bot-1",
+            user_id="u1",
+            binding_id=42,
+            bot=bot,
+        )
+
+        assert result == bot
+        baas.list_bot_publishes.assert_not_called()
+        baas.upgrade_bot.assert_not_called()
+        task_queue_service.enqueue.assert_not_called()
+
     def test_personal_baas_restart_marks_pending_and_enqueues_task(self):
         """personal baas 重启 → upgrade_bot 取 publish_id；bot/binding 双置 PENDING；
         持久化 restart poll task。"""

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -2052,6 +2052,49 @@ def test_restart_codefuse_failure_clears_recovery_intent():
     )
 
 
+def test_restart_failed_replay_retries_recovery_intent_cleanup():
+    request_id = "restart-request-1"
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.FAILED.value,
+        device_props={
+            "restart_request_id": request_id,
+            "restart_workflow_baseline": 1000,
+            "restart_publish_id": 1002,
+        },
+    )
+    baas_device_service = MagicMock()
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=MagicMock(),
+        baas_device_service=baas_device_service,
+    )
+
+    outcome = handler.handle(
+        build_restart_publish_poll_payload(
+            binding_id=42,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            publish_id=1002,
+            started_at_epoch_s=190.0,
+            bot_uuid="baas-bot-1",
+            request_id=request_id,
+            workflow_baseline=1000,
+        )
+    )
+
+    assert outcome == Complete()
+    repo.update_device_props.assert_called_once_with(
+        binding_id=42,
+        props={
+            "restart_request_id": None,
+            "restart_workflow_baseline": None,
+            "restart_image_policy_on_success": None,
+        },
+    )
+    baas_device_service.poll_publish_once.assert_not_called()
+
+
 def test_restart_default_policy_persistence_failure_retries_without_completion():
     reset_event_bus()
     received: list[BaasPublishCompletedEvent] = []

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -1990,6 +1990,68 @@ def test_restart_failed_publish_does_not_persist_default_policy():
     persist.assert_not_called()
 
 
+def test_restart_codefuse_failure_clears_recovery_intent():
+    request_id = "restart-request-1"
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_binding(
+        status=DeviceBindingStatus.PENDING.value,
+        device_props={
+            "restart_request_id": request_id,
+            "restart_workflow_baseline": 1000,
+            "restart_publish_id": 1002,
+        },
+    )
+    bot_repository = MagicMock()
+    bot_repository.get_by_binding_id.return_value = {
+        "bot_id": "bot-001",
+        "owner_id": "owner-001",
+        "active_engine": "openclaw",
+        "bot_type": "personal",
+    }
+    bot_repository.get_by_id_and_owner.return_value = {"ext": {}}
+    bot_repository.update_by_owner.return_value = {"status": "FAILED"}
+    bot_repository.compare_and_set_ext.return_value = {"status": "FAILED"}
+    baas_device_service = MagicMock()
+    baas_device_service.poll_publish_once.return_value = (
+        DeviceBindingStatus.ACTIVE.value
+    )
+    baas_device_service.refresh_codefuse_token_on_publish_success.return_value = (
+        "write codefuse token failed"
+    )
+    handler, _ = _make_restart_handler(
+        repo=repo,
+        bot_repository=bot_repository,
+        baas_device_service=baas_device_service,
+    )
+
+    outcome = handler.handle(
+        build_restart_publish_poll_payload(
+            binding_id=42,
+            bot_id="bot-001",
+            owner_id="owner-001",
+            publish_id=1002,
+            started_at_epoch_s=190.0,
+            bot_uuid="baas-bot-1",
+            request_id=request_id,
+            workflow_baseline=1000,
+        )
+    )
+
+    assert outcome == Complete()
+    repo.update_status.assert_called_once_with(
+        binding_id=42,
+        status=DeviceBindingStatus.FAILED.value,
+    )
+    repo.update_device_props.assert_called_once_with(
+        binding_id=42,
+        props={
+            "restart_request_id": None,
+            "restart_workflow_baseline": None,
+            "restart_image_policy_on_success": None,
+        },
+    )
+
+
 def test_restart_default_policy_persistence_failure_retries_without_completion():
     reset_event_bus()
     received: list[BaasPublishCompletedEvent] = []


### PR DESCRIPTION
## Problem

Legacy BaaS bindings may retain `restart_request_id` after a completed restart without a `restart_workflow_baseline`. The durable restart guard introduced for Runtime Pin treated any request id as an active recovery intent, so subsequent restarts returned before calling `upgrade_bot`. This affects both personal and service bots because they share the BaaS in-place restart path.

## Solution

- Treat a restart as an active durable intent only when it has both a non-empty request id and a valid non-negative integer workflow baseline.
- Allow legacy request-id-only bindings to proceed; the new restart naturally overwrites them with the current protocol, so no data migration is required.
- Preserve `baseline=0` as a valid first-workflow watermark.
- Clear request id, workflow baseline, and deferred image policy together when restart preparation rolls back.
- Clear the recovery intent after CodeFuse refresh reaches a persisted terminal failure.
- Cover both personal and service bot compatibility paths.

## Validation

- `uv run pytest tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py tests/community/core/devices/services/test_baas_publish_task_handlers.py -q` — 130 passed
- `uv run pytest tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py -q` — 26 passed
- `uv run ruff check ...` on all four changed files — passed
- `git diff --check` — passed

## Compatibility and risk

No schema change or data correction is required. Legacy bindings without a baseline resume normal restart behavior after deployment. Complete request-id/baseline intents continue to suppress duplicate BaaS workflows. Runtime Pin image-policy behavior remains service-bot-only; the shared restart recovery protocol continues to cover both bot types.
