### PR TITLE
fix(backend): honor Desktop engine for Skill uploads

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -549,7 +549,11 @@ async def upload_skill(
                 is_public=skill.get('is_public'),
                 is_builtin=skill.get('is_builtin'),
                 user_id=str(skill.get('user_id')) if skill.get('user_id') is not None else None,
-                bot_id=skill.get('bolt_id') if skill.get('bot_id') else "default",
+                bot_id=(
+                    str(skill["bolt_id"])
+                    if skill.get("bolt_id") is not None
+                    else "default"
+                ),
                 gmt_created=skill.get('gmt_created') if skill.get('gmt_created') else "",
                 gmt_modified=skill.get('gmt_modified') if skill.get('gmt_modified') else ""
             ),

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -176,6 +176,7 @@ internal_dependencies:
   - agentclaw.community.core.skill_center
   - agentclaw.community.core.service_bot
   - agentclaw.community.core.task_queue
+  - agentclaw.community.core.workspace
   - agentclaw.community.core.base
   - agentclaw.community.kernel.lifecycle
   - agentclaw.community.log

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -5,69 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-
-@dataclass(frozen=True, slots=True)
-class OpenClawPoolPaths:
-    """OpenClaw P3 的容器视角路径契约。"""
-
-    active: str = "/home/admin/.openclaw/workspace/skills"
-    legacy_local: str = "/home/admin/.openclaw/workspace/skills/skills-local"
-    legacy_repo: str = "/home/admin/.openclaw/workspace/skills/skills-repo"
-    pool_local: str = "/home/admin/.openclaw/workspace/skills-pool/skills-local"
-    pool_repo: str = "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
-
-
-@dataclass(frozen=True, slots=True)
-class ClaudeCodePoolPaths:
-    """Claude Code P3 的容器视角路径契约。"""
-
-    active: str = "/home/admin/.claude/skills"
-    legacy_local: str = "/home/admin/.claude_code/workspace/skills/skills-local"
-    legacy_repo: str = "/home/admin/.claude_code/skills-repo"
-    pool_local: str = "/home/admin/.claude_code/workspace/skills-pool/skills-local"
-    pool_repo: str = "/home/admin/.claude_code/workspace/skills-pool/skills-repo"
-
-
-@dataclass(frozen=True, slots=True)
-class AICodingPoolPaths:
-    """AICoding P3 的容器视角路径契约。"""
-
-    active: str = "/home/admin/.claude/skills"
-    legacy_local: str = "/home/admin/.aicoding/workspace/skills/skills-local"
-    legacy_repo: str = "/home/admin/.aicoding/skills-repo"
-    pool_local: str = "/home/admin/.aicoding/workspace/skills-pool/skills-local"
-    pool_repo: str = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
-
-
-@dataclass(frozen=True, slots=True)
-class HermesPoolPaths:
-    """Hermes P3 的容器视角路径契约。"""
-
-    active: str = "/home/admin/.hermes/skills"
-    legacy_local: str = "/home/admin/.hermes/workspace/skills/skills-local"
-    legacy_repo: str = "/home/admin/.hermes/skills-repo"
-    pool_local: str = "/home/admin/.hermes/workspace/skills-pool/skills-local"
-    pool_repo: str = "/home/admin/.hermes/workspace/skills-pool/skills-repo"
-
-
-PoolPaths = (
-    OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths | HermesPoolPaths
+from agentclaw.community.core.workspace.skill_layout import (
+    AICodingPoolPaths,
+    ClaudeCodePoolPaths,
+    FILESYSTEM_POOL_ENGINES,
+    HermesPoolPaths,
+    OpenClawPoolPaths,
+    PoolPaths,
+    pool_paths_for_engine,
 )
-FILESYSTEM_POOL_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
-
-
-def pool_paths_for_engine(engine: str) -> PoolPaths:
-    """Resolve only explicitly supported engine layouts; never fall back."""
-
-    if engine == "openclaw":
-        return OpenClawPoolPaths()
-    if engine == "claude_code":
-        return ClaudeCodePoolPaths()
-    if engine == "aicoding":
-        return AICodingPoolPaths()
-    if engine == "hermes":
-        return HermesPoolPaths()
-    raise ValueError(f"engine Pool layout not implemented: {engine}")
 
 
 def local_locator_prefixes(*, pool: bool) -> tuple[str, ...]:

--- a/src/backend/src/agentclaw/community/core/workspace/README.md
+++ b/src/backend/src/agentclaw/community/core/workspace/README.md
@@ -8,6 +8,7 @@ Workspace path factory + workspace constants — single source of truth for per-
 purpose: "Workspace path factory + workspace constants — single source of truth for per-bot / per-user paths."
 provides:
   - "WorkspacePathFactory"
+  - "Filesystem-engine Skill layout compatibility path contract"
   - "DEFAULT_ENGINE_TYPE, SUPPORTED_ENGINE_TYPES constants"
   - "EngineSandboxProvider Protocol + OpenClaw / ClaudeCode impls (mode-blind, take WorkspaceConfig)"
 consumes:

--- a/src/backend/src/agentclaw/community/core/workspace/path_factory.py
+++ b/src/backend/src/agentclaw/community/core/workspace/path_factory.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from injector import inject
 
+from agentclaw.community.core.workspace.skill_layout import pool_paths_for_engine
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
 
@@ -25,25 +26,6 @@ SQLITE_PERSONAL_ROOT = Path.home() / ".moltis"
 
 # NAS挂载根目录
 DEFAULT_ARCA_ROOT = Path("/home/admin/.merge_nas")
-
-# Desktop bot 桌面版的 engine-view skills 根目录（VM 内 virtiofs mount path）。
-# 跟 BAAS 同事 / Phase 2a/2b ocwn 编排约定：engine 在 VM 内看到的 skills 根永远是
-# `/home/admin/.openclaw/workspace/skills`。Backend 通过 BaasDeviceFileSystem 调
-# engine HTTP API 直接用这个路径，不再经过 OSS view 与 `_convert_path` 转写。
-# 仅 desktop bot 走这条路径（ac_bots.bot_type == "desktop"）；service bot 即使
-# device_provider 也是 baas，仍然走云端 OSS-view 分支。
-# 改路径前请同步 BAAS 同事 + ocwn (Phase 2a) + engine `_convert_path` 处。
-BAAS_ENGINE_SKILLS_ROOT = Path("/home/admin/.openclaw/workspace/skills")
-
-# Desktop bot 桌面版的 engine-view skills 根目录（VM 内 virtiofs mount path）。
-# 跟 BAAS 同事 / Phase 2a/2b ocwn 编排约定：engine 在 VM 内看到的 skills 根永远是
-# `/home/admin/.openclaw/workspace/skills`。Backend 通过 BaasDeviceFileSystem 调
-# engine HTTP API 直接用这个路径，不再经过 OSS view 与 `_convert_path` 转写。
-# 仅 desktop bot 走这条路径（ac_bots.bot_type == "desktop"）；service bot 即使
-# device_provider 也是 baas，仍然走云端 OSS-view 分支。
-# 改路径前请同步 BAAS 同事 + ocwn (Phase 2a) + engine `_convert_path` 处。
-BAAS_ENGINE_SKILLS_ROOT = Path("/home/admin/.openclaw/workspace/skills")
-
 
 def _get_aidesktop_root() -> Path:
     """Read aidesktop_root from env, then the process-cached config provider."""
@@ -480,10 +462,11 @@ class WorkspacePathFactory:
            ``git_path`` stays ``local://skills-local/<name>``. No host/OSS-view
            layout applies. This takes precedence over the host-path branches below.
         1. Desktop bot (``is_desktop=True``, ie. ``ac_bots.bot_type == "desktop"``):
-           engine-view path inside the VM
-           (``/home/admin/.openclaw/workspace/skills/skills-local``). Backend writes
-           via BaaS invoke-http; engine sees this path directly. No OSS-view layer
-           in this link — engine ``_convert_path`` falls through passthrough.
+           the selected engine's Legacy local path inside the VM. Backend writes
+           via BaaS invoke-http; the engine sees this path directly. The
+           compatibility paths come from the same fail-closed contract used by
+           Skills Pool; Pool-active requests are still overridden by
+           ``SkillServiceFactory`` from the authoritative layout state.
         2. Shared host root (``skill_repo_sync.get_local_skills_root()`` returns
            non-``None``, ie. local-dev impl): root + ``skills-local``.
         3. Per-bot cloud OSS-view path (``get_local_skills_root()`` returns
@@ -503,10 +486,11 @@ class WorkspacePathFactory:
             )
             return result
         if is_desktop:
-            result = BAAS_ENGINE_SKILLS_ROOT / "skills-local"
+            result = Path(pool_paths_for_engine(engine_type).legacy_local)
             logger.info(
-                "[path_factory.get_bot_skills_local_dir] entity=%s bot=%s → DESKTOP_BOT %s",
-                entity_id, bot_id, result,
+                "[path_factory.get_bot_skills_local_dir] entity=%s bot=%s "
+                "engine=%s → DESKTOP_BOT %s",
+                entity_id, bot_id, engine_type, result,
             )
             return result
         # singlebox 多 bot 改造: LOCAL+non-desktop 不再走 SHARED_ROOT (用户上传的 skill
@@ -553,10 +537,11 @@ class WorkspacePathFactory:
         is also baas but they use the cloud OSS-view path).
         """
         if is_desktop:
-            result = BAAS_ENGINE_SKILLS_ROOT / "skills-repo"
+            result = Path(pool_paths_for_engine(engine_type).legacy_repo)
             logger.info(
-                "[path_factory.get_bot_skills_repo_dir] entity=%s bot=%s → DESKTOP_BOT %s",
-                entity_id, bot_id, result,
+                "[path_factory.get_bot_skills_repo_dir] entity=%s bot=%s "
+                "engine=%s → DESKTOP_BOT %s",
+                entity_id, bot_id, engine_type, result,
             )
             return result
         local_root = self._skill_repo_sync.get_local_skills_root()

--- a/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
+++ b/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
@@ -1,0 +1,80 @@
+"""Pure filesystem-engine Skill layout compatibility contract.
+
+The Engine planner remains authoritative for runtime layout selection.  Backend
+consumers use these values only to address the selected Legacy/Pool roots at
+the device-filesystem seam and to validate Engine-returned evidence.  Keeping
+the value objects in this dependency-free workspace module lets low-level path
+code consume them without importing Skills Pool orchestration or initializing
+the DI composition root.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OpenClawPoolPaths:
+    active: str = "/home/admin/.openclaw/workspace/skills"
+    legacy_local: str = "/home/admin/.openclaw/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.openclaw/workspace/skills/skills-repo"
+    pool_local: str = "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeCodePoolPaths:
+    active: str = "/home/admin/.claude/skills"
+    legacy_local: str = "/home/admin/.claude_code/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.claude_code/skills-repo"
+    pool_local: str = "/home/admin/.claude_code/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.claude_code/workspace/skills-pool/skills-repo"
+
+
+@dataclass(frozen=True, slots=True)
+class AICodingPoolPaths:
+    active: str = "/home/admin/.claude/skills"
+    legacy_local: str = "/home/admin/.aicoding/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.aicoding/skills-repo"
+    pool_local: str = "/home/admin/.aicoding/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.aicoding/workspace/skills-pool/skills-repo"
+
+
+@dataclass(frozen=True, slots=True)
+class HermesPoolPaths:
+    active: str = "/home/admin/.hermes/skills"
+    legacy_local: str = "/home/admin/.hermes/workspace/skills/skills-local"
+    legacy_repo: str = "/home/admin/.hermes/skills-repo"
+    pool_local: str = "/home/admin/.hermes/workspace/skills-pool/skills-local"
+    pool_repo: str = "/home/admin/.hermes/workspace/skills-pool/skills-repo"
+
+
+PoolPaths = (
+    OpenClawPoolPaths | ClaudeCodePoolPaths | AICodingPoolPaths | HermesPoolPaths
+)
+FILESYSTEM_POOL_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
+
+
+def pool_paths_for_engine(engine: str) -> PoolPaths:
+    """Resolve explicitly supported filesystem engines; never fall back."""
+
+    if engine == "openclaw":
+        return OpenClawPoolPaths()
+    if engine == "claude_code":
+        return ClaudeCodePoolPaths()
+    if engine == "aicoding":
+        return AICodingPoolPaths()
+    if engine == "hermes":
+        return HermesPoolPaths()
+    raise ValueError(f"engine Pool layout not implemented: {engine}")
+
+
+__all__ = [
+    "AICodingPoolPaths",
+    "ClaudeCodePoolPaths",
+    "FILESYSTEM_POOL_ENGINES",
+    "HermesPoolPaths",
+    "OpenClawPoolPaths",
+    "PoolPaths",
+    "pool_paths_for_engine",
+]

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -374,6 +374,7 @@ def _upload_skill_di_app(
     bot_service=None,
     device_id=None,
     bot_owner_id=None,
+    engine_type="openclaw",
 ):
     bot_owner_id = bot_owner_id or mock_ctx.user_id
     mock_skill_service = MagicMock()
@@ -414,7 +415,7 @@ def _upload_skill_di_app(
         "owner_id": bot_owner_id,
         "entity_id": f"staff_{bot_owner_id}",
         "env": "local",
-        "active_engine": "openclaw",
+        "active_engine": engine_type,
         "bot_type": bot_type,
         "status": bot_status,
     }
@@ -630,6 +631,45 @@ class TestUploadSkillValidation:
             assert create_kwargs["entity_id"] == mock_ctx.user_id
             assert create_kwargs["bot_id"] == mock_ctx.bot_id
             assert create_kwargs["engine_type"] == "openclaw"
+
+    @pytest.mark.parametrize("engine_type", ["openclaw", "claude_code", "hermes"])
+    def test_desktop_upload_preserves_engine_and_bot_scope(
+        self, engine_type
+    ):
+        desktop_ctx = RequestContext(
+            user_id="desktop-owner",
+            bot_id=f"desktop-{engine_type}",
+        )
+        with _upload_skill_di_app(
+            desktop_ctx,
+            bot_status="ACTIVE",
+            bot_type="desktop",
+            engine_type=engine_type,
+        ) as (client, mock_svc, _, mock_factory):
+            # Real persistence returns ``bolt_id`` for the owning Bot; it does
+            # not populate the legacy response-only ``bot_id`` alias.
+            mock_svc.upload_skill.return_value.pop("bot_id")
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        (
+                            "SKILL.md",
+                            b"---\nname: a\ndescription: a\n---",
+                            "text/markdown",
+                        ),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.status_code == 200, response.text
+            assert response.json()["data"]["bot_id"] == desktop_ctx.bot_id
+            create_kwargs = mock_factory.create.call_args.kwargs
+            assert create_kwargs["bot_id"] == desktop_ctx.bot_id
+            assert create_kwargs["engine_type"] == engine_type
 
     def test_upload_normalizes_runtime_unavailable_error_message(self, mock_ctx):
         with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (client, mock_svc, _, _):

--- a/src/backend/tests/community/core/workspace/test_path_factory_is_desktop.py
+++ b/src/backend/tests/community/core/workspace/test_path_factory_is_desktop.py
@@ -1,4 +1,6 @@
 """Test path_factory.get_bot_skills_{local,repo}_dir routing by is_desktop."""
+import pytest
+
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.plugins.local.skill_repo_sync import LocalSkillRepoSyncPlugin
 
@@ -7,20 +9,38 @@ def _factory() -> WorkspacePathFactory:
     return WorkspacePathFactory(skill_repo_sync=LocalSkillRepoSyncPlugin())
 
 
-def test_local_dir_desktop_returns_engine_view():
+@pytest.mark.parametrize(
+    ("engine_type", "expected"),
+    [
+        ("openclaw", "/home/admin/.openclaw/workspace/skills/skills-local"),
+        ("claude_code", "/home/admin/.claude_code/workspace/skills/skills-local"),
+        ("aicoding", "/home/admin/.aicoding/workspace/skills/skills-local"),
+        ("hermes", "/home/admin/.hermes/workspace/skills/skills-local"),
+    ],
+)
+def test_local_dir_desktop_returns_selected_engine_view(engine_type, expected):
     factory = _factory()
     p = factory.get_bot_skills_local_dir(
-        "user_001", "bot_x", "openclaw", "staff", is_desktop=True
+        "user_001", "bot_x", engine_type, "staff", is_desktop=True
     )
-    assert str(p) == "/home/admin/.openclaw/workspace/skills/skills-local"
+    assert str(p) == expected
 
 
-def test_repo_dir_desktop_returns_engine_view():
+@pytest.mark.parametrize(
+    ("engine_type", "expected"),
+    [
+        ("openclaw", "/home/admin/.openclaw/workspace/skills/skills-repo"),
+        ("claude_code", "/home/admin/.claude_code/skills-repo"),
+        ("aicoding", "/home/admin/.aicoding/skills-repo"),
+        ("hermes", "/home/admin/.hermes/skills-repo"),
+    ],
+)
+def test_repo_dir_desktop_returns_selected_engine_view(engine_type, expected):
     factory = _factory()
     p = factory.get_bot_skills_repo_dir(
-        "user_001", "bot_x", "openclaw", "staff", is_desktop=True
+        "user_001", "bot_x", engine_type, "staff", is_desktop=True
     )
-    assert str(p) == "/home/admin/.openclaw/workspace/skills/skills-repo"
+    assert str(p) == expected
 
 
 def test_local_dir_non_desktop_falls_to_cloud_or_local():


### PR DESCRIPTION
## Problem

Desktop direct Skill uploads correctly carried the Bot engine through the HTTP route, but `WorkspacePathFactory` ignored it and always returned OpenClaw Legacy `skills-local` and `skills-repo` paths. Claude Code, AICoding, and Hermes uploads could therefore be written into the OpenClaw tree, producing an incorrect canonical locator and blocking later data-consistency validation. The upload response also returned `bot_id=default` when persistence supplied the owning Bot through `bolt_id` only.

## Solution

- Move the existing filesystem-engine path value objects into a dependency-free workspace contract and keep the Skills Pool imports as compatibility re-exports.
- Resolve Desktop Legacy local/repo roots from the selected engine for OpenClaw, Claude Code, AICoding, and Hermes, failing closed for unsupported filesystem layouts.
- Return the persisted `bolt_id` as the upload response Bot identity.
- Preserve the existing Pool-active override: authoritative layout selection remains in `SkillServiceFactory` and the Engine planner/state machine is unchanged.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community -q` — 10885 passed.
- Architecture, Skills Pool, Desktop upload/path, and Teclaw targeted regression suite — 690 passed.
- `uv run ruff check` on all changed Python files — passed.
- `scripts/ci/python_sast_local.sh src/backend 1 --base origin/REL20260806 --head HEAD` — passed.
- `git diff --check` — passed.

## Compatibility and risk

Cloud/non-Desktop routing is unchanged. Teclaw retains its artifact/logical local path branch. Pool rollout, claim, cutover, rollback, and mapping semantics are unchanged; only Desktop Legacy physical path selection and upload response metadata are corrected.

## Spec

Regression fix discovered during Desktop Skills Pool acceptance; no Spec or state-machine contract change.

## Related issues

Related to #455.