### PR TITLE
feat(harness): stream LLM calls to fit antchat's 90s gateway window

### DIFF
--- a/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
+++ b/src/backend/src/agentclaw/community/core/harness/diagnostics/tools/mcp_format.py
@@ -327,13 +327,15 @@ def _format_mcp_block(mcp: dict, *, include_guide: bool) -> str:
 # pre-batching prompt byte-for-byte. Batches run concurrently — llm.py's own
 # semaphore allows 10, so ``_BATCH_CONCURRENCY`` is the only limiter; 3 is
 # the safe default until antchat's rate limit is known (bump to 5 if clean).
-_BATCH_MAX_MCPS = 3
+_BATCH_MAX_MCPS = 5
 _BATCH_CHAR_BUDGET = 4000
 _BATCH_CONCURRENCY = 3
-# MCPs with more tools than this get a batch to themselves: a 3-large-MCP batch
-# (e.g. 27+19+19 tools) piles ~3k chars of signatures on top of the TOOLS.md
-# source and blows antchat's 90s window. Small MCPs still pack 3-per-batch.
-_LARGE_MCP_TOOL_THRESHOLD = 12
+# MCPs with more tools than this get a batch to themselves. With stream=True
+# (llm.py) antchat's ~90s output cap is gone (streaming budget ~1800s), so the
+# limiter is now first-token time: bigger batches → bigger input → slower TTFT,
+# and TTFT must stay under 90s. 5 MCPs/batch keeps TTFT comfortably under 90s
+# (measured ~46-80s); revisit up if a real bot shows TTFT headroom.
+_LARGE_MCP_TOOL_THRESHOLD = 20
 
 _BUCKET_ORDER = ("verified", "schema", "unreachable")
 _BUCKET_HEADERS = {

--- a/src/backend/src/agentclaw/community/core/harness/services/llm.py
+++ b/src/backend/src/agentclaw/community/core/harness/services/llm.py
@@ -8,6 +8,7 @@ patch — so there is no SpawnProcess ``AsyncClient.send`` hook to work around.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import random
 import time
@@ -346,19 +347,29 @@ class LLM:
     async def _do_request(self, body: dict[str, Any], headers: dict[str, str]) -> str:
         """Execute the HTTP request via the injected sync ``HttpClient``.
 
+        Uses ``stream=True`` to keep long outputs inside antchat's window: a
+        non-streaming call is capped at ~90s by the spanner gateway's read
+        timeout (``RemoteProtocolError`` mid-generation for any output that
+        takes longer), while streaming extends the budget to ~1800s as long as
+        the first token and inter-token gaps stay under 90s. SSE ``data:`` lines
+        are accumulated into the full content string; the external ``chat()``
+        contract (returns str) is unchanged.
+
         The client is synchronous (``httpx.Client``, which sofa_tracer does not
-        patch); run it off the event loop via ``asyncio.to_thread`` so the
-        (potentially long) call does not block. The ``general`` client has an
-        empty base_url, so we pass the full absolute URL."""
+        patch); the stream read runs off the event loop via ``asyncio.to_thread``."""
         url = f"{self._base_url}/v1/chat/completions"
+        stream_body = {**body, "stream": True}
         try:
-            resp = await asyncio.to_thread(
-                self._http.post,
-                url,
-                json=body,
-                headers=headers,
-                timeout=self._timeout_ms / 1000.0,
+            content = await asyncio.to_thread(
+                self._stream_read, url, stream_body, headers,
             )
+        except httpx.HTTPStatusError:
+            # raise_for_status() ran inside the stream context (unlike the old
+            # post path where it ran outside this try). Pass HTTPStatusError
+            # straight to the retry layer's status-based branch (4xx no-retry /
+            # 5xx retry) — do NOT route it through _exc_detail, which may touch
+            # ``.request`` on a wrapper-shaped error and mask the status code.
+            raise
         except Exception as e:
             # The send-hook wrapper raises an opaque exception whose real cause
             # (the underlying httpx transport error) is on __cause__/__context__.
@@ -369,11 +380,37 @@ class LLM:
                 url, body.get("max_tokens"), _exc_detail(e),
             )
             raise
-        resp.raise_for_status()
-        data = resp.json()
+        return content
 
-        choices = data.get("choices", [])
-        if choices:
-            return choices[0].get("message", {}).get("content", "")
+    def _stream_read(self, url: str, body: dict[str, Any], headers: dict[str, str]) -> str:
+        """Synchronous SSE stream reader (runs off the event loop via to_thread).
 
-        return ""
+        Reads ``data:`` lines from the streaming chat completion, accumulating
+        ``delta.content`` into the full text. ``[DONE]`` or end-of-stream stops
+        reading. Any transport error (gateway ``RemoteProtocolError`` on a
+        >90s gap, read timeout, etc.) propagates so the retry layer can shrink
+        ``max_tokens`` and retry.
+        """
+        chunks: list[str] = []
+        with self._http.stream(
+            "POST", url, json=body, headers=headers,
+            timeout=self._timeout_ms / 1000.0,
+        ) as resp:
+            resp.raise_for_status()
+            for line in resp.iter_lines():
+                if not line or not line.startswith("data:"):
+                    continue
+                payload = line[len("data:"):].strip()
+                if payload == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(payload)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                try:
+                    delta = obj["choices"][0]["delta"].get("content", "")
+                except (KeyError, IndexError, TypeError):
+                    continue
+                if delta:
+                    chunks.append(delta)
+        return "".join(chunks)

--- a/src/backend/src/agentclaw/community/plugin_api/http_client.py
+++ b/src/backend/src/agentclaw/community/plugin_api/http_client.py
@@ -36,7 +36,7 @@ Impls (Rule 20/21):
 """
 from __future__ import annotations
 
-from typing import Any, Mapping, Protocol, runtime_checkable
+from typing import Any, Iterator, Mapping, Protocol, runtime_checkable
 
 import httpx
 
@@ -104,6 +104,24 @@ class HttpClient(Plugin, Protocol):
         timeout: float = 30.0,
     ) -> httpx.Response:
         """Issue a DELETE to ``base_url + path`` and return the response."""
+        ...
+
+    def stream(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> Iterator[httpx.Response]:
+        """Issue a streaming request to ``base_url + path`` and yield a streaming
+        :class:`httpx.Response` for use inside a ``with`` block
+        (``resp.iter_lines()`` / ``raise_for_status()``). The wire shape matches a
+        direct ``httpx.Client.stream()`` call; transport errors and
+        ``raise_for_status`` propagate unchanged.
+        """
         ...
 
 

--- a/src/backend/src/agentclaw/community/plugins/http_client.py
+++ b/src/backend/src/agentclaw/community/plugins/http_client.py
@@ -14,7 +14,8 @@ so the wire shape matches a hand-written ``httpx`` call. Transport errors and
 """
 from __future__ import annotations
 
-from typing import Any, Mapping
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping
 
 import httpx
 
@@ -24,8 +25,9 @@ from agentclaw.community.plugin_api.http_client import HttpClient
 class HttpxClient(HttpClient):
     """Real ``httpx``-backed transport scoped to a single upstream ``base_url``."""
 
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, *, transport: Any | None = None):
         self._base_url = base_url
+        self._transport = transport
 
     def get(
         self,
@@ -107,5 +109,40 @@ class HttpxClient(HttpClient):
             kwargs["data"] = data
         if headers is not None:
             kwargs["headers"] = headers
-        with httpx.Client(base_url=self._base_url, timeout=timeout) as client:
+        client_kwargs = {"base_url": self._base_url, "timeout": timeout}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+        with httpx.Client(**client_kwargs) as client:
             return client.request(method, path, **kwargs)
+
+    @contextmanager
+    def stream(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> Iterator[httpx.Response]:
+        """Stream a request and yield a streaming ``httpx.Response`` for the
+        ``with`` block (``resp.iter_lines()`` / ``raise_for_status()``). Mirrors
+        ``post``'s short-lived-client pattern; transport errors and
+        ``raise_for_status`` propagate unchanged. The test-injected
+        ``transport`` (``httpx.MockTransport``) makes the streaming seam
+        conformance-testable without a real network.
+        """
+        kwargs: dict[str, Any] = {}
+        if params is not None:
+            kwargs["params"] = params
+        if json is not None:
+            kwargs["json"] = json
+        if headers is not None:
+            kwargs["headers"] = headers
+        client_kwargs = {"base_url": self._base_url, "timeout": timeout}
+        if self._transport is not None:
+            client_kwargs["transport"] = self._transport
+        with httpx.Client(**client_kwargs) as client:
+            with client.stream(method, path, **kwargs) as resp:
+                yield resp

--- a/src/backend/src/agentclaw/community/plugins/local/http_client.py
+++ b/src/backend/src/agentclaw/community/plugins/local/http_client.py
@@ -82,3 +82,15 @@ class LocalHttpClient(MockSeam, HttpClient):
         timeout: float = 30.0,
     ) -> httpx.Response:
         raise HttpNotConfiguredError("delete", self._base_url, path)
+
+    def stream(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> httpx.Response:
+        raise HttpNotConfiguredError("stream", self._base_url, path)

--- a/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
+++ b/src/backend/tests/community/core/harness/diagnostics/test_diagnostics.py
@@ -1198,7 +1198,7 @@ class TestToolsMcpFormatBatching:
     def test_pack_splits_on_count(self):
         items = [("schema", f"block-{i}", {"server_code": f"mcp.{i}"}) for i in range(7)]
         batches = _pack_mcp_batches(items)
-        assert [len(b) for b in batches] == [_BATCH_MAX_MCPS, _BATCH_MAX_MCPS, 1]
+        assert [len(b) for b in batches] == [_BATCH_MAX_MCPS, 2]
 
     def test_pack_splits_on_chars(self):
         big = "x" * (_BATCH_CHAR_BUDGET - 100)
@@ -1227,7 +1227,7 @@ class TestToolsMcpFormatBatching:
         # A many-tool MCP (tools > _LARGE_MCP_TOOL_THRESHOLD) gets its own
         # batch so that batch's output is one spec draft, not several —
         # keeps the call inside the 90s window for big MCPs.
-        big = {"server_code": "mcp.big", "tools": [{} for _ in range(15)]}
+        big = {"server_code": "mcp.big", "tools": [{} for _ in range(25)]}
         small_a = {"server_code": "mcp.a", "tools": [{} for _ in range(3)]}
         small_b = {"server_code": "mcp.b", "tools": [{} for _ in range(3)]}
         items = [
@@ -1277,7 +1277,7 @@ class TestToolsMcpFormatBatching:
     @pytest.mark.asyncio
     async def test_analyze_splits_into_batches_and_aggregates(self):
         diag = ToolsMcpFormatDiagnostic()
-        mcps = [{"server_code": f"mcp.{c}", "name": c} for c in "abcde"]
+        mcps = [{"server_code": f"mcp.{c}", "name": c} for c in "abcdefg"]
         ctx = _make_ctx({"TOOLS.md": "# Tools\n\n- some tools"}, activated_mcps=mcps)
         ctx.mcp_center = _MockMCPCenter({
             f"mcp.{c}": {
@@ -1288,7 +1288,7 @@ class TestToolsMcpFormatBatching:
                     "inputSchema": {"type": "object", "properties": {"p": {"type": "string"}}},
                 }],
             }
-            for c in "abcde"
+            for c in "abcdefg"
         })
 
         captured: list[str] = []
@@ -1302,10 +1302,11 @@ class TestToolsMcpFormatBatching:
         ctx.llm.chat = fake_chat
         findings = await diag.analyze(ctx)
 
-        assert len(captured) == 2  # 5 MCPs / _BATCH_MAX_MCPS per batch
+        # 7 MCPs / _BATCH_MAX_MCPS(5) -> 2 batches [a-e],[f-g]
+        assert len(captured) == 2
         assert "第 1/2 批" in captured[0] and "第 2/2 批" in captured[1]
-        assert "mcp.a" in captured[0] and "mcp.d" not in captured[0]
-        assert "mcp.e" in captured[1] and "mcp.a" not in captured[1]
+        assert "mcp.a" in captured[0] and "mcp.f" not in captured[0]
+        assert "mcp.g" in captured[1] and "mcp.a" not in captured[1]
         assert len(findings) == 1
         assert findings[0].score == 70
         assert findings[0].short_summary == "规范缺失"

--- a/src/backend/tests/community/core/harness/services/test_http_client_stream.py
+++ b/src/backend/tests/community/core/harness/services/test_http_client_stream.py
@@ -1,0 +1,87 @@
+"""Conformance tests for ``HttpClient.stream`` — the streaming seam llm.py uses.
+
+These exercise the REAL ``HttpxClient`` (via an injected ``httpx.MockTransport``,
+not a hand-rolled mock client) and ``LocalHttpClient``, covering both
+implementations of the ``HttpClient.stream`` contract (Rule 25). The
+``test_llm_chats_via_real_httpx_client_stream`` case pins the F1 regression:
+``LLM.chat()`` must drive a real ``HttpxClient.stream`` end-to-end, accumulating
+SSE ``delta.content`` — with no ``AttributeError`` on a missing method.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from agentclaw.community.core.harness.services.llm import LLM
+from agentclaw.community.plugins.http_client import HttpxClient
+from agentclaw.community.plugins.local.http_client import (
+    HttpNotConfiguredError,
+    LocalHttpClient,
+)
+
+
+def _sse_handler(content: str = "hello"):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = (
+            "data: " + json.dumps({"choices": [{"delta": {"content": content}}]}) + "\n"
+            "data: [DONE]\n"
+        )
+        return httpx.Response(200, content=body.encode("utf-8"))
+
+    return handler
+
+
+def test_httpx_client_stream_yields_streaming_response():
+    transport = httpx.MockTransport(_sse_handler("hello"))
+    client = HttpxClient("http://llm.local", transport=transport)
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={"model": "x"},
+        headers={"k": "v"},
+        timeout=5.0,
+    ) as resp:
+        assert resp.status_code == 200
+        resp.raise_for_status()
+        lines = [ln for ln in resp.iter_lines() if ln]
+    assert any('data: {"choices"' in ln for ln in lines)
+    assert any(ln.startswith("data: [DONE]") for ln in lines)
+
+
+def test_local_http_client_stream_raises():
+    client = LocalHttpClient("http://local.invalid")
+    with pytest.raises(HttpNotConfiguredError):
+        with client.stream("POST", "/v1/chat/completions", json={}, timeout=5.0):
+            pass
+
+
+class _Secret:
+    def __init__(self, value):
+        self.secret_value = value
+
+
+class _StubResolver:
+    def __init__(self, value):
+        self._value = value
+
+    def get_secret(self, name):
+        return _Secret(self._value)
+
+
+def test_llm_chats_via_real_httpx_client_stream():
+    """F1 regression: ``LLM.chat()`` drives a REAL ``HttpxClient.stream``
+    end-to-end (no ``AttributeError`` on a missing method), accumulating SSE
+    ``delta.content`` into the returned text."""
+    transport = httpx.MockTransport(_sse_handler("hello-from-real-client"))
+    http = HttpxClient("http://llm.local", transport=transport)
+    llm = LLM(
+        base_url="http://llm.local",
+        secret_name="k",
+        secret_resolver=_StubResolver("tok"),
+        http_client=http,
+    )
+    out = asyncio.run(llm.chat(system="s", user="u", max_tokens=8))
+    assert out == "hello-from-real-client"

--- a/src/backend/tests/community/core/harness/services/test_llm_helpers.py
+++ b/src/backend/tests/community/core/harness/services/test_llm_helpers.py
@@ -17,6 +17,7 @@ this file fills the remaining gaps:
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 
 import httpx
@@ -55,6 +56,23 @@ class _FakeResponse:
     def json(self):
         return self._payload
 
+    def iter_lines(self):
+        # llm._do_request streams; encode message.content as SSE delta + [DONE].
+        choices = self._payload.get("choices", [])
+        if choices:
+            content = choices[0].get("message", {}).get("content", "")
+            if content:
+                yield "data: " + json.dumps(
+                    {"choices": [{"delta": {"content": content}}]}, ensure_ascii=False
+                )
+        yield "data: [DONE]"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
 
 class _RecordingHttpClient:
     """Returns a canned OpenAI-shaped body and records each ``post()`` call."""
@@ -64,6 +82,14 @@ class _RecordingHttpClient:
         self.calls: list[dict] = []
 
     def post(self, path, *, json=None, headers=None, timeout=None, **kwargs):
+        self.calls.append(
+            {"url": path, "json": json, "headers": headers, "timeout": timeout}
+        )
+        return _FakeResponse(self._payload)
+
+    def stream(self, method, path, *, json=None, headers=None, timeout=None, **kwargs):
+        # llm._do_request now calls stream(); mirror post(), return a
+        # context-manager _FakeResponse.
         self.calls.append(
             {"url": path, "json": json, "headers": headers, "timeout": timeout}
         )

--- a/src/backend/tests/community/core/harness/services/test_llm_request_retry.py
+++ b/src/backend/tests/community/core/harness/services/test_llm_request_retry.py
@@ -18,6 +18,7 @@ caller's ``max_tokens`` into the posted request body.
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -59,6 +60,23 @@ class _FakeResponse:
     def json(self):
         return self._payload
 
+    def iter_lines(self):
+        # llm._do_request streams; encode message.content as SSE delta + [DONE].
+        choices = self._payload.get("choices", [])
+        if choices:
+            content = choices[0].get("message", {}).get("content", "")
+            if content:
+                yield "data: " + json.dumps(
+                    {"choices": [{"delta": {"content": content}}]}, ensure_ascii=False
+                )
+        yield "data: [DONE]"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
 
 class _ScriptedHttpClient:
     """Plays a scripted sequence of ``post()`` outcomes.
@@ -73,6 +91,15 @@ class _ScriptedHttpClient:
         self.calls: list[dict] = []
 
     def post(self, path, *, json=None, headers=None, timeout=None, **kwargs):
+        self.calls.append({"url": path, "json": json, "timeout": timeout})
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def stream(self, method, path, *, json=None, headers=None, timeout=None, **kwargs):
+        # llm._do_request now calls stream(); mirror post() and return the
+        # outcome as a context manager (_FakeResponse supports __enter__).
         self.calls.append({"url": path, "json": json, "timeout": timeout})
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, BaseException):

--- a/src/backend/tests/community/core/harness/test_llm_secret_resolver.py
+++ b/src/backend/tests/community/core/harness/test_llm_secret_resolver.py
@@ -10,6 +10,7 @@ once, at construction. When it does not resolve (``None``), ``chat()`` returns
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 
 import pytest
@@ -57,6 +58,23 @@ class _FakeResponse:
     def json(self):
         return self._payload
 
+    def iter_lines(self):
+        # llm._do_request streams; encode message.content as SSE delta + [DONE].
+        choices = self._payload.get("choices", [])
+        if choices:
+            content = choices[0].get("message", {}).get("content", "")
+            if content:
+                yield "data: " + json.dumps(
+                    {"choices": [{"delta": {"content": content}}]}, ensure_ascii=False
+                )
+        yield "data: [DONE]"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
 
 class _RecordingHttpClient:
     """Minimal ``HttpClient`` double: records ``post()`` calls and returns a
@@ -67,6 +85,14 @@ class _RecordingHttpClient:
         self.calls: list[dict] = []
 
     def post(self, path, *, json=None, headers=None, timeout=None, **kwargs):
+        self.calls.append(
+            {"url": path, "json": json, "headers": headers, "timeout": timeout}
+        )
+        return _FakeResponse({"choices": [{"message": {"content": self._content}}]})
+
+    def stream(self, method, path, *, json=None, headers=None, timeout=None, **kwargs):
+        # llm._do_request now calls stream(); mirror post(), return a
+        # context-manager _FakeResponse.
         self.calls.append(
             {"url": path, "json": json, "headers": headers, "timeout": timeout}
         )


### PR DESCRIPTION
## Problem

  antchat's gateway caps non-streaming LLM calls at ~90s, aborting long outputs mid-generation — the root cause of D-TOOLS-002 batch failures and patch timeouts on MCP-heavy bots.
  Streaming extends the budget to ~1800s (first-token / inter-token gaps still <90s). The fix landed on REL (#891); dev was rebased onto REL0806 and never got it.

  ## Solution

  Cherry-pick #891 (`9fdb8a35`) onto fresh `origin/dev`: 10 files, +306/−33.
  - `HttpClient` protocol + `HttpxClient`/`LocalHttpClient`: add `stream()`.
  - `llm.py`: POST `stream=True`, accumulate SSE via `_stream_read`; `chat()` contract unchanged.
  - `mcp_format`: batch 5 MCPs/call, large-MCP threshold 20.

  ## Validation

  - Pre-push lint gate: passed.
  - 42 streaming tests + 62 diagnostics tests passed.
  - Singlebox coverage not run locally (no BCS rust toolchain); CI to verify.

  ## Compatibility and risk

  `HttpClient` gains `stream()`; `LLM.chat()` unchanged. Revert to restore non-streaming + prior constants.

