### PR TITLE
feat: append auto initiate session links

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -14,6 +14,7 @@ Architecture compliance:
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Optional
 
 from injector import inject
@@ -55,6 +56,9 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 _CRON_UNSUPPORTED_ENGINES = frozenset({"hermes"})
+_ASSISTANT_SESSION_URL_BASE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE"
+_ASSISTANT_SESSION_URL_BASE_PRE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE_PRE"
+_ASSISTANT_SESSION_URL_BASE_DEFAULT = "https://teamclaw.example.com/assistant"
 
 
 class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
@@ -397,8 +401,8 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         task_id = auto_initiate_job.get("id") or auto_initiate_job.get("task_id")
         logger.info(f"[find_auto_initiate_and_run] Found autoInitiate job {task_id} for bot {bot_id}")
 
-        # 5. 复用 forward_request 触发执行
-        return await self.forward_request(
+        # 5. 复用 forward_request 触发执行，并为创建出的每个会话补充可点击链接
+        result = await self.forward_request(
             bot_id=bot_id,
             user_id=user_id,
             nick_name=nick_name,
@@ -406,6 +410,10 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             path=f"/api/cron/{task_id}/run",
             params={"force": force},
         )
+        self._append_auto_initiate_session_links_to_message(
+            result.get("data"), str(bot.get("bot_id") or bot_id)
+        )
+        return result
 
     async def run_single_auto_initiate(
         self,
@@ -479,7 +487,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         if model:
             body["model"] = model
 
-        return await self.forward_request(
+        result = await self.forward_request(
             bot_id=bot_id,
             user_id=user_id,
             nick_name=nick_name,
@@ -487,6 +495,84 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             path="/api/cron/auto-initiate/run-single",
             body=body,
         )
+        self._append_auto_initiate_session_links_to_message(
+            result.get("data"), str(body["agent_id"])
+        )
+        return result
+
+    @staticmethod
+    def _assistant_session_url(bot_id: str, session_id: str) -> str:
+        """Build the TeamClaw assistant deep link for a bot session."""
+        if get_current_env() == "pre":
+            base_url = os.getenv(_ASSISTANT_SESSION_URL_BASE_PRE_ENV) or os.getenv(
+                _ASSISTANT_SESSION_URL_BASE_ENV,
+                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
+            )
+        else:
+            base_url = os.getenv(
+                _ASSISTANT_SESSION_URL_BASE_ENV,
+                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
+            )
+        return f"{base_url}?botId={bot_id}&sessionId={session_id}"
+
+    @classmethod
+    def _append_auto_initiate_session_links_to_message(
+        cls,
+        payload: Any,
+        bot_id: str,
+    ) -> None:
+        """Append created session links to the top-level message only.
+
+        The public response should keep the engine summary fields but should not
+        expose the verbose ``sessions`` list; links are presented in ``message``.
+        """
+        if not isinstance(payload, dict):
+            return
+
+        session_urls = cls._collect_auto_initiate_session_links(payload, bot_id)
+        payload.pop("sessions", None)
+        if not session_urls:
+            return
+
+        message = payload.get("message")
+        message_prefix = message if isinstance(message, str) and message else ""
+        links_message = "会话链接：\n" + "\n".join(
+            f"- {url}" for url in session_urls
+        )
+        payload["message"] = (
+            f"{message_prefix}\n\n{links_message}"
+            if message_prefix
+            else links_message
+        )
+
+    @classmethod
+    def _collect_auto_initiate_session_links(
+        cls,
+        payload: Any,
+        bot_id: str,
+    ) -> list[str]:
+        """Return assistant links for every session-like dict in the payload."""
+        session_urls: list[str] = []
+        if isinstance(payload, list):
+            for item in payload:
+                session_urls.extend(
+                    cls._collect_auto_initiate_session_links(item, bot_id)
+                )
+            return session_urls
+
+        if not isinstance(payload, dict):
+            return session_urls
+
+        session_id = payload.get("session_id") or payload.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            session_urls.append(cls._assistant_session_url(bot_id, session_id))
+
+        for value in payload.values():
+            if isinstance(value, (dict, list)):
+                session_urls.extend(
+                    cls._collect_auto_initiate_session_links(value, bot_id)
+                )
+        return session_urls
 
     async def _fetch_bot_crons(
         self,

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
@@ -19,6 +19,18 @@ from agentclaw.community.core.cron.services.cron_relay import CronRelayService
 from agentclaw.community.core.devices.services.device_context import DeviceContext
 
 
+@pytest.fixture(autouse=True)
+def _assistant_url_env(monkeypatch):
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE",
+        "https://teamclaw.alipay.com/assistant",
+    )
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE_PRE",
+        "https://teamclaw-pre.alipay.com/assistant",
+    )
+
+
 def _make_service(
     *,
     bot_provider=None,
@@ -93,7 +105,13 @@ class TestFindAutoInitiateAndRun:
                 {"id": "task-auto", "payload": {"kind": "autoInitiate", "message": "|kind:autoInitiate| 查询dima空间..."}},
             ]},
             # 第二次 invoke: forward_request 内部的 POST
-            {"success": True, "data": {"job_id": "task-auto"}},
+            {"success": True, "data": {
+                "job_id": "task-auto",
+                "message": "本次发起 1 个新任务",
+                "sessions": [
+                    {"session_id": "user:382716:session:s-1:agent:bot-1"},
+                ],
+            }},
         ])
 
         # get_device_connection_v2 也要 mock (forward_request 内部调用)
@@ -119,8 +137,17 @@ class TestFindAutoInitiateAndRun:
         first_call = transport.invoke.call_args_list[0]
         assert first_call[0][1] == "GET"
         assert first_call[0][2] == "/api/cron"
-        # 验证最终结果
+        # 验证最终结果，并为发起的会话补充 TeamClaw assistant 链接
         assert result["success"] is True
+        expected_url = (
+            "https://teamclaw.alipay.com/assistant?botId=bot-1"
+            "&sessionId=user:382716:session:s-1:agent:bot-1"
+        )
+        assert "sessions" not in result["data"]
+        assert result["data"]["message"] == (
+            "本次发起 1 个新任务\n\n会话链接：\n"
+            f"- {expected_url}"
+        )
 
     @pytest.mark.asyncio
     async def test_no_binding_raises(self):
@@ -296,6 +323,54 @@ class TestFindAutoInitiateAndRun:
             )
 
 
+def test_assistant_session_url_uses_pre_domain(monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.core.cron.services.cron_relay.get_current_env",
+        lambda: "pre",
+    )
+
+    assert CronRelayService._assistant_session_url("bot-x", "session-x") == (
+        "https://teamclaw-pre.alipay.com/assistant?botId=bot-x"
+        "&sessionId=session-x"
+    )
+
+
+def test_append_auto_initiate_session_links_to_message():
+    payload = {
+        "message": "本次发起 2 个新任务",
+        "sessions": [
+            {"session_id": "user:u:session:s1:agent:bot-x"},
+            {"session_id": "user:u:session:s2:agent:bot-x"},
+        ],
+    }
+
+    CronRelayService._append_auto_initiate_session_links_to_message(payload, "bot-x")
+
+    assert payload["message"] == (
+        "本次发起 2 个新任务\n\n会话链接：\n"
+        "- https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s1:agent:bot-x\n"
+        "- https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s2:agent:bot-x"
+    )
+    assert "sessions" not in payload
+
+
+def test_collect_auto_initiate_session_links_handles_nested_shapes():
+    payload = {
+        "sessions": [
+            {"session_id": "user:u:session:s1:agent:bot-x"},
+            {"sessionId": "user:u:session:s2:agent:bot-x"},
+        ],
+        "ignored": {"session_id": ""},
+    }
+
+    urls = CronRelayService._collect_auto_initiate_session_links(payload, "bot-x")
+
+    assert urls == [
+        "https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s1:agent:bot-x",
+        "https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s2:agent:bot-x",
+    ]
+
+
 class TestRunSingleAutoInitiate:
     """CronRelayService.run_single_auto_initiate"""
 
@@ -312,7 +387,13 @@ class TestRunSingleAutoInitiate:
         transport = MagicMock()
         transport.invoke = AsyncMock(return_value={
             "success": True,
-            "data": {"total": 1, "created": 1, "errors": []},
+            "data": {
+                "total": 1,
+                "created": 1,
+                "message": "本次发起 1 个新任务",
+                "sessions": [{"session_id": "user:u1:session:s-2:agent:bot-1"}],
+                "errors": [],
+            },
         })
 
         template_repo = MagicMock()
@@ -332,6 +413,15 @@ class TestRunSingleAutoInitiate:
             dima_url="https://project.teamclaw.com/space/W1/requirement?openWorkItemId=123",
         )
         assert result["success"] is True
+        expected_url = (
+            "https://teamclaw.alipay.com/assistant?botId=bot-1"
+            "&sessionId=user:u1:session:s-2:agent:bot-1"
+        )
+        assert "sessions" not in result["data"]
+        assert result["data"]["message"] == (
+            "本次发起 1 个新任务\n\n会话链接：\n"
+            f"- {expected_url}"
+        )
         body = transport.invoke.call_args[0][3]
         assert body["workflow"] == "my-flow"
 


### PR DESCRIPTION
## Summary
- Re-apply the changes from #851 onto REL20260806
- Append auto-initiate session links in cron relay output
- Include the related cron relay test coverage

## Source
- Original PR: https://github.com/inclusionAI/Avernet/pull/851
- Original commit: 3614c5316be1f3a75df794dc5607fccfc72deacd
- New cherry-picked commit: 6b9b3cf91432f470f9a3cbc49fdcc2434a8a6d60

## Tests
- cd src/backend && uv run pytest tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py -q
- OCB pre-push gate passed in lint-only mode
