### PR TITLE
fix(baas): offload /http-info sync DB calls off the event loop

### DIFF
--- a/src/baas/scripts/lib/common.sh
+++ b/src/baas/scripts/lib/common.sh
@@ -89,7 +89,12 @@ _summary() {
         grep 'FAILED.*::' "$LOG_FILE" > "$tempfile" || true
         while IFS= read -r line; do
             FAILED_TESTS+=("$line")
-            ((log_failures++))
+            # Assign rather than ((log_failures++)): the post-increment form
+            # evaluates to 0 on the first pass and returns exit status 1, which
+            # aborts this function under the errexit that _run_pytest re-enables
+            # — the summary would then print its header and exit without ever
+            # naming the failing stages or tests.
+            log_failures=$(( log_failures + 1 ))
         done < "$tempfile"
         rm -f "$tempfile"
     fi

--- a/src/baas/src/secbaas/community/core/repository/__init__.py
+++ b/src/baas/src/secbaas/community/core/repository/__init__.py
@@ -8,6 +8,7 @@ Public exports:
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextvars import ContextVar
 from datetime import datetime
 from functools import wraps
 from typing import Any, TypeVar
@@ -15,6 +16,29 @@ from typing import Any, TypeVar
 from secbaas.community.spi.database import PluginDatabaseType
 
 R = TypeVar("R")
+
+# Open ORM sessions for the current execution context, keyed by repository
+# instance id.
+#
+# Repositories are DI singletons (``providers.Singleton`` in
+# ``bootstrap/_core_repository.py``), so one instance is shared by every caller
+# in the process. Storing the open session as a plain ``self._session``
+# attribute was safe only while every repository call ran to completion on the
+# single event-loop thread. Once callers offload repository calls to worker
+# threads (``asyncio.to_thread``), two concurrent requests race: thread B
+# overwrites ``self._session`` between thread A's assignment and A's query, and
+# A then runs against B's session — the wrong tenant's data, or a SQLAlchemy
+# error from using one session on two threads.
+#
+# A ContextVar removes the sharing. ``asyncio.to_thread`` runs its callable in a
+# copy of the calling context, and every asyncio task gets its own copy too, so
+# a session bound here is visible only to the call that opened it.
+#
+# Always bind by replacing the mapping (``{**current, id(self): session}``),
+# never by mutating it in place: copying a context copies the reference, not the
+# dict, so an in-place write would leak straight back across the very thread
+# boundary this exists to close.
+_active_sessions: ContextVar[dict[int, Any]] = ContextVar("orm_active_sessions")
 
 
 def with_orm_session[
@@ -34,13 +58,20 @@ def with_orm_session[
         t0 = time.monotonic()
         try:
             with self._database.orm_session() as session:
-                self._session = session
-                conn_id = (
-                    id(session.connection().connection) if session.is_active else "N/A"
+                token = _active_sessions.set(
+                    {**_active_sessions.get({}), id(self): session}
                 )
-                session_start = time.monotonic()
-                result = func(self, *args, **kwargs)
-                query_end = time.monotonic()
+                try:
+                    conn_id = (
+                        id(session.connection().connection)
+                        if session.is_active
+                        else "N/A"
+                    )
+                    session_start = time.monotonic()
+                    result = func(self, *args, **kwargs)
+                    query_end = time.monotonic()
+                finally:
+                    _active_sessions.reset(token)
             total_end = time.monotonic()
 
             _perf_logger.info(
@@ -84,11 +115,36 @@ class OrmConnectionMixin:
     the ``@with_orm_session`` decorator, plus common utility methods
     (e.g. :meth:`now`) so individual ORM repositories don't need to
     re-implement the same logic.
+
+    ``_session`` reads the session bound to this repository in the *calling*
+    context, not a shared instance attribute — repositories are singletons and
+    their methods run on worker threads, so an attribute would be shared by
+    concurrent requests. See :data:`_active_sessions`.
     """
 
     _database: Any
-    _session: Any
     _datasource_name: str | None = None
+
+    @property
+    def _session(self) -> Any:
+        """The ORM session opened for the current ``@with_orm_session`` call."""
+        session = _active_sessions.get({}).get(id(self))
+        if session is None:
+            raise RuntimeError(
+                f"{type(self).__name__}: no ORM session bound in this context. "
+                "Repository methods must be called through @with_orm_session."
+            )
+        return session
+
+    @_session.setter
+    def _session(self, session: Any) -> None:
+        """Bind a session for the current context (tests and direct callers).
+
+        The binding is not unwound on scope exit — only ``with_orm_session``
+        tracks a token for that. It stays context-local either way, so an
+        assignment here can never be seen by another request.
+        """
+        _active_sessions.set({**_active_sessions.get({}), id(self): session})
 
     @with_orm_session
     def now(self) -> datetime:

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_base_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_base_dispatcher.py
@@ -13,6 +13,7 @@ Design decisions (per design.md):
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from secbaas.community.api.bot_runtime import (
@@ -85,14 +86,20 @@ class BotBaseDispatcher:
             RuntimeError: Selected device has no provider_device_id
         """
         # 1. Look up bot by UUID
-        bot = self._bot_repo.get_active_by_bot_uuid(bot_uuid, tenant, env)
+        # Repositories are synchronous (blocking DB I/O); dispatchers run on the
+        # uvicorn event loop, so every repo call is offloaded to a worker thread.
+        # Running them inline parks the loop for the duration of the query and
+        # stalls every other request served by the same worker.
+        bot = await asyncio.to_thread(
+            self._bot_repo.get_active_by_bot_uuid, bot_uuid, tenant, env
+        )
         if not bot:
             logger.warning(f"Bot not found: bot_uuid={bot_uuid}, tenant={tenant}")
             raise BotNotFoundError(bot_uuid)
 
         # 2. Get devices associated with bot
-        devices = self._device_repo.list_by_bot_id(
-            bot_id=bot.id, tenant=tenant, env=env
+        devices = await asyncio.to_thread(
+            self._device_repo.list_by_bot_id, bot_id=bot.id, tenant=tenant, env=env
         )
         if not devices:
             logger.warning(f"No devices found for bot: bot_uuid={bot_uuid}")

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_http_conn_info_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_http_conn_info_dispatcher.py
@@ -6,6 +6,7 @@ Supports both auto-selection (default) and targeted device selection via device_
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from secbaas.community.api.bot_runtime import (
@@ -121,14 +122,18 @@ class DefaultBotHttpConnInfoDispatcher(BotBaseDispatcher, BotHttpConnInfoDispatc
         )
 
         # 1. Look up bot
-        bot = self._bot_repo.get_active_by_bot_uuid(bot_uuid, tenant, env)
+        # Sync repositories are offloaded to a worker thread so the blocking DB
+        # call does not park the event loop (see BotBaseDispatcher).
+        bot = await asyncio.to_thread(
+            self._bot_repo.get_active_by_bot_uuid, bot_uuid, tenant, env
+        )
         if not bot:
             logger.warning(f"Bot not found: bot_uuid={bot_uuid}, tenant={tenant}")
             raise BotNotFoundError(bot_uuid)
 
         # 2. List all devices for this bot and find the specific one
-        devices = self._device_repo.list_by_bot_id(
-            bot_id=bot.id, tenant=tenant, env=env
+        devices = await asyncio.to_thread(
+            self._device_repo.list_by_bot_id, bot_id=bot.id, tenant=tenant, env=env
         )
         # fmt: off
         device = next(

--- a/src/baas/src/secbaas/community/core/service/paas/_facade.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_facade.py
@@ -1033,7 +1033,12 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
         service = None
         try:
             # Step 1 & 2: Parse device ID and lookup template
-            template = self._device_template_service.get_by_template_id(
+            # DeviceTemplateService and PaasServiceFactory both issue synchronous
+            # DB queries. This coroutine runs on the uvicorn event loop, so both
+            # are offloaded to a worker thread — running them inline blocks the
+            # loop and stalls unrelated requests on the same worker.
+            template = await asyncio.to_thread(
+                self._device_template_service.get_by_template_id,
                 template_id=template_id,
             )
             if not template:
@@ -1049,8 +1054,10 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
                 )
 
             # Step 3: Create service via Factory using resolved template
-            service = self._factory.create(
-                tenant_name=template.tenant, template_uuid=template.template_uuid
+            service = await asyncio.to_thread(
+                self._factory.create,
+                tenant_name=template.tenant,
+                template_uuid=template.template_uuid,
             )
 
             # Step 4: Delegate to service polymorphic method

--- a/src/baas/tests/unit/core/repository/test_with_orm_session_isolation.py
+++ b/src/baas/tests/unit/core/repository/test_with_orm_session_isolation.py
@@ -1,0 +1,136 @@
+"""Session isolation tests for ``@with_orm_session``.
+
+Repositories are DI singletons, so one instance serves every request in the
+process. These tests pin down that the session opened for one call is never
+visible to another — the property that makes it safe for an ``async def``
+handler to offload repository calls with ``asyncio.to_thread``.
+
+The tests are deterministic rather than timing-based: a barrier holds both
+callers inside their repository method at the same moment, which is exactly the
+window in which a shared ``self._session`` attribute gets overwritten.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from secbaas.community.core.repository import OrmConnectionMixin, with_orm_session
+
+
+class _FakeSession:
+    """Stand-in for a SQLAlchemy Session, distinguishable by identity."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        # Keeps the decorator off the session.connection() path.
+        self.is_active = False
+
+
+class _FakeDatabase:
+    """Yields a fresh session per ``orm_session()`` call, like the real manager."""
+
+    def __init__(self) -> None:
+        self._counter = 0
+        self._lock = threading.Lock()
+
+    @contextmanager
+    def orm_session(self):
+        with self._lock:
+            self._counter += 1
+            label = f"session-{self._counter}"
+        yield _FakeSession(label)
+
+
+class _FakeRepository(OrmConnectionMixin):
+    """Minimal repository with the same shape as the ORM repositories."""
+
+    def __init__(self, database: _FakeDatabase) -> None:
+        self._database = database
+
+    @with_orm_session
+    def read_twice(self, barrier: threading.Barrier | None = None) -> tuple:
+        """Read the bound session, yield to the other caller, read it again."""
+        first = self._session
+        if barrier is not None:
+            barrier.wait(timeout=5)
+        second = self._session
+        return first, second
+
+    @with_orm_session
+    def read_once(self) -> _FakeSession:
+        return self._session
+
+
+@pytest.fixture
+def repository() -> _FakeRepository:
+    return _FakeRepository(_FakeDatabase())
+
+
+class TestConcurrentThreads:
+    """Concurrent worker threads must not share a session."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_to_thread_calls_keep_separate_sessions(self, repository):
+        """Two `asyncio.to_thread` calls on one singleton stay isolated.
+
+        Both threads sit inside `read_twice` simultaneously, so with the
+        session stored on the shared instance the second binding clobbers the
+        first and the earlier caller finishes against the later caller's
+        session — another request's transaction, and potentially another
+        tenant's data.
+        """
+        barrier = threading.Barrier(2)
+
+        first_call, second_call = await asyncio.wait_for(
+            asyncio.gather(
+                asyncio.to_thread(repository.read_twice, barrier),
+                asyncio.to_thread(repository.read_twice, barrier),
+            ),
+            timeout=10,
+        )
+
+        # Neither caller's session changed under it while it was suspended.
+        assert first_call[0] is first_call[1]
+        assert second_call[0] is second_call[1]
+        # And the two callers were handed genuinely different sessions.
+        assert first_call[0] is not second_call[0]
+
+    @pytest.mark.asyncio
+    async def test_session_unbound_after_call_completes(self, repository):
+        """The binding does not outlive the call that opened it."""
+        await asyncio.to_thread(repository.read_once)
+
+        with pytest.raises(RuntimeError, match="no ORM session bound"):
+            _ = repository._session
+
+
+class TestSequentialCalls:
+    """The single-threaded contract is unchanged."""
+
+    def test_each_call_sees_its_own_session(self, repository):
+        first = repository.read_once()
+        second = repository.read_once()
+
+        assert first is not second
+        assert (first.label, second.label) == ("session-1", "session-2")
+
+    def test_direct_assignment_is_visible_to_the_same_context(self, repository):
+        """Direct `_session` assignment still works for tests and callers."""
+        injected = _FakeSession("injected")
+        repository._session = injected
+
+        assert repository._session is injected
+
+    def test_two_repositories_do_not_share_a_binding(self):
+        """A session is bound per repository instance, not globally."""
+        database = _FakeDatabase()
+        left, right = _FakeRepository(database), _FakeRepository(database)
+
+        left_session = left.read_once()
+        right_session = right.read_once()
+
+        assert left_session is not right_session

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_http_conn_info_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_http_conn_info_dispatcher.py
@@ -8,6 +8,8 @@ Tests the bot HTTP connection info resolution service including:
 - PaasServiceFacade integration for HTTP connection info resolution
 """
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -715,3 +717,127 @@ class TestDispatchBotHttpConnInfoWithDeviceUuid:
             )
 
         assert "nonexistent-bot" in str(exc_info.value)
+
+
+# ==================== Event Loop Blocking Regression ====================
+
+
+class TestEventLoopNotBlocked:
+    """Repository calls must not run inline on the uvicorn event loop.
+
+    The repositories are synchronous (blocking DB I/O). Calling them directly
+    from an ``async def`` dispatcher parks the worker's event loop for the
+    duration of the query, so every other request on that worker waits — the
+    head-of-line blocking behind the observed /http-info 499s.
+
+    These tests are deterministic rather than timing-based: the fake repository
+    blocks its thread until a *loop-side* coroutine releases it. If the repo
+    call ran on the loop, the releasing coroutine could never be scheduled and
+    the fake would time out.
+    """
+
+    @staticmethod
+    def _blocking(return_value, reached, release):
+        """Build a sync repo stub that blocks until the loop releases it."""
+
+        def _call(*_args, **_kwargs):
+            reached.set()
+            if not release.wait(timeout=5):
+                raise AssertionError(
+                    "event loop was blocked: the loop-side coroutine never ran "
+                    "while the synchronous repository call was in flight"
+                )
+            return return_value
+
+        return _call
+
+    @staticmethod
+    async def _release_when_reached(reached, release):
+        """Loop-side coroutine — only progresses if the loop is free."""
+        await asyncio.to_thread(reached.wait, 5)
+        release.set()
+
+    @pytest.mark.asyncio
+    async def test_auto_select_flow_yields_loop_during_bot_lookup(
+        self,
+        mock_bot,
+        mock_active_device,
+        mock_bot_repo,
+        mock_device_repo,
+        mock_paas_facade,
+    ):
+        """Auto-select flow keeps the loop responsive during the bot lookup."""
+        from secbaas.community.core.service.bot_runtime.dispatcher import (
+            DefaultBotHttpConnInfoDispatcher,
+        )
+
+        reached = threading.Event()
+        release = threading.Event()
+        mock_bot_repo.get_active_by_bot_uuid.side_effect = self._blocking(
+            mock_bot, reached, release
+        )
+        mock_device_repo.list_by_bot_id.return_value = [mock_active_device]
+
+        service = DefaultBotHttpConnInfoDispatcher(
+            bot_repo=mock_bot_repo,
+            device_repo=mock_device_repo,
+            paas_facade=mock_paas_facade,
+        )
+
+        result, _ = await asyncio.wait_for(
+            asyncio.gather(
+                service.dispatch_bot_http_conn_info(
+                    bot_uuid="bot-uuid-001",
+                    port=20003,
+                    path="/api/health",
+                    tenant="test_tenant",
+                ),
+                self._release_when_reached(reached, release),
+            ),
+            timeout=10,
+        )
+
+        assert result.token == "test-jwt-token"
+
+    @pytest.mark.asyncio
+    async def test_specific_device_flow_yields_loop_during_device_listing(
+        self,
+        mock_bot,
+        mock_active_device,
+        mock_bot_repo,
+        mock_device_repo,
+        mock_paas_facade,
+    ):
+        """device_uuid flow keeps the loop responsive during the device listing."""
+        from secbaas.community.core.service.bot_runtime.dispatcher import (
+            DefaultBotHttpConnInfoDispatcher,
+        )
+
+        reached = threading.Event()
+        release = threading.Event()
+        mock_bot_repo.get_active_by_bot_uuid.return_value = mock_bot
+        mock_device_repo.list_by_bot_id.side_effect = self._blocking(
+            [mock_active_device], reached, release
+        )
+
+        service = DefaultBotHttpConnInfoDispatcher(
+            bot_repo=mock_bot_repo,
+            device_repo=mock_device_repo,
+            paas_facade=mock_paas_facade,
+        )
+
+        result, _ = await asyncio.wait_for(
+            asyncio.gather(
+                service.dispatch_bot_http_conn_info(
+                    bot_uuid="bot-uuid-001",
+                    port=20003,
+                    path="/api/health",
+                    tenant="test_tenant",
+                    device_uuid="device-uuid-001",
+                ),
+                self._release_when_reached(reached, release),
+            ),
+            timeout=10,
+        )
+
+        assert result.token == "test-jwt-token"

--- a/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade_coverage.py
@@ -1,5 +1,7 @@
 """Coverage tests for PaasServiceFacade — targets uncovered branches."""
 
+import asyncio
+import threading
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1566,3 +1568,77 @@ class TestFetchStartProgress:
 
         with pytest.raises(DeviceFacadeException):
             await f.fetch_start_progress("dev@42")
+
+
+# ---------------------------------------------------------------------------
+# resolve_invoke_http_info — event loop blocking regression
+# ---------------------------------------------------------------------------
+
+
+class TestResolveInvokeHttpInfoDoesNotBlockLoop:
+    """Template lookup and factory creation both issue synchronous DB queries.
+
+    Running them inline on the uvicorn event loop parks the whole worker for
+    the duration of the query. These tests block the calling thread until a
+    loop-side coroutine releases it: if the sync call ran on the loop, the
+    releasing coroutine could never be scheduled.
+    """
+
+    @staticmethod
+    def _blocking(return_value, reached, release):
+        def _call(*_args, **_kwargs):
+            reached.set()
+            if not release.wait(timeout=5):
+                raise AssertionError(
+                    "event loop was blocked: the loop-side coroutine never ran "
+                    "while the synchronous call was in flight"
+                )
+            return return_value
+
+        return _call
+
+    @staticmethod
+    async def _release_when_reached(reached, release):
+        await asyncio.to_thread(reached.wait, 5)
+        release.set()
+
+    @pytest.mark.asyncio
+    async def test_template_lookup_yields_loop(self):
+        f, tpl_svc, factory = _make_facade()
+        mock_svc = _make_mock_service()
+        factory.create.return_value = mock_svc
+
+        reached = threading.Event()
+        release = threading.Event()
+        tpl_svc.get_by_template_id.side_effect = self._blocking(
+            _make_template(), reached, release
+        )
+
+        result, _ = await asyncio.wait_for(
+            asyncio.gather(
+                f.resolve_invoke_http_info("dev@42", 8080, "/api"),
+                self._release_when_reached(reached, release),
+            ),
+            timeout=10,
+        )
+
+        assert isinstance(result, HttpConnectionInfo)
+
+    @pytest.mark.asyncio
+    async def test_factory_create_yields_loop(self):
+        f, tpl_svc, factory = _make_facade()
+        mock_svc = _make_mock_service()
+
+        reached = threading.Event()
+        release = threading.Event()
+        factory.create.side_effect = self._blocking(mock_svc, reached, release)
+
+        result, _ = await asyncio.wait_for(
+            asyncio.gather(
+                f.resolve_invoke_http_info("dev@42", 8080, "/api"),
+                self._release_when_reached(reached, release),
+            ),
+            timeout=10,
+        )
+
+        assert isinstance(result, HttpConnectionInfo)


### PR DESCRIPTION
## Problem

`GET /bots/{bot_uuid}/http-info` is an `async def` route, so it runs on the uvicorn worker's **event loop** — not the threadpool FastAPI would use for a plain `def` handler. Its resolution path called synchronous SQLAlchemy repositories inline:

| Step | Location | Blocking? |
| --- | --- | --- |
| `BotRepository.get_active_by_bot_uuid` | `dispatcher/_base_dispatcher.py` | yes — sync ORM |
| `DeviceRepository.list_by_bot_id` | `dispatcher/_base_dispatcher.py` | yes — sync ORM |
| `DeviceTemplateService.get_by_template_id` | `paas/_facade.py` | yes — sync ORM |
| `PaasServiceFactory.create` | `paas/_facade.py` | yes — issues its own `get_online_by_template_uuid` query |

The `device_uuid` branch (`_http_conn_info_dispatcher.py`) repeats the first two.

Each call parks the whole loop for the duration of the query, so every other request queued on that worker waits behind it. That head-of-line blocking matches the reported symptoms: bimodal `/http-info` latency (~60 ms or ~5000 ms with nothing between), 499s clustering across unrelated bots and unrelated paths at the same instant, and `$request_time ≈ 4996 ms` against the backend's 5 s deadline while BaaS itself never errored.

This is the BaaS-side cause deferred by the backend-side transport-resilience work, which only makes the caller tolerant of these stalls.

Two further defects surfaced while doing it:

**A cross-request session race, blocking the offload.** `with_orm_session` stored the session it opened as `self._session` on the repository, and repositories are DI singletons — one instance per process. That was safe only while every repository call ran to completion on the single event-loop thread. Offloading to worker threads removes the guarantee: thread B's assignment lands between thread A's assignment and A's query, so A executes against B's session — another request's transaction, potentially another tenant's data, or a SQLAlchemy error from driving one session from two threads. Raised in review; the fix is below.

**The CI summary swallowed its own failures.** `scripts/lib/common.sh` counted failing tests with `((log_failures++))`, whose post-increment returns exit status 1 on the first iteration. `_run_pytest` ends with a bare `set -e` that re-enables errexit for the rest of the run, so that status aborted `_summary` at the first counted failure. Every BaaS CI failure printed the summary header, no verdict, and exited 1 — red job, no diagnosis.

## Solution

**Offload the blocking calls** with `asyncio.to_thread`, following the existing house style in `core/service/session_file_sharing/_dispatcher.py`. The device-resolution fix lands in the shared `BotBaseDispatcher._resolve_bot_device`, so the sibling `bot_runtime` dispatchers that reuse it (`http`, `wss`, `cmd`, `open_folder`, `file_transfer`) get the same benefit. The facade offloads both the template lookup and `factory.create`.

**Bind ORM sessions per context, not per instance.** `with_orm_session` now binds into a `ContextVar` keyed by repository instance. `asyncio.to_thread` runs its callable in a copy of the calling context and each asyncio task gets its own copy, so a session is visible only to the call that opened it; the decorator resets its token on exit, so a binding also cannot outlive its call — nested calls on one repository restore the outer session instead of leaving the inner one bound, which the attribute version got wrong too. `OrmConnectionMixin._session` became a property reading that binding, so none of the 222 decorated repository methods changed. Reading it outside a session scope now raises `RuntimeError` naming the repository rather than silently using whatever the last caller left behind.

This also covers `session_file_sharing` and `file_transfer`, which were already calling repositories from worker threads before this PR — the hazard existed there, it just hadn't been named.

**The CI summary counter** becomes a plain assignment. Exit codes are unchanged — a clean run still prints `All stages passed!` and returns 0, a failing run still returns 1 — but it now names the failing stages and tests first. It proved itself immediately: the architecture-rule failure hit while developing the session fix was reported by name instead of vanishing.

Rejected alternatives:

- **Pass the pre-resolved template into `factory.create` to skip its second query.** Tempting (the factory's docstring supports it), but not semantics-preserving: the facade resolves via `get_by_template_id`, whereas the factory resolves via `get_online_by_template_uuid`, which additionally enforces that the template is online. Handing over the pre-resolved object would silently drop that check, so the query was kept and merely moved off the loop.
- **Convert the routes to plain `def` and let FastAPI's threadpool handle them.** Smaller per-route diff, but it changes concurrency characteristics and interacts with the `@inject` / `Provide[...]` DI wiring — a bigger blast radius than this fix warrants.
- **Thread-local storage for the session** instead of a `ContextVar`. Sufficient for the thread case, since the decorated body never yields, but it would not isolate two asyncio tasks sharing the loop thread. The `ContextVar` covers both.
- **Replace `NullPool` with a real pool.** Not actionable in this repository, see below.

### Findings on the surrounding questions

- **`NullPool` (`core/database/_manager.py:315`) is unreachable in this repository.** `DatabaseManager.init_orm_session()` has no callers anywhere in the tree; DB init always flows through `DatabaseManagerLifecycle.start()` → `plugin.init_database()` → `db_manager.init_plugin()`, and every session then delegates to the plugin. The connection-pooling fix therefore belongs in the `ZDAS_ORM` plugin implementation, which is not part of this repository. Git blame is uninformative — the file arrives whole in the initial import commit.
- **The bundled `SqliteOrmPlugin` uses `StaticPool` with `check_same_thread=False`**, i.e. it is already built for cross-thread access; the full ASGI E2E suite passes against it with these calls moved to worker threads.
- **Remaining scope is not addressed here.** There are ~143 `async def` route handlers and 222 `@with_orm_session` repository methods, so the same trap exists on routes outside this path. Fixing them in one sweep was deliberately avoided; the non-`/http-info` routes need a separately tracked item. The session-binding fix means those routes can now be converted safely, one at a time.

## Validation

Run from `src/baas`, on this branch as based on `REL20260806`:

- `bash scripts/ci_test.sh --base origin/REL20260806` — the full CI pipeline, exit 0. All three stages green, plus both gates: case pass rate 100.00% (7993/7993), line coverage 92.48%, **change line coverage 100.00% (8/8)**; ASGI gate 100.00% (1233/1233) at 55.45% line coverage.
- `pytest tests/e2e/asgi` — stable across repeated standalone runs (1190 passed, 43 skipped). Exercises the real ASGI stack against the SQLite/`StaticPool` backend, covering the cross-thread concern above.
- `ruff check src tests` — clean; `ruff format --check src tests` — 1321 files already formatted.
- `mypy src tests` — no new errors versus the pre-change baseline. The repository-wide total of 4043 errors is pre-existing and unrelated.

All the new tests are deterministic rather than timing-based, and each was verified to fail without its fix:

- **Event-loop guards** (4): the fake repository blocks its thread until a *loop-side* coroutine releases it, so an inline call deadlocks and fails instead of depending on a latency threshold.
- **Session-isolation guards** (5): two concurrent `to_thread` calls enter one repository instance and are parked *inside* the method on a `threading.Barrier` — the exact A/B interleaving from review. On the previous implementation the earlier caller finishes against the later caller's session.
- **CI summary**: with a `FAILED …::…` line in the log it now prints the failing stage and test list and returns 1 (previously: header only, silent exit 1); with a clean log it still prints `All stages passed!` and returns 0.

Not run: the load test asserting that unrelated endpoints on the same worker stay responsive under concurrent `/http-info` traffic, and confirmation against production `orm-timing` logs for the 20:41 window — neither production logs nor a load-test environment is reachable from here. The `orm-timing` line (`core/repository/__init__.py`) already splits `acquire` / `query` / `commit`; if `acquire` dominates in that window the connection-churn reading holds, and if `query` dominates the real problem is slow queries instead.

One note for anyone editing `core/repository/__init__.py`: the pre-push SAST gate resolves whichever `flake8` is on `PATH`, and reports `E999 SyntaxError` on that file if it is a CPython 3.11 build — the file uses PEP 695 generics (`def with_orm_session[**P, R]`), which need 3.12, the version this project targets. It is not caused by this change; the unmodified file fails the same way. Point `PYTHON_SAST_CMD` at a 3.12+ interpreter and the gate passes with all rules enabled.

## Compatibility and risk

No contract, schema, config, or migration impact. Return values, raised exceptions, and call arguments are unchanged — only the thread the synchronous work runs on, and where the open session is stored. Repository calls now execute on worker threads, so each holds its own session concurrently with other in-flight requests rather than being serialized by the event loop.

The one behavioral change beyond that: reading `_session` outside a `@with_orm_session` scope now raises `RuntimeError` instead of returning a stale session. Nothing in the tree does so — the decorator was the only writer — and the setter is retained for direct assignment, so injected sessions in tests keep working.

The CI script change affects reporting only — no gate is added, removed, or weakened, and module selection is untouched. Rollback is a straight revert of any of the three commits, though reverting the offload without the session fix is the wrong half to keep.

The six originally touched files are byte-identical on `dev` and `REL20260806`, so the commits cherry-picked onto the release branch without conflict.
