### PR TITLE
fix(backend): reject restart for teclaw bots to prevent destructive container destruction

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3876,6 +3876,17 @@ class BotService:
                 "use DesktopBotService instead"
             )
 
+        # teclaw containers are provisioned only inside TeclawProvisionService
+        # during bot creation; there is no standalone "start a teclaw container"
+        # primitive. The generic stop→start restart path would destroy the
+        # container via stop_bot and then fail to recreate it, leaving the bot
+        # FAILED with a stale binding. Reject restart early so the destructive
+        # path is never reached; the recovery path is delete-and-recreate.
+        if self.is_teclaw_bot(bot.get("active_engine")):
+            raise BotOperationNotAllowedError(
+                "teclaw 类型的 Bot 不支持重启，请删除后重新创建"
+            )
+
         bot_status = str(bot.get("status") or "").upper()
         # REACTIVATING is an explicit lifecycle operation. PENDING is not:
         # failed startup reporting can strand a bot there indefinitely, so a

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     RESTART_LOCK_TTL_SECONDS,
     BotInvalidLifecycleStateError,
     BotNotFoundError,
+    BotOperationNotAllowedError,
     BotService,
     BotServiceError,
 )
@@ -208,6 +209,32 @@ class TestRestartGuardOrchestration:
         assert repo.acquire_calls == 0
         stop.assert_not_called()
         start.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("status", "binding_id"),
+        [("ACTIVE", 42), ("FAILED", 42), ("PENDING", 42), ("FAILED", None)],
+        ids=["active-with-binding", "failed-with-binding", "pending-with-binding", "failed-without-binding"],
+    )
+    def test_teclaw_restart_rejected_before_any_side_effects(
+        self, status, binding_id
+    ):
+        """teclaw bots must be rejected before stop/start/lock — no side effects."""
+        repo = FakeRestartLockRepo()
+        svc = _make_service(repo)
+        bot = _make_bot(status=status, active_engine="teclaw", binding_id=binding_id)
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot") as stop, \
+             patch.object(svc, "start_bot") as start, \
+             patch.object(svc, "_resolve_current_device_restart_context") as resolve_ctx:
+            with pytest.raises(BotOperationNotAllowedError, match="teclaw"):
+                svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        # No lock acquired, no stop/start called, no binding context resolved
+        assert repo.acquire_calls == 0
+        stop.assert_not_called()
+        start.assert_not_called()
+        resolve_ctx.assert_not_called()
 
     @pytest.mark.parametrize(
         ("binding_id", "device_id"),

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -64,6 +64,10 @@ def _make_service() -> BotService:
     # tests that exercise the flag override ``_drm_reader.read.return_value``.
     svc._drm_reader = MagicMock()
     svc._drm_reader.read.return_value = None
+    # teclaw provision provider: default mock so is_teclaw_bot returns False
+    svc._teclaw_provision_provider = lambda: MagicMock(
+        is_teclaw=lambda active_engine: False
+    )
     return svc
 
 

--- a/src/frontend/src/hooks/useBot.ts
+++ b/src/frontend/src/hooks/useBot.ts
@@ -726,6 +726,16 @@ export function useBot(options?: { autoFetchTotalBotCount?: boolean }) {
         return false;
       }
 
+      // teclaw 容器没有独立的 restart 原语，generic restart 路径会销毁容器后无法重建。
+      // 在前端直接拦截，避免触发不可逆的破坏性操作。
+      const bot = getBotById(botId);
+      if (bot?.active_engine === ENGINE_TYPE.TECLAW) {
+        toast.error(
+          '该设备不支持重启，可尝试更新配置恢复。若问题持续，请联系运维。',
+        );
+        return false;
+      }
+
       try {
         const res = await BotController.restartBot(
           {

--- a/src/frontend/src/pages/GroupChat/components/TopNavBar.tsx
+++ b/src/frontend/src/pages/GroupChat/components/TopNavBar.tsx
@@ -8,7 +8,9 @@
 import { useExt } from '@/capabilities';
 import * as BcnController from '@/services/backend-api/BcnController';
 import * as BotController from '@/services/backend-api/BotController';
+import { ENGINE_TYPE } from '@/services/backend-api/BotController';
 import { AppExt } from '@/shell';
+import { useBotStore } from '@/stores/botStore';
 import type { BotNetworkInfo } from '@/stores/botNetworkStore';
 import { useUserStore } from '@/stores/userStore';
 import { resolveBotOwnerId } from '@/utils/activeBotContext';
@@ -109,33 +111,39 @@ const TopNavBar: React.FC<TopNavBarProps> = ({
       // 检查是否入网失败
       if (response.data?.onboarded === false) {
         const errorMsg = response.message || 'Bot 入网失败';
-        // 显示错误提示，带重启按钮
-        toast.error(errorMsg, {
-          action: {
-            label: '立即重启',
-            onClick: async () => {
-              try {
-                // 解析 bot_id（格式：bot_id:entity_id）
-                const [botId] = bot.bot_uuid.split(':');
-                await BotController.restartBot({
-                  bot_id: botId,
-                  user_id: '', // user_id 可选，后端会从 token 获取
-                  // BCN 闭包：botStore 已由 initUnifiedBotTabs 反写，
-                  // resolveBotOwnerId 能查到 owner_id；极端情况用 userId 兜底
-                  owner_id:
-                    resolveBotOwnerId(botId) || useUserStore.getState().userId,
-                });
-                toast.success('Bot 重启中，请稍后重试入网');
-              } catch (restartError) {
-                console.error(
-                  '[TopNavBar] Failed to restart bot:',
-                  restartError,
-                );
-                toast.error('Bot 重启失败');
-              }
+        const [botId] = bot.bot_uuid.split(':');
+        // 查询完整 Bot 记录判断是否 teclaw 引擎
+        const fullBot = useBotStore.getState().getBotById(botId);
+        const isTeclaw = fullBot?.active_engine === ENGINE_TYPE.TECLAW;
+
+        if (isTeclaw) {
+          // teclaw 不支持重启（会销毁容器且无法重建），引导用户更新配置或联系运维
+          toast.error('入网失败，可尝试更新配置后重试。如问题持续请联系运维。');
+        } else {
+          // 非 teclaw：保留原有重启入口
+          toast.error(errorMsg, {
+            action: {
+              label: '立即重启',
+              onClick: async () => {
+                try {
+                  await BotController.restartBot({
+                    bot_id: botId,
+                    user_id: '',
+                    owner_id:
+                      resolveBotOwnerId(botId) || useUserStore.getState().userId,
+                  });
+                  toast.success('Bot 重启中，请稍后重试入网');
+                } catch (restartError) {
+                  console.error(
+                    '[TopNavBar] Failed to restart bot:',
+                    restartError,
+                  );
+                  toast.error('Bot 重启失败');
+                }
+              },
             },
-          },
-        });
+          });
+        }
         return;
       }
 


### PR DESCRIPTION
## Problem

Teclaw containers are provisioned only inside `TeclawProvisionService` during bot creation; there is no standalone "start a teclaw container" primitive. The generic `stop_bot → start_bot` restart path in `BotService.restart_bot` destroys the container via `stop_bot` (which routes to BaaS `destroy_bot`) and then fails to recreate it in `start_bot`, leaving the bot `FAILED` with a stale binding pointing at a container that no longer exists.

Issue #869 documents this gap. PR #870 proposed the same guard but was closed without merging.

## Solution

**Backend guard** — Add a check at the top of `BotService.restart_bot`, beside the existing desktop guard, that rejects teclaw bots with `BotOperationNotAllowedError` before any state is read or written. This prevents the destructive `stop_bot` path from ever being reached.

**Frontend interception** — Two entry points that trigger restart are guarded:
- `useBot.ts` `restartBot`: checks `active_engine === ENGINE_TYPE.TECLAW` before calling the API, surfaces a user-facing message instead
- `TopNavBar.tsx` onboard-failure toast: queries `useBotStore` for the bot's engine type; teclaw bots get an "update config" message instead of a "restart" button

The recovery path for unhealthy teclaw containers is delete-and-recreate, confirmed by product. `update_teclaw_bot` only re-delivers configuration and cannot recover a wedged container.

## Validation

- **New tests**: 4 parametrized tests covering ACTIVE/FAILED/PENDING × with-binding/without-binding, asserting no side effects (no lock acquired, no stop/start called, no binding context resolved)
- **Regression**: 657 tests in `bot_management/services/` all pass, 0 regressions
- **Pre-push gate**: lint-only mode passed (SAST clean)
- **Frontend**: `tsc --noEmit` shows no new errors in changed files

## Compatibility and risk

No schema, config, or migration impact. The change is inert for every non-teclaw bot and strictly removes a destructive operation for teclaw bots. Bots already broken by the prior behavior have been recovered manually; no backfill required.

Behavioral change: the three `/api/bots` restart routes return 400 for teclaw bots (via `BotOperationNotAllowedError`). The OpenAPI v1 route returns 409. This asymmetry is pre-existing and is not changed here.

## Related issues

Closes #869
Closes #870