### PR TITLE
fix: resolve chat engine from bot metadata

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -280,6 +280,11 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         token = (ctx.template_config or {}).get("token")
         return token if isinstance(token, str) and token else None
 
+    def uses_adapter_chat_session_lifecycle(self, ctx: BotProvisioningContext) -> bool:
+        # AICoding / claude_code chat sessions are created lazily by the relay,
+        # so ExpertChat must not call Adapter /api/sessions create/check/delete.
+        return False
+
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         # Application-only hooks (DIMA workspace/memory/cron) intentionally stay
         # out of the personalCoding path.  Existing call sites can be migrated

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -34,6 +34,9 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     def extract_runtime_token(self, ctx: BotProvisioningContext) -> str | None:
         return None
 
+    def uses_adapter_chat_session_lifecycle(self, ctx: BotProvisioningContext) -> bool:
+        return True
+
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         return None
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -81,6 +81,16 @@ class EngineProvisioningStrategy(ABC):
         """Return the token value that should be forwarded to container init."""
 
     @abstractmethod
+    def uses_adapter_chat_session_lifecycle(self, ctx: BotProvisioningContext) -> bool:
+        """Whether ExpertChat should manage chat sessions through Adapter APIs.
+
+        ``True`` preserves the legacy OpenClaw adapter lifecycle: create, pre-check,
+        and delete call ``/api/sessions`` on the device adapter. Engines that create
+        sessions lazily through their relay/runtime should return ``False`` so
+        ExpertChat only keeps its local session key.
+        """
+
+    @abstractmethod
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         """Post-create hook. Default strategies should no-op."""
 

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -42,6 +42,10 @@ from agentclaw.community.core.repository.protocols.chat import ExpertChatReposit
 from agentclaw.community.core.expert_chat.services.expert_chat_instance_service import (
     ExpertChatInstanceService,
 )
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_baas_engine_bucket,
+    resolve_provisioning,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import DeviceAdapterTransport
 
@@ -593,29 +597,41 @@ class ExpertChatService:
         )
 
     def _resolve_chat_engine_type(self, bot: Dict[str, Any], conn: Dict[str, Any]) -> str:
-        """Resolve effective chat engine from business bot metadata.
+        """Resolve effective chat engine from authoritative bot metadata.
 
         ``conn["engine_type"]`` may be a resolver fallback when a historical
         runtime binding cannot reverse-resolve the business bot, for example
         caller-instance BaaS bindings created before ``device_props.bolt_id`` was
-        persisted. ExpertChat already has the authoritative bot row, so use it
-        as the final source and apply the same template normalization as BaaS
-        conn_info building.
+        persisted. ExpertChat already has the authoritative bot row, so prefer it
+        and apply the public BaaS bucket normalization used by runtime routing.
         """
-        from agentclaw.community.core.devices.services.baas_template_resolver import (
-            SystemConfigBaasTemplateResolver,
-        )
-
         template_config = bot.get("template_config") or {}
+        if not isinstance(template_config, dict):
+            template_config = {}
         raw_engine_type = (
             bot.get("active_engine")
             or template_config.get("active_runtime_engine_type")
             or conn.get("engine_type")
             or "openclaw"
         )
-        return SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+        return resolve_baas_engine_bucket(
             engine_type=raw_engine_type,
             template_type=bot.get("template_type") or "",
+        )
+
+    def _resolve_chat_engine_strategy(self, bot: Dict[str, Any], conn: Dict[str, Any]):
+        """Resolve normalized chat engine plus its registered strategy."""
+        engine_type = self._resolve_chat_engine_type(bot, conn)
+        template_config = bot.get("template_config")
+        if not isinstance(template_config, dict):
+            template_config = None
+        return resolve_provisioning(
+            bot_id=str(bot.get("bot_id") or ""),
+            owner_id=str(bot.get("owner_id") or ""),
+            bot_type=str(bot.get("bot_type") or ""),
+            active_engine=engine_type,
+            template_type=bot.get("template_type") or None,
+            template_config=template_config,
         )
 
     async def _create_session(self, bot: Dict[str, Any], user_id: str) -> str:
@@ -629,15 +645,13 @@ class ExpertChatService:
             session_key
         """
         conn = self._get_connection(bot, user_id)
-        engine_type = self._resolve_chat_engine_type(bot, conn)
-        conn["engine_type"] = engine_type
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
 
-        if engine_type == "aicoding":
-            return await self._create_aicoding_session(conn, bot, user_id)
-        elif engine_type == "claude_code":
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
             logger.info(
-                "[ExpertChatService] claude_code session: delegating to aicoding session for bot=%s, user=%s",
-                bot.get("bot_id"), user_id,
+                "[ExpertChatService] Relay-managed chat session: bot=%s, user=%s, engine=%s",
+                bot.get("bot_id"), user_id, ctx.active_engine,
             )
             return await self._create_aicoding_session(conn, bot, user_id)
 
@@ -762,17 +776,13 @@ class ExpertChatService:
         AI Coding 引擎：teamclaw-aicoding-relay 按需创建 session，始终返回 True。
         """
         conn = self._get_connection(bot, user_id)
-        engine_type = self._resolve_chat_engine_type(bot, conn)
-        conn["engine_type"] = engine_type
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
 
-        # AI Coding 引擎：session 由 teamclaw-aicoding-relay 按需创建，无需预检
-        if engine_type == "aicoding":
-            return True
-        # claude_code 引擎：session 按需创建，无需预检
-        if engine_type == "claude_code":
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
             logger.info(
-                "[ExpertChatService] claude_code session check: skipping adapter pre-check for session=%s",
-                session_key,
+                "[ExpertChatService] Relay-managed chat session check: skipping adapter pre-check for session=%s, engine=%s",
+                session_key, ctx.active_engine,
             )
             return True
 
@@ -799,32 +809,24 @@ class ExpertChatService:
         user_id: Optional[str] = None,
     ) -> None:
         """调用 Adapter 删除 session"""
-        # aicoding/claude_code sessions are created on demand by the relay;
-        # no Adapter /api/sessions deletion is required. Resolve from bot first
-        # so historical caller-instance bindings with conn_engine=openclaw do not
-        # accidentally call the OpenClaw adapter endpoint.
-        bot_engine_type = self._resolve_chat_engine_type(bot, {})
-        if bot_engine_type == "aicoding":
-            logger.info(f"[ExpertChatService] Skipping adapter session deletion for aicoding: {session_key}")
-            return
-        if bot_engine_type == "claude_code":
+        # Relay-managed sessions do not require Adapter deletion. Resolve from bot
+        # first so historical caller-instance bindings with conn_engine=openclaw do
+        # not accidentally call the OpenClaw adapter endpoint.
+        bot_ctx, bot_strategy = self._resolve_chat_engine_strategy(bot, {})
+        if not bot_strategy.uses_adapter_chat_session_lifecycle(bot_ctx):
             logger.info(
-                "[ExpertChatService] Skipping adapter session deletion for claude_code: bot=%s, session=%s",
-                bot.get("bot_id"), session_key,
+                "[ExpertChatService] Skipping adapter session deletion for relay-managed engine: bot=%s, session=%s, engine=%s",
+                bot.get("bot_id"), session_key, bot_ctx.active_engine,
             )
             return
 
         conn = self._get_connection(bot, user_id)
-        engine_type = self._resolve_chat_engine_type(bot, conn)
-        conn["engine_type"] = engine_type
-        if engine_type == "aicoding":
-            logger.info(f"[ExpertChatService] Skipping adapter session deletion for aicoding: {session_key}")
-            return
-        if engine_type == "claude_code":
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
             logger.info(
-                "[ExpertChatService] Skipping adapter session deletion for claude_code: bot=%s, session=%s",
-                bot.get("bot_id"),
-                session_key,
+                "[ExpertChatService] Skipping adapter session deletion for relay-managed engine: bot=%s, session=%s, engine=%s",
+                bot.get("bot_id"), session_key, ctx.active_engine,
             )
             return
 

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -507,10 +507,24 @@ class ExpertChatService:
 
         conn = ctx.conn_info
 
+        logger.info(
+            "[ExpertChatService] Resolved device context: bot=%s binding_id=%s "
+            "provider=%s conn_engine=%s active_engine=%s template_type=%s "
+            "runtime_engine=%s",
+            bot_id,
+            binding_id,
+            ctx.provider,
+            conn.get("engine_type"),
+            bot.get("active_engine"),
+            bot.get("template_type"),
+            (bot.get("template_config") or {}).get("active_runtime_engine_type"),
+        )
+
         if conn.get("use_proxy"):
             logger.info(
-                "[ExpertChatService] Got ARCA proxy connection: bot=%s, sandbox_id=%s",
+                "[ExpertChatService] Got proxy connection: bot=%s, provider=%s, sandbox_id=%s",
                 bot_id,
+                ctx.provider,
                 conn.get("sandbox_id"),
             )
         else:
@@ -578,6 +592,32 @@ class ExpertChatService:
             f"User {user_id} has no chat access to bot {bot_id}"
         )
 
+    def _resolve_chat_engine_type(self, bot: Dict[str, Any], conn: Dict[str, Any]) -> str:
+        """Resolve effective chat engine from business bot metadata.
+
+        ``conn["engine_type"]`` may be a resolver fallback when a historical
+        runtime binding cannot reverse-resolve the business bot, for example
+        caller-instance BaaS bindings created before ``device_props.bolt_id`` was
+        persisted. ExpertChat already has the authoritative bot row, so use it
+        as the final source and apply the same template normalization as BaaS
+        conn_info building.
+        """
+        from agentclaw.community.core.devices.services.baas_template_resolver import (
+            SystemConfigBaasTemplateResolver,
+        )
+
+        template_config = bot.get("template_config") or {}
+        raw_engine_type = (
+            bot.get("active_engine")
+            or template_config.get("active_runtime_engine_type")
+            or conn.get("engine_type")
+            or "openclaw"
+        )
+        return SystemConfigBaasTemplateResolver.normalize_engine_for_template(
+            engine_type=raw_engine_type,
+            template_type=bot.get("template_type") or "",
+        )
+
     async def _create_session(self, bot: Dict[str, Any], user_id: str) -> str:
         """调用 Adapter 创建 session
 
@@ -589,7 +629,8 @@ class ExpertChatService:
             session_key
         """
         conn = self._get_connection(bot, user_id)
-        engine_type = conn.get("engine_type", "openclaw")
+        engine_type = self._resolve_chat_engine_type(bot, conn)
+        conn["engine_type"] = engine_type
 
         if engine_type == "aicoding":
             return await self._create_aicoding_session(conn, bot, user_id)
@@ -721,12 +762,14 @@ class ExpertChatService:
         AI Coding 引擎：teamclaw-aicoding-relay 按需创建 session，始终返回 True。
         """
         conn = self._get_connection(bot, user_id)
+        engine_type = self._resolve_chat_engine_type(bot, conn)
+        conn["engine_type"] = engine_type
 
         # AI Coding 引擎：session 由 teamclaw-aicoding-relay 按需创建，无需预检
-        if conn.get("engine_type") == "aicoding":
+        if engine_type == "aicoding":
             return True
         # claude_code 引擎：session 按需创建，无需预检
-        if conn.get("engine_type") == "claude_code":
+        if engine_type == "claude_code":
             logger.info(
                 "[ExpertChatService] claude_code session check: skipping adapter pre-check for session=%s",
                 session_key,
@@ -756,12 +799,15 @@ class ExpertChatService:
         user_id: Optional[str] = None,
     ) -> None:
         """调用 Adapter 删除 session"""
-        # aicoding session 由 teamclaw-aicoding-relay 按需创建，Adapter 无 /api/sessions 端点，无需删除
-        if bot.get("engine_type") == "aicoding":
+        # aicoding/claude_code sessions are created on demand by the relay;
+        # no Adapter /api/sessions deletion is required. Resolve from bot first
+        # so historical caller-instance bindings with conn_engine=openclaw do not
+        # accidentally call the OpenClaw adapter endpoint.
+        bot_engine_type = self._resolve_chat_engine_type(bot, {})
+        if bot_engine_type == "aicoding":
             logger.info(f"[ExpertChatService] Skipping adapter session deletion for aicoding: {session_key}")
             return
-        # claude_code session 同理，按需创建，无需删除
-        if bot.get("engine_type") == "claude_code":
+        if bot_engine_type == "claude_code":
             logger.info(
                 "[ExpertChatService] Skipping adapter session deletion for claude_code: bot=%s, session=%s",
                 bot.get("bot_id"), session_key,
@@ -769,10 +815,12 @@ class ExpertChatService:
             return
 
         conn = self._get_connection(bot, user_id)
-        if conn.get("engine_type") == "aicoding":
+        engine_type = self._resolve_chat_engine_type(bot, conn)
+        conn["engine_type"] = engine_type
+        if engine_type == "aicoding":
             logger.info(f"[ExpertChatService] Skipping adapter session deletion for aicoding: {session_key}")
             return
-        if conn.get("engine_type") == "claude_code":
+        if engine_type == "claude_code":
             logger.info(
                 "[ExpertChatService] Skipping adapter session deletion for claude_code: bot=%s, session=%s",
                 bot.get("bot_id"),

--- a/src/backend/tests/community/architecture/test_expert_chat_engine_branching.py
+++ b/src/backend/tests/community/architecture/test_expert_chat_engine_branching.py
@@ -1,0 +1,64 @@
+"""Architecture guard — ExpertChat does not branch on concrete engine strings.
+
+ExpertChat may normalize an engine identity for routing/logging, but engine-specific
+chat-session behavior must be declared by the registered engine strategy. This keeps
+new relay-managed engines from adding new ``if engine_type == "..."`` branches in
+the core chat service.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_EXPERT_CHAT_ROOT = (
+    _BACKEND_ROOT / "src" / "agentclaw" / "community" / "core" / "expert_chat"
+)
+_ENGINE_LITERALS = frozenset({"aicoding", "claude_code", "openclaw"})
+
+
+def _is_engine_literal(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value in _ENGINE_LITERALS
+
+
+def _iter_source_files():
+    for path in _EXPERT_CHAT_ROOT.rglob("*.py"):
+        if "__pycache__" not in path.parts:
+            yield path
+
+
+class _EngineStringBranchVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.violations: list[tuple[int, str]] = []
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        has_engine_literal = _is_engine_literal(node.left) or any(
+            _is_engine_literal(comparator) for comparator in node.comparators
+        )
+        has_equality_op = any(isinstance(op, (ast.Eq, ast.NotEq)) for op in node.ops)
+        if has_engine_literal and has_equality_op:
+            self.violations.append((node.lineno, "compares against a concrete engine string"))
+        self.generic_visit(node)
+
+
+def test_expert_chat_does_not_branch_on_engine_strings() -> None:
+    failures: list[str] = []
+    for path in _iter_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, OSError):
+            continue
+        visitor = _EngineStringBranchVisitor()
+        visitor.visit(tree)
+        for lineno, what in visitor.violations:
+            rel = path.relative_to(_BACKEND_ROOT)
+            failures.append(f"{rel}:{lineno} — {what}")
+
+    if failures:
+        pytest.fail(
+            "ExpertChat must ask engine strategies for chat-session behavior "
+            "instead of branching on concrete engine strings:\n  "
+            + "\n  ".join(failures)
+        )

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -9,6 +9,9 @@ from agentclaw.community.core.bot_management.engines import (
 from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AicodingProvisioningStrategy,
 )
+from agentclaw.community.core.bot_management.engines.default import (
+    DefaultProvisioningStrategy,
+)
 from agentclaw.community.core.bot_management.engines.registry import (
     get_engine_provisioning_registry,
 )
@@ -56,6 +59,48 @@ def test_resolve_baas_engine_bucket_keeps_normal_cc_on_claude_code():
         == "claude_code"
     )
 
+
+
+def test_default_strategy_uses_adapter_chat_session_lifecycle():
+    strategy = DefaultProvisioningStrategy("openclaw")
+    ctx = BotProvisioningContext(
+        active_engine="openclaw",
+        template_type=None,
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="service",
+        template_config=None,
+    )
+
+    assert strategy.uses_adapter_chat_session_lifecycle(ctx) is True
+
+
+def test_aicoding_strategy_skips_adapter_chat_session_lifecycle():
+    strategy = AicodingProvisioningStrategy("aicoding")
+    ctx = BotProvisioningContext(
+        active_engine="aicoding",
+        template_type="personalCoding",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="personal",
+        template_config={"template_key": "personalCoding", "template_uid": "uid"},
+    )
+
+    assert strategy.uses_adapter_chat_session_lifecycle(ctx) is False
+
+
+def test_claude_code_strategy_skips_adapter_chat_session_lifecycle():
+    strategy = AicodingProvisioningStrategy("claude_code")
+    ctx = BotProvisioningContext(
+        active_engine="claude_code",
+        template_type="normalCC",
+        bot_id="b1",
+        owner_id="u1",
+        bot_type="personal",
+        template_config={"template_key": "normalCC", "template_uid": "uid"},
+    )
+
+    assert strategy.uses_adapter_chat_session_lifecycle(ctx) is False
 
 def test_aicoding_strategy_personal_coding_model_runtime_and_token():
     strategy = AicodingProvisioningStrategy("aicoding")

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
@@ -1422,3 +1422,91 @@ class TestGetChatSessionCallerAuthorization:
         mock_instance.get_caller_connection.assert_called_once_with(
             user_id="user1", bot_id="bot1", owner_id="owner1", iam_token=None
         )
+
+
+class TestChatEngineResolution:
+
+    @pytest.mark.asyncio
+    async def test_create_session_uses_bot_template_engine_when_conn_falls_back_openclaw(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        conn = dict(DEVICE_CONN, engine_type="openclaw")
+        resolver = MagicMock()
+        ctx = MagicMock()
+        ctx.conn_info = conn
+        ctx.provider = "baas"
+        resolver.resolve_for_binding = MagicMock(return_value=ctx)
+        transport = MagicMock()
+        transport.invoke = AsyncMock()
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_resolver=resolver,
+            mock_transport=transport,
+        )
+        bot = dict(
+            ACTIVE_BOT,
+            active_engine="claude_code",
+            template_type="architect",
+            template_config={"active_runtime_engine_type": "aicoding"},
+        )
+
+        session_key = await svc._create_session(bot, "owner1")
+
+        assert session_key.startswith("session:")
+        assert conn["engine_type"] == "aicoding"
+        transport.invoke.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_check_session_exists_skips_adapter_when_bot_template_maps_to_aicoding(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        conn = dict(DEVICE_CONN, engine_type="openclaw")
+        resolver = MagicMock()
+        ctx = MagicMock()
+        ctx.conn_info = conn
+        ctx.provider = "baas"
+        resolver.resolve_for_binding = MagicMock(return_value=ctx)
+        transport = MagicMock()
+        transport.invoke = AsyncMock()
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_resolver=resolver,
+            mock_transport=transport,
+        )
+        bot = dict(
+            ACTIVE_BOT,
+            active_engine="claude_code",
+            template_type="architect",
+            template_config={"active_runtime_engine_type": "aicoding"},
+        )
+
+        assert await svc._check_session_exists(bot, "session:old", "owner1") is True
+        assert conn["engine_type"] == "aicoding"
+        transport.invoke.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_session_skips_adapter_when_bot_template_maps_to_aicoding(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock()
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+        bot = dict(
+            ACTIVE_BOT,
+            active_engine="claude_code",
+            template_type="architect",
+            template_config={"active_runtime_engine_type": "aicoding"},
+        )
+
+        await svc._delete_adapter_session(bot, "session:old", "owner1")
+
+        transport.invoke.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Resolve ExpertChat session engine from authoritative bot metadata before falling back to connection metadata
- Apply the same BaaS template normalization for create/check/delete session flows
- Prevent historical caller-instance bindings with missing `device_props.bolt_id` from being treated as OpenClaw

## Test
- `cd src/backend && uv run pytest tests/community/core/expert_chat/services/test_expert_chat_service.py -q`