### PR TITLE
fix(bcs): enforce single-string iss/aud and classify principal verify errors

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -677,3 +677,26 @@ fn public_verify_uses_the_current_system_time() {
 
     assert!(verifier().verify(&token).is_ok());
 }
+
+#[test]
+fn wrong_issuer_and_audience_log_specific_mismatch() {
+    for (claim, value, needle) in [
+        ("iss", "other-gateway", "issuer mismatch"),
+        ("aud", "backend", "audience mismatch"),
+    ] {
+        let mut claims = valid_claims();
+        claims[claim] = json!(value);
+        let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+        let logs = capture_logs(|| {
+            assert_eq!(
+                verifier().verify_at(&token, NOW),
+                Err(GatewayPrincipalVerificationError::InvalidClaims),
+            );
+        });
+        assert!(logs.contains(needle), "missing {needle:?} in:\n{logs}");
+        assert!(
+            !logs.contains("claims are invalid"),
+            "generic decode log should not fire for {claim} mismatch:\n{logs}"
+        );
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/tests.rs
@@ -700,3 +700,45 @@ fn wrong_issuer_and_audience_log_specific_mismatch() {
         );
     }
 }
+
+#[test]
+fn rejects_array_valued_iss_and_aud() {
+    // RFC 7519 permits `aud` as a string or array; jsonwebtoken accepts the
+    // array form against set_audience. The gateway-principal contract
+    // requires the exact single-string iss/aud (contract.md: iss=gateway,
+    // aud=bcs), so array-form claims must be rejected by shape regardless of
+    // whether the value matches. The shape log must classify the failure
+    // without leaking the array contents (contract.md: no claim value logged).
+    let fixture = fixture();
+    let verifier = verifier_from(&fixture);
+    // The array includes the configured value so `decode` accepts it (forcing
+    // the shape guard, not value validation, to reject); the marker element
+    // proves the array contents are not logged.
+    for (claim, configured, marker) in [
+        ("iss", fixture.issuer.clone(), "SECRET_ISS_ARRAY_MARKER"),
+        ("aud", fixture.audience.clone(), "SECRET_AUD_ARRAY_MARKER"),
+    ] {
+        let mut claims = valid_claims();
+        claims[claim] = json!([configured, marker]);
+        let token = mint_with(header("JWT", "bare"), &claims, TEST_KEY);
+        let logs = capture_logs(|| {
+            assert_eq!(
+                verifier.verify_at(&token, NOW),
+                Err(GatewayPrincipalVerificationError::InvalidClaims),
+                "array-form {claim} must be rejected (exact-string contract)",
+            );
+        });
+        assert!(
+            logs.contains("must be a single string"),
+            "shape log missing for {claim}:\n{logs}"
+        );
+        assert!(
+            logs.contains("observed=array"),
+            "observed=array missing for {claim}:\n{logs}"
+        );
+        assert!(
+            !logs.contains(marker),
+            "array contents leaked into log for {claim}:\n{logs}"
+        );
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -138,6 +138,24 @@ impl GatewayPrincipalTokenVerifier {
                     );
                     GatewayPrincipalVerificationError::InvalidSignature
                 }
+                jsonwebtoken::errors::ErrorKind::InvalidIssuer => {
+                    warn!(
+                        expected_iss = %self.trust.issuer,
+                        kid = ?header.kid,
+                        token_fingerprint = %token_fingerprint,
+                        "Gateway Principal token issuer mismatch"
+                    );
+                    GatewayPrincipalVerificationError::InvalidClaims
+                }
+                jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+                    warn!(
+                        expected_aud = %self.trust.audience,
+                        kid = ?header.kid,
+                        token_fingerprint = %token_fingerprint,
+                        "Gateway Principal token audience mismatch"
+                    );
+                    GatewayPrincipalVerificationError::InvalidClaims
+                }
                 other => {
                     warn!(
                         kid = ?header.kid,
@@ -173,24 +191,6 @@ impl GatewayPrincipalTokenVerifier {
             GatewayPrincipalVerificationError::InvalidClaims
         })?;
 
-        if claims.iss != self.trust.issuer {
-            warn!(
-                expected_iss = %self.trust.issuer,
-                kid = ?header.kid,
-                token_fingerprint = %token_fingerprint,
-                "Gateway Principal token issuer mismatch"
-            );
-            return Err(GatewayPrincipalVerificationError::InvalidClaims);
-        }
-        if claims.aud != self.trust.audience {
-            warn!(
-                expected_aud = %self.trust.audience,
-                kid = ?header.kid,
-                token_fingerprint = %token_fingerprint,
-                "Gateway Principal token audience mismatch"
-            );
-            return Err(GatewayPrincipalVerificationError::InvalidClaims);
-        }
         if let Err(e) = validate_times(claims.iat, claims.exp, now) {
             warn!(
                 now,

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/verifier.rs
@@ -166,6 +166,24 @@ impl GatewayPrincipalTokenVerifier {
                     GatewayPrincipalVerificationError::InvalidClaims
                 }
             })?;
+
+        for claim in ["iss", "aud"] {
+            let observed = match token_data.claims.get(claim) {
+                Some(Value::String(_)) => continue,
+                Some(Value::Array(_)) => "array",
+                Some(_) => "non_string",
+                None => "missing",
+            };
+            warn!(
+                claim = %claim,
+                observed = %observed,
+                kid = ?header.kid,
+                token_fingerprint = %token_fingerprint,
+                "Gateway Principal claim must be a single string"
+            );
+            return Err(GatewayPrincipalVerificationError::InvalidClaims);
+        }
+
         let claims: GatewayClaims = serde_path_to_error::deserialize(
             token_data.claims.into_deserializer(),
         )

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/gateway_principal/wire.rs
@@ -3,8 +3,6 @@ use serde_json::Value;
 
 #[derive(Deserialize)]
 pub(super) struct GatewayClaims {
-    pub iss: String,
-    pub aud: String,
     pub iat: u64,
     pub exp: u64,
     pub principals: Vec<Value>,


### PR DESCRIPTION
## Problem

Gateway Principal token verification (`bcs-api-http` → `v1/gateway_principal`) had two correctness defects around the `iss` (issuer) and `aud` (audience) claims:

1. **Dead diagnostics.** `set_issuer` / `set_audience` are configured on `jsonwebtoken::Validation`, so `decode` short-circuits with `ErrorKind::InvalidIssuer` / `InvalidAudience` *before* the manual `claims.iss` / `claims.aud` checks could run. Those checks (and their issuer/audience-specific `warn` logs) were dead code — operators only ever saw the generic `"claims are invalid"` log with `error_kind=InvalidIssuer/InvalidAudience`, giving no signal whether the mismatch was issuer, audience, or something else.

2. **Widened auth boundary (P1, flagged by Codex review on #905).** Removing the manual `GatewayClaims.iss/aud` (`String`) fields and the manual equality check left only `decode` to enforce shape. But `jsonwebtoken` accepts RFC **array-form** `aud` (and parses array `iss`) against `set_issuer`/`set_audience`, so a correctly-signed token with `aud: ["bcs", ...]` was accepted. An array `iss` is additionally RFC-illegal (`iss` is defined as a single `StringOrURI`).

## Solution

Both fixes live in `bcs-api-http/src/v1/gateway_principal/verifier.rs` (with the now-unused fields removed from `wire.rs` and regression coverage added in `tests.rs`):

1. **Classify the decode errors.** Match `InvalidIssuer` and `InvalidAudience` in the decode error handler with dedicated `warn` logs (`expected_iss` / `expected_aud` + `kid` + `token_fingerprint`), mirroring how `InvalidSignature` is already classified. Removed the dead manual `iss`/`aud` checks and the now-unused `GatewayClaims.iss/aud` fields — presence, type, and value remain fully enforced by `decode` (`set_required_spec_claims` + `set_issuer`/`set_audience`). No token material is logged (existing safe fingerprint model).

2. **Guard the claim shape.** Add an explicit shape guard after `decode` requiring `iss` and `aud` to be **single strings**, rejecting array-form (and any other JSON type). It logs `claim` / `observed` (JSON *type* only — never the claim value, per `contract.md`) and returns `InvalidClaims`. `decode` still verifies the value via `set_issuer`/`set_audience`; the `InvalidIssuer`/`InvalidAudience` diagnostic arms from fix (1) are retained.

## Validation

- `cargo test -p bcs-api-http gateway_principal`: **24 passed** (was 23).
- `cargo test -p bcs --test openapi_v1_mount`: **3 passed**.
- `cargo build -p bcs-api-http`: **no warnings**.
- New regression tests:
  - `wrong_issuer_and_audience_log_specific_mismatch` — asserts the specific mismatch logs fire and the generic "claims are invalid" log does not. Fails before fix (1), passes after.
  - `rejects_array_valued_iss_and_aud` — mints array-form `iss`/`aud` (including a secret-marker element) and asserts rejection, the shape log fires, and that array **contents are not leaked** into the log.

## Compatibility and risk

- **Contract:** tightening `iss`/`aud` to single strings only rejects tokens that were invalid by spec anyway (array `iss` is RFC-illegal; array `aud` is legal but was never an intended shape for this principal). No schema/migration impact; no config changes.
- **Rollback:** revert the two commits — both are isolated to `gateway_principal` and independently revertible.

## Related issues

Refs #770. Addresses the P1 from Codex review on #905.

---
*Commits authored by @3toinf.*
