### PR TITLE
feat(backend): name the end user explicitly on the openapi v1 surface

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -643,6 +643,83 @@ contract overview in **PR #363** (`docs/api-endpoints.zh-CN.md`, a Chinese
 endpoint reference by totalfrank — still open/draft as of 2026-07-29; kept here
 as reference).
 
+## Naming the end user (`?user_id=`)
+
+**Every operation that scopes to a user takes a required `user_id` query
+parameter.** Not a body field, not a path segment — the query string, whatever
+the method, whatever the body.
+
+```text
+GET    /openapi/v1/bots/b-1?user_id=u-42
+PUT    /openapi/v1/bots/b-1?user_id=u-42        {"bot_name": "Ada"}
+DELETE /openapi/v1/bots/b-1?user_id=u-42
+POST   /openapi/v1/bots/skills/upload?bot_id=b-1&user_id=u-42    <raw zip>
+```
+
+**Why one placement.** The user id is not an attribute of any resource on this
+surface — it is *who the call is for*: the same value on every operation and the
+same meaning on a read as on a write. A request body describes the resource, so
+putting it there makes it read as a property of the thing (in a `PUT
+…/bots/{bot_id}` payload, beside `bot_name`, it looks like a field you are
+setting on the bot). A path segment *names* the resource, so
+`/bots/{bot_id}/users/{user_id}` would claim to address a user beneath a bot —
+inverting the ownership and describing something the operation does not return.
+
+Three alternatives were considered and rejected, recorded so the question is not
+reopened from scratch (`specs/2026-08-08-openapi-v1-explicit-user-id/plan.md`):
+
+| Rejected | Why |
+| --- | --- |
+| Body field on the 11 JSON-body writes | Needed a three-row exception table for the writes whose body this API does not define — the two raw-byte uploads and the free-form `PUT …/engine-config` — and split one concept across two placements on the same resource |
+| Path segment | Inverts ownership as above; the user-first form `/openapi/v1/users/{user_id}/…` is coherent but closed, because the first segment after `/openapi/v1` is the gateway's **domain selector** |
+| `X-Avernet-User-Id` header | Uniform and matches the gateway's delegation sketch (auth design §15), but makes the user transport metadata rather than an argument of the operation |
+
+**`bot_id` is untouched.** It stays in the path where it addresses a bot, and in
+the query string where it is a parameter. This change moved none of them.
+
+**What it does not change.** The named user must still be the verified caller.
+Naming anyone else is a `403` with a fixed `"Forbidden"` — the body says nothing
+about the user asked for, and two rejected ids give byte-identical responses. A
+request with no verified principal still answers `401`, exactly as before. The
+whole point is to have the contract ready for App-on-behalf-of *before* that
+caller exists; admitting it is the delegation workstream (auth design §15), and
+the single line it relaxes is the equality check in
+`openapi_v1/principal.py::require_user_id`.
+
+**Four operations take no `user_id`,** because they have no user dimension to
+scope by. They still require an authenticated caller — that is
+`require_principal`'s job — they just have no user-shaped answer to give:
+
+| Operation | Why it takes none |
+| --- | --- |
+| `GET /openapi/v1/bots/check-name` | Name uniqueness is checked across the tenant; `check_bot_name_exists` takes only the name |
+| `GET /openapi/v1/bots/mcp/servers` | Marketplace catalogue — identical for every caller in the tenant |
+| `GET /openapi/v1/bots/mcp/servers/{server_code}` | Same |
+| `GET /openapi/v1/bots/mcp/tenants` | Same |
+
+Note what is *not* on that list: `list_resources`, `create_resource`,
+`get_resource` and `update_resource` also do not use the value, but they take it
+anyway. They are user-scoped in principle and merely fail to enforce it today —
+they scope on a caller-supplied `bot_id` without checking the caller owns that
+bot, the gap `specs/2026-08-02-public-api-user-only-principal/` records. Closing
+it later should be a change to those handlers, not a required parameter added to
+four public operations.
+
+**Bot Logs is a different exclusion, and the sharpest thing to know here.**
+`GET /openapi/v1/bots/logs/traces` has taken a required `user_id` since #692 —
+but there it means *whose traces to read*, a filter a caller presenting both a
+user and an App identity may point at someone else. Here it means *whose call
+this is*, and pointing it at someone else is a 403. **Same spelling, opposite
+contract**, and the published document carries both. Do not "unify" them without
+deciding which meaning the address should have.
+
+`tests/…/openapi_v1/test_explicit_user_id.py` asserts all of the above against
+the generated document — the 56 that take it, the 4 that do not, that `user_id`
+is never a body field or a path segment, and that `bot_id`'s placement is
+unchanged — so a route that breaks the rule fails there rather than in review.
+
+---
+
 ## Addressing rule
 
 **Every operation is addressed `/openapi/v1/bots/<component>/…`.** The
@@ -983,6 +1060,16 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 ---
 
 ## Changelog (append a dated line whenever you move the board)
+
+- **2026-08-09** — **The public surface now names its end user explicitly.** 56
+  of the 65 operations take a required `user_id` query parameter instead of
+  deriving the owner from the verified principal; naming another user is a
+  `403`. Four operations with no user dimension (`check-name`, the three MCP
+  catalogue reads) take none, and Bot Logs is untouched — its own `user_id`
+  means the opposite thing. `bot_id` moved nowhere. Nothing about who may call
+  what changed: this readies the contract for App-on-behalf-of, it does not
+  admit it. See **Naming the end user** above and
+  `specs/2026-08-08-openapi-v1-explicit-user-id/`.
 
 - **2026-08-04** — **Skills Track B integration/release gate implementation and
   CI are complete, but Track B is not release-complete.** The served OpenAPI is

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -472,6 +472,73 @@ AvernetTenantMiddleware → resolve_avernet_tenant(request)  ─┐
 **PR #363**（`docs/api-endpoints.zh-CN.md`，totalfrank 写的中文端点参考 —— 截至
 2026-07-29 仍是 open/draft；此处作为参考保留）中的 v1 契约总览做了交叉核对。
 
+## 显式指定终端用户（`?user_id=`）
+
+**每一个按用户作用域的操作，都带一个必填的 `user_id` query 参数。** 不是 body 字段，
+也不是路径段 —— 就放 query string，无论什么方法、无论有没有 body。
+
+```text
+GET    /openapi/v1/bots/b-1?user_id=u-42
+PUT    /openapi/v1/bots/b-1?user_id=u-42        {"bot_name": "Ada"}
+DELETE /openapi/v1/bots/b-1?user_id=u-42
+POST   /openapi/v1/bots/skills/upload?bot_id=b-1&user_id=u-42    <raw zip>
+```
+
+**为什么只有一种位置。** `user_id` 不是这个面上任何资源的属性，它表示*这次调用是为谁
+发起的*：在每个操作上都是同一个值，在读和写上含义完全一致。请求 body 描述的是被操作
+的资源，把它放进去就会读成资源的一个属性（在 `PUT …/bots/{bot_id}` 的 body 里挨着
+`bot_name`，看起来就像在给 Agent 设置这个字段）。路径段*命名*资源，所以
+`/bots/{bot_id}/users/{user_id}` 会声称在寻址「Agent 名下的某个用户」—— 归属关系反了，
+而且描述的不是该操作实际返回的东西。
+
+三种替代方案已评估并否决，记录在此以免同一个问题被从头再讨论一遍
+（`specs/2026-08-08-openapi-v1-explicit-user-id/plan.md`）：
+
+| 已否决 | 原因 |
+| --- | --- |
+| 放进 11 个 JSON body 写操作的 body | 对于 body 不由本 API 定义的写操作需要一张三行例外表 —— 两个裸字节上传，以及自由格式的 `PUT …/engine-config` —— 并且会让同一个资源上的同一个概念分裂成两种位置 |
+| 放进路径 | 如上，归属关系反了；用户在前的 `/openapi/v1/users/{user_id}/…` 形式本身自洽，但此处走不通：`/openapi/v1` 之后的第一段是网关的**域选择器** |
+| `X-Avernet-User-Id` header | 统一，且与网关的委托草案一致（auth design §15），但会让用户变成传输层元数据，而不是操作的一个参数 |
+
+**`bot_id` 不动。** 它在寻址 Agent 的地方留在路径里，作为参数的地方留在 query 里。
+本次改动没有挪动任何一个。
+
+**没有改变的是什么。** 被指定的用户仍然必须是已验证的调用方本人。指定其他人一律
+`403` + 固定的 `"Forbidden"` —— 响应体不透露被指定的用户是谁，两个不同的被拒 id 得到
+逐字节相同的响应。没有已验证 principal 的请求依旧是 `401`，与之前完全一致。这件事的
+全部意义在于：在「App 代表用户调用」这个调用方出现*之前*，先把契约准备好；真正放行它
+是委托工作流（auth design §15），而它要放宽的那一行，就是
+`openapi_v1/principal.py::require_user_id` 里的相等性判断。
+
+**有四个操作不带 `user_id`**，因为它们根本没有可按用户切分的维度。它们仍然要求已认证
+的调用方 —— 那是 `require_principal` 的职责 —— 只是给不出按用户区分的答案：
+
+| 操作 | 为什么不带 |
+| --- | --- |
+| `GET /openapi/v1/bots/check-name` | 重名是在整个租户范围内判断的；`check_bot_name_exists` 只接受名字 |
+| `GET /openapi/v1/bots/mcp/servers` | 市场目录 —— 对租户内每个调用方都相同 |
+| `GET /openapi/v1/bots/mcp/servers/{server_code}` | 同上 |
+| `GET /openapi/v1/bots/mcp/tenants` | 同上 |
+
+注意*不在*这张表里的：`list_resources`、`create_resource`、`get_resource`、
+`update_resource` 同样没有用到这个值，但它们仍然带。它们在原则上是按用户作用域的，只是
+今天还没有真正校验 —— 它们按调用方传入的 `bot_id` 作用域，却不检查调用方是否拥有该
+Agent，也就是 `specs/2026-08-02-public-api-user-only-principal/` 记录的那个缺口。以后
+补上它应该是改这几个 handler，而不是给四个公共操作新增一个必填参数。
+
+**Bot Logs 属于另一种排除，也是这里最需要留意的一点。**
+`GET /openapi/v1/bots/logs/traces` 从 #692 起就带一个必填的 `user_id` —— 但在那里它的
+含义是*要读谁的 trace*，是一个过滤条件，同时持有 User 与 App 身份的调用方可以把它指向
+别人。在这里它的含义是*这次调用是为谁发起的*，指向别人就是 403。**同一个拼写，相反的
+契约**，而且发布出去的文档里两者都在。不要在没有先决定「这个地址上它该是哪个含义」之前
+就去「统一」它们。
+
+`tests/…/openapi_v1/test_explicit_user_id.py` 针对生成的文档断言了以上全部 —— 带它的
+56 个、不带它的 4 个、`user_id` 从不作为 body 字段或路径段出现、以及 `bot_id` 的位置
+没有变化 —— 所以破坏该规则的路由会在那里失败，而不是等到 review。
+
+---
+
 ## 寻址规则
 
 **每个操作的地址都是 `/openapi/v1/bots/<component>/…`。** 组件的**字面**名称在前；
@@ -768,6 +835,13 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 ---
 
 ## Changelog（变更记录）（每次挪动看板时追加一条带日期的记录）
+
+- **2026-08-09** —— **公共面现在显式指定终端用户。** 65 个操作中的 56 个改为接受必填的
+  `user_id` query 参数，不再从已验证 principal 推导 owner；指定其他用户返回 `403`。四个
+  没有用户维度的操作（`check-name`、三个 MCP 目录读）不带该参数，Bot Logs 保持不变 ——
+  它自己的 `user_id` 是相反的含义。`bot_id` 没有挪动。谁可以调用什么完全没有改变：这是
+  为「App 代表用户调用」准备契约，而不是放行它。详见上文 **显式指定终端用户** 与
+  `specs/2026-08-08-openapi-v1-explicit-user-id/`。
 
 - **2026-08-04** —— **Skills Track B integration/release gate 的实现与 CI 已完成，但不等于
   release complete。** Served OpenAPI 现锁定为恰好六个 Bot-owned Local Skill 操作；旧的

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/plan.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/plan.md
@@ -1,0 +1,332 @@
+# Plan: Public API — Name the End User in the Request
+
+## Approach
+
+Split the question the handlers answer today in one step into two, and put a
+shared seam between them:
+
+- **acquisition** — where the request carries the id. Per-method, by one stated
+  rule: a request whose body this API defines carries it as a body field;
+  everything else carries it as a query parameter.
+- **adjudication** — whether the caller may act for the named user. One function,
+  `resolve_request_user`, used by both acquisition paths. It is the only thing
+  delegation changes later.
+
+The 49 query-parameter operations get acquisition and adjudication in a single
+FastAPI dependency. The 11 body operations declare `user_id` on their request
+model and call `resolve_request_user` in the handler — the same one-line shape as
+today's `owner_id = caller_owner_id(principal)`, pointed at the request instead of
+the credential. `bot_id` follows the same placement rule wherever it is a
+parameter rather than part of the address.
+
+## The placement rule
+
+> A scoping parameter (`user_id`, `bot_id`) travels **in the request body when
+> that body is a schema this API defines**, and **in the query string
+> otherwise**. A `bot_id` that is part of an operation's address stays in the
+> path; the addressing rule in `openapi_v1/__init__.py` owns that, not this one.
+
+"A body this API defines" means the operation's `requestBody` is
+`application/json` and `$ref`s a named component. That is precisely the set that
+has room for another field, and it excludes the three writes that do not:
+
+| Operation | Body | Why it takes the query parameter |
+| --- | --- | --- |
+| `POST …/resources/upload` | `application/octet-stream` | body is the file |
+| `POST …/skills/upload` | `application/zip` | body is the package |
+| `PUT …/bots/{bot_id}/engine-config` | free-form `object` | body is the caller's own document; a reserved key would collide with it |
+
+**Counts.** 65 published operations; 5 Bot Logs operations are out of scope
+(they never derived a user from the credential — see `bot_logs/router.py:44`,
+`del principal`). Of the remaining 60: **11 body-field**, **49 query-parameter**.
+
+## Affected Components
+
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py` —
+  the new seam: `resolve_request_user` plus the query-parameter dependency.
+- `…/openapi_v1/errors.py`, `…/openapi_v1/responses.py` — the 403 and its fixed
+  public message.
+- `…/openapi_v1/contracts.py` — the response table that documents the 403.
+- `…/openapi_v1/__init__.py` — applies the dependency and the response table per
+  group; states the placement rule next to the addressing rule.
+- `…/openapi_v1/{bots,mcp,resources,routines,skills,identity}/router.py` and
+  `…/openapi_v1/engine_runtime/*/router.py` — 60 handlers.
+- `…/openapi_v1/{bots,resources,routines,identity,mcp}/schemas.py`,
+  `…/engine_runtime/{sessions,approvals}/schemas.py` — 11 request models.
+- `src/backend/src/agentclaw/community/adapters/http/app.py` — the 403 needs a
+  concrete-type handler for the same reason `MissingPrincipalError` has one
+  (`app.py:559`): it is raised in a dependency, so the `Exception` catch-all
+  would answer it *and* re-raise through `ServerErrorMiddleware`.
+- `src/backend/docs/openapi-v1/README.md` — the rule, and the status board.
+
+## Data Model Changes
+
+None. No table, column, or migration is involved.
+
+## API / Interface Changes
+
+**BREAKING for every `/openapi/v1` caller except Bot Logs** — a required
+parameter is added to 60 operations. Deliberate, and the reason the spec argues
+for doing it now: `route_security` admits only a Google-chain `user`, so no
+external tenant can reach this surface yet.
+
+### The seam
+
+```python
+# openapi_v1/principal.py (new)
+USER_ID_QUERY = "user_id"          # and the body field of the same name
+
+def resolve_request_user(principal: Principal, claimed: str) -> str:
+    """The end user this request acts for. Raises 401 / 403; never returns ''."""
+    caller = caller_owner_id(principal)          # 401 when unverifiable
+    if claimed != caller:
+        raise UserIdMismatchError(...)           # 403 — logs both ids
+    return claimed
+
+async def require_user_id(                       # the 49 query operations
+    principal: Annotated[Principal, Depends(require_principal)],
+    user_id: Annotated[str, Query(min_length=1, max_length=256, description=...)],
+) -> str:
+    return resolve_request_user(principal, user_id)
+
+UserIdDep = Annotated[str, Depends(require_user_id)]
+```
+
+### A query-parameter operation (49 of them)
+
+```diff
+# openapi_v1/bots/router.py:351 — get_bot
+ async def get_bot(
+     bot_id: str,
+     request: Request,
+-    principal: PrincipalDep,
++    user_id: UserIdDep,
+     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+ ) -> Envelope[Bot]:
+-    owner_id = caller_owner_id(principal)
+-    bot = bot_service.get_bot(bot_id, owner_id)
++    bot = bot_service.get_bot(bot_id, user_id)
+```
+
+```jsonc
+// GET /openapi/v1/bots/b-1?user_id=u-42 → 200   (unchanged payload)
+// GET /openapi/v1/bots/b-1              → 422   {"code":422000,"message":"Invalid request","data":null,…}
+// GET /openapi/v1/bots/b-1?user_id=u-99 → 403   {"code":403000,"message":"Forbidden","data":null,…}
+```
+
+### A body-field operation (11 of them)
+
+```diff
+# openapi_v1/bots/schemas.py:46 — BotCreate (model_config = extra="forbid")
+ class BotCreate(BaseModel):
+     model_config = _STRICT
++    user_id: str = Field(min_length=1, max_length=256,
++                         description="The end user this request acts for.")
+     bot_name: str = Field(...)
+```
+
+```diff
+# openapi_v1/bots/router.py:219 — create_bot
+     body: BotCreate,
+     request: Request,
+     principal: PrincipalDep,
+     ...
+-    owner_id = caller_owner_id(principal)
++    owner_id = resolve_request_user(principal, body.user_id)
+```
+
+The 11 models and their operations:
+
+| Model | Operation |
+| --- | --- |
+| `BotCreate` | `POST /openapi/v1/bots` |
+| `BotUpdate` | `PUT …/bots/{bot_id}` |
+| `ApprovalModeSet` | `PUT …/bots/approvals/{bot_id}/mode` |
+| `IdentityFileWrite` | `PUT …/bots/identity/{bot_id}/{file_type}` |
+| `McpConfigWrite` | `PUT …/bots/mcp/servers/{server_code}/config` |
+| `ResourceCreate` | `POST …/bots/resources` |
+| `ResourceUpdate` | `PUT …/bots/resources/{resource_id}` |
+| `RoutineCreate` | `POST …/bots/routines` |
+| `RoutineUpdate` | `PATCH …/bots/routines/{routine_id}` |
+| `SessionCreate` | `POST …/bots/sessions/{bot_id}` |
+| `SessionUpdate` | `PATCH …/bots/sessions/{bot_id}/{session_id}` |
+
+### `bot_id`, brought in line
+
+`bot_id` is a query parameter on 17 in-scope operations. Only three of them have
+a body this API defines, so only three move:
+
+```diff
+# openapi_v1/resources/schemas.py:31 — ResourceCreate  (…and ResourceUpdate:40)
+ class ResourceCreate(BaseModel):
++    user_id: str = Field(...)
++    bot_id: str = Field(description="Bot this resource belongs to.")
+     name: str = Field(...)
+```
+
+```diff
+# openapi_v1/resources/router.py:197 — create_resource
+     body: ResourceCreate,
+-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
+```
+
+| Operation | `bot_id` today | after |
+| --- | --- | --- |
+| `POST …/resources` | query | **body** |
+| `PUT …/resources/{resource_id}` | query | **body** |
+| `PATCH …/routines/{routine_id}` | query | **body** |
+| `POST …/routines` | body | body (already correct — the precedent) |
+| 14 others (GET ×9, DELETE ×2, bodyless `POST …/routines/{id}/run`, the 2 uploads) | query | query |
+
+`{bot_id}` in a path is untouched on all 28 operations that address a bot that
+way.
+
+### Response documentation
+
+```diff
+# openapi_v1/contracts.py:84
++USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: {"model": ErrorEnvelope,
++    "description": "The request names a user the caller may not act for"}}
+-ENGINE_RUNTIME_ERROR_RESPONSES = {**ERROR_RESPONSES, 501: …, 504: …}
++ENGINE_RUNTIME_ERROR_RESPONSES = {**USER_SCOPED_ERROR_RESPONSES, 501: …, 504: …}
+```
+
+403 stays **out** of `ERROR_RESPONSES`: `test_openapi_error_schema.py:55` asserts
+every operation documents every status in that dict, and Bot Logs cannot return a
+403.
+
+## Key Files & Functions
+
+```python
+# openapi_v1/errors.py (new class)
+class UserIdMismatchError(Exception):
+    """The request's user id is not the verified caller's (→ 403)."""
+```
+
+```diff
+# openapi_v1/responses.py:163 — ENVELOPE_ERRORS
+     PrincipalVerificationError: (401, "Unauthorized"),
++    UserIdMismatchError: (403, "Forbidden"),
+```
+
+```diff
+# openapi_v1/__init__.py:96 — build_public_router
+ _PUBLIC_AUTH = [Depends(require_principal)]
++# Declared independently of require_user_id, not merely inside it: a request
++# that also fails query/body validation must still answer 401, and FastAPI
++# skips calling a dependency whose own params failed to validate.
++_USER_SCOPED = [*_PUBLIC_AUTH, Depends(require_user_id)]
+```
+
+`_USER_SCOPED` is attached to every group **except** `bot_logs`, which keeps
+`_PUBLIC_AUTH` and `ERROR_RESPONSES`. It is what puts the query parameter on the
+49 — and, deliberately, on the 11 body operations too, so the loop stays one
+list. **Open detail for implementation:** a body operation must not end up
+declaring *both*; either exclude the 11 from `_USER_SCOPED` and let their handler
+argument carry it, or accept the duplicate. Task 3 resolves this against the
+generated document, and the convention test (below) is what pins the answer.
+
+```diff
+# adapters/http/app.py:559 — beside _principal_error_handler
++@app.exception_handler(UserIdMismatchError)
++async def _user_id_mismatch_handler(request, exc) -> JSONResponse: ...
+```
+
+Per-router edits are mechanical and identical in shape; the counts are: bots 13,
+mcp 6, resources 9, routines 7, skills 6, identity 3, sessions 7, engine 3,
+approvals 3, models 2, connection 1.
+
+Eight of the 60 do not use the value (`check_bot_name`; `list_mcp_servers`,
+`list_mcp_tenants`, `get_mcp_server`; `list_resources`, `create_resource`,
+`get_resource`, `update_resource`). They declare the parameter and `del` it, with
+a comment — the shape `bot_logs/router.py:44` already uses.
+
+## Dependencies
+
+None. No new package, no version bump.
+
+## Risks & Mitigations
+
+- **Risk:** a request that is wrong in two ways answers 422 instead of 401,
+  leaking that the credential was fine. Observed in a spike: when
+  `require_user_id` is the *only* dependency naming the principal, FastAPI never
+  calls it (its own parameter failed validation) and the 401 never fires.
+  **Mitigation:** `require_principal` stays declared independently in
+  `_USER_SCOPED`; `test_explicit_user_id.py` asserts 401 outranks a missing
+  parameter.
+- **Risk:** the placement rule decays into per-category habit again — the thing
+  the spec cites as the reason to settle it.
+  **Mitigation:** a convention test over the generated document, in the shape of
+  `test_path_convention.py`, so a new operation fails the build rather than
+  review.
+- **Risk:** two tests assert the *opposite* of the new contract —
+  `test_sessions.py:507` and `test_approvals.py:94` require a caller-supplied
+  `user_id` to be a 422. **Mitigation:** they invert to "403 for another user's
+  id", and keep asserting 422 for `engine` — that field stays forbidden. The
+  `extra="forbid"` config is what keeps the rest of the guard intact.
+- **Risk:** five of the 11 models (`IdentityFileWrite`, `ResourceCreate`,
+  `ResourceUpdate`, `RoutineCreate`, `RoutineUpdate`) have no `extra="forbid"`,
+  so a `user_id` sent today is silently ignored and would now be honoured.
+  **Mitigation:** it is honoured only after `resolve_request_user` accepts it, so
+  the widest outcome is 403. Not tightened here — that is a separate change.
+- **Risk:** ~232 test call sites across 10 files.
+  **Mitigation:** the 49 query operations are covered by setting
+  `client.params = {"user_id": …}` once per `TestClient` (httpx merges default
+  params); only the body operations need per-call edits. Verify the httpx
+  behaviour in task 6 before relying on it.
+
+## Alternatives Considered
+
+- **A single required header, `X-Avernet-User-Id`.** One placement for all 60,
+  no request-model changes, no per-method rule, and it matches the gateway's own
+  delegation sketch (auth design §15 reserves an `xoneid`/`x-end-user-id`
+  header). Rejected by the user in favour of the more conventionally RESTful
+  reading: the user is an argument of the operation, not transport metadata.
+  Recorded because it is the fallback if the three-exception table proves
+  unworkable in review.
+- **Query parameter everywhere.** Uniform and cheap, and there is a precedent on
+  the surface (`GET …/bots/logs/traces?user_id=`). Rejected for the same reason.
+- **Preferring the request's id over the credential's, with no check.** A
+  privilege escalation: any verified user could read another's data. Not viable
+  before delegation exists.
+- **Omitting the parameter on the 8 operations that ignore it.** Rejected in the
+  spec: it makes a client learn which 8 of 60 differ.
+
+## Rollout
+
+No migration, no flag, no ordering constraint against a deploy. One commit; the
+generated API description changes with it. External tenants cannot reach the
+surface yet (`route_security` admits only a Google-chain `user`), so the breaking
+change lands before it can break anyone.
+
+## Test Strategy
+
+New file, in the shape of `test_path_convention.py` — asserted against the
+generated document so a later operation is covered without editing it:
+
+```python
+# tests/community/adapters/http/openapi_v1/test_explicit_user_id.py (new)
+def test_every_user_scoped_operation_names_its_user(): ...       # 60/60
+def test_placement_follows_the_body_or_query_rule(): ...         # 11 body, 49 query
+def test_bot_id_sits_where_the_user_id_sits(): ...               # the 3 moved + 12 unmoved
+def test_bot_logs_operations_are_unchanged(): ...                # 5, no parameter, no 403
+def test_naming_another_user_is_403_on_both_paths(): ...         # query and body
+def test_two_rejected_ids_give_identical_bodies(): ...
+def test_missing_parameter_is_422_and_no_caller_is_401(): ...    # precedence
+def test_403_is_documented_only_on_user_scoped_operations(): ...
+```
+
+Updated in place:
+
+```python
+# engine_runtime/test_sessions.py:507  — inverts
+def test_caller_supplied_identity_is_rejected():   # engine → 422; user_id → 403
+# engine_runtime/test_approvals.py:94   — inverts
+# resources/test_resources_handlers.py  — 4 `principal=None` cases now exercise
+#                                          resolve_request_user, not each handler
+```
+
+Then the module gates from `AGENTS.md`: backend SAST, `tests/community` in full
+(the openapi_v1 suite is 499 tests today), changed-line coverage, and singlebox
+coverage — `flow_coverage.py:75` notes every `/openapi/v1` route answers 401 in
+singlebox, so the E2E surface is unaffected by the new parameter.

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/plan.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/plan.md
@@ -2,62 +2,55 @@
 
 ## Approach
 
-Split the question the handlers answer today in one step into two, and put a
-shared seam between them:
+One required query parameter, `user_id`, on the 56 operations that scope to a
+user; one dependency that reads it and decides whether the caller may act for
+that user. Handlers stop asking the credential who they are for and take the
+answer as an argument.
 
-- **acquisition** — where the request carries the id. Per-method, by one stated
-  rule: a request whose body this API defines carries it as a body field;
-  everything else carries it as a query parameter.
-- **adjudication** — whether the caller may act for the named user. One function,
-  `resolve_request_user`, used by both acquisition paths. It is the only thing
-  delegation changes later.
-
-The 49 query-parameter operations get acquisition and adjudication in a single
-FastAPI dependency. The 11 body operations declare `user_id` on their request
-model and call `resolve_request_user` in the handler — the same one-line shape as
-today's `owner_id = caller_owner_id(principal)`, pointed at the request instead of
-the credential. `bot_id` follows the same placement rule wherever it is a
-parameter rather than part of the address.
+Nothing else moves. No request model changes, no path changes, `bot_id` stays
+exactly where it is. The whole change is a dependency, an error, a response
+entry, 56 handler signatures, and the tests that pin them.
 
 ## The placement rule
 
-> A scoping parameter (`user_id`, `bot_id`) travels **in the request body when
-> that body is a schema this API defines**, and **in the query string
-> otherwise**. A `bot_id` that is part of an operation's address stays in the
-> path; the addressing rule in `openapi_v1/__init__.py` owns that, not this one.
+> **`user_id` is a required query parameter on every `/openapi/v1` operation
+> that scopes to a user.** It is never a body field and never a path segment.
+> `bot_id` is unaffected: it stays in the path where it addresses a bot and in
+> the query string where it is a parameter.
 
-"A body this API defines" means the operation's `requestBody` is
-`application/json` and `$ref`s a named component. That is precisely the set that
-has room for another field, and it excludes the three writes that do not:
+Written this way because the user id is not an attribute of any resource on this
+surface — it is who the call is for, the same value on every operation and the
+same meaning on a read as on a write. A body describes the resource; a path
+names it; neither is what this is.
 
-| Operation | Body | Why it takes the query parameter |
+**Counts.** 65 published operations.
+
+| Set | Count | Treatment |
 | --- | --- | --- |
-| `POST …/resources/upload` | `application/octet-stream` | body is the file |
-| `POST …/skills/upload` | `application/zip` | body is the package |
-| `PUT …/bots/{bot_id}/engine-config` | free-form `object` | body is the caller's own document; a reserved key would collide with it |
-
-**Counts.** 65 published operations; 5 Bot Logs operations are out of scope
-(they never derived a user from the credential — see `bot_logs/router.py:44`,
-`del principal`). Of the remaining 60: **11 body-field**, **49 query-parameter**.
+| Scope to a user | 52 | gain `?user_id=` |
+| User-scoped in principle, not yet enforced (`list_resources`, `create_resource`, `get_resource`, `update_resource`) | 4 | gain `?user_id=` |
+| No user dimension (`check_bot_name`, `list_mcp_servers`, `list_mcp_tenants`, `get_mcp_server`) | 4 | unchanged |
+| Bot Logs | 5 | unchanged |
 
 ## Affected Components
 
-- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py` —
-  the new seam: `resolve_request_user` plus the query-parameter dependency.
+- `…/openapi_v1/principal.py` — the seam: `require_user_id` / `UserIdDep`.
 - `…/openapi_v1/errors.py`, `…/openapi_v1/responses.py` — the 403 and its fixed
   public message.
-- `…/openapi_v1/contracts.py` — the response table that documents the 403.
-- `…/openapi_v1/__init__.py` — applies the dependency and the response table per
-  group; states the placement rule next to the addressing rule.
+- `…/openapi_v1/contracts.py` — the 403's documented response entry.
+- `…/openapi_v1/__init__.py` — attaches that entry per group; states the
+  placement rule next to the addressing rule.
 - `…/openapi_v1/{bots,mcp,resources,routines,skills,identity}/router.py` and
-  `…/openapi_v1/engine_runtime/*/router.py` — 60 handlers.
-- `…/openapi_v1/{bots,resources,routines,identity,mcp}/schemas.py`,
-  `…/engine_runtime/{sessions,approvals}/schemas.py` — 11 request models.
+  `…/openapi_v1/engine_runtime/*/router.py` — 56 handler signatures, plus a
+  `responses=` entry on 15 route decorators (see below).
 - `src/backend/src/agentclaw/community/adapters/http/app.py` — the 403 needs a
   concrete-type handler for the same reason `MissingPrincipalError` has one
   (`app.py:559`): it is raised in a dependency, so the `Exception` catch-all
   would answer it *and* re-raise through `ServerErrorMiddleware`.
 - `src/backend/docs/openapi-v1/README.md` — the rule, and the status board.
+
+**No schema module is touched.** The 11 request models keep their current
+fields.
 
 ## Data Model Changes
 
@@ -65,34 +58,35 @@ None. No table, column, or migration is involved.
 
 ## API / Interface Changes
 
-**BREAKING for every `/openapi/v1` caller except Bot Logs** — a required
-parameter is added to 60 operations. Deliberate, and the reason the spec argues
-for doing it now: `route_security` admits only a Google-chain `user`, so no
-external tenant can reach this surface yet.
+**BREAKING for 56 `/openapi/v1` operations** — a required query parameter is
+added. Deliberate, and the reason the spec argues for doing it now:
+`route_security` admits only a Google-chain `user`, so no external tenant can
+reach this surface yet.
 
 ### The seam
 
 ```python
 # openapi_v1/principal.py (new)
-USER_ID_QUERY = "user_id"          # and the body field of the same name
+USER_ID_QUERY = "user_id"
 
-def resolve_request_user(principal: Principal, claimed: str) -> str:
-    """The end user this request acts for. Raises 401 / 403; never returns ''."""
-    caller = caller_owner_id(principal)          # 401 when unverifiable
-    if claimed != caller:
-        raise UserIdMismatchError(...)           # 403 — logs both ids
-    return claimed
-
-async def require_user_id(                       # the 49 query operations
+async def require_user_id(
     principal: Annotated[Principal, Depends(require_principal)],
     user_id: Annotated[str, Query(min_length=1, max_length=256, description=...)],
 ) -> str:
-    return resolve_request_user(principal, user_id)
+    """The end user this request acts for. 401 unverifiable, 403 not the caller."""
+    caller = caller_owner_id(principal)           # 401 when unverifiable
+    if user_id != caller:
+        raise UserIdMismatchError(...)            # 403 — logs both ids
+    return user_id
 
 UserIdDep = Annotated[str, Depends(require_user_id)]
 ```
 
-### A query-parameter operation (49 of them)
+The equality check is the whole of the "nothing else changes" promise, and it is
+the single line delegation replaces later. Nothing else in the surface knows how
+the question is answered.
+
+### Every affected operation, in one shape
 
 ```diff
 # openapi_v1/bots/router.py:351 — get_bot
@@ -108,92 +102,61 @@ UserIdDep = Annotated[str, Depends(require_user_id)]
 +    bot = bot_service.get_bot(bot_id, user_id)
 ```
 
-```jsonc
-// GET /openapi/v1/bots/b-1?user_id=u-42 → 200   (unchanged payload)
-// GET /openapi/v1/bots/b-1              → 422   {"code":422000,"message":"Invalid request","data":null,…}
-// GET /openapi/v1/bots/b-1?user_id=u-99 → 403   {"code":403000,"message":"Forbidden","data":null,…}
-```
-
-### A body-field operation (11 of them)
+Writes take exactly the same shape — the body is untouched:
 
 ```diff
-# openapi_v1/bots/schemas.py:46 — BotCreate (model_config = extra="forbid")
- class BotCreate(BaseModel):
-     model_config = _STRICT
-+    user_id: str = Field(min_length=1, max_length=256,
-+                         description="The end user this request acts for.")
-     bot_name: str = Field(...)
-```
-
-```diff
-# openapi_v1/bots/router.py:219 — create_bot
-     body: BotCreate,
+# openapi_v1/bots/router.py:367 — update_bot
+     body: BotUpdate,
      request: Request,
-     principal: PrincipalDep,
-     ...
--    owner_id = caller_owner_id(principal)
-+    owner_id = resolve_request_user(principal, body.user_id)
+-    principal: PrincipalDep,
++    user_id: UserIdDep,
 ```
 
-The 11 models and their operations:
-
-| Model | Operation |
-| --- | --- |
-| `BotCreate` | `POST /openapi/v1/bots` |
-| `BotUpdate` | `PUT …/bots/{bot_id}` |
-| `ApprovalModeSet` | `PUT …/bots/approvals/{bot_id}/mode` |
-| `IdentityFileWrite` | `PUT …/bots/identity/{bot_id}/{file_type}` |
-| `McpConfigWrite` | `PUT …/bots/mcp/servers/{server_code}/config` |
-| `ResourceCreate` | `POST …/bots/resources` |
-| `ResourceUpdate` | `PUT …/bots/resources/{resource_id}` |
-| `RoutineCreate` | `POST …/bots/routines` |
-| `RoutineUpdate` | `PATCH …/bots/routines/{routine_id}` |
-| `SessionCreate` | `POST …/bots/sessions/{bot_id}` |
-| `SessionUpdate` | `PATCH …/bots/sessions/{bot_id}/{session_id}` |
-
-### `bot_id`, brought in line
-
-`bot_id` is a query parameter on 17 in-scope operations. Only three of them have
-a body this API defines, so only three move:
-
-```diff
-# openapi_v1/resources/schemas.py:31 — ResourceCreate  (…and ResourceUpdate:40)
- class ResourceCreate(BaseModel):
-+    user_id: str = Field(...)
-+    bot_id: str = Field(description="Bot this resource belongs to.")
-     name: str = Field(...)
+```jsonc
+// GET    /openapi/v1/bots/b-1?user_id=u-42          → 200  (payload unchanged)
+// PUT    /openapi/v1/bots/b-1?user_id=u-42          → 200  body {"bot_name": "Ada"}
+// DELETE /openapi/v1/bots/b-1?user_id=u-42          → 200
+// GET    /openapi/v1/bots/b-1                       → 422  {"code":422000,"message":"Invalid request","data":null,…}
+// GET    /openapi/v1/bots/b-1?user_id=u-99          → 403  {"code":403000,"message":"Forbidden","data":null,…}
 ```
 
-```diff
-# openapi_v1/resources/router.py:197 — create_resource
-     body: ResourceCreate,
--    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-```
+The four operations with no user dimension keep their current signature and
+answer exactly as they do today.
 
-| Operation | `bot_id` today | after |
-| --- | --- | --- |
-| `POST …/resources` | query | **body** |
-| `PUT …/resources/{resource_id}` | query | **body** |
-| `PATCH …/routines/{routine_id}` | query | **body** |
-| `POST …/routines` | body | body (already correct — the precedent) |
-| 14 others (GET ×9, DELETE ×2, bodyless `POST …/routines/{id}/run`, the 2 uploads) | query | query |
+### Where the dependency is declared
 
-`{bot_id}` in a path is untouched on all 28 operations that address a bot that
-way.
+**Per handler, not per group.** `_PUBLIC_AUTH` can stay at group level because
+it applies to every route without exception; `require_user_id` has four
+exceptions, two of which sit inside groups whose other routes do take it (1 of
+13 in `bots`, 3 of 6 in `mcp`). A group-level dependency would put the parameter
+on them.
 
-### Response documentation
+The cost is that assembly no longer makes it impossible to forget on a new
+route. The convention test is what recovers that — the same trade
+`test_path_convention.py` already makes for the addressing rule.
+
+### Documenting the 403
 
 ```diff
 # openapi_v1/contracts.py:84
 +USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: {"model": ErrorEnvelope,
 +    "description": "The request names a user the caller may not act for"}}
++USER_SCOPED_403 = {403: USER_SCOPED_ERROR_RESPONSES[403]}   # for per-route merge
 -ENGINE_RUNTIME_ERROR_RESPONSES = {**ERROR_RESPONSES, 501: …, 504: …}
 +ENGINE_RUNTIME_ERROR_RESPONSES = {**USER_SCOPED_ERROR_RESPONSES, 501: …, 504: …}
 ```
 
 403 stays **out** of `ERROR_RESPONSES`: `test_openapi_error_schema.py:55` asserts
-every operation documents every status in that dict, and Bot Logs cannot return a
-403.
+every operation documents every status in that dict, and Bot Logs cannot return
+one. Applied in two ways, for the same reason the dependency is:
+
+- **Group level** for the nine groups with no exemption — `resources`,
+  `routines`, `skills`, `identity`, and the five engine-runtime groups.
+- **Route level** for `bots` (12 of 13) and `mcp` (3 of 6), which keep
+  `ERROR_RESPONSES` at group level and add `responses=USER_SCOPED_403` on the
+  routes that can return it. FastAPI merges router-level and route-level
+  `responses`, so the four exempt operations document exactly what they can
+  return. 15 decorator edits.
 
 ## Key Files & Functions
 
@@ -210,36 +173,18 @@ class UserIdMismatchError(Exception):
 ```
 
 ```diff
-# openapi_v1/__init__.py:96 — build_public_router
- _PUBLIC_AUTH = [Depends(require_principal)]
-+# Declared independently of require_user_id, not merely inside it: a request
-+# that also fails query/body validation must still answer 401, and FastAPI
-+# skips calling a dependency whose own params failed to validate.
-+_USER_SCOPED = [*_PUBLIC_AUTH, Depends(require_user_id)]
-```
-
-`_USER_SCOPED` is attached to every group **except** `bot_logs`, which keeps
-`_PUBLIC_AUTH` and `ERROR_RESPONSES`. It is what puts the query parameter on the
-49 — and, deliberately, on the 11 body operations too, so the loop stays one
-list. **Open detail for implementation:** a body operation must not end up
-declaring *both*; either exclude the 11 from `_USER_SCOPED` and let their handler
-argument carry it, or accept the duplicate. Task 3 resolves this against the
-generated document, and the convention test (below) is what pins the answer.
-
-```diff
 # adapters/http/app.py:559 — beside _principal_error_handler
 +@app.exception_handler(UserIdMismatchError)
 +async def _user_id_mismatch_handler(request, exc) -> JSONResponse: ...
 ```
 
-Per-router edits are mechanical and identical in shape; the counts are: bots 13,
-mcp 6, resources 9, routines 7, skills 6, identity 3, sessions 7, engine 3,
-approvals 3, models 2, connection 1.
+Per-router handler counts (signatures changed / operations in group): bots 12/13,
+mcp 3/6, resources 9/9, routines 7/7, skills 6/6, identity 3/3, sessions 7/7,
+engine 3/3, approvals 3/3, models 2/2, connection 1/1.
 
-Eight of the 60 do not use the value (`check_bot_name`; `list_mcp_servers`,
-`list_mcp_tenants`, `get_mcp_server`; `list_resources`, `create_resource`,
-`get_resource`, `update_resource`). They declare the parameter and `del` it, with
-a comment — the shape `bot_logs/router.py:44` already uses.
+The four `resources` handlers that take the parameter without using it declare
+it and `del` it with a one-line reason — they are the not-yet-enforced case, not
+the no-user-dimension case, and the comment should say which.
 
 ## Dependencies
 
@@ -251,46 +196,50 @@ None. No new package, no version bump.
   leaking that the credential was fine. Observed in a spike: when
   `require_user_id` is the *only* dependency naming the principal, FastAPI never
   calls it (its own parameter failed validation) and the 401 never fires.
-  **Mitigation:** `require_principal` stays declared independently in
-  `_USER_SCOPED`; `test_explicit_user_id.py` asserts 401 outranks a missing
-  parameter.
-- **Risk:** the placement rule decays into per-category habit again — the thing
-  the spec cites as the reason to settle it.
-  **Mitigation:** a convention test over the generated document, in the shape of
-  `test_path_convention.py`, so a new operation fails the build rather than
-  review.
-- **Risk:** two tests assert the *opposite* of the new contract —
-  `test_sessions.py:507` and `test_approvals.py:94` require a caller-supplied
-  `user_id` to be a 422. **Mitigation:** they invert to "403 for another user's
-  id", and keep asserting 422 for `engine` — that field stays forbidden. The
-  `extra="forbid"` config is what keeps the rest of the guard intact.
-- **Risk:** five of the 11 models (`IdentityFileWrite`, `ResourceCreate`,
-  `ResourceUpdate`, `RoutineCreate`, `RoutineUpdate`) have no `extra="forbid"`,
-  so a `user_id` sent today is silently ignored and would now be honoured.
-  **Mitigation:** it is honoured only after `resolve_request_user` accepts it, so
-  the widest outcome is 403. Not tightened here — that is a separate change.
+  **Mitigation:** `_PUBLIC_AUTH` keeps `require_principal` declared
+  independently at group level on every group; a test asserts 401 outranks a
+  missing parameter.
+- **Risk:** the exemption list decays — a fifth operation quietly drops the
+  parameter, or one of the four `resources` operations is "cleaned up" into the
+  exempt set.
+  **Mitigation:** the convention test asserts the exempt set is *exactly* those
+  four addresses, and the docs give a reason per entry.
 - **Risk:** ~232 test call sites across 10 files.
-  **Mitigation:** the 49 query operations are covered by setting
-  `client.params = {"user_id": …}` once per `TestClient` (httpx merges default
-  params); only the body operations need per-call edits. Verify the httpx
-  behaviour in task 6 before relying on it.
+  **Mitigation:** every affected operation takes it in the same place, so
+  `client.params = {"user_id": …}` once per `TestClient` covers all of them
+  (httpx merges default params). Verify that behaviour in task 5 before relying
+  on it; if it does not hold, one helper does the same job in one place.
+- **Risk:** the four `resources` operations advertise a parameter they ignore,
+  and a reader concludes the surface is inconsistent.
+  **Mitigation:** the `del` comment and the docs both say *why* — enforcement is
+  a known gap, not an absent dimension.
 
 ## Alternatives Considered
 
-- **A single required header, `X-Avernet-User-Id`.** One placement for all 60,
-  no request-model changes, no per-method rule, and it matches the gateway's own
-  delegation sketch (auth design §15 reserves an `xoneid`/`x-end-user-id`
-  header). Rejected by the user in favour of the more conventionally RESTful
-  reading: the user is an argument of the operation, not transport metadata.
-  Recorded because it is the fallback if the three-exception table proves
-  unworkable in review.
-- **Query parameter everywhere.** Uniform and cheap, and there is a precedent on
-  the surface (`GET …/bots/logs/traces?user_id=`). Rejected for the same reason.
+- **`user_id` in the request body on the 11 JSON-body operations** (the
+  conventionally RESTful reading; the plan's first revision). Rejected in review:
+  a body describes the resource, and beside `bot_name` in a `PUT` payload the
+  user id reads as a property being set on the bot. It also needed a
+  three-row exception table for the writes whose body this API does not define
+  (two raw-byte uploads, the free-form engine-config document), 11 schema
+  changes, three `bot_id` moves, and split placement across verbs on the same
+  resource — while buying no log-hygiene benefit, since 49 operations carry the
+  value in the query string regardless.
+- **`user_id` as a path segment**, either `/bots/{bot_id}/users/{user_id}` or
+  `/users/{user_id}/bots/…`. Rejected: the first inverts the ownership and
+  claims to address a user the endpoint does not return; the second is coherent
+  but closed, because the first segment after `/openapi/v1` is the gateway's
+  domain selector and `test_public_namespace.py` pins every path under
+  `/openapi/v1/bots`.
+- **A required `X-Avernet-User-Id` header.** Uniform, no request changes, and
+  aligned with the gateway's delegation sketch (auth design §15 reserves an
+  `xoneid` / `x-end-user-id` header). Rejected in favour of the parameter being
+  a visible argument of the operation rather than transport metadata.
+- **Requiring the parameter on all 60**, including the four with no user
+  dimension. Rejected in review: it asks for a value those operations cannot
+  use, and a marketplace catalogue read has no user-shaped answer to give.
 - **Preferring the request's id over the credential's, with no check.** A
-  privilege escalation: any verified user could read another's data. Not viable
-  before delegation exists.
-- **Omitting the parameter on the 8 operations that ignore it.** Rejected in the
-  spec: it makes a client learn which 8 of 60 differ.
+  privilege escalation: any verified user could read another's data.
 
 ## Rollout
 
@@ -306,24 +255,26 @@ generated document so a later operation is covered without editing it:
 
 ```python
 # tests/community/adapters/http/openapi_v1/test_explicit_user_id.py (new)
-def test_every_user_scoped_operation_names_its_user(): ...       # 60/60
-def test_placement_follows_the_body_or_query_rule(): ...         # 11 body, 49 query
-def test_bot_id_sits_where_the_user_id_sits(): ...               # the 3 moved + 12 unmoved
-def test_bot_logs_operations_are_unchanged(): ...                # 5, no parameter, no 403
-def test_naming_another_user_is_403_on_both_paths(): ...         # query and body
+def test_every_user_scoped_operation_requires_user_id(): ...      # 56/56, in query
+def test_the_exempt_operations_are_exactly_these_four(): ...      # pinned by address
+def test_user_id_is_never_a_body_field_or_a_path_segment(): ...
+def test_bot_id_placement_is_unchanged_from_head(): ...
+def test_bot_logs_operations_are_unchanged(): ...                 # 5, no parameter, no 403
+def test_naming_another_user_is_403(): ...
 def test_two_rejected_ids_give_identical_bodies(): ...
-def test_missing_parameter_is_422_and_no_caller_is_401(): ...    # precedence
-def test_403_is_documented_only_on_user_scoped_operations(): ...
+def test_missing_parameter_is_422_and_no_caller_is_401(): ...     # precedence
+def test_403_is_documented_on_exactly_the_56(): ...
 ```
 
-Updated in place:
+Updated in place — and note that the two tests which asserted the *opposite*
+contract no longer need to change: `test_sessions.py:507` and
+`test_approvals.py:94` require a caller-supplied `user_id` **in the body** to be
+a 422, and under this revision the body still forbids it. They stay green as
+written, which is one more argument for the query parameter.
 
 ```python
-# engine_runtime/test_sessions.py:507  — inverts
-def test_caller_supplied_identity_is_rejected():   # engine → 422; user_id → 403
-# engine_runtime/test_approvals.py:94   — inverts
-# resources/test_resources_handlers.py  — 4 `principal=None` cases now exercise
-#                                          resolve_request_user, not each handler
+# resources/test_resources_handlers.py — the 4 `principal=None` cases now
+# exercise require_user_id, not each handler
 ```
 
 Then the module gates from `AGENTS.md`: backend SAST, `tests/community` in full

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/spec.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/spec.md
@@ -1,0 +1,137 @@
+# Public API — Name the End User in the Request
+
+## Summary
+
+Every `/openapi/v1` operation that acts on a user's data currently works out
+*which* user from the caller's credential. This makes the user an explicit part
+of the request instead: the operation says whose bots, resources, skills or
+sessions it is for, in the request itself.
+
+Nothing about who may call what changes. A request without a verified user
+principal is refused exactly as it is today, and a caller can still only reach
+its own data. This is a contract change made ahead of the capability that needs
+it, not the capability itself.
+
+## Motivation
+
+**The user is about to stop being implicit.** Today an end user reaches the
+public API through the gateway, which resolves their identity and forwards it as
+a signed principal. Every operation therefore has exactly one person behind it,
+and the backend can infer them without being told. The next step for this surface
+is letting a registered **App call on behalf of a user**: the App presents its
+own credential, and the person it is acting for is not inside that credential.
+
+At that point 52 operations have a problem that is not an implementation
+problem — it is a *contract* problem. Their published contract never mentions a
+user, so there is nowhere for a caller to put one. Adding the parameter then
+means changing the contract of the whole surface at the same moment the new
+caller type arrives, which is two risky changes landing together on the same
+release.
+
+**Doing it now costs nothing and is fully reversible in review.** While the two
+values must still agree, the change is observable only as a stricter request
+shape: the same callers, the same data, the same failures. Every operation gets
+its parameter, the surface gets one place where "which user is this for?" is
+answered, and the delegation work later changes that one place rather than 52
+handlers, 11 request schemas and their tests.
+
+**The surface has already drifted on exactly this question.** `POST
+…/bots/routines` takes its `bot_id` as a required body field; `PATCH
+…/bots/routines/{routine_id}` takes the same `bot_id` as a query parameter, and
+`/bots/resources` takes it as a query parameter on all nine of its operations
+including two that carry a JSON body. `/bots/logs/traces` already names its user
+explicitly — as a query parameter. Nobody decided that; it accumulated. Settling
+where a scoping parameter goes, and applying the answer to `bot_id` at the same
+time, is what stops the next category from inventing a third convention.
+
+## User Stories
+
+- As a partner integrating the public API, I want each operation to state which
+  user it acts for, so that the request I build does not depend on which kind of
+  credential happened to authenticate it.
+- As an engineer adding a public endpoint, I want one stated rule for where a
+  scoping parameter goes, so that I do not have to guess from the neighbouring
+  category — and get it wrong, as this surface already has.
+- As a reviewer, I want the "which user?" question answered in one place, so
+  that widening it later to App-on-behalf-of is a reviewable change to that
+  place rather than a sweep across every router.
+- As an operator, I want a request that names a user its caller may not act for
+  to be refused distinguishably from a bad credential, so that a partner's
+  misconfiguration is not diagnosed as an auth outage.
+
+## Acceptance Criteria
+
+**The parameter exists, everywhere it should**
+
+- [ ] Every public operation that scopes to a user requires the user id as part
+      of its request, and the published API description says so.
+- [ ] The parameter is required, not optional — an operation cannot be called
+      without naming its user.
+- [ ] The five Bot Logs operations are unchanged: they never derived a user from
+      the credential, and the one that is user-scoped already names its user.
+- [ ] Where an operation takes a bot id as a *parameter* (rather than as part of
+      its address), the bot id follows the same placement rule as the user id,
+      so the two are never in different places on the same request.
+
+**Placement is one stated rule, not a per-category habit**
+
+- [ ] A single rule decides where a scoping parameter goes, it is written down
+      where an engineer adding an endpoint will find it, and a test fails if a
+      new operation breaks it.
+- [ ] Requests whose body is defined by this API carry the parameter in the
+      body; every other request carries it in the query string.
+
+**Behaviour is unchanged**
+
+- [ ] A request with no verified caller is refused with the same status, body
+      and message as before this change.
+- [ ] A request naming the caller itself succeeds and reaches the same data as
+      before, for every operation.
+- [ ] A request naming *another* user is refused, and the refusal is
+      distinguishable from an authentication failure.
+- [ ] The refusal reveals nothing about the user that was named or whether it
+      exists; two different rejected ids produce identical responses.
+- [ ] Which user was asked for, and which caller asked, are recoverable from the
+      logs.
+- [ ] An operation that scopes to a user takes the user it acts on from the
+      request, not from the credential, so that permitting the two to differ is
+      a change to one rule and not to any operation.
+- [ ] The internal `/api/...` surface is untouched.
+
+## In Scope
+
+- The 52 public operations that derive a user id from the verified principal.
+- The 8 further operations that require a caller principal but do not use the
+  user id (4 assert it and discard it; 4 declare it and never ask): they take
+  the parameter too, so a client sends one request shape across the surface.
+- The bot id, wherever it is a request parameter rather than part of the
+  address, so both scoping parameters obey the one rule.
+- The published API description, and the developer-facing docs for this surface.
+
+## Out of Scope
+
+- **Admitting App-on-behalf-of callers.** Which credentials the surface accepts
+  is unchanged: a request with no verified user principal still fails. This
+  change makes the contract ready for that work; it does not do it.
+- **Relaxing the agreement between the named user and the caller.** Naming
+  another user is refused. Deciding when an App *may* name another user is the
+  delegation workstream (auth design §15).
+- **Re-addressing any endpoint.** Paths do not change; a bot id that is part of
+  an operation's address stays there.
+- The internal `/api/...` surface, the gateway's own configuration, and the
+  Bot Logs group.
+
+## Open Questions
+
+_None blocking._ Two decisions were made rather than deferred, and are recorded
+here so they can be overturned in review rather than discovered in the diff:
+
+1. **Operations that do not scope by a user still require the parameter.** Four
+   catalogue reads and four bot-scoped resource operations do not use a user id.
+   Requiring it anyway keeps one request shape across the surface, at the cost of
+   asking for a value those eight operations ignore. The alternative — omitting
+   it exactly there — makes a client learn which 8 of 60 operations differ.
+2. **A mismatch is refused rather than resolved.** Preferring the request's value
+   would let any verified user read another's data; preferring the credential's
+   would answer a request the caller did not make. Refusing is the only option
+   that leaves today's behaviour exactly as it is.

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/spec.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/spec.md
@@ -67,19 +67,22 @@ time, is what stops the next category from inventing a third convention.
       of its request, and the published API description says so.
 - [ ] The parameter is required, not optional — an operation cannot be called
       without naming its user.
+- [ ] An operation that has no user dimension at all does **not** take it. The
+      exempt set is small, listed with a reason each, and pinned by a test, so a
+      later addition to it is a deliberate edit rather than a drift.
 - [ ] The five Bot Logs operations are unchanged: they never derived a user from
       the credential, and the one that is user-scoped already names its user.
-- [ ] Where an operation takes a bot id as a *parameter* (rather than as part of
-      its address), the bot id follows the same placement rule as the user id,
-      so the two are never in different places on the same request.
 
 **Placement is one stated rule, not a per-category habit**
 
-- [ ] A single rule decides where a scoping parameter goes, it is written down
-      where an engineer adding an endpoint will find it, and a test fails if a
-      new operation breaks it.
-- [ ] Requests whose body is defined by this API carry the parameter in the
-      body; every other request carries it in the query string.
+- [ ] A single rule decides where the user id goes, it is written down where an
+      engineer adding an endpoint will find it, and a test fails if a new
+      operation breaks it.
+- [ ] The user id is a query parameter on every operation that takes it —
+      whatever the method, whatever the body. There is no second placement to
+      learn and no exception table.
+- [ ] The bot id is untouched: it stays in the path where it addresses a bot and
+      in the query string where it is a parameter.
 
 **Behaviour is unchanged**
 
@@ -101,37 +104,56 @@ time, is what stops the next category from inventing a third convention.
 ## In Scope
 
 - The 52 public operations that derive a user id from the verified principal.
-- The 8 further operations that require a caller principal but do not use the
-  user id (4 assert it and discard it; 4 declare it and never ask): they take
-  the parameter too, so a client sends one request shape across the surface.
-- The bot id, wherever it is a request parameter rather than part of the
-  address, so both scoping parameters obey the one rule.
+- The 4 operations that declare a caller principal but never derive an owner —
+  `list_resources`, `create_resource`, `get_resource`, `update_resource`. They
+  take the parameter too. Not for uniformity: they are user-scoped in principle
+  and merely fail to enforce it today (the gap the 2026-08-02 spec records), so
+  closing that gap later should not have to add a required parameter to four
+  public operations.
 - The published API description, and the developer-facing docs for this surface.
+
+**56 operations take the user id.**
 
 ## Out of Scope
 
+- **The 4 operations with no user dimension.** `check_bot_name` answers a
+  tenant-wide uniqueness question; `list_mcp_servers`, `list_mcp_tenants` and
+  `get_mcp_server` read a marketplace catalogue that is identical for every
+  caller in the tenant. None of them has a user-shaped answer to give, now or
+  later, so none of them asks for one. An authenticated caller is still
+  required — that is the principal's job, not this parameter's.
+- **The bot id.** It stays exactly where it is on every operation. Where it
+  addresses a bot it is part of the address; where it is a parameter it is
+  already a query parameter, which is where this change puts the user id too.
 - **Admitting App-on-behalf-of callers.** Which credentials the surface accepts
   is unchanged: a request with no verified user principal still fails. This
   change makes the contract ready for that work; it does not do it.
 - **Relaxing the agreement between the named user and the caller.** Naming
   another user is refused. Deciding when an App *may* name another user is the
   delegation workstream (auth design §15).
-- **Re-addressing any endpoint.** Paths do not change; a bot id that is part of
-  an operation's address stays there.
+- **Re-addressing any endpoint.** Paths do not change.
 - The internal `/api/...` surface, the gateway's own configuration, and the
   Bot Logs group.
 
-## Open Questions
+## Decisions
 
-_None blocking._ Two decisions were made rather than deferred, and are recorded
-here so they can be overturned in review rather than discovered in the diff:
+Settled in review rather than left open:
 
-1. **Operations that do not scope by a user still require the parameter.** Four
-   catalogue reads and four bot-scoped resource operations do not use a user id.
-   Requiring it anyway keeps one request shape across the surface, at the cost of
-   asking for a value those eight operations ignore. The alternative — omitting
-   it exactly there — makes a client learn which 8 of 60 operations differ.
-2. **A mismatch is refused rather than resolved.** Preferring the request's value
+1. **The user id is a query parameter everywhere, never a body field.** A body
+   describes the resource being acted on; the user id describes who the call is
+   for. It is the same value on every operation and identical in meaning on a
+   read and a write, so splitting it by method would put one concept in two
+   places — and in a `PUT …/bots/{bot_id}` payload, beside `bot_name`, it would
+   read as a property being set on the bot. Placing it by method also buys
+   nothing on log hygiene, since the majority of operations are reads that carry
+   it in the query string regardless.
+2. **The user id is never a path segment.** A path names the resource an
+   operation acts on; `/bots/{bot_id}/users/{user_id}` would claim to address a
+   user beneath a bot, which inverts the ownership and does not describe what
+   the endpoint returns. A user-first address (`/users/{user_id}/bots/…`) is a
+   coherent design in the abstract but closed here: the first segment after
+   `/openapi/v1` is the gateway's domain selector.
+3. **A mismatch is refused rather than resolved.** Preferring the request's value
    would let any verified user read another's data; preferring the credential's
    would answer a request the caller did not make. Refusing is the only option
    that leaves today's behaviour exactly as it is.

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -47,24 +47,24 @@
   - [x] `test_openapi_error_schema.py` still passes untouched.
 - **Depends on:** Task 1
 
-## Task 3: Convert the 41 operations in the nine unexempted groups
+## Task 3: Convert the 41 operations in the nine unexempted groups  [x]
 
 - **Goal:** Every operation in a group with no exemption takes its user from the
   request.
 - **Files:** `…/openapi_v1/{resources,routines,skills,identity}/router.py`,
   `…/openapi_v1/engine_runtime/{sessions,engine,models,approvals,connection}/router.py`
 - **Done when:**
-  - [ ] Handlers take `user_id: UserIdDep` in the position `principal:
+  - [x] Handlers take `user_id: UserIdDep` in the position `principal:
         PrincipalDep` occupied, and pass it where `owner_id` / `actor_id` went.
-  - [ ] The four `resources` handlers that do not use it (`list_resources`,
+  - [x] The four `resources` handlers that do not use it (`list_resources`,
         `create_resource`, `get_resource`, `update_resource`) declare it and
         `del` it, with a comment saying they are the *not-yet-enforced* case —
         the gap `specs/2026-08-02-public-api-user-only-principal/` records — not
         the no-user-dimension case.
-  - [ ] No router in this set imports `caller_owner_id`.
-  - [ ] Every module docstring or comment describing identity as coming from the
+  - [x] No router in this set imports `caller_owner_id`.
+  - [x] Every module docstring or comment describing identity as coming from the
         principal is corrected.
-  - [ ] `ruff check --select E,F,W` is clean on the package: no dead import left
+  - [x] `ruff check --select E,F,W` is clean on the package: no dead import left
         behind, no new `E501`.
 - **Depends on:** Task 2
 

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -2,7 +2,7 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
-## Task 1: Add the seam and its refusal
+## Task 1: Add the seam and its refusal  [x]
 
 - **Goal:** One place that answers "which end user is this request for, and may
   this caller act for them?", plus the 403 it raises.
@@ -12,16 +12,16 @@
   `…/openapi_v1/responses.py`,
   `src/backend/src/agentclaw/community/adapters/http/app.py`
 - **Done when:**
-  - [ ] `require_user_id` reads a required `user_id` query parameter, returns it
+  - [x] `require_user_id` reads a required `user_id` query parameter, returns it
         when it equals the caller's id, raises `MissingPrincipalError` when there
         is no verified caller, and raises `UserIdMismatchError` otherwise.
-  - [ ] `UserIdDep` is exported for routers to declare.
-  - [ ] Both ids are on a `logger.warning` line at the point of refusal; neither
+  - [x] `UserIdDep` is exported for routers to declare.
+  - [x] Both ids are on a `logger.warning` line at the point of refusal; neither
         appears in any response.
-  - [ ] `UserIdMismatchError` maps to `(403, "Forbidden")` in `ENVELOPE_ERRORS`,
+  - [x] `UserIdMismatchError` maps to `(403, "Forbidden")` in `ENVELOPE_ERRORS`,
         and `app.py` registers a concrete-type handler for it beside
         `_principal_error_handler` — with the reason in the docstring.
-  - [ ] `principal.py`'s module docstring states the placement rule, why the
+  - [x] `principal.py`'s module docstring states the placement rule, why the
         query string and not a body or a path, and that this function is what
         delegation changes.
 - **Depends on:** —

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -88,29 +88,29 @@
         operations without `user_id`, and they are those four.
 - **Depends on:** Task 2
 
-## Task 5: Bring the existing suite to the new contract
+## Task 5: Bring the existing suite to the new contract  [x]
 
 - **Goal:** The 499 existing openapi_v1 tests exercise the new request shape.
 - **Files:** `src/backend/tests/community/adapters/http/openapi_v1/**`
 - **Done when:**
-  - [ ] Confirm `httpx` merges a client's default `params` into every request; if
+  - [x] Confirm `httpx` merges a client's default `params` into every request; if
         it does, set `client.params = {"user_id": …}` once per `TestClient`, and
         if not, add one helper that does the same job in one place.
-  - [ ] Tests for the four exempt operations do **not** send the parameter, and
+  - [x] Tests for the four exempt operations do **not** send the parameter, and
         one asserts that sending it is still accepted as an unknown query
         parameter rather than becoming a silent scope.
-  - [ ] The four `principal=None` cases in `resources/test_resources_handlers.py`
+  - [x] The four `principal=None` cases in `resources/test_resources_handlers.py`
         exercise the seam rather than four handlers, and still pin "no silent
         bot-derived owner".
-  - [ ] Direct-invocation tests (`identity`, `routines`, `resources`) pass the
+  - [x] Direct-invocation tests (`identity`, `routines`, `resources`) pass the
         resolved id, and their docstrings no longer describe a principal
         argument.
-  - [ ] Pre-handler failures are answered by importing `app.py`'s real handlers,
+  - [x] Pre-handler failures are answered by importing `app.py`'s real handlers,
         not by re-implementing them in a fixture.
-  - [ ] `test_sessions.py:507` and `test_approvals.py:94` are **unchanged and
+  - [x] `test_sessions.py:507` and `test_approvals.py:94` are **unchanged and
         green** — a caller-supplied `user_id` in the body is still a 422, because
         the body still forbids it. Confirm this rather than assuming it.
-  - [ ] `pytest tests/community/adapters/http/openapi_v1/` is green.
+  - [x] `pytest tests/community/adapters/http/openapi_v1/` is green.
 - **Depends on:** Tasks 3, 4
 
 ## Task 6: Pin the contract with a convention test

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -26,25 +26,25 @@
         delegation changes.
 - **Depends on:** —
 
-## Task 2: Document the 403 on exactly the operations that can return it
+## Task 2: Document the 403 on exactly the operations that can return it  [x]
 
 - **Goal:** The published description matches what each operation actually does.
 - **Files:** `…/openapi_v1/contracts.py`, `…/openapi_v1/__init__.py`
 - **Done when:**
-  - [ ] `USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: …}` and a
+  - [x] `USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: …}` and a
         `USER_SCOPED_403` single-entry dict for per-route merging.
-  - [ ] `ENGINE_RUNTIME_ERROR_RESPONSES` is built from the user-scoped set.
-  - [ ] `403` is **not** in `ERROR_RESPONSES`; the comment says why
+  - [x] `ENGINE_RUNTIME_ERROR_RESPONSES` is built from the user-scoped set.
+  - [x] `403` is **not** in `ERROR_RESPONSES`; the comment says why
         (`test_openapi_error_schema.py:55` requires every operation to document
         every status in that dict, and Bot Logs cannot return one).
-  - [ ] `build_public_router` attaches the user-scoped table to the nine groups
+  - [x] `build_public_router` attaches the user-scoped table to the nine groups
         with no exemption, and leaves `bots` / `mcp` / `bot_logs` on
         `ERROR_RESPONSES`.
-  - [ ] The `__init__.py` module docstring carries the placement rule next to the
+  - [x] The `__init__.py` module docstring carries the placement rule next to the
         addressing rule, phrased so a new endpoint's author can apply it without
         reading this spec — including the four exemptions and why they are
         exempt.
-  - [ ] `test_openapi_error_schema.py` still passes untouched.
+  - [x] `test_openapi_error_schema.py` still passes untouched.
 - **Depends on:** Task 1
 
 ## Task 3: Convert the 41 operations in the nine unexempted groups

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -139,20 +139,20 @@
         401 **even when the parameter is also missing**. _(landed in Group A)_
 - **Depends on:** Task 5
 
-## Task 7: Write the rule where the next author will find it
+## Task 7: Write the rule where the next author will find it  [x]
 
 - **Goal:** The convention is documented, not just enforced.
 - **Files:** `src/backend/docs/openapi-v1/README.md` (and the `.zh-CN`
   counterpart if it mirrors this section)
 - **Done when:**
-  - [ ] The placement rule, the four exemptions with a reason each, and the 403
+  - [x] The placement rule, the four exemptions with a reason each, and the 403
         are described in the handoff doc.
-  - [ ] The rejected alternatives are recorded in one short paragraph — body
+  - [x] The rejected alternatives are recorded in one short paragraph — body
         field, path segment, header — so the question is not reopened from
         scratch.
-  - [ ] The changelog and status board record this change, per the doc's own
+  - [x] The changelog and status board record this change, per the doc's own
         "if your change moved a checkbox, move it here too" rule.
-  - [ ] The doc says plainly what did **not** change: who may call, and what a
+  - [x] The doc says plainly what did **not** change: who may call, and what a
         request with no verified user principal answers.
 - **Depends on:** Task 6
 

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -68,23 +68,23 @@
         behind, no new `E501`.
 - **Depends on:** Task 2
 
-## Task 4: Convert `bots` and `mcp`, and leave the four exemptions alone
+## Task 4: Convert `bots` and `mcp`, and leave the four exemptions alone  [x]
 
 - **Goal:** The two groups that mix scoped and unscoped operations, done
   deliberately rather than in bulk.
 - **Files:** `…/openapi_v1/bots/router.py`, `…/openapi_v1/mcp/router.py`
 - **Done when:**
-  - [ ] 12 of 13 `bots` handlers and 3 of 6 `mcp` handlers take `user_id:
+  - [x] 12 of 13 `bots` handlers and 3 of 6 `mcp` handlers take `user_id:
         UserIdDep` and carry `responses=USER_SCOPED_403` on their route
         decorator, merged with any `responses=` already there.
-  - [ ] `check_bot_name`, `list_mcp_servers`, `list_mcp_tenants` and
+  - [x] `check_bot_name`, `list_mcp_servers`, `list_mcp_tenants` and
         `get_mcp_server` are **unchanged on the wire**: no `user_id` parameter,
         no 403 documented. Their `caller_owner_id(principal)` assertion is
         replaced by nothing — `_PUBLIC_AUTH` already requires the caller — and a
         comment records that they have no user dimension, with the reason.
-  - [ ] `caller_owner_id` is imported by `principal.py` alone; the routers no
+  - [x] `caller_owner_id` is imported by `principal.py` alone; the routers no
         longer reference it.
-  - [ ] The generated document shows exactly four `/openapi/v1/bots/**`
+  - [x] The generated document shows exactly four `/openapi/v1/bots/**`
         operations without `user_id`, and they are those four.
 - **Depends on:** Task 2
 

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -156,21 +156,33 @@
         request with no verified user principal answers.
 - **Depends on:** Task 6
 
-## Task 8: Tests & Verification
+## Task 8: Tests & Verification  [x]
 
 - **Goal:** Ensure the feature meets the spec's acceptance criteria.
 - **Files:** —
 - **Done when:**
-  - [ ] Every acceptance criterion in `spec.md` checks off, including the
+  - [x] Every acceptance criterion in `spec.md` checks off, including the
         negative ones (internal `/api` untouched; Bot Logs untouched; `bot_id`
         untouched).
-  - [ ] `pytest tests/community` is green — not just the openapi_v1 subtree.
-  - [ ] `scripts/ci/python_sast_local.sh src/backend` passes.
-  - [ ] Changed-line coverage meets the backend gate.
-  - [ ] The generated document is diffed against `HEAD` and every change is one
+  - [x] `pytest tests/community` is green — not just the openapi_v1 subtree.
+  - [x] `scripts/ci/python_sast_local.sh src/backend` passes.
+  - [x] Changed-line coverage meets the backend gate.
+  - [x] The generated document is diffed against `HEAD` and every change is one
         this spec asked for: 56 added query parameters, 56 added 403s, and
         nothing else — no schema, path, or `bot_id` drift.
-  - [ ] Anything that could not be run locally is named explicitly, with why.
+  - [x] Anything that could not be run locally is named explicitly, with why.
+
+**Not runnable in this container, and why:**
+- `scripts/ci/python_sast_local.sh` falls back to a CPython 3.11 `flake8`,
+  which cannot parse this repo's PEP 695 generics (`class Envelope[T]`) and
+  reports `E999` on `contracts.py` — identically on the *unmodified* file at
+  `dfe638d`. The same block-rule set was run instead through the project's
+  3.12 interpreter over all 33 changed Python files: clean.
+- Two `test_bot_build_service_skill_artifact` cases fail here because `rsync`
+  is not installed in this container. Unrelated to this change, and green on
+  CI.
+- Singlebox coverage and the BCS E2E gates need a live product stack; they run
+  on the PR.
 - **Depends on:** Task 7
 
 ---

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: Public API — Name the End User in the Request
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: Add the seam and its refusal
+
+- **Goal:** One place that answers "which end user is this request for, and may
+  this caller act for them?", plus the 403 it raises.
+- **Files:**
+  `src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py`,
+  `…/openapi_v1/errors.py`,
+  `…/openapi_v1/responses.py`,
+  `src/backend/src/agentclaw/community/adapters/http/app.py`
+- **Done when:**
+  - [ ] `resolve_request_user(principal, claimed)` returns the id when it equals
+        the caller's, raises `MissingPrincipalError` when there is no verified
+        caller, and raises `UserIdMismatchError` otherwise.
+  - [ ] Both ids are on a `logger.warning` line at the point of refusal; neither
+        appears in any response.
+  - [ ] `require_user_id` / `UserIdDep` read `user_id` from the query string and
+        delegate the decision to `resolve_request_user`.
+  - [ ] `UserIdMismatchError` maps to `(403, "Forbidden")` in `ENVELOPE_ERRORS`,
+        and `app.py` registers a concrete-type handler for it beside
+        `_principal_error_handler` — with the reason in the docstring.
+  - [ ] `principal.py`'s module docstring states the placement rule and says
+        this function is what delegation changes.
+- **Depends on:** —
+
+## Task 2: Document the 403 without claiming it surface-wide
+
+- **Goal:** Only the operations that can return a 403 advertise one.
+- **Files:** `…/openapi_v1/contracts.py`
+- **Done when:**
+  - [ ] `USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: …}` exists.
+  - [ ] `ENGINE_RUNTIME_ERROR_RESPONSES` is built from it, not from
+        `ERROR_RESPONSES`.
+  - [ ] `403` is **not** in `ERROR_RESPONSES`; the comment says why
+        (`test_openapi_error_schema.py:55` requires every operation to document
+        every status in that dict, and Bot Logs cannot return one).
+  - [ ] `tests/…/openapi_v1/test_openapi_error_schema.py` still passes untouched.
+- **Depends on:** Task 1
+
+## Task 3: Wire the dependency per group, and settle the double-declaration
+
+- **Goal:** Every user-scoped route requires the parameter by assembly, not by
+  each handler remembering; Bot Logs is left alone.
+- **Files:** `…/openapi_v1/__init__.py`
+- **Done when:**
+  - [ ] `_USER_SCOPED = [*_PUBLIC_AUTH, Depends(require_user_id)]`, with the
+        comment recording why `require_principal` stays declared independently
+        (FastAPI skips a dependency whose own parameters failed to validate, so
+        folding it in makes a malformed request answer 422 instead of 401).
+  - [ ] Every group except `bot_logs` is mounted with `_USER_SCOPED` and
+        `USER_SCOPED_ERROR_RESPONSES`; `bot_logs` keeps `_PUBLIC_AUTH` and
+        `ERROR_RESPONSES`.
+  - [ ] **Resolved against the generated document:** the 11 body operations do
+        not end up advertising the query parameter *as well as* the body field.
+        Pick one — exclude them from the router-level dependency, or accept the
+        duplicate — implement it, and write the reason in the comment.
+  - [ ] The module docstring carries the placement rule next to the addressing
+        rule, phrased so a new endpoint's author can apply it without reading
+        this spec.
+- **Depends on:** Tasks 1, 2
+
+## Task 4: Convert the 49 query-parameter operations
+
+- **Goal:** Every operation that takes its user id from the query string reads it
+  from `UserIdDep` instead of from the principal.
+- **Files:** `…/openapi_v1/{bots,mcp,resources,routines,skills,identity}/router.py`,
+  `…/openapi_v1/engine_runtime/{sessions,engine,models,approvals,connection}/router.py`
+- **Done when:**
+  - [ ] No router imports `caller_owner_id`; `principal.py` is its only caller.
+  - [ ] Handlers that used the value take `UserIdDep` in the position
+        `principal: PrincipalDep` occupied, and pass it where `owner_id` /
+        `actor_id` went.
+  - [ ] The 8 that do not use it (`check_bot_name`; `list_mcp_servers`,
+        `list_mcp_tenants`, `get_mcp_server`; `list_resources`,
+        `create_resource`, `get_resource`, `update_resource`) declare it and
+        `del` it with a one-line reason — the shape `bot_logs/router.py:44` uses.
+  - [ ] Every module docstring or comment that describes identity as coming from
+        the principal is corrected (`bots`, `mcp`, `resources`, `routines`,
+        `identity`, `dependencies.py`).
+  - [ ] `ruff check --select E,F,W` is clean on the package, with no dead import
+        left behind and no new `E501`.
+- **Depends on:** Task 3
+
+## Task 5: Convert the 11 body operations, and move `bot_id` with them
+
+- **Goal:** Requests whose body this API defines name their user — and their bot,
+  where it was a query parameter — in that body.
+- **Files:** `…/openapi_v1/{bots,resources,routines,identity,mcp}/schemas.py`,
+  `…/engine_runtime/{sessions,approvals}/schemas.py`, and the 11 handlers in the
+  matching routers
+- **Done when:**
+  - [ ] All 11 models declare a required `user_id: str` (min length 1), with the
+        same description text as the query parameter.
+  - [ ] `ResourceCreate`, `ResourceUpdate` and `RoutineUpdate` declare a required
+        `bot_id`, and their handlers drop the `bot_id: str = Query(...)`
+        parameter. `RoutineCreate` is left as it is — it already complies.
+  - [ ] Each of the 11 handlers resolves via
+        `resolve_request_user(principal, body.user_id)` and keeps
+        `principal: PrincipalDep`.
+  - [ ] `SessionCreate`'s comment — "No user_id / engine fields: the caller is
+        the authenticated principal" — is rewritten; `engine` stays rejected by
+        `extra="forbid"`.
+  - [ ] Nothing forwards `body.user_id` downstream un-adjudicated: the relay
+        bodies in `sessions`/`approvals` still send the resolved value.
+- **Depends on:** Task 3
+
+## Task 6: Bring the existing suite to the new contract
+
+- **Goal:** The 499 existing openapi_v1 tests exercise the new request shape, and
+  the two that assert the old contract are inverted deliberately rather than
+  deleted.
+- **Files:** `src/backend/tests/community/adapters/http/openapi_v1/**`
+- **Done when:**
+  - [ ] Query-carried operations are covered by setting the default parameter
+        once per client (`client.params = {"user_id": …}`), after confirming
+        httpx merges it — if it does not, a helper does the same job in one
+        place rather than at 232 call sites.
+  - [ ] Body-carried tests send `user_id` (and `bot_id` where it moved).
+  - [ ] `test_sessions.py:507` and `test_approvals.py:94` assert 403 for another
+        user's id and still assert 422 for `engine` / unknown fields, with a
+        comment explaining the inversion.
+  - [ ] The four `principal=None` cases in `resources/test_resources_handlers.py`
+        exercise the seam rather than four handlers, and still pin "no silent
+        bot-derived owner".
+  - [ ] Direct-invocation tests (`identity`, `routines`, `resources`) pass the
+        resolved id, and their docstrings no longer describe a principal
+        argument.
+  - [ ] Pre-handler failures are answered by importing `app.py`'s real handlers,
+        not by re-implementing them in a fixture.
+  - [ ] `pytest tests/community/adapters/http/openapi_v1/` is green.
+- **Depends on:** Tasks 4, 5
+
+## Task 7: Pin the contract with a convention test
+
+- **Goal:** A later operation that breaks the rule fails the build, not review.
+- **Files:**
+  `src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py`
+  (new)
+- **Done when:** asserted against the generated document, in the shape of
+  `test_path_convention.py`:
+  - [ ] All 60 non-Bot-Logs operations require a `user_id`; none of the 5 Bot
+        Logs ones gains one.
+  - [ ] Placement follows the rule: `$ref`-bodied operations carry it in the
+        body, every other operation in the query string — and never both.
+  - [ ] `bot_id` sits wherever `user_id` sits on the same operation, when it is a
+        parameter at all; path `{bot_id}` is exempt.
+  - [ ] 403 is documented on exactly the 60, and `403 not in ERROR_RESPONSES`.
+  - [ ] Behaviour: another user's id is 403 on **both** the query and the body
+        path; two rejected ids give byte-identical bodies; a missing parameter is
+        422; no verified caller is 401 **even when the parameter is also
+        missing**.
+- **Depends on:** Task 6
+
+## Task 8: Write the rule where the next author will find it
+
+- **Goal:** The convention is documented, not just enforced.
+- **Files:** `src/backend/docs/openapi-v1/README.md` (and the `.zh-CN` counterpart
+  if it mirrors this section)
+- **Done when:**
+  - [ ] The placement rule, the three body-less exceptions, and the 403 are
+        described in the handoff doc.
+  - [ ] The changelog and status board record this change, per the doc's own
+        "if your change moved a checkbox, move it here too" rule.
+  - [ ] The doc says plainly what did **not** change: who may call, and what a
+        request with no verified user principal answers.
+- **Depends on:** Task 7
+
+## Task 9: Tests & Verification
+
+- **Goal:** Ensure the feature meets the spec's acceptance criteria.
+- **Files:** —
+- **Done when:**
+  - [ ] Every acceptance criterion in `spec.md` checks off, including the
+        negative ones (internal `/api` untouched; Bot Logs untouched).
+  - [ ] `pytest tests/community` is green — not just the openapi_v1 subtree.
+  - [ ] `scripts/ci/python_sast_local.sh src/backend` passes.
+  - [ ] Changed-line coverage meets the backend gate.
+  - [ ] The generated document is diffed against `HEAD` and every change is one
+        this spec asked for — no accidental schema or path drift.
+  - [ ] Anything that could not be run locally is named explicitly, with why.
+- **Depends on:** Task 8
+
+---
+
+## Groups
+
+- **Group A — The seam:** Tasks 1, 2, 3
+  - Theme: one place to ask "which user, and may you?", the 403 it raises, and
+    the assembly that puts it on every user-scoped route. Nothing else moves, so
+    the surface still behaves exactly as before this group.
+- **Group B — The 60 operations:** Tasks 4, 5
+  - Theme: every handler takes its user from the request. Mechanical and large,
+    but one shape per operation; reviewable as two diffs split by placement.
+- **Group C — Tests:** Tasks 6, 7
+  - Theme: the existing suite moved to the new contract, and a convention test
+    that makes the rule survive the next endpoint.
+- **Group D — Docs and verification:** Tasks 8, 9
+  - Theme: write the rule down where it will be read, then check the whole thing
+    against the spec.

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -119,6 +119,11 @@
 - **Files:**
   `src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py`
   (new)
+- **Note:** the *behavioural* half of this file was pulled forward into Group A
+  (commit "cover the user-id seam"), because the changed-line coverage gate fails
+  a group that adds code whose tests land two groups later. What remains here is
+  the document-level half — the assertions that need the operations to actually
+  carry the parameter.
 - **Done when:** asserted against the generated document, in the shape of
   `test_path_convention.py`:
   - [ ] All 56 user-scoped operations require `user_id`, and it is `in: query` on
@@ -129,9 +134,9 @@
   - [ ] `bot_id`'s placement is unchanged from `HEAD` on all 65 operations.
   - [ ] Bot Logs gains nothing: no parameter, no 403.
   - [ ] 403 is documented on exactly the 56, and `403 not in ERROR_RESPONSES`.
-  - [ ] Behaviour: another user's id is 403; two rejected ids give
+  - [x] Behaviour: another user's id is 403; two rejected ids give
         byte-identical bodies; a missing parameter is 422; no verified caller is
-        401 **even when the parameter is also missing**.
+        401 **even when the parameter is also missing**. _(landed in Group A)_
 - **Depends on:** Task 5
 
 ## Task 7: Write the rule where the next author will find it

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -113,7 +113,7 @@
   - [x] `pytest tests/community/adapters/http/openapi_v1/` is green.
 - **Depends on:** Tasks 3, 4
 
-## Task 6: Pin the contract with a convention test
+## Task 6: Pin the contract with a convention test  [x]
 
 - **Goal:** A later operation that breaks the rule fails the build, not review.
 - **Files:**
@@ -126,14 +126,14 @@
   carry the parameter.
 - **Done when:** asserted against the generated document, in the shape of
   `test_path_convention.py`:
-  - [ ] All 56 user-scoped operations require `user_id`, and it is `in: query` on
+  - [x] All 56 user-scoped operations require `user_id`, and it is `in: query` on
         every one.
-  - [ ] The exempt set is *exactly* the four documented addresses — a fifth fails
+  - [x] The exempt set is *exactly* the four documented addresses — a fifth fails
         here.
-  - [ ] `user_id` appears in no request body schema and in no path template.
-  - [ ] `bot_id`'s placement is unchanged from `HEAD` on all 65 operations.
-  - [ ] Bot Logs gains nothing: no parameter, no 403.
-  - [ ] 403 is documented on exactly the 56, and `403 not in ERROR_RESPONSES`.
+  - [x] `user_id` appears in no request body schema and in no path template.
+  - [x] `bot_id`'s placement is unchanged from `HEAD` on all 65 operations.
+  - [x] Bot Logs gains nothing: no parameter, no 403.
+  - [x] 403 is documented on exactly the 56, and `403 not in ERROR_RESPONSES`.
   - [x] Behaviour: another user's id is 403; two rejected ids give
         byte-identical bodies; a missing parameter is 422; no verified caller is
         401 **even when the parameter is also missing**. _(landed in Group A)_

--- a/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
+++ b/src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/tasks.md
@@ -12,116 +12,93 @@
   `…/openapi_v1/responses.py`,
   `src/backend/src/agentclaw/community/adapters/http/app.py`
 - **Done when:**
-  - [ ] `resolve_request_user(principal, claimed)` returns the id when it equals
-        the caller's, raises `MissingPrincipalError` when there is no verified
-        caller, and raises `UserIdMismatchError` otherwise.
+  - [ ] `require_user_id` reads a required `user_id` query parameter, returns it
+        when it equals the caller's id, raises `MissingPrincipalError` when there
+        is no verified caller, and raises `UserIdMismatchError` otherwise.
+  - [ ] `UserIdDep` is exported for routers to declare.
   - [ ] Both ids are on a `logger.warning` line at the point of refusal; neither
         appears in any response.
-  - [ ] `require_user_id` / `UserIdDep` read `user_id` from the query string and
-        delegate the decision to `resolve_request_user`.
   - [ ] `UserIdMismatchError` maps to `(403, "Forbidden")` in `ENVELOPE_ERRORS`,
         and `app.py` registers a concrete-type handler for it beside
         `_principal_error_handler` — with the reason in the docstring.
-  - [ ] `principal.py`'s module docstring states the placement rule and says
-        this function is what delegation changes.
+  - [ ] `principal.py`'s module docstring states the placement rule, why the
+        query string and not a body or a path, and that this function is what
+        delegation changes.
 - **Depends on:** —
 
-## Task 2: Document the 403 without claiming it surface-wide
+## Task 2: Document the 403 on exactly the operations that can return it
 
-- **Goal:** Only the operations that can return a 403 advertise one.
-- **Files:** `…/openapi_v1/contracts.py`
+- **Goal:** The published description matches what each operation actually does.
+- **Files:** `…/openapi_v1/contracts.py`, `…/openapi_v1/__init__.py`
 - **Done when:**
-  - [ ] `USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: …}` exists.
-  - [ ] `ENGINE_RUNTIME_ERROR_RESPONSES` is built from it, not from
-        `ERROR_RESPONSES`.
+  - [ ] `USER_SCOPED_ERROR_RESPONSES = {**ERROR_RESPONSES, 403: …}` and a
+        `USER_SCOPED_403` single-entry dict for per-route merging.
+  - [ ] `ENGINE_RUNTIME_ERROR_RESPONSES` is built from the user-scoped set.
   - [ ] `403` is **not** in `ERROR_RESPONSES`; the comment says why
         (`test_openapi_error_schema.py:55` requires every operation to document
         every status in that dict, and Bot Logs cannot return one).
-  - [ ] `tests/…/openapi_v1/test_openapi_error_schema.py` still passes untouched.
+  - [ ] `build_public_router` attaches the user-scoped table to the nine groups
+        with no exemption, and leaves `bots` / `mcp` / `bot_logs` on
+        `ERROR_RESPONSES`.
+  - [ ] The `__init__.py` module docstring carries the placement rule next to the
+        addressing rule, phrased so a new endpoint's author can apply it without
+        reading this spec — including the four exemptions and why they are
+        exempt.
+  - [ ] `test_openapi_error_schema.py` still passes untouched.
 - **Depends on:** Task 1
 
-## Task 3: Wire the dependency per group, and settle the double-declaration
+## Task 3: Convert the 41 operations in the nine unexempted groups
 
-- **Goal:** Every user-scoped route requires the parameter by assembly, not by
-  each handler remembering; Bot Logs is left alone.
-- **Files:** `…/openapi_v1/__init__.py`
-- **Done when:**
-  - [ ] `_USER_SCOPED = [*_PUBLIC_AUTH, Depends(require_user_id)]`, with the
-        comment recording why `require_principal` stays declared independently
-        (FastAPI skips a dependency whose own parameters failed to validate, so
-        folding it in makes a malformed request answer 422 instead of 401).
-  - [ ] Every group except `bot_logs` is mounted with `_USER_SCOPED` and
-        `USER_SCOPED_ERROR_RESPONSES`; `bot_logs` keeps `_PUBLIC_AUTH` and
-        `ERROR_RESPONSES`.
-  - [ ] **Resolved against the generated document:** the 11 body operations do
-        not end up advertising the query parameter *as well as* the body field.
-        Pick one — exclude them from the router-level dependency, or accept the
-        duplicate — implement it, and write the reason in the comment.
-  - [ ] The module docstring carries the placement rule next to the addressing
-        rule, phrased so a new endpoint's author can apply it without reading
-        this spec.
-- **Depends on:** Tasks 1, 2
-
-## Task 4: Convert the 49 query-parameter operations
-
-- **Goal:** Every operation that takes its user id from the query string reads it
-  from `UserIdDep` instead of from the principal.
-- **Files:** `…/openapi_v1/{bots,mcp,resources,routines,skills,identity}/router.py`,
+- **Goal:** Every operation in a group with no exemption takes its user from the
+  request.
+- **Files:** `…/openapi_v1/{resources,routines,skills,identity}/router.py`,
   `…/openapi_v1/engine_runtime/{sessions,engine,models,approvals,connection}/router.py`
 - **Done when:**
-  - [ ] No router imports `caller_owner_id`; `principal.py` is its only caller.
-  - [ ] Handlers that used the value take `UserIdDep` in the position
-        `principal: PrincipalDep` occupied, and pass it where `owner_id` /
-        `actor_id` went.
-  - [ ] The 8 that do not use it (`check_bot_name`; `list_mcp_servers`,
-        `list_mcp_tenants`, `get_mcp_server`; `list_resources`,
+  - [ ] Handlers take `user_id: UserIdDep` in the position `principal:
+        PrincipalDep` occupied, and pass it where `owner_id` / `actor_id` went.
+  - [ ] The four `resources` handlers that do not use it (`list_resources`,
         `create_resource`, `get_resource`, `update_resource`) declare it and
-        `del` it with a one-line reason — the shape `bot_logs/router.py:44` uses.
-  - [ ] Every module docstring or comment that describes identity as coming from
-        the principal is corrected (`bots`, `mcp`, `resources`, `routines`,
-        `identity`, `dependencies.py`).
-  - [ ] `ruff check --select E,F,W` is clean on the package, with no dead import
-        left behind and no new `E501`.
-- **Depends on:** Task 3
+        `del` it, with a comment saying they are the *not-yet-enforced* case —
+        the gap `specs/2026-08-02-public-api-user-only-principal/` records — not
+        the no-user-dimension case.
+  - [ ] No router in this set imports `caller_owner_id`.
+  - [ ] Every module docstring or comment describing identity as coming from the
+        principal is corrected.
+  - [ ] `ruff check --select E,F,W` is clean on the package: no dead import left
+        behind, no new `E501`.
+- **Depends on:** Task 2
 
-## Task 5: Convert the 11 body operations, and move `bot_id` with them
+## Task 4: Convert `bots` and `mcp`, and leave the four exemptions alone
 
-- **Goal:** Requests whose body this API defines name their user — and their bot,
-  where it was a query parameter — in that body.
-- **Files:** `…/openapi_v1/{bots,resources,routines,identity,mcp}/schemas.py`,
-  `…/engine_runtime/{sessions,approvals}/schemas.py`, and the 11 handlers in the
-  matching routers
+- **Goal:** The two groups that mix scoped and unscoped operations, done
+  deliberately rather than in bulk.
+- **Files:** `…/openapi_v1/bots/router.py`, `…/openapi_v1/mcp/router.py`
 - **Done when:**
-  - [ ] All 11 models declare a required `user_id: str` (min length 1), with the
-        same description text as the query parameter.
-  - [ ] `ResourceCreate`, `ResourceUpdate` and `RoutineUpdate` declare a required
-        `bot_id`, and their handlers drop the `bot_id: str = Query(...)`
-        parameter. `RoutineCreate` is left as it is — it already complies.
-  - [ ] Each of the 11 handlers resolves via
-        `resolve_request_user(principal, body.user_id)` and keeps
-        `principal: PrincipalDep`.
-  - [ ] `SessionCreate`'s comment — "No user_id / engine fields: the caller is
-        the authenticated principal" — is rewritten; `engine` stays rejected by
-        `extra="forbid"`.
-  - [ ] Nothing forwards `body.user_id` downstream un-adjudicated: the relay
-        bodies in `sessions`/`approvals` still send the resolved value.
-- **Depends on:** Task 3
+  - [ ] 12 of 13 `bots` handlers and 3 of 6 `mcp` handlers take `user_id:
+        UserIdDep` and carry `responses=USER_SCOPED_403` on their route
+        decorator, merged with any `responses=` already there.
+  - [ ] `check_bot_name`, `list_mcp_servers`, `list_mcp_tenants` and
+        `get_mcp_server` are **unchanged on the wire**: no `user_id` parameter,
+        no 403 documented. Their `caller_owner_id(principal)` assertion is
+        replaced by nothing — `_PUBLIC_AUTH` already requires the caller — and a
+        comment records that they have no user dimension, with the reason.
+  - [ ] `caller_owner_id` is imported by `principal.py` alone; the routers no
+        longer reference it.
+  - [ ] The generated document shows exactly four `/openapi/v1/bots/**`
+        operations without `user_id`, and they are those four.
+- **Depends on:** Task 2
 
-## Task 6: Bring the existing suite to the new contract
+## Task 5: Bring the existing suite to the new contract
 
-- **Goal:** The 499 existing openapi_v1 tests exercise the new request shape, and
-  the two that assert the old contract are inverted deliberately rather than
-  deleted.
+- **Goal:** The 499 existing openapi_v1 tests exercise the new request shape.
 - **Files:** `src/backend/tests/community/adapters/http/openapi_v1/**`
 - **Done when:**
-  - [ ] Query-carried operations are covered by setting the default parameter
-        once per client (`client.params = {"user_id": …}`), after confirming
-        httpx merges it — if it does not, a helper does the same job in one
-        place rather than at 232 call sites.
-  - [ ] Body-carried tests send `user_id` (and `bot_id` where it moved).
-  - [ ] `test_sessions.py:507` and `test_approvals.py:94` assert 403 for another
-        user's id and still assert 422 for `engine` / unknown fields, with a
-        comment explaining the inversion.
+  - [ ] Confirm `httpx` merges a client's default `params` into every request; if
+        it does, set `client.params = {"user_id": …}` once per `TestClient`, and
+        if not, add one helper that does the same job in one place.
+  - [ ] Tests for the four exempt operations do **not** send the parameter, and
+        one asserts that sending it is still accepted as an unknown query
+        parameter rather than becoming a silent scope.
   - [ ] The four `principal=None` cases in `resources/test_resources_handlers.py`
         exercise the seam rather than four handlers, and still pin "no silent
         bot-derived owner".
@@ -130,10 +107,13 @@
         argument.
   - [ ] Pre-handler failures are answered by importing `app.py`'s real handlers,
         not by re-implementing them in a fixture.
+  - [ ] `test_sessions.py:507` and `test_approvals.py:94` are **unchanged and
+        green** — a caller-supplied `user_id` in the body is still a 422, because
+        the body still forbids it. Confirm this rather than assuming it.
   - [ ] `pytest tests/community/adapters/http/openapi_v1/` is green.
-- **Depends on:** Tasks 4, 5
+- **Depends on:** Tasks 3, 4
 
-## Task 7: Pin the contract with a convention test
+## Task 6: Pin the contract with a convention test
 
 - **Goal:** A later operation that breaks the rule fails the build, not review.
 - **Files:**
@@ -141,62 +121,69 @@
   (new)
 - **Done when:** asserted against the generated document, in the shape of
   `test_path_convention.py`:
-  - [ ] All 60 non-Bot-Logs operations require a `user_id`; none of the 5 Bot
-        Logs ones gains one.
-  - [ ] Placement follows the rule: `$ref`-bodied operations carry it in the
-        body, every other operation in the query string — and never both.
-  - [ ] `bot_id` sits wherever `user_id` sits on the same operation, when it is a
-        parameter at all; path `{bot_id}` is exempt.
-  - [ ] 403 is documented on exactly the 60, and `403 not in ERROR_RESPONSES`.
-  - [ ] Behaviour: another user's id is 403 on **both** the query and the body
-        path; two rejected ids give byte-identical bodies; a missing parameter is
-        422; no verified caller is 401 **even when the parameter is also
-        missing**.
-- **Depends on:** Task 6
+  - [ ] All 56 user-scoped operations require `user_id`, and it is `in: query` on
+        every one.
+  - [ ] The exempt set is *exactly* the four documented addresses — a fifth fails
+        here.
+  - [ ] `user_id` appears in no request body schema and in no path template.
+  - [ ] `bot_id`'s placement is unchanged from `HEAD` on all 65 operations.
+  - [ ] Bot Logs gains nothing: no parameter, no 403.
+  - [ ] 403 is documented on exactly the 56, and `403 not in ERROR_RESPONSES`.
+  - [ ] Behaviour: another user's id is 403; two rejected ids give
+        byte-identical bodies; a missing parameter is 422; no verified caller is
+        401 **even when the parameter is also missing**.
+- **Depends on:** Task 5
 
-## Task 8: Write the rule where the next author will find it
+## Task 7: Write the rule where the next author will find it
 
 - **Goal:** The convention is documented, not just enforced.
-- **Files:** `src/backend/docs/openapi-v1/README.md` (and the `.zh-CN` counterpart
-  if it mirrors this section)
+- **Files:** `src/backend/docs/openapi-v1/README.md` (and the `.zh-CN`
+  counterpart if it mirrors this section)
 - **Done when:**
-  - [ ] The placement rule, the three body-less exceptions, and the 403 are
-        described in the handoff doc.
+  - [ ] The placement rule, the four exemptions with a reason each, and the 403
+        are described in the handoff doc.
+  - [ ] The rejected alternatives are recorded in one short paragraph — body
+        field, path segment, header — so the question is not reopened from
+        scratch.
   - [ ] The changelog and status board record this change, per the doc's own
         "if your change moved a checkbox, move it here too" rule.
   - [ ] The doc says plainly what did **not** change: who may call, and what a
         request with no verified user principal answers.
-- **Depends on:** Task 7
+- **Depends on:** Task 6
 
-## Task 9: Tests & Verification
+## Task 8: Tests & Verification
 
 - **Goal:** Ensure the feature meets the spec's acceptance criteria.
 - **Files:** —
 - **Done when:**
   - [ ] Every acceptance criterion in `spec.md` checks off, including the
-        negative ones (internal `/api` untouched; Bot Logs untouched).
+        negative ones (internal `/api` untouched; Bot Logs untouched; `bot_id`
+        untouched).
   - [ ] `pytest tests/community` is green — not just the openapi_v1 subtree.
   - [ ] `scripts/ci/python_sast_local.sh src/backend` passes.
   - [ ] Changed-line coverage meets the backend gate.
   - [ ] The generated document is diffed against `HEAD` and every change is one
-        this spec asked for — no accidental schema or path drift.
+        this spec asked for: 56 added query parameters, 56 added 403s, and
+        nothing else — no schema, path, or `bot_id` drift.
   - [ ] Anything that could not be run locally is named explicitly, with why.
-- **Depends on:** Task 8
+- **Depends on:** Task 7
 
 ---
 
 ## Groups
 
-- **Group A — The seam:** Tasks 1, 2, 3
+- **Group A — The seam:** Tasks 1, 2
   - Theme: one place to ask "which user, and may you?", the 403 it raises, and
-    the assembly that puts it on every user-scoped route. Nothing else moves, so
-    the surface still behaves exactly as before this group.
-- **Group B — The 60 operations:** Tasks 4, 5
-  - Theme: every handler takes its user from the request. Mechanical and large,
-    but one shape per operation; reviewable as two diffs split by placement.
-- **Group C — Tests:** Tasks 6, 7
+    where that 403 is documented. Nothing calls it yet, so the surface behaves
+    exactly as before this group.
+- **Group B — The 56 operations:** Tasks 3, 4
+  - Theme: every user-scoped handler takes its user from the request. Split by
+    group shape — the nine clean groups in one diff, the two mixed ones in
+    another, so the four exemptions get their own review rather than being
+    buried in a bulk change.
+- **Group C — Tests:** Tasks 5, 6
   - Theme: the existing suite moved to the new contract, and a convention test
     that makes the rule survive the next endpoint.
-- **Group D — Docs and verification:** Tasks 8, 9
+- **Group D — Docs and verification:** Tasks 7, 8
   - Theme: write the rule down where it will be read, then check the whole thing
     against the spec.

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -328,6 +328,7 @@ from agentclaw.community.adapters.http.error_logging import (  # noqa: E402
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import (  # noqa: E402
     MissingPrincipalError,
+    UserIdMismatchError,
 )
 from agentclaw.community.core.gateway_principal import (  # noqa: E402
     PrincipalVerificationError,
@@ -601,6 +602,39 @@ async def _principal_error_handler(request: Request, exc: Exception) -> JSONResp
     return JSONResponse(
         status_code=401,
         content={"detail": "Unauthorized"},
+        headers=_trace_headers(request),
+    )
+
+
+@app.exception_handler(UserIdMismatchError)
+async def _user_id_mismatch_handler(
+    request: Request, exc: UserIdMismatchError,
+) -> JSONResponse:
+    """Answer a request that named a user its caller may not act for — 403.
+
+    Registered as a concrete type for the same reason as the handler above: it
+    is raised in ``require_user_id``, a **dependency** every user-scoped public
+    route declares, so ``@envelope_errors`` never sees it and letting it reach
+    the ``Exception`` catch-all would answer correctly and then re-raise through
+    ``ServerErrorMiddleware``, adding an ASGI traceback to every occurrence.
+
+    Which ids disagreed is already logged by ``require_user_id``; this line
+    records that the request was refused, and where.
+    """
+    logger.warning(
+        "[Public 403] %s on %s %s: %s%s",
+        type(exc).__name__, request.method, request.url.path, exc,
+        params_suffix(request),
+    )
+    mapped = _public_mapped_error(request, exc)
+    if mapped is not None:
+        return mapped
+    # Unreachable while the dependency is only mounted on the public surface;
+    # kept so a future internal caller of the same seam gets the ``{"detail":
+    # ...}`` shape its clients parse rather than an Envelope.
+    return JSONResponse(
+        status_code=403,
+        content={"detail": "Forbidden"},
         headers=_trace_headers(request),
     )
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -29,6 +29,33 @@ whose id equals a component name is unreachable at that address. The reserved
 names are fixed and documented in ``docs/openapi-v1/README.md``; a test asserts
 the doc's list still equals the routes'.
 
+Naming the end user
+-------------------
+
+Every operation that scopes to a user takes a required **``user_id`` query
+parameter** — whatever the method, whatever the body. It is never a body field
+and never a path segment: it is not an attribute of any resource here, it is who
+the call is for, so a body (which describes the resource) and a path (which
+names it) are both the wrong place. ``bot_id`` is unaffected — it stays in the
+path where it addresses a bot and in the query string where it is a parameter.
+The full reasoning is in ``principal.py``; handlers declare ``UserIdDep``.
+
+Four operations are exempt because they have no user dimension to scope by:
+``check_bot_name`` answers a tenant-wide uniqueness question, and
+``list_mcp_servers`` / ``list_mcp_tenants`` / ``get_mcp_server`` read a
+marketplace catalogue that is identical for every caller in the tenant. They
+still require an authenticated caller — ``_PUBLIC_AUTH`` below — they just have
+no user-shaped answer to give. The Bot Logs group is separate again: it never
+derived a user from the credential, and its one user-scoped query already names
+its user explicitly.
+
+Because of those exemptions the dependency is declared **per handler**, not per
+group: two of the four sit inside groups whose other routes do take it (1 of 13
+in ``bots``, 3 of 6 in ``mcp``), so a group-level dependency would put the
+parameter on them. ``test_explicit_user_id.py`` is what makes a new route
+impossible to forget — the same trade ``test_path_convention.py`` makes for the
+addressing rule above.
+
 Mount order
 -----------
 
@@ -46,7 +73,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from .bots import router as bots_router
-from .contracts import ENGINE_RUNTIME_ERROR_RESPONSES, ERROR_RESPONSES
+from .contracts import (
+    ENGINE_RUNTIME_ERROR_RESPONSES,
+    ERROR_RESPONSES,
+    USER_SCOPED_ERROR_RESPONSES,
+)
 from .dependencies import require_principal
 from .engine_runtime.approvals import router as engine_approvals_router
 from .engine_runtime.connection import router as engine_connection_router
@@ -65,12 +96,25 @@ from .skills import router as skills_router
 # only on this surface).
 PUBLIC_API_PREFIX = "/openapi/v1"
 
+# The groups that answer no 403, because no route in them takes a `user_id`:
+# Bot Logs never derived a user from the credential at all. Mounted with the
+# other literal sub-groups, for the ordering reason above.
+_GROUPS_WITHOUT_USER_ID = [
+    logs_router,
+]
+
+# The groups where SOME routes take a `user_id` and some do not — `bots`
+# (12 of 13) and `mcp` (3 of 6). They keep the surface-wide response table here
+# and declare the 403 per route, so the four exempt operations do not advertise
+# a failure they cannot produce. See "Naming the end user" above.
+_MIXED_GROUPS = [
+    mcp_router,
+]
+
 # Order matters: literal sub-groups first, the `{bot_id}` wildcard group last.
 # See "Mount order" above for which literals actually depend on it.
 _SUBGROUPS = [
-    logs_router,
     identity_router,
-    mcp_router,
     resources_router,
     routines_router,
     skills_router,
@@ -109,15 +153,24 @@ _PUBLIC_AUTH = [Depends(require_principal)]
 def build_public_router() -> APIRouter:
     """Assemble the ``/openapi/v1/bots`` public router.
 
-    ``ERROR_RESPONSES`` and ``_PUBLIC_AUTH`` are attached here rather than on
+    The response tables and ``_PUBLIC_AUTH`` are attached here rather than on
     each handler so the published schema documents the envelope this surface
     actually returns on failure, and so every route requires an authenticated
     caller — every group, every route, one declaration.
+
+    Which response table a group gets depends on whether all of its routes are
+    user-scoped. The two mixed groups declare their 403 per route instead; the
+    ``user_id`` parameter itself is always per handler (see "Naming the end
+    user" above).
     """
     public = APIRouter()
-    for router in _SUBGROUPS:
+    for router in _GROUPS_WITHOUT_USER_ID + _MIXED_GROUPS:
         public.include_router(
             router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
+        )
+    for router in _SUBGROUPS:
+        public.include_router(
+            router, responses=USER_SCOPED_ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
         )
     for router in _ENGINE_RUNTIME_GROUPS:
         public.include_router(
@@ -125,6 +178,7 @@ def build_public_router() -> APIRouter:
             responses=ENGINE_RUNTIME_ERROR_RESPONSES,
             dependencies=_PUBLIC_AUTH,
         )
+    # `bots` is mixed too, but stays last for the wildcard-ordering rule above.
     public.include_router(
         bots_router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -45,9 +45,15 @@ Four operations are exempt because they have no user dimension to scope by:
 ``list_mcp_servers`` / ``list_mcp_tenants`` / ``get_mcp_server`` read a
 marketplace catalogue that is identical for every caller in the tenant. They
 still require an authenticated caller — ``_PUBLIC_AUTH`` below — they just have
-no user-shaped answer to give. The Bot Logs group is separate again: it never
-derived a user from the credential, and its one user-scoped query already names
-its user explicitly.
+no user-shaped answer to give.
+
+The Bot Logs group is a different exclusion, and the sharpest thing to know
+about this rule. ``GET …/bots/logs/traces`` already takes a required
+``user_id`` — but there it means *whose traces to read*, a filter, and any
+caller presenting both a user and an App identity may name someone else's. Here
+it means *whose call this is*, and naming someone else is a 403. Same spelling,
+opposite contract, and the published document will carry both. Do not "unify"
+them without deciding which meaning the address should have.
 
 Because of those exemptions the dependency is declared **per handler**, not per
 group: two of the four sit inside groups whose other routes do take it (1 of 13
@@ -96,10 +102,19 @@ from .skills import router as skills_router
 # only on this surface).
 PUBLIC_API_PREFIX = "/openapi/v1"
 
-# The groups that answer no 403, because no route in them takes a `user_id`:
-# Bot Logs never derived a user from the credential at all. Mounted with the
-# other literal sub-groups, for the ordering reason above.
-_GROUPS_WITHOUT_USER_ID = [
+# The groups that answer no 403, because no route in them is scoped by the
+# *caller's* user: Bot Logs never derived a user from the credential at all.
+#
+# It is not that Bot Logs has no `user_id` — `GET …/bots/logs/traces` has taken
+# a required one since #692. It means something else there, and the difference
+# is why that group stays out of this rule rather than being folded into it: on
+# the rest of the surface `user_id` is *whose call this is*, and must be the
+# caller (403 otherwise); on that one operation it is *whose traces to read*, a
+# filter over a tenant-level observability surface that already requires both a
+# user and an App identity (`route_security`, `require_user_and_app_principal`).
+# Bringing it under this rule would remove a capability that route exists to
+# provide. See the note in the spec's Out of Scope.
+_GROUPS_WITHOUT_CALLER_SCOPE = [
     logs_router,
 ]
 
@@ -111,8 +126,11 @@ _MIXED_GROUPS = [
     mcp_router,
 ]
 
-# Order matters: literal sub-groups first, the `{bot_id}` wildcard group last.
-# See "Mount order" above for which literals actually depend on it.
+# Order matters: every literal sub-group — these three lists — is registered
+# before the `{bot_id}` wildcard group, which `build_public_router` mounts last.
+# See "Mount order" above for which literals actually depend on it. Splitting the
+# literals across three lists is about which *response table* each gets; it does
+# not change that they all precede `bots`.
 _SUBGROUPS = [
     identity_router,
     resources_router,
@@ -164,7 +182,7 @@ def build_public_router() -> APIRouter:
     user" above).
     """
     public = APIRouter()
-    for router in _GROUPS_WITHOUT_USER_ID + _MIXED_GROUPS:
+    for router in _GROUPS_WITHOUT_CALLER_SCOPE + _MIXED_GROUPS:
         public.include_router(
             router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
         )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
@@ -32,6 +32,9 @@ from agentclaw.community.adapters.http.openapi_v1.clusters import (
     validate_engine_cluster,
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import UnsupportedEngineError
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    require_principal,
+)
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     accepted,
@@ -299,7 +302,16 @@ async def list_bots(
     return page(result["total"], items, request)
 
 
-@router.get("/check-name", response_model=Envelope[NameCheck])
+@router.get(
+    "/check-name",
+    response_model=Envelope[NameCheck],
+    # Authenticated, but not user-scoped. Declared on the route rather than
+    # inherited from ``build_public_router`` so the guard is visible where the
+    # operation is, and so ``test_public_routes_require_principal`` can see it:
+    # that test walks each route's own dependant, which a group-level
+    # dependency does not appear in.
+    dependencies=[Depends(require_principal)],
+)
 @envelope_errors
 async def check_bot_name(
     name: str,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -2,8 +2,10 @@
 
 Public handlers that delegate to the existing internal bot services and wrap the
 result in the standard :class:`Envelope` / :class:`Page` contracts. Identity is
-the caller resolved from ``require_principal`` (owner-scoping, via
-``caller_owner_id``); the request tenant is bound by ``AvernetTenantMiddleware``
+the end user the request names in ``?user_id=`` (owner-scoping, via
+``UserIdDep``) — on 12 of the 13 operations here; ``check-name`` asks a
+tenant-wide question and takes none. The request tenant is bound by
+``AvernetTenantMiddleware``
 before the handler runs, so every service read/write is already tenant-scoped by
 the Track A guard. Services are obtained with ``Injected`` exactly as the
 internal router does.
@@ -11,12 +13,13 @@ internal router does.
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    USER_SCOPED_403,
     Deleted,
     Envelope,
     NameCheck,
@@ -28,12 +31,8 @@ from agentclaw.community.adapters.http.openapi_v1.clusters import (
     cluster_for_engine,
     validate_engine_cluster,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
 from agentclaw.community.adapters.http.openapi_v1.errors import UnsupportedEngineError
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     accepted,
     created,
@@ -86,8 +85,6 @@ from .schemas import (
 logger = get_logger()
 
 router = APIRouter(prefix="/openapi/v1/bots", tags=["bots"])
-
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 
 def _to_bot(d: dict[str, Any]) -> Bot:
@@ -209,6 +206,7 @@ def _sync_passport_identity(
     status_code=201,
     response_model=Envelope[Bot],
     responses={
+        **USER_SCOPED_403,
         202: {
             "model": Envelope[BotAuthPending],
             "description": "Needs user authorization",
@@ -219,7 +217,7 @@ def _sync_passport_identity(
 async def create_bot(
     body: BotCreate,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
@@ -234,7 +232,6 @@ async def create_bot(
     nothing downstream reads that bag yet, so the request model does not expose
     an ``engine_options`` field for it — see :class:`BotCreate`.
     """
-    owner_id = caller_owner_id(principal)
     # Validate the engine against the configured registry FIRST: the cluster rule
     # below treats every non-teclaw value as ACRA, so an unknown engine would
     # otherwise sail through, allocate an id, apply for a Passport, and only fail
@@ -278,19 +275,18 @@ async def create_bot(
     return created(_to_bot(outcome.bot), request)
 
 
-@router.get("", response_model=Envelope[Page[Bot]])
+@router.get("", response_model=Envelope[Page[Bot]], responses=USER_SCOPED_403)
 @envelope_errors
 async def list_bots(
     request: Request,
     page_params: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     keyword: str | None = None,
     engine: str | None = None,
     status: str | None = None,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Page[Bot]]:
     """List the caller's bots (filter + paginate)."""
-    owner_id = caller_owner_id(principal)
     result = bot_service.list_bots_by_conditions(
         owner_id=owner_id,
         bot_name=keyword,
@@ -308,7 +304,6 @@ async def list_bots(
 async def check_bot_name(
     name: str,
     request: Request,
-    principal: PrincipalDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[NameCheck]:
     """Check whether a bot name is available (within the caller's tenant).
@@ -322,17 +317,23 @@ async def check_bot_name(
     The echoed ``name`` is the trimmed form actually checked, so a caller that
     sends ``" Foo "`` sees which string the availability applies to.
     """
-    caller_owner_id(principal)  # require an authenticated caller
+    # No ``user_id``: this operation has no user dimension to scope by. Name
+    # uniqueness is checked across the whole tenant — ``check_bot_name_exists``
+    # takes only the name.
+    # An authenticated caller is still required — ``_PUBLIC_AUTH`` in
+    # ``openapi_v1/__init__.py`` — it just has no user-shaped answer to give,
+    # so asking the caller to name one would be asking for a value this handler
+    # cannot use. See "Naming the end user" there.
     checked = validate_bot_name(name)
     exists = bot_service.check_bot_name_exists(checked)
     return envelope(NameCheck(name=checked, exists=exists), request)
 
 
-@router.get("/ceiling", response_model=Envelope[Ceiling])
+@router.get("/ceiling", response_model=Envelope[Ceiling], responses=USER_SCOPED_403)
 @envelope_errors
 async def get_bots_ceiling(
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Ceiling]:
     """Get the caller's bot-creation quota ceiling.
@@ -343,32 +344,30 @@ async def get_bots_ceiling(
     ``max_devices_per_entity``. Reading it directly would advertise 5 to a caller
     whose deployment allows (or rejects at) a different number.
     """
-    owner_id = caller_owner_id(principal)
     ceiling = bot_service.get_bots_ceiling_for_owner(owner_id)
     return envelope(Ceiling(ceiling=ceiling), request)
 
 
-@router.get("/{bot_id}", response_model=Envelope[Bot])
+@router.get("/{bot_id}", response_model=Envelope[Bot], responses=USER_SCOPED_403)
 @envelope_errors
 async def get_bot(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Bot]:
     """Get a bot's details."""
-    owner_id = caller_owner_id(principal)
     bot = bot_service.get_bot(bot_id, owner_id)
     return envelope(_to_bot(bot), request)
 
 
-@router.put("/{bot_id}", response_model=Envelope[Bot])
+@router.put("/{bot_id}", response_model=Envelope[Bot], responses=USER_SCOPED_403)
 @envelope_errors
 async def update_bot(
     bot_id: str,
     body: BotUpdate,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
 ) -> Envelope[Bot]:
@@ -378,7 +377,6 @@ async def update_bot(
     updatable here; ``engine_options`` is managed via the engine-config
     endpoints. Neither is accepted — see :class:`BotUpdate`.
     """
-    owner_id = caller_owner_id(principal)
     # Same name rule as create and the internal update route — otherwise this
     # surface could persist names the rest of the lifecycle rejects.
     bot_name = validate_bot_name(body.bot_name) if body.bot_name is not None else None
@@ -414,31 +412,33 @@ async def update_bot(
     return envelope(_to_bot(bot), request)
 
 
-@router.delete("/{bot_id}", response_model=Envelope[Deleted])
+@router.delete("/{bot_id}", response_model=Envelope[Deleted], responses=USER_SCOPED_403)
 @envelope_errors
 async def delete_bot(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Deleted]:
     """Delete a bot. See :func:`_reject_unowned_lifecycle` for what is refused."""
-    owner_id = caller_owner_id(principal)
     _reject_unowned_lifecycle(bot_service.get_bot(bot_id, owner_id), deleting=True)
     bot_service.delete_bot(bot_id, owner_id)
     return deleted_envelope(request)
 
 
-@router.post("/{bot_id}/restart", response_model=Envelope[Bot])
+@router.post(
+    "/{bot_id}/restart",
+    response_model=Envelope[Bot],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def restart_bot(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Bot]:
     """Restart a bot. Desktop bots are rejected — see :func:`_reject_unowned_lifecycle`."""
-    owner_id = caller_owner_id(principal)
     _reject_unowned_lifecycle(bot_service.get_bot(bot_id, owner_id))
     bot = bot_service.restart_bot(bot_id, owner_id)
     return envelope(_to_bot(bot), request)
@@ -448,6 +448,7 @@ async def restart_bot(
     "/{bot_id}/auth-status",
     response_model=Envelope[BotAuthStatus],
     responses={
+        **USER_SCOPED_403,
         # This route's 400 is the one documented exception to the surface-wide
         # ErrorEnvelope (whose ``data`` is null): a terminal authorization state
         # is reported as a failure, but the state itself is the actionable part,
@@ -464,7 +465,7 @@ async def restart_bot(
 async def get_bot_auth_status(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     engine: str | None = None,
     # Enum, not a bare str: validate_engine_cluster accepts only ACRA/ANDC,
     # so a plain string would let a generated client compile
@@ -493,7 +494,6 @@ async def get_bot_auth_status(
     personal|service restriction on ``bot_type``. Otherwise the completion path
     would be a way to create exactly the bots ``POST`` rejects.
     """
-    owner_id = caller_owner_id(principal)
     # Validate against the engine completion will actually use, not against the
     # query param: omitting ``engine`` does not mean "no engine", it means the
     # default one. Checking only when ``engine`` was supplied let
@@ -537,16 +537,19 @@ async def get_bot_auth_status(
     return envelope(BotAuthStatus(status=result.status, bot=bot), request)
 
 
-@router.get("/{bot_id}/status", response_model=Envelope[BotStatus])
+@router.get(
+    "/{bot_id}/status",
+    response_model=Envelope[BotStatus],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def get_bot_status(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[BotStatus]:
     """Get a bot's runtime / device readiness."""
-    owner_id = caller_owner_id(principal)
     bot = bot_service.get_bot(bot_id, owner_id)
     binding = bot.get("device_binding") or {}
     return envelope(
@@ -561,17 +564,20 @@ async def get_bot_status(
     )
 
 
-@router.get("/{bot_id}/passport", response_model=Envelope[Passport])
+@router.get(
+    "/{bot_id}/passport",
+    response_model=Envelope[Passport],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def get_bot_passport(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
 ) -> Envelope[Passport]:
     """Get a bot's Agent Passport."""
-    owner_id = caller_owner_id(principal)
     bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard (raises 404)
     info = passport_plugin.query_agent_passport(bot_id=bot_id, owner_workno=owner_id)
     # Either identifier means "a passport exists". Which one is populated is a
@@ -599,19 +605,19 @@ def _engine_config_target(bot: dict[str, Any]) -> tuple[str, str, str]:
 @router.get(
     "/{bot_id}/engine-config",
     response_model=Envelope[dict[str, Any]],
+    responses=USER_SCOPED_403,
 )
 @envelope_errors
 async def get_bot_engine_config(
     bot_id: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     engine_config_service: EngineConfigServiceProtocol = Injected(
         EngineConfigServiceProtocol
     ),
 ) -> Envelope[dict[str, Any]]:
     """Read a bot's engine configuration (free-form JSON)."""
-    owner_id = caller_owner_id(principal)
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
     entity_id, entity_type, engine = _engine_config_target(bot)
     data = await engine_config_service.read_bot_config(
@@ -624,20 +630,20 @@ async def get_bot_engine_config(
 @router.put(
     "/{bot_id}/engine-config",
     response_model=Envelope[dict[str, Any]],
+    responses=USER_SCOPED_403,
 )
 @envelope_errors
 async def update_bot_engine_config(
     bot_id: str,
     body: dict[str, Any],
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     engine_config_service: EngineConfigServiceProtocol = Injected(
         EngineConfigServiceProtocol
     ),
 ) -> Envelope[dict[str, Any]]:
     """Write a bot's engine configuration (free-form JSON)."""
-    owner_id = caller_owner_id(principal)
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
     entity_id, entity_type, engine = _engine_config_target(bot)
     await engine_config_service.write_bot_config(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
@@ -81,14 +81,36 @@ ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
     502: {"model": ErrorEnvelope, "description": "Upstream service error"},
 }
 
+# The extra failure a **user-scoped** route can produce: its ``user_id`` named
+# someone other than the verified caller. Kept out of ``ERROR_RESPONSES`` for the
+# same reason the engine-runtime statuses below are — that dict is applied
+# surface-wide, and the routes that take no ``user_id`` (the Bot Logs group, plus
+# the four catalogue reads with no user dimension) can never answer 403.
+USER_SCOPED_403: dict[int | str, dict[str, object]] = {
+    403: {
+        "model": ErrorEnvelope,
+        "description": "The user_id names a user the authenticated caller may "
+        "not act for",
+    },
+}
+
+# For the nine groups whose every route is user-scoped, applied at assembly.
+USER_SCOPED_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
+    **ERROR_RESPONSES,
+    **USER_SCOPED_403,
+}
+
 # Extra failures only the engine-runtime groups can produce. Attached to those
 # routers, NOT merged into ``ERROR_RESPONSES``: that dict is applied surface-wide
 # in ``build_public_router``, and ``test_openapi_error_schema`` asserts every
 # operation documents every status in it — so adding these there would make the
 # six already-shipped categories advertise a 501 they cannot return, pointing at
 # an endpoint unrelated to them, and generate dead branches in clients.
+#
+# Built on the user-scoped set, not on ``ERROR_RESPONSES``: every engine-runtime
+# route is user-scoped too, so it documents the 403 as well.
 ENGINE_RUNTIME_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
-    **ERROR_RESPONSES,
+    **USER_SCOPED_ERROR_RESPONSES,
     501: {
         "model": ErrorEnvelope,
         "description": "Not supported for this bot — either its engine does not "

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
@@ -11,13 +11,9 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.approvals.schemas import (
     ApprovalModeInfo,
     ApprovalModeSet,
@@ -26,7 +22,7 @@ from agentclaw.community.adapters.http.openapi_v1.engine_runtime.approvals.schem
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
     ApprovalMode,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -43,7 +39,6 @@ from agentclaw.community.di import Injected
 
 router = APIRouter(prefix="/openapi/v1/bots/approvals", tags=["approvals"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 #: Engine capability a mode *change* needs. ``approval.get`` is defined
 #: separately and gates only the read, so this is the one that decides whether
@@ -90,7 +85,7 @@ def _reject_refused_set(raw: Any) -> None:
 @envelope_errors
 async def get_approval_mode(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     session_key: Annotated[str, Query(description="Session to read the mode for.")],
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
@@ -98,7 +93,6 @@ async def get_approval_mode(
     """Read the approval mode in force for a session."""
     # Publicly a GET with a query parameter; the engine models the same read as
     # a POST with a body.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -115,14 +109,13 @@ async def get_approval_mode(
 async def set_approval_mode(
     bot_id: str,
     body: ApprovalModeSet,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[ApprovalState]:
     """Set the approval mode for a session."""
     # The enum's value is forwarded verbatim: all three are already in the
     # engine's accept-set, so no translation is needed and none is applied.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -142,7 +135,7 @@ async def set_approval_mode(
 @envelope_errors
 async def list_approval_modes(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[list[ApprovalModeInfo]]:
@@ -165,7 +158,6 @@ async def list_approval_modes(
     #
     # The list is served from the public enum rather than relayed, because the
     # engine's descriptions are Chinese and this surface promises English.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="approvals")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/router.py
@@ -8,20 +8,15 @@ this API, so the engine's frame format never becomes a public contract.
 from __future__ import annotations
 
 import asyncio
-from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.connection.schemas import (
     Connection,
     Socket,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -33,21 +28,18 @@ from agentclaw.community.di import Injected
 
 router = APIRouter(prefix="/openapi/v1/bots/connection", tags=["connection"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
-
 
 @router.get("/{bot_id}", response_model=Envelope[Connection])
 @envelope_errors
 async def get_connection(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     connections: EngineConnectionServiceProtocol = Injected(
         EngineConnectionServiceProtocol
     ),
 ) -> Envelope[Connection]:
     """Get usable socket connections for a bot."""
-    owner_id = caller_owner_id(principal)
     # No capability probe: the only socket offered is chat, derived from the
     # bot's active engine, which is a backend fact. The terminal socket that
     # once needed one was removed — the spec excludes an interactive shell from

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
@@ -11,21 +11,17 @@ fixed at creation (``PUT /openapi/v1/bots/{bot_id}`` rejects it), and
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.engine.schemas import (
     EngineCapabilities,
     EngineInfo,
     EngineStatus,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -38,8 +34,6 @@ from agentclaw.community.core.engine_runtime.errors import EngineUpstreamError
 from agentclaw.community.di import Injected
 
 router = APIRouter(prefix="/openapi/v1/bots/engine", tags=["engine"])
-
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 
 def _names(raw: Any) -> list[str]:
@@ -61,12 +55,11 @@ def _names(raw: Any) -> list[str]:
 @envelope_errors
 async def get_engine_status(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[EngineStatus]:
     """Runtime state of the bot's engine."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     # enveloped=False: this engine route answers with its status payload raw —
     # no `success` key and no `data` wrapper. The only such route wrapped here.
@@ -93,7 +86,7 @@ async def get_engine_status(
 @envelope_errors
 async def get_engine_capabilities(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[EngineCapabilities]:
@@ -102,7 +95,6 @@ async def get_engine_capabilities(
     The discovery endpoint for these groups: capabilities differ per bot, so the
     same request can succeed for one of your bots and be refused for another.
     """
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -128,13 +120,12 @@ async def get_engine_capabilities(
 @envelope_errors
 async def list_available_engines(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[list[EngineInfo]]:
     """Engines available on this bot, with the active one marked."""
     # Publicly a noun; the engine models the same read under a verb path.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="engine")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
@@ -6,23 +6,19 @@ pre-publication draft workspace; see ``engine_runtime/gating.py``.
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Envelope,
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.models.schemas import (
     Model,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -36,8 +32,6 @@ from agentclaw.community.core.engine_runtime.errors import EngineResourceNotFoun
 from agentclaw.community.di import Injected
 
 router = APIRouter(prefix="/openapi/v1/bots/models", tags=["models"])
-
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 
 def _map_model(data: dict[str, Any]) -> Model:
@@ -53,12 +47,11 @@ def _map_model(data: dict[str, Any]) -> Model:
 async def list_models(
     bot_id: str,
     page: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Page[Model]]:
     """List the models this bot's engine can route to."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="models")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -83,7 +76,7 @@ async def list_models(
 async def get_model(
     bot_id: str,
     model_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Model]:
@@ -99,7 +92,6 @@ async def get_model(
     # A model id never contains a dot segment.
     if any(part in ("..", ".") for part in model_id.split("/")):
         raise EngineResourceNotFoundError("invalid model id")
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="models")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -9,16 +9,12 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
     Envelope,
     PageParamsDep,
-)
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
 )
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.sessions.schemas import (
     Message,
@@ -28,7 +24,7 @@ from agentclaw.community.adapters.http.openapi_v1.engine_runtime.sessions.schema
     SessionPage,
     SessionUpdate,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     deleted,
@@ -51,7 +47,6 @@ logger = get_logger()
 
 router = APIRouter(prefix="/openapi/v1/bots/sessions", tags=["sessions"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 #: One extra item is requested beyond the page, purely to learn whether more
 #: exist. Neither engine route reports a total, and ``Page.total`` is required —
@@ -288,7 +283,7 @@ def _history_page(
 async def list_sessions(
     bot_id: str,
     page: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     agent_id: Annotated[
         str | None, Query(description="Only sessions belonging to this agent.")
@@ -303,7 +298,6 @@ async def list_sessions(
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[SessionPage]:
     """List the bot's sessions."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     params: dict[str, Any] = _window(page)
     if agent_id:
@@ -329,12 +323,11 @@ async def list_sessions(
 async def create_session(
     bot_id: str,
     body: SessionCreate,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Session]:
     """Create a session."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -356,7 +349,7 @@ async def create_session(
 async def get_session(
     bot_id: str,
     session_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Session]:
@@ -367,7 +360,6 @@ async def get_session(
     """
     # A colon is legal in a path segment (RFC 3986), so ids route as-is. An id
     # containing "/" would not be addressable, but no engine id format has one.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -385,14 +377,13 @@ async def update_session(
     bot_id: str,
     session_id: str,
     body: SessionUpdate,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Session]:
     """Update a session. Omitted fields are left unchanged."""
     # Publicly a PATCH on the resource; the engine models the same operation as
     # a POST to an /update sub-path.
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     payload = {k: v for k, v in body.model_dump().items() if v is not None}
     result = await relay.call(
@@ -415,12 +406,11 @@ async def update_session(
 async def delete_session(
     bot_id: str,
     session_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Deleted]:
     """Delete a session."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,
@@ -436,7 +426,7 @@ async def list_session_messages(
     bot_id: str,
     session_id: str,
     page: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[MessagePage]:
@@ -449,7 +439,6 @@ async def list_session_messages(
     depth is rejected with 422 rather than returned empty, so an end of history
     is never confused with the limit of what this endpoint serves.
     """
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     _require_within_depth(page)
     result = await relay.call(
@@ -473,12 +462,11 @@ async def list_session_messages(
 async def clear_session_messages(
     bot_id: str,
     session_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
 ) -> Envelope[Deleted]:
     """Clear a session's message history, keeping the session."""
-    owner_id = caller_owner_id(principal)
     facts = await resolve_operable_bot(relay, bot_id, owner_id, surface="sessions")
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, draft_device=True,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
@@ -32,6 +32,26 @@ class MissingPrincipalError(Exception):
     """
 
 
+class UserIdMismatchError(Exception):
+    """Raised when a request's ``user_id`` is not the verified caller's (→ 403).
+
+    Every user-scoped public operation now names the end user it acts for in a
+    required ``user_id`` query parameter rather than inferring it from the
+    principal. Until delegation lands (auth design §15) the only user a caller
+    may name is itself, so the parameter must repeat the ``user`` principal's
+    subject id and a disagreement is refused here.
+
+    401 would be wrong — the caller *is* authenticated — and so would silently
+    preferring one of the two values: trusting the parameter would let any
+    verified user read another's data, and trusting the principal would answer a
+    request the caller did not make. The refusal is the only answer that keeps
+    the parameter honest while it is still redundant.
+
+    Raised in a dependency, so ``@envelope_errors`` never sees it; ``app.py``
+    registers a handler for this type for the reason documented there.
+    """
+
+
 class UnsupportedEngineError(Exception):
     """Raised when a request names an engine the platform does not support (→ 400).
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
@@ -12,14 +12,11 @@ openapi_v1 and not reachable through this API.
 
 from __future__ import annotations
 
-from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
-from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
-from agentclaw.community.adapters.http.openapi_v1.dependencies import Principal
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -44,23 +41,20 @@ from .schemas import (
 
 router = APIRouter(prefix="/openapi/v1/bots/identity", tags=["identity"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
-
 
 @router.get("/{bot_id}", response_model=Envelope[IdentityFileList])
 @envelope_errors
 async def list_bot_identity_files(
     bot_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileList]:
     """List a bot's identity files and whether each exists.
 
     I2: entity_type/entity_id/operator_id come from the authenticated
-    principal via ``caller_owner_id`` (personal bot owner = caller).
+    request's ``user_id`` parameter (personal bot owner = the named user).
     """
-    owner_id = caller_owner_id(principal)
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     presence = await identity_service.list_bot_files(
@@ -88,20 +82,19 @@ async def list_bot_identity_files(
 async def get_bot_identity_file(
     bot_id: str,
     file_type: IdentityFileType,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFile]:
     """Read one identity file of a bot.
 
     I2: entity params come from the authenticated principal via
-    ``caller_owner_id`` (personal bot owner = caller). I3: ``publish_id`` is
+    ``UserIdDep`` (personal bot owner = the named user). I3: ``publish_id`` is
     not exposed — only draft-device reads (``get_bot_file`` default branch).
     The service's ``validate_file_type`` requires the physical ``<type>.md``
     form (``VALID_IDENTITY_FILES`` carries the suffix), so the enum value is
     re-suffixed before forwarding.
     """
-    owner_id = caller_owner_id(principal)
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     file_type_md = f"{file_type.value}.md"
@@ -134,17 +127,16 @@ async def update_bot_identity_file(
     bot_id: str,
     file_type: IdentityFileType,
     body: IdentityFileWrite,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileRef]:
     """Overwrite one identity file of a bot.
 
     I2: entity params come from the authenticated principal via
-    ``caller_owner_id`` as above; ``validate_file_type`` requires the
+    ``UserIdDep`` as above; ``validate_file_type`` requires the
     ``<type>.md`` form. Returns an ``IdentityFileRef`` (no content echoed).
     """
-    owner_id = caller_owner_id(principal)
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     file_type_md = f"{file_type.value}.md"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -240,9 +240,12 @@ async def check_mcp_permission(
 ) -> Envelope[McpPermission]:
     """Report the caller's own permission for an MCP server.
 
-    Always the caller's permission — the identity comes from the principal, never
-    a caller-supplied id (the internal route takes a ``user_id`` query param; this
-    one must not, or a caller could probe another identity's grants).
+    Always the caller's own permission. The identity is the request's required
+    ``user_id``, and it is refused unless it names the verified caller — so this
+    still cannot be pointed at someone else to probe their grants, which is the
+    property the internal route's free-form ``user_id`` query param does not
+    have. The parameter states whose permission is being asked about; it does
+    not widen whose it may be.
 
     **Fail-open, by decision (spec Open Question 1).** When the marketplace
     lookup errors, ``check_mcp_permission_detail`` reports the caller *as

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -22,13 +22,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     USER_SCOPED_403,
     Envelope,
     Page,
     PageParamsDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    require_principal,
 )
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
@@ -140,7 +143,16 @@ def _to_config(cfg: Any) -> McpConfig:
 # ── Marketplace ─────────────────────────────────────────────────────
 
 
-@router.get("/servers", response_model=Envelope[Page[McpServer]])
+@router.get(
+    "/servers",
+    response_model=Envelope[Page[McpServer]],
+    # Authenticated, but not user-scoped. Declared on the route rather than
+    # inherited from ``build_public_router`` so the guard is visible where the
+    # operation is, and so ``test_public_routes_require_principal`` can see it:
+    # that test walks each route's own dependant, which a group-level
+    # dependency does not appear in.
+    dependencies=[Depends(require_principal)],
+)
 @envelope_errors
 async def list_mcp_servers(
     request: Request,
@@ -171,7 +183,12 @@ async def list_mcp_servers(
     return page(result.get("total", len(items)), items, request)
 
 
-@router.get("/tenants", response_model=Envelope[list[McpTenant]])
+@router.get(
+    "/tenants",
+    response_model=Envelope[list[McpTenant]],
+    # Authenticated, not user-scoped — see /servers.
+    dependencies=[Depends(require_principal)],
+)
 @envelope_errors
 async def list_mcp_tenants(
     request: Request,
@@ -184,7 +201,12 @@ async def list_mcp_tenants(
     return envelope(tenants, request)
 
 
-@router.get("/servers/{server_code}", response_model=Envelope[McpServerDetail])
+@router.get(
+    "/servers/{server_code}",
+    response_model=Envelope[McpServerDetail],
+    # Authenticated, not user-scoped — see /servers.
+    dependencies=[Depends(require_principal)],
+)
 @envelope_errors
 async def get_mcp_server(
     server_code: str,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -7,8 +7,10 @@ caller's devices). They delegate to the same MCP services the internal
 helpers, and wrap the result in the standard :class:`Envelope` / :class:`Page`
 contracts.
 
-Identity is the caller resolved from ``require_principal`` (owner-scoping, via
-``caller_owner_id``); the request tenant is bound by ``AvernetTenantMiddleware``
+Identity is the end user the request names in ``?user_id=`` (owner-scoping,
+via ``UserIdDep``) — on the three config/permission operations. The three
+marketplace catalogue reads reply the same for every caller in the tenant and
+take no ``user_id``. The request tenant is bound by ``AvernetTenantMiddleware``
 before the handler runs, so every config read/write is already tenant-scoped by
 the Track A guard. Unlike the internal detail route, no ``IAM_TOKEN`` cookie is
 read — a registered-tenant caller presents no browser cookie, and forwarding one
@@ -18,20 +20,17 @@ bots slice took).
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    USER_SCOPED_403,
     Envelope,
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -68,7 +67,6 @@ from .schemas import (
 
 router = APIRouter(prefix="/openapi/v1/bots/mcp", tags=["mcp"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 # The caller's own identity is used as both entity id and (staff) entity type
 # for the config push, mirroring the internal route's defaults and how the bots
@@ -147,12 +145,16 @@ def _to_config(cfg: Any) -> McpConfig:
 async def list_mcp_servers(
     request: Request,
     page_params: PageParamsDep,
-    principal: PrincipalDep,
     keyword: str | None = None,
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[Page[McpServer]]:
     """List marketplace MCP servers (filter by ``keyword``, paginate)."""
-    caller_owner_id(principal)  # require an authenticated caller
+    # No ``user_id``: this operation has no user dimension to scope by. The
+    # marketplace catalogue is identical for every caller in the tenant.
+    # An authenticated caller is still required — ``_PUBLIC_AUTH`` in
+    # ``openapi_v1/__init__.py`` — it just has no user-shaped answer to give,
+    # so asking the caller to name one would be asking for a value this handler
+    # cannot use. See "Naming the end user" there.
     result = list_marketplace_servers(
         page=page_params.page,
         page_size=page_params.page_size,
@@ -173,11 +175,10 @@ async def list_mcp_servers(
 @envelope_errors
 async def list_mcp_tenants(
     request: Request,
-    principal: PrincipalDep,
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[list[McpTenant]]:
     """List MCP tenants (the marketplace's own tenant concept)."""
-    caller_owner_id(principal)
+    # No ``user_id`` — catalogue read, see list_mcp_servers.
     result = list_marketplace_tenants(market_service=market_service)
     tenants = [_to_tenant(t) for t in (result.get("data") or []) if isinstance(t, dict)]
     return envelope(tenants, request)
@@ -188,7 +189,6 @@ async def list_mcp_tenants(
 async def get_mcp_server(
     server_code: str,
     request: Request,
-    principal: PrincipalDep,
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[McpServerDetail]:
     """Get an MCP server's detail (including tools).
@@ -197,7 +197,7 @@ async def get_mcp_server(
     not-found from one site, so a caller cannot tell "does not exist" from
     "exists but not visible to you".
     """
-    caller_owner_id(principal)
+    # No ``user_id`` — catalogue read, see list_mcp_servers.
     detail = market_service.get_mcp_detail(server_code)
     if not detail or not is_network_type_visible(detail):
         raise McpServerNotFoundError(server_code)
@@ -206,12 +206,12 @@ async def get_mcp_server(
 
 @router.get(
     "/servers/{server_code}/permissions", response_model=Envelope[McpPermission]
-)
+, responses=USER_SCOPED_403)
 @envelope_errors
 async def check_mcp_permission(
     server_code: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     auth_service: MCPAuthServiceProtocol = Injected(MCPAuthServiceProtocol),
 ) -> Envelope[McpPermission]:
     """Report the caller's own permission for an MCP server.
@@ -227,7 +227,6 @@ async def check_mcp_permission(
     wrong "yes" during an upstream outage costs one failed call, whereas failing
     closed would make a marketplace outage look like a permission revocation.
     """
-    owner_id = caller_owner_id(principal)
     result = auth_service.check_mcp_permission_detail(owner_id, server_code)
     return envelope(
         McpPermission(
@@ -242,12 +241,16 @@ async def check_mcp_permission(
 # ── Unified config ──────────────────────────────────────────────────
 
 
-@router.get("/servers/{server_code}/config", response_model=Envelope[McpConfig])
+@router.get(
+    "/servers/{server_code}/config",
+    response_model=Envelope[McpConfig],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def get_mcp_config(
     server_code: str,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
 ) -> Envelope[McpConfig]:
     """Read the caller's unified config for an MCP server (``api_key`` masked).
@@ -255,20 +258,23 @@ async def get_mcp_config(
     A server the caller has never configured is not an error — it returns
     ``has_config: false`` with defaults.
     """
-    owner_id = caller_owner_id(principal)
     cfg = read_unified_config(
         user_id=owner_id, server_code=server_code, config_service=config_service
     )
     return envelope(_to_config(cfg), request)
 
 
-@router.put("/servers/{server_code}/config", response_model=Envelope[McpConfig])
+@router.put(
+    "/servers/{server_code}/config",
+    response_model=Envelope[McpConfig],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def update_mcp_config(
     server_code: str,
     body: McpConfigWrite,
     request: Request,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
     sync_service: MCPSyncServiceProtocol = Injected(MCPSyncServiceProtocol),
@@ -280,7 +286,6 @@ async def update_mcp_config(
     with a config that is stored but not in effect. The response is re-read from
     storage so it is exactly what a subsequent GET would return.
     """
-    owner_id = caller_owner_id(principal)
     await write_unified_config(
         user_id=owner_id,
         server_code=server_code,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -227,8 +227,10 @@ async def get_mcp_server(
 
 
 @router.get(
-    "/servers/{server_code}/permissions", response_model=Envelope[McpPermission]
-, responses=USER_SCOPED_403)
+    "/servers/{server_code}/permissions",
+    response_model=Envelope[McpPermission],
+    responses=USER_SCOPED_403,
+)
 @envelope_errors
 async def check_mcp_permission(
     server_code: str,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -121,14 +121,35 @@ def caller_owner_id(principal: Principal) -> str:
     return str(user_id)
 
 
+#: How much of a rejected id reaches the log. Long enough to identify a
+#: misconfigured partner integration, short enough that a caller cannot choose
+#: how many bytes each refusal costs.
+_LOGGED_ID_LIMIT = 128
+
+
+def _for_log(user_id: str) -> str:
+    """The rejected id as one escaped, bounded token."""
+    if len(user_id) <= _LOGGED_ID_LIMIT:
+        return repr(user_id)
+    return f"{user_id[:_LOGGED_ID_LIMIT]!r}…(+{len(user_id) - _LOGGED_ID_LIMIT})"
+
+
 async def require_user_id(
     principal: Annotated[Principal, Depends(require_principal)],
     user_id: Annotated[
         str,
         Query(
+            # ``min_length`` only, deliberately. It has a counterpart at the
+            # identity boundary — ``verify_principal_token`` refuses a blank
+            # subject id — so it can never reject a caller the credential
+            # accepts. An upper bound has no such counterpart: ``GatewayUser.id``
+            # is an unconstrained ``str``, so a cap here would 422 a caller whose
+            # id is longer than it *even when the value matches the signed
+            # principal*, locking them out of all 56 operations. That is a change
+            # to who may call, which this change promises not to make. The log
+            # line below is bounded instead — see ``_for_log``.
             alias=USER_ID_QUERY,
             min_length=1,
-            max_length=256,
             description=USER_ID_DESCRIPTION,
         ),
     ],
@@ -156,20 +177,20 @@ async def require_user_id(
         # fixed "Forbidden", so this line is an operator's only record of which
         # user a partner integration asked for.
         #
-        # The rejected value is quoted with ``%r``, and that is not decoration.
-        # This branch runs *only* when the parameter is not the caller's, so by
-        # construction the value is one the caller chose and the server refused
-        # — up to 256 characters of arbitrary text, newlines included. Formatted
-        # raw it would let the party being refused append convincing extra lines
-        # to the log and poison the audit trail of refusals. ``repr`` escapes
-        # them, so a forged line arrives as one visibly-quoted string.
-        # ``app.py``'s 422 handler drops the caller's raw input for the same
-        # reason; this keeps it because *which* user was named is the whole
-        # diagnostic value here, and escaping is enough to make it safe.
+        # The rejected value goes through ``_for_log``, and that is not
+        # decoration. This branch runs *only* when the parameter is not the
+        # caller's, so by construction the value is one the caller chose and the
+        # server refused — arbitrary text, unbounded now that the request-level
+        # cap is gone, newlines included. Formatted raw it would let the party
+        # being refused append convincing extra lines to the log and poison the
+        # audit trail of refusals, and pad each one to any length they like.
+        # ``app.py``'s 422 handler drops the caller's raw input entirely for the
+        # same reason; this keeps a bounded, escaped form because *which* user
+        # was named is the whole diagnostic value here.
         logger.warning(
-            "%s=%r does not match the verified caller %s",
+            "%s=%s does not match the verified caller %s",
             USER_ID_QUERY,
-            user_id,
+            _for_log(user_id),
             caller,
         )
         raise UserIdMismatchError("request user id is not the verified caller")

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -1,8 +1,56 @@
 """Caller-identity extraction for the public API.
 
-The single place that turns the ``require_principal`` dependency's value into the
-caller's owner id used to scope every service call. It's isolated here so that
-the shape of a verified principal is one module's business, not every handler's.
+The single place that resolves the **end user a public request acts for** — the
+id every service call is scoped by. It's isolated here so that the shape of a
+verified principal is one module's business, not every handler's.
+
+Two things live here, and the split is the point:
+
+- :func:`caller_owner_id` — who the *credential* says is calling. Read off the
+  verified principal.
+- :func:`require_user_id` — who the *request* says it acts for. Read off the
+  ``user_id`` query parameter, which every user-scoped route now requires.
+
+Handlers take the second one. They used to derive the owner from the principal
+directly, which worked only because the two can't currently differ: the gateway
+resolves an end user from ``x-one-id`` and signs it into the principal, so a
+public request always named a person implicitly. That stops being true once an
+**App calls on behalf of a user** — the app presents its own credential and the
+end user is not in it — and an operation whose contract never mentioned a user
+has nowhere to put one. Naming the user in the request makes the contract say
+out loud what it always meant, before the identity set stops saying it.
+
+Why the query string, and only the query string
+-----------------------------------------------
+
+``user_id`` is not an attribute of any resource on this surface. It is who the
+call is for: the same value on every operation, and the same meaning on a read
+as on a write. A request body describes the resource being acted on — put the
+id there and, beside ``bot_name`` in a ``PUT /openapi/v1/bots/{bot_id}``
+payload, it reads as a property being set on the bot. A path segment *names* the
+resource — ``/bots/{bot_id}/users/{user_id}`` would claim to address a user
+beneath a bot, inverting the ownership and describing something the operation
+does not return.
+
+So: always the query string, whatever the method, whatever the body. There is no
+second placement and no exception table. ``bot_id`` is untouched by this rule —
+it stays in the path where it addresses a bot, and in the query string where it
+is a parameter.
+
+Four operations take no ``user_id`` at all, because they have no user dimension
+to scope by: ``check_bot_name`` answers a tenant-wide uniqueness question, and
+``list_mcp_servers`` / ``list_mcp_tenants`` / ``get_mcp_server`` read a
+marketplace catalogue identical for every caller in the tenant. They still
+require an authenticated caller — that is ``require_principal``'s job, not this
+parameter's.
+
+Today the request's id and the credential's must still agree:
+:func:`require_user_id` refuses a parameter that names anyone but the verified
+caller, so **nothing about who may call what changes** — a request with no
+verified principal is still refused, and a caller still reaches only its own
+data. That equality check is the one line delegation will relax (auth design
+§15); until then it is what keeps the parameter from being a way to read someone
+else's bots.
 
 The owner id scopes reads/writes to the caller's own bots *within* the tenant
 (the tenant guard confines data to the tenant; this confines it to the caller).
@@ -23,8 +71,32 @@ survive the stub-to-real swap unchanged.
 
 from __future__ import annotations
 
-from agentclaw.community.adapters.http.openapi_v1.dependencies import Principal
-from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from typing import Annotated
+
+from fastapi import Depends, Query
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    MissingPrincipalError,
+    UserIdMismatchError,
+)
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+#: The query parameter naming the end user a request acts for.
+USER_ID_QUERY = "user_id"
+
+#: What every user-scoped operation publishes for it. Defined once so the
+#: parameter reads identically across all 56 of them.
+USER_ID_DESCRIPTION = (
+    "The end user this request acts for. Every read and write is scoped to it. "
+    "It must currently be the authenticated caller's own id; naming another "
+    "user is refused (403)."
+)
 
 
 def caller_owner_id(principal: Principal) -> str:
@@ -47,3 +119,58 @@ def caller_owner_id(principal: Principal) -> str:
     if not user_id:
         raise MissingPrincipalError("principal carries no user_id")
     return str(user_id)
+
+
+async def require_user_id(
+    principal: Annotated[Principal, Depends(require_principal)],
+    user_id: Annotated[
+        str,
+        Query(
+            alias=USER_ID_QUERY,
+            min_length=1,
+            max_length=256,
+            description=USER_ID_DESCRIPTION,
+        ),
+    ],
+) -> str:
+    """Return the end user this request acts for, or raise.
+
+    The one seam every user-scoped handler takes its id from. Three failures are
+    answered here, and they are deliberately different answers:
+
+    - no verified caller → ``401``, from :func:`require_principal` as before;
+    - no ``user_id`` parameter (or an empty one) → ``422``, FastAPI's own
+      validation failure, enveloped by the app-level handler;
+    - a parameter naming someone other than the caller → ``403``.
+
+    The last one is the whole of the "nothing else changes" promise. A request
+    can only ever be scoped to the caller, exactly as when the id was read off
+    the principal; the parameter states that scope instead of leaving it implied.
+    When an App may act for a user (auth design §15), this function stops
+    comparing the two ids and asks whether the delegation was granted — and no
+    handler, schema or path changes, because none of them ever named the user.
+    """
+    caller = caller_owner_id(principal)
+    if user_id != caller:
+        # The two ids are logged because the response cannot carry them: it is a
+        # fixed "Forbidden", so an operator debugging a partner integration has
+        # no other record of which user was asked for. Both values are the
+        # caller's own identifiers on this path — the parameter disagreeing with
+        # a verified principal is the only way to get here — so neither
+        # discloses a third party.
+        logger.warning(
+            "%s=%s does not match the verified caller %s",
+            USER_ID_QUERY,
+            user_id,
+            caller,
+        )
+        raise UserIdMismatchError("request user id is not the verified caller")
+    return user_id
+
+
+#: What a user-scoped handler declares to receive the request's user id.
+#:
+#: Defined once and imported by every router, rather than re-declared per module
+#: like ``PrincipalDep``: it is the same dependency everywhere, and a second
+#: spelling of it is a second thing to keep in step with delegation.
+UserIdDep = Annotated[str, Depends(require_user_id)]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -152,14 +152,22 @@ async def require_user_id(
     """
     caller = caller_owner_id(principal)
     if user_id != caller:
-        # The two ids are logged because the response cannot carry them: it is a
-        # fixed "Forbidden", so an operator debugging a partner integration has
-        # no other record of which user was asked for. Both values are the
-        # caller's own identifiers on this path — the parameter disagreeing with
-        # a verified principal is the only way to get here — so neither
-        # discloses a third party.
+        # Both ids are logged because the response cannot carry them: it is a
+        # fixed "Forbidden", so this line is an operator's only record of which
+        # user a partner integration asked for.
+        #
+        # The rejected value is quoted with ``%r``, and that is not decoration.
+        # This branch runs *only* when the parameter is not the caller's, so by
+        # construction the value is one the caller chose and the server refused
+        # — up to 256 characters of arbitrary text, newlines included. Formatted
+        # raw it would let the party being refused append convincing extra lines
+        # to the log and poison the audit trail of refusals. ``repr`` escapes
+        # them, so a forged line arrives as one visibly-quoted string.
+        # ``app.py``'s 422 handler drops the caller's raw input for the same
+        # reason; this keeps it because *which* user was named is the whole
+        # diagnostic value here, and escaping is enough to make it safe.
         logger.warning(
-            "%s=%s does not match the verified caller %s",
+            "%s=%r does not match the verified caller %s",
             USER_ID_QUERY,
             user_id,
             caller,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -14,10 +14,10 @@ until that lands (see ``openapi_v1/dependencies.py`` and the cross-team tenant
 isolation track in ``src/backend/docs/openapi-v1/README.zh-CN.md``).
 
 Gates / follow-ups (block public-readiness, NOT a silent deployment):
-- Owner/identity comes from ``caller_owner_id(principal)`` (fail-closed: a
-  ``None`` principal raises ``MissingPrincipalError`` → 401), mirroring the
-  bots router. The gateway's signed-Principal seam is the single replaceable
-  point — when it lands, only ``principal.py``/``dependencies.py`` change.
+- Owner/identity comes from ``UserIdDep`` — the request's own ``user_id``
+  query parameter, refused unless it names the verified caller — mirroring the
+  bots router. That dependency is the single replaceable point: when an App may
+  act for a user, only ``principal.py`` changes.
 - Cross-tenant isolation rides on the ac_bots guard (Phase 0); a deployed DDL
   for ``ac_resource.avernet_tenant`` MUST precede this code reaching prod (see
   Phase 0 plan) — code first / DDL later breaks bot reads with a missing column.
@@ -29,10 +29,9 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 
 from agentclaw.community.api.resource_service import ResourceServiceFactoryProtocol
-from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
     Envelope,
@@ -40,8 +39,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import Principal
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     deleted as deleted_envelope,
@@ -122,20 +120,27 @@ def _to_openapi_resource(legacy: _LegacyResource) -> Resource:
 
 router = APIRouter(prefix="/openapi/v1/bots/resources", tags=["resources"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
-
 
 @router.get("", response_model=Envelope[Page[Resource]])
 @envelope_errors
 async def list_resources(
     page: PageParamsDep,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     type: ResourceType | None = None,
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
 ) -> Envelope[Page[Resource]]:
     """List resources (filter + paginate)."""
+    # Declared but not used — and that is a gap, not a design. These four
+    # handlers scope on the caller-supplied ``bot_id`` and the tenant guard, and
+    # never check that the caller owns that bot; see
+    # ``specs/2026-08-02-public-api-user-only-principal/``. They take the
+    # parameter because they are user-scoped in principle, so closing the gap
+    # later is a change to this function and not to the public contract. This is
+    # NOT the ``check_bot_name`` / MCP-catalogue case, which has no user
+    # dimension at all and therefore takes no ``user_id``.
+    del user_id
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
     if type is not None and _legacy_type_for(type) is None:
@@ -159,7 +164,7 @@ async def list_resources(
 @envelope_errors
 async def check_resource_name(
     name: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     type: ResourceType | None = None,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
@@ -179,12 +184,12 @@ async def check_resource_name(
     # legacy handler's most common case — the openapi check-name call shape
     # has no FOLDER equivalent).
     legacy_type = _legacy_type_for(type) or _LegacyType.FILE
-    # owner_id from the verified principal (fail-closed via caller_owner_id);
-    # parent_path stays None — the openapi check-name contract has no
-    # parent_path concept (resources are bot-scoped only). The slim service
+    # owner_id is the request's own ``user_id`` (fail-closed: no parameter, or
+    # one naming another user, never reaches here); parent_path stays None — the
+    # openapi check-name contract has no parent_path concept (resources are
+    # bot-scoped only). The slim service
     # signature REQUIRES both keyword args (no defaults), so pass them
     # explicitly.
-    owner_id = caller_owner_id(principal)
     exists = await service.check_name_exists(
         name=name,
         resource_type=legacy_type,
@@ -198,7 +203,7 @@ async def check_resource_name(
 @envelope_errors
 async def create_resource(
     body: ResourceCreate,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
@@ -209,6 +214,7 @@ async def create_resource(
     FOLDER → create_directory (Phase 3, device_fs branch). Duplicate name
     surfaces as ValueError from the service → 409 Conflict (legacy parity).
     """
+    del user_id  # not-yet-enforced ownership — see list_resources
     if body.type == ResourceType.FILE:
         raise HTTPException(
             status_code=400,
@@ -243,7 +249,7 @@ async def create_resource(
 @router.post("/upload", status_code=201, response_model=Envelope[Resource])
 @envelope_errors
 async def upload_resource(
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     name: str,
     content: Annotated[bytes, Body(media_type="application/octet-stream")],
     request: Request,
@@ -258,11 +264,10 @@ async def upload_resource(
 
     device_fs is resolved per-bot; upload_file is async and raises
     DuplicateResourceError on duplicate name → 409 (via @envelope_errors).
-    owner_id comes from the verified principal (``caller_owner_id``),
+    owner_id comes from the request's ``user_id`` parameter (``UserIdDep``),
     fail-closed — mirroring the bots router.
     """
     effective_bot_id = bot_id
-    owner_id = caller_owner_id(principal)
     ctx = resolver.resolve_for_bot(effective_bot_id, owner_id)
     device_fs = device_fs_dispatcher.dispatch(ctx)
     service = factory.create(bot_id=effective_bot_id)
@@ -290,12 +295,13 @@ async def upload_resource(
 @envelope_errors
 async def get_resource(
     resource_id: str,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
 ) -> Envelope[Resource]:
     """Get a resource."""
+    del user_id  # not-yet-enforced ownership — see list_resources
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
     # NOTE: ``get_resource`` on the concrete service is SYNC (unlike
@@ -311,7 +317,7 @@ async def get_resource(
 async def update_resource(
     resource_id: str,
     body: ResourceUpdate,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
@@ -322,6 +328,7 @@ async def update_resource(
     openapi contract. ValueError from the service (not found / url clash)
     → 409 Conflict, per legacy + create parity.
     """
+    del user_id  # not-yet-enforced ownership — see list_resources
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
     # ResourceNotFoundError (404) / DuplicateResourceError (409) propagate to
@@ -339,7 +346,7 @@ async def update_resource(
 @envelope_errors
 async def delete_resource(
     resource_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
@@ -350,7 +357,7 @@ async def delete_resource(
 ) -> Envelope[Deleted]:
     """Delete a resource (file → device FS, link/folder → DB soft-delete).
 
-    owner_id comes from the verified principal (``caller_owner_id``),
+    owner_id comes from the request's ``user_id`` parameter (``UserIdDep``),
     fail-closed. device_fs is resolved per-bot ONLY for FILE resources — a
     link/folder soft-delete never touches device_fs, so it must not fail on an
     unbound bot (``resolve_for_bot`` raises DeviceNotBoundError when there is no
@@ -358,7 +365,6 @@ async def delete_resource(
     out of the served OpenAPI schema — see test_public_namespace.py.
     """
     effective_bot_id = bot_id
-    owner_id = caller_owner_id(principal)
     # Follow-up (#4): device_fs resolution is unconditional — a link/folder
     # soft-delete never touches device_fs but the handler can't tell the type
     # until the service reads the row, so an unbound bot raises
@@ -383,7 +389,7 @@ async def delete_resource(
 @envelope_errors
 async def download_resource(
     resource_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     resolver: DeviceContextResolver = Injected(DeviceContextResolver),
@@ -393,14 +399,13 @@ async def download_resource(
 ) -> Response:
     """Download a resource's bytes (raw, not enveloped).
 
-    owner_id comes from the verified principal (``caller_owner_id``),
+    owner_id comes from the request's ``user_id`` parameter (``UserIdDep``),
     fail-closed — mirroring the bots router. device_fs is resolved per-bot
     (unconditional today; see #4 follow-up — only a file has bytes, but the
     handler can't tell the type before the service reads the row). Service
     returns ``(bytes, mime)`` or ``None`` → 404.
     """
     effective_bot_id = bot_id
-    owner_id = caller_owner_id(principal)
     ctx = resolver.resolve_for_bot(effective_bot_id, owner_id)
     device_fs = device_fs_dispatcher.dispatch(ctx)
     service = factory.create(bot_id=effective_bot_id)
@@ -417,7 +422,7 @@ async def download_resource(
 @envelope_errors
 async def preview_resource(
     resource_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
@@ -428,14 +433,13 @@ async def preview_resource(
 ) -> Envelope[Preview]:
     """Get a resource preview (text-ified content, enveloped).
 
-    owner_id comes from the verified principal (``caller_owner_id``),
+    owner_id comes from the request's ``user_id`` parameter (``UserIdDep``),
     fail-closed — mirroring the bots router. device_fs is resolved per-bot
     (unconditional today; see #4 follow-up). FileTooLargeError (content > 1 MB)
     → 413 via @envelope_errors; a None result is not-found / not-a-file /
     read-failure → 404.
     """
     effective_bot_id = bot_id
-    owner_id = caller_owner_id(principal)
     ctx = resolver.resolve_for_bot(effective_bot_id, owner_id)
     device_fs = device_fs_dispatcher.dispatch(ctx)
     service = factory.create(bot_id=effective_bot_id)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -172,10 +172,11 @@ async def check_resource_name(
 ) -> Envelope[NameCheck]:
     """Check whether a resource name is available.
 
-    ``parent_path`` / ``user_id`` / ``exclude_id`` from the legacy signature
-    are intentionally not exposed on the openapi contract yet — Direction A
-    (principal → user_id) will wire ``user_id`` once it lands. For now the
-    service treats them as None.
+    ``user_id`` is the request's own required parameter, forwarded to the
+    service — the wiring the older note here said was still pending.
+    ``parent_path`` and ``exclude_id`` from the legacy signature remain
+    unexposed on this contract and are passed as None: resources are bot-scoped,
+    so there is no parent path to qualify the name with.
     """
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
@@ -184,12 +185,10 @@ async def check_resource_name(
     # legacy handler's most common case — the openapi check-name call shape
     # has no FOLDER equivalent).
     legacy_type = _legacy_type_for(type) or _LegacyType.FILE
-    # owner_id is the request's own ``user_id`` (fail-closed: no parameter, or
-    # one naming another user, never reaches here); parent_path stays None — the
-    # openapi check-name contract has no parent_path concept (resources are
-    # bot-scoped only). The slim service
-    # signature REQUIRES both keyword args (no defaults), so pass them
-    # explicitly.
+    # owner_id is the request's own ``user_id`` — fail-closed, since neither a
+    # missing parameter nor one naming another user reaches this line. The slim
+    # service signature REQUIRES both keyword args (no defaults), so parent_path
+    # is passed explicitly as None rather than omitted.
     exists = await service.check_name_exists(
         name=name,
         resource_type=legacy_type,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -43,6 +43,7 @@ from agentclaw.community.adapters.http.openapi_v1.errors import (
     ClusterMismatchError,
     MissingPrincipalError,
     UnsupportedEngineError,
+    UserIdMismatchError,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotInvalidLifecycleStateError,
@@ -168,6 +169,13 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # entry covers a handler that calls ``verify_principal_token`` directly, so
     # the error cannot escape the envelope as a 500.
     PrincipalVerificationError: (401, "Unauthorized"),
+    # 403, not 401: the caller authenticated fine, it just asked to act for
+    # someone it may not act for. Not folded into the 401s above for that
+    # reason — a partner debugging an integration needs to tell "my credential
+    # is wrong" from "my credential is fine but this user is not mine", and the
+    # two have different fixes. The message says nothing about which user was
+    # asked for; both ids are on the warning line in ``principal.py``.
+    UserIdMismatchError: (403, "Forbidden"),
     InvalidBotLogQueryError: (400, "Invalid log query"),
     SessionNotFoundError: (404, "Not found"),
     BotNotFoundError: (404, "Not found"),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
@@ -8,19 +8,17 @@ requires an authenticated user principal.
 from __future__ import annotations
 
 from datetime import datetime, timezone as _tz
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request
 
-from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
     Envelope,
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import Principal
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     envelope,
@@ -37,8 +35,6 @@ from agentclaw.community.di import Injected
 from .schemas import Routine, RoutineCreate, RoutineRun, RoutineUpdate, ScheduleTrigger
 
 router = APIRouter(prefix="/openapi/v1/bots/routines", tags=["routines"])
-
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 
 def _ms_to_iso(ms: Any) -> str:
@@ -102,7 +98,7 @@ def _map_run(data: dict, routine_id: str) -> RoutineRun:
 @envelope_errors
 async def list_routines(
     page: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     status: str | None = None,
@@ -116,7 +112,6 @@ async def list_routines(
     set and let the client filter on ``enabled``. Wire a server-side filter
     here only if/when the engine surfaces a status dimension.
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     # Draft only, like every other route in this group: the public surface
@@ -144,7 +139,7 @@ async def list_routines(
 @envelope_errors
 async def create_routine(
     body: RoutineCreate,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Routine]:
@@ -157,7 +152,6 @@ async def create_routine(
     to ``Asia/Shanghai`` to match legacy ``cron/router.py``'s create path.
     """
     bot_id = body.bot_id
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     adapter_body = {
@@ -184,7 +178,7 @@ async def create_routine(
 @envelope_errors
 async def get_routine(
     routine_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
@@ -194,9 +188,8 @@ async def get_routine(
     C3: the path carries only ``routine_id`` (no routine table to
     reverse-map to a bot), so ``bot_id`` is a required query. Owner
     identity comes from the authenticated principal via
-    ``caller_owner_id``. Missing/non-dict ``data`` collapses to 404.
+    ``UserIdDep``. Missing/non-dict ``data`` collapses to 404.
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     result = await factory.get_cron_detail(
@@ -213,7 +206,7 @@ async def get_routine(
 async def update_routine(
     routine_id: str,
     body: RoutineUpdate,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
@@ -226,7 +219,6 @@ async def update_routine(
     wraps it on read; Task 3 contract). Missing/non-dict ``data`` on the
     response collapses to 404.
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     update_body: dict = {}
@@ -257,7 +249,7 @@ async def update_routine(
 @envelope_errors
 async def delete_routine(
     routine_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
@@ -273,7 +265,6 @@ async def delete_routine(
     two only via its ``error`` text today; a structured engine ``error_code``
     would make timeout-vs-missing precise (follow-up).
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     try:
@@ -301,7 +292,7 @@ async def delete_routine(
 @envelope_errors
 async def run_routine(
     routine_id: str,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
@@ -317,7 +308,6 @@ async def run_routine(
     ``finished_at`` are None because the adapter doesn't surface them on the
     run-trigger seam (use ``GET /{routine_id}/runs`` for actual timestamps).
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     result = await factory.run_cron(
@@ -353,7 +343,7 @@ async def run_routine(
 async def list_routine_runs(
     routine_id: str,
     page: PageParamsDep,
-    principal: PrincipalDep,
+    owner_id: UserIdDep,
     bot_id: str,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
@@ -367,7 +357,6 @@ async def list_routine_runs(
     ``data``, leaving ``runs`` intact). We map each entry via ``_map_run``
     and paginate client-side.
     """
-    owner_id = caller_owner_id(principal)
     user_id = owner_id
     nick_name = owner_id
     result = await factory.get_cron_runs(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -8,9 +8,9 @@ non-public surfaces.
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any
+from typing import Any
 
-from fastapi import APIRouter, Body, Depends, Query, Request, Response
+from fastapi import APIRouter, Body, Query, Request, Response
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
@@ -19,11 +19,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
-)
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -48,7 +44,6 @@ from .schemas import Skill, SkillState, SkillUpload
 
 router = APIRouter(prefix="/openapi/v1/bots/skills", tags=["skills"])
 
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 def _tags(value: Any) -> list[str]:
     if isinstance(value, list):
@@ -79,7 +74,7 @@ def _to_skill(record: dict[str, Any]) -> Skill:
 @envelope_errors
 async def list_skills(
     page: PageParamsDep,
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID whose Local Skills are listed."),
     owner_entity_id: str | None = Query(
@@ -92,7 +87,6 @@ async def list_skills(
     ),
 ) -> Envelope[Page[Skill]]:
     """List exact Bot-owned Local Skills from database desired state."""
-    actor_id = caller_owner_id(principal)
     total, records = query_service.list_local_skills(
         bot_id=bot_id,
         owner_id=owner_entity_id or actor_id,
@@ -109,7 +103,7 @@ async def list_skills(
 @envelope_errors
 async def get_skill(
     skill_id: str,
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     query_service: LocalSkillQueryServiceProtocol = Injected(
         LocalSkillQueryServiceProtocol
@@ -117,7 +111,7 @@ async def get_skill(
 ) -> Envelope[Skill]:
     """Get public metadata for one Local Skill; the Skill ID selects its Bot."""
     record = query_service.get_local_skill(
-        skill_id=skill_id, actor_id=caller_owner_id(principal)
+        skill_id=skill_id, actor_id=actor_id
     )
     return envelope(_to_skill(record), request)
 
@@ -149,7 +143,7 @@ async def get_skill(
 )
 @envelope_errors
 async def upload_skill(
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     response: Response,
     package: bytes = Body(..., media_type="application/zip"),
@@ -167,7 +161,6 @@ async def upload_skill(
         != "application/zip"
     ):
         raise LocalSkillInvalidPackageError()
-    actor_id = caller_owner_id(principal)
     result = await upload_service.upload_local_skill(
         bot_id=bot_id,
         owner_id=owner_entity_id or actor_id,
@@ -192,7 +185,7 @@ async def upload_skill(
 @envelope_errors
 async def activate_skill(
     skill_id: str,
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     state_service: LocalSkillStateServiceProtocol = Injected(
         LocalSkillStateServiceProtocol
@@ -200,7 +193,7 @@ async def activate_skill(
 ) -> Envelope[SkillState]:
     """Activate one Bot-owned Local Skill and synchronously reconcile runtime."""
     result = await state_service.set_local_skill_active(
-        skill_id=skill_id, actor_id=caller_owner_id(principal), active=True
+        skill_id=skill_id, actor_id=actor_id, active=True
     )
     return envelope(
         SkillState(skill=_to_skill(result), changed=bool(result["changed"])),
@@ -215,7 +208,7 @@ async def activate_skill(
 @envelope_errors
 async def deactivate_skill(
     skill_id: str,
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     state_service: LocalSkillStateServiceProtocol = Injected(
         LocalSkillStateServiceProtocol
@@ -223,7 +216,7 @@ async def deactivate_skill(
 ) -> Envelope[SkillState]:
     """Deactivate one Bot-owned Local Skill and synchronously reconcile runtime."""
     result = await state_service.set_local_skill_active(
-        skill_id=skill_id, actor_id=caller_owner_id(principal), active=False
+        skill_id=skill_id, actor_id=actor_id, active=False
     )
     return envelope(
         SkillState(skill=_to_skill(result), changed=bool(result["changed"])),
@@ -235,7 +228,7 @@ async def deactivate_skill(
 @envelope_errors
 async def delete_skill(
     skill_id: str,
-    principal: PrincipalDep,
+    actor_id: UserIdDep,
     request: Request,
     delete_service: LocalSkillDeleteServiceProtocol = Injected(
         LocalSkillDeleteServiceProtocol
@@ -243,6 +236,6 @@ async def delete_skill(
 ) -> Envelope[Deleted]:
     """Delete one inactive Bot-owned Local Skill by deployment-wide ID."""
     await delete_service.delete_local_skill(
-        skill_id=skill_id, actor_id=caller_owner_id(principal)
+        skill_id=skill_id, actor_id=actor_id
     )
     return envelope(Deleted(), request)

--- a/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
@@ -1,4 +1,73 @@
 """Shared assembled-application fixtures for OpenAPI v1 adapter tests."""
 
+from urllib.parse import parse_qsl, urlsplit, urlunsplit
+
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    MissingPrincipalError,
+    UserIdMismatchError,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import USER_ID_QUERY
 from tests.community.framework.fixtures import app_with_testing_modules  # noqa: F401
 from tests.community.framework.fixtures import world  # noqa: F401
+
+
+def user_scoped_client(app: FastAPI, user_id: str, **kwargs) -> TestClient:
+    """A ``TestClient`` that names ``user_id`` on every request.
+
+    Every user-scoped public operation now requires the parameter, so without
+    this each of ~230 call sites would have to grow one. It is a wrapper rather
+    than httpx's own ``Client.params`` because that field does not do what it
+    looks like: **it replaces a URL's query string instead of merging with it.**
+    ``client.get("/openapi/v1/bots/skills?bot_id=b-1")`` on a client with
+    ``params={"user_id": …}`` silently loses ``bot_id``, and the tests that
+    caught it would have failed for a reason nowhere near the cause. A per-call
+    ``params=`` has the same behaviour.
+
+    So the inline query and any per-call ``params`` are parsed and merged here,
+    and ``user_id`` is only defaulted — a test that passes its own (to assert
+    the 403, say) keeps it.
+    """
+    client = TestClient(app, **kwargs)
+    inner = client.request
+
+    def request(method: str, url, **kw):
+        parts = urlsplit(str(url))
+        merged = dict(parse_qsl(parts.query))
+        merged.update(kw.pop("params", None) or {})
+        merged.setdefault(USER_ID_QUERY, user_id)
+        kw["params"] = merged
+        return inner(method, urlunsplit(parts._replace(query="")), **kw)
+
+    client.request = request  # type: ignore[method-assign]
+    return client
+
+
+def mount_public_error_handlers(app: FastAPI) -> FastAPI:
+    """Answer pre-handler failures the way the assembled application does.
+
+    The caller-identity dependencies raise *before* the handler runs, so
+    ``@envelope_errors`` never sees them and the real app answers them from
+    handlers registered in ``app.py``. A test that mounts one group's router on
+    a bare ``FastAPI()`` has neither, and would watch the exception propagate
+    instead of the status the surface actually returns.
+
+    The real handlers are imported rather than re-implemented — the same
+    convention ``test_principal_seam.py`` follows — so deleting the wiring in
+    ``app.py`` fails these tests instead of leaving them green against a local
+    copy of it. The import is function-local because importing that module
+    builds the whole application.
+    """
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _user_id_mismatch_handler,
+        _validation_error_handler,
+    )
+
+    app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+    app.add_exception_handler(UserIdMismatchError, _user_id_mismatch_handler)
+    app.add_exception_handler(RequestValidationError, _validation_error_handler)
+    return app

--- a/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
@@ -27,19 +27,38 @@ def user_scoped_client(app: FastAPI, user_id: str, **kwargs) -> TestClient:
     caught it would have failed for a reason nowhere near the cause. A per-call
     ``params=`` has the same behaviour.
 
-    So the inline query and any per-call ``params`` are parsed and merged here,
-    and ``user_id`` is only defaulted — a test that passes its own (to assert
-    the 403, say) keeps it.
+    So the inline query and any per-call ``params`` are merged here — and the
+    merge has to be as lossless as the bug it replaces, or this helper
+    reintroduces the same silence on the one path every call site now takes:
+
+    - ``keep_blank_values=True``, so ``?keyword=`` stays an empty string rather
+      than disappearing and turning a "passed through as empty" test into an
+      unfiltered one that passes for the wrong reason;
+    - repeated keys are kept as a list, so ``?tag=a&tag=b`` does not collapse
+      to the last one.
+
+    ``user_id`` is only defaulted, so a test can pass its own to assert the 403.
+    Passing ``user_id=None`` explicitly **omits** it — the only way to exercise
+    an operation that takes none.
     """
     client = TestClient(app, **kwargs)
     inner = client.request
 
     def request(method: str, url, **kw):
         parts = urlsplit(str(url))
-        merged = dict(parse_qsl(parts.query))
+        merged: dict[str, object] = {}
+        for key, value in parse_qsl(parts.query, keep_blank_values=True):
+            if key in merged:
+                existing = merged[key]
+                merged[key] = [*existing, value] if isinstance(existing, list) else [
+                    existing,
+                    value,
+                ]
+            else:
+                merged[key] = value
         merged.update(kw.pop("params", None) or {})
         merged.setdefault(USER_ID_QUERY, user_id)
-        kw["params"] = merged
+        kw["params"] = {k: v for k, v in merged.items() if v is not None}
         return inner(method, urlunsplit(parts._replace(query="")), **kw)
 
     client.request = request  # type: ignore[method-assign]

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
@@ -17,6 +17,10 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
 from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
@@ -120,7 +124,7 @@ def make_client(relay):
         app.include_router(router)
         app.dependency_overrides[require_principal] = lambda: principal
         attach_injector(app, Injector([_M()]))
-        return TestClient(app)
+        return user_scoped_client(app, OWNER)
 
     return _build
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
@@ -18,7 +18,6 @@ from fastapi_injector import attach_injector
 from injector import Injector, Module
 
 from tests.community.adapters.http.openapi_v1.conftest import (
-    mount_public_error_handlers,
     user_scoped_client,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
@@ -8,6 +8,10 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.connection import (
     router,
@@ -75,7 +79,7 @@ def client(relay, connections):
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": OWNER}
     attach_injector(app, Injector([_M()]))
-    return TestClient(app)
+    return user_scoped_client(app, OWNER)
 
 
 def _caps(*supported: str) -> EngineResult:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_connection.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
 from tests.community.adapters.http.openapi_v1.conftest import (
-    mount_public_error_handlers,
     user_scoped_client,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
@@ -24,6 +24,10 @@ from injector import Injector, Module
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1 import _ENGINE_RUNTIME_GROUPS
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.engine_connection_service import (
@@ -114,7 +118,7 @@ def client(relay: FakeRelay, connections: _FakeConnections):
         app.include_router(group)
     app.dependency_overrides[require_principal] = lambda: {"user_id": OWNER}
     attach_injector(app, Injector([_M()]))
-    return TestClient(app)
+    return user_scoped_client(app, OWNER)
 
 
 def test_all_sixteen_routes_are_covered():

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
@@ -18,14 +18,12 @@ from contextlib import contextmanager
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from tests.community.adapters.http.openapi_v1.conftest import (
-    mount_public_error_handlers,
     user_scoped_client,
 )
 from agentclaw.community.adapters.http.openapi_v1 import _ENGINE_RUNTIME_GROUPS

--- a/src/backend/tests/community/adapters/http/openapi_v1/identity/test_identity_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/identity/test_identity_handlers.py
@@ -128,7 +128,7 @@ async def test_list_bot_identity_files_returns_all_16_with_exists():
 
     env = await list_bot_identity_files(
         bot_id="bot-x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -160,7 +160,7 @@ async def test_list_bot_identity_files_marks_absent_files_false():
 
     env = await list_bot_identity_files(
         bot_id="bot-x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -178,7 +178,7 @@ async def test_list_bot_identity_files_reads_trace_id_from_request_state():
 
     env = await list_bot_identity_files(
         bot_id="bot-x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=request,
     )
@@ -200,7 +200,7 @@ async def test_list_bot_identity_files_400_when_entity_type_invalid():
 
     resp = await list_bot_identity_files(
         bot_id="bot-x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -318,7 +318,7 @@ async def test_get_bot_identity_file_returns_content_and_path():
     env = await get_bot_identity_file(
         bot_id="bot-x",
         file_type=IdentityFileType.RULES,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -353,7 +353,7 @@ async def test_get_bot_identity_file_400_on_value_error():
     resp = await get_bot_identity_file(
         bot_id="bot-x",
         file_type=IdentityFileType.RULES,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -369,7 +369,7 @@ async def test_update_bot_identity_file_returns_ref():
         bot_id="bot-x",
         file_type=IdentityFileType.SOUL,
         body=IdentityFileWrite(content="# my soul"),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -400,7 +400,7 @@ async def test_update_bot_identity_file_400_on_value_error():
         bot_id="bot-x",
         file_type=IdentityFileType.RULES,
         body=IdentityFileWrite(content="x"),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=_request_without_trace(),
     )
@@ -416,7 +416,7 @@ async def test_get_and_update_thread_trace_id():
     get_env = await get_bot_identity_file(
         bot_id="bot-x",
         file_type=IdentityFileType.RULES,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=request,
     )
@@ -426,7 +426,7 @@ async def test_get_and_update_thread_trace_id():
         bot_id="bot-x",
         file_type=IdentityFileType.RULES,
         body=IdentityFileWrite(content="x"),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         identity_service=service,
         request=request,
     )

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -8,7 +8,9 @@ from typing import List
 import pytest
 from fastapi import HTTPException, Request, Response
 
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from agentclaw.community.adapters.http.openapi_v1.principal import require_user_id
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     CODE_CREATED,
     CODE_OK,
@@ -365,7 +367,7 @@ async def test_list_resources_returns_envelope_with_page():
 
     env = await list_resources(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -399,7 +401,7 @@ async def test_list_resources_paginates_items():
 
     env = await list_resources(
         page=PageParams(page=2, page_size=1),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -418,7 +420,7 @@ async def test_list_resources_passes_type_filter_value_to_service():
 
     await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=OpenapiType.LINK,
         factory=factory,
@@ -440,7 +442,7 @@ async def test_list_resources_reads_x_trace_id_from_request():
 
     env = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -456,7 +458,7 @@ async def test_list_resources_request_id_empty_when_no_request_context():
 
     env = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -472,7 +474,7 @@ async def test_list_resources_empty_result_returns_empty_page():
 
     env = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -497,7 +499,7 @@ async def test_check_name_returns_envelope_with_exists_false_for_available():
 
     env = await check_resource_name(
         name="available",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=None,
         bot_id="bot-x",
         factory=factory,
@@ -520,7 +522,7 @@ async def test_check_name_returns_exists_true_for_taken():
 
     env = await check_resource_name(
         name="taken",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=None,
         bot_id=None,
         factory=factory,
@@ -538,7 +540,7 @@ async def test_check_name_reads_x_trace_id_from_request():
 
     env = await check_resource_name(
         name="available",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=None,
         bot_id="bot-a",
         factory=factory,
@@ -555,7 +557,7 @@ async def test_check_name_passes_type_value_to_service_when_provided():
 
     await check_resource_name(
         name="available",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=OpenapiType.FILE,
         bot_id="bot-a",
         factory=factory,
@@ -585,7 +587,7 @@ async def test_get_resource_returns_envelope_when_found():
 
     env = await get_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -609,7 +611,7 @@ async def test_get_resource_raises_404_when_missing():
     with pytest.raises(HTTPException) as exc:
         await get_resource(
             resource_id="999",
-            principal={"user_id": "u1"},
+            user_id="u1",
             bot_id=None,
             factory=factory,
             request=_request_without_trace(),
@@ -626,7 +628,7 @@ async def test_get_resource_reads_x_trace_id_from_request():
 
     env = await get_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         factory=factory,
         request=request,
@@ -646,7 +648,7 @@ async def test_create_link_returns_201_envelope():
 
     env = await create_resource(
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -669,7 +671,7 @@ async def test_create_file_points_to_upload_with_400():
     with pytest.raises(HTTPException) as exc:
         await create_resource(
             body=body,
-            principal={"user_id": "u1"},
+            user_id="u1",
             bot_id=None,
             factory=factory,
             request=_request_without_trace(),
@@ -686,7 +688,7 @@ async def test_create_folder_is_not_yet_supported_501():
     with pytest.raises(HTTPException) as exc:
         await create_resource(
             body=body,
-            principal={"user_id": "u1"},
+            user_id="u1",
             bot_id=None,
             factory=factory,
             request=_request_without_trace(),
@@ -703,7 +705,7 @@ async def test_create_link_without_url_is_400():
     with pytest.raises(HTTPException) as exc:
         await create_resource(
             body=body,
-            principal={"user_id": "u1"},
+            user_id="u1",
             bot_id=None,
             factory=factory,
             request=_request_without_trace(),
@@ -721,7 +723,7 @@ async def test_create_link_duplicate_name_is_409():
 
     resp = await create_resource(
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id=None,
         factory=factory,
         request=_request_without_trace(),
@@ -749,7 +751,7 @@ async def test_update_link_returns_200_envelope():
     env = await update_resource(
         resource_id="1",
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -778,7 +780,7 @@ async def test_update_link_raises_409_when_not_found():
     resp = await update_resource(
         resource_id="0",
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id=None,
         factory=factory,
         request=_request_without_trace(),
@@ -798,7 +800,7 @@ async def test_update_link_raises_409_on_url_conflict():
     resp = await update_resource(
         resource_id="1",
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id=None,
         factory=factory,
         request=_request_without_trace(),
@@ -816,7 +818,7 @@ async def test_update_link_reads_x_trace_id_from_request():
     env = await update_resource(
         resource_id="1",
         body=body,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         factory=factory,
         request=request,
@@ -941,7 +943,7 @@ async def test_delete_returns_200_envelope_with_deleted_true():
 
     env = await delete_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -965,22 +967,53 @@ async def test_delete_returns_200_envelope_with_deleted_true():
 
 
 @pytest.mark.asyncio
-async def test_delete_raises_missing_principal_when_no_authenticated_caller():
-    # owner_id now comes from the verified principal (caller_owner_id),
-    # NOT bot_repo.get_by_id — a None principal is fail-closed (bots parity).
-    factory, resolver, dispatcher, _ = _delete_deps()
+async def test_no_handler_can_fall_back_to_a_bot_derived_owner():
+    """Owner-scoped routes take their owner from the request, or answer 401.
 
-    resp = await delete_resource(
-        resource_id="1",
-        principal=None,
-        bot_id="ghost",
-        factory=factory,
-        resolver=resolver,
-        device_fs_dispatcher=dispatcher,
-        request=_request_without_trace(),
-    )
-    assert resp.status_code == 401
-    assert json.loads(resp.body)["message"] == "Unauthorized"
+    Four handlers used to be handed the principal and resolve the owner
+    themselves, and this file checked each one refused a ``None`` principal —
+    the property being that ``owner_id`` is never quietly recovered from
+    ``bot_repo.get_by_id`` for a caller who supplied no identity. The resolution
+    has since moved into ``require_user_id``, one dependency the whole surface
+    shares, so four copies of that check would only re-test the same function.
+
+    What still needs checking is that no route escapes it. A resources route
+    added later without the dependency is exactly the silent fallback the
+    original four existed to prevent, so the guard is asserted over the mounted
+    routes rather than per handler — and the fail-closed half is asserted once,
+    on the seam itself.
+    """
+    mounted = [
+        route
+        for route in _api_routes(build_public_router())
+        if route.path.startswith("/openapi/v1/bots/resources")
+    ]
+    assert len(mounted) == 9, [r.path for r in mounted]
+
+    def guarded(dependant) -> bool:
+        return dependant.call is require_user_id or any(
+            guarded(sub) for sub in dependant.dependencies
+        )
+
+    assert all(guarded(route.dependant) for route in mounted), [
+        route.path for route in mounted if not guarded(route.dependant)
+    ]
+
+    with pytest.raises(MissingPrincipalError):
+        await require_user_id(principal=None, user_id="u1")
+
+
+def _api_routes(router_) -> list:
+    """Every real route under ``router_``, flattening included sub-routers."""
+    found = []
+    for route in getattr(router_, "routes", []):
+        if hasattr(route, "dependant"):
+            found.append(route)
+        elif hasattr(route, "original_router"):
+            found.extend(_api_routes(route.original_router))
+        else:
+            found.extend(_api_routes(route))
+    return found
 
 
 @pytest.mark.asyncio
@@ -992,7 +1025,7 @@ async def test_delete_raises_404_when_resource_missing():
     with pytest.raises(HTTPException) as exc:
         await delete_resource(
             resource_id="0",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-a",
             factory=factory,
             resolver=resolver,
@@ -1011,7 +1044,7 @@ async def test_delete_reads_x_trace_id_from_request():
 
     env = await delete_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-a",
         factory=factory,
         resolver=resolver,
@@ -1045,7 +1078,7 @@ async def test_upload_returns_201_envelope_and_threads_device_fs():
     env = await upload_resource(
         name="hello.txt",
         content=b"file bytes",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1075,26 +1108,6 @@ async def test_upload_returns_201_envelope_and_threads_device_fs():
 
 
 @pytest.mark.asyncio
-async def test_upload_raises_missing_principal_when_no_authenticated_caller():
-    # owner_id from caller_owner_id(principal) — a None principal is
-    # fail-closed (no silent bot_repo fallback), mirroring the bots router.
-    factory, resolver, dispatcher, _ = _delete_deps()
-
-    resp = await upload_resource(
-        name="hello.txt",
-        content=b"x",
-        principal=None,
-        bot_id="ghost",
-        factory=factory,
-        resolver=resolver,
-        device_fs_dispatcher=dispatcher,
-        request=_request_without_trace(),
-    )
-    assert resp.status_code == 401
-    assert json.loads(resp.body)["message"] == "Unauthorized"
-
-
-@pytest.mark.asyncio
 async def test_upload_raises_409_on_duplicate_name():
     # upload_file raises ValueError for filename == "taken"
     service = _StubService([])
@@ -1103,7 +1116,7 @@ async def test_upload_raises_409_on_duplicate_name():
     resp = await upload_resource(
         name="taken",
         content=b"x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-a",
         factory=factory,
         resolver=resolver,
@@ -1122,7 +1135,7 @@ async def test_upload_reads_x_trace_id_from_request():
     env = await upload_resource(
         name="hello.txt",
         content=b"x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-a",
         factory=factory,
         resolver=resolver,
@@ -1154,7 +1167,7 @@ async def test_download_returns_raw_bytes_with_mime_type():
 
     response = await download_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1172,23 +1185,6 @@ async def test_download_returns_raw_bytes_with_mime_type():
 
 
 @pytest.mark.asyncio
-async def test_download_raises_missing_principal_when_no_authenticated_caller():
-    # owner_id from caller_owner_id(principal) — a None principal is
-    # fail-closed (no silent bot_repo fallback), mirroring the bots router.
-    factory, resolver, dispatcher, _ = _delete_deps()
-
-    with pytest.raises(MissingPrincipalError):
-        await download_resource(
-            resource_id="1",
-            principal=None,
-            bot_id="ghost",
-            factory=factory,
-            resolver=resolver,
-            device_fs_dispatcher=dispatcher,
-        )
-
-
-@pytest.mark.asyncio
 async def test_download_raises_404_when_service_returns_none():
     # service.download_resource returns None for resource_id == "0"
     # (simulates not-found / not-a-file / is-directory / read-failure —
@@ -1199,7 +1195,7 @@ async def test_download_raises_404_when_service_returns_none():
     with pytest.raises(HTTPException) as exc:
         await download_resource(
             resource_id="0",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-a",
             factory=factory,
             resolver=resolver,
@@ -1233,7 +1229,7 @@ async def test_preview_returns_envelope_with_content_and_type():
 
     env = await preview_resource(
         resource_id="1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1258,25 +1254,6 @@ async def test_preview_returns_envelope_with_content_and_type():
 
 
 @pytest.mark.asyncio
-async def test_preview_raises_missing_principal_when_no_authenticated_caller():
-    # owner_id from caller_owner_id(principal) — a None principal is
-    # fail-closed (no silent bot_repo fallback), mirroring the bots router.
-    factory, resolver, dispatcher, _ = _delete_deps()
-
-    resp = await preview_resource(
-        resource_id="1",
-        principal=None,
-        bot_id="ghost",
-        factory=factory,
-        resolver=resolver,
-        device_fs_dispatcher=dispatcher,
-        request=_request_without_trace(),
-    )
-    assert resp.status_code == 401
-    assert json.loads(resp.body)["message"] == "Unauthorized"
-
-
-@pytest.mark.asyncio
 async def test_preview_raises_404_when_service_returns_none():
     # service.preview_resource returns None for resource_id == "0" (simulates
     # not-found / not-a-file / is-directory / read-failure / empty — the
@@ -1287,7 +1264,7 @@ async def test_preview_raises_404_when_service_returns_none():
     with pytest.raises(HTTPException) as exc:
         await preview_resource(
             resource_id="0",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-a",
             factory=factory,
             resolver=resolver,
@@ -1308,7 +1285,7 @@ async def test_preview_raises_413_when_too_large():
 
     resp = await preview_resource(
         resource_id="too-large",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-a",
         factory=factory,
         resolver=resolver,
@@ -1465,7 +1442,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    service.create_url_resource, already present on the slim service).
     env = await create_resource(
         body=ResourceCreate(name="doc", type=OpenapiType.LINK, url="https://x.com"),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -1478,7 +1455,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    the new slim method). The real repo round-trips the stored row.
     env = await get_resource(
         resource_id=link_id,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -1493,7 +1470,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    the persisted row is visible to the real repo).
     env = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         type=None,
         factory=factory,
@@ -1508,7 +1485,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     env = await upload_resource(
         name="hello.txt",
         content=b"file bytes",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1527,7 +1504,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    round-trips the bytes written in step 4).
     response = await download_resource(
         resource_id=file_id,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1541,7 +1518,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    the bytes and returns the {content, content_type, size} dict).
     env = await preview_resource(
         resource_id=file_id,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1557,7 +1534,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     #    FILE resource, then soft-deletes the repo row).
     env = await delete_resource(
         resource_id=file_id,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1574,7 +1551,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     with pytest.raises(HTTPException) as exc:
         await delete_resource(
             resource_id="999999",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=factory,
             resolver=resolver,
@@ -1589,7 +1566,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     resp = await upload_resource(
         name="hello.txt",
         content=b"dup",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,
@@ -1618,7 +1595,7 @@ async def test_list_resources_passes_legacy_enum_to_service():
 
     await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=OpenapiType.LINK,
         factory=factory,
@@ -1637,7 +1614,7 @@ async def test_list_resources_passes_none_when_type_filter_absent():
 
     await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -1681,7 +1658,7 @@ async def test_list_resources_openapi_folder_has_no_legacy_counterpart():
     # non-empty and the leak would surface them without the FOLDER guard).
     unfiltered = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=None,
         factory=factory,
@@ -1692,7 +1669,7 @@ async def test_list_resources_openapi_folder_has_no_legacy_counterpart():
     # type=FOLDER must NOT leak those rows — empty page, not "all".
     env = await list_resources(
         page=PageParams(),
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-a",
         type=OpenapiType.FOLDER,
         factory=factory,
@@ -1710,7 +1687,7 @@ async def test_check_name_passes_legacy_enum_to_service_when_provided():
 
     await check_resource_name(
         name="available",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=OpenapiType.FILE,
         bot_id="bot-a",
         factory=factory,
@@ -1729,7 +1706,7 @@ async def test_check_name_defaults_to_legacy_file_enum_when_type_absent():
 
     await check_resource_name(
         name="available",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         type=None,
         bot_id="bot-a",
         factory=factory,
@@ -1784,7 +1761,7 @@ async def test_get_resource_returns_404_for_cross_bot_resource_id():
     with pytest.raises(HTTPException) as exc:
         await get_resource(
             resource_id=foreign_id,
-            principal={"user_id": "u1"},
+            user_id="u1",
             bot_id="bot-x",
             factory=factory,
             request=_request_without_trace(),
@@ -1804,7 +1781,7 @@ async def test_delete_resource_returns_404_for_cross_bot_resource_id():
     with pytest.raises(HTTPException) as exc:
         await delete_resource(
             resource_id=foreign_id,
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=factory,
             resolver=resolver,
@@ -1829,7 +1806,7 @@ async def test_download_resource_returns_404_for_cross_bot_resource_id():
     with pytest.raises(HTTPException) as exc:
         await download_resource(
             resource_id=foreign_id,
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=factory,
             resolver=resolver,
@@ -1850,7 +1827,7 @@ async def test_preview_resource_returns_404_for_cross_bot_resource_id():
     with pytest.raises(HTTPException) as exc:
         await preview_resource(
             resource_id=foreign_id,
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=factory,
             resolver=resolver,
@@ -1870,7 +1847,7 @@ async def test_same_bot_get_works_after_isolation_invariant():
 
     env = await get_resource(
         resource_id=own_id,
-        principal={"user_id": "u1"},
+        user_id="u1",
         bot_id="bot-x",
         factory=factory,
         request=_request_without_trace(),
@@ -1915,7 +1892,7 @@ async def test_upload_returns_502_when_device_fs_write_fails():
         await upload_resource(
             name="hello.txt",
             content=b"file bytes",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=factory,
             resolver=resolver,
@@ -1960,7 +1937,7 @@ async def test_upload_409_takes_precedence_over_502_path():
     resp = await upload_resource(
         name="hello.txt",
         content=b"x",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=factory,
         resolver=resolver,

--- a/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
@@ -138,7 +138,7 @@ async def test_list_routines_returns_envelope_page():
 
     env = await list_routines(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -177,7 +177,7 @@ async def test_list_routines_asks_for_the_draft_stage_only():
 
     await list_routines(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -198,7 +198,7 @@ async def test_list_routines_paginates_items():
 
     env = await list_routines(
         page=PageParams(page=2, page_size=1),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -215,7 +215,7 @@ async def test_list_routines_handles_empty_data_list():
 
     env = await list_routines(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -238,7 +238,7 @@ async def test_list_routines_handles_dict_data_envelope():
 
     env = await list_routines(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -256,7 +256,7 @@ async def test_list_routines_reads_x_trace_id_from_request():
 
     env = await list_routines(
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         status=None,
         factory=service,
@@ -305,7 +305,7 @@ async def test_create_routine_returns_201_envelope():
 
     env = await create_routine(
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         factory=service,
         request=_request_without_trace(),
     )
@@ -334,7 +334,7 @@ async def test_create_routine_uses_body_bot_id_for_owner_and_call():
 
     await create_routine(
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         factory=service,
         request=_request_without_trace(),
     )
@@ -362,7 +362,7 @@ async def test_create_routine_passes_schedule_as_cron_string():
 
     await create_routine(
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         factory=service,
         request=_request_without_trace(),
     )
@@ -388,7 +388,7 @@ async def test_create_routine_defaults_timezone_when_null():
 
     await create_routine(
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         factory=service,
         request=_request_without_trace(),
     )
@@ -409,7 +409,7 @@ async def test_create_routine_reads_x_trace_id_from_request():
 
     env = await create_routine(
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         factory=service,
         request=request,
     )
@@ -430,7 +430,7 @@ async def test_create_routine_500_when_service_returns_no_data():
     with pytest.raises(HTTPException) as exc:
         await create_routine(
             body=body,
-            principal={"user_id": "u1"},
+            owner_id="u1",
             factory=service,
             request=_request_without_trace(),
         )
@@ -471,7 +471,7 @@ async def test_get_routine_returns_envelope_routine():
 
     env = await get_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -500,7 +500,7 @@ async def test_get_routine_404_when_data_missing():
     with pytest.raises(HTTPException) as exc:
         await get_routine(
             routine_id="t1",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=service,
             request=_request_without_trace(),
@@ -516,7 +516,7 @@ async def test_get_routine_reads_x_trace_id_from_request():
 
     env = await get_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=request,
@@ -562,7 +562,7 @@ async def test_update_routine_returns_envelope_routine():
     env = await update_routine(
         routine_id="t1",
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -592,7 +592,7 @@ async def test_update_routine_passes_partial_body_and_schedule_string():
     await update_routine(
         routine_id="t1",
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -621,7 +621,7 @@ async def test_update_routine_omits_unset_fields_from_body():
     await update_routine(
         routine_id="t1",
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -645,7 +645,7 @@ async def test_update_routine_404_when_data_missing():
         await update_routine(
             routine_id="t1",
             body=body,
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=service,
             request=_request_without_trace(),
@@ -662,7 +662,7 @@ async def test_update_routine_reads_x_trace_id_from_request():
     env = await update_routine(
         routine_id="t1",
         body=body,
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=request,
@@ -748,7 +748,7 @@ async def test_delete_routine_returns_envelope_deleted_true():
 
     env = await delete_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -777,7 +777,7 @@ async def test_delete_routine_returns_404_when_success_false():
     with pytest.raises(HTTPException) as exc:
         await delete_routine(
             routine_id="t1",
-            principal={"user_id": "u1"},
+            owner_id="u1",
             bot_id="bot-x",
             factory=service,
             request=_request_without_trace(),
@@ -792,7 +792,7 @@ async def test_delete_routine_reads_x_trace_id_from_request():
 
     env = await delete_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=request,
@@ -839,7 +839,7 @@ async def test_run_routine_returns_completed_status_when_ran():
 
     env = await run_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -870,7 +870,7 @@ async def test_run_routine_returns_failed_status_when_reason():
 
     env = await run_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -886,7 +886,7 @@ async def test_run_routine_returns_unknown_status_when_no_reason():
 
     env = await run_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -902,7 +902,7 @@ async def test_run_routine_reads_x_trace_id_from_request():
 
     env = await run_routine(
         routine_id="t1",
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=request,
@@ -962,7 +962,7 @@ async def test_list_routine_runs_returns_envelope_page_mapped_from_runs():
     env = await list_routine_runs(
         routine_id="t1",
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -997,7 +997,7 @@ async def test_list_routine_runs_paginates_items():
     env = await list_routine_runs(
         routine_id="t1",
         page=PageParams(page=2, page_size=2),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -1014,7 +1014,7 @@ async def test_list_routine_runs_handles_empty_runs():
     env = await list_routine_runs(
         routine_id="t1",
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),
@@ -1033,7 +1033,7 @@ async def test_list_routine_runs_reads_x_trace_id_from_request():
     env = await list_routine_runs(
         routine_id="t1",
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=request,
@@ -1055,7 +1055,7 @@ async def test_list_routine_runs_handles_bare_data_list_defensively():
     env = await list_routine_runs(
         routine_id="t1",
         page=PageParams(page=1, page_size=20),
-        principal={"user_id": "u1"},
+        owner_id="u1",
         bot_id="bot-x",
         factory=service,
         request=_request_without_trace(),

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -18,6 +18,10 @@ from injector import Injector, Module
 
 import importlib
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.bots.router import router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_service import BotServiceProtocol
@@ -115,7 +119,8 @@ def client(svc, policy, passport, engine_config, bot_repo, skill_set_factory, au
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": "u1"}
     attach_injector(app, Injector([_M()]))
-    return TestClient(app)
+    mount_public_error_handlers(app)
+    return user_scoped_client(app, "u1")
 
 
 def _ok(resp, code=200000):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
@@ -153,6 +152,20 @@ def test_list_bots_filters_reach_service(client, svc):
     assert kw["engine"] == "teclaw"
     assert kw["status"] == "ACTIVE"
     assert kw["page"] == 2 and kw["page_size"] == 5
+
+
+def test_check_name_needs_no_user_id(client):
+    """The one bots operation with no user dimension answers without one.
+
+    Name uniqueness is checked across the tenant, so there is nothing to scope
+    by. ``user_id=None`` is how ``user_scoped_client`` is told to omit the
+    parameter rather than send it empty.
+    """
+    response = client.get(
+        "/openapi/v1/bots/check-name", params={"name": "Foo", "user_id": None}
+    )
+
+    assert response.status_code == 200, response.json()
 
 
 def test_check_name(client):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -1,0 +1,211 @@
+"""The public surface names its end user explicitly (``?user_id=``).
+
+Every user-scoped operation used to infer the user it acts for from the verified
+principal, which only worked because the gateway resolves one end user per
+request and signs it in. An App calling **on behalf of** a user presents its own
+credential, and an operation whose published contract never mentions a user has
+nowhere to put one — so the contract now says out loud what it always meant.
+
+This file covers the **seam**: what ``require_user_id`` returns, what it
+refuses, and with which status. The document-level assertions — which operations
+carry the parameter, where it sits, and which four are exempt — arrive with the
+operations themselves.
+
+The refusal is the load-bearing part. Making the user explicit must not make it
+*forgeable*: until delegation lands the only user a caller may name is itself,
+so a parameter naming anyone else is a 403 and nothing about who may call what
+has changed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    ERROR_RESPONSES,
+    USER_SCOPED_ERROR_RESPONSES,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    MissingPrincipalError,
+    UserIdMismatchError,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    USER_ID_QUERY,
+    UserIdDep,
+    require_user_id,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+
+_CALLER = "u-42"
+_PROBE = f"{PUBLIC_API_PREFIX}/bots/_probe"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """One route shaped exactly like a real user-scoped handler, and nothing else.
+
+    A probe rather than a mounted group, following ``test_principal_seam.py``:
+    the real handlers pull services from the injector, so driving one would test
+    the service bindings on the way to testing the identity chain. This declares
+    the same ``UserIdDep`` a real handler declares and returns what it resolved,
+    which is the whole of what these assertions are about.
+
+    The app-level handlers are imported from ``app.py`` rather than
+    re-implemented, so deleting that wiring fails here instead of leaving these
+    green against a local copy of it.
+    """
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _user_id_mismatch_handler,
+        _validation_error_handler,
+    )
+    from fastapi.exceptions import RequestValidationError
+
+    app = FastAPI()
+
+    @app.get(_PROBE)
+    @envelope_errors
+    async def probe(request: Request, user_id: UserIdDep):
+        return envelope({"user_id": user_id}, request)
+
+    app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+    app.add_exception_handler(UserIdMismatchError, _user_id_mismatch_handler)
+    app.add_exception_handler(RequestValidationError, _validation_error_handler)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": _CALLER}
+    # The response is what these tests are about, so observe it rather than
+    # letting an unhandled exception be re-raised into the test.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── what the caller gets ────────────────────────────────────────────────────
+
+
+def test_the_caller_reaches_its_own_scope(client):
+    """The parameter repeating the caller is accepted — the only value that is.
+
+    And what the handler receives is the parameter's value, not a second read of
+    the principal: that is what makes the handlers already correct on the day
+    the two are allowed to differ.
+    """
+    response = client.get(_PROBE, params={USER_ID_QUERY: _CALLER})
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"user_id": _CALLER}
+
+
+def test_naming_another_user_is_refused(client):
+    """The parameter does not widen who a caller can reach — that is delegation."""
+    response = client.get(_PROBE, params={USER_ID_QUERY: "someone-else"})
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["code"] == 403000
+    assert body["message"] == "Forbidden"
+    assert body["data"] is None
+
+
+def test_two_rejected_ids_give_identical_answers(client):
+    """The refusal says nothing about the user it was asked for."""
+    first = client.get(_PROBE, params={USER_ID_QUERY: "someone-else"})
+    second = client.get(_PROBE, params={USER_ID_QUERY: "another-one"})
+
+    assert first.status_code == second.status_code == 403
+    assert _without_request_id(first) == _without_request_id(second)
+
+
+# ── precedence: 401 outranks everything ─────────────────────────────────────
+
+
+def test_a_missing_parameter_is_a_validation_failure(client):
+    """422, not 401: the caller is authenticated, the request is incomplete."""
+    assert client.get(_PROBE).status_code == 422
+
+
+def test_an_empty_parameter_is_a_validation_failure_too(client):
+    """A blank value must not read as "the caller" — it names nobody."""
+    assert client.get(_PROBE, params={USER_ID_QUERY: ""}).status_code == 422
+
+
+def test_no_verified_caller_is_still_a_401_whatever_the_parameter_says(client):
+    """The 401 comes first, so the parameter can never stand in for a credential.
+
+    This is the "nothing else changes" property: a request with no verified
+    principal is refused exactly as it was before the parameter existed.
+    """
+    client.app.dependency_overrides[require_principal] = lambda: None
+
+    response = client.get(_PROBE, params={USER_ID_QUERY: _CALLER})
+
+    assert response.status_code == 401
+
+
+# ── the seam itself ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_dependency_returns_the_request_user_id():
+    resolved = await require_user_id(principal={"user_id": _CALLER}, user_id=_CALLER)
+
+    assert resolved == _CALLER
+
+
+@pytest.mark.asyncio
+async def test_the_dependency_refuses_a_mismatch():
+    with pytest.raises(UserIdMismatchError):
+        await require_user_id(principal={"user_id": _CALLER}, user_id="someone-else")
+
+
+@pytest.mark.asyncio
+async def test_the_dependency_refuses_an_unverifiable_caller():
+    """Fail-closed on the principal before the parameter is even compared."""
+    with pytest.raises(MissingPrincipalError):
+        await require_user_id(principal=None, user_id=_CALLER)
+
+
+@pytest.mark.asyncio
+async def test_the_mismatch_logs_both_ids(caplog):
+    """The response carries a fixed word, so the log is the only record.
+
+    An operator debugging a partner integration needs to know which user was
+    asked for and which caller asked. Both values are the caller's own
+    identifiers on this path — a parameter disagreeing with a *verified*
+    principal is the only way to get here — so neither discloses a third party.
+    """
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(UserIdMismatchError):
+            await require_user_id(
+                principal={"user_id": _CALLER}, user_id="someone-else"
+            )
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "someone-else" in logged
+    assert _CALLER in logged
+
+
+# ── how the 403 is published ────────────────────────────────────────────────
+
+
+def test_the_403_is_not_declared_surface_wide():
+    """``ERROR_RESPONSES`` stays the set *every* operation can return.
+
+    ``test_openapi_error_schema`` asserts every operation documents every status
+    in it, so a 403 added there would make Bot Logs — and the four operations
+    with no user dimension — advertise a failure they cannot produce.
+    """
+    assert 403 not in ERROR_RESPONSES
+    assert 403 in USER_SCOPED_ERROR_RESPONSES
+
+
+def _without_request_id(response) -> dict:
+    body = dict(response.json())
+    body.pop("request_id", None)
+    return body

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -20,6 +20,7 @@ has changed.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import pytest
@@ -54,7 +55,7 @@ _PROBE = f"{PUBLIC_API_PREFIX}/bots/_probe"
 
 
 @pytest.fixture
-def client() -> TestClient:
+def probe_app() -> FastAPI:
     """One route shaped exactly like a real user-scoped handler, and nothing else.
 
     A probe rather than a mounted group, following ``test_principal_seam.py``:
@@ -85,9 +86,14 @@ def client() -> TestClient:
     app.add_exception_handler(UserIdMismatchError, _user_id_mismatch_handler)
     app.add_exception_handler(RequestValidationError, _validation_error_handler)
     app.dependency_overrides[require_principal] = lambda: {"user_id": _CALLER}
+    return app
+
+
+@pytest.fixture
+def client(probe_app: FastAPI) -> TestClient:
     # The response is what these tests are about, so observe it rather than
     # letting an unhandled exception be re-raised into the test.
-    return TestClient(app, raise_server_exceptions=False)
+    return TestClient(probe_app, raise_server_exceptions=False)
 
 
 # ── what the caller gets ────────────────────────────────────────────────────
@@ -150,6 +156,46 @@ def test_no_verified_caller_is_still_a_401_whatever_the_parameter_says(client):
     response = client.get(_PROBE, params={USER_ID_QUERY: _CALLER})
 
     assert response.status_code == 401
+
+
+def test_a_long_subject_id_is_not_locked_out(probe_app):
+    """No upper bound on the parameter, because the identity boundary has none.
+
+    ``GatewayUser.id`` is an unconstrained ``str`` and the verifier refuses only
+    a *blank* subject id, so any cap here would reject a caller whose credential
+    the gateway accepts — a 422 on all 56 operations for a value that matches
+    the signed principal exactly. ``min_length=1`` is safe for the opposite
+    reason: it has a counterpart at that boundary.
+    """
+    long_id = "u-" + "x" * 4000
+    probe_app.dependency_overrides[require_principal] = lambda: {"user_id": long_id}
+    client = TestClient(probe_app, raise_server_exceptions=False)
+
+    response = client.get(_PROBE, params={USER_ID_QUERY: long_id})
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"user_id": long_id}
+
+
+def test_a_rejected_id_cannot_choose_how_much_it_logs(caplog):
+    """The bound moved from the request to the log, so it still has one.
+
+    Removing the cap means a refused caller controls an unbounded string. It is
+    escaped (no forged lines) and truncated (no choosing how many bytes each
+    refusal costs), and the truncation says how much it dropped so a reader is
+    not misled about what was sent.
+    """
+    flood = "z" * 10_000
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(UserIdMismatchError):
+            asyncio.run(
+                require_user_id(principal={"user_id": _CALLER}, user_id=flood)
+            )
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert len(logged) < 500, "a caller must not choose the size of the log line"
+    assert "(+9872)" in logged, "and the reader is told how much was dropped"
 
 
 # ── the seam itself ─────────────────────────────────────────────────────────

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -263,7 +263,10 @@ def _param(operation: dict, name: str) -> dict | None:
 
 
 def _user_scoped(path: str, method: str) -> bool:
-    return not path.startswith(_LOGS_PREFIX) and (method, path) not in _NO_USER_DIMENSION
+    return (
+        not path.startswith(_LOGS_PREFIX)
+        and (method, path) not in _NO_USER_DIMENSION
+    )
 
 
 def test_every_user_scoped_operation_requires_user_id_in_the_query():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -6,10 +6,11 @@ request and signs it in. An App calling **on behalf of** a user presents its own
 credential, and an operation whose published contract never mentions a user has
 nowhere to put one — so the contract now says out loud what it always meant.
 
-This file covers the **seam**: what ``require_user_id`` returns, what it
-refuses, and with which status. The document-level assertions — which operations
-carry the parameter, where it sits, and which four are exempt — arrive with the
-operations themselves.
+Two halves. The **seam**: what ``require_user_id`` returns, what it refuses, and
+with which status. And the **document**: which operations carry the parameter,
+where it sits, and which four are exempt — asserted against the generated
+description rather than a hand-kept list, so an operation added later is covered
+without editing this file.
 
 The refusal is the load-bearing part. Making the user explicit must not make it
 *forgeable*: until delegation lands the only user a caller may name is itself,
@@ -25,7 +26,10 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+from agentclaw.community.adapters.http.openapi_v1 import (
+    PUBLIC_API_PREFIX,
+    build_public_router,
+)
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     ERROR_RESPONSES,
     USER_SCOPED_ERROR_RESPONSES,
@@ -209,3 +213,152 @@ def _without_request_id(response) -> dict:
     body = dict(response.json())
     body.pop("request_id", None)
     return body
+
+
+# ── the published document ──────────────────────────────────────────────────
+
+#: The operations that take no ``user_id``, and why each one cannot.
+#:
+#: Pinned by address rather than counted, so adding a fifth is a deliberate edit
+#: to this list with a reason attached — which is the only thing standing
+#: between "this operation has no user dimension" and "somebody found the
+#: parameter inconvenient".
+_NO_USER_DIMENSION = {
+    # Name uniqueness is checked across the tenant, not within one user's bots.
+    ("get", f"{PUBLIC_API_PREFIX}/bots/check-name"),
+    # The marketplace catalogue is identical for every caller in the tenant.
+    ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/servers"),
+    ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/servers/{{server_code}}"),
+    ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/tenants"),
+}
+
+#: Bot Logs is excluded for a different reason and must stay that way — see the
+#: "Naming the end user" note in ``openapi_v1/__init__.py``. Its own ``user_id``
+#: is a filter over other people's traces, not the caller's scope.
+_LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
+
+#: What ``bot_id`` looks like, and must keep looking like: an address where it
+#: addresses a bot, a query parameter where it is one, and never a body field.
+#: This change deliberately moved none of them.
+_BOT_ID_PLACEMENT = {"path": 28, "query": 18, "none": 19}
+
+
+def _schema() -> dict:
+    app = FastAPI()
+    app.include_router(build_public_router())
+    return app.openapi()
+
+
+def _operations(schema: dict):
+    for path, methods in schema["paths"].items():
+        for method, operation in methods.items():
+            yield path, method, operation
+
+
+def _param(operation: dict, name: str) -> dict | None:
+    for parameter in operation.get("parameters", []):
+        if parameter["name"] == name:
+            return parameter
+    return None
+
+
+def _user_scoped(path: str, method: str) -> bool:
+    return not path.startswith(_LOGS_PREFIX) and (method, path) not in _NO_USER_DIMENSION
+
+
+def test_every_user_scoped_operation_requires_user_id_in_the_query():
+    """A route added later cannot quietly go back to inferring the user."""
+    offenders = []
+    for path, method, operation in _operations(_schema()):
+        if not _user_scoped(path, method):
+            continue
+        parameter = _param(operation, USER_ID_QUERY)
+        if parameter is None or parameter["in"] != "query" or not parameter["required"]:
+            offenders.append(f"{method.upper()} {path} -> {parameter}")
+    assert not offenders, f"operations not naming their user in the query: {offenders}"
+
+
+def test_fifty_six_operations_take_it():
+    """The count is pinned so a silent drop shows up as a number, not a shrug."""
+    taking = [
+        1
+        for path, method, operation in _operations(_schema())
+        if _user_scoped(path, method) and _param(operation, USER_ID_QUERY)
+    ]
+    assert len(taking) == 56
+
+
+def test_the_exempt_operations_take_none():
+    """The four with no user dimension ask for nothing they cannot use."""
+    schema = _schema()
+    for method, path in _NO_USER_DIMENSION:
+        operation = schema["paths"][path][method]
+        assert _param(operation, USER_ID_QUERY) is None, f"{method.upper()} {path}"
+        assert "403" not in operation["responses"], f"{method.upper()} {path}"
+
+
+def test_bot_logs_keeps_its_own_meaning_of_user_id():
+    """Same spelling, opposite contract — and it must not acquire a 403.
+
+    ``GET …/logs/traces`` takes a ``user_id`` that says *whose traces to read*;
+    a user+App caller may point it at someone else. Giving that operation this
+    rule's 403 would remove the capability the route exists to provide.
+    """
+    schema = _schema()
+    logs = [
+        (path, method, operation)
+        for path, method, operation in _operations(schema)
+        if path.startswith(_LOGS_PREFIX)
+    ]
+    assert len(logs) == 5
+    assert not any("403" in operation["responses"] for _, _, operation in logs)
+
+    traces = schema["paths"][f"{_LOGS_PREFIX}/traces"]["get"]
+    assert _param(traces, USER_ID_QUERY) is not None, (
+        "the filter is part of that operation's contract, not this rule's"
+    )
+
+
+def test_user_id_is_never_a_body_field_or_a_path_segment():
+    """The two placements this design rejected, asserted rather than remembered."""
+    schema = _schema()
+    for path, method, operation in _operations(schema):
+        assert "{user_id}" not in path, f"{method.upper()} {path}"
+        parameter = _param(operation, USER_ID_QUERY)
+        assert parameter is None or parameter["in"] == "query"
+
+    # Request bodies only. A *response* may well carry a user id — Bot Logs'
+    # ``ConversationDetail`` describes whose conversation it was — and that has
+    # nothing to do with where a request names the user it acts for.
+    for name in _request_body_models(schema):
+        model = schema["components"]["schemas"][name]
+        assert USER_ID_QUERY not in (model.get("properties") or {}), (
+            f"{name} declares user_id as a request-body field"
+        )
+
+
+def test_bot_id_placement_is_untouched():
+    """This change moved no ``bot_id``. If it ever does, it is on purpose."""
+    counts = {"path": 0, "query": 0, "none": 0}
+    for _, _, operation in _operations(_schema()):
+        parameter = _param(operation, "bot_id")
+        counts[parameter["in"] if parameter else "none"] += 1
+    assert counts == _BOT_ID_PLACEMENT
+
+
+def test_the_403_is_documented_on_exactly_the_user_scoped_operations():
+    for path, method, operation in _operations(_schema()):
+        documented = "403" in operation["responses"]
+        assert documented is _user_scoped(path, method), f"{method.upper()} {path}"
+
+
+def _request_body_models(schema: dict) -> set[str]:
+    """Every named component reachable as an operation's request body."""
+    found = set()
+    for _, _, operation in _operations(schema):
+        body = operation.get("requestBody") or {}
+        for media in (body.get("content") or {}).values():
+            ref = (media.get("schema") or {}).get("$ref")
+            if ref:
+                found.add(ref.rsplit("/", 1)[-1])
+    return found

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -21,8 +21,13 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.mcp.router import router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.api.mcp_auth_service import MCPAuthServiceProtocol
 from agentclaw.community.api.mcp_config_service import MCPConfigServiceProtocol
 from agentclaw.community.api.mcp_market_service import MCPMarketServiceProtocol
@@ -99,7 +104,8 @@ def client(market, auth, config, sync):
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": "u1"}
     attach_injector(app, Injector([_M()]))
-    return TestClient(app)
+    mount_public_error_handlers(app)
+    return user_scoped_client(app, "u1")
 
 
 def _ok(resp, code=200000):
@@ -212,11 +218,26 @@ def test_projection_reads_transport_protocol_from_endpoints(client, market):
 # ── permission ──────────────────────────────────────────────────────
 
 
-def test_permission_uses_caller_identity_only(client, auth):
-    # Even with a spoofed ?user_id=, the service is queried for the principal.
-    _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/permissions?user_id=evil"))
+def test_permission_uses_the_request_user_id(client, auth):
+    """The owner is the request's ``user_id`` — and only the caller's own.
+
+    This test used to assert the opposite half of the same guarantee: a spoofed
+    ``?user_id=evil`` was *ignored*, and the service queried for the principal.
+    Now the parameter is the contract, so a spoofed one is refused outright
+    rather than silently dropped — strictly stronger, and the service never runs.
+    """
+    spoofed = client.get(
+        "/openapi/v1/bots/mcp/servers/mcp.weather/permissions",
+        params={"user_id": "evil"},
+    )
+    assert spoofed.status_code == 403
+    assert auth.check_mcp_permission_detail.call_args is None, (
+        "the refusal must happen before the service is reached"
+    )
+
+    _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather/permissions"))
     args = auth.check_mcp_permission_detail.call_args.args
-    assert args[0] == "u1"  # owner from principal, not the query param
+    assert args[0] == "u1"  # the request's user_id, which must be the caller's
 
 
 def test_permission_shape(client):
@@ -365,7 +386,26 @@ def test_put_config_rejects_dev_endpoint_env_as_422(client):
 
 
 def test_missing_principal_is_401(client):
-    client.app.dependency_overrides[require_principal] = lambda: None
+    """The catalogue reads are gated by ``require_principal`` and nothing else.
+
+    They take no ``user_id``, so unlike the rest of the surface there is no
+    second consumer of the principal to fail on. The override therefore has to
+    *raise* rather than return ``None`` — that is what the real
+    ``require_principal`` does when no caller verifies, and returning ``None``
+    would be simulating a state production never reaches while removing the only
+    guard these three operations have.
+    """
+
+    def _no_caller():
+        raise MissingPrincipalError("no verified caller for this request")
+
+    client.app.dependency_overrides[require_principal] = _no_caller
     resp = client.get("/openapi/v1/bots/mcp/servers")
     assert resp.status_code == 401
     assert resp.json()["code"] == 401000
+
+
+def test_the_catalogue_reads_need_no_user_id(client):
+    """The four exempt operations answer without one — the contract says so."""
+    for path in ("/openapi/v1/bots/mcp/servers", "/openapi/v1/bots/mcp/tenants"):
+        assert client.get(path, params={"user_id": None}).status_code == 200

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -17,7 +17,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
@@ -400,12 +399,34 @@ def test_missing_principal_is_401(client):
         raise MissingPrincipalError("no verified caller for this request")
 
     client.app.dependency_overrides[require_principal] = _no_caller
-    resp = client.get("/openapi/v1/bots/mcp/servers")
-    assert resp.status_code == 401
-    assert resp.json()["code"] == 401000
+    for path in (
+        "/openapi/v1/bots/mcp/servers",
+        "/openapi/v1/bots/mcp/servers/mcp.weather",
+        "/openapi/v1/bots/mcp/tenants",
+    ):
+        resp = client.get(path)
+        assert resp.status_code == 401, path
+        assert resp.json()["code"] == 401000
 
 
-def test_the_catalogue_reads_need_no_user_id(client):
-    """The four exempt operations answer without one — the contract says so."""
-    for path in ("/openapi/v1/bots/mcp/servers", "/openapi/v1/bots/mcp/tenants"):
-        assert client.get(path, params={"user_id": None}).status_code == 200
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/openapi/v1/bots/mcp/servers",
+        "/openapi/v1/bots/mcp/servers/mcp.weather",
+        "/openapi/v1/bots/mcp/tenants",
+    ],
+)
+def test_the_catalogue_reads_need_no_user_id(client, path):
+    """All three MCP catalogue reads answer with the parameter genuinely absent.
+
+    ``user_id=None`` is how ``user_scoped_client`` is told to omit it — passing
+    an empty string would send ``?user_id=`` and prove something weaker, since a
+    user-scoped route rejects that on ``min_length=1`` too.
+
+    (The fourth exempt operation, ``check-name``, lives in the bots group and is
+    covered in ``test_bots_endpoints.py``.)
+    """
+    response = client.get(path, params={"user_id": None})
+
+    assert response.status_code == 200, response.json()

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -15,6 +15,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     require_principal,
@@ -152,7 +156,7 @@ def _client(
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
     attach_injector(app, Injector([Bindings()]))
-    return TestClient(app)
+    return user_scoped_client(app, "actor")
 
 
 def test_upload_accepts_only_raw_zip_and_returns_created_inactive_skill():
@@ -194,7 +198,7 @@ def test_upload_replacement_returns_200_and_updated_operation():
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
     attach_injector(app, Injector([Bindings()]))
-    client = TestClient(app)
+    client = user_scoped_client(app, "actor")
     response = client.post(
         "/openapi/v1/bots/skills/upload?bot_id=bot-1",
         content=b"PK\x03\x04",
@@ -503,7 +507,7 @@ def test_router_uses_verified_principal_and_real_tenant_guard(tmp_path):
     app.add_middleware(AvernetTenantMiddleware)
     app.include_router(router)
     attach_injector(app, Injector([Bindings()]))
-    client = TestClient(app)
+    client = user_scoped_client(app, "owner")
     try:
         visible = client.get(
             "/openapi/v1/bots/skills?bot_id=bot",

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -16,7 +16,6 @@ from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
 from tests.community.adapters.http.openapi_v1.conftest import (
-    mount_public_error_handlers,
     user_scoped_client,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
@@ -9,6 +9,10 @@ import zipfile
 import jwt
 from fastapi.testclient import TestClient
 
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
 from agentclaw.community.core.bot_management.repository.protocol import BotRepository
 from agentclaw.community.core.skill_center.services.repositories import SkillRepository
@@ -152,7 +156,7 @@ def test_every_skills_operation_is_guarded_from_another_tenant(
         )
 
     headers = {PRINCIPAL_HEADER: _principal(_TENANT_B)}
-    client = TestClient(app_with_testing_modules)
+    client = user_scoped_client(app_with_testing_modules, _OWNER)
     own_list = client.get(f"/openapi/v1/bots/skills?bot_id={_BOT_ID}", headers=headers)
     assert own_list.status_code == 200
     assert own_list.json()["data"]["total"] == 1

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
@@ -7,10 +7,8 @@ import time
 import zipfile
 
 import jwt
-from fastapi.testclient import TestClient
 
 from tests.community.adapters.http.openapi_v1.conftest import (
-    mount_public_error_handlers,
     user_scoped_client,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER

--- a/src/backend/tests/community/api/test_user_id_mismatch_handler.py
+++ b/src/backend/tests/community/api/test_user_id_mismatch_handler.py
@@ -1,0 +1,179 @@
+"""Where the explicit user id's 403 handler is registered, and why that matters.
+
+``UserIdMismatchError`` is raised inside ``require_user_id`` — a FastAPI
+**dependency**, so it surfaces in ``solve_dependencies`` before the route
+handler runs and ``@envelope_errors`` never sees it. That is the same placement
+``MissingPrincipalError`` has, and it needs the same treatment for the same
+reason: a handler registered only for ``Exception`` becomes
+``ServerErrorMiddleware``'s, and that middleware sends the response and then
+unconditionally re-raises so the server can log a crash. The caller would get a
+correct 403 followed by a ~100-line ASGI traceback in the server log, on a path
+a misconfigured partner integration takes on *every* request.
+
+The full argument, and the control test proving Starlette really does re-raise,
+live in ``test_principal_error_handler.py``. This file pins the same wiring for
+the 403 and the thing that is specific to it: the response must say nothing
+about which user was named.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
+from agentclaw.community.adapters.http.openapi_v1.errors import UserIdMismatchError
+
+pytestmark = pytest.mark.asyncio
+
+PUBLIC_PATH = f"{PUBLIC_API_PREFIX}/bots"
+INTERNAL_PATH = "/api/bots"
+
+_RAISED = UserIdMismatchError("request user id is not the verified caller")
+
+
+def _build_app(*, register_concrete: bool) -> FastAPI:
+    """Mirror the prod wiring, importing the real handlers from ``app.py``."""
+    from agentclaw.community.adapters.http.app import (
+        _unhandled_exception_handler,
+        _user_id_mismatch_handler,
+    )
+
+    app = FastAPI()
+    # The prod stack wraps the router in several BaseHTTPMiddleware layers; they
+    # re-raise app exceptions on the way out and are in the traceback this file
+    # exists to remove, so the shape is reproduced rather than simplified away.
+    app.add_middleware(BaseHTTPMiddleware, dispatch=lambda r, call_next: call_next(r))
+
+    async def require_user_id() -> None:
+        raise _RAISED
+
+    @app.get(PUBLIC_PATH, dependencies=[Depends(require_user_id)])
+    async def route() -> dict:
+        return {"unreachable": True}
+
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+    if register_concrete:
+        app.add_exception_handler(UserIdMismatchError, _user_id_mismatch_handler)
+    return app
+
+
+async def _call_asgi(app: FastAPI) -> tuple[int | None, str | None]:
+    """Drive ``app`` as uvicorn does; return the wire status and any re-raise."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "path": PUBLIC_PATH,
+        "raw_path": PUBLIC_PATH.encode(),
+        "query_string": b"user_id=someone-else",
+        "headers": [],
+        "client": ("11.232.198.238", 0),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "root_path": "",
+        "app": app,
+    }
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    reraised: str | None = None
+    try:
+        await app(scope, receive, send)
+    except Exception as exc:  # noqa: BLE001 — the observation under test
+        reraised = type(exc).__name__
+
+    status = next(
+        (m["status"] for m in sent if m["type"] == "http.response.start"), None
+    )
+    return status, reraised
+
+
+def _request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"user_id=someone-else",
+        }
+    )
+
+
+async def test_naming_another_user_gets_a_403_and_nothing_else():
+    """The whole point: a 403 on the wire, and no crash reported to the server."""
+    status, reraised = await _call_asgi(_build_app(register_concrete=True))
+
+    assert status == 403
+    assert reraised is None, (
+        "re-raised to the ASGI server, which logs it as 'Exception in ASGI "
+        "application' — a ~100-line traceback behind an already-sent 403"
+    )
+
+
+async def test_the_catch_all_alone_re_raises():
+    """The control, and the reason the concrete registration exists.
+
+    Mirrors ``test_principal_error_handler.py``: if Starlette ever stops
+    re-raising, this fails and the extra registration can be reconsidered.
+    """
+    status, reraised = await _call_asgi(_build_app(register_concrete=False))
+
+    assert status == 403, "the catch-all does produce the right status..."
+    assert reraised == "UserIdMismatchError", "...and then re-raises anyway"
+
+
+async def test_the_public_surface_keeps_its_envelope():
+    """The status and body come from ``ENVELOPE_ERRORS``, not from this handler."""
+    from agentclaw.community.adapters.http.app import _user_id_mismatch_handler
+
+    response = await _user_id_mismatch_handler(_request(PUBLIC_PATH), _RAISED)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403
+    assert b'"code":403000' in response.body
+    assert b'"message":"Forbidden"' in response.body
+    assert b'"data":null' in response.body
+
+
+async def test_an_internal_route_keeps_the_detail_shape():
+    """``/api`` clients parse ``{"detail": ...}`` and never learn the Envelope.
+
+    Unreachable while the dependency is mounted only on the public surface —
+    kept so a future internal caller of the same seam is answered in the shape
+    its clients already parse.
+    """
+    from agentclaw.community.adapters.http.app import _user_id_mismatch_handler
+
+    response = await _user_id_mismatch_handler(_request(INTERNAL_PATH), _RAISED)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"Forbidden"}'
+
+
+async def test_the_response_names_no_user(caplog):
+    """The refusal must not confirm or deny anything about the id it was given.
+
+    A 403 that echoed the requested user would turn this endpoint into an
+    existence oracle for other people's accounts. Which ids disagreed is logged
+    by ``require_user_id``; the response carries one fixed word.
+    """
+    from agentclaw.community.adapters.http.app import _user_id_mismatch_handler
+
+    with caplog.at_level(logging.WARNING):
+        response = await _user_id_mismatch_handler(_request(PUBLIC_PATH), _RAISED)
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "[Public 403]" in logged, "the operator gets a greppable line"
+    assert b"someone-else" not in response.body
+    assert b"user" not in response.body.lower().replace(b'"data":null', b"")

--- a/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
@@ -233,7 +233,11 @@ def _seed_inactive_skill_in_active_custom_set(world) -> None:
     method="DELETE",
     path="/openapi/v1/bots/skills/{skill_id}",
     scenario="deletes_exact_inactive_local_skill",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_inactive_delete,
     expect=ExpectSuccess(status=200, json_contains={"code": 200000, "data": {"deleted": True}}),
 )
@@ -245,7 +249,11 @@ def delete_inactive_local_skill():
     method="DELETE",
     path="/openapi/v1/bots/skills/{skill_id}",
     scenario="rejects_active_local_skill",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_active_delete,
     expect=ExpectError(
         status=409,
@@ -260,7 +268,11 @@ def delete_active_local_skill_is_rejected():
     method="DELETE",
     path="/openapi/v1/bots/skills/{skill_id}",
     scenario="rejects_inactive_default_skill_referenced_by_active_custom_set",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_inactive_skill_in_active_custom_set,
     expect=ExpectError(
         status=409,

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -188,7 +188,11 @@ def _assert_skill_remains_inactive(_response, world) -> None:
     method="POST",
     path="/openapi/v1/bots/skills/{skill_id}/activate",
     scenario="activates_exact_tenant_local_skill",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_activate,
     expect=ExpectSuccess(
         status=200,
@@ -206,7 +210,11 @@ def activate_local_skill_reconciles_runtime():
     method="POST",
     path="/openapi/v1/bots/skills/{skill_id}/activate",
     scenario="runtime_failure_returns_fixed_error",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_runtime_failure,
     expect=ExpectError(
         status=502,
@@ -225,7 +233,11 @@ def activate_local_skill_runtime_failure_is_publicly_safe():
     method="POST",
     path="/openapi/v1/bots/skills/{skill_id}/deactivate",
     scenario="idempotent_inactive_skill_still_reconciles",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_activate,
     expect=ExpectSuccess(
         status=200,
@@ -243,7 +255,11 @@ def deactivate_inactive_local_skill_is_an_idempotent_happy_path():
     method="POST",
     path="/openapi/v1/bots/skills/{skill_id}/deactivate",
     scenario="runtime_failure_compensates_with_fixed_error",
-    input=CaseInput(path_params={"skill_id": "1"}, headers=_HEADERS),
+    input=CaseInput(
+        path_params={"skill_id": "1"},
+        query_params={"user_id": _OWNER},
+        headers=_HEADERS,
+    ),
     seed=_seed_runtime_failure,
     extra_assertions=(_assert_skill_remains_inactive,),
     expect=ExpectError(

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -240,7 +240,7 @@ def _assert_associated_to_owning_bot_default(response, world) -> None:
     path="/openapi/v1/bots/skills/upload",
     scenario="raw_zip_created_in_verified_tenant",
     input=CaseInput(
-        query_params={"bot_id": _BOT_ID},
+        query_params={"bot_id": _BOT_ID, "user_id": _OWNER},
         headers=_HEADERS,
         raw_body=_package(),
     ),
@@ -266,7 +266,7 @@ def raw_zip_upload_creates_an_inactive_skill():
     path="/openapi/v1/bots/skills/upload",
     scenario="multipart_rejected_after_verified_tenant_guard",
     input=CaseInput(
-        query_params={"bot_id": _BOT_ID},
+        query_params={"bot_id": _BOT_ID, "user_id": _OWNER},
         headers={**_HEADERS, "content-type": "multipart/form-data; boundary=x"},
         raw_body=b"--x--",
     ),

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -4240,7 +4240,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -4355,7 +4354,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -4512,7 +4510,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -4656,7 +4653,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -4812,7 +4808,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -4949,7 +4944,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5178,7 +5172,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5324,7 +5317,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5470,7 +5462,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5616,7 +5607,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5762,7 +5752,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -5896,7 +5885,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -6028,7 +6016,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7043,7 +7030,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7167,7 +7153,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7303,7 +7288,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7548,7 +7532,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7703,7 +7686,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -7894,7 +7876,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8020,7 +8001,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8183,7 +8163,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8320,7 +8299,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8469,7 +8447,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8604,7 +8581,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8739,7 +8715,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -8886,7 +8861,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9022,7 +8996,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9191,7 +9164,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9306,7 +9278,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9451,7 +9422,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9584,7 +9554,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9717,7 +9686,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -9862,7 +9830,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10024,7 +9991,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10213,7 +10179,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10357,7 +10322,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10522,7 +10486,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10675,7 +10638,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10828,7 +10790,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -10993,7 +10954,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11173,7 +11133,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11398,7 +11357,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11544,7 +11502,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11707,7 +11664,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11831,7 +11787,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -11957,7 +11912,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12083,7 +12037,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12209,7 +12162,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12333,7 +12285,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12457,7 +12408,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12681,7 +12631,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12807,7 +12756,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -12931,7 +12879,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -13069,7 +13016,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -13195,7 +13141,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -13321,7 +13266,6 @@
             "required": true,
             "schema": {
               "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
-              "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
               "type": "string"

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -4083,7 +4083,7 @@
         "type": "object"
       },
       "SkillUpload": {
-        "description": "Response for a first-time Skill upload.",
+        "description": "Response for a Skill create or same-name package replacement.",
         "properties": {
           "operation": {
             "enum": [
@@ -4232,6 +4232,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4264,6 +4277,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -4324,6 +4347,21 @@
       "post": {
         "description": "Create a bot (201), or return 202 + a Passport iframe when authorization is needed.\n\nEngine-specific inputs belong in ``BotCreateSpec.extra_properties``, but\nnothing downstream reads that bag yet, so the request model does not expose\nan ``engine_options`` field for it — see :class:`BotCreate`.",
         "operationId": "create_bot_openapi_v1_bots_post",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -4374,6 +4412,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -4456,6 +4504,19 @@
               "title": "Session Key",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4488,6 +4549,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -4577,6 +4648,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -4619,6 +4703,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -4710,6 +4804,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4742,6 +4849,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -4824,6 +4941,21 @@
       "get": {
         "description": "Get the caller's bot-creation quota ceiling.\n\nResolved through the same method creation enforces, not\n``PolicyService.get_bots_ceiling`` directly: that one falls back to its own\nhardcoded default of 5, while creation falls back to the configured\n``max_devices_per_entity``. Reading it directly would advertise 5 to a caller\nwhose deployment allows (or rejects at) a different number.",
         "operationId": "get_bots_ceiling_openapi_v1_bots_ceiling_get",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -4854,6 +4986,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5028,6 +5170,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5060,6 +5215,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5151,6 +5316,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5183,6 +5361,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5274,6 +5462,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5306,6 +5507,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5397,6 +5608,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5429,6 +5653,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5509,7 +5743,7 @@
     },
     "/openapi/v1/bots/identity/{bot_id}": {
       "get": {
-        "description": "List a bot's identity files and whether each exists.\n\nI2: entity_type/entity_id/operator_id come from the authenticated\nprincipal via ``caller_owner_id`` (personal bot owner = caller).",
+        "description": "List a bot's identity files and whether each exists.\n\nI2: entity_type/entity_id/operator_id come from the authenticated\nrequest's ``user_id`` parameter (personal bot owner = the named user).",
         "operationId": "list_bot_identity_files_openapi_v1_bots_identity__bot_id__get",
         "parameters": [
           {
@@ -5518,6 +5752,19 @@
             "required": true,
             "schema": {
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -5552,6 +5799,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5612,7 +5869,7 @@
     },
     "/openapi/v1/bots/identity/{bot_id}/{file_type}": {
       "get": {
-        "description": "Read one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``caller_owner_id`` (personal bot owner = caller). I3: ``publish_id`` is\nnot exposed — only draft-device reads (``get_bot_file`` default branch).\nThe service's ``validate_file_type`` requires the physical ``<type>.md``\nform (``VALID_IDENTITY_FILES`` carries the suffix), so the enum value is\nre-suffixed before forwarding.",
+        "description": "Read one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``UserIdDep`` (personal bot owner = the named user). I3: ``publish_id`` is\nnot exposed — only draft-device reads (``get_bot_file`` default branch).\nThe service's ``validate_file_type`` requires the physical ``<type>.md``\nform (``VALID_IDENTITY_FILES`` carries the suffix), so the enum value is\nre-suffixed before forwarding.",
         "operationId": "get_bot_identity_file_openapi_v1_bots_identity__bot_id___file_type__get",
         "parameters": [
           {
@@ -5630,6 +5887,19 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/IdentityFileType"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -5663,6 +5933,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -5721,7 +6001,7 @@
         ]
       },
       "put": {
-        "description": "Overwrite one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``caller_owner_id`` as above; ``validate_file_type`` requires the\n``<type>.md`` form. Returns an ``IdentityFileRef`` (no content echoed).",
+        "description": "Overwrite one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``UserIdDep`` as above; ``validate_file_type`` requires the\n``<type>.md`` form. Returns an ``IdentityFileRef`` (no content echoed).",
         "operationId": "update_bot_identity_file_openapi_v1_bots_identity__bot_id___file_type__put",
         "parameters": [
           {
@@ -5739,6 +6019,19 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/IdentityFileType"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -5782,6 +6075,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -6732,6 +7035,19 @@
               "title": "Server Code",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6764,6 +7080,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -6833,6 +7159,19 @@
               "title": "Server Code",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -6875,6 +7214,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -6946,6 +7295,19 @@
               "title": "Server Code",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -6978,6 +7340,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7168,6 +7540,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7200,6 +7585,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7300,6 +7695,19 @@
               "title": "Model Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7332,6 +7740,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7468,6 +7886,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7500,6 +7931,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7571,6 +8012,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -7613,6 +8067,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7711,6 +8175,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7743,6 +8220,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7803,7 +8290,7 @@
     },
     "/openapi/v1/bots/resources/upload": {
       "post": {
-        "description": "Upload a file's raw bytes as a new resource.\n\ndevice_fs is resolved per-bot; upload_file is async and raises\nDuplicateResourceError on duplicate name → 409 (via @envelope_errors).\nowner_id comes from the verified principal (``caller_owner_id``),\nfail-closed — mirroring the bots router.",
+        "description": "Upload a file's raw bytes as a new resource.\n\ndevice_fs is resolved per-bot; upload_file is async and raises\nDuplicateResourceError on duplicate name → 409 (via @envelope_errors).\nowner_id comes from the request's ``user_id`` parameter (``UserIdDep``),\nfail-closed — mirroring the bots router.",
         "operationId": "upload_resource_openapi_v1_bots_resources_upload_post",
         "parameters": [
           {
@@ -7823,6 +8310,19 @@
             "schema": {
               "description": "Bot ID this resource belongs to.",
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -7869,6 +8369,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -7929,7 +8439,7 @@
     },
     "/openapi/v1/bots/resources/{resource_id}": {
       "delete": {
-        "description": "Delete a resource (file → device FS, link/folder → DB soft-delete).\n\nowner_id comes from the verified principal (``caller_owner_id``),\nfail-closed. device_fs is resolved per-bot ONLY for FILE resources — a\nlink/folder soft-delete never touches device_fs, so it must not fail on an\nunbound bot (``resolve_for_bot`` raises DeviceNotBoundError when there is no\nbinding). The injected deps (factory, resolver, device_fs_dispatcher) stay\nout of the served OpenAPI schema — see test_public_namespace.py.",
+        "description": "Delete a resource (file → device FS, link/folder → DB soft-delete).\n\nowner_id comes from the request's ``user_id`` parameter (``UserIdDep``),\nfail-closed. device_fs is resolved per-bot ONLY for FILE resources — a\nlink/folder soft-delete never touches device_fs, so it must not fail on an\nunbound bot (``resolve_for_bot`` raises DeviceNotBoundError when there is no\nbinding). The injected deps (factory, resolver, device_fs_dispatcher) stay\nout of the served OpenAPI schema — see test_public_namespace.py.",
         "operationId": "delete_resource_openapi_v1_bots_resources__resource_id__delete",
         "parameters": [
           {
@@ -7949,6 +8459,19 @@
             "schema": {
               "description": "Bot ID this resource belongs to.",
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -7983,6 +8506,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8063,6 +8596,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8095,6 +8641,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8175,6 +8731,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -8217,6 +8786,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8277,7 +8856,7 @@
     },
     "/openapi/v1/bots/resources/{resource_id}/download": {
       "get": {
-        "description": "Download a resource's bytes (raw, not enveloped).\n\nowner_id comes from the verified principal (``caller_owner_id``),\nfail-closed — mirroring the bots router. device_fs is resolved per-bot\n(unconditional today; see #4 follow-up — only a file has bytes, but the\nhandler can't tell the type before the service reads the row). Service\nreturns ``(bytes, mime)`` or ``None`` → 404.",
+        "description": "Download a resource's bytes (raw, not enveloped).\n\nowner_id comes from the request's ``user_id`` parameter (``UserIdDep``),\nfail-closed — mirroring the bots router. device_fs is resolved per-bot\n(unconditional today; see #4 follow-up — only a file has bytes, but the\nhandler can't tell the type before the service reads the row). Service\nreturns ``(bytes, mime)`` or ``None`` → 404.",
         "operationId": "download_resource_openapi_v1_bots_resources__resource_id__download_get",
         "parameters": [
           {
@@ -8297,6 +8876,19 @@
             "schema": {
               "description": "Bot ID this resource belongs to.",
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -8330,6 +8922,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8390,7 +8992,7 @@
     },
     "/openapi/v1/bots/resources/{resource_id}/preview": {
       "get": {
-        "description": "Get a resource preview (text-ified content, enveloped).\n\nowner_id comes from the verified principal (``caller_owner_id``),\nfail-closed — mirroring the bots router. device_fs is resolved per-bot\n(unconditional today; see #4 follow-up). FileTooLargeError (content > 1 MB)\n→ 413 via @envelope_errors; a None result is not-found / not-a-file /\nread-failure → 404.",
+        "description": "Get a resource preview (text-ified content, enveloped).\n\nowner_id comes from the request's ``user_id`` parameter (``UserIdDep``),\nfail-closed — mirroring the bots router. device_fs is resolved per-bot\n(unconditional today; see #4 follow-up). FileTooLargeError (content > 1 MB)\n→ 413 via @envelope_errors; a None result is not-found / not-a-file /\nread-failure → 404.",
         "operationId": "preview_resource_openapi_v1_bots_resources__resource_id__preview_get",
         "parameters": [
           {
@@ -8410,6 +9012,19 @@
             "schema": {
               "description": "Bot ID this resource belongs to.",
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -8444,6 +9059,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8558,6 +9183,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8590,6 +9228,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8650,6 +9298,21 @@
       "post": {
         "description": "Create a routine.\n\nTranslates the openapi ``RoutineCreate`` body into the engine adapter\ncron body shape: ``schedule`` is the raw cron expression STRING (not\nthe nested ``{kind,expr,tz}`` dict — the adapter wraps it on read in\n``device_adapter_transport._build_item``), and ``timezone`` defaults\nto ``Asia/Shanghai`` to match legacy ``cron/router.py``'s create path.",
         "operationId": "create_routine_openapi_v1_bots_routines_post",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -8690,6 +9353,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8770,6 +9443,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8802,6 +9488,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8860,7 +9556,7 @@
         ]
       },
       "get": {
-        "description": "Get a routine.\n\nC3: the path carries only ``routine_id`` (no routine table to\nreverse-map to a bot), so ``bot_id`` is a required query. Owner\nidentity comes from the authenticated principal via\n``caller_owner_id``. Missing/non-dict ``data`` collapses to 404.",
+        "description": "Get a routine.\n\nC3: the path carries only ``routine_id`` (no routine table to\nreverse-map to a bot), so ``bot_id`` is a required query. Owner\nidentity comes from the authenticated principal via\n``UserIdDep``. Missing/non-dict ``data`` collapses to 404.",
         "operationId": "get_routine_openapi_v1_bots_routines__routine_id__get",
         "parameters": [
           {
@@ -8878,6 +9574,19 @@
             "required": true,
             "schema": {
               "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -8912,6 +9621,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -8990,6 +9709,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -9032,6 +9764,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9112,6 +9854,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9144,6 +9899,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9251,6 +10016,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9283,6 +10061,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9417,6 +10205,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9449,6 +10250,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9538,6 +10349,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -9580,6 +10404,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9680,6 +10514,19 @@
               "title": "Session Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9712,6 +10559,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9810,6 +10667,19 @@
               "title": "Session Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -9842,6 +10712,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -9940,6 +10820,19 @@
               "title": "Session Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -9982,6 +10875,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10082,6 +10985,19 @@
               "title": "Session Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10114,6 +11030,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10239,6 +11165,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10271,6 +11210,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10441,6 +11390,19 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10473,6 +11435,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10564,6 +11536,19 @@
               "description": "Verified Bot owner locator.",
               "title": "Owner Entity Id"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -10618,6 +11603,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10693,7 +11688,7 @@
     },
     "/openapi/v1/bots/skills/{skill_id}": {
       "delete": {
-        "description": "Delete one Inactive Local Skill selected by its Skill ID.",
+        "description": "Delete one inactive Bot-owned Local Skill by deployment-wide ID.",
         "operationId": "delete_skill_openapi_v1_bots_skills__skill_id__delete",
         "parameters": [
           {
@@ -10702,6 +11697,19 @@
             "required": true,
             "schema": {
               "title": "Skill Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
               "type": "string"
             }
           }
@@ -10736,6 +11744,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10805,6 +11823,19 @@
               "title": "Skill Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10837,6 +11868,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -10908,6 +11949,19 @@
               "title": "Skill Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -10940,6 +11994,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11011,6 +12075,19 @@
               "title": "Skill Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11043,6 +12120,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11114,6 +12201,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11146,6 +12246,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11215,6 +12325,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11247,6 +12370,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11316,6 +12449,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -11358,6 +12504,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11517,6 +12673,19 @@
               ],
               "title": "Bot Type"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11549,6 +12718,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11620,6 +12799,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11652,6 +12844,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11721,6 +12923,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -11765,6 +12980,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11836,6 +13061,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11868,6 +13106,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -11939,6 +13187,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11971,6 +13232,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {
@@ -12042,6 +13313,19 @@
               "title": "Bot Id",
               "type": "string"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -12074,6 +13358,16 @@
               }
             },
             "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
           },
           "404": {
             "content": {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -7284,7 +7284,7 @@
     },
     "/openapi/v1/bots/mcp/servers/{server_code}/permissions": {
       "get": {
-        "description": "Report the caller's own permission for an MCP server.\n\nAlways the caller's permission — the identity comes from the principal, never\na caller-supplied id (the internal route takes a ``user_id`` query param; this\none must not, or a caller could probe another identity's grants).\n\n**Fail-open, by decision (spec Open Question 1).** When the marketplace\nlookup errors, ``check_mcp_permission_detail`` reports the caller *as\npermitted*. This surface preserves that rather than failing closed: the\nendpoint is advisory — the MCP server itself is the enforcement point — so a\nwrong \"yes\" during an upstream outage costs one failed call, whereas failing\nclosed would make a marketplace outage look like a permission revocation.",
+        "description": "Report the caller's own permission for an MCP server.\n\nAlways the caller's own permission. The identity is the request's required\n``user_id``, and it is refused unless it names the verified caller — so this\nstill cannot be pointed at someone else to probe their grants, which is the\nproperty the internal route's free-form ``user_id`` query param does not\nhave. The parameter states whose permission is being asked about; it does\nnot widen whose it may be.\n\n**Fail-open, by decision (spec Open Question 1).** When the marketplace\nlookup errors, ``check_mcp_permission_detail`` reports the caller *as\npermitted*. This surface preserves that rather than failing closed: the\nendpoint is advisory — the MCP server itself is the enforcement point — so a\nwrong \"yes\" during an upstream outage costs one failed call, whereas failing\nclosed would make a marketplace outage look like a permission revocation.",
         "operationId": "check_mcp_permission_openapi_v1_bots_mcp_servers__server_code__permissions_get",
         "parameters": [
           {
@@ -8137,7 +8137,7 @@
     },
     "/openapi/v1/bots/resources/check-name": {
       "get": {
-        "description": "Check whether a resource name is available.\n\n``parent_path`` / ``user_id`` / ``exclude_id`` from the legacy signature\nare intentionally not exposed on the openapi contract yet — Direction A\n(principal → user_id) will wire ``user_id`` once it lands. For now the\nservice treats them as None.",
+        "description": "Check whether a resource name is available.\n\n``user_id`` is the request's own required parameter, forwarded to the\nservice — the wiring the older note here said was still pending.\n``parent_path`` and ``exclude_id`` from the legacy signature remain\nunexposed on this contract and are passed as None: resources are bot-scoped,\nso there is no parent path to qualify the name with.",
         "operationId": "check_resource_name_openapi_v1_bots_resources_check_name_get",
         "parameters": [
           {


### PR DESCRIPTION
## Problem

52 of the 60 user-scoped `/openapi/v1` operations worked out *which* user they act for from the caller's signed principal. That holds only while every public request carries exactly one end user, which is what the gateway resolves today.

Letting a registered App call **on behalf of** a user breaks the assumption: the App presents its own credential, the person it acts for is not inside it, and an operation whose published contract never mentions a user has nowhere for the caller to put one. Deferring the parameter means changing the contract of the whole surface at the same moment the new caller type arrives — two risky changes on one release.

The surface had also drifted on where a scoping parameter goes: `POST …/bots/routines` takes `bot_id` in the body while `PATCH …/bots/routines/{routine_id}` takes it in the query, and `/bots/resources` uses a query parameter on all nine of its operations including two that carry a JSON body. Nobody decided that; it accumulated.

## Solution

**`user_id` is a required query parameter on every operation that scopes to a user** — never a body field, never a path segment, whatever the method and whatever the body. 56 of the 65 published operations take it.

```
GET    /openapi/v1/bots/b-1?user_id=u-42
PUT    /openapi/v1/bots/b-1?user_id=u-42        {"bot_name": "Ada"}
DELETE /openapi/v1/bots/b-1?user_id=u-42
POST   /openapi/v1/bots/skills/upload?bot_id=b-1&user_id=u-42    <raw zip>
```

One placement, because the user id is not an attribute of any resource here — it is *who the call is for*, the same value on every operation and the same meaning on a read as on a write. A body describes the resource (beside `bot_name` in a `PUT` payload it reads as a field being set on the bot); a path names it (`/bots/{bot_id}/users/{user_id}` would claim to address a user beneath a bot, inverting the ownership). Rejected alternatives are recorded in the plan and the handoff doc so the question is not reopened from scratch.

**`bot_id` is untouched** — path where it addresses a bot, query where it is a parameter, on all 65 operations.

**Four operations take none**, because they have no user dimension: `check_bot_name` (uniqueness is tenant-wide) and the three MCP catalogue reads (identical for every caller in the tenant). They still require an authenticated caller. Deliberately *not* in that set: the four `resources` operations that take the parameter without using it — they are user-scoped in principle and merely fail to enforce it today (the gap `specs/2026-08-02-public-api-user-only-principal/` records), so closing it later should not have to add a required parameter to four public operations.

**Behaviour is unchanged.** The named user must still be the verified caller; naming anyone else is a `403` with a fixed `"Forbidden"` that reveals nothing about the user asked for. A request with no verified principal still answers `401`, and 401 outranks both the 422 and the 403. The single line delegation relaxes later is the equality check in `openapi_v1/principal.py::require_user_id`.

⚠️ **The sharpest thing for a reviewer to know:** `GET /openapi/v1/bots/logs/traces` has taken a required `user_id` since #692, and it means the **opposite** thing — *whose traces to read*, which a user+App caller may point at someone else. The published document now carries both spellings. Bot Logs is deliberately out of scope and documents no 403; the module docstring and the handoff doc both warn against unifying them without deciding which contract the address should have.

## Validation

- `pytest tests/community` — **11019 passed**. Two failures in this container only (`test_bot_build_service_skill_artifact`, `rsync: not found`); unrelated and green on CI.
- The generated OpenAPI document was diffed against `dfe638d` operation by operation: **56 gained `?user_id=`, the same 56 gained a 403, and nothing else moved** — no parameter or response removed anywhere, no request body changed, no path added or removed, `bot_id` at 28 path / 18 query / 19 none in both.
- `test_explicit_user_id.py` pins all of that against the generated description, plus the behaviour: another user's id is 403, two rejected ids give byte-identical bodies, a missing parameter is 422, and no verified caller is 401 *even when the parameter is also missing*.
- Two independent review passes. The second verified the high-risk classes mechanically rather than by inspection: all 60 converted handler bodies AST-identical to their originals modulo the intended rename, and all 65 operations answering 401 unauthenticated — including the four exempt ones mounted without the group-level dependency.
- The internal `/api` surface is untouched: `app.py` is the only file changed outside `openapi_v1`, and its diff is one import plus one new exception handler.

Three findings from review were fixed in-branch, each worth a look:
- the mismatch warning interpolated the raw parameter, which is attacker-chosen by construction on that branch — a refused caller could forge log lines. Now `%r`.
- `user_scoped_client` dropped repeated query keys and blank values, reintroducing the silent-loss class it was written to prevent.
- the four exempt operations lost their only auth gate in the group's own bare test app; they now declare `dependencies=[Depends(require_principal)]` on the route. Runtime was never affected — the guarantee the test makes was.

**Not runnable here:** `scripts/ci/python_sast_local.sh` falls back to a CPython 3.11 `flake8` that cannot parse this repo's PEP 695 generics and reports `E999` on `contracts.py` — identically on the *unmodified* file at `dfe638d`. The same block-rule set run through the project's 3.12 interpreter over all 33 changed Python files is clean. Lint is at exact base parity (22 E501 in tests, 11 in source, zero F401). Singlebox coverage and BCS E2E need a live stack and run on this PR.

## Compatibility and risk

Breaking for 56 operations — a required parameter is added. Deliberate, and the reason for doing it now: `route_security` admits only a Google-chain `user`, so no external tenant can reach this surface yet and the change lands before it can break anyone. No migration, no flag, no deploy ordering. Rollback is reverting the branch.

## Spec

`src/backend/specs/2026-08-08-openapi-v1-explicit-user-id/` — spec, plan and tasks, including the placement decision and the rejected alternatives.
