### PR TITLE
feat(openapi-v1): serve draft service bots across the public surface, draft device always

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
@@ -1,4 +1,11 @@
-"""Approvals group — ``/openapi/v1/bots/approvals/{bot_id}``."""
+"""Approvals group — ``/openapi/v1/bots/approvals/{bot_id}``.
+
+**Private bots only** — private personal bots, and a service bot's
+pre-publication draft workspace; see ``engine_runtime/gating.py``.
+Approval state is session-scoped, so on a shared bot these routes
+would reach other callers' sessions — the same hazard the sessions
+group gates on.
+"""
 
 from __future__ import annotations
 
@@ -23,6 +30,9 @@ from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
 from agentclaw.community.core.engine_runtime.errors import (
@@ -89,8 +99,10 @@ async def get_approval_mode(
     # Publicly a GET with a query parameter; the engine models the same read as
     # a POST with a body.
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="POST",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="POST",
         path="/api/approvals/mode/get",
         # user_id is filled from the principal; the engine uses it to route.
         body={"session_key": session_key, "user_id": owner_id},
@@ -111,8 +123,10 @@ async def set_approval_mode(
     # The enum's value is forwarded verbatim: all three are already in the
     # engine's accept-set, so no translation is needed and none is applied.
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="POST",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="POST",
         path="/api/approvals/mode/set",
         body={
             "session_key": body.session_key,
@@ -152,8 +166,10 @@ async def list_approval_modes(
     # The list is served from the public enum rather than relayed, because the
     # engine's descriptions are Chinese and this surface promises English.
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET",
         path="/api/engine/capabilities",
     )
     caps = result.data if isinstance(result.data, dict) else {}

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
@@ -1,5 +1,8 @@
 """Engine group (read-only) — ``/openapi/v1/bots/engine/{bot_id}``.
 
+**Private bots only** — private personal bots, and a service bot's
+pre-publication draft workspace; see ``engine_runtime/gating.py``.
+
 Three reads. ``switch`` and ``restart`` are deliberately **not** wrapped:
 wrapping ``switch`` would be a back door around the rule that a bot's engine is
 fixed at creation (``PUT /openapi/v1/bots/{bot_id}`` rejects it), and
@@ -26,6 +29,9 @@ from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
 from agentclaw.community.core.engine_runtime.errors import EngineUpstreamError
@@ -61,10 +67,12 @@ async def get_engine_status(
 ) -> Envelope[EngineStatus]:
     """Runtime state of the bot's engine."""
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     # enveloped=False: this engine route answers with its status payload raw —
     # no `success` key and no `data` wrapper. The only such route wrapped here.
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET", path="/api/engine/status",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET", path="/api/engine/status",
         enveloped=False,
     )
     raw = result.data if isinstance(result.data, dict) else {}
@@ -95,8 +103,10 @@ async def get_engine_capabilities(
     same request can succeed for one of your bots and be refused for another.
     """
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET",
         path="/api/engine/capabilities",
     )
     raw = result.data if isinstance(result.data, dict) else {}
@@ -125,8 +135,10 @@ async def list_available_engines(
     """Engines available on this bot, with the active one marked."""
     # Publicly a noun; the engine models the same read under a verb path.
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET", path="/api/engine/list",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET", path="/api/engine/list",
     )
     raw = result.data
     if isinstance(raw, dict):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/gating.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/gating.py
@@ -1,0 +1,45 @@
+"""The resolve-and-gate step every engine-runtime group runs before forwarding.
+
+One helper, used by the sessions, engine, models and approvals routers (the
+connection endpoint runs the same gate inside ``EngineConnectionService``,
+where its socket is composed). The rule itself lives in
+``core/engine_runtime/gate.py``: these groups serve private personal bots and
+a service bot's pre-publication **draft** workspace, and nothing any other
+caller can reach.
+
+The gate only holds together with how the groups forward — every
+``relay.call`` in a gated group passes ``draft_device=True``, so a service
+bot's request reaches the draft binding the owner alone uses, never the
+published runtime, which is a multi-caller device whose data (sessions,
+approvals) is not scoped per caller.
+"""
+
+from __future__ import annotations
+
+from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.core.engine_runtime.gate import require_operable_bot
+from agentclaw.community.core.engine_runtime.models import BotFacts
+
+
+async def resolve_operable_bot(
+    relay: EngineRuntimeRelayProtocol, bot_id: str, owner_id: str, *, surface: str
+) -> BotFacts:
+    """Resolve the caller's bot and reject anything more than one caller reaches.
+
+    Runs **before** any device call, deliberately: a filter applied to what the
+    device returned would already have fetched device-wide data. This also
+    performs the owner-scoped resolve, so a foreign ``bot_id`` raises
+    ``BotNotFoundError`` here — before a device is touched. The resolved facts
+    are returned so the forward can reuse them (``relay.call(..., facts=facts,
+    draft_device=True)``) instead of resolving again.
+
+    ``surface`` names the group for the refusal message; the adapter maps both
+    refusals to the same public 501 — what the surface cannot serve, rather
+    than something the caller may retry or fix.
+    """
+    facts = await relay.resolve_bot_off_loop(bot_id, owner_id)
+    require_operable_bot(facts.bot_type, is_shared=facts.is_shared, surface=surface)
+    return facts
+
+
+__all__ = ["resolve_operable_bot"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
@@ -1,4 +1,8 @@
-"""Models group — ``/openapi/v1/bots/models/{bot_id}``."""
+"""Models group — ``/openapi/v1/bots/models/{bot_id}``.
+
+**Private bots only** — private personal bots, and a service bot's
+pre-publication draft workspace; see ``engine_runtime/gating.py``.
+"""
 
 from __future__ import annotations
 
@@ -23,6 +27,9 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
     page as page_envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
 from agentclaw.community.core.engine_runtime.errors import EngineResourceNotFoundError
@@ -52,8 +59,10 @@ async def list_models(
 ) -> Envelope[Page[Model]]:
     """List the models this bot's engine can route to."""
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="models")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET", path="/api/models",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET", path="/api/models",
     )
     # The engine wraps this one: data is {"models": [...], "total": n}, not a
     # bare list. Reading it as a list yields an empty page on every call against
@@ -91,8 +100,10 @@ async def get_model(
     if any(part in ("..", ".") for part in model_id.split("/")):
         raise EngineResourceNotFoundError("invalid model id")
     owner_id = caller_owner_id(principal)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="models")
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, method="GET",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET",
         path=f"/api/models/{model_id}",
     )
     if not isinstance(result.data, dict):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -1,7 +1,8 @@
 """Sessions group — ``/openapi/v1/bots/sessions/{bot_id}``.
 
-Wraps the engine's ``/api/sessions`` surface. **Private personal bots only** —
-see :func:`_require_private_personal_bot`.
+Wraps the engine's ``/api/sessions`` surface. **Private bots only** — private
+personal bots, and a service bot's pre-publication draft workspace. See
+:func:`_require_operable_bot`.
 """
 
 from __future__ import annotations
@@ -37,10 +38,10 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
 from agentclaw.community.core.engine_runtime.errors import (
-    EngineBotTypeNotSupportedError,
     EngineHistoryDepthExceededError,
     EngineResourceNotFoundError,
 )
+from agentclaw.community.core.engine_runtime.gate import require_operable_bot
 from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
@@ -50,13 +51,6 @@ logger = get_logger()
 router = APIRouter(prefix="/openapi/v1/bots/sessions", tags=["sessions"])
 
 PrincipalDep = Annotated[Principal, Depends(require_principal)]
-
-#: The only bot type this group serves. A ``service`` bot's device is reached by
-#: many callers and the engine's session list is not scoped per caller, so
-#: listing there would show the bot's owner other people's conversations.
-#:
-#: Necessary but **not** sufficient — see :func:`_require_private_personal_bot`.
-_SUPPORTED_BOT_TYPE = "personal"
 
 #: One extra item is requested beyond the page, purely to learn whether more
 #: exist. Neither engine route reports a total, and ``Page.total`` is required —
@@ -75,7 +69,7 @@ _LOOKAHEAD = 1
 _MAX_HISTORY_DEPTH = 5000
 
 
-async def _require_private_personal_bot(
+async def _require_operable_bot(
     relay: EngineRuntimeRelayProtocol, bot_id: str, owner_id: str
 ) -> BotFacts:
     """Resolve the caller's bot and reject anything more than one caller reaches.
@@ -86,26 +80,19 @@ async def _require_private_personal_bot(
     ``BotNotFoundError`` here — before a device is touched. The resolved facts
     are returned so the forward can reuse them instead of resolving again.
 
-    Two conditions, because the hazard is *multi-caller*, not *bot type*. A
-    ``service`` bot is the obvious case. But ``personal`` is single-caller only
-    by default: the bot can be made public, and a coding app can take
-    collaborators, and ``ExpertChatService`` then creates those callers'
-    sessions on this same binding. Since the engine's collection is not scoped
-    per caller (see :attr:`BotFacts.is_shared`), serving this group for such a
-    bot would let its owner list, read, rename and delete other people's
-    conversations. Both refusals are the same 501: what the surface cannot
-    serve, rather than something the caller may retry or fix.
+    Which bots pass is the shared gate's rule (see ``core/engine_runtime/
+    gate.py``): unshared personal bots, and a service bot's **draft** device.
+    The gate only holds together with how this group forwards — every
+    ``relay.call`` below passes ``draft_device=True``, so a service bot's
+    request reaches the pre-publication binding the owner alone uses, never
+    the published runtime, which is a multi-caller device whose session
+    collection is not scoped per caller. Refusals are a 501: what the surface
+    cannot serve, rather than something the caller may retry or fix.
     """
     facts = await relay.resolve_bot_off_loop(bot_id, owner_id)
-    if facts.bot_type != _SUPPORTED_BOT_TYPE:
-        raise EngineBotTypeNotSupportedError(
-            f"sessions are not served for bot_type={facts.bot_type!r}"
-        )
-    if facts.is_shared:
-        raise EngineBotTypeNotSupportedError(
-            "sessions are not served for a shared bot: the engine's session "
-            "collection is not scoped per caller"
-        )
+    require_operable_bot(
+        facts.bot_type, is_shared=facts.is_shared, surface="sessions"
+    )
     return facts
 
 
@@ -343,7 +330,7 @@ async def list_sessions(
 ) -> Envelope[SessionPage]:
     """List the bot's sessions."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     params: dict[str, Any] = _window(page)
     if agent_id:
         params["agent_id"] = agent_id
@@ -353,7 +340,8 @@ async def list_sessions(
     if session_key:
         params["session_key"] = session_key
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="GET", path="/api/sessions",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET", path="/api/sessions",
         params=params,
     )
     mapped = [_map_session(d) for d in _as_list(result.data)]
@@ -373,9 +361,10 @@ async def create_session(
 ) -> Envelope[Session]:
     """Create a session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="POST", path="/api/sessions",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="POST", path="/api/sessions",
         body={
             "title": body.title,
             "model": body.model,
@@ -405,9 +394,10 @@ async def get_session(
     # A colon is legal in a path segment (RFC 3986), so ids route as-is. An id
     # containing "/" would not be addressable, but no engine id format has one.
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="GET",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET",
         path=f"/api/sessions/{session_id}",
     )
     if not isinstance(result.data, dict):
@@ -429,10 +419,11 @@ async def update_session(
     # Publicly a PATCH on the resource; the engine models the same operation as
     # a POST to an /update sub-path.
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     payload = {k: v for k, v in body.model_dump().items() if v is not None}
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="POST",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="POST",
         # QUERY params, not a body. The engine declares this route's fields as
         # bare scalar arguments, which FastAPI binds from the query string —
         # there is no Body(...) on it. Sending a body is silently discarded and
@@ -456,9 +447,10 @@ async def delete_session(
 ) -> Envelope[Deleted]:
     """Delete a session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="DELETE",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="DELETE",
         path=f"/api/sessions/{session_id}",
     )
     return deleted(request)
@@ -484,10 +476,11 @@ async def list_session_messages(
     is never confused with the limit of what this endpoint serves.
     """
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     _require_within_depth(page)
     result = await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="GET",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="GET",
         path=f"/api/sessions/{session_id}/messages",
         # The history route tail-limits rather than paginating, so the offset is
         # applied here instead of being sent. See ``_history_window``.
@@ -512,9 +505,10 @@ async def clear_session_messages(
 ) -> Envelope[Deleted]:
     """Clear a session's message history, keeping the session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_private_personal_bot(relay, bot_id, owner_id)
+    facts = await _require_operable_bot(relay, bot_id, owner_id)
     await relay.call(
-        bot_id=bot_id, owner_id=owner_id, facts=facts, method="DELETE",
+        bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
+        method="DELETE",
         path=f"/api/sessions/{session_id}/messages",
     )
     return deleted(request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -2,7 +2,7 @@
 
 Wraps the engine's ``/api/sessions`` surface. **Private bots only** — private
 personal bots, and a service bot's pre-publication draft workspace. See
-:func:`_require_operable_bot`.
+``engine_runtime/gating.py``.
 """
 
 from __future__ import annotations
@@ -37,12 +37,13 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
     page as page_envelope,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
+)
 from agentclaw.community.core.engine_runtime.errors import (
     EngineHistoryDepthExceededError,
     EngineResourceNotFoundError,
 )
-from agentclaw.community.core.engine_runtime.gate import require_operable_bot
-from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 
@@ -67,33 +68,6 @@ _LOOKAHEAD = 1
 #: Generous for a conversation; bounded enough that a page number cannot be
 #: turned into device load.
 _MAX_HISTORY_DEPTH = 5000
-
-
-async def _require_operable_bot(
-    relay: EngineRuntimeRelayProtocol, bot_id: str, owner_id: str
-) -> BotFacts:
-    """Resolve the caller's bot and reject anything more than one caller reaches.
-
-    Runs **before** any device call, deliberately: a filter applied to what the
-    device returned would already have fetched every caller's sessions. This
-    also performs the owner-scoped resolve, so a foreign ``bot_id`` raises
-    ``BotNotFoundError`` here — before a device is touched. The resolved facts
-    are returned so the forward can reuse them instead of resolving again.
-
-    Which bots pass is the shared gate's rule (see ``core/engine_runtime/
-    gate.py``): unshared personal bots, and a service bot's **draft** device.
-    The gate only holds together with how this group forwards — every
-    ``relay.call`` below passes ``draft_device=True``, so a service bot's
-    request reaches the pre-publication binding the owner alone uses, never
-    the published runtime, which is a multi-caller device whose session
-    collection is not scoped per caller. Refusals are a 501: what the surface
-    cannot serve, rather than something the caller may retry or fix.
-    """
-    facts = await relay.resolve_bot_off_loop(bot_id, owner_id)
-    require_operable_bot(
-        facts.bot_type, is_shared=facts.is_shared, surface="sessions"
-    )
-    return facts
 
 
 def _map_session(data: dict[str, Any]) -> Session:
@@ -330,7 +304,7 @@ async def list_sessions(
 ) -> Envelope[SessionPage]:
     """List the bot's sessions."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     params: dict[str, Any] = _window(page)
     if agent_id:
         params["agent_id"] = agent_id
@@ -361,7 +335,7 @@ async def create_session(
 ) -> Envelope[Session]:
     """Create a session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
         method="POST", path="/api/sessions",
@@ -394,7 +368,7 @@ async def get_session(
     # A colon is legal in a path segment (RFC 3986), so ids route as-is. An id
     # containing "/" would not be addressable, but no engine id format has one.
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
         method="GET",
@@ -419,7 +393,7 @@ async def update_session(
     # Publicly a PATCH on the resource; the engine models the same operation as
     # a POST to an /update sub-path.
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     payload = {k: v for k, v in body.model_dump().items() if v is not None}
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -447,7 +421,7 @@ async def delete_session(
 ) -> Envelope[Deleted]:
     """Delete a session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
         method="DELETE",
@@ -476,7 +450,7 @@ async def list_session_messages(
     is never confused with the limit of what this endpoint serves.
     """
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     _require_within_depth(page)
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -505,7 +479,7 @@ async def clear_session_messages(
 ) -> Envelope[Deleted]:
     """Clear a session's message history, keeping the session."""
     owner_id = caller_owner_id(principal)
-    facts = await _require_operable_bot(relay, bot_id, owner_id)
+    facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
         method="DELETE",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
@@ -29,6 +29,9 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
 )
 from agentclaw.community.api.cron_relay_service import CronRelayServiceProtocol
 from agentclaw.community.core.cron.errors import CronRelayError
+from agentclaw.community.core.cron.services.cron_runtime_targets import (
+    RUNTIME_STAGE_DRAFT,
+)
 from agentclaw.community.di import Injected
 
 from .schemas import Routine, RoutineCreate, RoutineRun, RoutineUpdate, ScheduleTrigger
@@ -116,8 +119,12 @@ async def list_routines(
     owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
+    # Draft only, like every other route in this group: the public surface
+    # operates a bot's pre-publication workspace, so a service bot's published
+    # verify/online runtimes are neither listed nor queried here.
     result = await factory.list_all_crons(
-        user_id=user_id, nick_name=nick_name, bot_id=bot_id
+        user_id=user_id, nick_name=nick_name, bot_id=bot_id,
+        runtime_stage=RUNTIME_STAGE_DRAFT,
     )
     data = result.get("data") if isinstance(result, dict) else None
     if isinstance(data, list):

--- a/src/backend/src/agentclaw/community/api/engine_runtime_service.py
+++ b/src/backend/src/agentclaw/community/api/engine_runtime_service.py
@@ -50,6 +50,7 @@ class EngineRuntimeRelayProtocol(Protocol):
         timeout: float | None = None,
         enveloped: bool = True,
         facts: BotFacts | None = None,
+        draft_device: bool = False,
     ) -> EngineResult:
         """Issue ``method path`` against the caller's bot's engine adapter.
 
@@ -59,6 +60,11 @@ class EngineRuntimeRelayProtocol(Protocol):
         ``facts`` reuses a resolve a gating handler already paid for; ``None``
         resolves here. Only a value this relay returned for the same
         ``bot_id``/``owner_id`` is safe — it stands in for the ownership proof.
+
+        ``draft_device=True`` addresses a ``service`` bot's pre-publication
+        draft binding instead of its published runtime; inert for a personal
+        bot. The sessions group passes it — that surface operates the owner's
+        draft workspace, and the published runtime is a multi-caller device.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -100,7 +100,8 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         self,
         user_id: str,
         nick_name: str,
-        bot_id: Optional[str] = None
+        bot_id: Optional[str] = None,
+        runtime_stage: Optional[str] = None,
     ) -> dict:
         """获取用户所有 Bots 的定时任务（平铺展示）
 
@@ -108,10 +109,16 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             user_id: 用户ID
             nick_name: 用户花名
             bot_id: 如果为 "all" 或 None，返回所有 bots 的任务；否则返回指定 bot 的任务
+            runtime_stage: 仅返回该运行态的任务；None 表示全部运行态。openapi_v1
+                传 draft——公开面只操作草稿态；内部控制台不传，保持全运行态聚合。
 
         Returns:
             {"success": True, "data": [...], "total": N}
         """
+        if runtime_stage is not None and runtime_stage not in VALID_RUNTIME_STAGES:
+            raise CronRelayError(
+                f"Invalid runtime_stage: {runtime_stage}", error_code=400
+            )
         # 1. 获取用户的所有 bots
         if bot_id and bot_id != "all":
             bot = self._bot_provider.get_bot(bot_id, user_id)
@@ -136,6 +143,13 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             bot_targets, bot_failed_targets = self._build_runtime_targets(bot, user_id)
             targets.extend(bot_targets)
             failed_targets.extend(bot_failed_targets)
+
+        if runtime_stage is not None:
+            # 过滤在取数之前：范围之外的运行态既不查询也不产生失败项。
+            targets = [t for t in targets if t.runtime_stage == runtime_stage]
+            failed_targets = [
+                t for t in failed_targets if t.get("runtime_stage") == runtime_stage
+            ]
 
         tasks = []
         for target in targets:

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -34,10 +34,10 @@ from agentclaw.community.core.devices.repository.protocol import (
 from agentclaw.community.core.devices.models import OperatorContext
 from agentclaw.community.core.devices.services.device_service import DeviceService
 from agentclaw.community.core.engine_runtime.errors import (
-    EngineBotTypeNotSupportedError,
     EngineDeviceNotReadyError,
     EngineUpstreamError,
 )
+from agentclaw.community.core.engine_runtime.gate import require_operable_bot
 from agentclaw.community.core.engine_runtime.models import ConnectionResult, SocketInfo
 from agentclaw.community.core.engine_runtime.sharing import bot_is_shared
 from agentclaw.community.di.config import GatewayEndpoint
@@ -103,12 +103,6 @@ _CHAT_WS_PATHS = {
 # tenant's device from v1 at any scope.
 
 
-#: The only bot type a socket is published for — the same rule, and the same
-#: reason, as the sessions group's gate. Necessary but not sufficient; the bot
-#: must also be unshared. See :func:`_require_private_personal_bot`.
-_SUPPORTED_BOT_TYPE = "personal"
-
-
 def _quote_or_reject(value: str, *, safe: str, what: str) -> str:
     """Percent-encode ``value`` for a URL, or refuse it by name.
 
@@ -126,47 +120,6 @@ def _quote_or_reject(value: str, *, safe: str, what: str) -> str:
         raise EngineUpstreamError(
             f"device connection carries an unencodable {what}"
         ) from exc
-
-
-def _require_private_personal_bot(
-    bot_type: str, bot_id: str, *, is_shared: bool
-) -> None:
-    """Reject bots more than one caller reaches, before a socket is composed.
-
-    The socket this endpoint publishes is **not** chat-scoped, however it is
-    labelled. The engine's WebSocket server answers ``hello`` by advertising
-    ``sessions.list``, ``sessions.patch``, ``sessions.delete``,
-    ``sessions.reset`` and the ``exec.approvals`` methods, grants
-    ``operator.admin``, and forwards any method it does not handle itself to
-    the active engine's relay plugin. A caller holding the returned credential
-    therefore has an operator channel, not a chat channel.
-
-    On a ``service`` bot that is the same exposure the sessions group already
-    refuses. The engine has no tenant axis and its session list is not scoped
-    per caller, so one device holds every caller's sessions; the sessions group
-    answers 501 rather than let the bot's owner enumerate them. Publishing this
-    socket for the same bot would hand the same owner the same data over a
-    different transport — a 501 on the front door with the window left open.
-
-    ``is_shared`` closes the same window on a ``personal`` bot that is public
-    or has collaborators: those are multi-caller too, and this socket's
-    ``sessions.*`` methods reach every caller's conversations on the device.
-    See :func:`~agentclaw.community.core.engine_runtime.sharing.bot_is_shared`
-    — one predicate, so this gate and the sessions gate cannot drift apart.
-
-    Gated here rather than in the router because the rule is about what may be
-    *composed*, not about how it is served: any future caller of ``build`` is
-    covered without repeating the check.
-    """
-    if bot_type != _SUPPORTED_BOT_TYPE:
-        raise EngineBotTypeNotSupportedError(
-            f"connections are not served for bot_type={bot_type!r}"
-        )
-    if is_shared:
-        raise EngineBotTypeNotSupportedError(
-            "connections are not served for a shared bot: the socket grants "
-            "operator.admin over every caller's sessions on the device"
-        )
 
 
 class EngineConnectionService:
@@ -198,15 +151,25 @@ class EngineConnectionService:
         can never widen it.
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
-        _require_private_personal_bot(
+        # The socket this endpoint publishes is **not** chat-scoped, however it
+        # is labelled: the engine's ``hello`` advertises the ``sessions.*`` and
+        # ``exec.approvals`` methods and grants ``operator.admin``, so the
+        # credential is an operator channel over every session on the device.
+        # The shared gate admits exactly the bots whose device only the owner
+        # reaches — see ``gate.py`` for the full rule, including why a service
+        # bot's *draft* device (the one ``_active_binding_id`` resolves) is in
+        # that set. Gated here rather than in the router because the rule is
+        # about what may be *composed*, not about how it is served: any future
+        # caller of ``build`` is covered without repeating the check.
+        require_operable_bot(
             str(bot.get("bot_type") or ""),
-            bot_id,
             is_shared=bot_is_shared(
                 bot,
                 self._collaborator_repo,
                 bot_id=str(bot.get("bot_id") or bot_id),
                 owner_id=str(bot.get("owner_id") or owner_id),
             ),
+            surface="connections",
         )
         engine = str(bot.get("active_engine") or "")
 
@@ -274,6 +237,11 @@ class EngineConnectionService:
         Owner-scoped for the same reason ``resolve_for_bot`` was: the query is
         ``(bot_id, owner_id)``, so another owner's binding cannot be returned
         even though ownership was already established above.
+
+        For a ``service`` bot this is the **draft** binding, and that is what
+        the gate above relies on: the verify/online runtimes publishing
+        produces are bound under ``publish_bot_id`` on the publish records,
+        so a ``bot_id``-keyed read cannot select them.
         """
         binding = self._binding_repository.get_active_by_bot_and_owner(
             bot_id, owner_id

--- a/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
@@ -1,0 +1,75 @@
+"""The bot gate the operator surfaces share.
+
+Two public surfaces hand a caller a channel onto their bot's device: the
+sessions group (``adapters/http/openapi_v1/.../sessions/router.py``) wraps the
+engine's ``/api/sessions`` routes over HTTP, and the connection endpoint
+(:mod:`agentclaw.community.core.engine_runtime.connection`) publishes a
+WebSocket whose ``hello`` advertises the ``sessions.*`` and ``exec.approvals``
+methods and grants ``operator.admin``. Both are *operator* channels: whoever
+holds them reaches every session on the device.
+
+They must therefore agree on which bots they serve — a bot refused a session
+list but handed an operator socket is a 501 on the front door with the window
+left open — so the rule lives here, once, rather than as a constant restated at
+each gate. :func:`bot_is_shared <agentclaw.community.core.engine_runtime.\
+sharing.bot_is_shared>` is the same idea for the sharing half of the check.
+
+**Which bots pass.** The hazard is *multi-caller*, not bot type: the engine has
+no tenant axis and its session collection is not scoped per caller, so the gate
+admits exactly the bots whose device only the owner reaches.
+
+- A ``personal`` bot — provided it is unshared. ``personal`` is single-caller
+  only by default: the bot can be made public and a coding app can take
+  collaborators, and ``ExpertChatService`` then creates those callers' sessions
+  on this same binding.
+- A ``service`` bot — for its **draft** device, and again only unshared. Both
+  surfaces address the device by ``bot_id``: the connection service reads the
+  binding via ``get_active_by_bot_and_owner`` and the sessions group forwards
+  with ``draft_device=True``, both of which resolve ``ac_bots.binding_id`` —
+  the pre-publication draft. The verify/online runtimes publishing produces are
+  bound under ``publish_bot_id`` (``source_bot_id + "pub" + version``) on the
+  publish records, so a ``bot_id``-addressed call structurally cannot reach the
+  multi-caller published device. The unshared draft binding holds only the
+  owner's own sessions, which is the same exposure as a private personal bot.
+  A surface that instead resolves the *published* runtime (the relay's default
+  for service bots) must not be opened with this gate.
+
+Anything else — an empty type, a type this build has never heard of — is
+refused rather than assumed personal: the gate is an allowlist.
+"""
+
+from __future__ import annotations
+
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineBotTypeNotSupportedError,
+)
+
+#: The bot types an operator surface may serve. Necessary but **not**
+#: sufficient — see :func:`require_operable_bot`.
+SUPPORTED_BOT_TYPES = frozenset({"personal", "service"})
+
+
+def require_operable_bot(bot_type: str, *, is_shared: bool, surface: str) -> None:
+    """Reject bots more than one caller reaches, before any device is touched.
+
+    Callers run this before composing a socket or forwarding a request — a
+    filter applied to what the device returned would already have fetched
+    every caller's sessions.
+
+    ``surface`` names what the caller serves ("sessions", "connections") so
+    the refusal reads the same as it always has on each surface. Both refusals
+    are the same 501: what the surface cannot serve, rather than something the
+    caller may retry or fix.
+    """
+    if bot_type not in SUPPORTED_BOT_TYPES:
+        raise EngineBotTypeNotSupportedError(
+            f"{surface} are not served for bot_type={bot_type!r}"
+        )
+    if is_shared:
+        raise EngineBotTypeNotSupportedError(
+            f"{surface} are not served for a shared bot: the engine's session "
+            "collection is not scoped per caller"
+        )
+
+
+__all__ = ["SUPPORTED_BOT_TYPES", "require_operable_bot"]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
@@ -1,12 +1,14 @@
 """The bot gate the operator surfaces share.
 
-Two public surfaces hand a caller a channel onto their bot's device: the
-sessions group (``adapters/http/openapi_v1/.../sessions/router.py``) wraps the
-engine's ``/api/sessions`` routes over HTTP, and the connection endpoint
-(:mod:`agentclaw.community.core.engine_runtime.connection`) publishes a
-WebSocket whose ``hello`` advertises the ``sessions.*`` and ``exec.approvals``
-methods and grants ``operator.admin``. Both are *operator* channels: whoever
-holds them reaches every session on the device.
+The public engine-runtime surfaces hand a caller a channel onto their bot's
+device: the sessions, engine, models and approvals groups
+(``adapters/http/openapi_v1/engine_runtime/`` — gated through
+``gating.resolve_operable_bot``) forward over HTTP, and the connection
+endpoint (:mod:`agentclaw.community.core.engine_runtime.connection`) publishes
+a WebSocket whose ``hello`` advertises the ``sessions.*`` and
+``exec.approvals`` methods and grants ``operator.admin``. These are *operator*
+channels: whoever holds them reaches device-wide state, including every
+session on the device.
 
 They must therefore agree on which bots they serve — a bot refused a session
 list but handed an operator socket is a 501 on the front door with the window
@@ -22,11 +24,11 @@ admits exactly the bots whose device only the owner reaches.
   only by default: the bot can be made public and a coding app can take
   collaborators, and ``ExpertChatService`` then creates those callers' sessions
   on this same binding.
-- A ``service`` bot — for its **draft** device, and again only unshared. Both
-  surfaces address the device by ``bot_id``: the connection service reads the
-  binding via ``get_active_by_bot_and_owner`` and the sessions group forwards
-  with ``draft_device=True``, both of which resolve ``ac_bots.binding_id`` —
-  the pre-publication draft. The verify/online runtimes publishing produces are
+- A ``service`` bot — for its **draft** device, and again only unshared. Every
+  gated surface addresses the device by ``bot_id``: the connection service
+  reads the binding via ``get_active_by_bot_and_owner`` and the HTTP groups
+  forward with ``draft_device=True``, both of which resolve
+  ``ac_bots.binding_id`` — the pre-publication draft. The verify/online runtimes publishing produces are
   bound under ``publish_bot_id`` (``source_bot_id + "pub" + version``) on the
   publish records, so a ``bot_id``-addressed call structurally cannot reach the
   multi-caller published device. The unshared draft binding holds only the

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -148,9 +148,19 @@ class EngineRuntimeRelay:
         return await asyncio.to_thread(self.resolve_bot, bot_id, owner_id)
 
     def _resolve_device(
-        self, bot_id: str, owner_id: str, facts: BotFacts
+        self, bot_id: str, owner_id: str, facts: BotFacts, draft_device: bool
     ) -> DeviceContext:
         """Resolve the bot's device, translating "not reachable" to one error.
+
+        ``draft_device`` picks which of a ``service`` bot's devices this call
+        addresses. The default resolves the **published** runtime — the device
+        the bot a caller addressed actually runs on. ``True`` resolves the
+        bot's own binding (``ac_bots.binding_id``, the pre-publication draft)
+        instead; the sessions group passes it because that surface operates the
+        owner's draft workspace, and the published runtime is a multi-caller
+        device whose session collection is not scoped per caller. The draft
+        lookup is the same owner-scoped ``resolve_for_bot`` a personal bot
+        uses, so for a personal bot the flag changes nothing.
 
         ``DeviceNotBoundError`` (never provisioned, released, or — for a service
         bot — never published) and ``ConnInfoBuildError`` (the provider could not
@@ -166,7 +176,7 @@ class EngineRuntimeRelay:
         timeout — so :meth:`call` runs it in a worker thread.
         """
         try:
-            if facts.bot_type == _SERVICE_BOT_TYPE:
+            if facts.bot_type == _SERVICE_BOT_TYPE and not draft_device:
                 return self._resolve_published_device(facts, owner_id)
             return self._resolver.resolve_for_bot(bot_id, owner_id)
         except (DeviceNotBoundError, ConnInfoBuildError) as exc:
@@ -266,7 +276,7 @@ class EngineRuntimeRelay:
         )
 
     def _resolve_bot_and_device(
-        self, bot_id: str, owner_id: str, facts: BotFacts | None
+        self, bot_id: str, owner_id: str, facts: BotFacts | None, draft_device: bool
     ) -> DeviceContext:
         """Prove ownership, then resolve the device — one worker-thread hop.
 
@@ -275,7 +285,7 @@ class EngineRuntimeRelay:
         caller does not own, before any device is touched.
         """
         resolved = facts if facts is not None else self.resolve_bot(bot_id, owner_id)
-        return self._resolve_device(bot_id, owner_id, resolved)
+        return self._resolve_device(bot_id, owner_id, resolved, draft_device)
 
     # ── forwarding ────────────────────────────────────────────────────────
 
@@ -291,6 +301,7 @@ class EngineRuntimeRelay:
         timeout: float | None = None,
         enveloped: bool = True,
         facts: BotFacts | None = None,
+        draft_device: bool = False,
     ) -> EngineResult:
         """Issue ``method path`` against the caller's bot's engine adapter.
 
@@ -307,6 +318,10 @@ class EngineRuntimeRelay:
         from outside: the only safe value is one this relay returned for the
         same ``bot_id``/``owner_id``, since it stands in for the ownership
         proof.
+
+        ``draft_device`` addresses a ``service`` bot's pre-publication draft
+        binding instead of its published runtime — see :meth:`_resolve_device`
+        for the rule and who passes it. Inert for a personal bot.
 
         Bot and device resolution share one **worker thread** hop. Both legs are
         synchronous and neither belongs on the event loop:
@@ -333,7 +348,7 @@ class EngineRuntimeRelay:
         to lack one is exactly the malformed case that must still fail.
         """
         ctx = await asyncio.to_thread(
-            self._resolve_bot_and_device, bot_id, owner_id, facts
+            self._resolve_bot_and_device, bot_id, owner_id, facts, draft_device
         )
         raw = await self._invoke(ctx, method, path, body, params, timeout)
         return self._normalise(raw, bot_id=bot_id, path=path, enveloped=enveloped)

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
@@ -56,6 +56,7 @@ class FakeRelay:
     async def call(
         self, *, bot_id, owner_id, method, path,
         body=None, params=None, timeout=None, enveloped=True, facts=None,
+        draft_device=False,
     ) -> EngineResult:
         # Record the ATTEMPT first, then resolve. Ordering it the other way
         # made "no device was touched" tautological: a foreign bot raises in
@@ -71,6 +72,7 @@ class FakeRelay:
                 "bot_id": bot_id, "owner_id": owner_id, "method": method,
                 "path": path, "body": body, "params": params,
                 "timeout": timeout, "enveloped": enveloped,
+                "draft_device": draft_device,
             }
         )
         if self.raises is not None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_approvals.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_approvals.py
@@ -147,3 +147,32 @@ def test_modes_serves_a_write_only_engine(client, relay):
 def test_foreign_bot_is_masked_404_without_a_device_call(client, relay):
     assert fails(client.get("/openapi/v1/bots/approvals/other/modes"), 404)
     assert relay.calls == []
+
+
+# ── the private-bots-only gate ───────────────────────────────────────────────
+
+
+def test_a_service_bot_is_served_at_its_draft_device(client, relay):
+    """Approval reads/writes on a service bot must reach the DRAFT device —
+    the published runtime is multi-caller, and approval state is
+    session-scoped."""
+    relay.set_bot_type("service")
+    relay.results = [EngineResult(data={"sessionKey": "sk", "mode": "approve"})]
+    resp = client.get(
+        f"/openapi/v1/bots/approvals/{BOT}/mode", params={"session_key": "sk"}
+    )
+    assert resp.status_code == 200, resp.json()
+    assert relay.calls and all(c["draft_device"] is True for c in relay.calls)
+
+
+def test_a_shared_bot_gets_501_without_touching_the_device(client, relay):
+    """On a shared bot these routes would reach other callers' sessions."""
+    relay.set_shared()
+    body = fails(
+        client.get(
+            f"/openapi/v1/bots/approvals/{BOT}/mode", params={"session_key": "sk"}
+        ),
+        501,
+    )
+    assert body["message"] == "Not supported for this bot type"
+    assert relay.calls == []

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_models.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_models.py
@@ -223,3 +223,50 @@ def test_foreign_bot_is_masked_404_without_a_device_call(engine_client, relay):
 def test_relay_errors_are_enveloped(models_client, relay, exc, status):
     relay.raises = exc
     fails(models_client.get(f"/openapi/v1/bots/models/{BOT}"), status)
+
+
+# ── the private-bots-only gate ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("client_name", "path"),
+    [
+        ("engine_client", f"/openapi/v1/bots/engine/{BOT}/status"),
+        ("engine_client", f"/openapi/v1/bots/engine/{BOT}/capabilities"),
+        ("engine_client", f"/openapi/v1/bots/engine/{BOT}/available"),
+        ("models_client", f"/openapi/v1/bots/models/{BOT}"),
+        ("models_client", f"/openapi/v1/bots/models/{BOT}/openai/gpt-5.3"),
+    ],
+)
+def test_a_service_bot_is_served_at_its_draft_device(
+    request, relay, client_name, path
+):
+    """Every route serves an unshared service bot — at its DRAFT binding.
+
+    The relay's default for a service bot is the *published* runtime; these
+    groups operate a bot's pre-publication workspace, so every forward must
+    carry ``draft_device=True``.
+    """
+    client = request.getfixturevalue(client_name)
+    relay.set_bot_type("service")
+    relay.results = [EngineResult(data={"engines": [], "models": []})]
+    resp = client.get(path)
+    assert resp.status_code == 200, resp.json()
+    assert relay.calls, "the route never forwarded"
+    assert all(c["draft_device"] is True for c in relay.calls)
+
+
+def test_a_shared_bot_gets_501_without_touching_the_device(engine_client, relay):
+    relay.set_shared()
+    body = fails(engine_client.get(f"/openapi/v1/bots/engine/{BOT}/status"), 501)
+    assert body["message"] == "Not supported for this bot type"
+    assert relay.calls == []
+
+
+def test_an_unknown_bot_type_gets_501_without_touching_the_device(
+    models_client, relay
+):
+    relay.set_bot_type("something-new")
+    body = fails(models_client.get(f"/openapi/v1/bots/models/{BOT}"), 501)
+    assert body["message"] == "Not supported for this bot type"
+    assert relay.calls == []

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
@@ -406,7 +406,7 @@ def test_the_session_window_stays_page_sized(client, relay):
     assert relay.calls[0]["params"] == {"offset": 100, "limit": 51}
 
 
-# ── the personal-bots-only gate ──────────────────────────────────────────────
+# ── the private-bots-only gate ───────────────────────────────────────────────
 
 
 @pytest.mark.parametrize(
@@ -417,19 +417,46 @@ def test_the_session_window_stays_page_sized(client, relay):
         ("get", f"/{SESSION_ID}/messages"), ("delete", f"/{SESSION_ID}/messages"),
     ],
 )
-def test_service_bot_gets_501_without_touching_the_device(
+def test_a_service_bot_is_served_and_addressed_at_its_draft_device(
     client, relay, method, suffix
 ):
-    """All seven routes, gated BEFORE the forward.
+    """All seven routes serve an unshared service bot — at its DRAFT binding.
 
-    A filter applied to what the device returned would already have fetched
-    every caller's sessions — so the assertion is that no call happened, not
-    merely that the status was 501.
+    The relay's default for a service bot is the *published* runtime, which is
+    a multi-caller device whose session collection is not scoped per caller —
+    forwarding there would hand the owner other callers' conversations. So the
+    assertion is not merely that the route answered: every forward must carry
+    ``draft_device=True``, addressing the pre-publication binding the owner
+    alone uses.
     """
     relay.set_bot_type("service")
     kwargs = {"json": {}} if method in ("post", "patch") else {}
     resp = getattr(client, method)(f"{_base()}{suffix}", **kwargs)
-    body = fails(resp, 501)
+    assert resp.status_code in (200, 201), resp.json()
+    assert relay.calls, "the route never forwarded"
+    assert all(c["draft_device"] is True for c in relay.calls)
+
+
+def test_a_shared_service_bot_gets_501_without_touching_the_device(client, relay):
+    """Sharing closes the draft window too: ``ExpertChatService`` creates
+    collaborator and public callers' sessions on the bot's own draft binding,
+    so a shared service bot's draft device is multi-caller like the published
+    one."""
+    relay.set_bot_type("service")
+    relay.set_shared()
+    body = fails(client.get(_base()), 501)
+    assert body["message"] == "Not supported for this bot type"
+    assert relay.calls == []
+
+
+@pytest.mark.parametrize("bot_type", ["", "something-new"])
+def test_an_unknown_bot_type_gets_501_without_touching_the_device(
+    client, relay, bot_type
+):
+    """The gate is an allowlist — a type this build has never heard of is not
+    silently treated as the permissive case."""
+    relay.set_bot_type(bot_type)
+    body = fails(client.get(_base()), 501)
     assert body["message"] == "Not supported for this bot type"
     assert relay.calls == []
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
@@ -165,6 +165,29 @@ async def test_list_routines_returns_envelope_page():
 
 
 @pytest.mark.asyncio
+async def test_list_routines_asks_for_the_draft_stage_only():
+    """The list is draft-only, like every other route in this group.
+
+    ``list_all_crons`` fans a service bot out over draft, verify and online
+    runtimes when no stage is given — but this public surface operates a bot's
+    pre-publication workspace, so listing here must neither show nor query the
+    published runtimes' crons.
+    """
+    service = _StubCronService([_adapter_dict()])
+
+    await list_routines(
+        page=PageParams(page=1, page_size=20),
+        principal={"user_id": "u1"},
+        bot_id="bot-x",
+        status=None,
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert service.last_call_kwargs.get("runtime_stage") == "draft"
+
+
+@pytest.mark.asyncio
 async def test_list_routines_paginates_items():
     items = [
         _adapter_dict(id="t1"),

--- a/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
+++ b/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
@@ -68,6 +68,7 @@ _NON_ENDPOINT_NAME_PATTERNS: tuple[str, ...] = (
     "converter",     # domain-model → API Response transforms
     "models",        # adapter-owned identity / response dataclasses
     "errors",        # adapter-owned error types (kept import-light on purpose)
+    "gating",        # engine-runtime resolve-and-gate helper shared by groups
     "clusters",      # public-API domain rule (engine ↔ cluster bijection)
     "principal",     # caller-identity extraction from the principal seam
     "enums",         # adapter-owned public enums (import-light by design:
@@ -238,6 +239,10 @@ _CORE_SERVICE_NAMES_OK: frozenset[str] = frozenset({
     "IdentityFileListResponse", "BotIdentityFileResponse",
     "BotIdentityFileUpdateResponse",
     "VALID_ENTITY_TYPES",
+    # Runtime-stage constant, not a service: the routines router passes it to
+    # ``list_all_crons`` so the public list stays draft-only, the same stage
+    # every other route in that group already defaults to.
+    "RUNTIME_STAGE_DRAFT",
     "is_readonly",
     "_HIDDEN_BASENAMES", "_HIDDEN_DIRNAMES",
     "_POOL_SKILLS_LOCAL_RELPATH", "_SKILLS_LOCAL_RELPATH",

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_list_stage_filter.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_list_stage_filter.py
@@ -1,0 +1,121 @@
+"""``list_all_crons`` 的 runtime_stage 过滤。
+
+openapi_v1 的 routines 列表只操作草稿态：服务 Bot 的 verify/online 运行态
+既不能出现在结果里，也不能被查询（发布态设备的失败项同样不该泄漏到公开面）。
+内部控制台不传 stage，保持全运行态聚合——默认行为必须不变。
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.cron.errors import CronRelayError
+from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.cron.services.cron_runtime_targets import (
+    CronRuntimeTarget,
+    RUNTIME_STAGE_DRAFT,
+    RUNTIME_STAGE_ONLINE,
+)
+
+
+def _make_service(*, bot_provider=None):
+    return CronRelayService(
+        bot_provider=bot_provider or MagicMock(),
+        device_provider=MagicMock(),
+        transport=MagicMock(),
+        resolver=MagicMock(),
+        template_repo=MagicMock(),
+        publish_repo=MagicMock(),
+    )
+
+
+def _target(stage: str, binding_id: int) -> CronRuntimeTarget:
+    return CronRuntimeTarget(
+        bot_id="bot-1",
+        bot_name="bot-1",
+        owner_id="user-1",
+        bot_type="service",
+        runtime_stage=stage,
+        binding_id=binding_id,
+    )
+
+
+def _service_with_stage_targets():
+    """一个已发布服务 Bot：draft + online 两个运行态目标，外加一个发布态失败项。"""
+    bot_provider = MagicMock()
+    bot_provider.get_bot.return_value = {
+        "bot_id": "bot-1",
+        "bot_type": "service",
+        "owner_id": "user-1",
+        "binding_id": 1,
+    }
+    svc = _make_service(bot_provider=bot_provider)
+    svc._build_runtime_targets = MagicMock(
+        return_value=(
+            [_target(RUNTIME_STAGE_DRAFT, 1), _target(RUNTIME_STAGE_ONLINE, 42)],
+            [
+                {
+                    "bot_id": "bot-1",
+                    "runtime_stage": RUNTIME_STAGE_ONLINE,
+                    "reason": "publish_query_failed",
+                }
+            ],
+        )
+    )
+    svc._fetch_runtime_target_crons = AsyncMock(
+        return_value={"success": True, "data": [{"task_id": "t1"}]}
+    )
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_draft_stage_filter_neither_returns_nor_queries_published_targets():
+    svc = _service_with_stage_targets()
+
+    result = await svc.list_all_crons(
+        user_id="user-1", nick_name="user-1", bot_id="bot-1",
+        runtime_stage=RUNTIME_STAGE_DRAFT,
+    )
+
+    # 只取草稿态目标——发布态设备一次都不被触达。
+    fetched = [
+        call.args[0] for call in svc._fetch_runtime_target_crons.await_args_list
+    ]
+    assert [t.runtime_stage for t in fetched] == [RUNTIME_STAGE_DRAFT]
+    assert all(c.get("runtime_stage") == RUNTIME_STAGE_DRAFT for c in result["data"])
+    # 发布态的失败项同样不进入公开面的响应。
+    assert result["failed_targets"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_stage_keeps_the_all_stage_aggregation():
+    """默认（内部控制台）行为不变：全部运行态都被查询。"""
+    svc = _service_with_stage_targets()
+
+    result = await svc.list_all_crons(
+        user_id="user-1", nick_name="user-1", bot_id="bot-1",
+    )
+
+    fetched = [
+        call.args[0] for call in svc._fetch_runtime_target_crons.await_args_list
+    ]
+    assert {t.runtime_stage for t in fetched} == {
+        RUNTIME_STAGE_DRAFT,
+        RUNTIME_STAGE_ONLINE,
+    }
+    assert len(result["failed_targets"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_stage_is_refused_before_any_bot_is_read():
+    bot_provider = MagicMock()
+    svc = _make_service(bot_provider=bot_provider)
+
+    with pytest.raises(CronRelayError):
+        await svc.list_all_crons(
+            user_id="user-1", nick_name="user-1", bot_id="bot-1",
+            runtime_stage="something-new",
+        )
+
+    bot_provider.get_bot.assert_not_called()

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -549,24 +549,55 @@ def test_result_exposes_no_field_beside_the_url_to_compose_with():
 # ── bot-type gate ─────────────────────────────────────────────────────────
 
 
-def test_a_service_bot_is_refused_before_a_device_is_touched():
-    """The published socket is an operator channel, not a chat channel.
+def test_an_unshared_service_bot_is_served_its_draft_socket():
+    """The socket a service bot gets addresses its DRAFT device, and only that.
 
-    The engine's WebSocket server advertises the ``sessions.*`` and
-    ``exec.approvals.*`` methods and grants ``operator.admin``, and one service
-    bot's device holds every caller's sessions. Serving this endpoint there
-    would hand the owner over a socket precisely what the sessions group
-    answers 501 to refuse over HTTP.
+    The published socket is an operator channel — ``sessions.*``,
+    ``exec.approvals.*``, ``operator.admin`` — so it may only reach a device
+    the owner alone uses. For an unshared service bot that is the draft
+    binding: this endpoint reads it owner-scoped by ``bot_id``, and the
+    verify/online runtimes publishing produces are bound under
+    ``publish_bot_id`` on the publish records, so they cannot be addressed
+    here at all.
     """
+    bindings, devices = _Bindings(), _Devices()
+    result = _build(
+        _svc(bots=_Bots(bot_type="service"), bindings=bindings, devices=devices)
+    )
+
+    assert [s.kind for s in result.sockets] == ["chat"]
+    # The one binding consulted is the (bot_id, owner_id) draft binding.
+    assert bindings.calls == [(BOT, OWNER)]
+
+
+def test_a_shared_service_bot_is_refused_before_a_device_is_touched():
+    """Sharing closes the draft window too: ``ExpertChatService`` creates
+    collaborator and public callers' sessions on the bot's own draft binding,
+    so a shared service bot's draft device is multi-caller — the exposure this
+    gate exists to prevent."""
     bindings = _Bindings(raises=AssertionError("must not be reached"))
     devices = _Devices()
-    svc = _svc(bots=_Bots(bot_type="service"), bindings=bindings, devices=devices)
+    svc = _svc(
+        bots=_Bots(bot_type="service", public="1"), bindings=bindings, devices=devices
+    )
 
     with pytest.raises(EngineBotTypeNotSupportedError):
         _build(svc)
 
     # Refused at composition time — no device call was made on the way out.
     assert devices.kwargs is None
+
+
+def test_a_collaborated_service_bot_is_refused():
+    """Service bots are exactly the type that takes collaborators."""
+    bindings = _Bindings(raises=AssertionError("must not be reached"))
+    collaborators = _CollaboratorRepo({(BOT, OWNER): [{"user_id": "someone"}]})
+    svc = _svc(
+        bots=_Bots(bot_type="service"), bindings=bindings, collaborators=collaborators
+    )
+
+    with pytest.raises(EngineBotTypeNotSupportedError):
+        _build(svc)
 
 
 def test_a_public_personal_bot_is_refused_before_a_device_is_touched():

--- a/src/backend/tests/community/core/engine_runtime/test_relay.py
+++ b/src/backend/tests/community/core/engine_runtime/test_relay.py
@@ -706,6 +706,48 @@ async def test_publish_ext_is_read_when_it_arrives_as_json_text():
     assert resolver.binding_calls == [(9, OWNER, BOT)]
 
 
+@pytest.mark.asyncio
+async def test_draft_device_addresses_a_service_bots_draft_binding():
+    """``draft_device=True`` resolves the bot's own pre-publication binding.
+
+    The sessions group operates the owner's draft workspace, and the published
+    runtime is a multi-caller device whose session collection is not scoped
+    per caller — so its forwards must reach the draft binding even though the
+    bot is published. The draft lookup is the same owner-scoped
+    ``resolve_for_bot`` a personal bot uses, and the publish records are not
+    consulted at all.
+    """
+    resolver = _Resolver()
+    repo = _PublishRepo(
+        {100: [_PublishRecord({"binding": {"online": 42, "verify": 41}})]}
+    )
+    relay = _relay(
+        bot_service=_service_bot_service(100), resolver=resolver, publish_repo=repo
+    )
+
+    await relay.call(
+        bot_id=BOT, owner_id=OWNER, method="GET", path="/api/sessions",
+        draft_device=True,
+    )
+
+    assert resolver.calls == [(BOT, OWNER)]
+    assert resolver.binding_calls == []
+    assert repo.calls == []
+
+
+@pytest.mark.asyncio
+async def test_draft_device_is_inert_for_a_personal_bot():
+    """A personal bot has only the one binding, so the flag changes nothing."""
+    resolver = _Resolver()
+    await _relay(resolver=resolver).call(
+        bot_id=BOT, owner_id=OWNER, method="GET", path="/api/sessions",
+        draft_device=True,
+    )
+
+    assert resolver.calls == [(BOT, OWNER)]
+    assert resolver.binding_calls == []
+
+
 # ── device resolution stays off the event loop ────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

The public Open API (`/openapi/v1/...`) had no coherent story for service bots. The sessions group and the connection endpoint refused every `service` bot outright, each with its own copy of `_SUPPORTED_BOT_TYPE = "personal"` — so a draft-stage service bot's owner had no API access to their draft workspace at all. Meanwhile the engine, models and approvals groups forwarded ungated, and the relay routed their service-bot traffic to the **published online runtime** (409 for a never-published bot), and the routines list fanned a service bot out over draft, verify *and* online runtimes. The same `bot_id` therefore meant three different things depending on the route, and the duplicated gate constants could drift apart — which the codebase explicitly documents against.

## Solution

The surface now has one uniform rule: **openapi_v1 serves private personal bots and a service bot's pre-publication draft workspace, and a service bot's `bot_id` always addresses the draft device.**

- **One shared gate** (`core/engine_runtime/gate.py`): `SUPPORTED_BOT_TYPES = {"personal", "service"}` plus `require_operable_bot(bot_type, is_shared, surface)`. Unknown types stay refused (allowlist), and the shared-bot refusal stays for both types — `ExpertChatService` creates collaborator/public callers' sessions on the bot's own draft binding, so a shared bot's draft device is multi-caller. The sessions, engine, models and approvals routers gate through one adapter helper (`engine_runtime/gating.py`); the connection endpoint runs the same gate where its socket is composed.
- **Draft-only is structural, not a stage check.** Every gated surface addresses the device by `bot_id`, which resolves `ac_bots.binding_id` — the draft. Verify/online runtimes are bound under `publish_bot_id` (`source_bot_id + "pub" + version`) on the publish records, so a `bot_id`-keyed read cannot select them.
- **New `draft_device` flag on `EngineRuntimeRelay.call`** (mirrored on the Protocol): the relay's default for service bots resolves the published runtime with no draft fallback, so a gate-only relaxation would have answered "not ready" for draft-only bots and — worse — exposed the published multi-caller device for published ones. All four gated HTTP groups pass `draft_device=True` on every forward; the flag is inert for personal bots and defaults to the published-runtime behavior for any other relay caller.
- **Routines list is draft-only**: `list_all_crons` grows an optional `runtime_stage` filter, applied before any device is queried so published-stage targets are neither fetched nor leaked as `failed_targets`; the openapi list passes `draft`, matching the draft-only default every other routines route already had. The internal console omits the parameter and keeps its all-stage aggregation.
- **Audited, unchanged**: resources, mcp, skills and identity already resolve the draft binding (`resolve_for_bot` / draft-device reads); bots and bot_logs touch no runtime device.

Rejected alternatives: relaxing only the gate constants (unsafe for published service bots, as above); an explicit publish-stage lookup in the gate (unnecessary — the binding structure already makes published runtimes unreachable from these surfaces).

## Validation

- Targeted suites: `tests/community/adapters/http/openapi_v1/` + `tests/community/core/{engine_runtime,cron}/` + `tests/community/architecture/` + `tests/community/contracts/`: 1104 passed. Full backend suite on commit 1: 10,692 passed / 3 skipped; full suite re-run for commit 2 in progress at push time (CI runs the same gates).
- New coverage: service bot served on all seven session routes, all three engine routes, both models routes and the approvals routes, with `draft_device=True` asserted per forward; connection socket built from the `(bot_id, owner_id)` draft binding; shared/public/collaborated bots and unknown bot types refused before any device call; relay `draft_device=True` resolves via `resolve_for_bot` without consulting publish records and is inert for personal bots; `list_all_crons` draft filter neither queries nor leaks published-stage targets, all-stage default preserved, unknown stage refused before any bot read.
- `ruff check` on all changed files: clean.

## Compatibility and risk (optional)

`relay.call` and `list_all_crons` gain optional parameters whose defaults preserve existing behavior for all other callers (Protocol updated in step; the signature-equality architecture gate covers it). Public behavior changes are deliberate: (1) sessions/connection/engine/models/approvals now answer for unshared service bots at the draft device instead of 501/published; (2) engine/models/approvals now refuse shared bots and unknown bot types with 501 (previously forwarded); (3) the routines list no longer includes a service bot's verify/online crons. Rollback is reverting the two commits — no schema, config, or migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPSzYYgiNZS2KozbG6h1sz