### PR TITLE
fix(backend): normalize baas engine type by template

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from agentclaw.community.core.bot_management.engines.aicoding import CODING_TEMPLATE_TYPES
 from agentclaw.community.core.devices.errors import DeviceServiceError
+from agentclaw.community.core.devices.services.effective_engine_resolver import (
+    resolve_effective_engine_for_template,
+)
 from agentclaw.community.log import get_logger
 
 
@@ -384,11 +386,10 @@ class SystemConfigBaasTemplateResolver:
         template_type: str | None,
     ) -> str:
         """把历史 engine 表达归一成 template 配置里的 engine。"""
-        normalized_engine = (engine_type or "openclaw").strip().lower().replace("-", "_")
-        # Claude Code 的 coding 模板沿用 AI Coding 模板，配置侧统一写 engine=aicoding。
-        if normalized_engine == "claude_code" and template_type in CODING_TEMPLATE_TYPES:
-            return "aicoding"
-        return normalized_engine
+        return resolve_effective_engine_for_template(
+            engine_type=engine_type,
+            template_type=template_type,
+        )
 
     def _legacy_template_whitelist_hit(
         self,

--- a/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
@@ -8,6 +8,9 @@ from agentclaw.community.core.devices.repository.protocol import DeviceBindingRe
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.devices.services.device_context import ConnInfoBuildError
 from agentclaw.community.core.devices.services.baas_conn_info import build_baas_conn_info_for_http
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    SystemConfigBaasTemplateResolver,
+)
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
@@ -77,8 +80,13 @@ class BaasConnInfoBuilder:
         # 现场:trace 0be8ed2217816832272041880e9da7(协作者公开访问 service bot)
         # 跟进:docs/superpowers/baas-refactor-dirty-work.md §7
         bot = self._resolve_bot(binding)
-        engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
+        raw_engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
         bot_type = (bot or {}).get("bot_type") or ""
+        template_type = (bot or {}).get("template_type") or ""
+        engine_type = SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type=raw_engine_type,
+            template_type=template_type,
+        )
 
         if not bot:
             logger.warning(

--- a/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
@@ -8,8 +8,8 @@ from agentclaw.community.core.devices.repository.protocol import DeviceBindingRe
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.devices.services.device_context import ConnInfoBuildError
 from agentclaw.community.core.devices.services.baas_conn_info import build_baas_conn_info_for_http
-from agentclaw.community.core.devices.services.baas_template_resolver import (
-    SystemConfigBaasTemplateResolver,
+from agentclaw.community.core.devices.services.effective_engine_resolver import (
+    EffectiveEngineResolverProtocol,
 )
 from agentclaw.community.log import get_logger
 
@@ -37,12 +37,14 @@ class BaasConnInfoBuilder:
         baas_service,
         bot_repository: BotRepository,
         device_binding_repository: DeviceBindingRepository,
+        effective_engine_resolver: EffectiveEngineResolverProtocol,
         sandbox_client: "SandboxRuntimeClient | None" = None,
     ):
         self._baas_service = baas_service
         self._bot_repo = bot_repository
         self._device_repo = device_binding_repository
         self._sandbox_client = sandbox_client
+        self._effective_engine_resolver = effective_engine_resolver
 
     def build(
         self,
@@ -83,7 +85,7 @@ class BaasConnInfoBuilder:
         raw_engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
         bot_type = (bot or {}).get("bot_type") or ""
         template_type = (bot or {}).get("template_type") or ""
-        engine_type = SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+        engine_type = self._effective_engine_resolver.resolve_effective_engine(
             engine_type=raw_engine_type,
             template_type=template_type,
         )

--- a/src/backend/src/agentclaw/community/core/devices/services/effective_engine_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/effective_engine_resolver.py
@@ -1,0 +1,104 @@
+"""Resolve the effective runtime engine from bot metadata.
+
+This module keeps engine-identity rules in a small, explicit contract so core
+callers can depend on a stable interface instead of a concrete template helper.
+Composition roots select the concrete resolver.
+"""
+from __future__ import annotations
+
+from typing import Mapping, Protocol
+
+
+def normalize_engine_type(engine_type: str | None) -> str:
+    """Normalize historical engine spellings to the canonical wire form."""
+    return (engine_type or "openclaw").strip().lower().replace("-", "_")
+
+
+def normalize_template_type(template_type: str | None) -> str:
+    return (template_type or "").strip().lower()
+
+
+def resolve_effective_engine_for_template(
+    *,
+    engine_type: str | None,
+    template_type: str | None,
+) -> str:
+    """Resolve the effective runtime engine for a bot/template pair."""
+    normalized_engine = normalize_engine_type(engine_type)
+    normalized_template_type = normalize_template_type(template_type)
+    if (
+        normalized_engine == "claude_code"
+        and normalized_template_type
+        and normalized_template_type != "normalcc"
+    ):
+        return "aicoding"
+    return normalized_engine
+
+
+class EffectiveEngineResolverProtocol(Protocol):
+    """Contract for resolving the effective runtime engine."""
+
+    def resolve_effective_engine(
+        self,
+        *,
+        engine_type: str | None,
+        template_type: str | None,
+    ) -> str:
+        """Return the effective engine after template-aware normalization."""
+        ...
+
+
+class IdentityEffectiveEngineResolver:
+    """Default resolver that only normalizes the raw engine spelling."""
+
+    def resolve_effective_engine(
+        self,
+        *,
+        engine_type: str | None,
+        template_type: str | None,
+    ) -> str:
+        return normalize_engine_type(engine_type)
+
+
+class ClaudeCodeTemplateEffectiveEngineResolver:
+    """Template-aware resolver for claude_code bots."""
+
+    def resolve_effective_engine(
+        self,
+        *,
+        engine_type: str | None,
+        template_type: str | None,
+    ) -> str:
+        return resolve_effective_engine_for_template(
+            engine_type=engine_type,
+            template_type=template_type,
+        )
+
+
+class ConfiguredEffectiveEngineResolver:
+    """Composition-root helper that picks a resolver by normalized engine key."""
+
+    def __init__(
+        self,
+        *,
+        resolvers: Mapping[str, EffectiveEngineResolverProtocol],
+        default_resolver: EffectiveEngineResolverProtocol | None = None,
+    ) -> None:
+        self._default_resolver = default_resolver or IdentityEffectiveEngineResolver()
+        self._resolvers = {
+            normalize_engine_type(engine_type): resolver
+            for engine_type, resolver in resolvers.items()
+        }
+
+    def resolve_effective_engine(
+        self,
+        *,
+        engine_type: str | None,
+        template_type: str | None,
+    ) -> str:
+        normalized_engine = normalize_engine_type(engine_type)
+        resolver = self._resolvers.get(normalized_engine, self._default_resolver)
+        return resolver.resolve_effective_engine(
+            engine_type=normalized_engine,
+            template_type=template_type,
+        )

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -66,6 +66,11 @@ from agentclaw.community.core.devices.services.baas_publish_task_handlers import
 from agentclaw.community.core.devices.services.baas_template_resolver import (
     SystemConfigBaasTemplateResolver,
 )
+from agentclaw.community.core.devices.services.effective_engine_resolver import (
+    ClaudeCodeTemplateEffectiveEngineResolver,
+    ConfiguredEffectiveEngineResolver,
+    EffectiveEngineResolverProtocol,
+)
 from agentclaw.community.core.devices.services.conn_info_builders.arca_builder import (
     ArcaConnInfoBuilder,
 )
@@ -340,18 +345,32 @@ class DevicesModule(Module):
     @singleton
     @provider
     @inject
+    def effective_engine_resolver(
+        self,
+    ) -> EffectiveEngineResolverProtocol:
+        return ConfiguredEffectiveEngineResolver(
+            resolvers={
+                "claude_code": ClaudeCodeTemplateEffectiveEngineResolver(),
+            },
+        )
+
+    @singleton
+    @provider
+    @inject
     def baas_conn_info_builder(
         self,
         baas_service: BaasService,
         bot_repository: BotRepository,
         device_binding_repository: DeviceBindingRepository,
         sandbox_client: SandboxRuntimeClient,
+        effective_engine_resolver: EffectiveEngineResolverProtocol,
     ) -> BaasConnInfoBuilder:
         return BaasConnInfoBuilder(
             baas_service=baas_service,
             bot_repository=bot_repository,
             device_binding_repository=device_binding_repository,
             sandbox_client=sandbox_client,
+            effective_engine_resolver=effective_engine_resolver,
         )
 
     @singleton

--- a/src/backend/tests/community/core/devices/services/conftest.py
+++ b/src/backend/tests/community/core/devices/services/conftest.py
@@ -293,6 +293,10 @@ def device_context_resolver(world, fake_baas_service, device_service):
     from agentclaw.community.core.devices.services.conn_info_builders.baas_builder import (
         BaasConnInfoBuilder,
     )
+    from agentclaw.community.core.devices.services.effective_engine_resolver import (
+        ConfiguredEffectiveEngineResolver,
+        ClaudeCodeTemplateEffectiveEngineResolver,
+    )
     from agentclaw.community.core.devices.services.conn_info_builders.local_builder import (
         LocalConnInfoBuilder,
     )
@@ -314,6 +318,11 @@ def device_context_resolver(world, fake_baas_service, device_service):
             baas_service=fake_baas_service,
             bot_repository=bot_repo,
             device_binding_repository=repo,
+            effective_engine_resolver=ConfiguredEffectiveEngineResolver(
+                resolvers={
+                    "claude_code": ClaudeCodeTemplateEffectiveEngineResolver(),
+                },
+            ),
         ),
         teclaw_builder=TeclawConnInfoBuilder(baas_service=fake_baas_service),
         local_builder=LocalConnInfoBuilder(device_service=device_service),

--- a/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
+++ b/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
@@ -143,6 +143,38 @@ def test_step1_hit_engine_type_openclaw_regression_guard(
     assert conn_info["engine_type"] == "openclaw"
 
 
+def test_step1_hit_claude_code_with_non_normalcc_template_normalizes_to_aicoding(
+    fake_binding, fake_baas_service, fake_bot_repo, fake_device_repo
+):
+    """claude_code + 非 normalCC template_type 应归一到 aicoding。"""
+    fake_bot_repo.get_by_binding_id.return_value = {
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "bot_type": "desktop",
+    }
+    builder = _make_builder(fake_baas_service, fake_bot_repo, fake_device_repo)
+
+    conn_info = builder.build(fake_binding, user_id="user-1")
+
+    assert conn_info["engine_type"] == "aicoding"
+
+
+def test_step1_hit_claude_code_with_normalcc_stays_claude_code(
+    fake_binding, fake_baas_service, fake_bot_repo, fake_device_repo
+):
+    """claude_code + normalCC 保持 claude_code。"""
+    fake_bot_repo.get_by_binding_id.return_value = {
+        "active_engine": "claude_code",
+        "template_type": "normalCC",
+        "bot_type": "desktop",
+    }
+    builder = _make_builder(fake_baas_service, fake_bot_repo, fake_device_repo)
+
+    conn_info = builder.build(fake_binding, user_id="user-1")
+
+    assert conn_info["engine_type"] == "claude_code"
+
+
 # ── Step 2 反查:service bot via binding.device_props.bolt_id ──────
 #
 # 现场:trace 0be8ed2217816832272041880e9da7

--- a/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
+++ b/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
@@ -184,6 +184,22 @@ def test_step1_hit_claude_code_with_normalcc_stays_claude_code(
     assert conn_info["engine_type"] == "claude_code"
 
 
+def test_step1_hit_claude_code_with_empty_template_type_stays_claude_code(
+    fake_binding, fake_baas_service, fake_bot_repo, fake_device_repo
+):
+    """claude_code + 空 template_type 不应归一为 aicoding。"""
+    fake_bot_repo.get_by_binding_id.return_value = {
+        "active_engine": "claude_code",
+        "template_type": "",
+        "bot_type": "desktop",
+    }
+    builder = _make_builder(fake_baas_service, fake_bot_repo, fake_device_repo)
+
+    conn_info = builder.build(fake_binding, user_id="user-1")
+
+    assert conn_info["engine_type"] == "claude_code"
+
+
 # ── Step 2 反查:service bot via binding.device_props.bolt_id ──────
 #
 # 现场:trace 0be8ed2217816832272041880e9da7

--- a/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
+++ b/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
@@ -6,6 +6,10 @@ from agentclaw.community.core.devices.services.device_context import ConnInfoBui
 from agentclaw.community.core.devices.services.conn_info_builders.baas_builder import (
     BaasConnInfoBuilder,
 )
+from agentclaw.community.core.devices.services.effective_engine_resolver import (
+    ConfiguredEffectiveEngineResolver,
+    ClaudeCodeTemplateEffectiveEngineResolver,
+)
 
 
 @pytest.fixture
@@ -60,6 +64,11 @@ def _make_builder(baas_service, bot_repo, device_repo):
         baas_service=baas_service,
         bot_repository=bot_repo,
         device_binding_repository=device_repo,
+        effective_engine_resolver=ConfiguredEffectiveEngineResolver(
+            resolvers={
+                "claude_code": ClaudeCodeTemplateEffectiveEngineResolver(),
+            },
+        ),
     )
 
 


### PR DESCRIPTION
## Problem
- `expert-chat` 在创建 session 时收到的 `ctx.conn_info.engine_type` 还是 `openclaw`，导致后端 `session/router.py` 报 `Unsupported engine type: openclaw. Only 'aicoding' is supported.`
- 这个问题出现在 BaaS service bot 场景：`active_engine=claude_code` 但 `template_type` 需要参与引擎归一。

## Solution
- 在 `BaasConnInfoBuilder` 上游统一按 `active_engine + template_type` 计算最终 `engine_type`。
- `claude_code + 非 normalCC` 归一为 `aicoding`；`claude_code + normalCC` 保持 `claude_code`。
- 补充回归测试覆盖这两个分支。

## Summary
- Normalize baas conn_info engine_type by template_type upstream.
- Keep claude_code + normalCC unchanged; map other claude_code templates to aicoding.
- Add regression tests for both cases.

## Validation
- python3 -m py_compile src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
