### PR TITLE
feat(backend): add hello-world load-test HTTP and WebSocket endpoints

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -831,8 +831,8 @@ list still equals the literals the routes actually publish:
 
 <!-- reserved-component-names -->
 ```text
-approvals  ceiling  check-name  connection  engine  identity  logs
-mcp  models  resources  routines  sessions  skills
+approvals  ceiling  check-name  connection  engine  identity  loadtest
+logs  mcp  models  resources  routines  sessions  skills
 ```
 
 **Reserved ahead of their routes.** A second, separate list — names claimed here

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -1001,6 +1001,65 @@ enum whitelist. No own Track A stage — scoped by bots isolation (Stage 1 ✅).
 | GET | `/openapi/v1/bots/identity/{bot_id}/{file_type}` | Read one identity file | `Envelope[IdentityFile]` |
 | PUT | `/openapi/v1/bots/identity/{bot_id}/{file_type}` | Overwrite one identity file (`content`) | `Envelope[IdentityFileRef]` |
 
+### ✅ loadtest (2 endpoints) · `openapi_v1/loadtest/router.py` — **IMPLEMENTED**
+
+Two synthetic endpoints that do nothing, so a load run can measure what the
+*path* costs — gateway authentication and forwarding, this service's middleware
+stack, the framework's request handling — without a database round trip, an
+engine call, or a bot's state in the same number. Not a product surface: they
+are the baseline every other endpoint's number is read against.
+
+| Method | Path | Purpose | Success |
+|---|---|---|---|
+| GET | `/openapi/v1/bots/loadtest/hello` | Answer the constant `hello world` | `Envelope[HelloWorld]` (`data.message == "hello world"`) |
+| WEBSOCKET | `/openapi/v1/bots/loadtest/ws/echo` | Send every received frame straight back | — (see below) |
+
+**Authentication — the same as every other operation on this surface.** Both
+declare `require_principal`, so a caller with no verified `X-Avernet-Principal`
+is refused before the handler runs: `401` with the standard `ErrorEnvelope` on
+the HTTP endpoint, and close code `1008` on the socket — the handshake is
+refused before the socket is accepted, which a client sees as an HTTP `403`.
+Through the gateway both inherit `user: required` from `/openapi/v1/bots/**`;
+neither is exempted in `route_security`. A measurement taken without the auth
+would describe a path no caller can take, which is why they are not exempt.
+
+**Not user-scoped.** Neither takes `?user_id=` — they read and write nothing, so
+there is no scope for it to name. See "Naming the end user" above; the HTTP one
+is recorded in `test_explicit_user_id.py` alongside the four catalogue reads
+that are exempt for the same reason, and it documents no `403`.
+
+**The socket's contract**, written out here because a WebSocket has no OpenAPI
+representation and therefore appears in **no** generated artifact — this table
+is the whole of it, not a summary of something machine-readable:
+
+- **Frames.** Text and binary are both accepted, and each is echoed back as the
+  same type it arrived as. The payload is returned byte for byte: nothing is
+  trimmed, re-encoded, parsed, or interpreted, so a driver picks its own payload
+  shape.
+- **Ordering.** One frame in, one frame out, in order. No batching, no coalescing,
+  and no server-initiated frames — the socket says nothing the client did not
+  say first.
+- **Disconnect.** The client closing ends the connection; the server does not
+  close first and sends no close frame of its own. A dropped transport is the
+  same outcome. Neither is an error, and neither is logged as one.
+- **Lifetime.** No idle timeout, no ping/pong, no message-count or size limit
+  beyond whatever the ASGI server and any L7 hop impose.
+
+**Routing.** The HTTP endpoint reaches the backend through the `bots` domain
+with no gateway change. The socket needs its own domain — `bots` declares no
+`protocols` and so serves HTTP only — which is `bots-loadtest-ws` in
+`src/gateway/configs/application.yaml`: socket-only, forwarded verbatim to the
+backend, no rewrite. The `ws` segment is what that claim is pinned to, following
+`/openapi/v1/bots/messages/ws/**`, so an HTTP endpoint added under `loadtest`
+later falls outside it by construction.
+
+> **Known gap.** `AvernetTenantMiddleware` and the public access log both return
+> early on a non-HTTP scope, so the socket runs under the **default** tenant and
+> writes no access line. Harmless here — it reads and writes nothing — and the
+> first thing to fix before any socket route on this surface touches data, since
+> a tenant-scoped read under the default tenant is a data-isolation failure
+> rather than a missing log.
+
 ### ⬜ unassigned · Track C — engine runtime (16 endpoints)
 Not a Track B category — these wrap the **engine adapter** on the bot's device
 rather than a backend service. The per-endpoint checklist, the engine route each
@@ -1161,6 +1220,21 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   draft/published separation is binding storage — `ac_bots.binding_id` vs
   `ac_bot_publish.ext.binding.{verify,online}`) and was corrected by the
   access expansion.
+
+- **2026-08-09** — **A `loadtest` component was added, and it is the surface's
+  first WebSocket.** Two synthetic endpoints — `GET …/loadtest/hello` answering a
+  constant, and `WEBSOCKET …/loadtest/ws/echo` echoing its input — so a load run
+  can measure the shared path without a service call in the number. Both require
+  `require_principal` like everything else here; neither is user-scoped, so the
+  HTTP one joins the four operations with no user dimension. To make one
+  dependency serve both planes, `require_principal` and `resolve_caller` now take
+  an `HTTPConnection` rather than a `Request`, and a handshake with no verified
+  caller is refused with close code `1008` instead of a `401` envelope it cannot
+  carry — **HTTP behaviour is unchanged**. Because a WebSocket appears in no
+  generated artifact, the socket's full contract is written out under
+  **Endpoints per component** above rather than published; the gateway serves it
+  through a socket-only `bots-loadtest-ws` domain, and the tenant/access-log gap
+  on the socket plane is recorded there too.
 
 - **2026-08-09** — **The public surface now names its end user explicitly.** 56
   of the 65 operations take a required `user_id` query parameter instead of

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -626,8 +626,8 @@ id 恰好等于某个组件名，它在该地址上就不可达。这个集合�
 
 <!-- reserved-component-names -->
 ```text
-approvals  ceiling  check-name  connection  engine  identity  logs
-mcp  models  resources  routines  sessions  skills
+approvals  ceiling  check-name  connection  engine  identity  loadtest
+logs  mcp  models  resources  routines  sessions  skills
 ```
 
 **先于路由保留的名字。** 另有一份独立清单 —— 在任何路由发布它们之前就已在此占位的名字。

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -781,6 +781,52 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
 | GET | `/openapi/v1/bots/identity/{bot_id}/{file_type}` | 读取单个身份文件 | `Envelope[IdentityFile]` |
 | PUT | `/openapi/v1/bots/identity/{bot_id}/{file_type}` | 覆写单个身份文件（`content`） | `Envelope[IdentityFileRef]` |
 
+### ✅ loadtest（2 个端点）· `openapi_v1/loadtest/router.py` —— **已实现**
+
+两个刻意什么都不做的端点，用于让压测量出**链路本身**的开销 —— 网关的鉴权与转发、
+本服务的中间件栈、框架的请求处理 —— 而不让这个数字里混进数据库往返、engine 调用或
+Agent 状态。它们不是产品面，而是其它端点的数字所参照的基线。
+
+| 方法 | 路径 | 用途 | 成功响应 |
+|---|---|---|---|
+| GET | `/openapi/v1/bots/loadtest/hello` | 返回常量 `hello world` | `Envelope[HelloWorld]`（`data.message == "hello world"`） |
+| WEBSOCKET | `/openapi/v1/bots/loadtest/ws/echo` | 把收到的每一帧原样回送 | ——（见下） |
+
+**鉴权 —— 与本面上其它操作完全一致。** 两者都声明了 `require_principal`，因此没有通过
+校验的 `X-Avernet-Principal` 的调用方在 handler 运行前就会被拒绝：HTTP 端点返回标准
+`ErrorEnvelope` 的 `401`；socket 则以关闭码 `1008` 拒绝 —— 在 accept 之前拒绝握手，
+客户端看到的是 HTTP `403`。经网关时两者都从 `/openapi/v1/bots/**` 继承
+`user: required`，`route_security` 中没有为它们开豁免。**不豁免是刻意的**：绕开鉴权测出
+的数字描述的是一条没有调用方能走的链路。
+
+**不按用户维度收敛。** 两者都不带 `?user_id=` —— 它们不读也不写任何数据，没有可供该参数
+指称的范围。参见上文"为终端用户命名"；HTTP 那个已与另外四个同理豁免的目录类读操作一起
+记录在 `test_explicit_user_id.py` 中，并且不声明 `403`。
+
+**socket 的契约**（在此写全，因为 WebSocket 没有 OpenAPI 表示，**不会**出现在任何生成
+产物里 —— 下面这份就是契约全文，而不是某份机器可读文件的摘要）：
+
+- **帧类型。** 文本帧与二进制帧都接受，并按收到时的类型原样回送。载荷逐字节返回：不做
+  裁剪、不重新编码、不解析、不作任何解释，因此驱动端可以自行选择载荷形态。
+- **顺序。** 进一帧、出一帧，保持顺序。不做批处理与合并，也没有服务端主动发起的帧 ——
+  客户端没先说的话，socket 不会说。
+- **断开。** 由客户端关闭结束连接；服务端不主动先关，也不自行发送关闭帧。传输层掉线是
+  同样的结果。两者都不是错误，也不会按错误记录日志。
+- **生命周期。** 无空闲超时、无 ping/pong，除 ASGI server 及前置 L7 跳所施加的限制外，
+  不设消息条数或大小上限。
+
+**路由。** HTTP 端点通过 `bots` domain 直达后端，网关无需改动。socket 需要自己的
+domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 即
+`src/gateway/configs/application.yaml` 中的 `bots-loadtest-ws`：仅 socket 平面、
+原样转发到后端、无 rewrite。`ws` 这一段正是该占用所锚定的位置，与
+`/openapi/v1/bots/messages/ws/**` 同形，因此日后在 `loadtest` 下新增的 HTTP 端点
+天然落在其外。
+
+> **已知缺口。** `AvernetTenantMiddleware` 与公共访问日志在非 HTTP scope 上都会提前
+> 返回，因此该 socket 运行在**默认**租户下，且不写访问日志行。在这里无害 —— 它不读也
+> 不写数据 —— 但在本面上任何 socket 路由开始接触数据之前，这是第一件要修的事：在默认
+> 租户下执行按租户收敛的读取是数据隔离故障，而不只是少了一行日志。
+
 ### ⬜ 未分配 · Track C —— engine 运行时（16 个端点）
 这不是一个 Track B 类别 —— 它们包装的是 Bot 设备上的 **engine adapter**，
 而不是某个后端服务。逐端点清单、每个端点对应的 engine 路由，以及那约 72 条
@@ -910,6 +956,17 @@ Track A 阶段 —— 由 bots 隔离（Stage 1 ✅）覆盖。
   `publish_bot_id = bot_id`；draft 与已发布运行态的真正分界是 binding 的存放位置 ——
   `ac_bots.binding_id` 与 `ac_bot_publish.ext.binding.{verify,online}`），已由访问扩展
   修正。
+
+- **2026-08-09** —— **新增 `loadtest` 组件，也是本面上第一个 WebSocket。** 两个刻意
+  什么都不做的端点 —— `GET …/loadtest/hello` 返回常量，`WEBSOCKET …/loadtest/ws/echo`
+  原样回送 —— 让压测能够测出公共链路本身的开销，而不把服务调用混进这个数字。两者都和其它
+  端点一样要求 `require_principal`；都不按用户维度收敛，因此 HTTP 那个与另外四个没有用户
+  维度的操作归为一类。为了让同一个依赖服务于两个平面，`require_principal` 与
+  `resolve_caller` 的入参从 `Request` 放宽为 `HTTPConnection`，没有已验证调用方的握手以
+  关闭码 `1008` 拒绝，而不是用它根本无法承载的 `401` envelope —— **HTTP 行为没有变化**。
+  由于 WebSocket 不会出现在任何生成产物中，socket 的完整契约写在上文 **各组件端点** 一节
+  里而非通过文档发布；网关经仅 socket 平面的 `bots-loadtest-ws` domain 提供该地址，
+  socket 平面上的租户与访问日志缺口也一并记录在那里。
 
 - **2026-08-09** —— **公共面现在显式指定终端用户。** 65 个操作中的 56 个改为接受必填的
   `user_id` query 参数，不再从已验证 principal 推导 owner；指定其他用户返回 `403`。四个

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -45,7 +45,28 @@ Four operations are exempt because they have no user dimension to scope by:
 ``list_mcp_servers`` / ``list_mcp_tenants`` / ``get_mcp_server`` read a
 marketplace catalogue that is identical for every caller in the tenant. They
 still require an authenticated caller — ``_PUBLIC_AUTH`` below — they just have
-no user-shaped answer to give.
+no user-shaped answer to give. The load-test group is exempt on the same
+grounds and for the plainest reason of all: it reads and writes nothing.
+
+Planes
+------
+
+Every group here served HTTP only until the load-test group added a WebSocket.
+That changes nothing about the rule above — ``_PUBLIC_AUTH`` reaches a socket
+route as it reaches any other, and ``require_principal`` verifies the same
+signed header the gateway puts in a handshake — but two mechanical facts follow
+from it. A WebSocket route has no OpenAPI representation, so it appears in none
+of the generated-document assertions and its address is governed by
+``test_loadtest_endpoints.py`` instead; and the response tables below are an
+HTTP notion, so attaching one to a group with socket routes describes only its
+HTTP half.
+
+One thing the socket plane does **not** currently get: ``AvernetTenantMiddleware``
+and the public access log both return early on a non-HTTP scope, so a WebSocket
+runs under the *default* tenant and leaves no access line. That is harmless for
+a route that reads and writes nothing — the only socket route here — and it is
+the first thing to fix before adding one that does, because a tenant-scoped
+read under the default tenant is a data-isolation failure, not a missing log.
 
 The Bot Logs group is a different exclusion, and the sharpest thing to know
 about this rule. ``GET …/bots/logs/traces`` already takes a required
@@ -91,6 +112,7 @@ from .engine_runtime.engine import router as engine_engine_router
 from .engine_runtime.models import router as engine_models_router
 from .engine_runtime.sessions import router as engine_sessions_router
 from .identity import router as identity_router
+from .loadtest import router as loadtest_router
 from .mcp import router as mcp_router
 from .bot_logs import router as logs_router
 from .resources import router as resources_router
@@ -103,7 +125,9 @@ from .skills import router as skills_router
 PUBLIC_API_PREFIX = "/openapi/v1"
 
 # The groups that answer no 403, because no route in them is scoped by the
-# *caller's* user: Bot Logs never derived a user from the credential at all.
+# *caller's* user: Bot Logs never derived a user from the credential at all, and
+# the load-test group has nothing to scope — its two endpoints answer a constant
+# and echo their input, so they touch no user's data on the way.
 #
 # It is not that Bot Logs has no `user_id` — `GET …/bots/logs/traces` has taken
 # a required one since #692. It means something else there, and the difference
@@ -116,6 +140,7 @@ PUBLIC_API_PREFIX = "/openapi/v1"
 # provide. See the note in the spec's Out of Scope.
 _GROUPS_WITHOUT_CALLER_SCOPE = [
     logs_router,
+    loadtest_router,
 ]
 
 # The groups where SOME routes take a `user_id` and some do not — `bots`

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/dependencies.py
@@ -6,7 +6,9 @@ backend end of that contract. It holds the two seams the rest of the public
 surface was built against, and nothing else changes when they go live:
 
 - :func:`require_principal` — the FastAPI dependency every public route already
-  declares. Returns the verified caller, or raises so the route answers ``401``.
+  declares. Returns the verified caller, or raises so the route answers ``401``
+  (a WebSocket handshake is refused with close code ``1008`` instead — same
+  rule, and the only shape a handshake can be refused in).
 - :func:`resolve_avernet_tenant` — the data-isolation tenant for the request,
   read by ``AvernetTenantMiddleware`` before any route runs.
 
@@ -42,7 +44,9 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, Request
+from fastapi import Depends, Request, WebSocketException
+from starlette.requests import HTTPConnection
+from starlette.status import WS_1008_POLICY_VIOLATION
 
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.core.gateway_principal import (
@@ -82,26 +86,45 @@ _UNSET = _Unset()
 Principal = VerifiedCaller
 
 
-def resolve_caller(request: Request) -> VerifiedCaller | None:
-    """Verify the forwarded principal once per request, caching the outcome.
+def _verb(connection: HTTPConnection) -> str:
+    """What to call this connection in a log line.
+
+    The HTTP method where there is one, and the literal ``WEBSOCKET`` on the
+    socket plane — the same word the gateway's route table qualifies a socket
+    rule with, so a refusal here and the rule that let the handshake through are
+    greppable by the same token. A WebSocket scope carries no ``method`` key at
+    all, so this is a substitution rather than a default.
+    """
+    return connection.scope.get("method") or "WEBSOCKET"
+
+
+def resolve_caller(connection: HTTPConnection) -> VerifiedCaller | None:
+    """Verify the forwarded principal once per connection, caching the outcome.
 
     ``None`` means "no caller we can trust" — absent header or failed
     verification, deliberately indistinguishable to the caller. The cache holds
     ``None`` too, so a failed verification is not retried on the same request.
+
+    Takes an :class:`HTTPConnection` rather than a ``Request`` because both
+    planes of this surface arrive here: the gateway signs the same
+    ``X-Avernet-Principal`` into a WebSocket handshake's headers as into an HTTP
+    request's, and a handshake is where a socket's credential is checked. The
+    body of the function never needed anything narrower — headers and
+    ``state`` are what it reads, and both belong to the base class.
     """
-    cached = getattr(request.state, _CALLER_STATE_ATTR, _UNSET)
+    cached = getattr(connection.state, _CALLER_STATE_ATTR, _UNSET)
     if cached is not _UNSET:
         return cached
 
-    caller = _verify_from_headers(request)
-    setattr(request.state, _CALLER_STATE_ATTR, caller)
+    caller = _verify_from_headers(connection)
+    setattr(connection.state, _CALLER_STATE_ATTR, caller)
     return caller
 
 
-def _verify_from_headers(request: Request) -> VerifiedCaller | None:
-    """Verify the request's principal header, logging why if it fails."""
+def _verify_from_headers(connection: HTTPConnection) -> VerifiedCaller | None:
+    """Verify the connection's principal header, logging why if it fails."""
     config = get_principal_verifier_config()
-    token = request.headers.get(PRINCIPAL_HEADER, "").strip()
+    token = connection.headers.get(PRINCIPAL_HEADER, "").strip()
     if not token:
         # Distinguished from a rejected token, and on its own log line, because
         # the two point at completely different things. A *missing* header is
@@ -115,8 +138,8 @@ def _verify_from_headers(request: Request) -> VerifiedCaller | None:
             "no %s header on %s %s (request did not arrive through the "
             "gateway's authenticated path; verifier key fp=%s)",
             PRINCIPAL_HEADER,
-            request.method,
-            request.url.path,
+            _verb(connection),
+            connection.url.path,
             config.key_fingerprint,
         )
         return None
@@ -133,17 +156,37 @@ def _verify_from_headers(request: Request) -> VerifiedCaller | None:
         # the header is unauthenticated and can say anything a forger likes.
         logger.warning(
             "rejected forwarded principal on %s %s: %s",
-            request.method,
-            request.url.path,
+            _verb(connection),
+            connection.url.path,
             exc,
         )
         return None
 
 
-async def require_principal(request: Request) -> Principal:
-    """Return the verified caller, or raise :class:`MissingPrincipalError` (401)."""
-    caller = resolve_caller(request)
+async def require_principal(connection: HTTPConnection) -> Principal:
+    """Return the verified caller, or refuse the connection.
+
+    One dependency for both planes, because the surface's rule is one rule:
+    every public route requires an authenticated caller. Only the *shape* of the
+    refusal differs, and it has to — an HTTP request is answered with a body and
+    a status, and a WebSocket handshake has neither:
+
+    - HTTP → :class:`MissingPrincipalError`, which ``app.py``'s handler turns
+      into the surface's ``401`` envelope, exactly as before.
+    - WebSocket → :class:`~fastapi.WebSocketException` with ``1008``
+      (policy violation). Raised before the endpoint runs, so the socket is
+      never accepted and Starlette refuses the handshake instead of opening a
+      connection it would immediately have to close.
+
+    Both say only "no caller we can trust"; which half of verification failed is
+    logged above and never returned, on either plane.
+    """
+    caller = resolve_caller(connection)
     if caller is None:
+        if connection.scope["type"] == "websocket":
+            raise WebSocketException(
+                code=WS_1008_POLICY_VIOLATION, reason="Unauthorized"
+            )
         raise MissingPrincipalError("no verified caller for this request")
     return caller
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/__init__.py
@@ -1,0 +1,5 @@
+"""loadtest public API group."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
@@ -1,0 +1,103 @@
+"""Load-test group — ``/openapi/v1/bots/loadtest`` synthetic endpoints.
+
+Two endpoints that do nothing, on purpose. They exist so a load test can measure
+what the *path* costs — the gateway's authentication and forwarding, this
+service's middleware stack, and the framework's own request handling — without
+that number also containing a database round trip, an engine call, or a bot's
+state. A run against these is the baseline every other endpoint's number is read
+against; a regression that shows up here is in the shared path, and one that
+does not is in the endpoint under test.
+
+- ``GET /openapi/v1/bots/loadtest/hello`` answers the constant ``hello world``
+  in the surface's standard envelope.
+- ``WEBSOCKET /openapi/v1/bots/loadtest/ws/echo`` sends back every frame it
+  receives, byte for byte, until the peer disconnects.
+
+**Authenticated like every other operation here.** Both declare
+``require_principal``, so an unverified caller is refused before the handler
+runs — 401 on the HTTP endpoint, a refused handshake on the socket. That is not
+ceremony: a load test measures the path callers actually take, and on this
+surface that path includes verifying the gateway's signed principal. Numbers
+gathered without it would describe a route nobody can call.
+
+**Not user-scoped, so no ``user_id``.** Neither endpoint reads or writes
+anything belonging to anyone, so there is no scope for the parameter to name
+(``test_explicit_user_id.py`` records both alongside the four catalogue reads
+that are exempt for the same reason). The caller still has to be authenticated;
+it just has no user-shaped answer to receive.
+
+Why the socket lives under its own ``ws`` segment rather than at
+``…/loadtest/echo``: the gateway resolves a WebSocket by a domain that claims a
+path pattern on the socket plane, and the ``bots`` domain serves HTTP only. A
+visible ``ws`` subtree is what such a claim can be pinned to — the same shape
+``/openapi/v1/bots/messages/ws/**`` already uses — so an HTTP endpoint added
+under ``loadtest`` later stays outside it by construction.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request, WebSocket, WebSocketDisconnect
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+
+from .schemas import HelloWorld
+
+router = APIRouter(prefix="/openapi/v1/bots/loadtest", tags=["loadtest"])
+
+#: The one thing this group says. A constant rather than a literal in two
+#: places, so the test asserts the same bytes the handler returns.
+HELLO_WORLD = "hello world"
+
+# Authenticated, but not user-scoped. Declared on each route rather than
+# inherited from ``build_public_router`` for the reason ``check_bot_name`` does
+# the same: the guard is visible where the operation is, and
+# ``test_public_routes_require_principal`` walks each route's own dependant,
+# which a group-level dependency does not appear in.
+_AUTH = [Depends(require_principal)]
+
+
+@router.get("/hello", response_model=Envelope[HelloWorld], dependencies=_AUTH)
+@envelope_errors
+async def hello_world(request: Request) -> Envelope[HelloWorld]:
+    """Answer the constant ``hello world``.
+
+    Reads nothing and calls nothing, so the response time is the path's, not the
+    handler's.
+    """
+    return envelope(HelloWorld(message=HELLO_WORLD), request)
+
+
+@router.websocket("/ws/echo", dependencies=_AUTH)
+async def echo(websocket: WebSocket) -> None:
+    """Send every received frame straight back, until the peer goes away.
+
+    Frames are relayed through the raw ASGI message rather than
+    ``receive_text``/``receive_bytes``, because those two commit the socket to
+    one frame type and answer the other with a ``RuntimeError``. A load driver
+    chooses its own payload shape, and an echo that refuses half of them would
+    make the choice for it.
+
+    The disconnect is handled twice over, and both are reachable: a peer that
+    closes cleanly delivers a ``websocket.disconnect`` message, while one whose
+    transport drops raises :class:`WebSocketDisconnect` out of the send. Either
+    way the coroutine returns instead of propagating — a closed socket is how
+    this endpoint ends, not a failure to report.
+    """
+    await websocket.accept()
+    try:
+        while True:
+            message = await websocket.receive()
+            if message["type"] == "websocket.disconnect":
+                return
+            text = message.get("text")
+            if text is not None:
+                await websocket.send_text(text)
+            else:
+                await websocket.send_bytes(message["bytes"])
+    except WebSocketDisconnect:
+        return

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/schemas.py
@@ -1,0 +1,16 @@
+"""Payloads for the load-test group.
+
+One model, one field. The point of the group is that the payload is fixed and
+trivial — see ``router.py`` — so anything more here would be measured cost with
+nothing behind it.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class HelloWorld(BaseModel):
+    """What the load-test HTTP endpoint returns, always."""
+
+    message: str = Field(description='Always the constant "hello world".')

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -276,6 +276,11 @@ _NO_USER_DIMENSION = {
     ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/servers"),
     ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/servers/{{server_code}}"),
     ("get", f"{PUBLIC_API_PREFIX}/bots/mcp/tenants"),
+    # The load-test endpoint answers a constant. It reads nothing and writes
+    # nothing, so there is no scope for a user id to name — and a synthetic
+    # endpoint measuring the shared path must not be the one exception that
+    # measures a dependency the path does not have.
+    ("get", f"{PUBLIC_API_PREFIX}/bots/loadtest/hello"),
 }
 
 #: Bot Logs is excluded for a different reason and must stay that way — see the
@@ -285,8 +290,10 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 
 #: What ``bot_id`` looks like, and must keep looking like: an address where it
 #: addresses a bot, a query parameter where it is one, and never a body field.
-#: This change deliberately moved none of them.
-_BOT_ID_PLACEMENT = {"path": 28, "query": 18, "none": 19}
+#: This change deliberately moved none of them. ``none`` counts operations with
+#: no ``bot_id`` at all, so it grows by one for each such operation added — the
+#: load-test endpoint is the twentieth.
+_BOT_ID_PLACEMENT = {"path": 28, "query": 18, "none": 20}
 
 
 def _schema() -> dict:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
@@ -1,0 +1,256 @@
+"""The load-test group answers a constant, echoes a socket, and gates both.
+
+These two endpoints exist to be measured, so what is asserted here is exactly
+what a load driver depends on: the HTTP one returns fixed bytes in the standard
+envelope, the socket returns whatever it was sent, and **neither is reachable
+without the gateway's signed principal**. That last one is the reason this file
+drives real tokens through the real assembly rather than overriding
+``require_principal``: a synthetic endpoint that quietly skipped the auth the
+rest of the surface pays for would report a number no real caller can achieve,
+and nothing about a passing "it returns hello world" test would say so.
+
+The socket carries a second burden. A WebSocket route has no OpenAPI
+representation, so ``test_path_convention.py`` — which reads the generated
+document — cannot see it: the address ``/openapi/v1/bots/loadtest/ws/echo`` is
+pinned here or nowhere, and the gateway's socket-plane claim will be written
+against it.
+
+Token minting is imported from ``test_principal_seam`` rather than repeated. It
+is the same seam under test, and a second copy of the claim set would keep
+passing here on the day the real one changes shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from agentclaw.community.adapters.http.openapi_v1 import (
+    PUBLIC_API_PREFIX,
+    build_public_router,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    PRINCIPAL_HEADER,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.loadtest.router import HELLO_WORLD
+from agentclaw.community.utils.gateway_principal_config import (
+    reset_principal_verifier_config_cache,
+)
+
+from .conftest import mount_public_error_handlers
+from .test_principal_seam import KEY, boot_with_key, mint
+
+_HELLO = f"{PUBLIC_API_PREFIX}/bots/loadtest/hello"
+_ECHO = f"{PUBLIC_API_PREFIX}/bots/loadtest/ws/echo"
+
+
+@pytest.fixture(autouse=True)
+def signing_key():
+    """Install the shared verification key, and drop it again afterwards."""
+    boot_with_key(KEY)
+    yield
+    reset_principal_verifier_config_cache()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """The real public surface, with the app's own pre-handler error handlers.
+
+    ``mount_public_error_handlers`` is what turns the auth seam's raise into the
+    surface's 401 envelope — the dependency raises before any handler runs, so
+    ``@envelope_errors`` never sees it.
+    """
+    app = FastAPI()
+    app.include_router(build_public_router())
+    return TestClient(mount_public_error_handlers(app))
+
+
+def _authorized() -> dict[str, str]:
+    return {PRINCIPAL_HEADER: mint()}
+
+
+# ── the HTTP endpoint ───────────────────────────────────────────────────────
+
+
+def test_hello_answers_the_constant_in_the_standard_envelope(client):
+    """A load driver asserts on this body, so its shape is part of the contract."""
+    response = client.get(_HELLO, headers=_authorized())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["code"] == 200000
+    assert body["message"] == "OK"
+    assert body["data"] == {"message": HELLO_WORLD}
+
+
+def test_hello_needs_no_user_id(client):
+    """Not user-scoped, so the parameter every other operation requires is absent.
+
+    Asserted as a *success without it* rather than as a schema property: the
+    document side is covered by ``test_explicit_user_id.py``, and what matters
+    to a driver is that the call it makes is complete.
+    """
+    assert client.get(_HELLO, headers=_authorized()).status_code == 200
+
+
+def test_hello_refuses_a_caller_with_no_principal(client):
+    """The whole point of measuring this path is that it includes the auth."""
+    response = client.get(_HELLO)
+
+    assert response.status_code == 401
+    assert response.json()["data"] is None
+
+
+def test_hello_refuses_a_principal_signed_with_another_key(client):
+    """A forged token is refused exactly as an absent one is."""
+    response = client.get(
+        _HELLO, headers={PRINCIPAL_HEADER: mint(key="a-different-secret-key-32-bytes+")}
+    )
+
+    assert response.status_code == 401
+
+
+# ── the socket ──────────────────────────────────────────────────────────────
+
+
+def test_the_socket_echoes_a_text_frame(client):
+    with client.websocket_connect(_ECHO, headers=_authorized()) as socket:
+        socket.send_text("ping")
+
+        assert socket.receive_text() == "ping"
+
+
+def test_the_socket_echoes_a_binary_frame(client):
+    """Both frame types, because a driver picks its own payload shape.
+
+    This is what the raw ``receive()`` in the handler buys: ``receive_text``
+    would answer a binary frame with a ``RuntimeError`` and take the choice away.
+    """
+    with client.websocket_connect(_ECHO, headers=_authorized()) as socket:
+        socket.send_bytes(b"\x00\x01\x02")
+
+        assert socket.receive_bytes() == b"\x00\x01\x02"
+
+
+def test_the_socket_echoes_every_frame_in_order(client):
+    """One connection, many frames — the shape a throughput run actually drives."""
+    with client.websocket_connect(_ECHO, headers=_authorized()) as socket:
+        for index in range(5):
+            socket.send_text(f"frame-{index}")
+
+        assert [socket.receive_text() for _ in range(5)] == [
+            f"frame-{index}" for index in range(5)
+        ]
+
+
+def test_the_socket_returns_the_payload_byte_for_byte(client):
+    """No trimming, no re-encoding, no interpretation of the payload."""
+    payload = '  {"nested": "json"} \n\t☃  '
+
+    with client.websocket_connect(_ECHO, headers=_authorized()) as socket:
+        socket.send_text(payload)
+
+        assert socket.receive_text() == payload
+
+
+def test_the_socket_closes_cleanly_when_the_peer_goes_away(client):
+    """Leaving the block disconnects; the handler must return, not raise.
+
+    An exception escaping the endpoint would reach the ASGI error path on every
+    single connection a load run closes, which is a lot of tracebacks for the
+    normal end of a socket.
+    """
+    with client.websocket_connect(_ECHO, headers=_authorized()) as socket:
+        socket.send_text("bye")
+        assert socket.receive_text() == "bye"
+
+
+def test_the_socket_refuses_a_handshake_with_no_principal(client):
+    """1008, and never accepted — the socket plane's form of the 401.
+
+    A handshake has no body to put an envelope in, so the refusal is the close
+    code. It happens in the dependency, before the endpoint runs, so a rejected
+    caller never gets an open connection at all.
+    """
+    with pytest.raises(WebSocketDisconnect) as refused:
+        with client.websocket_connect(_ECHO):
+            pass
+
+    assert refused.value.code == 1008
+
+
+def test_the_socket_refuses_a_principal_signed_with_another_key(client):
+    with pytest.raises(WebSocketDisconnect) as refused:
+        with client.websocket_connect(
+            _ECHO,
+            headers={PRINCIPAL_HEADER: mint(key="a-different-secret-key-32-bytes+")},
+        ):
+            pass
+
+    assert refused.value.code == 1008
+
+
+# ── the address and the guard, asserted where the document cannot ───────────
+
+
+def _routes():
+    """Every route of the assembled public surface, flattened.
+
+    ``include_router`` stores a lazy wrapper rather than copying routes, so the
+    nesting has to be walked — the same shape ``test_principal_seam`` uses.
+    """
+    found = []
+
+    def walk(router):
+        for route in getattr(router, "routes", []):
+            if hasattr(route, "dependant"):
+                found.append(route)
+            elif hasattr(route, "original_router"):
+                walk(route.original_router)
+            else:
+                walk(route)
+
+    walk(build_public_router())
+    return found
+
+
+def _loadtest_routes():
+    return [route for route in _routes() if "/loadtest" in route.path]
+
+
+def test_the_group_publishes_exactly_the_two_endpoints():
+    """A third one added here would be a third thing every run has to explain."""
+    assert sorted(route.path for route in _loadtest_routes()) == [_HELLO, _ECHO]
+
+
+def test_the_socket_address_is_pinned_here_or_nowhere():
+    """The generated document has no WebSocket, so this is the only guard.
+
+    The ``ws`` segment is what the gateway's socket-plane claim gets pinned to
+    (``/openapi/v1/bots/loadtest/ws/**``), so moving the endpoint out of that
+    subtree makes it unroutable through the gateway with nothing failing here.
+    """
+    sockets = [route for route in _loadtest_routes() if not hasattr(route, "methods")]
+
+    assert [route.path for route in sockets] == [_ECHO]
+
+
+def test_both_endpoints_are_gated_by_require_principal():
+    """Declared per route, so the route's own dependant carries the guard.
+
+    ``test_public_routes_require_principal`` makes this assertion for the whole
+    surface; it is repeated here because the socket is the first route on it
+    that the *group-level* declaration alone would have to cover, and this file
+    is where a change to the group's wiring is read.
+    """
+    def gated(dependant) -> bool:
+        if dependant.call is require_principal:
+            return True
+        return any(gated(sub) for sub in dependant.dependencies)
+
+    ungated = [route.path for route in _loadtest_routes() if not gated(route.dependant)]
+
+    assert not ungated, f"load-test routes not gated by require_principal: {ungated}"

--- a/src/backend/tests/community/endpoints/test_openapi_loadtest_hello.py
+++ b/src/backend/tests/community/endpoints/test_openapi_loadtest_hello.py
@@ -1,0 +1,108 @@
+"""Endpoint-framework coverage for the load-test hello endpoint.
+
+The framework owns invocation, so these two cases are what makes
+``GET /openapi/v1/bots/loadtest/hello`` *covered* rather than merely tested:
+the happy path against the assembled application, and the refusal that a
+synthetic endpoint most needs pinned — no signed principal, no answer.
+
+``test_loadtest_endpoints.py`` covers the same two outcomes plus the socket in
+the adapter's own suite. The duplication is the coverage gate's design: it reads
+this registry, not that file.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.adapters.http.openapi_v1.loadtest.router import HELLO_WORLD
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_PATH = "/openapi/v1/bots/loadtest/hello"
+_CALLER = "loadtest-caller"
+_KEY = "loadtest-framework-signing-key-at-least-32-bytes"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    """A user-only identity set — this endpoint scopes to nothing else."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {"id": _CALLER, "username": "loadtest@example.test"},
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+def _boot_verifier(_world) -> None:
+    """Install the shared key both cases are judged against.
+
+    The refusal case needs it as much as the happy one: without a booted
+    verifier the 401 could come from an unconfigured seam rather than from the
+    missing header, and the case would pass for the wrong reason.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="returns_hello_world",
+    input=CaseInput(headers={PRINCIPAL_HEADER: _principal()}),
+    seed=_boot_verifier,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "message": "OK",
+            "data": {"message": HELLO_WORLD},
+        },
+    ),
+)
+def loadtest_hello_ok():
+    """Body intentionally empty — the framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="unauthenticated",
+    input=CaseInput(),
+    seed=_boot_verifier,
+    expect=ExpectError(
+        status=401,
+        json_contains={"code": 401000, "message": "Unauthorized", "data": None},
+    ),
+)
+def loadtest_hello_requires_a_principal():
+    """No ``X-Avernet-Principal`` header — the surface's uniform refusal."""

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -321,6 +321,34 @@ user_config:
           from: /openapi/v1/bots/messages/ws
           to: /proxypass
 
+      # The load-test socket — the backend's echo endpoint, forwarded verbatim.
+      #
+      # It exists so a load run can measure this relay: what a handshake and a
+      # round trip cost through the gateway, with an upstream that does nothing
+      # but send the frame back. The HTTP half of the same group needs no entry
+      # here — `bots` above already carries `/openapi/v1/bots/**` to the backend
+      # on the HTTP plane — but the socket plane has no such catch-all, because
+      # `bots` declares no `protocols` and so serves HTTP only. Without this
+      # domain the handshake is refused with "no route for path" and only the
+      # HTTP endpoint is measurable.
+      #
+      # Socket-only, like the domain above, so an HTTP request under this prefix
+      # is not this domain's at all and still resolves through `bots`.
+      #
+      # No `rewrite:` — the backend serves this address itself, so only the
+      # origin changes. And no `schema:`: a WebSocket has no OpenAPI
+      # representation.
+      #
+      # Authentication is inherited, deliberately. This prefix appears nowhere
+      # in `route_security`, so it falls to `/openapi/v1/bots/**` — user
+      # required — and the relay signs that identity into the handshake the
+      # backend verifies. A load test that measured an exempted path would be
+      # measuring a path no caller can take.
+      bots-loadtest-ws:
+        match: /openapi/v1/bots/loadtest/ws/**
+        server: backend
+        protocols: [websocket]
+
     servers:
       backend:
         base_url: "${backend_server_url}"

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -3797,6 +3797,31 @@
         "title": "RoutineUpdate",
         "type": "object"
       },
+      "RuntimeStage": {
+        "description": "Which of the bot's runtimes an operation addresses.",
+        "enum": [
+          "draft",
+          "verify",
+          "online"
+        ],
+        "title": "RuntimeStage",
+        "type": "string",
+        "x-enum-descriptions": [
+          "The bot's own workspace runtime — the pre-publication draft, and the only runtime a personal bot has. The default.",
+          "A service bot's pre-production runtime, served while a release is validating (or retained after promotion).",
+          "A service bot's live published runtime."
+        ],
+        "x-enum-varnames": [
+          "DRAFT",
+          "VERIFY",
+          "ONLINE"
+        ],
+        "x-enumNames": [
+          "DRAFT",
+          "VERIFY",
+          "ONLINE"
+        ]
+      },
       "ScheduleTrigger": {
         "description": "A schedule trigger. Modeled as a typed nested object so other trigger\nkinds (event, webhook) can be added later without a breaking change.",
         "properties": {
@@ -4557,6 +4582,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -4566,6 +4602,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -4700,6 +4755,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -4709,6 +4775,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -4855,6 +4940,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -4864,6 +4960,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -5219,6 +5334,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -5228,6 +5354,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -5364,6 +5509,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -5373,6 +5529,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -5509,6 +5684,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -5518,6 +5704,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -5654,6 +5859,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -5663,6 +5879,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -7644,6 +7879,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -7680,6 +7926,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -7825,6 +8090,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -7834,6 +8110,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -10255,6 +10550,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "Only sessions belonging to this agent.",
             "in": "query",
             "name": "agent_id",
@@ -10327,6 +10633,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -10461,6 +10786,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -10470,6 +10806,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -10625,6 +10980,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -10634,6 +11000,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -10777,6 +11162,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -10786,6 +11182,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -10929,6 +11344,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -10938,6 +11364,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -11093,6 +11538,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "The end user this request acts for. Every read and write is scoped to it. It must currently be the authenticated caller's own id; naming another user is refused (403).",
             "in": "query",
             "name": "user_id",
@@ -11102,6 +11558,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],
@@ -11245,6 +11720,17 @@
             }
           },
           {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -11281,6 +11767,25 @@
               "minLength": 1,
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
             }
           }
         ],

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -1380,6 +1380,44 @@
         "title": "Envelope[EngineStatus]",
         "type": "object"
       },
+      "Envelope_HelloWorld_": {
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HelloWorld"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[HelloWorld]",
+        "type": "object"
+      },
       "Envelope_IdentityFileList_": {
         "properties": {
           "code": {
@@ -2602,6 +2640,21 @@
           "request_id"
         ],
         "title": "ErrorEnvelope",
+        "type": "object"
+      },
+      "HelloWorld": {
+        "description": "What the load-test HTTP endpoint returns, always.",
+        "properties": {
+          "message": {
+            "description": "Always the constant \"hello world\".",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "HelloWorld",
         "type": "object"
       },
       "IdentityFile": {
@@ -6127,6 +6180,98 @@
         "summary": "Update Bot Identity File",
         "tags": [
           "identity"
+        ]
+      }
+    },
+    "/openapi/v1/bots/loadtest/hello": {
+      "get": {
+        "description": "Answer the constant ``hello world``.\n\nReads nothing and calls nothing, so the response time is the path's, not the\nhandler's.",
+        "operationId": "hello_world_openapi_v1_bots_loadtest_hello_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_HelloWorld_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Hello World",
+        "tags": [
+          "loadtest"
         ]
       }
     },

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -106,6 +106,49 @@ def test_shipped_config_routes_collaboration_verbatim_to_bcs() -> None:
     assert websocket_requirement == {}
 
 
+def test_shipped_config_routes_the_load_test_socket_to_the_backend() -> None:
+    """The load-test echo is reachable on the socket plane, and authenticated.
+
+    Both halves matter, and neither is inferable from the `bots` domain. That
+    domain declares no `protocols`, so it serves HTTP only and a handshake under
+    `/openapi/v1/bots/**` resolves to nothing without an entry of its own — the
+    socket would be refused with "no route for path" while its HTTP sibling
+    worked, which is exactly the asymmetry a load run would misread as a
+    backend fault.
+
+    And the prefix appears nowhere in `route_security`, so it inherits
+    `/openapi/v1/bots/**` — user required. Asserted rather than assumed: the
+    `messages` socket a few lines below in the shipped config IS exempted, so
+    "a socket under bots is unauthenticated" is a live and wrong generalisation
+    to make here. A load test measuring an exempted path measures a path no
+    caller can take.
+    """
+    raw = yaml.safe_load(_CONFIG.read_text())
+    dm = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)
+
+    socket = dm.websocket_domain_for("/openapi/v1/bots/loadtest/ws/echo")
+    assert socket is not None
+    assert socket.server.name == "backend"
+    assert socket.serves_websocket and not socket.serves_http
+    # No rewrite: the backend serves this address itself, so only the origin
+    # changes and the path travels byte for byte.
+    assert socket.rewrite is None
+    assert socket.upstream_path("/openapi/v1/bots/loadtest/ws/echo") == (
+        "/openapi/v1/bots/loadtest/ws/echo"
+    )
+
+    # Socket-only, so the group's HTTP half is still the `bots` domain's — the
+    # same split the messages socket relies on.
+    hello = dm.http_domain_for("/openapi/v1/bots/loadtest/hello")
+    assert hello is not None and hello.name == "bots"
+    assert dm.websocket_domain_for("/openapi/v1/bots/loadtest/hello") is None
+
+    security = RouteSecurity.from_table(raw["user_config"]["route_security"])
+    requirement = security.resolve("WEBSOCKET", "/openapi/v1/bots/loadtest/ws/echo")
+    assert requirement is not None
+    assert requirement[PrincipalType.USER] is Presence.REQUIRED
+
+
 def test_shipped_config_routes_bcsfuse_clean_paths() -> None:
     raw = yaml.safe_load(_CONFIG.read_text())
     dm = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)


### PR DESCRIPTION
## Problem

There is nowhere to measure what a call to the public API *costs before it does
anything*. Every endpoint on `/openapi/v1/bots` reaches a service, a database,
or an engine, so a load run against any of them produces one number covering the
gateway's authentication and forwarding, this service's middleware stack, the
framework's request handling, and the endpoint's own work — with no way to say
which part moved. A baseline the other numbers are read against has to be an
endpoint that does nothing, on both planes the surface will be load-tested on.

## Solution

A new `loadtest` group under the public surface, in its own sub-package
(`adapters/http/openapi_v1/loadtest/`), with two endpoints:

| Address | Behaviour |
| --- | --- |
| `GET /openapi/v1/bots/loadtest/hello` | the constant `hello world` in the standard `Envelope` |
| `WEBSOCKET /openapi/v1/bots/loadtest/ws/echo` | sends every received frame straight back, text or binary |

**Authenticated exactly like the rest of the surface.** Both declare
`require_principal`, so a caller with no verified gateway principal is refused
before the handler runs. This is the point rather than ceremony: a load test
measures the path callers actually take, and on this surface that path includes
verifying the gateway's signed principal — a number gathered without it would
describe a route nobody can call.

**Not user-scoped, so no `user_id`.** Neither endpoint reads or writes anything
belonging to anyone, so there is no scope for the parameter to name. The HTTP
one joins the four catalogue reads already recorded as exempt in
`test_explicit_user_id.py`, with its reason attached, and therefore documents no
403.

Supporting changes, each because the alternative was worse:

- **`require_principal` now takes an `HTTPConnection`, not a `Request`.** The
  surface's rule is one rule — every public route requires an authenticated
  caller — and `_PUBLIC_AUTH` already reaches a socket route. A second
  WebSocket-only dependency would have been a second thing to keep in step with
  delegation, and would have left the group-level declaration raising on the
  socket plane anyway. Only the *shape* of the refusal is plane-specific: HTTP
  keeps `MissingPrincipalError` → the 401 envelope, and a handshake — which can
  carry neither a body nor a status — is refused with close code 1008 before the
  socket is accepted. `resolve_caller` was widened the same way; it only ever
  read headers and `state`, both of which belong to the base class.
- **A gateway socket-plane domain for the echo endpoint.** The `bots` domain
  declares no `protocols`, so it serves HTTP only: the hello endpoint is already
  routable through the gateway with no config change, and the handshake resolves
  to no domain at all and is refused with "no route for path". `bots-loadtest-ws`
  forwards `/openapi/v1/bots/loadtest/ws/**` verbatim to the backend, socket-only
  (so the group's HTTP half still resolves through `bots`), with no
  `route_security` entry — it inherits `user: required` from
  `/openapi/v1/bots/**`, and the relay signs that identity into the handshake
  the backend verifies.
- **The socket's contract is written into the docs** (`docs/openapi-v1/README.md`
  and the zh-CN mirror), because a WebSocket has no OpenAPI representation and so
  appears in no generated artifact. Address, per-plane auth behaviour, accepted
  frame types and byte-for-byte echo, ordering, disconnect, lifetime limits, and
  which gateway domain serves it — the section is the contract, not a summary of
  something machine-readable.
- **The published Bots OpenAPI artifact is regenerated.**
  `configs/schemas/bots.openapi.json` is what the single-box gateway serves as
  the Bots contract, so leaving it at the previous dump would have meant the new
  endpoint working at runtime but absent from the served document. Regenerated
  through the pipeline that owns it rather than hand-edited — `dump_openapi.py`
  produced the candidate, `gate_and_publish_openapi.py` published it and reported
  it backward-compatible.

Rejected: mounting the group outside `build_public_router()`. It would have
dodged every convention test on this surface, which is what those tests exist to
prevent — and it would have skipped the auth the measurement is supposed to
include.

The `ws` segment is deliberate, following `/openapi/v1/bots/messages/ws/**`: a
socket-plane claim and its auth rule get pinned to a subtree that is visible as
one in a URL, so an HTTP endpoint added under `loadtest` later is outside both by
construction.

## Validation

Rebased onto `dev` at `5e8bc36` (#904). Everything below was re-run on the
rebased tree.

Ran in `src/backend`:

- `pytest` (full unit suite, `-n 4 --dist loadfile`) — **11211 passed, 3 skipped**.
  Two failures in `test_bot_build_service_skill_artifact.py` are **pre-existing**;
  confirmed by stashing the change and re-running on a clean tree.
- `tests/community/adapters/http/openapi_v1/` + the coverage gate — 625 passed.
  Includes the surface's own convention gates: `test_path_convention` (docs'
  reserved-name list still equals the routes'), `test_explicit_user_id`,
  `test_openapi_error_schema`, `test_public_routes_require_principal`.
- Two endpoint-framework cases (happy + unauthenticated) cover the HTTP endpoint,
  so `test_coverage_gate` passes without a baseline entry.
- The block-rule lint gate (`python_sast_local.sh`'s rule set, via flake8) over
  every changed file — clean. The repo-wide run reports pre-existing E999s on
  PEP 695 generics elsewhere; none in these files.

Ran in `src/gateway`:

- `pytest tests/unit tests/integration tests/contracts` — 710 passed. The one
  failure (`test_bcn_dump_uses_the_gateway_managed_python_environment`) is
  **pre-existing** and environmental; confirmed on a stashed clean tree.
- `gate_and_publish_openapi.py` — reported the re-dumped artifact `(compatible)`;
  exit 0.

Ran against a real uvicorn server (not `TestClient`, whose WebSocket handling
differs from an ASGI server's):

```
HTTP authed: 200 {'code': 200000, 'message': 'OK', 'data': {'message': 'hello world'}}
HTTP anon:   401 {'code': 401000, 'message': 'Unauthorized', 'data': None}
WS text:     hello world
WS binary:   b'\x01\x02\x03'
WS 200 round trips in 56 ms
WS anon:     server rejected WebSocket connection: HTTP 403
```

CI was green on all 7 checks on the pre-rebase commit `6efb670`, Singlebox
coverage included; it is re-running on the rebased head.

Not run: the singlebox coverage gate and acceptance E2E locally (they need a
spawned product stack this container cannot provide — CI covers them), and any
load run through a live gateway.

## Compatibility and risk

Additive. No existing route, schema, or response changes; `require_principal`'s
HTTP behaviour is identical and its signature change is invisible to callers
(FastAPI fills an `HTTPConnection` parameter on both planes, and
`dependency_overrides` is unaffected).

**Read the artifact diff with the rebase in mind.** #904 merged without
republishing `bots.openapi.json`, so re-dumping on the rebased tree picks up its
two optional engine-runtime query parameters (`owner_id`, `stage`) and the
`RuntimeStage` schema alongside this branch's one path. That is 505 additive
lines this branch did not author, isolated in its own commit (`a148f31`) with
that stated in the message. This branch changes no engine-runtime behaviour —
only the description of it catches up. Publishing a dump known to be wrong about
eleven paths was the alternative, and the artifact's README exists to prevent
exactly that.

One thing a reviewer should weigh: **the gateway changes touch a second module.**
They are in this PR because without the socket domain the WebSocket endpoint
cannot be load-tested through the gateway at all — the stated purpose — and
because an artifact that describes a surface the upstream does not serve is the
thing its README exists to prevent. Both are separable if you would rather they
landed on their own.

One gap is documented rather than fixed, in `openapi_v1/__init__.py` and beside
the socket's contract in the README: `AvernetTenantMiddleware` and the public
access log both return early on a non-HTTP scope, so a WebSocket runs under the
*default* tenant and leaves no access line. Harmless for a route that reads and
writes nothing — the only socket route on the surface — and noted as the first
thing to fix before adding one that does, since a tenant-scoped read under the
default tenant is a data-isolation failure rather than a missing log.

Rollback is deleting the group, the domain entry, and re-running the publish
script; nothing depends on any of them.
