### PR TITLE
fix: persist bolt id for caller chat bindings

### DIFF
--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -459,7 +459,7 @@ class ExpertChatInstanceService:
             device_id=bot_uuid,
             device_provider="baas",
             env=env,
-            device_props={},
+            device_props={"bolt_id": bot_id},
             status=DeviceBindingStatus.PENDING.value,
             apply_reason=f"caller_instance:{bot_id}",
             applied_by=user_id,

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -255,6 +255,8 @@ class TestCreateContainer:
         call_kwargs = binding_repo.insert_binding.call_args[1]
         assert call_kwargs["entity_id"] == OWNER_ID
         assert call_kwargs["device_id"] == BOT_UUID
+        assert call_kwargs["device_provider"] == "baas"
+        assert call_kwargs["device_props"] == {"bolt_id": BOT_ID}
 
     @pytest.mark.asyncio
     async def test_release_async_called_with_correct_params(self):


### PR DESCRIPTION
## Summary
- Persist `bolt_id` in caller expert-chat BaaS binding device_props
- Allow BaaS conn info builder to reverse-resolve the business bot and compute the correct engine type
- Add unit test coverage for the caller binding props

## Test
- `cd src/backend && uv run pytest tests/community/core/expert_chat/services/test_expert_chat_instance_service.py -q`