### PR TITLE
fix(service-bot): route claude templates to aicoding baas template

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from agentclaw.community.core.bot_management.engines.aicoding import (
-    CODING_TEMPLATE_TYPES as AICODING_TEMPLATE_TYPES,
-)
 from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_branches import (
     SUPPORTED_ARCA_CREATE_BAAS_ROLLOUT_BRANCHES,
 )
@@ -41,7 +38,6 @@ class ArcaBotCreateBaasRolloutPolicy:
     ``device_provider``，绕过本策略。
     """
 
-    CODING_TEMPLATE_TYPES = AICODING_TEMPLATE_TYPES
     LEGACY_ARCA_CREATE_BRANCHES = SUPPORTED_ARCA_CREATE_BAAS_ROLLOUT_BRANCHES
 
     def __init__(
@@ -58,7 +54,7 @@ class ArcaBotCreateBaasRolloutPolicy:
         user_id: str,
         bot_type: str,
         engine_type: str,
-        template_type: str,
+        template_type: str | None,
     ) -> ArcaBotCreateBaasRolloutDecision:
         engine_bucket = self.normalize_engine_bucket(
             engine_type=engine_type,
@@ -199,12 +195,14 @@ class ArcaBotCreateBaasRolloutPolicy:
         cls,
         *,
         engine_type: str,
-        template_type: str,
+        template_type: str | None,
     ) -> str:
         normalized_engine = engine_type.strip().lower().replace("-", "_")
+        normalized_template_type = (template_type or "").strip().lower()
         if (
             normalized_engine == "claude_code"
-            and template_type in cls.CODING_TEMPLATE_TYPES
+            and normalized_template_type
+            and normalized_template_type != "normalcc"
         ):
             return "aicoding"
         return normalized_engine

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from agentclaw.community.core.bot_management.engines.aicoding import CODING_TEMPLATE_TYPES
 from agentclaw.community.core.devices.errors import DeviceServiceError
 from agentclaw.community.log import get_logger
 
@@ -385,8 +384,14 @@ class SystemConfigBaasTemplateResolver:
     ) -> str:
         """把历史 engine 表达归一成 template 配置里的 engine。"""
         normalized_engine = (engine_type or "openclaw").strip().lower().replace("-", "_")
-        # Claude Code 的 coding 模板沿用 AI Coding 模板，配置侧统一写 engine=aicoding。
-        if normalized_engine == "claude_code" and template_type in CODING_TEMPLATE_TYPES:
+        normalized_template_type = (template_type or "").strip().lower()
+        # Claude Code 除 normalCC 外，只要有明确 template_type，
+        # 都复用 AI Coding 模板，配置侧统一写 engine=aicoding。
+        if (
+            normalized_engine == "claude_code"
+            and normalized_template_type
+            and normalized_template_type != "normalcc"
+        ):
             return "aicoding"
         return normalized_engine
 

--- a/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
@@ -369,6 +369,48 @@ def test_claude_code_coding_template_uses_aicoding_bucket():
     assert decision.engine_bucket == "aicoding"
 
 
+def test_claude_code_architect_template_uses_aicoding_bucket():
+    decision = _policy(
+        ArcaBotCreateBaasRolloutConfig(
+            enabled=True,
+            rules=(
+                ArcaBotCreateBaasRolloutRule(
+                    bot_type="service",
+                    engine_bucket="aicoding",
+                    allow_user_ids=("u001",),
+                ),
+            ),
+        )
+    ).decide(
+        user_id="u001",
+        bot_type="service",
+        engine_type="claude_code",
+        template_type="architect",
+    )
+
+    assert decision.target_provider == BAAS_DEVICE_PROVIDER
+    assert decision.engine_bucket == "aicoding"
+
+
+def test_claude_code_normalcc_template_keeps_claude_code_bucket():
+    assert (
+        ArcaBotCreateBaasRolloutPolicy.normalize_engine_bucket(
+            engine_type="claude_code",
+            template_type="normalCC",
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_missing_template_type_keeps_claude_code_bucket():
+    assert (
+        ArcaBotCreateBaasRolloutPolicy.normalize_engine_bucket(
+            engine_type="claude_code",
+            template_type=None,
+        )
+        == "claude_code"
+    )
+
 def test_drm_payload_parser_accepts_rule_allow_list():
     provider = _provider()
     config = provider._parse(

--- a/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
@@ -176,6 +176,66 @@ def test_claude_code_coding_template_maps_to_aicoding_engine():
     )
 
 
+def test_claude_code_architect_template_maps_to_aicoding_engine():
+    resolver, _ = _resolver(
+        {
+            "selectors": [
+                {
+                    "bot_type": "service",
+                    "engine": "aicoding",
+                    "template_type": "architect",
+                    "template_uid": "aicoding_architect_template",
+                }
+            ],
+            "templates": {
+                "aicoding_architect_template": {
+                    "template_uuid": "TEMPLATE-aicoding-architect"
+                }
+            },
+        }
+    )
+
+    assert (
+        resolver.resolve_template_uid(
+            env="pre",
+            bot_type="service",
+            engine_type="claude_code",
+            template_type="architect",
+            template_config=None,
+        )
+        == "aicoding_architect_template"
+    )
+
+
+def test_claude_code_normalcc_template_keeps_claude_code_engine():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type="normalCC",
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_missing_template_type_keeps_claude_code_engine():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type=None,
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_non_normalcc_template_type_maps_to_aicoding_case_insensitive():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude-code",
+            template_type=" Architect ",
+        )
+        == "aicoding"
+    )
+
 def test_resolves_personal_hermes_template_uid():
     resolver, _ = _resolver(
         {


### PR DESCRIPTION
## Summary
- Route claude_code bots with explicit non-normalCC template_type to the aicoding BaaS template bucket.
- Keep normalCC and missing template_type on the claude_code bucket.
- Align ARCA->BaaS rollout engine bucket normalization with BaaS template resolution.

## Tests
- uv run pytest tests/community/core/devices/services/test_baas_template_resolver.py tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py -q
