### PR TITLE
fix(backend): normalize baas engine routing by template

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -22,7 +22,12 @@ from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 # detected from active_engine + template_config snapshot, not by extending this
 # set with template keys.
 CODING_TEMPLATE_TYPES = frozenset({"applicationCoding", "personalCoding"})
-TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset({"aicoding", "claude_code"})
+AICODING_ENGINE_TYPE = "aicoding"
+CLAUDE_CODE_ENGINE_TYPE = "claude_code"
+NORMAL_CC_TEMPLATE_TYPE = "normalcc"
+TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset(
+    {AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE}
+)
 LEGACY_BOT_TYPE_ENV_MAP = {
     "personalCoding": "personal",
     "applicationCoding": "application",
@@ -40,8 +45,43 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return self._engine_type
 
     @staticmethod
+    def normalize_engine_type(
+        engine_type: str | None, *, default: str = "openclaw"
+    ) -> str:
+        return (engine_type or default).strip().lower().replace("-", "_")
+
+    @staticmethod
+    def normalize_template_type(template_type: str | None) -> str:
+        return (template_type or "").strip().lower()
+
+    @staticmethod
     def is_coding_template(template_type: str | None) -> bool:
         return template_type in CODING_TEMPLATE_TYPES
+
+    @classmethod
+    def should_use_aicoding_baas_bucket(
+        cls,
+        *,
+        active_engine: str | None,
+        template_type: str | None,
+    ) -> bool:
+        """Whether this context should select the aicoding BaaS bucket.
+
+        BaaS bucket routing is an image/runtime selection policy: all explicit
+        claude_code template-factory types except normalCC reuse the aicoding
+        BaaS template bucket. It only depends on active_engine + template_type;
+        caller/create routing may only have template_type available.
+        """
+        if (
+            cls.normalize_engine_type(active_engine, default="")
+            != CLAUDE_CODE_ENGINE_TYPE
+        ):
+            return False
+        normalized_template_type = cls.normalize_template_type(template_type)
+        return bool(
+            normalized_template_type
+            and normalized_template_type != NORMAL_CC_TEMPLATE_TYPE
+        )
 
     has_template_factory_config = staticmethod(is_template_factory_config)
 
@@ -66,7 +106,8 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         has_template_identity = isinstance(template_config, dict) and bool(
             template_config.get("template_key") and template_config.get("template_uid")
         )
-        return active_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES and has_template_identity
+        normalized_engine = cls.normalize_engine_type(active_engine, default="")
+        return normalized_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES and has_template_identity
 
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -34,6 +34,21 @@ LEGACY_BOT_TYPE_ENV_MAP = {
 }
 
 
+class AicodingBaasEngineBucketResolver:
+    """BaaS bucket resolver contributed by the aicoding engine module."""
+
+    def resolve_baas_engine_bucket(
+        self,
+        *,
+        normalized_engine_type: str,
+        template_type: str | None,
+    ) -> str | None:
+        return AicodingProvisioningStrategy.resolve_baas_engine_bucket(
+            active_engine=normalized_engine_type,
+            template_type=template_type,
+        )
+
+
 class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     """Provisioning strategy shared by ``aicoding`` and ``claude_code`` engines."""
 
@@ -82,6 +97,21 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             normalized_template_type
             and normalized_template_type != NORMAL_CC_TEMPLATE_TYPE
         )
+
+    @classmethod
+    def resolve_baas_engine_bucket(
+        cls,
+        *,
+        active_engine: str | None,
+        template_type: str | None,
+    ) -> str | None:
+        """Return the aicoding BaaS bucket override, if this engine owns it."""
+        if cls.should_use_aicoding_baas_bucket(
+            active_engine=active_engine,
+            template_type=template_type,
+        ):
+            return AICODING_ENGINE_TYPE
+        return None
 
     has_template_factory_config = staticmethod(is_template_factory_config)
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from .aicoding.strategy import AicodingProvisioningStrategy, CODING_TEMPLATE_TYPES
+from .aicoding.strategy import (
+    AICODING_ENGINE_TYPE,
+    CLAUDE_CODE_ENGINE_TYPE,
+    AicodingProvisioningStrategy,
+    CODING_TEMPLATE_TYPES,
+)
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
@@ -51,7 +56,7 @@ class EngineProvisioningRegistry:
         if ctx.active_engine:
             return self.resolve(ctx.active_engine)
         if ctx.template_type in CODING_TEMPLATE_TYPES:
-            return self.resolve("aicoding")
+            return self.resolve(AICODING_ENGINE_TYPE)
         return self._default
 
 
@@ -63,8 +68,8 @@ def _build_default_registry() -> EngineProvisioningRegistry:
     obvious and no lazy double-checked-locking is needed.
     """
     registry = EngineProvisioningRegistry()
-    registry.register(AicodingProvisioningStrategy("aicoding"))
-    registry.register(AicodingProvisioningStrategy("claude_code"))
+    registry.register(AicodingProvisioningStrategy(AICODING_ENGINE_TYPE))
+    registry.register(AicodingProvisioningStrategy(CLAUDE_CODE_ENGINE_TYPE))
     for engine_type in ("openclaw", "teclaw", "hermes"):
         registry.register(DefaultProvisioningStrategy(engine_type))
     return registry
@@ -78,6 +83,32 @@ _REGISTRY: EngineProvisioningRegistry = _build_default_registry()
 def get_engine_provisioning_registry() -> EngineProvisioningRegistry:
     """Return the process-wide strategy registry."""
     return _REGISTRY
+
+
+def normalize_engine_type(engine_type: str | None, *, default: str = "openclaw") -> str:
+    """Normalize public engine spelling to the registry key form."""
+    return AicodingProvisioningStrategy.normalize_engine_type(
+        engine_type, default=default
+    )
+
+
+def resolve_baas_engine_bucket(
+    *,
+    engine_type: str | None,
+    template_type: str | None,
+) -> str:
+    """Resolve the engine bucket used by BaaS template/rollout routing.
+
+    The claude_code -> aicoding exception is owned by the aicoding provisioning
+    strategy, so device services do not duplicate engine-name policy.
+    """
+    normalized_engine = normalize_engine_type(engine_type)
+    if AicodingProvisioningStrategy.should_use_aicoding_baas_bucket(
+        active_engine=normalized_engine,
+        template_type=template_type,
+    ):
+        return AICODING_ENGINE_TYPE
+    return normalized_engine
 
 
 def resolve_provisioning(
@@ -113,8 +144,11 @@ def resolve_provisioning(
 
 
 __all__ = [
+    "AICODING_ENGINE_TYPE",
     "BotProvisioningContext",
     "EngineProvisioningRegistry",
     "get_engine_provisioning_registry",
+    "normalize_engine_type",
+    "resolve_baas_engine_bucket",
     "resolve_provisioning",
 ]

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -1,16 +1,60 @@
 """Composition root for engine provisioning strategies."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
 from .aicoding.strategy import (
     AICODING_ENGINE_TYPE,
     CLAUDE_CODE_ENGINE_TYPE,
+    AicodingBaasEngineBucketResolver,
     AicodingProvisioningStrategy,
     CODING_TEMPLATE_TYPES,
 )
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
+
+
+class BaasEngineBucketResolver(Protocol):
+    """Resolver that may map an engine context to a BaaS engine bucket.
+
+    Return ``None`` when the resolver does not own the input.  The routing
+    registry continues with the next resolver and eventually falls back to the
+    normalized engine type.
+    """
+
+    def resolve_baas_engine_bucket(
+        self,
+        *,
+        normalized_engine_type: str,
+        template_type: str | None,
+    ) -> str | None:
+        """Return a bucket override, or ``None`` when not applicable."""
+
+
+class BaasEngineBucketResolverRegistry:
+    """Registry for engine-contributed BaaS bucket resolvers."""
+
+    def __init__(self) -> None:
+        self._resolvers: list[BaasEngineBucketResolver] = []
+
+    def register(self, resolver: BaasEngineBucketResolver) -> None:
+        self._resolvers.append(resolver)
+
+    def resolve(
+        self,
+        *,
+        engine_type: str | None,
+        template_type: str | None,
+    ) -> str:
+        normalized_engine = normalize_engine_type(engine_type)
+        for resolver in self._resolvers:
+            engine_bucket = resolver.resolve_baas_engine_bucket(
+                normalized_engine_type=normalized_engine,
+                template_type=template_type,
+            )
+            if engine_bucket is not None:
+                return engine_bucket
+        return normalized_engine
 
 
 class EngineProvisioningRegistry:
@@ -85,11 +129,26 @@ def get_engine_provisioning_registry() -> EngineProvisioningRegistry:
     return _REGISTRY
 
 
+def _build_default_baas_engine_bucket_resolver_registry() -> BaasEngineBucketResolverRegistry:
+    """Assemble the process-wide BaaS bucket resolver registry."""
+    registry = BaasEngineBucketResolverRegistry()
+    registry.register(AicodingBaasEngineBucketResolver())
+    return registry
+
+
+_BAAS_ENGINE_BUCKET_RESOLVER_REGISTRY: BaasEngineBucketResolverRegistry = (
+    _build_default_baas_engine_bucket_resolver_registry()
+)
+
+
+def get_baas_engine_bucket_resolver_registry() -> BaasEngineBucketResolverRegistry:
+    """Return the process-wide BaaS bucket resolver registry."""
+    return _BAAS_ENGINE_BUCKET_RESOLVER_REGISTRY
+
+
 def normalize_engine_type(engine_type: str | None, *, default: str = "openclaw") -> str:
     """Normalize public engine spelling to the registry key form."""
-    return AicodingProvisioningStrategy.normalize_engine_type(
-        engine_type, default=default
-    )
+    return (engine_type or default).strip().lower().replace("-", "_")
 
 
 def resolve_baas_engine_bucket(
@@ -99,16 +158,14 @@ def resolve_baas_engine_bucket(
 ) -> str:
     """Resolve the engine bucket used by BaaS template/rollout routing.
 
-    The claude_code -> aicoding exception is owned by the aicoding provisioning
-    strategy, so device services do not duplicate engine-name policy.
+    This public entrypoint delegates to the bucket resolver registry. Concrete
+    engine-specific overrides are contributed by registered resolvers; unclaimed
+    inputs fall back to the normalized engine type.
     """
-    normalized_engine = normalize_engine_type(engine_type)
-    if AicodingProvisioningStrategy.should_use_aicoding_baas_bucket(
-        active_engine=normalized_engine,
+    return get_baas_engine_bucket_resolver_registry().resolve(
+        engine_type=engine_type,
         template_type=template_type,
-    ):
-        return AICODING_ENGINE_TYPE
-    return normalized_engine
+    )
 
 
 def resolve_provisioning(
@@ -145,8 +202,11 @@ def resolve_provisioning(
 
 __all__ = [
     "AICODING_ENGINE_TYPE",
+    "BaasEngineBucketResolver",
+    "BaasEngineBucketResolverRegistry",
     "BotProvisioningContext",
     "EngineProvisioningRegistry",
+    "get_baas_engine_bucket_resolver_registry",
     "get_engine_provisioning_registry",
     "normalize_engine_type",
     "resolve_baas_engine_bucket",

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -21,7 +21,11 @@ from agentclaw.community.core.bot_management.capabilities import (
     has_declared_capabilities,
     is_template_factory_config,
 )
-from agentclaw.community.core.bot_management.engines.aicoding import CODING_TEMPLATE_TYPES
+from agentclaw.community.core.bot_management.engines.registry import (
+    AICODING_ENGINE_TYPE,
+    normalize_engine_type,
+    resolve_baas_engine_bucket,
+)
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
 from agentclaw.community.core.bot_management.services.aicoding.workspace_hosting_service import WorkspaceHostingService
 from agentclaw.community.core.desktop_bot.device_status_client import DeviceStatusClient
@@ -689,16 +693,15 @@ class BotService:
         if source_provider != ARCA_DEVICE_PROVIDER:
             return source_provider
 
-        active_engine = (
-            str(bot.get("active_engine") or "")
-            .strip()
-            .lower()
-            .replace("-", "_")
-        )
+        active_engine = normalize_engine_type(bot.get("active_engine"), default="")
         template_type = bot.get("template_type")
+        engine_bucket = resolve_baas_engine_bucket(
+            engine_type=active_engine,
+            template_type=template_type,
+        )
         if active_engine not in {"openclaw", "hermes", "claude_code"}:
             return source_provider
-        if active_engine == "claude_code" and template_type in CODING_TEMPLATE_TYPES:
+        if engine_bucket == AICODING_ENGINE_TYPE:
             return source_provider
 
         template_resolver = getattr(self, "_baas_template_resolver", None)

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -21,8 +21,10 @@ from agentclaw.community.core.bot_management.capabilities import (
     has_declared_capabilities,
     is_template_factory_config,
 )
-from agentclaw.community.core.bot_management.engines.registry import (
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AICODING_ENGINE_TYPE,
+)
+from agentclaw.community.core.bot_management.engines.registry import (
     normalize_engine_type,
     resolve_baas_engine_bucket,
 )

--- a/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from agentclaw.community.core.bot_management.engines.aicoding import (
-    CODING_TEMPLATE_TYPES as AICODING_TEMPLATE_TYPES,
-)
 from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_branches import (
     SUPPORTED_ARCA_CREATE_BAAS_ROLLOUT_BRANCHES,
 )
@@ -41,7 +38,6 @@ class ArcaBotCreateBaasRolloutPolicy:
     ``device_provider``，绕过本策略。
     """
 
-    CODING_TEMPLATE_TYPES = AICODING_TEMPLATE_TYPES
     LEGACY_ARCA_CREATE_BRANCHES = SUPPORTED_ARCA_CREATE_BAAS_ROLLOUT_BRANCHES
 
     def __init__(
@@ -58,7 +54,7 @@ class ArcaBotCreateBaasRolloutPolicy:
         user_id: str,
         bot_type: str,
         engine_type: str,
-        template_type: str,
+        template_type: str | None,
     ) -> ArcaBotCreateBaasRolloutDecision:
         engine_bucket = self.normalize_engine_bucket(
             engine_type=engine_type,
@@ -199,12 +195,14 @@ class ArcaBotCreateBaasRolloutPolicy:
         cls,
         *,
         engine_type: str,
-        template_type: str,
+        template_type: str | None,
     ) -> str:
         normalized_engine = engine_type.strip().lower().replace("-", "_")
+        normalized_template_type = (template_type or "").strip().lower()
         if (
             normalized_engine == "claude_code"
-            and template_type in cls.CODING_TEMPLATE_TYPES
+            and normalized_template_type
+            and normalized_template_type != "normalcc"
         ):
             return "aicoding"
         return normalized_engine

--- a/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/arca_bot_create_baas_rollout_policy.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_baas_engine_bucket,
+)
 from agentclaw.community.core.devices.services.arca_bot_create_baas_rollout_branches import (
     SUPPORTED_ARCA_CREATE_BAAS_ROLLOUT_BRANCHES,
 )
@@ -54,7 +56,7 @@ class ArcaBotCreateBaasRolloutPolicy:
         user_id: str,
         bot_type: str,
         engine_type: str,
-        template_type: str | None,
+        template_type: str,
     ) -> ArcaBotCreateBaasRolloutDecision:
         engine_bucket = self.normalize_engine_bucket(
             engine_type=engine_type,
@@ -195,14 +197,9 @@ class ArcaBotCreateBaasRolloutPolicy:
         cls,
         *,
         engine_type: str,
-        template_type: str | None,
+        template_type: str,
     ) -> str:
-        normalized_engine = engine_type.strip().lower().replace("-", "_")
-        normalized_template_type = (template_type or "").strip().lower()
-        if (
-            normalized_engine == "claude_code"
-            and normalized_template_type
-            and normalized_template_type != "normalcc"
-        ):
-            return "aicoding"
-        return normalized_engine
+        return resolve_baas_engine_bucket(
+            engine_type=engine_type,
+            template_type=template_type,
+        )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from agentclaw.community.core.bot_management.engines.aicoding import CODING_TEMPLATE_TYPES
 from agentclaw.community.core.devices.errors import DeviceServiceError
 from agentclaw.community.log import get_logger
 
@@ -385,8 +384,14 @@ class SystemConfigBaasTemplateResolver:
     ) -> str:
         """把历史 engine 表达归一成 template 配置里的 engine。"""
         normalized_engine = (engine_type or "openclaw").strip().lower().replace("-", "_")
-        # Claude Code 的 coding 模板沿用 AI Coding 模板，配置侧统一写 engine=aicoding。
-        if normalized_engine == "claude_code" and template_type in CODING_TEMPLATE_TYPES:
+        normalized_template_type = (template_type or "").strip().lower()
+        # Claude Code 除 normalCC 外，只要有明确 template_type，
+        # 都复用 AI Coding 模板，配置侧统一写 engine=aicoding。
+        if (
+            normalized_engine == "claude_code"
+            and normalized_template_type
+            and normalized_template_type != "normalcc"
+        ):
             return "aicoding"
         return normalized_engine
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_baas_engine_bucket,
+)
 from agentclaw.community.core.devices.errors import DeviceServiceError
 from agentclaw.community.log import get_logger
 
@@ -383,17 +386,10 @@ class SystemConfigBaasTemplateResolver:
         template_type: str | None,
     ) -> str:
         """把历史 engine 表达归一成 template 配置里的 engine。"""
-        normalized_engine = (engine_type or "openclaw").strip().lower().replace("-", "_")
-        normalized_template_type = (template_type or "").strip().lower()
-        # Claude Code 除 normalCC 外，只要有明确 template_type，
-        # 都复用 AI Coding 模板，配置侧统一写 engine=aicoding。
-        if (
-            normalized_engine == "claude_code"
-            and normalized_template_type
-            and normalized_template_type != "normalcc"
-        ):
-            return "aicoding"
-        return normalized_engine
+        return resolve_baas_engine_bucket(
+            engine_type=engine_type,
+            template_type=template_type,
+        )
 
     def _legacy_template_whitelist_hit(
         self,

--- a/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
@@ -8,6 +8,9 @@ from agentclaw.community.core.devices.repository.protocol import DeviceBindingRe
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.devices.services.device_context import ConnInfoBuildError
 from agentclaw.community.core.devices.services.baas_conn_info import build_baas_conn_info_for_http
+from agentclaw.community.core.devices.services.baas_template_resolver import (
+    SystemConfigBaasTemplateResolver,
+)
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
@@ -77,8 +80,13 @@ class BaasConnInfoBuilder:
         # 现场:trace 0be8ed2217816832272041880e9da7(协作者公开访问 service bot)
         # 跟进:docs/superpowers/baas-refactor-dirty-work.md §7
         bot = self._resolve_bot(binding)
-        engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
+        raw_engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
         bot_type = (bot or {}).get("bot_type") or ""
+        template_type = (bot or {}).get("template_type") or ""
+        engine_type = SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type=raw_engine_type,
+            template_type=template_type,
+        )
 
         if not bot:
             logger.warning(

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -11,7 +11,48 @@ from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
 )
 from agentclaw.community.core.bot_management.engines.registry import (
     get_engine_provisioning_registry,
+    resolve_baas_engine_bucket,
 )
+
+
+def test_resolve_baas_engine_bucket_routes_general_cc_by_template_type():
+    assert (
+        resolve_baas_engine_bucket(
+            engine_type="claude_code",
+            template_type="generalCC",
+        )
+        == "aicoding"
+    )
+
+
+def test_resolve_baas_engine_bucket_routes_architect_by_template_type():
+    assert (
+        resolve_baas_engine_bucket(
+            engine_type="claude_code",
+            template_type="architect",
+        )
+        == "aicoding"
+    )
+
+
+def test_resolve_baas_engine_bucket_routes_architect_without_template_config():
+    assert (
+        resolve_baas_engine_bucket(
+            engine_type="claude_code",
+            template_type="architect",
+        )
+        == "aicoding"
+    )
+
+
+def test_resolve_baas_engine_bucket_keeps_normal_cc_on_claude_code():
+    assert (
+        resolve_baas_engine_bucket(
+            engine_type="claude-code",
+            template_type="normalCC",
+        )
+        == "claude_code"
+    )
 
 
 def test_aicoding_strategy_personal_coding_model_runtime_and_token():

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -11,6 +11,8 @@ from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
 )
 from agentclaw.community.core.bot_management.engines.registry import (
     get_engine_provisioning_registry,
+)
+from agentclaw.community.core.bot_management.engines.registry import (
     resolve_baas_engine_bucket,
 )
 

--- a/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
+++ b/src/backend/tests/community/core/devices/services/conn_info_builders/test_baas_builder.py
@@ -143,6 +143,38 @@ def test_step1_hit_engine_type_openclaw_regression_guard(
     assert conn_info["engine_type"] == "openclaw"
 
 
+def test_step1_hit_claude_code_with_non_normalcc_template_normalizes_to_aicoding(
+    fake_binding, fake_baas_service, fake_bot_repo, fake_device_repo
+):
+    """claude_code + 非 normalCC template_type 应归一到 aicoding。"""
+    fake_bot_repo.get_by_binding_id.return_value = {
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "bot_type": "desktop",
+    }
+    builder = _make_builder(fake_baas_service, fake_bot_repo, fake_device_repo)
+
+    conn_info = builder.build(fake_binding, user_id="user-1")
+
+    assert conn_info["engine_type"] == "aicoding"
+
+
+def test_step1_hit_claude_code_with_normalcc_stays_claude_code(
+    fake_binding, fake_baas_service, fake_bot_repo, fake_device_repo
+):
+    """claude_code + normalCC 保持 claude_code。"""
+    fake_bot_repo.get_by_binding_id.return_value = {
+        "active_engine": "claude_code",
+        "template_type": "normalCC",
+        "bot_type": "desktop",
+    }
+    builder = _make_builder(fake_baas_service, fake_bot_repo, fake_device_repo)
+
+    conn_info = builder.build(fake_binding, user_id="user-1")
+
+    assert conn_info["engine_type"] == "claude_code"
+
+
 # ── Step 2 反查:service bot via binding.device_props.bolt_id ──────
 #
 # 现场:trace 0be8ed2217816832272041880e9da7

--- a/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
@@ -406,7 +406,7 @@ def test_claude_code_missing_template_type_keeps_claude_code_bucket():
     assert (
         ArcaBotCreateBaasRolloutPolicy.normalize_engine_bucket(
             engine_type="claude_code",
-            template_type=None,
+            template_type="",
         )
         == "claude_code"
     )

--- a/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
+++ b/src/backend/tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py
@@ -369,6 +369,48 @@ def test_claude_code_coding_template_uses_aicoding_bucket():
     assert decision.engine_bucket == "aicoding"
 
 
+def test_claude_code_architect_template_uses_aicoding_bucket():
+    decision = _policy(
+        ArcaBotCreateBaasRolloutConfig(
+            enabled=True,
+            rules=(
+                ArcaBotCreateBaasRolloutRule(
+                    bot_type="service",
+                    engine_bucket="aicoding",
+                    allow_user_ids=("u001",),
+                ),
+            ),
+        )
+    ).decide(
+        user_id="u001",
+        bot_type="service",
+        engine_type="claude_code",
+        template_type="architect",
+    )
+
+    assert decision.target_provider == BAAS_DEVICE_PROVIDER
+    assert decision.engine_bucket == "aicoding"
+
+
+def test_claude_code_normalcc_template_keeps_claude_code_bucket():
+    assert (
+        ArcaBotCreateBaasRolloutPolicy.normalize_engine_bucket(
+            engine_type="claude_code",
+            template_type="normalCC",
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_missing_template_type_keeps_claude_code_bucket():
+    assert (
+        ArcaBotCreateBaasRolloutPolicy.normalize_engine_bucket(
+            engine_type="claude_code",
+            template_type=None,
+        )
+        == "claude_code"
+    )
+
 def test_drm_payload_parser_accepts_rule_allow_list():
     provider = _provider()
     config = provider._parse(

--- a/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
@@ -177,33 +177,32 @@ def test_claude_code_coding_template_maps_to_aicoding_engine():
 
 
 def test_claude_code_architect_template_maps_to_aicoding_engine():
-    resolver, _ = _resolver(
-        {
-            "selectors": [
-                {
-                    "bot_type": "service",
-                    "engine": "aicoding",
-                    "template_type": "architect",
-                    "template_uid": "aicoding_architect_template",
-                }
-            ],
-            "templates": {
-                "aicoding_architect_template": {
-                    "template_uuid": "TEMPLATE-aicoding-architect"
-                }
-            },
-        }
-    )
-
     assert (
-        resolver.resolve_template_uid(
-            env="pre",
-            bot_type="service",
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
             engine_type="claude_code",
             template_type="architect",
-            template_config=None,
         )
-        == "aicoding_architect_template"
+        == "aicoding"
+    )
+
+
+def test_claude_code_architect_without_template_identity_maps_to_aicoding():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type="architect",
+        )
+        == "aicoding"
+    )
+
+
+def test_claude_code_generalcc_template_maps_to_aicoding():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type="generalCC",
+        )
+        == "aicoding"
     )
 
 
@@ -221,7 +220,7 @@ def test_claude_code_missing_template_type_keeps_claude_code_engine():
     assert (
         SystemConfigBaasTemplateResolver.normalize_engine_for_template(
             engine_type="claude_code",
-            template_type=None,
+            template_type="",
         )
         == "claude_code"
     )

--- a/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_template_resolver.py
@@ -176,6 +176,66 @@ def test_claude_code_coding_template_maps_to_aicoding_engine():
     )
 
 
+def test_claude_code_architect_template_maps_to_aicoding_engine():
+    resolver, _ = _resolver(
+        {
+            "selectors": [
+                {
+                    "bot_type": "service",
+                    "engine": "aicoding",
+                    "template_type": "architect",
+                    "template_uid": "aicoding_architect_template",
+                }
+            ],
+            "templates": {
+                "aicoding_architect_template": {
+                    "template_uuid": "TEMPLATE-aicoding-architect"
+                }
+            },
+        }
+    )
+
+    assert (
+        resolver.resolve_template_uid(
+            env="pre",
+            bot_type="service",
+            engine_type="claude_code",
+            template_type="architect",
+            template_config=None,
+        )
+        == "aicoding_architect_template"
+    )
+
+
+def test_claude_code_normalcc_template_keeps_claude_code_engine():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type="normalCC",
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_missing_template_type_keeps_claude_code_engine():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude_code",
+            template_type=None,
+        )
+        == "claude_code"
+    )
+
+
+def test_claude_code_non_normalcc_template_type_maps_to_aicoding_case_insensitive():
+    assert (
+        SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type="claude-code",
+            template_type=" Architect ",
+        )
+        == "aicoding"
+    )
+
 def test_resolves_personal_hermes_template_uid():
     resolver, _ = _resolver(
         {


### PR DESCRIPTION
## Summary
- Route claude_code bots with explicit non-normalCC template_type to the aicoding BaaS template bucket
- Normalize BaaS connection engine type by template context
- Keep normalCC and missing template_type on claude_code behavior

## Commits included
- ab2b2200610012a2589c8455a3886043809f1be5
- c433b3a598c825ccbde4a8c04f77d6d1c23adce1

## Tests
- `cd src/backend && uv run pytest tests/community/core/devices/services/test_baas_template_resolver.py tests/community/core/devices/services/test_arca_bot_create_baas_rollout_policy.py tests/community/core/devices/services/conn_info_builders/test_baas_builder.py -q`
- OCB pre-push gate passed in lint-only mode
