### PR TITLE
feat: append auto initiate session links

### DIFF
--- a/src/backend/src/agentclaw/community/core/cron/protocols.py
+++ b/src/backend/src/agentclaw/community/core/cron/protocols.py
@@ -57,6 +57,21 @@ class BotInfoProvider(Protocol):
         """
         ...
 
+
+@runtime_checkable
+class AssistantSessionEndpointProvider(Protocol):
+    """Protocol for the selected assistant session deep-link endpoint.
+
+    Implementations are bound by DI/config loading so cron core logic does not
+    branch on process environment or read env vars directly.
+    """
+
+    @property
+    def base_url(self) -> str:
+        """Selected assistant deep-link base URL for this deployment."""
+        ...
+
+
 @runtime_checkable
 class DeviceConnectionProvider(Protocol):
     """Protocol for device connection provider.

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -14,6 +14,7 @@ Architecture compliance:
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Optional
 
 from injector import inject
@@ -55,6 +56,9 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 _CRON_UNSUPPORTED_ENGINES = frozenset({"hermes"})
+_ASSISTANT_SESSION_URL_BASE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE"
+_ASSISTANT_SESSION_URL_BASE_PRE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE_PRE"
+_ASSISTANT_SESSION_URL_BASE_DEFAULT = "https://teamclaw.example.com/assistant"
 
 
 class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
@@ -397,8 +401,8 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         task_id = auto_initiate_job.get("id") or auto_initiate_job.get("task_id")
         logger.info(f"[find_auto_initiate_and_run] Found autoInitiate job {task_id} for bot {bot_id}")
 
-        # 5. 复用 forward_request 触发执行
-        return await self.forward_request(
+        # 5. 复用 forward_request 触发执行，并为创建出的每个会话补充可点击链接
+        result = await self.forward_request(
             bot_id=bot_id,
             user_id=user_id,
             nick_name=nick_name,
@@ -406,6 +410,10 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             path=f"/api/cron/{task_id}/run",
             params={"force": force},
         )
+        self._append_auto_initiate_session_links_to_message(
+            result.get("data"), str(bot.get("bot_id") or bot_id)
+        )
+        return result
 
     async def run_single_auto_initiate(
         self,
@@ -479,7 +487,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         if model:
             body["model"] = model
 
-        return await self.forward_request(
+        result = await self.forward_request(
             bot_id=bot_id,
             user_id=user_id,
             nick_name=nick_name,
@@ -487,6 +495,84 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             path="/api/cron/auto-initiate/run-single",
             body=body,
         )
+        self._append_auto_initiate_session_links_to_message(
+            result.get("data"), str(body["agent_id"])
+        )
+        return result
+
+    @staticmethod
+    def _assistant_session_url(bot_id: str, session_id: str) -> str:
+        """Build the TeamClaw assistant deep link for a bot session."""
+        if get_current_env() == "pre":
+            base_url = os.getenv(_ASSISTANT_SESSION_URL_BASE_PRE_ENV) or os.getenv(
+                _ASSISTANT_SESSION_URL_BASE_ENV,
+                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
+            )
+        else:
+            base_url = os.getenv(
+                _ASSISTANT_SESSION_URL_BASE_ENV,
+                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
+            )
+        return f"{base_url}?botId={bot_id}&sessionId={session_id}"
+
+    @classmethod
+    def _append_auto_initiate_session_links_to_message(
+        cls,
+        payload: Any,
+        bot_id: str,
+    ) -> None:
+        """Append created session links to the top-level message only.
+
+        The public response should keep the engine summary fields but should not
+        expose the verbose ``sessions`` list; links are presented in ``message``.
+        """
+        if not isinstance(payload, dict):
+            return
+
+        session_urls = cls._collect_auto_initiate_session_links(payload, bot_id)
+        payload.pop("sessions", None)
+        if not session_urls:
+            return
+
+        message = payload.get("message")
+        message_prefix = message if isinstance(message, str) and message else ""
+        links_message = "会话链接：\n" + "\n".join(
+            f"- {url}" for url in session_urls
+        )
+        payload["message"] = (
+            f"{message_prefix}\n\n{links_message}"
+            if message_prefix
+            else links_message
+        )
+
+    @classmethod
+    def _collect_auto_initiate_session_links(
+        cls,
+        payload: Any,
+        bot_id: str,
+    ) -> list[str]:
+        """Return assistant links for every session-like dict in the payload."""
+        session_urls: list[str] = []
+        if isinstance(payload, list):
+            for item in payload:
+                session_urls.extend(
+                    cls._collect_auto_initiate_session_links(item, bot_id)
+                )
+            return session_urls
+
+        if not isinstance(payload, dict):
+            return session_urls
+
+        session_id = payload.get("session_id") or payload.get("sessionId")
+        if isinstance(session_id, str) and session_id:
+            session_urls.append(cls._assistant_session_url(bot_id, session_id))
+
+        for value in payload.values():
+            if isinstance(value, (dict, list)):
+                session_urls.extend(
+                    cls._collect_auto_initiate_session_links(value, bot_id)
+                )
+        return session_urls
 
     async def _fetch_bot_crons(
         self,

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -14,7 +14,6 @@ Architecture compliance:
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any, Optional
 
 from injector import inject
@@ -27,6 +26,7 @@ from agentclaw.community.core.cron.protocols import (
     BotInfoProvider,
     DeviceConnectionProvider,
     DeviceBindingStatus,
+    AssistantSessionEndpointProvider,
 )
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
@@ -56,9 +56,6 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 _CRON_UNSUPPORTED_ENGINES = frozenset({"hermes"})
-_ASSISTANT_SESSION_URL_BASE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE"
-_ASSISTANT_SESSION_URL_BASE_PRE_ENV = "TEAMCLAW_ASSISTANT_URL_BASE_PRE"
-_ASSISTANT_SESSION_URL_BASE_DEFAULT = "https://teamclaw.example.com/assistant"
 
 
 class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
@@ -73,6 +70,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         resolver: DeviceContextResolver,
         template_repo: TemplateRepository,
         publish_repo: BotPublishRepositoryProtocol,
+        assistant_session_endpoint: AssistantSessionEndpointProvider,
     ):
         """Initialise.
 
@@ -95,6 +93,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         self._resolver = resolver
         self._template_repo = template_repo
         self._publish_repo = publish_repo
+        self._assistant_session_endpoint = assistant_session_endpoint
         # Cron 批量查询共用限流器，控制同步设备连接准备占用的线程数。
         self._runtime_query_prepare_semaphore = asyncio.Semaphore(
             RUNTIME_QUERY_PREPARE_CONCURRENCY
@@ -500,24 +499,13 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         )
         return result
 
-    @staticmethod
-    def _assistant_session_url(bot_id: str, session_id: str) -> str:
+    def _assistant_session_url(self, bot_id: str, session_id: str) -> str:
         """Build the TeamClaw assistant deep link for a bot session."""
-        if get_current_env() == "pre":
-            base_url = os.getenv(_ASSISTANT_SESSION_URL_BASE_PRE_ENV) or os.getenv(
-                _ASSISTANT_SESSION_URL_BASE_ENV,
-                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
-            )
-        else:
-            base_url = os.getenv(
-                _ASSISTANT_SESSION_URL_BASE_ENV,
-                _ASSISTANT_SESSION_URL_BASE_DEFAULT,
-            )
+        base_url = self._assistant_session_endpoint.base_url
         return f"{base_url}?botId={bot_id}&sessionId={session_id}"
 
-    @classmethod
     def _append_auto_initiate_session_links_to_message(
-        cls,
+        self,
         payload: Any,
         bot_id: str,
     ) -> None:
@@ -529,7 +517,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         if not isinstance(payload, dict):
             return
 
-        session_urls = cls._collect_auto_initiate_session_links(payload, bot_id)
+        session_urls = self._collect_auto_initiate_session_links(payload, bot_id)
         payload.pop("sessions", None)
         if not session_urls:
             return
@@ -545,9 +533,8 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
             else links_message
         )
 
-    @classmethod
     def _collect_auto_initiate_session_links(
-        cls,
+        self,
         payload: Any,
         bot_id: str,
     ) -> list[str]:
@@ -556,7 +543,7 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         if isinstance(payload, list):
             for item in payload:
                 session_urls.extend(
-                    cls._collect_auto_initiate_session_links(item, bot_id)
+                    self._collect_auto_initiate_session_links(item, bot_id)
                 )
             return session_urls
 
@@ -565,12 +552,12 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
 
         session_id = payload.get("session_id") or payload.get("sessionId")
         if isinstance(session_id, str) and session_id:
-            session_urls.append(cls._assistant_session_url(bot_id, session_id))
+            session_urls.append(self._assistant_session_url(bot_id, session_id))
 
         for value in payload.values():
             if isinstance(value, (dict, list)):
                 session_urls.extend(
-                    cls._collect_auto_initiate_session_links(value, bot_id)
+                    self._collect_auto_initiate_session_links(value, bot_id)
                 )
         return session_urls
 

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -120,6 +120,19 @@ class GatewayEndpoint:
 
 
 @dataclass(frozen=True)
+class AssistantSessionEndpoint:
+    """The TeamClaw assistant deep-link origin selected for this env.
+
+    :class:`AssistantSessionEndpoint` keeps the env choice in the
+    composition root so core services only format the final URL. The
+    base itself is neutral configuration; the provider resolves the
+    ``pre``/``prod`` selection once at boot.
+    """
+
+    base_url: str = "https://teamclaw.example.com/assistant"
+
+
+@dataclass(frozen=True)
 class KbConfig:
     """Internal knowledge-base config for the D-TOOLS-002 diagnostic (the ``kb``
     user_config block).

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -19,10 +19,12 @@ and client construction happen in downstream module providers.
 """
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from injector import Module, inject, provider, singleton
 
+from agentclaw.community.core.cron.protocols import AssistantSessionEndpointProvider
 from agentclaw.community.di import config as cfg
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
@@ -362,6 +364,27 @@ class ConfigModule(Module):
                 else gateway.base_url
             )
         )
+
+    @singleton
+    @provider
+    def assistant_session_endpoint(self) -> AssistantSessionEndpointProvider:
+        """TeamClaw assistant deep-link base for this environment.
+
+        The core cron relay only formats the final session URL. The env
+        split lives here, alongside the rest of the composition-root
+        wiring, so the service does not read process env directly.
+        """
+        defaults = cfg.AssistantSessionEndpoint()
+        prod_base_url = os.getenv(
+            "TEAMCLAW_ASSISTANT_URL_BASE",
+            defaults.base_url,
+        )
+        base_url = (
+            os.getenv("TEAMCLAW_ASSISTANT_URL_BASE_PRE") or prod_base_url
+            if get_current_env() == "pre"
+            else prod_base_url
+        )
+        return cfg.AssistantSessionEndpoint(base_url=base_url)
 
     @singleton
     @provider

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
@@ -19,6 +19,18 @@ from agentclaw.community.core.cron.services.cron_relay import CronRelayService
 from agentclaw.community.core.devices.services.device_context import DeviceContext
 
 
+@pytest.fixture(autouse=True)
+def _assistant_url_env(monkeypatch):
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE",
+        "https://teamclaw.alipay.com/assistant",
+    )
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE_PRE",
+        "https://teamclaw-pre.alipay.com/assistant",
+    )
+
+
 def _make_service(
     *,
     bot_provider=None,
@@ -93,7 +105,13 @@ class TestFindAutoInitiateAndRun:
                 {"id": "task-auto", "payload": {"kind": "autoInitiate", "message": "|kind:autoInitiate| 查询dima空间..."}},
             ]},
             # 第二次 invoke: forward_request 内部的 POST
-            {"success": True, "data": {"job_id": "task-auto"}},
+            {"success": True, "data": {
+                "job_id": "task-auto",
+                "message": "本次发起 1 个新任务",
+                "sessions": [
+                    {"session_id": "user:382716:session:s-1:agent:bot-1"},
+                ],
+            }},
         ])
 
         # get_device_connection_v2 也要 mock (forward_request 内部调用)
@@ -119,8 +137,17 @@ class TestFindAutoInitiateAndRun:
         first_call = transport.invoke.call_args_list[0]
         assert first_call[0][1] == "GET"
         assert first_call[0][2] == "/api/cron"
-        # 验证最终结果
+        # 验证最终结果，并为发起的会话补充 TeamClaw assistant 链接
         assert result["success"] is True
+        expected_url = (
+            "https://teamclaw.alipay.com/assistant?botId=bot-1"
+            "&sessionId=user:382716:session:s-1:agent:bot-1"
+        )
+        assert "sessions" not in result["data"]
+        assert result["data"]["message"] == (
+            "本次发起 1 个新任务\n\n会话链接：\n"
+            f"- {expected_url}"
+        )
 
     @pytest.mark.asyncio
     async def test_no_binding_raises(self):
@@ -296,6 +323,54 @@ class TestFindAutoInitiateAndRun:
             )
 
 
+def test_assistant_session_url_uses_pre_domain(monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.core.cron.services.cron_relay.get_current_env",
+        lambda: "pre",
+    )
+
+    assert CronRelayService._assistant_session_url("bot-x", "session-x") == (
+        "https://teamclaw-pre.alipay.com/assistant?botId=bot-x"
+        "&sessionId=session-x"
+    )
+
+
+def test_append_auto_initiate_session_links_to_message():
+    payload = {
+        "message": "本次发起 2 个新任务",
+        "sessions": [
+            {"session_id": "user:u:session:s1:agent:bot-x"},
+            {"session_id": "user:u:session:s2:agent:bot-x"},
+        ],
+    }
+
+    CronRelayService._append_auto_initiate_session_links_to_message(payload, "bot-x")
+
+    assert payload["message"] == (
+        "本次发起 2 个新任务\n\n会话链接：\n"
+        "- https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s1:agent:bot-x\n"
+        "- https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s2:agent:bot-x"
+    )
+    assert "sessions" not in payload
+
+
+def test_collect_auto_initiate_session_links_handles_nested_shapes():
+    payload = {
+        "sessions": [
+            {"session_id": "user:u:session:s1:agent:bot-x"},
+            {"sessionId": "user:u:session:s2:agent:bot-x"},
+        ],
+        "ignored": {"session_id": ""},
+    }
+
+    urls = CronRelayService._collect_auto_initiate_session_links(payload, "bot-x")
+
+    assert urls == [
+        "https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s1:agent:bot-x",
+        "https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s2:agent:bot-x",
+    ]
+
+
 class TestRunSingleAutoInitiate:
     """CronRelayService.run_single_auto_initiate"""
 
@@ -312,7 +387,13 @@ class TestRunSingleAutoInitiate:
         transport = MagicMock()
         transport.invoke = AsyncMock(return_value={
             "success": True,
-            "data": {"total": 1, "created": 1, "errors": []},
+            "data": {
+                "total": 1,
+                "created": 1,
+                "message": "本次发起 1 个新任务",
+                "sessions": [{"session_id": "user:u1:session:s-2:agent:bot-1"}],
+                "errors": [],
+            },
         })
 
         template_repo = MagicMock()
@@ -332,6 +413,15 @@ class TestRunSingleAutoInitiate:
             dima_url="https://project.teamclaw.com/space/W1/requirement?openWorkItemId=123",
         )
         assert result["success"] is True
+        expected_url = (
+            "https://teamclaw.alipay.com/assistant?botId=bot-1"
+            "&sessionId=user:u1:session:s-2:agent:bot-1"
+        )
+        assert "sessions" not in result["data"]
+        assert result["data"]["message"] == (
+            "本次发起 1 个新任务\n\n会话链接：\n"
+            f"- {expected_url}"
+        )
         body = transport.invoke.call_args[0][3]
         assert body["workflow"] == "my-flow"
 

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py
@@ -10,6 +10,7 @@
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -19,18 +20,6 @@ from agentclaw.community.core.cron.services.cron_relay import CronRelayService
 from agentclaw.community.core.devices.services.device_context import DeviceContext
 
 
-@pytest.fixture(autouse=True)
-def _assistant_url_env(monkeypatch):
-    monkeypatch.setenv(
-        "TEAMCLAW_ASSISTANT_URL_BASE",
-        "https://teamclaw.alipay.com/assistant",
-    )
-    monkeypatch.setenv(
-        "TEAMCLAW_ASSISTANT_URL_BASE_PRE",
-        "https://teamclaw-pre.alipay.com/assistant",
-    )
-
-
 def _make_service(
     *,
     bot_provider=None,
@@ -38,6 +27,7 @@ def _make_service(
     transport=None,
     resolver=None,
     publish_repo=None,
+    assistant_session_endpoint=None,
 ):
     return CronRelayService(
         bot_provider=bot_provider or MagicMock(),
@@ -46,6 +36,8 @@ def _make_service(
         resolver=resolver or MagicMock(),
         template_repo=MagicMock(),
         publish_repo=publish_repo or MagicMock(),
+        assistant_session_endpoint=assistant_session_endpoint
+        or SimpleNamespace(base_url="https://teamclaw.alipay.com/assistant"),
     )
 
 
@@ -323,13 +315,14 @@ class TestFindAutoInitiateAndRun:
             )
 
 
-def test_assistant_session_url_uses_pre_domain(monkeypatch):
-    monkeypatch.setattr(
-        "agentclaw.community.core.cron.services.cron_relay.get_current_env",
-        lambda: "pre",
+def test_assistant_session_url_uses_injected_endpoint():
+    svc = _make_service(
+        assistant_session_endpoint=SimpleNamespace(
+            base_url="https://teamclaw-pre.alipay.com/assistant",
+        )
     )
 
-    assert CronRelayService._assistant_session_url("bot-x", "session-x") == (
+    assert svc._assistant_session_url("bot-x", "session-x") == (
         "https://teamclaw-pre.alipay.com/assistant?botId=bot-x"
         "&sessionId=session-x"
     )
@@ -344,7 +337,7 @@ def test_append_auto_initiate_session_links_to_message():
         ],
     }
 
-    CronRelayService._append_auto_initiate_session_links_to_message(payload, "bot-x")
+    _make_service()._append_auto_initiate_session_links_to_message(payload, "bot-x")
 
     assert payload["message"] == (
         "本次发起 2 个新任务\n\n会话链接：\n"
@@ -363,7 +356,7 @@ def test_collect_auto_initiate_session_links_handles_nested_shapes():
         "ignored": {"session_id": ""},
     }
 
-    urls = CronRelayService._collect_auto_initiate_session_links(payload, "bot-x")
+    urls = _make_service()._collect_auto_initiate_session_links(payload, "bot-x")
 
     assert urls == [
         "https://teamclaw.alipay.com/assistant?botId=bot-x&sessionId=user:u:session:s1:agent:bot-x",

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_uses_resolver.py
@@ -54,6 +54,9 @@ def _make_service(
         resolver=resolver or MagicMock(),
         template_repo=MagicMock(),
         publish_repo=publish_repo or MagicMock(),
+        assistant_session_endpoint=SimpleNamespace(
+            base_url="https://teamclaw.alipay.com/assistant"
+        ),
     )
 
 

--- a/src/backend/tests/community/di/test_assistant_session_endpoint_provider.py
+++ b/src/backend/tests/community/di/test_assistant_session_endpoint_provider.py
@@ -1,0 +1,64 @@
+"""ConfigModule assistant-session endpoint provider.
+
+The cron core formats links from an injected endpoint; the env-specific base URL
+selection belongs in the composition/config layer.
+"""
+from __future__ import annotations
+
+from agentclaw.community.di.modules import config_module
+from agentclaw.community.di.modules.config_module import ConfigModule
+
+
+def test_assistant_session_endpoint_uses_prod_base(monkeypatch):
+    monkeypatch.setattr(config_module, "get_current_env", lambda: "prod")
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE",
+        "https://teamclaw.alipay.com/assistant",
+    )
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE_PRE",
+        "https://teamclaw-pre.alipay.com/assistant",
+    )
+
+    endpoint = ConfigModule().assistant_session_endpoint()
+
+    assert endpoint.base_url == "https://teamclaw.alipay.com/assistant"
+
+
+def test_assistant_session_endpoint_uses_pre_base(monkeypatch):
+    monkeypatch.setattr(config_module, "get_current_env", lambda: "pre")
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE",
+        "https://teamclaw.alipay.com/assistant",
+    )
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE_PRE",
+        "https://teamclaw-pre.alipay.com/assistant",
+    )
+
+    endpoint = ConfigModule().assistant_session_endpoint()
+
+    assert endpoint.base_url == "https://teamclaw-pre.alipay.com/assistant"
+
+
+def test_assistant_session_endpoint_pre_falls_back_to_prod_base(monkeypatch):
+    monkeypatch.setattr(config_module, "get_current_env", lambda: "pre")
+    monkeypatch.setenv(
+        "TEAMCLAW_ASSISTANT_URL_BASE",
+        "https://teamclaw.alipay.com/assistant",
+    )
+    monkeypatch.delenv("TEAMCLAW_ASSISTANT_URL_BASE_PRE", raising=False)
+
+    endpoint = ConfigModule().assistant_session_endpoint()
+
+    assert endpoint.base_url == "https://teamclaw.alipay.com/assistant"
+
+
+def test_assistant_session_endpoint_uses_default_when_env_unset(monkeypatch):
+    monkeypatch.setattr(config_module, "get_current_env", lambda: "prod")
+    monkeypatch.delenv("TEAMCLAW_ASSISTANT_URL_BASE", raising=False)
+    monkeypatch.delenv("TEAMCLAW_ASSISTANT_URL_BASE_PRE", raising=False)
+
+    endpoint = ConfigModule().assistant_session_endpoint()
+
+    assert endpoint.base_url == "https://teamclaw.example.com/assistant"

--- a/src/backend/tests/community/plugins/test_routine_tenant_indirect_isolation.py
+++ b/src/backend/tests/community/plugins/test_routine_tenant_indirect_isolation.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Any, Dict
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -157,6 +158,9 @@ def _make_service(*, bot_provider: BotInfoProvider) -> CronRelayService:
         resolver=resolver,
         template_repo=MagicMock(),
         publish_repo=MagicMock(),
+        assistant_session_endpoint=SimpleNamespace(
+            base_url="https://teamclaw.alipay.com/assistant"
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- append TeamClaw assistant session links to autoInitiate result message
- use pre assistant domain when current env is pre
- remove verbose top-level sessions from public response

## Tests
- uv run pytest tests/community/core/cron/services/test_cron_relay_find_auto_initiate.py tests/community/api/cron/test_cron_noauth_router.py