### PR TITLE
perf(bcs): unblock the three slow-test clusters in the unit suite

### DIFF
--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -300,3 +300,19 @@ bcs-auth-wechat            = { path = "crates/plugins/bcs-auth-wechat" }
 bcs-auth-alipay            = { path = "crates/plugins/bcs-auth-alipay" }
 bcs-auth-local             = { path = "crates/plugins/bcs-auth-local" }
 bcs-auth-oauth             = { path = "crates/plugins/bcs-auth-oauth" }
+
+# ────────────────────────────────────────────────────────────────
+# Optimize the bignum stack even in dev/test builds.
+#
+# `bcs-auth-alipay` generates RSA-2048 keypairs in its tests. Prime search is
+# pure bignum arithmetic, and unoptimized it costs ~5s per keypair — ten
+# keypairs across the alipay tests, ~36s of the unit-test suite. Building just
+# these two dependencies with optimizations brings that back to noise. Both are
+# third-party leaf dependencies, so this does not affect coverage of workspace
+# code (llvm-cov reports on workspace crates).
+# ────────────────────────────────────────────────────────────────
+[profile.dev.package.rsa]
+opt-level = 3
+
+[profile.dev.package.num-bigint-dig]
+opt-level = 3

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -204,6 +204,8 @@ enabled = false
 url = "https://bcsfuse.example.com"
 fusion_timeout_ms = 120000
 sync_timeout_ms = 10000
+# Base backoff between worker-sync retry attempts; doubles per attempt.
+sync_retry_base_ms = 1000
 profile_id = "default"
 recommend_top_k = 10
 recommend_min_score = 0.1

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -154,6 +154,8 @@ enabled = false
 url = "http://127.0.0.1:8765"
 fusion_timeout_ms = 120000
 sync_timeout_ms = 10000
+# Base backoff between worker-sync retry attempts; doubles per attempt.
+sync_retry_base_ms = 1000
 profile_id = "default"
 recommend_top_k = 10
 recommend_min_score = 0.1

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/token_expiry_e2e.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/token_expiry_e2e.rs
@@ -38,6 +38,15 @@ use futures::{SinkExt, StreamExt};
 use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message;
 
+/// Upper bound on how long a disconnected client is given to observe the close.
+///
+/// `disconnect()` drops the sender synchronously, so a close frame — or a dead
+/// stream — is visible immediately if it is coming at all. Every wait below also
+/// accepts the elapsed-timeout arm, and the load-bearing assertion is the
+/// `is_connected` check that follows, so a generous bound bought nothing but a
+/// guaranteed multi-second stall on the three tests that exercise this path.
+const CLOSE_OBSERVE_TIMEOUT: Duration = Duration::from_millis(500);
+
 // ─── Minimal mocks ──────────────────────────────────────────────────────────
 
 #[derive(Default)]
@@ -357,7 +366,7 @@ async fn scanner_disconnects_bot_with_expired_token() {
     }
 
     // The client should receive a Close frame or the stream should end
-    let msg = tokio::time::timeout(Duration::from_secs(5), ws.next()).await;
+    let msg = tokio::time::timeout(CLOSE_OBSERVE_TIMEOUT, ws.next()).await;
     match msg {
         Ok(Some(Ok(Message::Close(_)))) => {} // explicit close frame
         Ok(None) => {}                         // stream ended cleanly
@@ -454,7 +463,7 @@ async fn scanner_respects_grace_period_on_real_connection() {
     }
 
     // Client sees close
-    let msg = tokio::time::timeout(Duration::from_secs(5), ws.next()).await;
+    let msg = tokio::time::timeout(CLOSE_OBSERVE_TIMEOUT, ws.next()).await;
     match msg {
         Ok(Some(Ok(Message::Close(_)))) | Ok(None) | Ok(Some(Err(_))) => {}
         Err(_) => {} // timeout (connection already dead)
@@ -486,7 +495,7 @@ async fn scanner_disconnects_only_expired_bots_in_batch() {
     }
 
     // expired-bot should be closed
-    let msg = tokio::time::timeout(Duration::from_secs(5), ws_expired.next()).await;
+    let msg = tokio::time::timeout(CLOSE_OBSERVE_TIMEOUT, ws_expired.next()).await;
     match msg {
         Ok(Some(Ok(Message::Close(_)))) | Ok(None) | Ok(Some(Err(_))) => {}
         Err(_) => {} // timeout (connection already dead)

--- a/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/http_adapter.rs
@@ -404,7 +404,13 @@ impl VisibilitySyncPort for BootstrapVisibilitySyncPort {
             &request.visibility,
         );
 
-        bcs_fusion::sync_worker_with_retry(&fuse_client, &request.bot_uuid, &sync_req).await;
+        bcs_fusion::sync_worker_with_retry(
+            &self.bcsfuse_config,
+            &fuse_client,
+            &request.bot_uuid,
+            &sync_req,
+        )
+        .await;
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_bcsfuse.rs
@@ -53,6 +53,9 @@ fn create_test_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
             url: "http://127.0.0.1:19999".to_string(), // no server here
             sync_timeout_ms: 1000,
             fusion_timeout_ms: 2000,
+            // Every sync here is guaranteed to fail; the production 1s/2s
+            // backoff would add 3s of pure sleep per onboard/visibility change.
+            sync_retry_base_ms: 1,
             ..Default::default()
         },
         auth_sdk: Default::default(),

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_discover_fuse.rs
@@ -61,6 +61,9 @@ fn create_config_bcsfuse_enabled(bots_dir: &PathBuf) -> BcsConfig {
             url: "http://127.0.0.1:19999".to_string(), // no server here
             sync_timeout_ms: 1000,
             fusion_timeout_ms: 2000,
+            // Every sync here is guaranteed to fail; the production 1s/2s
+            // backoff would add 3s of pure sleep per onboard/visibility change.
+            sync_retry_base_ms: 1,
             ..Default::default()
         },
         auth_sdk: Default::default(),

--- a/src/bcs/crates/service-api/bcs-config-api/src/bcsfuse.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/bcsfuse.rs
@@ -21,6 +21,14 @@ pub struct BcsFuseConfig {
     #[serde(default = "default_sync_timeout")]
     pub sync_timeout_ms: u64,
 
+    /// Base backoff between worker-sync retry attempts, in milliseconds.
+    ///
+    /// Attempt N waits `sync_retry_base_ms * 2^(N-1)` before the next attempt,
+    /// so the default 1000 gives 1s + 2s between the three attempts. Tests that
+    /// point at a dead bcsfuse set this near zero to avoid paying the backoff.
+    #[serde(default = "default_sync_retry_base")]
+    pub sync_retry_base_ms: u64,
+
     /// Profile ID for worker profiles (default: "default").
     #[serde(default = "default_profile_id")]
     pub profile_id: String,
@@ -46,6 +54,10 @@ fn default_sync_timeout() -> u64 {
     10_000 // 10s — simple CRUD
 }
 
+fn default_sync_retry_base() -> u64 {
+    1_000 // 1s, doubling per attempt
+}
+
 fn default_profile_id() -> String {
     "default".to_string()
 }
@@ -65,6 +77,7 @@ impl Default for BcsFuseConfig {
             url: default_url(),
             fusion_timeout_ms: default_fusion_timeout(),
             sync_timeout_ms: default_sync_timeout(),
+            sync_retry_base_ms: default_sync_retry_base(),
             profile_id: default_profile_id(),
             recommend_top_k: default_recommend_top_k(),
             recommend_min_score: default_recommend_min_score(),

--- a/src/bcs/crates/services/bcs-fusion/src/core/fuse_backed_sync.rs
+++ b/src/bcs/crates/services/bcs-fusion/src/core/fuse_backed_sync.rs
@@ -72,8 +72,12 @@ pub fn build_sync_request(
 
 /// Sync worker with inline retry (3 attempts, exponential backoff).
 ///
+/// The backoff between attempts is `config.sync_retry_base_ms * 2^attempt`; the
+/// last attempt is not followed by a wait, since there is nothing left to retry.
+///
 /// Designed to be called inside `tokio::spawn` — never panics, only logs.
 pub async fn sync_worker_with_retry(
+    config: &BcsFuseConfig,
     client: &FuseClient,
     bot_id: &str,
     sync_req: &SyncWorkerRequest,
@@ -104,7 +108,11 @@ pub async fn sync_worker_with_retry(
                     error = %e,
                     "Worker sync failed, retrying"
                 );
-                tokio::time::sleep(Duration::from_secs(2u64.pow(attempt))).await;
+                // No point waiting after the final attempt — the loop is done.
+                if attempt + 1 < MAX_SYNC_RETRIES {
+                    let backoff = config.sync_retry_base_ms.saturating_mul(2u64.pow(attempt));
+                    tokio::time::sleep(Duration::from_millis(backoff)).await;
+                }
             }
         }
     }
@@ -207,5 +215,36 @@ mod tests {
         let ctx = make_context(None, None, None, None);
         let contents = build_contents_from_context(&ctx);
         assert!(contents.is_empty());
+    }
+
+    /// The retry backoff must come from config, and the loop must not wait after
+    /// the attempt it has no intention of following up on.
+    ///
+    /// With the default 1s base this sequence sleeps 1s + 2s between the three
+    /// attempts (and used to sleep a further 4s after the last one, for nothing).
+    /// At `sync_retry_base_ms = 0` it should sleep not at all, leaving only three
+    /// connection refusals against a dead port.
+    #[tokio::test]
+    async fn sync_retry_backoff_honours_config_and_skips_the_final_wait() {
+        let config = BcsFuseConfig {
+            enabled: true,
+            // Nothing listens here, so every attempt fails fast with a refusal.
+            url: "http://127.0.0.1:19998".to_string(),
+            sync_timeout_ms: 500,
+            sync_retry_base_ms: 0,
+            ..Default::default()
+        };
+        let client = FuseClient::new(&config).expect("client builds");
+        let ctx = make_context(None, None, None, None);
+        let req = build_sync_request(&config, "bot1", "Bot One", None, &[], &[], &ctx, "public");
+
+        let started = std::time::Instant::now();
+        sync_worker_with_retry(&config, &client, "bot1", &req).await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "zero backoff should add no sleep; took {elapsed:?}"
+        );
     }
 }

--- a/src/bcs/scripts/ci_test.sh
+++ b/src/bcs/scripts/ci_test.sh
@@ -83,6 +83,7 @@ date
 # ---- Environment check ----
 # Any missing prerequisite blocks BCS build/test. See src/bcs/CLAUDE.md Prerequisites:
 # Rust/Cargo, cargo-nextest, protobuf. --coverage additionally needs cargo-llvm-cov + llvm-tools.
+# scripts/install_cargo_test_tools.sh installs the two cargo subcommands from prebuilt binaries.
 env_status=0
 check_bin() {
   local bin="$1"
@@ -97,11 +98,11 @@ check_bin() {
 
 echo "--- environment check ---"
 check_bin cargo "Install Rust toolchain via rustup: https://rustup.rs"
-check_bin cargo-nextest "Run: cargo install cargo-nextest --locked"
+check_bin cargo-nextest "Run: bash scripts/install_cargo_test_tools.sh nextest"
 # protobuf: BCS build.rs depends on protoc; CI images usually have it, local may not.
 check_bin protoc "Install protobuf compiler (macOS: brew install protobuf; Linux: yum/apt install protobuf-compiler)"
 if [[ "$coverage" -eq 1 ]]; then
-  check_bin cargo-llvm-cov "Run: cargo install cargo-llvm-cov --locked"
+  check_bin cargo-llvm-cov "Run: bash scripts/install_cargo_test_tools.sh llvm-cov"
   # llvm-cov requires the llvm-tools component. rustup component list --installed
   # prints entries with a target suffix (e.g. llvm-tools-aarch64-apple-darwin),
   # so match with ^llvm-tools.

--- a/src/bcs/scripts/install_cargo_test_tools.sh
+++ b/src/bcs/scripts/install_cargo_test_tools.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the cargo subcommands the BCS test gates need, from prebuilt release
+# binaries instead of `cargo install`.
+#
+# Owner: 章梧
+#
+# Why this exists: `cargo install cargo-nextest --locked` plus
+# `cargo install cargo-llvm-cov --locked` builds ~380 crates from source. On a
+# 4-core `ubuntu-latest` runner that is ~215s per job — a third of the whole
+# `BCS unit tests` wall clock — spent producing two binaries that upstream
+# already publishes for this exact target. Downloading them takes a few seconds.
+#
+# Both projects publish per-target release tarballs on GitHub:
+#   cargo-nextest   https://github.com/nextest-rs/nextest/releases
+#   cargo-llvm-cov  https://github.com/taiki-e/cargo-llvm-cov/releases
+#
+# Usage:
+#   bash scripts/install_cargo_test_tools.sh                # nextest + llvm-cov
+#   bash scripts/install_cargo_test_tools.sh nextest        # just nextest
+#   bash scripts/install_cargo_test_tools.sh llvm-cov       # just llvm-cov
+#
+# Versions are pinned so CI is reproducible; bump them here deliberately. If a
+# download fails for any reason — release-asset outage, a renamed asset, an
+# unrecognised platform — the script falls back to `cargo install --locked` at
+# the same pinned version. A failed download therefore costs the time it used
+# to cost, and never breaks the gate.
+
+NEXTEST_VERSION="${BCS_NEXTEST_VERSION:-0.9.143}"
+LLVM_COV_VERSION="${BCS_LLVM_COV_VERSION:-0.8.7}"
+
+cargo_bin_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
+mkdir -p "$cargo_bin_dir"
+
+# Both projects name their assets by target triple, but not always with the same
+# libc flavour available, so each host maps to the triples to try in order.
+# An unrecognised host leaves the lists empty and takes the cargo-install path.
+host_targets=()
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    host_targets=(x86_64-unknown-linux-musl x86_64-unknown-linux-gnu)
+    ;;
+  Linux-aarch64 | Linux-arm64)
+    host_targets=(aarch64-unknown-linux-musl aarch64-unknown-linux-gnu)
+    ;;
+  Darwin-x86_64)
+    host_targets=(x86_64-apple-darwin)
+    ;;
+  Darwin-arm64)
+    host_targets=(aarch64-apple-darwin)
+    ;;
+esac
+
+# Download $1, extract it, and move the binary named $2 into the cargo bin dir.
+# Returns non-zero on any failure so callers can fall back to cargo install.
+fetch_tarball() {
+  local url="$1"
+  local binary="$2"
+  local tmp
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064  # expand $tmp now, not at trap time
+  trap "rm -rf '$tmp'" RETURN
+
+  curl --proto '=https' --tlsv1.2 -fsSL --retry 3 --retry-delay 2 \
+    -o "$tmp/tool.tar.gz" "$url" || return 1
+  tar -xzf "$tmp/tool.tar.gz" -C "$tmp" || return 1
+
+  # Tarball layouts differ (flat vs nested), so locate the binary rather than
+  # assuming a path.
+  local extracted
+  extracted="$(find "$tmp" -type f -name "$binary" -print -quit)"
+  [[ -n "$extracted" ]] || return 1
+  chmod +x "$extracted"
+  mv -f "$extracted" "$cargo_bin_dir/$binary"
+}
+
+# install_prebuilt <binary> <version> <url-template-with-{target}-placeholder>
+# Tries each host target in turn; returns non-zero if none produced a binary.
+install_prebuilt() {
+  local binary="$1"
+  local version="$2"
+  local url_template="$3"
+  local target
+  for target in ${host_targets[@]+"${host_targets[@]}"}; do
+    if fetch_tarball "${url_template//\{target\}/$target}" "$binary"; then
+      echo "  ✓ ${binary} ${version} installed from prebuilt binary (${target})"
+      return 0
+    fi
+  done
+  return 1
+}
+
+install_nextest() {
+  if command -v cargo-nextest >/dev/null 2>&1; then
+    echo "  ✓ cargo-nextest already present -> $(command -v cargo-nextest)"
+    return 0
+  fi
+  if install_prebuilt cargo-nextest "$NEXTEST_VERSION" \
+       "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-${NEXTEST_VERSION}/cargo-nextest-${NEXTEST_VERSION}-{target}.tar.gz"; then
+    return 0
+  fi
+  echo "  ! prebuilt cargo-nextest unavailable; falling back to cargo install" >&2
+  cargo install cargo-nextest --locked --version "$NEXTEST_VERSION"
+}
+
+install_llvm_cov() {
+  if command -v cargo-llvm-cov >/dev/null 2>&1; then
+    echo "  ✓ cargo-llvm-cov already present -> $(command -v cargo-llvm-cov)"
+    return 0
+  fi
+  if install_prebuilt cargo-llvm-cov "$LLVM_COV_VERSION" \
+       "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${LLVM_COV_VERSION}/cargo-llvm-cov-{target}.tar.gz"; then
+    return 0
+  fi
+  echo "  ! prebuilt cargo-llvm-cov unavailable; falling back to cargo install" >&2
+  cargo install cargo-llvm-cov --locked --version "$LLVM_COV_VERSION"
+}
+
+targets=("$@")
+if [[ "${#targets[@]}" -eq 0 ]]; then
+  targets=(nextest llvm-cov)
+fi
+
+echo "--- installing cargo test tools ---"
+for target in "${targets[@]}"; do
+  case "$target" in
+    nextest) install_nextest ;;
+    llvm-cov) install_llvm_cov ;;
+    *)
+      echo "unknown tool: $target (expected 'nextest' or 'llvm-cov')" >&2
+      exit 2
+      ;;
+  esac
+done

--- a/src/bcs/scripts/setup_dev_env.sh
+++ b/src/bcs/scripts/setup_dev_env.sh
@@ -137,8 +137,8 @@ else
   if [[ "$check_only" -eq 1 ]]; then
     missing=1
   else
-    echo "  → cargo install cargo-llvm-cov --locked ..."
-    cargo install cargo-llvm-cov --locked --quiet
+    echo "  → installing cargo-llvm-cov (prebuilt binary) ..."
+    bash "${script_dir}/install_cargo_test_tools.sh" llvm-cov
     have cargo-llvm-cov && echo "  ✓ cargo-llvm-cov installed" || { echo "  ✗ cargo-llvm-cov install failed" >&2; exit 1; }
   fi
 fi

--- a/src/bcs/scripts/setup_dev_env.sh
+++ b/src/bcs/scripts/setup_dev_env.sh
@@ -78,8 +78,8 @@ else
   if [[ "$check_only" -eq 1 ]]; then
     missing=1
   else
-    echo "  → cargo install cargo-nextest --locked ..."
-    cargo install cargo-nextest --locked --quiet
+    echo "  → installing cargo-nextest (prebuilt binary) ..."
+    bash "${script_dir}/install_cargo_test_tools.sh" nextest
     have cargo-nextest && echo "  ✓ cargo-nextest installed" || { echo "  ✗ cargo-nextest install failed" >&2; exit 1; }
   fi
 fi


### PR DESCRIPTION
## Problem

The `BCS unit tests` gate takes **10m38s**. The `--dist loadfile` xdist fix from #836 has no analogue here: nextest already runs `test-threads = "num-cpus"`, and the suite's 312s of test CPU comes back in 101s of wall clock — 3.08× on a 4-core runner. Parallelism was never the problem.

Profiling [run 31248758254](https://github.com/inclusionAI/Avernet/actions/runs/31248758254) shows where the 638s actually goes:

| Step | Time | What it is |
| --- | --- | --- |
| `cargo install` (nextest + llvm-cov) | **215s** | compiles 380 crates from source |
| cache restore | 122s | 3.28 GB at ~135 MB/s |
| workspace compile | 143s | 82 workspace crates, zero external deps recompiled |
| tests | **101s** | 312s of CPU over 4 cores |
| apt / rustup / checkout / gates | 57s | |

Two of those are avoidable, and neither is about parallelism.

**Tool installation builds what upstream already ships.** Both cargo subcommands publish prebuilt release tarballs for `x86_64-unknown-linux-gnu`; CI compiles them from source on every run.

**Three test clusters account for 143s of the 312s of test CPU, all of it spent sleeping.** Per-test timings parsed out of the CI log:

| Test | CI time | Why |
| --- | --- | --- |
| `integration_discover_fuse::set_visibility_to_private_succeeds_and_triggers_sync` | 22.03s | 3 × 7s of sync-retry backoff |
| `integration_discover_fuse::set_visibility_succeeds_with_fuse_unreachable` | 22.03s | same |
| `integration_discover_fuse::discover_with_fuse_unreachable_degrades_to_registry_only` | 14.70s | 2 × 7s |
| `integration_bcsfuse::fuse_with_bcsfuse_enabled_but_unreachable_returns_error` | 14.68s | 2 × 7s |
| `bcs-auth-alipay::sign::tests::verify_fails_with_wrong_key` | 12.75s | two RSA-2048 keygens, unoptimized |
| `integration_bcsfuse::onboard_with_bcsfuse_enabled_but_unreachable_succeeds` | 7.88s | 1 × 7s |
| `integration_discover_fuse::leave_bot_does_not_trigger_offline` | 7.76s | 1 × 7s |
| `bcs-ws::token_expiry_e2e` × 3 | 5.01s each | 5s wait for a close frame that never arrives |

The 7s figure is `sync_worker_with_retry`'s hardcoded `2^attempt`-second backoff: 1s + 2s between the three attempts, **plus a further 4s slept after the final attempt, before giving up** — waiting out a retry that is never going to happen.

That trailing sleep is not only a test cost. `sync_visibility_after_update` awaits this call, so a `PUT /bots/{id}/visibility` with bcsfuse unreachable blocks the HTTP caller for the full 7s in production.

## Solution

**Prebuilt tool binaries.** `scripts/install_cargo_test_tools.sh` downloads pinned release tarballs for `cargo-nextest` and `cargo-llvm-cov` instead of building them. Versions are pinned (0.9.143 / 0.8.7 — what `cargo install` unpinned resolves to today) so CI stays reproducible, and any download failure falls back to `cargo install --locked` at that same version. A release-asset outage therefore costs exactly what it costs today rather than breaking the gate. Wired into `ci_test.sh`'s env-check hints and `setup_dev_env.sh` too.

**Worker sync retry.** The backoff base becomes `BcsFuseConfig::sync_retry_base_ms`, defaulting to 1000 — production timing is unchanged — and the loop no longer sleeps after the attempt it will not follow up on. The two integration suites that point BCS at a dead port set it to 1ms. A new unit test pins the contract: at `sync_retry_base_ms = 0`, three attempts complete without sleeping.

**Alipay RSA keygen.** Prime search is pure bignum arithmetic and costs ~5s per keypair unoptimized; the crate generates ten of them. `[profile.dev.package.rsa]` and `[profile.dev.package.num-bigint-dig]` at `opt-level = 3` bring `verify_fails_with_wrong_key` from 12.75s to 0.57s. Rejected the alternative of committing fixed test-key PEMs — no key material in the repo, and this speeds up any future crypto test for free. Both crates are third-party leaves and neither appears in the cobertura report, so the coverage gate cannot see the difference.

**Token expiry WS close.** Three tests waited up to 5s to observe a close, and always waited the full 5s because the close never comes. Every one of them already accepts the elapsed-timeout arm, and the load-bearing assertion is the `is_connected` check that follows — the generous bound bought nothing but a guaranteed stall. Now a named 500ms constant that says so. (Worth a separate look: `disconnect()` dropping the sender apparently never surfaces to the client. These tests do not assert it does, so this change hides nothing new.)

## Validation

### Measured in CI — [run 31263443424](https://github.com/inclusionAI/Avernet/actions/runs/31263443424), all 5 jobs green

**3276/3276 tests pass (100.00%), overall line coverage 79.74%** against a 79.73% baseline — the `opt-level` change is invisible to the gate, as predicted.

| | baseline (run 31248758254) | this branch |
| --- | --- | --- |
| **test wall clock** (nextest `Summary`) | 101.538s | **62.041s** |
| test CPU, summed over all tests | 312.5s | **175.3s** |

Per cluster, in CI:

| binary | before | after |
| --- | --- | --- |
| `bcs::integration_discover_fuse` | 68.5s | **5.9s** |
| `bcs::integration_bcsfuse` | 23.5s | **2.6s** |
| `bcs-auth-alipay` | 19.7s | **2.6s** |
| `bcs-auth-alipay::alipay_provider_tests` | 16.4s | **2.1s** |
| `bcs-ws::token_expiry_e2e` | 15.0s | **1.5s** |

**The job total on that run was 11m15s, up from 10m38s — read that carefully, because neither cause is this branch.** The workflow commit is still missing (see below), so `cargo install` ran again and took 283s this time rather than 215s; and the cargo cache had been evicted, so the run did a cold build — 381 external crates recompiled where the baseline recompiled zero, 245s of compile instead of 143s, plus 50s to save the cache back. The test phase is the only part of the job this branch touches, and it went 101.5s → 62.0s.

### Locally, on the same 4 cores

| Suite | Result | Test CPU |
| --- | --- | --- |
| `bcs-auth-alipay` | 11/11 pass | 36.1s → 2.2s |
| `bcs-ws::token_expiry_e2e` | 5/5 pass | 15.0s → 1.6s |
| `integration_discover_fuse` + `integration_bcsfuse` | 10/10 pass | 92.0s → 8.7s |
| `bcs-fusion` | 41/41 pass | incl. the new backoff test (0.09s) |
| `bcs-http` / `bcs-service-api` / `bcs-config` | 648 pass | |
| `bcs` (lib) | 161/161 pass | incl. config loader |

- `cargo check --workspace --tests` clean.
- `cargo llvm-cov nextest -p bcs-auth-alipay --cobertura` produces a report containing exactly two files, both under `crates/plugins/bcs-auth-alipay/src/` — confirming dependency crates are absent from the coverage gate's input and the `opt-level` change cannot move the number.
- `scripts/ci/tests/test_unit_test_workflow_diff.py` passes.
- The full instrumented suite could not run locally (all ~47 test binaries exceed this sandbox's disk allowance); that verdict comes from the CI run above, which is green.

## ⚠️ One commit could not be pushed — needs a hand

This session's token lacks the `workflow` scope, so **`.github/workflows/unit-tests.yml` is not in this branch**. Without it the tools still build from source and that ~215–283s stays on the clock; the test-side win lands regardless. Please apply:

```diff
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -86,9 +86,11 @@ jobs:
       - name: Install cargo-nextest and cargo-llvm-cov
         if: steps.changes.outputs.skip-bcs != 'true'
-        run: |
-          cargo install cargo-nextest --locked
-          cargo install cargo-llvm-cov --locked
+        # Downloads pinned prebuilt release binaries. `cargo install --locked`
+        # built both from source (~380 crates, ~215s on a 4-core runner) for
+        # tools upstream already publishes for this target; the script falls
+        # back to cargo install if a download fails.
+        run: bash scripts/install_cargo_test_tools.sh
 
       - name: Cache Cargo registry and target
         if: steps.changes.outputs.skip-bcs != 'true'
@@ -97,9 +99,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             src/bcs/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('src/bcs/Cargo.lock') }}
+          # Cargo.toml is part of the key because it carries the workspace
+          # profile settings (see [profile.dev.package.*]): a profile change
+          # invalidates every cached artifact's fingerprint, so the cache has to
+          # rotate with it or the affected crates rebuild on every single run.
+          key: ${{ runner.os }}-bcs-cargo-v2-${{ hashFiles('src/bcs/Cargo.lock', 'src/bcs/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-bcs-cargo-v2-
```

The cache-key part is not cosmetic. Workspace profile settings live in `Cargo.toml`, and the `[profile.dev.package.*]` entries this PR adds invalidate the cached `rsa` / `num-bigint-dig` fingerprints. Today's key hashes only `Cargo.lock`, so it would keep hitting a cache that no longer matches — and a primary-key hit never re-saves — leaving those crates to rebuild on every single run, forever. Rotating the key costs one cold build and is correct from then on.

## Compatibility and risk

`BcsFuseConfig` gains `sync_retry_base_ms`, `#[serde(default)]` at 1000 — existing config files deserialize unchanged and production backoff is identical. Documented in both example configs.

The one deliberate behaviour change is dropping the sleep after the final retry: a failing worker sync now gives up 4s sooner. It was pure dead time — the loop had already decided to stop.

Rollback needs no revert: set `sync_retry_base_ms` back per-deployment, and `BCS_NEXTEST_VERSION` / `BCS_LLVM_COV_VERSION` override the pinned tool versions.

## Follow-ups, deliberately not in scope

- **The 3.28 GB cargo cache is being evicted, and that matters more than its restore time.** Run 31263443424 missed on the *exact key* that hit 6½ hours earlier, with `Cargo.lock` untouched — GitHub's 10 GB per-repo LRU dropped it, in a repo that also caches uv for backend, baas, engine and gateway. So the 143s warm compile in the baseline is the lucky case and BCS lands on the 245s cold path often. Shrinking the entry is what makes it survive: none of the 82 workspace-crate artifacts in it are reused (every one recompiles, verified in both logs), and `~/.cargo/registry/src` is unpacked sources cargo can re-extract from the `.crate` files it already caches.
- **`integration_collab_reachability`** carries `threads-required = "num-cpus"`, so its 21.5s runs with the rest of the machine idle. Four of its tests sit at exactly 3.14s — the client-side `Duration::from_secs(3)` in `bot_chat_http` — despite passing `timeout_ms: 2000` to the server, which suggests the server is not honouring it. Worth understanding before touching, since shrinking the client timeout alone could turn a real 403 into a fake pass on a loaded runner.
- Next hot spots after this PR: `integration_onboarding` (14.0s, two tests at ~5.2s), `integration_bcn_protocol` (13.6s, `test_proposal_flow_end_to_end` alone 5.72s), `integration_group_visibility` (13.0s).
- The same `cargo install cargo-llvm-cov --locked` appears in `singlebox-coverage.yml` and `e2e-tests.yml`; both can call the new script.