### PR TITLE
docs(backend): design the openapi v1 publish lifecycle and the release-core evolution

### DIFF
--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/design.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/design.md
@@ -1,0 +1,349 @@
+# Design — Evolving the Service-Bot Release Lifecycle
+
+Companion to `spec.md` / `plan.md` in this directory. The spec defines the
+public contract; this document defines the internal evolution the public
+surface is built on — requested during review: *"take this time for the
+service bot lifecycle service to evolve … a lot of things are put into the ext
+field of `ac_bot_publish` and it's hard for people to follow; publish_id can
+be in different fields in that ext; the logic itself is also a mess."*
+
+This is a design to review, not a description of code already written.
+
+---
+
+## 1. The mess, precisely
+
+### 1.1 `ext` is four different things in one JSON column
+
+A census of every `ext` read/write in `core/service_bot` shows the blob
+conflating four concerns with four different lifecycles:
+
+| Concern | Keys | Lifecycle |
+|---|---|---|
+| **Deployment topology** — what is running where | `binding.{verify,online}`, `publish.{verify,online}`, `restart.{stage}`, `restart.restarting`, `scale.publish_id`, `bot_uuid`, `destroy_publish_id` | Written by every deploy-shaped operation; read by progress sync, retry, restart, rollback, engine-runtime stage resolution, cron |
+| **Build artifact** — what to deploy | `migration_path`, `config_artifact`, `build_target_path`, `skills_manifest`, `build_rsync_excludes` | Written once per build; read by both release stages |
+| **Failure / recovery bookkeeping** | `error_message`, `source_status`, `retry` | Written on failure; read by retry and the status report |
+| **Hitchhiking domain states** | `approval`, `approval_history`, `rollback`, `rollback_restored_from`, `engine_overrides_by_stage`, `data_init_status`, eval keys | Each owned by a different service, sharing the column because it was there |
+
+### 1.2 "publish_id" lives in four homes
+
+The BaaS workflow id for an operation is stored in **four places depending on
+which operation minted it**:
+
+1. `ext.publish.{stage}` — first release / upgrade (`publish_ext_mixin.py`,
+   `release_stage.py`)
+2. `ext.restart.{stage}` — restart (`restart_mixin.py`)
+3. `ext.scale.publish_id` — scale (`scale_mixin.py`)
+4. `ac_publish_operation.baas_publish_id` — **every** operation, since the #197
+   idempotency ledger
+
+Reading it back therefore requires knowing who wrote it —
+`restart_mixin.py:525-527` literally compares a ledger row's id against *two*
+ext homes to classify it:
+
+```python
+if op.baas_publish_id != (ext.get("publish") or {}).get(stage_enum.value): ...
+if op.baas_publish_id != (ext.get("restart") or {}).get(stage_enum.value): ...
+```
+
+The root cause is historical: the ext stashes predate the ledger. Since #197,
+every BaaS mutation opens a ledger row keyed
+`(publish_id, operation_kind, stage, attempt)` carrying `baas_publish_id`,
+`state`, `params`, `result`. **The ext copies are a legacy shadow of a table
+that is already the better answer.**
+
+### 1.3 The logic is a mixin soup
+
+`PublishFlowService` inherits **14 mixins** (`ProgressSyncMixin`,
+`RestartMixin`, `ScaleMixin`, `StageStatusMixin`, `RollbackOpsMixin`,
+`BaasPublishOpsMixin`, `DeviceBindingMixin`, `PublishExtMixin`,
+`EvalPublishMixin`, `UpgradeResolutionMixin`, `RetryOpsMixin`,
+`DraftRestoreOpsMixin`, `PublishImagePolicyMixin`, + the facade itself) over
+~8,000 lines. The mixins share state through `self._ext_state`,
+`self._publish_service`, `self._baas_service` — none of which they declare, so
+no mixin can be read, tested, or reasoned about alone, and the effective call
+graph only exists at runtime. The extraction of `BuildStageRunner`,
+`ReleaseStageRunner` and `PublishOperationRunner` (the
+`2026-07-12-publish-flow-service-refactor` work) already proved the better
+shape: **explicit collaborators taking their real dependencies** — it just
+stopped before the mixins.
+
+### 1.4 The status machine is implicit
+
+`DRAFT → BUILDING → BUILT → VALIDATE_PUB → VALIDATING → ONLINE_PUB → SUCCESS`
+(+ `FAILED`, `UPGRADED`, `RELEASED`) exists nowhere as a declaration. It is
+smeared across `process()`'s two if-branches, the task handlers in `tasks.py`,
+`progress_sync_mixin`'s advance table, and the `source_status` values each
+failure path happens to write. Whether a transition is user-driven or
+task-driven, and what its failure rollback target is, can only be recovered by
+reading all four places.
+
+---
+
+## 2. Design principles
+
+1. **One concept, one home.** A fact is stored in exactly one place; everything
+   else derives it. The ledger is the home of operation facts; the release row
+   is the home of release facts.
+2. **Typed at the boundary, typed inside.** The `ext` JSON is parsed into a
+   Pydantic model at the persistence seam and serialized back there; no raw
+   dict-key access anywhere else. What today is `(ext.get("binding") or
+   {}).get(stage)` in eleven files becomes `facts.bindings.for_stage(stage)`
+   in one.
+3. **The state machine is data.** Transitions — source, target, driver
+   (user/task), failure rollback target — are one declared table. `process()`
+   and the task handlers *consult* it; nothing else encodes it.
+4. **Explicit collaborators, no mixins.** Every unit takes its dependencies in
+   its constructor. The facade composes; it does not inherit.
+5. **Wire-compatible evolution.** The stored JSON keys, the internal HTTP
+   surface, and the DB schema do not change in this phase; the shape of the
+   *code* changes. Schema changes are a later phase with their own out-of-band
+   DDL, per the repo's standing rule.
+6. **Strangler, not big-bang.** ~8k lines with production crash-safety
+   semantics (#197) and three subsequent fix-specs is not rewritten in one PR.
+   Each phase leaves the system fully working and fully tested.
+
+---
+
+## 3. Target architecture
+
+New package: `core/service_bot/release/` — the lifecycle's future home. The
+name is deliberate: the domain concept is a *release*; "publish" remains the
+verb.
+
+```
+core/service_bot/release/
+├── facts.py          # ReleaseFacts — the typed ext model (§3.1)
+├── store.py          # ReleaseStore — the only reader/writer of ext (§3.2)
+├── machine.py        # the declared status machine (§3.3)
+├── operations.py     # ledger-backed operation queries (§3.4)
+└── lifecycle.py      # ReleaseLifecycleService — the public surface's core (§3.5)
+```
+
+### 3.1 `ReleaseFacts` — the typed ext
+
+```python
+class StageBindings(BaseModel):      # ext["binding"]
+    verify: int | None = None
+    online: int | None = None
+    def for_stage(self, stage: PublishStage) -> int | None: ...
+
+class BuildArtifact(BaseModel):      # migration_path / config_artifact / …
+    migration_path: str | None = None        # ARCA (mounted)
+    config_artifact: dict | None = None      # teclaw (frozen, possibly offloaded)
+    build_target_path: str | None = None
+    skills_manifest: dict | None = None
+    @property
+    def present(self) -> bool: ...           # replaces the copy-pasted
+                                             # "neither present → not built" check
+
+class FailureInfo(BaseModel):        # error_message / source_status / retry
+    message: str | None = None
+    failed_from: PublishStatus | None = None # today's "source_status"
+    retry_in_progress: bool = False          # today's "retry"
+
+class ReleaseFacts(BaseModel):
+    bindings: StageBindings
+    artifact: BuildArtifact
+    failure: FailureInfo
+    engine_overrides_by_stage: dict[str, dict]
+    passthrough: dict[str, Any]              # approval, rollback, eval, data_init …
+                                             # — owned by other services, carried
+                                             # opaquely, NOT typed here (yet)
+
+    @classmethod
+    def from_ext(cls, ext: dict | None) -> "ReleaseFacts": ...
+    def to_ext(self) -> dict: ...            # emits the EXACT legacy keys
+```
+
+`from_ext`/`to_ext` round-trip the **existing** JSON keys byte-compatibly —
+including tolerating the legacy shapes in old rows — so no stored record is
+migrated and a rolling deploy can mix old and new code. A round-trip
+property test (`to_ext(from_ext(x))` preserves every key it does not own,
+verbatim) is the contract.
+
+`passthrough` is the honest boundary of this phase: approval, rollback and eval
+state are other services' property. They keep their keys, untouched, and their
+typing is Phase 3's work — *typed here now* would mean this design deciding
+three other domains' models in passing.
+
+### 3.2 `ReleaseStore` — the only door to `ext`
+
+The evolution of `PublishExtState`, absorbing it. Same persistence semantics
+(latest-read-back, CAS status+ext writes via `compare_and_set_status_with_ext`,
+the deep-copy snapshot discipline) — but its read surface returns
+`ReleaseFacts` and its write surface takes mutators of `ReleaseFacts`:
+
+```python
+class ReleaseStore:
+    def load(self, publish_id) -> tuple[BotPublishRecord, ReleaseFacts]
+    def mutate(self, publish_id, fn: Callable[[ReleaseFacts], None]) -> ReleaseFacts
+    def advance(self, publish_id, target, source) -> bool                  # CAS
+    def advance_with_facts(self, publish_id, target, source, fn) -> bool   # CAS + ext
+```
+
+**Enforcement, not convention:** a new architecture test asserts that outside
+`release/facts.py` and `release/store.py`, no module under `core/service_bot`
+touches `ext[`, `ext.get(`, or `ext.setdefault(` on a publish record. That is
+what makes the census in §1.1 impossible to regrow.
+
+### 3.3 The status machine as data
+
+```python
+@dataclass(frozen=True)
+class Transition:
+    source: PublishStatus
+    target: PublishStatus
+    driver: Driver                 # USER | TASK
+    on_failure: PublishStatus | None   # today's implicit source_status target
+
+RELEASE_MACHINE: tuple[Transition, ...] = (
+    Transition(DRAFT,        BUILDING,    USER, on_failure=None),
+    Transition(BUILDING,     BUILT,       TASK, on_failure=BUILDING),
+    Transition(BUILT,        VALIDATE_PUB,TASK, on_failure=BUILT),
+    Transition(VALIDATE_PUB, VALIDATING,  TASK, on_failure=VALIDATE_PUB),
+    Transition(VALIDATING,   ONLINE_PUB,  USER, on_failure=None),
+    Transition(ONLINE_PUB,   SUCCESS,     TASK, on_failure=ONLINE_PUB),
+)
+```
+
+- `process()` stops being two hand-written branches: it looks up the
+  USER-driven transition for the current status; found → CAS-advance + enqueue,
+  not found → describe. The public surface's two writes and the internal
+  `process` become provably the same two transitions — the spec's "only two
+  user-driven advance points" claim becomes a property of data.
+- The failure paths stop hand-writing `ext["source_status"] = <status>.value`
+  eight times; the machine names each transition's rollback target once and the
+  store's failure write consults it.
+- A test asserts the machine and `PublishStatus` stay in agreement (every
+  non-terminal status reachable, exactly two USER transitions, terminal set =
+  {SUCCESS, UPGRADED, RELEASED, FAILED} minus re-entry rules).
+
+This is a *representation* change: the transitions themselves are today's,
+unchanged.
+
+### 3.4 Operation queries: the ledger becomes the single home
+
+New writes of `ext.publish.{stage}`, `ext.restart.{stage}` and
+`ext.scale.publish_id` **stop**. The ledger already records every one of these
+ids at `ID_RECORDED` — the ext copies are pure duplication.
+
+`release/operations.py` exposes the read side the flow actually needs, backed
+by `PublishOperationRepository`:
+
+```python
+def latest_release_workflow(publish_id, stage)  -> int | None   # FIRST_RELEASE/UPGRADE
+def latest_restart_workflow(publish_id, stage)  -> int | None   # RESTART
+def latest_scale_workflow(publish_id)           -> int | None   # SCALE
+def is_restart_in_flight(publish_id, stage)     -> bool         # replaces ext.restart.restarting
+```
+
+with **read-fallback to the legacy ext keys** for records that predate #197's
+ledger (parsed via `ReleaseFacts`' legacy fields, marked deprecated). The
+classification dance in `restart_mixin.py:525-527` collapses: a ledger row
+*carries* its `operation_kind`; nothing needs to guess it back from which ext
+home matched.
+
+`ext.binding` (topology: which device binding serves a stage) **stays in the
+release row** — it is a fact about the release, not about one operation, and
+it has cross-module readers (`engine_runtime/stage.py`, cron,
+`bot_publish_service.get_bot_stage_binding_info`) whose contract does not
+move in this phase. It becomes typed (`StageBindings`) but not relocated.
+
+### 3.5 `ReleaseLifecycleService` — the public surface's core
+
+As specified in `plan.md` §5, unchanged in role: target resolution + role bar,
+the two precondition-guarded advances, the two reads. What this design changes
+is what it is built on — it consults `RELEASE_MACHINE` for the advance points
+and `ReleaseStore` for state, so the public surface is a client of the evolved
+core, not of the mixin soup.
+
+One simplification falls out: the CAS winner/loser discrimination no longer
+needs the message-constant comparison hack (`plan.md` §4). The lifecycle
+service drives the USER transition **itself** via `ReleaseStore.advance` (the
+same CAS the flow uses) and enqueues the same durable task on a win — the
+machine guarantees these are the same two transitions `process()` drives. A
+lost CAS is a direct boolean, not a parsed message. `process()` remains for
+the internal surface, now delegating to the same machine lookup, so the two
+surfaces cannot drift.
+
+### 3.6 Dissolving the mixins (bounded here, executed per-phase)
+
+End state: `PublishFlowService` is a composition facade over explicit units —
+`BuildStageRunner` and `ReleaseStageRunner` (exist), plus `ProgressSync`,
+`RestartOps`, `ScaleOps`, `RollbackOps`, `RetryOps`, `DraftRestoreOps`,
+`EvalOps` as constructor-injected collaborators; the facade keeps its public
+method names (the Service API protocol is unchanged) and forwards.
+
+This is mechanical but large (§1.3), so it is **phased per mixin**, and each
+conversion's proof is the existing suite for that mixin passing unmodified.
+
+---
+
+## 4. Phasing
+
+| Phase | Content | Ships |
+|---|---|---|
+| **1 — this change** | `release/` package: `ReleaseFacts` + `ReleaseStore` (absorbing `PublishExtState`), the declared machine consulted by `process()` and the failure writes, ledger-backed operation queries replacing ext id writes/reads, the no-raw-ext architecture test, and the public `publish` category on top | with the public API PR (this SDD) |
+| **2 — mixin dissolution** | Convert the mixins to collaborators one at a time (`ProgressSync` first — biggest, most-read); no behaviour change, suites unmodified | follow-up PRs, own spec dir |
+| **3 — hitchhikers move out** | Type/relocate `approval`, `rollback`, eval and data-init state with their owning services; shrink `passthrough` toward empty | follow-up, with those services' owners |
+| **4 — schema** | If then still warranted: hoist `bindings` and `failure` to real columns with out-of-band DDL and tenant-axis decisions taken together | separate spec; **explicitly not now** |
+
+Phase 1 is sized to this session and removes the two things called out in
+review — the untyped ext maze and the scattered publish ids — while phases 2–4
+are recorded so the direction survives the session.
+
+**What Phase 1 deliberately does not change:** stored JSON keys (round-trip
+compatible), the internal HTTP surface, the DB schema, the durable task
+handlers' semantics, the #197 crash-safety properties (the ledger writes are
+untouched — only the *duplicate* ext writes stop), and the three fix-specs'
+behaviour (retry routing, supersede cleanup, idempotency), all pinned by their
+existing suites.
+
+### Rolling-deploy compatibility (Phase 1)
+
+Old and new code briefly coexist against the same rows. Safe because: new code
+reads workflow ids ledger-first with ext fallback (old rows and old writers
+both satisfied); old code reading rows written by new code finds `binding`,
+artifact and failure keys exactly where they always were — the only absent
+things are the duplicate id stashes for *operations started by new code*, and
+ledger rows exist for those, which old code also consults where it matters
+(`restart_mixin` already reads the ledger first). The one-version window where
+an old reader's ext-only path misses a new writer's id resolves to "re-derive
+from ledger/BaaS", the same path #197 built for crash recovery.
+
+---
+
+## 5. What this changes in `plan.md`
+
+- §4 (message-constant lift) is **withdrawn** — replaced by the machine-driven
+  advance in §3.5 of this design. No edit to `publish_flow_service.py`'s
+  strings is needed; instead `process()` is refactored to consult the machine
+  (same transitions, same messages, internal suite unmodified).
+- §5's `ReleaseLifecycleService` moves to `core/service_bot/release/lifecycle.py`
+  and gains `ReleaseStore`/`RELEASE_MACHINE` as its substrate.
+- The test plan gains: the facts round-trip property test, the machine
+  agreement test, the ledger-first/ext-fallback tests, and the no-raw-ext
+  architecture test.
+- Everything else in `plan.md` (endpoints, preconditions, projections, role
+  bar, error mapping, docs) stands as written.
+
+## 6. Open questions for this design's review
+
+1. **Phase 1 blast radius.** Stopping the ext id writes touches
+   `publish_ext_mixin`, `release_stage`, `restart_mixin`, `scale_mixin`, and
+   their readers (`progress_sync`, `retry_ops`, `rollback_ops`,
+   `upgrade_resolution`, `baas_service:3425`, `arca_image_pin`,
+   `bot_publish_service:641`). That is the minimal set that kills the
+   scattered-id problem for real. The alternative — dual-write during Phase 1
+   and stop writes in Phase 2 — is safer but means the mess's headline symptom
+   survives this session. Recommendation: stop the writes now, keep the read
+   fallback; the ledger has been authoritative since #197 shipped.
+2. **Does `process()` refactor in Phase 1 or Phase 2?** Consulting the machine
+   from `process()` is a small edit with a big drift-prevention payoff
+   (recommendation: Phase 1); dissolving `progress_sync`'s advance table into
+   it is Phase 2.
+3. **The `release/` package name** — `release/` vs widening the existing
+   `publish_flow/`. Recommendation: new package; `publish_flow/` becomes the
+   legacy it strangles, and the import direction (`publish_flow` may import
+   `release`, never the reverse) is testable.

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/plan.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/plan.md
@@ -3,6 +3,13 @@
 Implements `spec.md` in this directory. Issue
 [#909](https://github.com/inclusionAI/Avernet/issues/909).
 
+**Read `design.md` first.** During review the scope widened: the public surface
+is built on an *evolved* internal core (the `core/service_bot/release/`
+package — typed release facts, one store for `ext`, the status machine as
+data, the ledger as the single home of BaaS workflow ids), not on the current
+mixin pipeline as-is. `design.md` defines that evolution and its phasing;
+this plan implements **Phase 1** of it plus the public category.
+
 All paths are relative to `src/backend/src/agentclaw/community/` unless stated
 otherwise.
 
@@ -10,27 +17,34 @@ otherwise.
 
 ## 1. Shape of the change
 
-Five public operations in a new `publish` category, backed by one new core
-service that composes services that already exist. Nothing in the publish
-pipeline changes: `PublishFlowService.process` is called exactly as the internal
-router calls it, and the internal router is not touched.
+Four public operations in a new `publish` category, on top of the Phase-1 core
+evolution from `design.md`. The stored JSON keys, the internal HTTP surface and
+the DB schema do not change; the shape of the code does. Neither write mints a
+release record — creating a service bot already creates its first draft
+(`bot_service.create_bot`, the `resolved_bot_type == "service"` branch), so a
+first release has a draft to advance from the moment the bot exists.
 
 ```
 adapters/http/openapi_v1/publish/router.py      ← thin: params, envelope, projection
         │  (UserIdDep, OwnerIdDep, PageParamsDep)
         ▼
-core/service_bot/services/release_lifecycle_service.py   ← ALL policy lives here
+core/service_bot/release/lifecycle.py            ← ALL public-surface policy
         │
         ├── BotService.get_bot ............... owner-scoped, tenant-guarded resolve
         ├── core/bot_collaborator/access.py .. role bar (extracted, see §3)
-        ├── BotPublishService ................ create-first / upgrade / read records
-        ├── PublishFlowService.process ....... the two CAS advances (unchanged)
-        └── PublishOperationRepository ....... the ledger read
+        ├── release/machine.py ............... the declared status machine
+        ├── release/store.py ................. typed ext + CAS advance
+        └── release/operations.py ............ ledger-backed workflow-id reads
+
+core/service_bot/release/                        ← Phase 1 of design.md §3–§4
+        facts.py / store.py / machine.py / operations.py
+        (PublishExtState absorbed; ext id-stash writes stopped;
+         process() consults the machine)
 ```
 
 The router owns no domain decision. That is the architecture rule (`core` stays
 transport-agnostic; adapters translate protocol details) and it is also what
-makes the state-machine behaviour testable without a TestClient.
+makes the precondition behaviour testable without a TestClient.
 
 ### Endpoints
 
@@ -38,19 +52,28 @@ Component literal `publish`; addressing rule `/openapi/v1/bots/<component>/{bot_
 
 | Method | Path | Purpose | Success |
 |---|---|---|---|
-| POST | `/openapi/v1/bots/publish/{bot_id}/releases` | Start a verify release | `202 Envelope[Release]` started · `200 Envelope[Release]` already in flight |
+| POST | `/openapi/v1/bots/publish/{bot_id}/releases` | Start a verify release — **requires the newest release to be a draft** | `202 Envelope[Release]` |
 | GET | `/openapi/v1/bots/publish/{bot_id}/releases` | List releases, newest first | `Envelope[Page[Release]]` |
 | GET | `/openapi/v1/bots/publish/{bot_id}/releases/{version}` | One release's state | `Envelope[Release]` |
-| POST | `/openapi/v1/bots/publish/{bot_id}/releases/{version}/promote` | Promote verify → online | `202 Envelope[Release]` promoted · `200 Envelope[Release]` already promoted |
-| GET | `/openapi/v1/bots/publish/{bot_id}/releases/{version}/operations` | The release's operation ledger | `Envelope[Page[ReleaseOperation]]` |
+| POST | `/openapi/v1/bots/publish/{bot_id}/releases/{version}/promote` | Promote verify → online — **requires the release to be validating** | `202 Envelope[Release]` |
+
+The operation-ledger endpoint from the first draft of this plan is **dropped**
+(spec Decision 4): `ac_publish_operation` stays internal, and nothing in this
+change reads it.
 
 Every operation takes the required `user_id` query parameter and the optional
 `owner_id` query parameter. **No `stage` parameter**: a release *is* the stage
-transition; `stage` appears inside a ledger entry as data, never as an address.
+transition. **No request body on either write**: the operations take no
+arguments beyond their address, so there is nothing for a body to carry, and no
+body means no `extra="forbid"` surface to get wrong.
 
 `{version}` is `ac_bot_publish.version` — per-bot, monotonic from 1, assigned by
 `BotPublishService._get_next_version`. Declared `int` with `ge=1`, so a
 non-numeric segment is a 422 before any lookup runs.
+
+The start write takes no version: it advances the bot's newest release, and its
+precondition is exactly that the newest release is a draft. The response carries
+the version it advanced.
 
 ---
 
@@ -97,24 +120,6 @@ and the whole of `ext` — which carries `binding.{verify,online}` binding ids,
 `source_status`. `ext` is never read by the projection, so a key added to it
 later cannot leak by default.
 
-### `ReleaseOperation` payload
-
-Published: `kind`, `stage`, `attempt`, `state`, `operator`, `created_at`,
-`updated_at`.
-
-`kind` and `state` are published enums mirroring `PublishOperationKind` and
-`PublishOperationState` value-for-value (both are already stable, English,
-caller-meaningful vocabularies); both mappings are asserted exhaustive, so a new
-kind fails CI here as it already does in the deploy-partition test. `stage`
-publishes the raw `PublishStage` value (`draft`/`verify`/`online`/`eval`) or the
-empty string, unchanged.
-
-Withheld: `id`, `publish_id`, `bot_uuid`, `baas_publish_id`, `params`, `result`,
-`last_error`, `request_id`, `env` (spec Decision 7).
-
-Ordering: `gmt_create` ascending, then `id` ascending — a timeline reads
-forward, and ties inside one second stay stable across pages.
-
 ---
 
 ## 3. Extraction: the role bar
@@ -146,30 +151,81 @@ behaviour-preserving extraction (recipe step 6): proved by leaving
 Bars used by this category:
 
 - **Writes** (start, promote): `PermissionLevel.ADMIN` — `CollaboratorRole.ADMIN`
-  is defined as *edit + publish* (spec Decision 2).
-- **Reads** (get, list, operations): `PermissionLevel.MEMBER` — the same
-  `OPERATOR_LEVEL` the access expansion applies to the runtimes these releases
-  produce.
+  is defined as *edit + publish* (spec Decision 3).
+- **Reads** (get, list): `PermissionLevel.MEMBER` — the same `OPERATOR_LEVEL`
+  the access expansion applies to the runtimes these releases produce.
 
 Both constants are named once in the new core service
 (`PUBLISH_LEVEL` / `PUBLISH_READ_LEVEL`), not spelled at call sites.
 
 ---
 
-## 4. New core service
+## 4. The Phase-1 core evolution (from `design.md`)
 
-`core/service_bot/services/release_lifecycle_service.py` —
+Executed before the public surface is wired, in this order:
+
+1. **`release/facts.py`** — `ReleaseFacts` (`StageBindings`, `BuildArtifact`,
+   `FailureInfo`, `engine_overrides_by_stage`, opaque `passthrough`), with
+   `from_ext`/`to_ext` round-tripping the existing JSON keys byte-compatibly.
+   Contract: a round-trip property test over real-shaped ext blobs, including
+   legacy variants.
+2. **`release/store.py`** — `ReleaseStore` absorbs `PublishExtState` (same
+   CAS/status+ext persistence semantics, verbatim), exposing
+   `load`/`mutate`/`advance`/`advance_with_facts` in `ReleaseFacts` terms.
+   `PublishExtState` becomes a thin delegating shell for the one release it
+   takes the mixins to migrate off it, then dies with them (Phase 2).
+3. **`release/machine.py`** — `RELEASE_MACHINE` as declared in design §3.3.
+   `process()` is refactored to consult it for the USER transition instead of
+   its two hand-written branches; the failure writes take each transition's
+   `on_failure` target from the machine instead of hand-writing
+   `ext["source_status"]` at eight sites. Same transitions, same messages,
+   same wire payloads — the internal suite passing **unmodified** is the proof.
+4. **`release/operations.py`** — ledger-backed workflow-id reads
+   (`latest_release_workflow` / `latest_restart_workflow` /
+   `latest_scale_workflow` / `is_restart_in_flight`) with read-fallback to the
+   legacy ext keys for pre-#197 rows. The ext id-stash **writes stop**:
+   `ext.publish.{stage}` (`publish_ext_mixin`, `release_stage`),
+   `ext.restart.{stage}` + `restart.restarting` (`restart_mixin`),
+   `ext.scale.publish_id` (`scale_mixin`); their readers
+   (`progress_sync_mixin`, `retry_ops_mixin`, `rollback_ops_mixin`,
+   `upgrade_resolution_mixin`, `restart_mixin:525`, `baas_service:3425`,
+   `arca_image_pin:134`, `bot_publish_service:641` — the binding reads among
+   these move to `StageBindings`, the id reads to `operations.py`) are
+   converted call-site by call-site. Rolling-deploy safety per design §4.
+5. **Architecture test** — outside `release/facts.py` and `release/store.py`,
+   no module under `core/service_bot` touches `ext[`/`ext.get(`/
+   `ext.setdefault(` on a publish record. (Grandfathered exceptions, each
+   named in the test with its Phase-2/3 ticket: the approval / rollback /
+   draft-restore / eval mixins' `passthrough` keys.)
+
+What Phase 1 does **not** touch, per design §4: the durable task handlers'
+semantics, the #197 ledger writes, the internal HTTP surface, the DB schema,
+and the hitchhiking domain states (approval, rollback, eval, data-init).
+
+---
+
+## 5. New core service
+
+`core/service_bot/release/lifecycle.py` —
 `ReleaseLifecycleService`, `@inject`, singleton.
 
 Collaborators: `BotService`, `CollaboratorServiceProtocol` (core),
-`BotPublishService`, `PublishFlowService`, `PublishOperationRepository`, plus
-`get_current_env()` for the env scope.
+`BotPublishRepositoryProtocol`, `ReleaseStore`, `TaskQueueService` (for the
+enqueue on a won advance — the same `enqueue_verify_flow` /
+`enqueue_online_release` helpers the flow uses), plus `get_current_env()` for
+the env scope.
 
-Returns transport-agnostic values only: `BotPublishRecord`,
-`list[PublishOperationRecord]`, and a small frozen
-`ReleaseAdvance(record, started: bool)` for the two writes — `started` is what
-the adapter turns into 202 vs 200. No HTTP types, no dicts shaped like
-responses.
+The two writes drive the USER transitions **directly** through
+`ReleaseStore.advance` — the same CAS `process()` uses — and enqueue the same
+durable task on a win, consulting `RELEASE_MACHINE` so this service and
+`process()` cannot disagree about what the two transitions are. A lost CAS is
+a boolean, not a parsed message (this replaces the message-comparison
+mechanism from an earlier draft of this plan; see design §3.5).
+
+Returns transport-agnostic values only: `BotPublishRecord` and
+`(total, list[BotPublishRecord])`. No HTTP types, no dicts shaped like
+responses. The writes return the **re-read record** after the advance, so the
+payload reports the state the advance actually produced.
 
 ### `_resolve_target(bot_id, owner_id, caller_id, *, min_level) -> BotFacts`
 
@@ -186,53 +242,45 @@ Synchronous and not cheap (row read + template fetch + possible collaborator
 query), so the service exposes an `async` façade that runs it via
 `asyncio.to_thread`, exactly as `resolve_bot_off_loop` does.
 
-### `start_verify_release(...) -> ReleaseAdvance`
+### `start_verify_release(...) -> BotPublishRecord`
 
 After `_resolve_target(min_level=ADMIN)`:
 
 1. Newest record for the bot: `publish_repo.list_by_source_bot(bot_pk, env)`
-   returns newest-first; take `records[0]` (`None` when the bot has never
-   published). Keyed on `bot_pk`, never `bot_id` (spec Decision 8).
-2. Choose the draft to advance:
+   returns newest-first; take `records[0]`. Keyed on `bot_pk`, never `bot_id`
+   (spec Decision 7).
+2. **Precondition:** the newest record exists and `status == DRAFT`. Anything
+   else — no record at all (a data anomaly for a service bot, since creation
+   mints the draft), `BUILDING`…`ONLINE_PUB` in flight, `SUCCESS`, `UPGRADED`,
+   `RELEASED`, `FAILED` — raises `ReleaseNotStartableError`. **No side effect on
+   this path**: nothing is minted, nothing is advanced.
+3. Advance via the machine: look up the USER transition from `DRAFT` in
+   `RELEASE_MACHINE` and drive it with `ReleaseStore.advance(draft.id,
+   BUILDING, DRAFT)`. `False` means a concurrent submit won between the
+   precondition read and the CAS — raise `ReleaseNotStartableError`, the same
+   answer as step 2, per spec Decision 2.
+4. On a win, enqueue the transition's durable task (`enqueue_verify_flow`,
+   the same helper `process()` uses) — CAS-then-enqueue in the same order as
+   `process()`, so the double-submit guarantee is identical.
+5. Re-read and return the record.
 
-   | Newest record | Action |
-   |---|---|
-   | *none* | `create_first_publish_for_bot(...)` → DRAFT v1 |
-   | `DRAFT` | use it |
-   | `SUCCESS` | `upgrade_publish(record.id, owner_id)` → DRAFT vN+1 (idempotent via `last_pub_id`) |
-   | `BUILDING`/`BUILT`/`VALIDATE_PUB`/`VALIDATING`/`ONLINE_PUB` | in flight → `ReleaseAdvance(record, started=False)`, **no side effect** |
-   | `FAILED`/`UPGRADED`/`RELEASED` | `ReleaseNotStartableError` → 409 |
-
-   `create_first_publish_for_bot` needs a name; it is derived from the bot's own
-   name (`bot["bot_name"]`, falling back to `bot_id`). The public surface takes
-   no release name: the internal one exists because the workbench asks a human
-   for it, and inventing a required public field to satisfy an internal column
-   would be a contract we then have to keep. `permission_owner` keeps its
-   `"owner"` default. `description` is optional in the request body.
-3. `await flow_service.process(publish_id=draft.id, operator=caller_id)`.
-4. Re-read the record and compare: `started = result.status == BUILDING and
-   the record was at DRAFT before the call`. Concretely — `process` returns
-   `PublishFlowResult`; `started` is `result.action == "process" and
-   result.status == PublishStatus.BUILDING`. The CAS loser gets the describe
-   path, whose status is whatever the winner advanced to, so `started=False`
-   falls out without a second query in the normal case.
-5. Return `ReleaseAdvance(record=<re-read record>, started=...)`.
-
-The record is re-read after `process` so the payload reports the state the
-advance actually produced, not the pre-call snapshot.
-
-### `promote_release(...) -> ReleaseAdvance`
+### `promote_release(...) -> BotPublishRecord`
 
 After `_resolve_target(min_level=ADMIN)` and `_load_release(bot_facts, version)`:
 
-| Record state | Result |
-|---|---|
-| `VALIDATING` | `process` → `ReleaseAdvance(started=True)` on `ONLINE_PUB`, `started=False` if the CAS was lost |
-| `ONLINE_PUB` / `SUCCESS` | `ReleaseAdvance(started=False)` — already promoted |
-| anything else | `ReleaseNotPromotableError` → 409 |
+1. **Precondition:** `status == VALIDATING`. Anything else — including
+   `ONLINE_PUB` (already promoted) and `SUCCESS` (already online) — raises
+   `ReleaseNotPromotableError`. No side effect on this path.
+2. Advance via the machine: `ReleaseStore.advance(record.id, ONLINE_PUB,
+   VALIDATING)`; `False` (the CAS loser) ⇒ `ReleaseNotPromotableError`, the
+   same answer as step 1.
+3. On a win, enqueue `enqueue_online_release` — same order as `process()`.
+4. Re-read and return the record.
 
-`process` is called **only** from `VALIDATING`, so promotion can never fall
-through into the `DRAFT` branch of the flow's own dispatch.
+Both writes and `process()` drive **the same two machine transitions through
+the same CAS**, so the surfaces cannot drift, and a stale observation advances
+nothing even under a race. A machine-agreement test pins that the transitions
+this service drives are exactly the machine's USER-driven set.
 
 ### `_load_release(bot_facts, version) -> BotPublishRecord`
 
@@ -240,7 +288,7 @@ through into the `DRAFT` branch of the flow's own dispatch.
 bot_facts.owner_id, version, env)`, then **assert
 `record.source_bot_pk == bot_facts.bot_pk`** and raise `PublishNotFoundError`
 otherwise. The repository lookup is already owner-scoped; the primary-key assert
-is what closes the `bot_id`-is-not-unique hole for good (spec Decision 8).
+is what closes the `bot_id`-is-not-unique hole for good (spec Decision 7).
 
 ### `list_releases(...) -> tuple[int, list[BotPublishRecord]]`
 
@@ -251,16 +299,13 @@ how many times a human published; adding pagination to the repository protocol
 would change a contract three other callers share, for no benefit here. This is
 stated in the service docstring so the choice reads as deliberate.
 
-### `list_release_operations(...) -> tuple[int, list[PublishOperationRecord]]`
+### `get_release(...) -> BotPublishRecord`
 
-`publish_operation_repo.list_by_publish_id(record.id)` after `_load_release`,
-sorted ascending by `(gmt_create, id)`, sliced the same way. Because the
-`publish_id` comes from a record already proven to belong to the addressed bot,
-no ledger row from another bot can be reached.
+`_resolve_target(min_level=MEMBER)` then `_load_release`.
 
 ### Errors
 
-New, in `core/service_bot/services/release_errors.py` (dependency-free, so the
+New, in `core/service_bot/release/errors.py` (dependency-free, so the
 adapter can map them without importing the service):
 
 - `ReleaseNotStartableError`
@@ -272,7 +317,7 @@ still lands on a sane base — and both are therefore mapped **before** it in
 
 ---
 
-## 5. Service API protocol + DI
+## 6. Service API protocol + DI
 
 - `api/release_lifecycle_service.py` — `ReleaseLifecycleServiceProtocol`,
   `@runtime_checkable`, with **real signatures** (not `*args/**kwargs`): the
@@ -287,7 +332,7 @@ still lands on a sane base — and both are therefore mapped **before** it in
 
 ---
 
-## 6. Adapter
+## 7. Adapter
 
 New package `adapters/http/openapi_v1/publish/` — `__init__.py`, `router.py`,
 `schemas.py`.
@@ -298,13 +343,10 @@ New package `adapters/http/openapi_v1/publish/` — `__init__.py`, `router.py`,
   (imported from `openapi_v1/engine_runtime/params.py` — one spelling of
   `owner_id` on the surface, per that module's own instruction), `PageParamsDep`,
   `request: Request`, `@envelope_errors`.
-- Responses via `responses.py` builders: `envelope`, `page`, `accepted`. The
-  202-vs-200 split is `accepted(...)` vs `envelope(...)`, chosen from
-  `ReleaseAdvance.started`; the route declares `status_code=202` and the handler
-  returns a `JSONResponse`-free model, so the 200 branch sets
-  `response.status_code = 200` on the injected `Response`. (`bots/router.py`'s
-  create handler already does exactly this for its `201`/`202` split — follow it,
-  don't invent a second mechanism.)
+- Responses via `responses.py` builders: `envelope`, `page`, `accepted`. Both
+  writes declare `status_code=202` and return `accepted(...)` — there is no
+  alternate success status, because a call that did not advance the release is a
+  409, not a success.
 - Mount in `openapi_v1/__init__.py`: add `publish_router` to `_SUBGROUPS`
   (before the bots router, per the mount-order rule) with
   `USER_SCOPED_ERROR_RESPONSES` — which already documents the 403 and the 409
@@ -319,10 +361,9 @@ Order matters — leaves before their base:
 | `service_bot…bot_publish_service.BotNotFoundError` | 404 | `"Not found"` |
 | `PublishNotFoundError` | 404 | `"Not found"` |
 | `BotNotServiceTypeError` | 409 | `"Operation not supported for this bot"` |
-| `ReleaseNotStartableError` | 409 | `"Release cannot be started from its current state"` |
+| `ReleaseNotStartableError` | 409 | `"Release is not in a state that can be started"` |
 | `ReleaseNotPromotableError` | 409 | `"Release is not awaiting promotion"` |
 | `PublishStatusInvalidError` | 409 | `"Release is not in a state that allows this operation"` |
-| `PublishAlreadyExistsError` | 409 | `"Release already exists"` |
 | `BotPublishServiceError` *(base — last)* | 500 | `"Publish service error"` |
 | `PublishFlowServiceError` | 500 | `"Publish service error"` |
 
@@ -332,18 +373,20 @@ which the table already maps. Both must be present, and the 404 messages must be
 byte-identical so "no such bot" and "not your bot" stay indistinguishable.
 
 Business subcodes follow the existing scheme (`xxx000` unless the category needs
-distinguishable leaves); the four 409s here are operationally distinct, so they
-get `409` + a per-error subcode in `ERROR_SUBCODES`, matching how the skills
-category already differentiates its conflicts.
+distinguishable leaves); the three publish 409s are operationally distinct, so
+they get `409` + a per-error subcode in `ERROR_SUBCODES`, matching how the
+skills category already differentiates its conflicts.
 
 ---
 
-## 7. Documentation
+## 8. Documentation
 
 - `docs/openapi-v1/README.md`:
   - Track B status board: new `publish` row, `✅ DONE — PR #___`.
-  - New endpoint section with the five-row table, the state map, the ledger's
-    published/withheld field sets, and the role bar.
+  - New endpoint section with the four-row table, the state map, the
+    precondition rule for the two writes, the role bar, and the **known
+    limitation** (re-publishing a live bot still needs the internal upgrade to
+    mint the next draft — spec's Known limitation section).
   - Reserved names: add `publish` to the `<!-- reserved-component-names -->`
     fenced list (the routed one — a route publishes it in this change, so it
     must not go in the unrouted list).
@@ -353,29 +396,38 @@ category already differentiates its conflicts.
 
 ---
 
-## 8. Tests
+## 9. Tests
 
 New, under `tests/community/adapters/http/openapi_v1/publish/`:
 
 | File | Pins |
 |---|---|
-| `test_publish_endpoints.py` | all five handlers, success + every mapped error; the 202/200 split; `extra="forbid"` on the request body |
-| `test_release_state_machine.py` | start and promote from **each** of the ten `PublishStatus` values, plus both CAS-loser paths |
+| `test_publish_endpoints.py` | all four handlers, success + every mapped error; both writes answer 202 on success and nothing else |
+| `test_release_state_machine.py` | start and promote attempted from **each** of the ten `PublishStatus` values — exactly one succeeds per write, the other nine are the fixed 409, with **no side effect** (no record minted, no status moved); plus both CAS-loser paths refused with the same 409 |
 | `test_publish_access.py` | role matrix — owner / admin collaborator / member collaborator / stranger × writes and reads; every refusal byte-identical to a missing bot |
-| `test_publish_projection.py` | the state map is exhaustive over `PublishStatus`; the kind/op-state maps exhaustive over their enums; the withheld field sets absent from both payloads; no `ext` key reachable |
+| `test_publish_projection.py` | the state map is exhaustive over `PublishStatus`; the withheld field set absent from the payload; no `ext` key reachable; the `failed` message carries no internal text |
 | `test_publish_tenant_isolation.py` | a foreign tenant's bot and a foreign bot's version are both masked 404s, against the real Track A guard |
 
-Under `tests/community/core/service_bot/services/`:
+New, under `tests/community/core/service_bot/release/` (the Phase-1 core):
 
 | File | Pins |
 |---|---|
-| `test_release_lifecycle_service.py` | the draft-resolution table, `_load_release`'s `source_bot_pk` assert, ledger scoping, the read/write bar constants |
+| `test_release_facts.py` | `from_ext`/`to_ext` round-trip property over real-shaped and legacy ext blobs — every key the model does not own preserved verbatim; passthrough keys untouched |
+| `test_release_store.py` | the CAS/status+ext persistence semantics carried over from `PublishExtState`, in `ReleaseFacts` terms |
+| `test_release_machine.py` | machine agreement — exactly two USER transitions; every non-terminal status covered; `on_failure` targets equal today's `source_status` writes; `process()` and `ReleaseLifecycleService` drive the same USER set |
+| `test_release_operations.py` | ledger-first workflow-id reads with ext fallback for pre-#197 rows; the restart-vs-release classification needs no ext comparison |
+| `test_lifecycle_service.py` | both preconditions row by row; the CAS-loser boolean path; `_load_release`'s `source_bot_pk` assert; the read/write bar constants |
+
+New, under `tests/community/architecture/`:
+
+- the no-raw-ext gate from plan §4 step 5, with its named grandfathered
+  exceptions.
 
 Amended:
 
 - `test_path_convention.py` — reserved-name lists (doc ↔ routes) pick up `publish`
   automatically; the run must confirm it.
-- `test_explicit_user_id.py` — the counts move from 56/4 to 61/4; update the
+- `test_explicit_user_id.py` — the counts move from 56/4 to 60/4; update the
   expectation.
 - `test_openapi_error_schema.py` — the new group must document exactly the
   `USER_SCOPED_ERROR_RESPONSES` set.
@@ -385,41 +437,58 @@ Amended:
   ← the new protocol). This has failed CI twice before on exactly this;
   declare first, then run.
 
-Unmodified and green, as the proof that nothing internal moved:
+Unmodified and green, as the proof the Phase-1 refactor preserved behaviour:
 `tests/community/adapters/http/service_bot/test_router_publish_coverage.py`,
 `tests/community/core/service_bot/services/test_publish_flow_service.py`,
+`test_publish_crash_windows.py`, `test_publish_tasks.py`,
 `tests/community/e2e/publish_boundary/`, and the engine-runtime operator/stage
-suites.
+suites. One honest caveat: any existing test that *asserts the ext id stashes
+are written* (`ext.publish`/`ext.restart`/`ext.scale`) is asserting the exact
+duplication this change removes — such assertions are updated to assert the
+ledger row instead, and each such edit is called out individually in the PR so
+it reads as a contract change made on purpose, not a test bent to pass.
 
 ---
 
-## 9. Rejected alternatives
+## 10. Rejected alternatives
 
 Recorded so they are not reopened:
 
 | Rejected | Why |
 |---|---|
-| Publish `POST …/releases` as *advance only*, requiring the record to be minted elsewhere | Leaves the public surface unable to start a first release at all; the draft record is storage, not a user-facing artifact (spec Decision 1) |
-| A second public write that mints the release record | Two calls for one intent, and the second is pure bookkeeping the caller cannot reason about |
-| Address a release by its record id | Global auto-increment; leaks cross-tenant volume, and its meaning is internal (spec Decision 9) |
+| Publish the operation ledger (a fifth, read-only endpoint) | The ledger is the pipeline's internal step structure — provider workflow ids, attempt bookkeeping, crash-recovery state. Publishing even a projection turns a crash-safety mechanism into a contract that then cannot be restructured (spec Decision 4) |
+| Start-release resolves-or-creates the draft (mint on demand) | Folds `create_first_publish_for_bot` / `upgrade_publish` — each with its own preconditions — into one public call whose effect depends on state the caller cannot see. The precondition form keeps the operation's meaning fixed; the cost is the recorded known limitation (spec Decision 1) |
+| Return the release's state with a 200 when a write's precondition fails | Four flavours of "no" (too early, too late, repeat, race-loser) would advertise timing detail a caller cannot act on differently; one fixed 409 plus the read endpoint answers all four (spec Decision 2) |
+| Detect the CAS winner by parsing `process()`'s result (message comparison, or an `advanced: bool` field) | The message form is a string tripwire; the field form changes the internal wire payload (`ApiResponse.data` serializes the whole result). Driving the machine transition directly through `ReleaseStore.advance` makes the outcome a boolean at the source (design §3.5) |
+| Wrap the current pipeline as-is and defer the core evolution entirely | The review asked for the evolution, and the public surface would otherwise be a fourth consumer of the untyped ext maze — every new consumer makes the eventual cleanup strictly harder (design §1) |
+| Big-bang rewrite of the whole pipeline in this change | ~8k lines carrying production crash-safety semantics (#197) and three fix-specs; the strangler phasing in design §4 keeps every step provable against the existing suites |
+| Address a release by its record id | Global auto-increment; leaks cross-tenant volume, and its meaning is internal (spec Decision 8) |
 | Collapse the ten statuses into three or four coarse phases | The whole point of the read side is following progress; `built` vs `publishing_verify` is exactly the distinction a stalled publish turns on |
-| Return 409 to the loser of a double-submit | Makes correct retry logic read as failure on an API that is asynchronous by construction (spec Decision 3) |
 | Publish `ext.error_message` on a failed release | Raw internal text — exception reprs, provider ids, internal-language strings; the surface's fixed-message rule exists for this |
-| Publish the ledger's `params` / `result` / `baas_publish_id` | Unversioned internal payloads and provider-side identifiers would become a contract the moment they shipped |
-| Hide ledger kinds this surface cannot trigger (rollback, restore, scale) | Would make `attempt` numbering and the timeline lie about the bot's own history |
-| One role bar for the whole category | Either hides progress from members who can already watch the runtime, or lets them ship (spec Decision 2) |
-| A `stage` query parameter, matching the engine-runtime groups | A release *is* the stage transition; `stage` is data inside a ledger entry, not an address |
-| Add `avernet_tenant` to the publish tables | Not this change's job; isolation already derives from the tenant-guarded bot resolve plus primary-key keying, the same argument PR #904 made (spec Decision 8) |
+| One role bar for the whole category | Either hides progress from members who can already watch the runtime, or lets them ship (spec Decision 3) |
+| A `stage` query parameter, matching the engine-runtime groups | A release *is* the stage transition; there is nothing left for a `stage` to address |
+| Add `avernet_tenant` to the publish tables | Not this change's job; isolation already derives from the tenant-guarded bot resolve plus primary-key keying, the same argument PR #904 made (spec Decision 7) |
 
 ---
 
-## 10. Risk and rollback
+## 11. Risk and rollback
 
 - **No schema change, no DDL, no migration.** Rollback is reverting the code.
-- **The internal surface is untouched**, so a revert cannot strand a release: any
-  record this surface created is an ordinary draft the internal surface already
-  knows how to drive.
-- **The one shared-code edit is the role-bar extraction (§3).** It is
+  The stored JSON keys are round-trip compatible, so rows written by the new
+  code are readable by the old — except the stopped id-stash writes, whose
+  rolling-deploy story is design §4: the ledger has carried those ids
+  authoritatively since #197, and both old and new readers consult it.
+- **The internal HTTP surface's contract is untouched.** The internal-file
+  edits are the Phase-1 refactor (§4) — `process()` consulting the machine,
+  the ext accessors migrating to `ReleaseStore`, the id-stash writes stopping
+  — all behaviour-preserving by the suites named in §9. A revert cannot strand
+  a release: every record this surface advances is an ordinary record the
+  internal surface already drives.
+- **The largest real risk is the Phase-1 read migration** (the ~11 call sites
+  in §4 step 4). It is sequenced first, lands with the round-trip and
+  ledger-fallback tests before the public surface is wired on top, and each
+  call-site conversion is a small, individually-revertable commit.
+- **The one shared-code move is the role-bar extraction (§3).** It is
   behaviour-preserving and its proof is the engine-runtime suites staying
   unmodified and green. If review prefers not to move it, the fallback is a
   `min_level` parameter on `require_bot_operator` with the current bar as the

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/plan.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/plan.md
@@ -1,0 +1,430 @@
+# Plan — Public API: Publish Lifecycle for Service Bots
+
+Implements `spec.md` in this directory. Issue
+[#909](https://github.com/inclusionAI/Avernet/issues/909).
+
+All paths are relative to `src/backend/src/agentclaw/community/` unless stated
+otherwise.
+
+---
+
+## 1. Shape of the change
+
+Five public operations in a new `publish` category, backed by one new core
+service that composes services that already exist. Nothing in the publish
+pipeline changes: `PublishFlowService.process` is called exactly as the internal
+router calls it, and the internal router is not touched.
+
+```
+adapters/http/openapi_v1/publish/router.py      ← thin: params, envelope, projection
+        │  (UserIdDep, OwnerIdDep, PageParamsDep)
+        ▼
+core/service_bot/services/release_lifecycle_service.py   ← ALL policy lives here
+        │
+        ├── BotService.get_bot ............... owner-scoped, tenant-guarded resolve
+        ├── core/bot_collaborator/access.py .. role bar (extracted, see §3)
+        ├── BotPublishService ................ create-first / upgrade / read records
+        ├── PublishFlowService.process ....... the two CAS advances (unchanged)
+        └── PublishOperationRepository ....... the ledger read
+```
+
+The router owns no domain decision. That is the architecture rule (`core` stays
+transport-agnostic; adapters translate protocol details) and it is also what
+makes the state-machine behaviour testable without a TestClient.
+
+### Endpoints
+
+Component literal `publish`; addressing rule `/openapi/v1/bots/<component>/{bot_id}/…`.
+
+| Method | Path | Purpose | Success |
+|---|---|---|---|
+| POST | `/openapi/v1/bots/publish/{bot_id}/releases` | Start a verify release | `202 Envelope[Release]` started · `200 Envelope[Release]` already in flight |
+| GET | `/openapi/v1/bots/publish/{bot_id}/releases` | List releases, newest first | `Envelope[Page[Release]]` |
+| GET | `/openapi/v1/bots/publish/{bot_id}/releases/{version}` | One release's state | `Envelope[Release]` |
+| POST | `/openapi/v1/bots/publish/{bot_id}/releases/{version}/promote` | Promote verify → online | `202 Envelope[Release]` promoted · `200 Envelope[Release]` already promoted |
+| GET | `/openapi/v1/bots/publish/{bot_id}/releases/{version}/operations` | The release's operation ledger | `Envelope[Page[ReleaseOperation]]` |
+
+Every operation takes the required `user_id` query parameter and the optional
+`owner_id` query parameter. **No `stage` parameter**: a release *is* the stage
+transition; `stage` appears inside a ledger entry as data, never as an address.
+
+`{version}` is `ac_bot_publish.version` — per-bot, monotonic from 1, assigned by
+`BotPublishService._get_next_version`. Declared `int` with `ge=1`, so a
+non-numeric segment is a 422 before any lookup runs.
+
+---
+
+## 2. Published contracts
+
+### `ReleaseState` — the published projection of `PublishStatus`
+
+A closed enum in the adapter's `schemas.py`, mapped 1:1 so nothing is collapsed
+and no internal spelling leaks:
+
+| `PublishStatus` | `ReleaseState` | Meaning published |
+|---|---|---|
+| `draft` | `draft` | Created, not started |
+| `building` | `building` | Build running |
+| `built` | `built` | Built, verify release starting |
+| `validate_pub` | `publishing_verify` | Publishing to the verify runtime |
+| `validating` | `verifying` | Verify runtime live, awaiting promotion |
+| `online_pub` | `publishing_online` | Online publish running |
+| `success` | `online` | Live online |
+| `upgraded` | `superseded` | A newer version took over |
+| `released` | `retired` | Taken offline |
+| `failed` | `failed` | Failed |
+
+The mapping table is exhaustive over `PublishStatus` and asserted so by a test —
+a status added later fails CI here rather than escaping as an unmapped 500.
+
+The accompanying `message` is the fixed English string
+`PublishFlowService` already publishes for that status (`_DESCRIBE_STATUS_MESSAGES`
+/ `_SYNC_ONLY_STATUS_MESSAGES`), obtained by calling `describe_publish` rather
+than by copying the table. For `failed` the message is the fixed
+`"Publish failed"` — **not** `describe_publish`'s
+`f"Publish failed: {error_message}"`, which interpolates internal text
+(spec Decision 6). The projection strips it; it is not read and then discarded.
+
+### `Release` payload
+
+Published: `version`, `state`, `message`, `bot_id`, `name`, `description`,
+`created_at`, `updated_at` (ISO-8601).
+
+Withheld, deliberately: `id` (internal pk), `source_bot_pk`, `publish_bot_id`,
+`owner_id` (the caller supplied it), `last_pub_id`, `env`, `permission_owner`,
+and the whole of `ext` — which carries `binding.{verify,online}` binding ids,
+`migration_path`, `config_artifact`, `error_message`, retry flags and
+`source_status`. `ext` is never read by the projection, so a key added to it
+later cannot leak by default.
+
+### `ReleaseOperation` payload
+
+Published: `kind`, `stage`, `attempt`, `state`, `operator`, `created_at`,
+`updated_at`.
+
+`kind` and `state` are published enums mirroring `PublishOperationKind` and
+`PublishOperationState` value-for-value (both are already stable, English,
+caller-meaningful vocabularies); both mappings are asserted exhaustive, so a new
+kind fails CI here as it already does in the deploy-partition test. `stage`
+publishes the raw `PublishStage` value (`draft`/`verify`/`online`/`eval`) or the
+empty string, unchanged.
+
+Withheld: `id`, `publish_id`, `bot_uuid`, `baas_publish_id`, `params`, `result`,
+`last_error`, `request_id`, `env` (spec Decision 7).
+
+Ordering: `gmt_create` ascending, then `id` ascending — a timeline reads
+forward, and ties inside one second stay stable across pages.
+
+---
+
+## 3. Extraction: the role bar
+
+`core/engine_runtime/gate.py` already holds the level-parameterised half of the
+role check (`resolve_operator_level`) welded to a fixed `OPERATOR_LEVEL` bar
+(`require_bot_operator`). Publishing needs the same fail-closed lookup at a
+*different* bar, and a `publishing` module importing `engine_runtime` for it
+would be the wrong dependency direction.
+
+**Move both into the domain that owns role policy** —
+`core/bot_collaborator/access.py`, new file:
+
+```python
+def resolve_permission_level(collaborators, *, bot_pk, caller_id, owner_id) -> PermissionLevel
+def require_bot_role(collaborators, *, bot_pk, bot_id, caller_id, owner_id, min_level) -> None
+```
+
+`require_bot_role` raises `BotNotFoundError` — the masked 404 — and logs both
+ids at the refusal, byte-for-byte as `require_bot_operator` does today.
+
+`core/engine_runtime/gate.py` keeps `OPERATOR_LEVEL`, `require_bot_operator` and
+`resolve_operator_level` as thin, re-exported delegations to the new module, so
+every existing import site and every existing test is untouched. This is a
+behaviour-preserving extraction (recipe step 6): proved by leaving
+`tests/…/openapi_v1/engine_runtime/test_operator_access.py` and
+`tests/community/core/engine_runtime/` unmodified and green.
+
+Bars used by this category:
+
+- **Writes** (start, promote): `PermissionLevel.ADMIN` — `CollaboratorRole.ADMIN`
+  is defined as *edit + publish* (spec Decision 2).
+- **Reads** (get, list, operations): `PermissionLevel.MEMBER` — the same
+  `OPERATOR_LEVEL` the access expansion applies to the runtimes these releases
+  produce.
+
+Both constants are named once in the new core service
+(`PUBLISH_LEVEL` / `PUBLISH_READ_LEVEL`), not spelled at call sites.
+
+---
+
+## 4. New core service
+
+`core/service_bot/services/release_lifecycle_service.py` —
+`ReleaseLifecycleService`, `@inject`, singleton.
+
+Collaborators: `BotService`, `CollaboratorServiceProtocol` (core),
+`BotPublishService`, `PublishFlowService`, `PublishOperationRepository`, plus
+`get_current_env()` for the env scope.
+
+Returns transport-agnostic values only: `BotPublishRecord`,
+`list[PublishOperationRecord]`, and a small frozen
+`ReleaseAdvance(record, started: bool)` for the two writes — `started` is what
+the adapter turns into 202 vs 200. No HTTP types, no dicts shaped like
+responses.
+
+### `_resolve_target(bot_id, owner_id, caller_id, *, min_level) -> BotFacts`
+
+1. `BotService.get_bot(bot_id, owner_id)` — owner-scoped and tenant-guarded;
+   a bot outside the tenant or under another owner raises `BotNotFoundError`.
+2. `require_bot_role(..., bot_pk=bot["id"], min_level=min_level)`.
+3. Bot type must be `service`, else `BotNotServiceTypeError`. **After** the role
+   check, so a stranger does not learn the type.
+4. Returns the existing `BotFacts` value object (`bot_id`, `bot_type`,
+   `active_engine`, `owner_id`, `bot_pk`) — already the narrow, no-device-topology
+   shape this surface needs, reused rather than re-invented.
+
+Synchronous and not cheap (row read + template fetch + possible collaborator
+query), so the service exposes an `async` façade that runs it via
+`asyncio.to_thread`, exactly as `resolve_bot_off_loop` does.
+
+### `start_verify_release(...) -> ReleaseAdvance`
+
+After `_resolve_target(min_level=ADMIN)`:
+
+1. Newest record for the bot: `publish_repo.list_by_source_bot(bot_pk, env)`
+   returns newest-first; take `records[0]` (`None` when the bot has never
+   published). Keyed on `bot_pk`, never `bot_id` (spec Decision 8).
+2. Choose the draft to advance:
+
+   | Newest record | Action |
+   |---|---|
+   | *none* | `create_first_publish_for_bot(...)` → DRAFT v1 |
+   | `DRAFT` | use it |
+   | `SUCCESS` | `upgrade_publish(record.id, owner_id)` → DRAFT vN+1 (idempotent via `last_pub_id`) |
+   | `BUILDING`/`BUILT`/`VALIDATE_PUB`/`VALIDATING`/`ONLINE_PUB` | in flight → `ReleaseAdvance(record, started=False)`, **no side effect** |
+   | `FAILED`/`UPGRADED`/`RELEASED` | `ReleaseNotStartableError` → 409 |
+
+   `create_first_publish_for_bot` needs a name; it is derived from the bot's own
+   name (`bot["bot_name"]`, falling back to `bot_id`). The public surface takes
+   no release name: the internal one exists because the workbench asks a human
+   for it, and inventing a required public field to satisfy an internal column
+   would be a contract we then have to keep. `permission_owner` keeps its
+   `"owner"` default. `description` is optional in the request body.
+3. `await flow_service.process(publish_id=draft.id, operator=caller_id)`.
+4. Re-read the record and compare: `started = result.status == BUILDING and
+   the record was at DRAFT before the call`. Concretely — `process` returns
+   `PublishFlowResult`; `started` is `result.action == "process" and
+   result.status == PublishStatus.BUILDING`. The CAS loser gets the describe
+   path, whose status is whatever the winner advanced to, so `started=False`
+   falls out without a second query in the normal case.
+5. Return `ReleaseAdvance(record=<re-read record>, started=...)`.
+
+The record is re-read after `process` so the payload reports the state the
+advance actually produced, not the pre-call snapshot.
+
+### `promote_release(...) -> ReleaseAdvance`
+
+After `_resolve_target(min_level=ADMIN)` and `_load_release(bot_facts, version)`:
+
+| Record state | Result |
+|---|---|
+| `VALIDATING` | `process` → `ReleaseAdvance(started=True)` on `ONLINE_PUB`, `started=False` if the CAS was lost |
+| `ONLINE_PUB` / `SUCCESS` | `ReleaseAdvance(started=False)` — already promoted |
+| anything else | `ReleaseNotPromotableError` → 409 |
+
+`process` is called **only** from `VALIDATING`, so promotion can never fall
+through into the `DRAFT` branch of the flow's own dispatch.
+
+### `_load_release(bot_facts, version) -> BotPublishRecord`
+
+`publish_repo.get_by_publish_bot_id_and_version(bot_facts.bot_id,
+bot_facts.owner_id, version, env)`, then **assert
+`record.source_bot_pk == bot_facts.bot_pk`** and raise `PublishNotFoundError`
+otherwise. The repository lookup is already owner-scoped; the primary-key assert
+is what closes the `bot_id`-is-not-unique hole for good (spec Decision 8).
+
+### `list_releases(...) -> tuple[int, list[BotPublishRecord]]`
+
+`list_by_source_bot(bot_pk, env)` (newest-first), sliced in the service for the
+page window, with the full count as `total`. `list_by_source_bot` has no
+limit/offset parameters and the per-bot release count is small and bounded by
+how many times a human published; adding pagination to the repository protocol
+would change a contract three other callers share, for no benefit here. This is
+stated in the service docstring so the choice reads as deliberate.
+
+### `list_release_operations(...) -> tuple[int, list[PublishOperationRecord]]`
+
+`publish_operation_repo.list_by_publish_id(record.id)` after `_load_release`,
+sorted ascending by `(gmt_create, id)`, sliced the same way. Because the
+`publish_id` comes from a record already proven to belong to the addressed bot,
+no ledger row from another bot can be reached.
+
+### Errors
+
+New, in `core/service_bot/services/release_errors.py` (dependency-free, so the
+adapter can map them without importing the service):
+
+- `ReleaseNotStartableError`
+- `ReleaseNotPromotableError`
+
+Both subclass the existing `BotPublishServiceError` so an unmapped-anywhere path
+still lands on a sane base — and both are therefore mapped **before** it in
+`ENVELOPE_ERRORS` (base class last; the surface's standing order rule).
+
+---
+
+## 5. Service API protocol + DI
+
+- `api/release_lifecycle_service.py` — `ReleaseLifecycleServiceProtocol`,
+  `@runtime_checkable`, with **real signatures** (not `*args/**kwargs`): the
+  architecture gate `tests/community/architecture/test_service_api_conformance.py`
+  checks conformance for registered pairs, and a new protocol should be written
+  to the standard the gate exists to enforce.
+- Register the `(ReleaseLifecycleServiceProtocol, ReleaseLifecycleService)` pair
+  in that gate's registry.
+- Bind in `di/modules/service_bot_module.py`, beside
+  `_publish_flow_service_protocol` — same module, same publish collaborators,
+  same database-mode-keyed repository bindings.
+
+---
+
+## 6. Adapter
+
+New package `adapters/http/openapi_v1/publish/` — `__init__.py`, `router.py`,
+`schemas.py`.
+
+- `APIRouter(prefix="/bots/publish", tags=["publish"])`, mirroring the
+  engine-runtime groups' literal-first prefix.
+- Handlers: `require_principal` (`PrincipalDep`), `UserIdDep`, `OwnerIdDep`
+  (imported from `openapi_v1/engine_runtime/params.py` — one spelling of
+  `owner_id` on the surface, per that module's own instruction), `PageParamsDep`,
+  `request: Request`, `@envelope_errors`.
+- Responses via `responses.py` builders: `envelope`, `page`, `accepted`. The
+  202-vs-200 split is `accepted(...)` vs `envelope(...)`, chosen from
+  `ReleaseAdvance.started`; the route declares `status_code=202` and the handler
+  returns a `JSONResponse`-free model, so the 200 branch sets
+  `response.status_code = 200` on the injected `Response`. (`bots/router.py`'s
+  create handler already does exactly this for its `201`/`202` split — follow it,
+  don't invent a second mechanism.)
+- Mount in `openapi_v1/__init__.py`: add `publish_router` to `_SUBGROUPS`
+  (before the bots router, per the mount-order rule) with
+  `USER_SCOPED_ERROR_RESPONSES` — which already documents the 403 and the 409
+  this category needs, and none of the 501/504 it cannot return.
+
+### `ENVELOPE_ERRORS` additions (`openapi_v1/responses.py`)
+
+Order matters — leaves before their base:
+
+| Exception | Status | Fixed message |
+|---|---|---|
+| `service_bot…bot_publish_service.BotNotFoundError` | 404 | `"Not found"` |
+| `PublishNotFoundError` | 404 | `"Not found"` |
+| `BotNotServiceTypeError` | 409 | `"Operation not supported for this bot"` |
+| `ReleaseNotStartableError` | 409 | `"Release cannot be started from its current state"` |
+| `ReleaseNotPromotableError` | 409 | `"Release is not awaiting promotion"` |
+| `PublishStatusInvalidError` | 409 | `"Release is not in a state that allows this operation"` |
+| `PublishAlreadyExistsError` | 409 | `"Release already exists"` |
+| `BotPublishServiceError` *(base — last)* | 500 | `"Publish service error"` |
+| `PublishFlowServiceError` | 500 | `"Publish service error"` |
+
+**Trap to avoid:** `service_bot.services.bot_publish_service.BotNotFoundError` is
+a *different class* from `bot_management.services.bot_service.BotNotFoundError`,
+which the table already maps. Both must be present, and the 404 messages must be
+byte-identical so "no such bot" and "not your bot" stay indistinguishable.
+
+Business subcodes follow the existing scheme (`xxx000` unless the category needs
+distinguishable leaves); the four 409s here are operationally distinct, so they
+get `409` + a per-error subcode in `ERROR_SUBCODES`, matching how the skills
+category already differentiates its conflicts.
+
+---
+
+## 7. Documentation
+
+- `docs/openapi-v1/README.md`:
+  - Track B status board: new `publish` row, `✅ DONE — PR #___`.
+  - New endpoint section with the five-row table, the state map, the ledger's
+    published/withheld field sets, and the role bar.
+  - Reserved names: add `publish` to the `<!-- reserved-component-names -->`
+    fenced list (the routed one — a route publishes it in this change, so it
+    must not go in the unrouted list).
+  - Deferred-items list: strike the publish-lifecycle entry pointing at #909.
+  - Changelog: dated line.
+- `docs/openapi-v1/README.zh-CN.md`: the same edits, mirrored.
+
+---
+
+## 8. Tests
+
+New, under `tests/community/adapters/http/openapi_v1/publish/`:
+
+| File | Pins |
+|---|---|
+| `test_publish_endpoints.py` | all five handlers, success + every mapped error; the 202/200 split; `extra="forbid"` on the request body |
+| `test_release_state_machine.py` | start and promote from **each** of the ten `PublishStatus` values, plus both CAS-loser paths |
+| `test_publish_access.py` | role matrix — owner / admin collaborator / member collaborator / stranger × writes and reads; every refusal byte-identical to a missing bot |
+| `test_publish_projection.py` | the state map is exhaustive over `PublishStatus`; the kind/op-state maps exhaustive over their enums; the withheld field sets absent from both payloads; no `ext` key reachable |
+| `test_publish_tenant_isolation.py` | a foreign tenant's bot and a foreign bot's version are both masked 404s, against the real Track A guard |
+
+Under `tests/community/core/service_bot/services/`:
+
+| File | Pins |
+|---|---|
+| `test_release_lifecycle_service.py` | the draft-resolution table, `_load_release`'s `source_bot_pk` assert, ledger scoping, the read/write bar constants |
+
+Amended:
+
+- `test_path_convention.py` — reserved-name lists (doc ↔ routes) pick up `publish`
+  automatically; the run must confirm it.
+- `test_explicit_user_id.py` — the counts move from 56/4 to 61/4; update the
+  expectation.
+- `test_openapi_error_schema.py` — the new group must document exactly the
+  `USER_SCOPED_ERROR_RESPONSES` set.
+- `tests/community/architecture/` — the new cross-module imports must be declared
+  in the touched modules' `README.md` `## Context Boundary` sections
+  (`core/service_bot` ← `core/bot_collaborator`, `adapters/http/openapi_v1`
+  ← the new protocol). This has failed CI twice before on exactly this;
+  declare first, then run.
+
+Unmodified and green, as the proof that nothing internal moved:
+`tests/community/adapters/http/service_bot/test_router_publish_coverage.py`,
+`tests/community/core/service_bot/services/test_publish_flow_service.py`,
+`tests/community/e2e/publish_boundary/`, and the engine-runtime operator/stage
+suites.
+
+---
+
+## 9. Rejected alternatives
+
+Recorded so they are not reopened:
+
+| Rejected | Why |
+|---|---|
+| Publish `POST …/releases` as *advance only*, requiring the record to be minted elsewhere | Leaves the public surface unable to start a first release at all; the draft record is storage, not a user-facing artifact (spec Decision 1) |
+| A second public write that mints the release record | Two calls for one intent, and the second is pure bookkeeping the caller cannot reason about |
+| Address a release by its record id | Global auto-increment; leaks cross-tenant volume, and its meaning is internal (spec Decision 9) |
+| Collapse the ten statuses into three or four coarse phases | The whole point of the read side is following progress; `built` vs `publishing_verify` is exactly the distinction a stalled publish turns on |
+| Return 409 to the loser of a double-submit | Makes correct retry logic read as failure on an API that is asynchronous by construction (spec Decision 3) |
+| Publish `ext.error_message` on a failed release | Raw internal text — exception reprs, provider ids, internal-language strings; the surface's fixed-message rule exists for this |
+| Publish the ledger's `params` / `result` / `baas_publish_id` | Unversioned internal payloads and provider-side identifiers would become a contract the moment they shipped |
+| Hide ledger kinds this surface cannot trigger (rollback, restore, scale) | Would make `attempt` numbering and the timeline lie about the bot's own history |
+| One role bar for the whole category | Either hides progress from members who can already watch the runtime, or lets them ship (spec Decision 2) |
+| A `stage` query parameter, matching the engine-runtime groups | A release *is* the stage transition; `stage` is data inside a ledger entry, not an address |
+| Add `avernet_tenant` to the publish tables | Not this change's job; isolation already derives from the tenant-guarded bot resolve plus primary-key keying, the same argument PR #904 made (spec Decision 8) |
+
+---
+
+## 10. Risk and rollback
+
+- **No schema change, no DDL, no migration.** Rollback is reverting the code.
+- **The internal surface is untouched**, so a revert cannot strand a release: any
+  record this surface created is an ordinary draft the internal surface already
+  knows how to drive.
+- **The one shared-code edit is the role-bar extraction (§3).** It is
+  behaviour-preserving and its proof is the engine-runtime suites staying
+  unmodified and green. If review prefers not to move it, the fallback is a
+  `min_level` parameter on `require_bot_operator` with the current bar as the
+  default — smaller, but leaves `publishing` importing `engine_runtime`.
+- **The surface still answers 401 in every environment without a gateway
+  principal signing key**, exactly like the other categories. Like them, this
+  category's end-to-end verification is blocked on the same event, and the tests
+  above exercise the handlers directly.

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/spec.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/spec.md
@@ -12,11 +12,11 @@ transition between stages is internal: starting a verify release, promoting a
 validated release online, and even asking how far a release has got all require
 the internal `/api/service-bot/publish` surface.
 
-This adds a **publish** category to the public surface: one operation that
-starts a verify release, one that promotes a validated release online, and
-three read-only operations that report a release's state, the bot's release
-history, and the release's operation ledger. The two writes are the only two
-user-driven advance points the publish flow has; everything else the internal
+This adds a **publish** category to the public surface with four operations:
+one that starts a verify release, one that promotes a validated release online,
+and two read-only operations that report a release's state and a bot's release
+history. The two writes are the only two user-driven advance points the publish
+flow has, and each advances from exactly one state; everything else the internal
 surface offers — retry, rollback, offline, restore-draft, scale, restart,
 approval — stays internal.
 
@@ -38,25 +38,23 @@ statuses: `DRAFT → BUILDING` (which starts the build and the verify release)
 and `VALIDATING → ONLINE_PUB` (which promotes the validated release online).
 Every other status is a side-effect-free status report, because the durable
 task chain owns the rest. So the public surface does not have to reproduce a
-state machine — it has to publish two buttons and a progress view. That is what
-makes this a category-sized change rather than a project.
+state machine — it publishes those two transitions, each with the single
+precondition that makes it legal, plus a way to see where a release is.
 
-**Progress is the third of those, and it is not optional.** Both writes are
+**Progress is the third thing, and it is not optional.** Both writes are
 asynchronous by design: they win a compare-and-set, enqueue a durable task, and
 return. A caller that cannot then ask "where is my release?" has been handed a
 fire-and-forget API. The publish flow already answers that question internally
-in two shapes — the record's own status, and the crash-safe operation ledger
-built by `2026-07-15-publish-service-idempotency` — and the ledger is what turns
-"still building" into something an operator can act on: which attempt is
-running, at which stage, on whose behalf.
+from the record's own status, and that answer is what tells an integrator
+whether to keep waiting, to promote, or to stop.
 
 **The states that look like errors are the ones an integrator most needs.** A
 release can be superseded by a newer version
 (`2026-07-28-online-bot-supersede-cleanup`) or taken offline; a failed release
 can be retried into a fresh attempt (`2026-07-23-online-release-retry-fix`).
-Internally these are just statuses and ledger rows. If the public surface maps
-them to errors, an integrator polling a superseded release sees a 409 and
-assumes breakage. They are outcomes, and this spec publishes them as such.
+Internally these are just statuses. If the public surface maps them to errors,
+an integrator polling a superseded release sees a 409 and assumes breakage.
+They are outcomes, and this spec publishes them as such.
 
 ## User Stories
 
@@ -68,9 +66,8 @@ assumes breakage. They are outcomes, and this spec publishes them as such.
   production is mine to hold.
 - As a partner, I want to poll a release and see how far it has got, so that an
   asynchronous publish is observable rather than a guess.
-- As an operator debugging a slow or failed publish, I want to see the release's
-  operation ledger — which operation, which stage, which attempt, what state —
-  so that "still building" becomes a diagnosis rather than a wait.
+- As a partner, I want a write that cannot legally run right now to say so
+  plainly, so that I never have to guess whether my call did something.
 - As an operator of a bot that was re-published or taken offline, I want the
   older release to report that it was superseded or retired, so that my poller
   reads an outcome instead of an error.
@@ -85,34 +82,31 @@ assumes breakage. They are outcomes, and this spec publishes them as such.
 
 ### Starting a verify release
 
-- [ ] An operator can start a verify release for a service bot in one call,
-      without first calling the internal surface to mint a release record.
-- [ ] Starting a release on a bot that has never published produces its first
-      release; starting one on a bot whose latest release is live online
-      produces the next version.
-- [ ] The call is safe to repeat. A second call while a release is already in
-      flight starts nothing, and reports the in-flight release rather than
-      failing.
-- [ ] Two concurrent calls advance the release exactly once. The loser reports
-      the release's state; it does not error, and it does not start a second
-      build.
-- [ ] A release that cannot be started from its current state — most notably a
-      failed release, whose recovery is retry and stays internal — is refused
-      with one fixed answer that says so.
+- [ ] An operator can start a verify release for a service bot whose newest
+      release is a draft, and the call advances that draft.
+- [ ] The bot's newest release being a draft is the operation's **precondition**.
+      When it is not — the release is already building, already validating,
+      already online, superseded, retired, or failed — the call is refused with
+      one fixed answer that says the release is not in a state that can be
+      started. It never starts a second release, and it never mints one.
+- [ ] Two concurrent calls advance the release exactly once. The one that loses
+      the compare-and-set is refused by the same precondition answer as any
+      other caller who asked at a moment when the release was not a draft.
 - [ ] Starting a release is refused for any bot that is not a service bot.
-- [ ] The answer distinguishes "this call started the release" from "a release
-      was already running", so a caller knows whether it is the owner of the
-      transition.
+- [ ] A successful call reports that the release has been accepted for
+      processing, and returns the release in the state the advance produced.
 
 ### Promoting a release online
 
 - [ ] An operator can promote a release that is awaiting promotion, and the
       promotion is the only thing that opens the online publish.
-- [ ] Promotion is safe to repeat and safe under concurrency, on the same terms
-      as starting a release: one advance, no error for the loser.
-- [ ] Promoting a release that is not awaiting promotion is refused with one
-      fixed answer; promoting one that is already promoted or already online
-      reports its state instead of failing.
+- [ ] The release being at the awaiting-promotion state is the operation's
+      **precondition**, on exactly the same terms as starting a release: any
+      other state — including a release already promoted or already online — is
+      refused with one fixed answer, and the loser of a concurrent promotion is
+      refused the same way.
+- [ ] A successful call reports that the promotion has been accepted for
+      processing, and returns the release in the state the advance produced.
 
 ### Reading release state
 
@@ -128,29 +122,18 @@ assumes breakage. They are outcomes, and this spec publishes them as such.
       failure text is not published.
 - [ ] Nothing in a release payload exposes device topology, binding ids, build
       artifact locations, provider workflow ids, or the internal record id.
-
-### Reading the operation ledger
-
-- [ ] An operator can read a release's operation ledger: which operations ran
-      for that release, in order, paged.
-- [ ] Each entry publishes what an operator can act on — the operation, the
-      stage, the attempt number, its state, who ran it, and when.
-- [ ] Each entry withholds the provider-side identifiers and the free-form
-      internal payloads: the BaaS bot identity, the BaaS workflow id, the
-      operation's parameters and results, its internal correlation id, its
-      internal row id, and its last internal error text.
-- [ ] A retried operation is visible as a later attempt rather than as a
-      rewritten row, so a caller can see that a retry happened.
-- [ ] Only operations belonging to the addressed release are returned.
+- [ ] Reading a release is how a caller learns why a write was refused: the two
+      writes disclose only that the precondition failed, and the read says what
+      the state actually is.
 
 ### Who may publish
 
 - [ ] The bot's owner may start and promote releases.
 - [ ] A collaborator holding the platform's publish-capable role may start and
       promote releases; a collaborator below it may not.
-- [ ] Reading a release, the release list, and the ledger is held to the same
-      bar the access expansion already applies to operating the bot's runtimes,
-      so anyone who can watch a runtime can see why it is what it is.
+- [ ] Reading a release and the release list is held to the same bar the access
+      expansion already applies to operating the bot's runtimes, so anyone who
+      can watch a runtime can see why it is what it is.
 - [ ] Anyone else — including a caller who can reach the bot for other reasons
       — is answered byte-identically to naming a bot that does not exist.
 - [ ] Which caller asked, and which owner's bot they asked for, are recoverable
@@ -180,30 +163,35 @@ assumes breakage. They are outcomes, and this spec publishes them as such.
 ### Documentation
 
 - [ ] The surface's handoff documentation records the new category — its
-      endpoints, its role bar, the published state set, and what the ledger
-      publishes and withholds — in the same change, including the Chinese
-      mirror.
-- [ ] The decisions this spec settles are recorded where the next reader of the
-      surface will find them, not only in this directory.
+      endpoints, its preconditions, its role bar, and the published state set —
+      in the same change, including the Chinese mirror.
+- [ ] The known limitation below is recorded there too, not only in this
+      directory, so the next reader of the surface finds it.
 
 ## In Scope
 
-- A new public category with five operations: start a verify release, promote a
-  release online, read a release, list a bot's releases, read a release's
-  operation ledger.
-- The published projections of `ac_bot_publish` (release state) and
-  `ac_publish_operation` (the ledger).
+- A new public category with four operations: start a verify release, promote a
+  release online, read a release, list a bot's releases.
+- The published projection of `ac_bot_publish` (release state).
+- The precondition model for the two writes.
 - The role adjudication for publishing, and its reuse of the platform's existing
   role policy.
-- The composition that makes "start a verify release" a single call for a bot
-  with no release record and for a bot whose last release is live.
-- Tests: the endpoint contract, the role matrix, the state-machine behaviour
-  from every internal status, cross-tenant and cross-bot isolation, and the
-  ledger's published/withheld field sets.
+- Tests: the endpoint contract, the role matrix, the precondition behaviour from
+  every internal status, cross-tenant and cross-bot isolation, and the release
+  payload's published/withheld field sets.
 - The surface's documentation, as listed above.
 
 ## Out of Scope
 
+- **The operation ledger.** `ac_publish_operation` stays internal. Its rows
+  carry provider-side identifiers and free-form internal payloads, and
+  publishing even a projection of them would make the pipeline's internal step
+  structure an external contract. A release's own state is what this surface
+  publishes.
+- **Minting a release record.** Neither write creates one. Creating a service
+  bot already creates its first draft, so a first release needs nothing extra —
+  but taking a *live* bot to a new version does, and that draft is minted on the
+  internal surface. See **Known limitation**.
 - **Retry, rollback, offline, and restore-draft.** Each is a recovery or
   teardown decision with its own preconditions and its own blast radius; each
   deserves its own decision about what an external operator may do, and none is
@@ -224,25 +212,46 @@ assumes breakage. They are outcomes, and this spec publishes them as such.
   turning the internal error text into a stable, enumerated public reason set is
   its own contract and its own change.
 - **Any schema change.** Neither publish table gains a column, and neither gains
-  a tenant axis — see Decision 8.
+  a tenant axis — see Decision 7.
 - **Delegation.** Who may *call* is unchanged: a verified end user, whose
   `user_id` must be the caller.
+
+## Known limitation
+
+**Re-publishing a live bot still needs one internal call.** Because neither
+write mints a release record, the public surface can take a bot from its
+first draft all the way to online, but cannot start version *N+1* of a bot
+already online: after a successful publish the newest release is `online`, not
+`draft`, and the draft for the next version is created by the internal
+upgrade operation.
+
+This is a deliberate consequence of Decision 1, not an oversight. It is
+recorded here, and in the surface's handoff documentation, so an integrator
+meets it in the docs rather than in a 409. Closing it is a follow-up decision
+about whether minting a release belongs on the public surface at all, and if so
+whether it is a third operation or a widening of this precondition.
 
 ## Decisions
 
 Settled here rather than left open:
 
-1. **Starting a release is one call, and it mints the release record when
-   there is none.** The issue names the `DRAFT → BUILDING` advance as the
-   scope, but a bot that has never published has no draft to advance, and a bot
-   whose last release is live online must first be upgraded to a new draft.
-   Making the caller mint the record separately would mean either publishing a
-   second write whose only purpose is bookkeeping, or leaving the public surface
-   unable to start a first release at all. The public concept is *a release*;
-   the draft record is how the platform stores one. So one operation resolves or
-   creates the release record and advances it, and the underlying create is
-   already idempotent, so repeating the call does not fork a version.
-2. **Publishing is held to the platform's publish role, not to the operator
+1. **This surface advances releases; it does not mint them.** Both writes
+   require the release to already be in the one state their transition starts
+   from. The alternative — having "start a release" resolve-or-create the draft
+   record — would fold two internal operations with their own preconditions
+   (`create_first_publish_for_bot`, `upgrade_publish`) into one public call
+   whose effect depended on state the caller could not see. Requiring the state
+   makes the operation's meaning fixed: it advances the draft that is there. The
+   cost is recorded above as a known limitation.
+2. **One legal source state per write, and anything else is a fixed refusal.**
+   Starting requires `draft`; promoting requires the awaiting-promotion state.
+   This is uniform: a caller who is early, a caller who is late, a caller
+   repeating themselves, and the loser of a concurrent race are all told the
+   same thing — the release is not in a state this operation can act on — and
+   they all find out what the state *is* by reading the release. Publishing four
+   different flavours of "no" for the same condition would advertise timing
+   detail the caller cannot act on differently.
+3. **Publishing is held to the platform's publish role, not to the operator
    bar.** The role vocabulary already draws this line: `ADMIN` is defined as
    edit *and publish*, `MEMBER` as edit only. The access expansion's member-level
    operator bar is about reaching a runtime that exists; starting a release
@@ -251,18 +260,12 @@ Settled here rather than left open:
    watch the verify runtime learns nothing new from being told it is at
    `building`. Owner-only was rejected: it would make the platform's own
    definition of `ADMIN` untrue on the surface partners use.
-3. **A lost race is not an error.** Both writes advance under an optimistic
-   compare-and-set, and the loser of a double-submit is a caller who asked for
-   a state the system is already in. It gets the release's current state, with
-   the response distinguishing "you started this" from "this was already
-   running". Publishing a 409 there would make correct client retry logic —
-   the thing an asynchronous API most needs — read as failure.
-4. **A release that cannot advance is refused with one fixed answer, and retry
-   stays internal.** Starting a release from a failed record, or promoting a
-   record that is not awaiting promotion, is a genuine precondition failure and
-   answers 409 with a fixed message. It does not silently retry, and it does not
-   describe what recovery would require, because recovery is not on this
-   surface.
+4. **The ledger stays internal.** An operator following a release wants to know
+   where it is, which the release state answers. The ledger answers *how the
+   pipeline got there* — which BaaS workflow, on which attempt, against which
+   provider bot — and that is the pipeline's internal step structure. Publishing
+   it, even projected, would turn a crash-safety mechanism into a contract we
+   could not then restructure.
 5. **Superseded and retired are published states, not errors.** They are the
    normal end of a release's life under re-publish and offline. A poller that
    was following a release must be able to see that a newer version took over,
@@ -274,39 +277,30 @@ Settled here rather than left open:
    surface's standing rule is that failure messages are fixed and never
    `str(exc)`. The diagnosis stays in the logs, where the surface already
    records it.
-7. **The ledger publishes the timeline, not the payloads.** An operator needs to
-   know which operation ran, at which stage, on which attempt, in what state,
-   by whom, and when — that is what makes a stalled publish diagnosable. The
-   provider-side identifiers (the BaaS bot, the BaaS workflow id) and the
-   free-form `params` / `result` / `last_error` blobs are internal plumbing that
-   would become an unversioned contract the moment they were published; they are
-   withheld. Every kind of operation is shown, including ones this surface
-   cannot trigger: hiding rows would make the attempt numbering and the
-   timeline lie.
-8. **No tenant column, and no schema change — isolation comes from the bot
+7. **No tenant column, and no schema change — isolation comes from the bot
    resolve.** The publish tables carry no `avernet_tenant`, and adding one is
    not this change's job. Every operation here resolves the addressed bot
    through the tenant-guarded, owner-scoped bot read first, and every subsequent
    lookup is keyed on that row's **primary key** — the same argument the access
    expansion made for the engine-runtime groups, for the same reason: `bot_id`
    is not unique across owners.
-9. **A release is addressed by its version, not by its record id.** The version
+8. **A release is addressed by its version, not by its record id.** The version
    is per-bot, monotonic, already stored, and already how the platform talks
    about releases. The record id is a global auto-increment whose value would
    leak cross-tenant volume and whose meaning is internal.
 
 ## Open Questions
 
-1. **The read bar.** Decision 2 splits the category: publish-role for the two
-   writes, operator-level for the three reads. The alternative is one bar for
-   the whole category. Recommendation: keep the split — it is the platform's
+1. **The read bar.** Decision 3 splits the category: publish-role for the two
+   writes, operator-level for the two reads. The alternative is one bar for the
+   whole category. Recommendation: keep the split — it is the platform's
    existing role semantics, and a single bar would either hide progress from
    members who can already watch the runtime, or let them ship.
-2. **Whether a superseded release should name its successor.** The record
-   carries the link internally. Publishing it on a list would cost a lookup per
-   row; publishing it only on the detail read would make the field's presence
-   depend on which endpoint you called. Recommendation: omit for now, and add it
-   as a whole-payload decision if integrators ask.
+2. **Whether the known limitation should be closed in this change.** Adding a
+   third write that mints the next version's draft would make the public surface
+   complete for re-publish. It is deliberately not here. Recommendation: ship
+   the four operations, and let a real integrator's need decide the shape of the
+   fifth rather than guessing it now.
 3. **The category literal.** `publish` is proposed. It matches the internal
    surface's vocabulary and reads correctly in the address. It must be added to
    the reserved-names list, which makes any existing bot whose id is literally

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/spec.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/spec.md
@@ -1,0 +1,314 @@
+# Public API — Publish Lifecycle for Service Bots
+
+GitHub issue: [#909](https://github.com/inclusionAI/Avernet/issues/909)
+
+## Summary
+
+A service bot exists to be published. The public `/openapi/v1` surface can
+create one, drive its draft workspace, and — since the access expansion
+(`2026-08-09-openapi-v1-access-expansion`, PR #904) — watch its verify and
+online runtimes once they exist. What it cannot do is *make* them exist. Every
+transition between stages is internal: starting a verify release, promoting a
+validated release online, and even asking how far a release has got all require
+the internal `/api/service-bot/publish` surface.
+
+This adds a **publish** category to the public surface: one operation that
+starts a verify release, one that promotes a validated release online, and
+three read-only operations that report a release's state, the bot's release
+history, and the release's operation ledger. The two writes are the only two
+user-driven advance points the publish flow has; everything else the internal
+surface offers — retry, rollback, offline, restore-draft, scale, restart,
+approval — stays internal.
+
+## Motivation
+
+**The surface stops exactly where the product starts.** An integrator can
+create a service bot through the public API, upload its skills, write its
+identity files, configure its MCP servers, and drive its draft runtime — and
+then must leave the public API to publish any of it. PR #904 made the published
+runtimes *observable* and named this gap in the same breath, filing it as this
+issue. A publish API that can build everything but ship nothing is a partial
+integration by construction: every partner ends up with a two-surface workflow,
+and the internal surface's contract (Chinese messages, `ApiResponse`, staff-id
+auth) is not one we can hand out.
+
+**Only two transitions are actually driven by a person.** The publish flow's
+`process()` reads as a large state machine, but it advances on exactly two
+statuses: `DRAFT → BUILDING` (which starts the build and the verify release)
+and `VALIDATING → ONLINE_PUB` (which promotes the validated release online).
+Every other status is a side-effect-free status report, because the durable
+task chain owns the rest. So the public surface does not have to reproduce a
+state machine — it has to publish two buttons and a progress view. That is what
+makes this a category-sized change rather than a project.
+
+**Progress is the third of those, and it is not optional.** Both writes are
+asynchronous by design: they win a compare-and-set, enqueue a durable task, and
+return. A caller that cannot then ask "where is my release?" has been handed a
+fire-and-forget API. The publish flow already answers that question internally
+in two shapes — the record's own status, and the crash-safe operation ledger
+built by `2026-07-15-publish-service-idempotency` — and the ledger is what turns
+"still building" into something an operator can act on: which attempt is
+running, at which stage, on whose behalf.
+
+**The states that look like errors are the ones an integrator most needs.** A
+release can be superseded by a newer version
+(`2026-07-28-online-bot-supersede-cleanup`) or taken offline; a failed release
+can be retried into a fresh attempt (`2026-07-23-online-release-retry-fix`).
+Internally these are just statuses and ledger rows. If the public surface maps
+them to errors, an integrator polling a superseded release sees a 409 and
+assumes breakage. They are outcomes, and this spec publishes them as such.
+
+## User Stories
+
+- As a partner integrating the public API, I want to start a verify release for
+  my service bot, so that building the bot and shipping it are one workflow on
+  one surface.
+- As a partner, I want to promote a validated release online once I have
+  checked the verify runtime, so that the gate between pre-production and
+  production is mine to hold.
+- As a partner, I want to poll a release and see how far it has got, so that an
+  asynchronous publish is observable rather than a guess.
+- As an operator debugging a slow or failed publish, I want to see the release's
+  operation ledger — which operation, which stage, which attempt, what state —
+  so that "still building" becomes a diagnosis rather than a wait.
+- As an operator of a bot that was re-published or taken offline, I want the
+  older release to report that it was superseded or retired, so that my poller
+  reads an outcome instead of an error.
+- As a team member on a shared service bot, I want the surface to hold
+  publishing to the same role bar the platform already defines for it, so that
+  who may ship is not decided differently by which API they call.
+- As a partner, I want a release I may not see to answer exactly like a bot that
+  does not exist, so that the surface discloses nothing about other users' or
+  tenants' bots.
+
+## Acceptance Criteria
+
+### Starting a verify release
+
+- [ ] An operator can start a verify release for a service bot in one call,
+      without first calling the internal surface to mint a release record.
+- [ ] Starting a release on a bot that has never published produces its first
+      release; starting one on a bot whose latest release is live online
+      produces the next version.
+- [ ] The call is safe to repeat. A second call while a release is already in
+      flight starts nothing, and reports the in-flight release rather than
+      failing.
+- [ ] Two concurrent calls advance the release exactly once. The loser reports
+      the release's state; it does not error, and it does not start a second
+      build.
+- [ ] A release that cannot be started from its current state — most notably a
+      failed release, whose recovery is retry and stays internal — is refused
+      with one fixed answer that says so.
+- [ ] Starting a release is refused for any bot that is not a service bot.
+- [ ] The answer distinguishes "this call started the release" from "a release
+      was already running", so a caller knows whether it is the owner of the
+      transition.
+
+### Promoting a release online
+
+- [ ] An operator can promote a release that is awaiting promotion, and the
+      promotion is the only thing that opens the online publish.
+- [ ] Promotion is safe to repeat and safe under concurrency, on the same terms
+      as starting a release: one advance, no error for the loser.
+- [ ] Promoting a release that is not awaiting promotion is refused with one
+      fixed answer; promoting one that is already promoted or already online
+      reports its state instead of failing.
+
+### Reading release state
+
+- [ ] An operator can read one release's current state and a human-readable
+      message describing it.
+- [ ] An operator can list a bot's releases, newest first, paged.
+- [ ] Every internal publish status maps to exactly one published state, and the
+      published set is closed, documented, and independent of the internal
+      spelling.
+- [ ] A superseded release and a retired (taken-offline) release each report
+      their own state. Neither is an error, and neither is reported as failed.
+- [ ] A failed release reports a failed state with a fixed message. Internal
+      failure text is not published.
+- [ ] Nothing in a release payload exposes device topology, binding ids, build
+      artifact locations, provider workflow ids, or the internal record id.
+
+### Reading the operation ledger
+
+- [ ] An operator can read a release's operation ledger: which operations ran
+      for that release, in order, paged.
+- [ ] Each entry publishes what an operator can act on — the operation, the
+      stage, the attempt number, its state, who ran it, and when.
+- [ ] Each entry withholds the provider-side identifiers and the free-form
+      internal payloads: the BaaS bot identity, the BaaS workflow id, the
+      operation's parameters and results, its internal correlation id, its
+      internal row id, and its last internal error text.
+- [ ] A retried operation is visible as a later attempt rather than as a
+      rewritten row, so a caller can see that a retry happened.
+- [ ] Only operations belonging to the addressed release are returned.
+
+### Who may publish
+
+- [ ] The bot's owner may start and promote releases.
+- [ ] A collaborator holding the platform's publish-capable role may start and
+      promote releases; a collaborator below it may not.
+- [ ] Reading a release, the release list, and the ledger is held to the same
+      bar the access expansion already applies to operating the bot's runtimes,
+      so anyone who can watch a runtime can see why it is what it is.
+- [ ] Anyone else — including a caller who can reach the bot for other reasons
+      — is answered byte-identically to naming a bot that does not exist.
+- [ ] Which caller asked, and which owner's bot they asked for, are recoverable
+      from the logs at the point of refusal; the response carries neither.
+
+### Addressing and parameters
+
+- [ ] The category is addressed by its own component literal, following the
+      surface's addressing rule, and the literal is added to the published
+      reserved-names list in the same change.
+- [ ] Every operation takes the required `user_id` query parameter the surface
+      settled on, and may name the bot's owner with the same optional `owner_id`
+      parameter the access expansion introduced.
+- [ ] A release is addressed by a caller-meaningful identifier scoped to the
+      bot, not by an internal database id.
+- [ ] A release identifier belonging to a different bot, a different owner, or a
+      different tenant is answered as not found.
+
+### Isolation and internal surface
+
+- [ ] Every release lookup is keyed on the primary key of the bot row the
+      caller's access was proven against, never on `bot_id` alone.
+- [ ] The internal `/api/service-bot/publish` surface is unchanged: its routes,
+      its responses, and its test suite are untouched.
+- [ ] No schema change is required.
+
+### Documentation
+
+- [ ] The surface's handoff documentation records the new category — its
+      endpoints, its role bar, the published state set, and what the ledger
+      publishes and withholds — in the same change, including the Chinese
+      mirror.
+- [ ] The decisions this spec settles are recorded where the next reader of the
+      surface will find them, not only in this directory.
+
+## In Scope
+
+- A new public category with five operations: start a verify release, promote a
+  release online, read a release, list a bot's releases, read a release's
+  operation ledger.
+- The published projections of `ac_bot_publish` (release state) and
+  `ac_publish_operation` (the ledger).
+- The role adjudication for publishing, and its reuse of the platform's existing
+  role policy.
+- The composition that makes "start a verify release" a single call for a bot
+  with no release record and for a bot whose last release is live.
+- Tests: the endpoint contract, the role matrix, the state-machine behaviour
+  from every internal status, cross-tenant and cross-bot isolation, and the
+  ledger's published/withheld field sets.
+- The surface's documentation, as listed above.
+
+## Out of Scope
+
+- **Retry, rollback, offline, and restore-draft.** Each is a recovery or
+  teardown decision with its own preconditions and its own blast radius; each
+  deserves its own decision about what an external operator may do, and none is
+  an advance point in the publish flow. A failed release is therefore a terminal
+  state on this surface, and this spec says so plainly rather than half-exposing
+  a recovery path.
+- **Scale, restart, and bot-type changes.** Runtime capacity and lifecycle
+  operations on a published bot, not publish transitions. Restart already has a
+  public form on the bots category for the bot record.
+- **Human approval.** The approval path is delegated to BaaS server-side
+  auto-approval and has no caller-driven step left to publish.
+- **The eval stage.** It has no long-lived runtime, and its publish/teardown
+  operations are an internal evaluation mechanism.
+- **Creating the service bot, or making it public.** Bot creation is the bots
+  category; visibility and collaborator management are
+  [#910](https://github.com/inclusionAI/Avernet/issues/910).
+- **A published failure taxonomy.** A failed release reports that it failed;
+  turning the internal error text into a stable, enumerated public reason set is
+  its own contract and its own change.
+- **Any schema change.** Neither publish table gains a column, and neither gains
+  a tenant axis — see Decision 8.
+- **Delegation.** Who may *call* is unchanged: a verified end user, whose
+  `user_id` must be the caller.
+
+## Decisions
+
+Settled here rather than left open:
+
+1. **Starting a release is one call, and it mints the release record when
+   there is none.** The issue names the `DRAFT → BUILDING` advance as the
+   scope, but a bot that has never published has no draft to advance, and a bot
+   whose last release is live online must first be upgraded to a new draft.
+   Making the caller mint the record separately would mean either publishing a
+   second write whose only purpose is bookkeeping, or leaving the public surface
+   unable to start a first release at all. The public concept is *a release*;
+   the draft record is how the platform stores one. So one operation resolves or
+   creates the release record and advances it, and the underlying create is
+   already idempotent, so repeating the call does not fork a version.
+2. **Publishing is held to the platform's publish role, not to the operator
+   bar.** The role vocabulary already draws this line: `ADMIN` is defined as
+   edit *and publish*, `MEMBER` as edit only. The access expansion's member-level
+   operator bar is about reaching a runtime that exists; starting a release
+   creates or replaces one and changes what the bot's audience talks to. Reads
+   in this category stay at the operator bar, because a member who can already
+   watch the verify runtime learns nothing new from being told it is at
+   `building`. Owner-only was rejected: it would make the platform's own
+   definition of `ADMIN` untrue on the surface partners use.
+3. **A lost race is not an error.** Both writes advance under an optimistic
+   compare-and-set, and the loser of a double-submit is a caller who asked for
+   a state the system is already in. It gets the release's current state, with
+   the response distinguishing "you started this" from "this was already
+   running". Publishing a 409 there would make correct client retry logic —
+   the thing an asynchronous API most needs — read as failure.
+4. **A release that cannot advance is refused with one fixed answer, and retry
+   stays internal.** Starting a release from a failed record, or promoting a
+   record that is not awaiting promotion, is a genuine precondition failure and
+   answers 409 with a fixed message. It does not silently retry, and it does not
+   describe what recovery would require, because recovery is not on this
+   surface.
+5. **Superseded and retired are published states, not errors.** They are the
+   normal end of a release's life under re-publish and offline. A poller that
+   was following a release must be able to see that a newer version took over,
+   or that the service was taken down, and continue — not receive an error for a
+   record that behaved exactly as designed.
+6. **Internal failure text is not published.** A failed release publishes the
+   fixed message for its state. The internal `error_message` is raw operational
+   text — exception reprs, provider ids, internal-language strings — and the
+   surface's standing rule is that failure messages are fixed and never
+   `str(exc)`. The diagnosis stays in the logs, where the surface already
+   records it.
+7. **The ledger publishes the timeline, not the payloads.** An operator needs to
+   know which operation ran, at which stage, on which attempt, in what state,
+   by whom, and when — that is what makes a stalled publish diagnosable. The
+   provider-side identifiers (the BaaS bot, the BaaS workflow id) and the
+   free-form `params` / `result` / `last_error` blobs are internal plumbing that
+   would become an unversioned contract the moment they were published; they are
+   withheld. Every kind of operation is shown, including ones this surface
+   cannot trigger: hiding rows would make the attempt numbering and the
+   timeline lie.
+8. **No tenant column, and no schema change — isolation comes from the bot
+   resolve.** The publish tables carry no `avernet_tenant`, and adding one is
+   not this change's job. Every operation here resolves the addressed bot
+   through the tenant-guarded, owner-scoped bot read first, and every subsequent
+   lookup is keyed on that row's **primary key** — the same argument the access
+   expansion made for the engine-runtime groups, for the same reason: `bot_id`
+   is not unique across owners.
+9. **A release is addressed by its version, not by its record id.** The version
+   is per-bot, monotonic, already stored, and already how the platform talks
+   about releases. The record id is a global auto-increment whose value would
+   leak cross-tenant volume and whose meaning is internal.
+
+## Open Questions
+
+1. **The read bar.** Decision 2 splits the category: publish-role for the two
+   writes, operator-level for the three reads. The alternative is one bar for
+   the whole category. Recommendation: keep the split — it is the platform's
+   existing role semantics, and a single bar would either hide progress from
+   members who can already watch the runtime, or let them ship.
+2. **Whether a superseded release should name its successor.** The record
+   carries the link internally. Publishing it on a list would cost a lookup per
+   row; publishing it only on the detail read would make the field's presence
+   depend on which endpoint you called. Recommendation: omit for now, and add it
+   as a whole-payload decision if integrators ask.
+3. **The category literal.** `publish` is proposed. It matches the internal
+   surface's vocabulary and reads correctly in the address. It must be added to
+   the reserved-names list, which makes any existing bot whose id is literally
+   `publish` unreachable at the bare bot address — the same one-time cost every
+   component literal carries.

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/tasks.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/tasks.md
@@ -2,244 +2,268 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 >
-> Sequencing: bases on `dev` at `5e8bc36` (the access expansion, PR #904). This
-> reuses that change's `OwnerIdDep` and its `BotFacts` shape but does not depend
-> on any of its behaviour, so a rebase is the only coupling.
+> Sequencing: bases on `dev` at `5e8bc36` (the access expansion, PR #904).
+> Groups A–B are the Phase-1 core evolution from `design.md` and land **before**
+> the public surface (Groups C–D) is wired on top of them.
 >
 > Paths below are relative to `src/backend/src/agentclaw/community/` unless the
 > path starts with `src/` or `tests/`.
 
 ---
 
-## Group A — Core policy
+## Group A — The evolved core (`design.md` Phase 1)
 
-### Task 1: Extract the role bar into the collaborator domain  `[ ]`
+### Task 1: `ReleaseFacts` — the typed ext  `[ ]`
 
-- **Goal:** one level-parameterised, fail-closed "does this caller hold at
-  least level L on this bot?" that both the operator surfaces and publishing
-  can call, owned by the domain that owns role policy.
-- **Files:** `core/bot_collaborator/access.py` (new),
-  `core/engine_runtime/gate.py`, `core/bot_collaborator/README.md`,
-  `core/engine_runtime/README.md`
+- **Goal:** one Pydantic model that owns the publish record's `ext` shape;
+  byte-compatible round-trip with every stored key.
+- **Files:** `core/service_bot/release/__init__.py`,
+  `core/service_bot/release/facts.py` (new),
+  `tests/community/core/service_bot/release/test_release_facts.py` (new)
 - **Done when:**
-  - [ ] `access.py` exposes `resolve_permission_level(...)` and
-        `require_bot_role(..., min_level)`; the latter raises `BotNotFoundError`
-        and logs caller id (`%r`) and owner id at the refusal.
-  - [ ] A collaborator-lookup exception resolves to `PermissionLevel.NONE` and
-        logs — the fail-closed direction is preserved exactly.
-  - [ ] `gate.py` keeps `OPERATOR_LEVEL`, `require_bot_operator` and
-        `resolve_operator_level` as delegations, with `__all__` unchanged, so
-        no import site anywhere moves.
-  - [ ] Both modules' `## Context Boundary` sections declare the new
-        cross-module import.
-  - [ ] `tests/community/core/engine_runtime/` and
-        `tests/…/openapi_v1/engine_runtime/test_operator_access.py` pass
-        **unmodified** — the proof the extraction is behaviour-preserving.
-  - [ ] `tests/community/architecture/` passes.
+  - [ ] `StageBindings`, `BuildArtifact` (with `.present`), `FailureInfo`,
+        `engine_overrides_by_stage` and opaque `passthrough` exist as designed
+        (design §3.1); the legacy id-stash keys (`publish`, `restart`,
+        `scale`) are parsed into clearly-deprecated fields for fallback reads.
+  - [ ] `from_ext(None)`, `from_ext({})` and every legacy shape observed in
+        the census (design §1.1) parse without loss.
+  - [ ] The round-trip property test passes: `to_ext(from_ext(x))` preserves
+        every key the model does not own, verbatim, including unknown keys.
 - **Depends on:** —
 
-### Task 2: Release errors  `[ ]`
+### Task 2: `ReleaseStore` — the only door to ext  `[ ]`
 
-- **Goal:** two dependency-free precondition errors the adapter can map without
-  importing the service layer.
-- **Files:** `core/service_bot/services/release_errors.py` (new)
+- **Goal:** absorb `PublishExtState`'s persistence semantics behind a
+  `ReleaseFacts`-typed surface.
+- **Files:** `core/service_bot/release/store.py` (new),
+  `core/service_bot/services/publish_flow/ext_state.py`,
+  `tests/community/core/service_bot/release/test_release_store.py` (new)
 - **Done when:**
-  - [ ] `ReleaseNotStartableError` and `ReleaseNotPromotableError` exist, both
-        subclassing `BotPublishServiceError`.
-  - [ ] Each docstring states the exact precondition it reports and the fixed
-        public message it maps to.
-- **Depends on:** —
+  - [ ] `load` / `mutate` / `advance` / `advance_with_facts` carry over the
+        latest-read-back, deep-copy-snapshot and CAS semantics verbatim
+        (design §3.2).
+  - [ ] `PublishExtState` delegates to the store (thin shell; dies in
+        Phase 2) — its callers and tests are untouched in this task.
+  - [ ] The store's tests pin the semantics independently of any mixin.
+- **Depends on:** Task 1
 
-### Task 3: `ReleaseLifecycleService`  `[ ]`
+### Task 3: The status machine as data  `[ ]`
 
-- **Goal:** every domain decision in this feature, in one transport-agnostic
-  place: target resolution + role bar, the draft-resolution table, the two
-  guarded advances, and the two scoped reads.
-- **Files:** `core/service_bot/services/release_lifecycle_service.py` (new),
-  `core/service_bot/README.md`
+- **Goal:** `RELEASE_MACHINE` declared once; `process()` and the failure
+  writes consult it.
+- **Files:** `core/service_bot/release/machine.py` (new),
+  `core/service_bot/services/publish_flow_service.py`,
+  the failure-write sites in `publish_flow/` (`build_stage.py`,
+  `progress_sync_mixin.py`, `publish_flow_service.py`),
+  `tests/community/core/service_bot/release/test_release_machine.py` (new)
 - **Done when:**
-  - [ ] `PUBLISH_LEVEL = PermissionLevel.ADMIN` and
-        `PUBLISH_READ_LEVEL = PermissionLevel.MEMBER` are named once, with the
-        rationale from spec Decision 2 in the module docstring.
-  - [ ] `_resolve_target` runs owner-scoped `get_bot` → `require_bot_role` →
-        service-type check **in that order**, and returns `BotFacts`. An async
-        façade runs it via `asyncio.to_thread`.
-  - [ ] `start_verify_release` implements the draft-resolution table in
-        `plan.md` §4 exactly, including the no-side-effect in-flight branch and
-        the 409 branch for `FAILED`/`UPGRADED`/`RELEASED`.
-  - [ ] The first release's name is derived from the bot's own name; no public
-        release-name field is introduced.
-  - [ ] `promote_release` calls `process` **only** from `VALIDATING`; already
-        promoted / already online return `started=False`; everything else
-        raises `ReleaseNotPromotableError`.
-  - [ ] Both writes return `ReleaseAdvance(record, started)` with the record
-        **re-read after** `process`.
-  - [ ] `_load_release` looks up by `(publish_bot_id, owner_id, version, env)`
-        **and** asserts `record.source_bot_pk == facts.bot_pk`, raising
-        `PublishNotFoundError` otherwise.
-  - [ ] `list_releases` and `list_release_operations` are keyed on `bot_pk` /
-        the proven record id respectively, page in the service, and return
-        `(total, items)`. The ledger sorts ascending by `(gmt_create, id)`.
-  - [ ] The in-service pagination choice is justified in the docstring rather
-        than left to be re-litigated.
-  - [ ] No HTTP type, no response-shaped dict, no `ext` read anywhere in the
-        module.
+  - [ ] The machine carries today's transitions exactly (design §3.3),
+        including each TASK transition's `on_failure` target equal to the
+        `source_status` value that site writes today.
+  - [ ] `process()` looks up the USER transition instead of its two
+        hand-written branches; messages and wire payloads are unchanged.
+  - [ ] Failure writes take their rollback target from the machine; no site
+        hand-writes `ext["source_status"]` a literal anymore.
+  - [ ] The agreement test passes: exactly two USER transitions; every
+        non-terminal status covered.
+  - [ ] `test_publish_flow_service.py`, `test_publish_crash_windows.py`,
+        `test_publish_tasks.py` pass **unmodified**.
+- **Depends on:** Task 2
+
+### Task 4: The ledger becomes the single home of workflow ids  `[ ]`
+
+- **Goal:** stop the ext id-stash writes; convert every reader to
+  ledger-first with legacy-ext fallback. Kills the "publish_id in four
+  places" problem at the root.
+- **Files:** `core/service_bot/release/operations.py` (new);
+  writers: `publish_flow/publish_ext_mixin.py`, `publish_flow/release_stage.py`,
+  `publish_flow/restart_mixin.py`, `publish_flow/scale_mixin.py`;
+  readers: `publish_flow/progress_sync_mixin.py`, `publish_flow/retry_ops_mixin.py`,
+  `publish_flow/rollback_ops_mixin.py`, `publish_flow/upgrade_resolution_mixin.py`,
+  `services/baas_service.py`, `services/arca_image_pin.py`,
+  `services/bot_publish_service.py`;
+  `tests/community/core/service_bot/release/test_release_operations.py` (new)
+- **Done when:**
+  - [ ] `latest_release_workflow` / `latest_restart_workflow` /
+        `latest_scale_workflow` / `is_restart_in_flight` answer from
+        `PublishOperationRepository`, falling back to the deprecated
+        `ReleaseFacts` fields only when the ledger has no row (pre-#197 data).
+  - [ ] No site writes `ext.publish.*`, `ext.restart.*` or `ext.scale.*`
+        anymore; `ext.binding` stays (typed, not relocated — design §3.4).
+  - [ ] `restart_mixin`'s id-classification (`:525-527`) reads the ledger
+        row's `operation_kind` instead of comparing two ext homes.
+  - [ ] Binding reads at `baas_service.py:3425`, `arca_image_pin.py:134`,
+        `bot_publish_service.py:641` go through `StageBindings`.
+  - [ ] Existing tests asserting the removed ext writes are updated to assert
+        the ledger row instead — each such edit listed individually in the PR.
+  - [ ] Crash-window and e2e publish-boundary suites pass **unmodified**.
 - **Depends on:** Tasks 1, 2
 
-### Task 4: Service API protocol + DI  `[ ]`
+### Task 5: The no-raw-ext architecture gate  `[ ]`
 
-- **Files:** `api/release_lifecycle_service.py` (new),
-  `di/modules/service_bot_module.py`,
-  `tests/community/architecture/test_service_api_conformance.py`
+- **Files:** `tests/community/architecture/test_release_ext_access.py` (new)
 - **Done when:**
-  - [ ] `ReleaseLifecycleServiceProtocol` is `@runtime_checkable` with **real**
-        signatures, not `*args/**kwargs`.
-  - [ ] The `(Protocol, ReleaseLifecycleService)` pair is registered in the
-        conformance gate and the gate passes.
-  - [ ] The binding sits beside `_publish_flow_service_protocol`, singleton,
-        and resolves in the community composition root.
-- **Depends on:** Task 3
+  - [ ] Outside `release/facts.py` and `release/store.py`, no module under
+        `core/service_bot` touches `ext[` / `ext.get(` / `ext.setdefault(` on
+        a publish record.
+  - [ ] Grandfathered exceptions (approval / rollback / draft-restore / eval
+        passthrough sites) are enumerated in the test, each with its
+        Phase-2/3 pointer, so the list can only shrink.
+- **Depends on:** Tasks 3, 4
 
 ---
 
-## Group B — Public surface
+## Group B — Policy for the public surface
 
-### Task 5: Schemas and projections  `[ ]`
+### Task 6: Extract the role bar into the collaborator domain  `[ ]`
 
-- **Goal:** the published contract, and the mappings that make an unmapped
-  internal value a CI failure instead of a 500.
-- **Files:** `adapters/http/openapi_v1/publish/schemas.py` (new),
-  `adapters/http/openapi_v1/publish/__init__.py` (new)
+- **Goal:** one level-parameterised, fail-closed "does this caller hold at
+  least level L on this bot?" — publishing needs a different bar than the
+  operator surfaces, and role policy belongs to `bot_collaborator`.
+- **Files:** `core/bot_collaborator/access.py` (new),
+  `core/engine_runtime/gate.py`, both modules' `README.md`
 - **Done when:**
-  - [ ] `ReleaseState` carries the ten published values from `plan.md` §2 and a
-        `PublishStatus → ReleaseState` map that is exhaustive by construction.
-  - [ ] `ReleaseOperationKind` and `ReleaseOperationState` mirror their internal
-        enums value-for-value, both maps exhaustive.
-  - [ ] `Release` publishes exactly `version`, `state`, `message`, `bot_id`,
-        `name`, `description`, `created_at`, `updated_at`.
-  - [ ] `ReleaseOperation` publishes exactly `kind`, `stage`, `attempt`,
-        `state`, `operator`, `created_at`, `updated_at`.
-  - [ ] The projection functions never read `ext`, `params`, `result`,
-        `last_error`, `bot_uuid`, `baas_publish_id` or `request_id`.
-  - [ ] The `failed` message is the fixed `"Publish failed"`; the internal
-        `error_message` is never interpolated.
-  - [ ] The request body model for the two writes sets `extra="forbid"`.
+  - [ ] `resolve_permission_level(...)` and `require_bot_role(..., min_level)`
+        exist; the latter raises `BotNotFoundError` and logs caller (`%r`) and
+        owner at the refusal; a lookup failure resolves to `NONE` (fail
+        closed).
+  - [ ] `gate.py` keeps `OPERATOR_LEVEL`, `require_bot_operator`,
+        `resolve_operator_level` as delegations; `__all__` unchanged; no
+        import site moves.
+  - [ ] `## Context Boundary` sections updated in both modules.
+  - [ ] `tests/community/core/engine_runtime/` and
+        `…/openapi_v1/engine_runtime/test_operator_access.py` pass
+        **unmodified**; `tests/community/architecture/` passes.
 - **Depends on:** —
 
-### Task 6: The router  `[ ]`
+### Task 7: `ReleaseLifecycleService` + errors + protocol + DI  `[ ]`
 
-- **Files:** `adapters/http/openapi_v1/publish/router.py` (new),
-  `adapters/http/openapi_v1/__init__.py`
+- **Goal:** the public surface's core: target resolution + role bars, the two
+  precondition-guarded machine advances, the two reads.
+- **Files:** `core/service_bot/release/lifecycle.py` (new),
+  `core/service_bot/release/errors.py` (new),
+  `api/release_lifecycle_service.py` (new),
+  `di/modules/service_bot_module.py`,
+  `tests/community/architecture/test_service_api_conformance.py`,
+  `tests/community/core/service_bot/release/test_lifecycle_service.py` (new)
 - **Done when:**
-  - [ ] Five routes at the paths in `plan.md` §1, prefix `/bots/publish`.
-  - [ ] Every handler takes `PrincipalDep`, `UserIdDep`, `OwnerIdDep`
-        (imported from `engine_runtime/params.py`, not re-declared),
-        `request: Request`, and `@envelope_errors`.
-  - [ ] The two writes return 202 when `started`, 200 when not, using the same
-        mechanism `bots/router.py` uses for its 201/202 split.
-  - [ ] The lists use the shared `PageParamsDep` and `page(...)`.
-  - [ ] No domain branching in the router — it maps parameters in and
-        projections out, nothing else.
-  - [ ] The group is added to `_SUBGROUPS` in `openapi_v1/__init__.py` with
-        `USER_SCOPED_ERROR_RESPONSES`, above the bots router.
-- **Depends on:** Tasks 4, 5
+  - [ ] `PUBLISH_LEVEL = ADMIN`, `PUBLISH_READ_LEVEL = MEMBER`, named once with
+        the spec-Decision-3 rationale.
+  - [ ] `_resolve_target` runs owner-scoped `get_bot` → `require_bot_role` →
+        service-type check in that order; async façade via `asyncio.to_thread`.
+  - [ ] `start_verify_release`: newest record by `bot_pk` must be `DRAFT`,
+        else `ReleaseNotStartableError` with **no side effect**; the advance is
+        `ReleaseStore.advance(DRAFT→BUILDING)` + `enqueue_verify_flow` on a
+        win, CAS-then-enqueue in `process()`'s order; a lost CAS raises the
+        same error.
+  - [ ] `promote_release`: record must be `VALIDATING`, else
+        `ReleaseNotPromotableError`; advance is
+        `ReleaseStore.advance(VALIDATING→ONLINE_PUB)` + `enqueue_online_release`;
+        lost CAS → same error.
+  - [ ] The machine-agreement test extends to pin that this service drives
+        exactly the machine's USER transitions.
+  - [ ] `_load_release` asserts `record.source_bot_pk == facts.bot_pk` →
+        masked `PublishNotFoundError` otherwise.
+  - [ ] `list_releases` pages in the service (`total`, newest first);
+        docstring records the deliberate non-paginated repository read.
+  - [ ] Both writes re-read and return the post-advance record.
+  - [ ] `ReleaseLifecycleServiceProtocol` has real signatures, is registered
+        in the conformance gate, and is bound in `service_bot_module`.
+- **Depends on:** Tasks 3, 6 (and 2 for the store)
 
-### Task 7: Error mapping  `[ ]`
+---
+
+## Group C — Public surface
+
+### Task 8: Schemas, projections, router, mounting  `[ ]`
+
+- **Files:** `adapters/http/openapi_v1/publish/{__init__,router,schemas}.py`
+  (new), `adapters/http/openapi_v1/__init__.py`
+- **Done when:**
+  - [ ] `ReleaseState` maps `PublishStatus` 1:1 per plan §2, exhaustive by
+        construction; `Release` publishes exactly the eight plan-§2 fields;
+        the projection never reads `ext`; `failed` carries the fixed message.
+  - [ ] Four routes at the plan-§1 paths, prefix `/bots/publish`; handlers
+        take `PrincipalDep`, `UserIdDep`, `OwnerIdDep` (imported from
+        `engine_runtime/params.py`), `PageParamsDep`, `request: Request`,
+        `@envelope_errors`; writes declare `status_code=202` and have no
+        request body.
+  - [ ] Mounted in `_SUBGROUPS` above the bots router with
+        `USER_SCOPED_ERROR_RESPONSES`.
+- **Depends on:** Task 7
+
+### Task 9: Error mapping  `[ ]`
 
 - **Files:** `adapters/http/openapi_v1/responses.py`
 - **Done when:**
-  - [ ] Every row of the `plan.md` §6 table is present, leaves before
-        `BotPublishServiceError`.
-  - [ ] **Both** `BotNotFoundError` classes are mapped (the `service_bot` one is
-        a different class from the `bot_management` one already in the table),
-        with byte-identical 404 messages.
-  - [ ] The four 409s get distinct business subcodes in `ERROR_SUBCODES`.
-  - [ ] No mapped message interpolates `str(exc)`.
-- **Depends on:** Task 2
+  - [ ] Every row of the plan-§7 table present, leaves before
+        `BotPublishServiceError`; **both** `BotNotFoundError` classes mapped
+        with byte-identical 404 messages; distinct 409 subcodes in
+        `ERROR_SUBCODES`; no message interpolates `str(exc)`.
+- **Depends on:** Task 7
 
 ---
 
-## Group C — Tests
+## Group D — Tests, docs, gates
 
-### Task 8: Core service tests  `[ ]`
+### Task 10: Public-surface test suites  `[ ]`
 
-- **Files:** `tests/community/core/service_bot/services/test_release_lifecycle_service.py` (new)
+- **Files:** `tests/community/adapters/http/openapi_v1/publish/` (new package
+  per plan §9: endpoints, state-machine, access, projection, tenant-isolation)
 - **Done when:**
-  - [ ] The draft-resolution table is covered row by row, including that the
-        in-flight branch performs **no** write.
-  - [ ] `_load_release` rejects a version whose `source_bot_pk` differs.
-  - [ ] The ledger read cannot return a row from another release.
-  - [ ] The read and write bar constants are asserted, so changing one is a
-        deliberate test edit.
-- **Depends on:** Task 3
+  - [ ] All four handlers: success + every mapped error; writes answer 202 and
+        nothing else.
+  - [ ] Start and promote attempted from each of the ten `PublishStatus`
+        values — exactly one succeeds per write, the rest are the fixed 409
+        with no side effect; both CAS-loser paths refused identically.
+  - [ ] Role matrix (owner / admin / member / stranger × writes and reads);
+        refusals byte-identical to a missing bot.
+  - [ ] State map exhaustive; withheld fields absent; no `ext` key reachable.
+  - [ ] Cross-tenant and cross-bot lookups masked 404 against the real Track A
+        guard.
+- **Depends on:** Tasks 8, 9
 
-### Task 9: Endpoint, access, projection and isolation tests  `[ ]`
+### Task 11: Amend the surface-wide contract tests  `[ ]`
 
-- **Files:** `tests/community/adapters/http/openapi_v1/publish/` (new package:
-  `__init__.py`, `conftest.py`, `test_publish_endpoints.py`,
-  `test_release_state_machine.py`, `test_publish_access.py`,
-  `test_publish_projection.py`, `test_publish_tenant_isolation.py`)
-- **Done when:**
-  - [ ] All five handlers, success and every mapped error, including the
-        202/200 split and an `extra="forbid"` 422.
-  - [ ] Start and promote are exercised from **each** of the ten
-        `PublishStatus` values, plus both CAS-loser paths.
-  - [ ] The role matrix (owner / admin / member / stranger × writes and reads)
-        holds, and every refusal is byte-identical to a missing bot.
-  - [ ] The three enum maps are asserted exhaustive over their internal enums.
-  - [ ] The withheld field sets are asserted absent from both payloads.
-  - [ ] Cross-tenant and cross-bot lookups are masked 404s against the real
-        Track A guard.
-- **Depends on:** Tasks 6, 7
-
-### Task 10: Amend the surface-wide contract tests  `[ ]`
-
-- **Files:** `tests/community/adapters/http/openapi_v1/test_explicit_user_id.py`,
+- **Files:** `tests/…/openapi_v1/test_explicit_user_id.py`,
   `…/test_path_convention.py`, `…/test_openapi_error_schema.py`
 - **Done when:**
-  - [ ] `test_explicit_user_id` expects 61 user-scoped operations and the same
-        4 exempt ones.
-  - [ ] `test_path_convention` passes with `publish` in the routed reserved
-        list and absent from the unrouted one (it asserts the two are
-        disjoint).
-  - [ ] `test_openapi_error_schema` passes: the group documents exactly the
-        user-scoped set, and no 501/504.
-- **Depends on:** Tasks 6, 11
+  - [ ] user-id counts 56/4 → 60/4; `publish` in the routed reserved list and
+        absent from the unrouted one; the new group documents exactly the
+        user-scoped response set.
+- **Depends on:** Tasks 8, 12
 
----
+### Task 12: Handoff documentation  `[ ]`
 
-## Group D — Documentation and gates
-
-### Task 11: Handoff documentation  `[ ]`
-
-- **Files:** `src/backend/docs/openapi-v1/README.md`,
-  `src/backend/docs/openapi-v1/README.zh-CN.md`
+- **Files:** `src/backend/docs/openapi-v1/README.md`, `README.zh-CN.md`
 - **Done when:**
-  - [ ] Track B status board gains a `publish` row.
-  - [ ] A new endpoint section carries the five-row table, the `PublishStatus →
-        ReleaseState` map, the ledger's published/withheld field sets, and the
-        two role bars with their reasoning.
-  - [ ] `publish` is added to the `<!-- reserved-component-names -->` fenced
-        list (routed, not unrouted).
-  - [ ] The deferred-items line pointing at #909 is struck.
-  - [ ] A dated changelog line is appended.
-  - [ ] The Chinese mirror carries every one of the above.
-- **Depends on:** Task 6
+  - [ ] Track B board row; endpoint section with the four-row table, state
+        map, precondition rule, role bars, and the known limitation
+        (re-publish of a live bot needs the internal upgrade).
+  - [ ] `publish` added to `<!-- reserved-component-names -->` (routed list);
+        the #909 deferred line struck; dated changelog entry; Chinese mirror
+        carries all of it.
+  - [ ] The internal evolution is recorded too: a short section pointing at
+        `design.md`, the new `release/` package, and the phase plan — so the
+        next person extending the pipeline builds on the new core, not the
+        mixins.
+- **Depends on:** Task 8
 
-### Task 12: Full gates and PR  `[ ]`
+### Task 13: Full gates and PR  `[ ]`
 
 - **Done when:**
   - [ ] `tests/community/architecture/` green — run **after** every new
-        cross-module import is declared, not before.
-  - [ ] The internal publish suites pass **unmodified**:
-        `tests/community/adapters/http/service_bot/test_router_publish_coverage.py`,
-        `tests/community/core/service_bot/services/test_publish_flow_service.py`,
+        cross-module import is declared in the touched READMEs.
+  - [ ] Internal suites green, unmodified except the individually-listed
+        id-stash assertions from Task 4:
+        `test_router_publish_coverage.py`, `test_publish_flow_service.py`,
+        `test_publish_crash_windows.py`, `test_publish_tasks.py`,
         `tests/community/e2e/publish_boundary/`.
-  - [ ] The engine-runtime operator and stage suites pass **unmodified**.
+  - [ ] Engine-runtime operator and stage suites green, unmodified.
   - [ ] Full `tests/community` green; backend SAST/lint green.
-  - [ ] Draft PR opened, titled
+  - [ ] PR (existing draft #918's branch) updated, titled
         `feat(backend): publish service-bot releases on the openapi v1 surface`,
-        with the `Problem` / `Solution` / `Validation` sections from
-        `.github/pull_request_template.md`, linking #909 and this spec
-        directory. State explicitly what could not be run locally and why.
+        with `Problem` / `Solution` / `Validation` sections, linking #909,
+        this spec directory and `design.md`. State explicitly what could not
+        be run locally and why.
 - **Depends on:** all

--- a/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/tasks.md
+++ b/src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/tasks.md
@@ -1,0 +1,245 @@
+# Tasks: Public API — Publish Lifecycle for Service Bots
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+>
+> Sequencing: bases on `dev` at `5e8bc36` (the access expansion, PR #904). This
+> reuses that change's `OwnerIdDep` and its `BotFacts` shape but does not depend
+> on any of its behaviour, so a rebase is the only coupling.
+>
+> Paths below are relative to `src/backend/src/agentclaw/community/` unless the
+> path starts with `src/` or `tests/`.
+
+---
+
+## Group A — Core policy
+
+### Task 1: Extract the role bar into the collaborator domain  `[ ]`
+
+- **Goal:** one level-parameterised, fail-closed "does this caller hold at
+  least level L on this bot?" that both the operator surfaces and publishing
+  can call, owned by the domain that owns role policy.
+- **Files:** `core/bot_collaborator/access.py` (new),
+  `core/engine_runtime/gate.py`, `core/bot_collaborator/README.md`,
+  `core/engine_runtime/README.md`
+- **Done when:**
+  - [ ] `access.py` exposes `resolve_permission_level(...)` and
+        `require_bot_role(..., min_level)`; the latter raises `BotNotFoundError`
+        and logs caller id (`%r`) and owner id at the refusal.
+  - [ ] A collaborator-lookup exception resolves to `PermissionLevel.NONE` and
+        logs — the fail-closed direction is preserved exactly.
+  - [ ] `gate.py` keeps `OPERATOR_LEVEL`, `require_bot_operator` and
+        `resolve_operator_level` as delegations, with `__all__` unchanged, so
+        no import site anywhere moves.
+  - [ ] Both modules' `## Context Boundary` sections declare the new
+        cross-module import.
+  - [ ] `tests/community/core/engine_runtime/` and
+        `tests/…/openapi_v1/engine_runtime/test_operator_access.py` pass
+        **unmodified** — the proof the extraction is behaviour-preserving.
+  - [ ] `tests/community/architecture/` passes.
+- **Depends on:** —
+
+### Task 2: Release errors  `[ ]`
+
+- **Goal:** two dependency-free precondition errors the adapter can map without
+  importing the service layer.
+- **Files:** `core/service_bot/services/release_errors.py` (new)
+- **Done when:**
+  - [ ] `ReleaseNotStartableError` and `ReleaseNotPromotableError` exist, both
+        subclassing `BotPublishServiceError`.
+  - [ ] Each docstring states the exact precondition it reports and the fixed
+        public message it maps to.
+- **Depends on:** —
+
+### Task 3: `ReleaseLifecycleService`  `[ ]`
+
+- **Goal:** every domain decision in this feature, in one transport-agnostic
+  place: target resolution + role bar, the draft-resolution table, the two
+  guarded advances, and the two scoped reads.
+- **Files:** `core/service_bot/services/release_lifecycle_service.py` (new),
+  `core/service_bot/README.md`
+- **Done when:**
+  - [ ] `PUBLISH_LEVEL = PermissionLevel.ADMIN` and
+        `PUBLISH_READ_LEVEL = PermissionLevel.MEMBER` are named once, with the
+        rationale from spec Decision 2 in the module docstring.
+  - [ ] `_resolve_target` runs owner-scoped `get_bot` → `require_bot_role` →
+        service-type check **in that order**, and returns `BotFacts`. An async
+        façade runs it via `asyncio.to_thread`.
+  - [ ] `start_verify_release` implements the draft-resolution table in
+        `plan.md` §4 exactly, including the no-side-effect in-flight branch and
+        the 409 branch for `FAILED`/`UPGRADED`/`RELEASED`.
+  - [ ] The first release's name is derived from the bot's own name; no public
+        release-name field is introduced.
+  - [ ] `promote_release` calls `process` **only** from `VALIDATING`; already
+        promoted / already online return `started=False`; everything else
+        raises `ReleaseNotPromotableError`.
+  - [ ] Both writes return `ReleaseAdvance(record, started)` with the record
+        **re-read after** `process`.
+  - [ ] `_load_release` looks up by `(publish_bot_id, owner_id, version, env)`
+        **and** asserts `record.source_bot_pk == facts.bot_pk`, raising
+        `PublishNotFoundError` otherwise.
+  - [ ] `list_releases` and `list_release_operations` are keyed on `bot_pk` /
+        the proven record id respectively, page in the service, and return
+        `(total, items)`. The ledger sorts ascending by `(gmt_create, id)`.
+  - [ ] The in-service pagination choice is justified in the docstring rather
+        than left to be re-litigated.
+  - [ ] No HTTP type, no response-shaped dict, no `ext` read anywhere in the
+        module.
+- **Depends on:** Tasks 1, 2
+
+### Task 4: Service API protocol + DI  `[ ]`
+
+- **Files:** `api/release_lifecycle_service.py` (new),
+  `di/modules/service_bot_module.py`,
+  `tests/community/architecture/test_service_api_conformance.py`
+- **Done when:**
+  - [ ] `ReleaseLifecycleServiceProtocol` is `@runtime_checkable` with **real**
+        signatures, not `*args/**kwargs`.
+  - [ ] The `(Protocol, ReleaseLifecycleService)` pair is registered in the
+        conformance gate and the gate passes.
+  - [ ] The binding sits beside `_publish_flow_service_protocol`, singleton,
+        and resolves in the community composition root.
+- **Depends on:** Task 3
+
+---
+
+## Group B — Public surface
+
+### Task 5: Schemas and projections  `[ ]`
+
+- **Goal:** the published contract, and the mappings that make an unmapped
+  internal value a CI failure instead of a 500.
+- **Files:** `adapters/http/openapi_v1/publish/schemas.py` (new),
+  `adapters/http/openapi_v1/publish/__init__.py` (new)
+- **Done when:**
+  - [ ] `ReleaseState` carries the ten published values from `plan.md` §2 and a
+        `PublishStatus → ReleaseState` map that is exhaustive by construction.
+  - [ ] `ReleaseOperationKind` and `ReleaseOperationState` mirror their internal
+        enums value-for-value, both maps exhaustive.
+  - [ ] `Release` publishes exactly `version`, `state`, `message`, `bot_id`,
+        `name`, `description`, `created_at`, `updated_at`.
+  - [ ] `ReleaseOperation` publishes exactly `kind`, `stage`, `attempt`,
+        `state`, `operator`, `created_at`, `updated_at`.
+  - [ ] The projection functions never read `ext`, `params`, `result`,
+        `last_error`, `bot_uuid`, `baas_publish_id` or `request_id`.
+  - [ ] The `failed` message is the fixed `"Publish failed"`; the internal
+        `error_message` is never interpolated.
+  - [ ] The request body model for the two writes sets `extra="forbid"`.
+- **Depends on:** —
+
+### Task 6: The router  `[ ]`
+
+- **Files:** `adapters/http/openapi_v1/publish/router.py` (new),
+  `adapters/http/openapi_v1/__init__.py`
+- **Done when:**
+  - [ ] Five routes at the paths in `plan.md` §1, prefix `/bots/publish`.
+  - [ ] Every handler takes `PrincipalDep`, `UserIdDep`, `OwnerIdDep`
+        (imported from `engine_runtime/params.py`, not re-declared),
+        `request: Request`, and `@envelope_errors`.
+  - [ ] The two writes return 202 when `started`, 200 when not, using the same
+        mechanism `bots/router.py` uses for its 201/202 split.
+  - [ ] The lists use the shared `PageParamsDep` and `page(...)`.
+  - [ ] No domain branching in the router — it maps parameters in and
+        projections out, nothing else.
+  - [ ] The group is added to `_SUBGROUPS` in `openapi_v1/__init__.py` with
+        `USER_SCOPED_ERROR_RESPONSES`, above the bots router.
+- **Depends on:** Tasks 4, 5
+
+### Task 7: Error mapping  `[ ]`
+
+- **Files:** `adapters/http/openapi_v1/responses.py`
+- **Done when:**
+  - [ ] Every row of the `plan.md` §6 table is present, leaves before
+        `BotPublishServiceError`.
+  - [ ] **Both** `BotNotFoundError` classes are mapped (the `service_bot` one is
+        a different class from the `bot_management` one already in the table),
+        with byte-identical 404 messages.
+  - [ ] The four 409s get distinct business subcodes in `ERROR_SUBCODES`.
+  - [ ] No mapped message interpolates `str(exc)`.
+- **Depends on:** Task 2
+
+---
+
+## Group C — Tests
+
+### Task 8: Core service tests  `[ ]`
+
+- **Files:** `tests/community/core/service_bot/services/test_release_lifecycle_service.py` (new)
+- **Done when:**
+  - [ ] The draft-resolution table is covered row by row, including that the
+        in-flight branch performs **no** write.
+  - [ ] `_load_release` rejects a version whose `source_bot_pk` differs.
+  - [ ] The ledger read cannot return a row from another release.
+  - [ ] The read and write bar constants are asserted, so changing one is a
+        deliberate test edit.
+- **Depends on:** Task 3
+
+### Task 9: Endpoint, access, projection and isolation tests  `[ ]`
+
+- **Files:** `tests/community/adapters/http/openapi_v1/publish/` (new package:
+  `__init__.py`, `conftest.py`, `test_publish_endpoints.py`,
+  `test_release_state_machine.py`, `test_publish_access.py`,
+  `test_publish_projection.py`, `test_publish_tenant_isolation.py`)
+- **Done when:**
+  - [ ] All five handlers, success and every mapped error, including the
+        202/200 split and an `extra="forbid"` 422.
+  - [ ] Start and promote are exercised from **each** of the ten
+        `PublishStatus` values, plus both CAS-loser paths.
+  - [ ] The role matrix (owner / admin / member / stranger × writes and reads)
+        holds, and every refusal is byte-identical to a missing bot.
+  - [ ] The three enum maps are asserted exhaustive over their internal enums.
+  - [ ] The withheld field sets are asserted absent from both payloads.
+  - [ ] Cross-tenant and cross-bot lookups are masked 404s against the real
+        Track A guard.
+- **Depends on:** Tasks 6, 7
+
+### Task 10: Amend the surface-wide contract tests  `[ ]`
+
+- **Files:** `tests/community/adapters/http/openapi_v1/test_explicit_user_id.py`,
+  `…/test_path_convention.py`, `…/test_openapi_error_schema.py`
+- **Done when:**
+  - [ ] `test_explicit_user_id` expects 61 user-scoped operations and the same
+        4 exempt ones.
+  - [ ] `test_path_convention` passes with `publish` in the routed reserved
+        list and absent from the unrouted one (it asserts the two are
+        disjoint).
+  - [ ] `test_openapi_error_schema` passes: the group documents exactly the
+        user-scoped set, and no 501/504.
+- **Depends on:** Tasks 6, 11
+
+---
+
+## Group D — Documentation and gates
+
+### Task 11: Handoff documentation  `[ ]`
+
+- **Files:** `src/backend/docs/openapi-v1/README.md`,
+  `src/backend/docs/openapi-v1/README.zh-CN.md`
+- **Done when:**
+  - [ ] Track B status board gains a `publish` row.
+  - [ ] A new endpoint section carries the five-row table, the `PublishStatus →
+        ReleaseState` map, the ledger's published/withheld field sets, and the
+        two role bars with their reasoning.
+  - [ ] `publish` is added to the `<!-- reserved-component-names -->` fenced
+        list (routed, not unrouted).
+  - [ ] The deferred-items line pointing at #909 is struck.
+  - [ ] A dated changelog line is appended.
+  - [ ] The Chinese mirror carries every one of the above.
+- **Depends on:** Task 6
+
+### Task 12: Full gates and PR  `[ ]`
+
+- **Done when:**
+  - [ ] `tests/community/architecture/` green — run **after** every new
+        cross-module import is declared, not before.
+  - [ ] The internal publish suites pass **unmodified**:
+        `tests/community/adapters/http/service_bot/test_router_publish_coverage.py`,
+        `tests/community/core/service_bot/services/test_publish_flow_service.py`,
+        `tests/community/e2e/publish_boundary/`.
+  - [ ] The engine-runtime operator and stage suites pass **unmodified**.
+  - [ ] Full `tests/community` green; backend SAST/lint green.
+  - [ ] Draft PR opened, titled
+        `feat(backend): publish service-bot releases on the openapi v1 surface`,
+        with the `Problem` / `Solution` / `Validation` sections from
+        `.github/pull_request_template.md`, linking #909 and this spec
+        directory. State explicitly what could not be run locally and why.
+- **Depends on:** all


### PR DESCRIPTION
## Problem

With the access expansion (PR #904) the public `/openapi/v1` surface can create a service bot, drive its draft, and *watch* its verify and online runtimes — but it cannot make those runtimes exist. Every transition between stages is internal (`/api/service-bot/publish`), whose contract is not one we can hand to a partner. Issue #909.

Review of the first draft added a second problem, in scope by request: the internal lifecycle code itself. `ac_bot_publish.ext` is an untyped grab-bag conflating deployment topology, build artifacts, failure bookkeeping and other services' state; the BaaS workflow id lives in **four different homes** depending on which operation minted it (`ext.publish.{stage}`, `ext.restart.{stage}`, `ext.scale.publish_id`, and — properly, since #197 — `ac_publish_operation.baas_publish_id`); and the flow is ~8k lines under a 14-mixin service whose state machine exists nowhere as a declaration.

## Solution

SDD artifacts only — `spec.md`, `plan.md`, `tasks.md`, and a new **`design.md`**. No production code in this PR; implementation follows once the design is approved.

**The public category** (`spec.md`, four operations — the operation-ledger endpoint from the first draft is dropped; the ledger stays internal):

| Method | Path | Success |
|---|---|---|
| POST | `/openapi/v1/bots/publish/{bot_id}/releases` | `202` — **requires the newest release to be a draft** |
| GET | `/openapi/v1/bots/publish/{bot_id}/releases` | `Envelope[Page[Release]]` |
| GET | `…/releases/{version}` | `Envelope[Release]` |
| POST | `…/releases/{version}/promote` | `202` — **requires the release to be validating** |

Both writes are strict precondition advances: one legal source state each, everything else (early, late, repeat, race-loser) one fixed 409, with the read endpoint answering what the state actually is. Nothing is minted on the public path — creating a service bot already creates its first draft — and the consequence (re-publishing a live bot still needs the internal upgrade to mint the next draft) is recorded as a known limitation rather than discovered as a 409.

**The internal evolution** (`design.md`, requested in review — the public surface is built on an evolved core, not on the mixin pipeline as-is):

- `ReleaseFacts` — a typed model over the existing ext JSON, round-tripping every stored key byte-compatibly; `ReleaseStore` as the only reader/writer of ext, enforced by a new architecture test.
- The status machine as declared data (`RELEASE_MACHINE`); `process()` and the failure writes consult it, making "only two user-driven advance points" a property of data.
- The #197 ledger becomes the **single home** of BaaS workflow ids: the ext id-stash writes stop; readers go ledger-first with legacy-ext fallback.
- Mixin dissolution, hitchhiker state relocation, and any schema change are phased out explicitly (Phases 2–4, each with its own proof obligations); Phase 1 is sized to this change and kills the two headline problems.

Role bar: `ADMIN` (the platform's own *edit + publish* definition) for the writes, `MEMBER` (the #904 operator bar) for the reads. Releases addressed by per-bot `version`, never the global record id. Failed releases publish a fixed message, never `ext.error_message`.

## Validation

Documentation-only change. The design's claims were checked against the code they describe: the ext-key census across `core/service_bot`, the four workflow-id homes (including `restart_mixin.py:525-527`'s double ext comparison), `PublishFlowService.process`, the #197 ledger model and repository, `bot_service.create_bot`'s draft-minting branch, `core/engine_runtime/{gate,stage}.py`, and the `openapi_v1` shared primitives. The backend gates run on the implementation commits (Task 13).

## Compatibility and risk

No behaviour change in this PR. For the planned Phase 1: no DDL, no migration, stored JSON keys round-trip compatible, internal HTTP surface untouched; the stopped id-stash writes are rolling-deploy safe because the ledger has carried those ids authoritatively since #197 and both old and new readers consult it. Largest real risk is the ~11-call-site read migration, sequenced first and individually revertable.

## Spec

`src/backend/specs/2026-08-09-openapi-v1-publish-lifecycle/` — `spec.md`, `design.md`, `plan.md`, `tasks.md`. Open questions for review are at the end of `spec.md` (read bar; whether to close the known limitation now; the `publish` literal) and `design.md` §6 (Phase-1 blast radius; where `process()`'s refactor lands; the package name).

## Related issues

Addresses #909. Pairs with #904. Builds on the #197 idempotency ledger (`2026-07-15-publish-service-idempotency`).