### PR TITLE
fix(auth): expose empty tenant on user principal

### DIFF
--- a/src/backend/src/agentclaw/community/core/gateway_principal/models.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/models.py
@@ -132,6 +132,17 @@ class UserPrincipal(BaseModel):
     type: Literal[PrincipalType.USER] = PrincipalType.USER
     subject: GatewayUser
 
+    @property
+    def tenant(self) -> None:
+        """User principals assert no isolation tenant.
+
+        Kept as a read-only compatibility attribute for callers/tests that
+        check ``principal.tenant is None``. It is intentionally not a Pydantic
+        field, so a forged ``tenant`` key on a user principal is still ignored
+        rather than honoured as an isolation claim.
+        """
+        return None
+
 
 class BotPrincipal(BaseModel):
     """A bot/agent calling as a first-class caller in its own right."""

--- a/src/backend/tests/community/core/gateway_principal/test_verifier.py
+++ b/src/backend/tests/community/core/gateway_principal/test_verifier.py
@@ -139,6 +139,7 @@ def test_user_only_token_yields_the_internal_tenant_and_the_owner():
     assert caller.tenant == DEFAULT_AVERNET_TENANT
     assert caller.user_id == "u-1"
     assert isinstance(caller.principals[0], UserPrincipal)
+    assert caller.principals[0].tenant is None
 
 
 def test_user_wins_over_app_when_both_identities_are_present():


### PR DESCRIPTION
## Summary
- Add a read-only compatibility `tenant` property on `UserPrincipal` returning `None`
- Keep user principals tenant-less semantically: this is not a Pydantic field, so forged user `tenant` input is still ignored rather than honored
- Add verifier coverage for `principal.tenant is None`

## Tests
- `cd ocb-public/src/backend && uv run pytest tests/community/core/gateway_principal/test_verifier.py -q`
