### PR TITLE
feat(bcs-cli): surface run_id/session_id early and on failure in chat

### DIFF
--- a/src/bcs/crates/tools/bcs-cli/Cargo.toml
+++ b/src/bcs/crates/tools/bcs-cli/Cargo.toml
@@ -59,6 +59,9 @@ bcs-config     = { workspace = true }
 bcs-config-api = { workspace = true }
 bcs-protocol    = { workspace = true }
 
+# Local timestamp for chat ack line
+chrono = { workspace = true }
+
 [build-dependencies]
 chrono = { workspace = true }
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -4039,6 +4039,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_chat_async_returns_invalid_response_on_malformed_202() {
+        // A 202 whose body cannot deserialize into ChatRunSubmitResponse: the
+        // server has accepted (and may have created a run), but the ID is
+        // unreadable. This must classify as InvalidResponse so main.rs maps
+        // it to submit_indeterminate (not submit_failed).
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/bots/bot-target/chat-async"))
+            .respond_with(
+                ResponseTemplate::new(202)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string("{not valid json"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::new(server.uri());
+        let result = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 2_000, false)
+            .await;
+        assert!(
+            matches!(result, Err(ChatAsyncError::InvalidResponse(_))),
+            "expected InvalidResponse on malformed 202, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
     async fn test_chat_poll_run_returns_poll_error_on_http_500() {
         use wiremock::{
             Mock, MockServer, ResponseTemplate,

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -113,6 +113,55 @@ pub struct BcsClient {
     traceparent: Option<HeaderValue>,
 }
 
+// ============================================================================
+// CLI-internal chat outcome types (NOT bcs-protocol wire DTOs)
+// ============================================================================
+
+/// Structured result of a chat run poll flow, assembled by `bcs-cli` from
+/// existing fields of [`ChatRunSubmitResponse`] / [`ChatRunStatusResponse`].
+/// This is a CLI- internal type; it is NOT a `bcs-protocol` wire DTO and
+/// introduces no new on-wire fields.
+#[derive(Debug, Clone)]
+pub struct ChatRunOutcome {
+    /// Did the run reach a success state?
+    /// sync = `ChatRunState::Completed`; detach = `Running` or `Completed`.
+    pub delivered: bool,
+    /// Was the run created (`chat_async` returned a `run_id`)?
+    /// False only on submit-level failure.
+    pub submitted: bool,
+    /// Run ID. `None` only on submit-level failure (no run was created).
+    pub run_id: Option<String>,
+    /// Session ID. `None` only on submit-level failure.
+    pub session_id: Option<String>,
+    /// Bot UUID. Filled from the submit/status response, or the CLI
+    /// `--bot-uuid` arg on submit-level failure.
+    pub bot_uuid: Option<String>,
+    /// `running|completed|failed|cancelled|timeout|poll_error|
+    ///  submit_failed|submit_indeterminate`
+    pub state: String,
+    /// Response content. Only meaningful for sync terminal runs.
+    pub response_content: Option<String>,
+    /// Error message (from server status, timeout, or poll error).
+    pub error_message: Option<String>,
+    /// Whether the server truncated `response.content`.
+    pub content_truncated: bool,
+}
+
+/// Typed errors for `chat_async` submission. `main.rs` maps each variant to a
+/// distinct [`ChatRunOutcome`] state so stdout is never empty and known IDs
+/// are preserved.
+#[derive(Debug)]
+pub enum ChatAsyncError {
+    /// `.send()` failed (connect refused/reset/client 10s timeout). A run
+    /// MAY have been created server-side; its ID is unknown to the CLI.
+    Transport(String),
+    /// Server responded with a non-2xx status (it explicitly did not accept
+    /// the run). No run was created.
+    NotSuccessful { status: u16, body: String },
+    /// Response body could not be deserialized as `ChatRunSubmitResponse`.
+    InvalidResponse(String),
+}
+
 impl BcsClient {
     ///Create a new BCS client with the given base URL.
     pub fn new(base_url: impl Into<String>) -> Self {
@@ -1175,7 +1224,7 @@ impl BcsClient {
         organization_code: Option<&str>,
         client_wait_timeout_ms: u64,
         detach: bool,
-    ) -> Result<ChatRunSubmitResponse> {
+    ) -> Result<ChatRunSubmitResponse, ChatAsyncError> {
         let url = format!("{}/bots/{}/chat-async", self.base_url, bot_id);
         let payload = Self::chat_async_payload(
             message,
@@ -1197,18 +1246,18 @@ impl BcsClient {
             )
             .send()
             .await
-            .context("Failed to submit chat_async")?;
+            .map_err(|err| ChatAsyncError::Transport(err.to_string()))?;
 
         if !response.status().is_success() {
-            let status = response.status();
+            let status = response.status().as_u16();
             let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!("chat_async failed ({}): {}", status, body));
+            return Err(ChatAsyncError::NotSuccessful { status, body });
         }
 
         let submit: ChatRunSubmitResponse = response
             .json()
             .await
-            .context("Invalid chat_async response")?;
+            .map_err(|err| ChatAsyncError::InvalidResponse(err.to_string()))?;
         Ok(submit)
     }
 
@@ -1309,198 +1358,184 @@ impl BcsClient {
             .context("Invalid chat_run_cancel response")
     }
 
-    /// Submit a chat run and poll until it reaches a terminal state. Returns
-    /// a JSON value shaped like the legacy [`Self::chat`] response plus a few
-    /// additive fields (`run_id`, `state`, `session_id`, `error_message`).
+    /// Poll a chat run until it reaches a terminal state (sync mode).
     ///
-    /// `overall_timeout_ms` caps the total wall-clock spent polling. Reaching
-    /// the budget stops only local polling; the server-side run keeps executing.
-    /// `poll_wait_ms` controls each long-poll HTTP hop (default 15 s, capped
-    /// at the server's configured max).
-    pub async fn chat_polling(
-        &self,
-        bot_id: &str,
-        message: &str,
-        from: Option<&str>,
-        session_id: Option<&str>,
-        tags: &[String],
-        response_mode: Option<&str>,
-        overall_timeout_ms: Option<u64>,
-        poll_wait_ms: Option<u64>,
-        organization_code: Option<&str>,
-    ) -> Result<serde_json::Value> {
-        let client_wait_timeout_ms = overall_timeout_ms.unwrap_or(30 * 60 * 1_000);
-        let overall_timeout = Duration::from_millis(client_wait_timeout_ms);
-        let poll_wait_ms = poll_wait_ms.unwrap_or(15_000);
-
-        let submit = self
-            .chat_async(
-                bot_id,
-                message,
-                from,
-                session_id,
-                tags,
-                response_mode,
-                organization_code,
-                client_wait_timeout_ms,
-                false,
-            )
-            .await?;
-        let run_id = submit.run_id.clone();
-        let reported_session = submit.session_id.clone();
-        debug!(
-            run_id = %run_id,
-            session_id = %reported_session,
-            "chat_polling: submitted"
-        );
-
-        let deadline = tokio::time::Instant::now() + overall_timeout;
-        let mut since_version: u64 = 0;
-        loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                warn!(run_id = %run_id, "chat_polling: local polling timeout; run left active");
-                return Err(anyhow!(
-                    "chat_polling: local polling timeout after {} ms; run {} is still active",
-                    overall_timeout.as_millis(),
-                    run_id,
-                ));
-            }
-            let wait_ms = remaining.as_millis().min(poll_wait_ms as u128) as u64;
-            let status = self
-                .chat_run_status(&run_id, Some(since_version), Some(wait_ms))
-                .await?;
-            since_version = status.version;
-            if status.is_terminal() {
-                let delivered = matches!(status.state, ChatRunState::Completed);
-                let state_str = status.state.as_str();
-                if !delivered {
-                    return Err(anyhow!(
-                        "chat_polling: run {} ended in state {}: {}",
-                        run_id,
-                        state_str,
-                        status
-                            .error_message
-                            .as_deref()
-                            .unwrap_or("<no error message>"),
-                    ));
-                }
-                return Ok(serde_json::json!({
-                    "delivered": delivered,
-                    "bot_uuid": status.bot_uuid,
-                    "run_id": status.run_id,
-                    "session_id": status.session_id,
-                    "state": state_str,
-                    "response": {"content": status.response.content},
-                    "error_message": status.error_message,
-                    "content_truncated": status.content_truncated,
-                }));
-            }
-        }
-    }
-
-    /// Submit a chat run and detach once BCS reports it as `running` (or a
-    /// legacy `completed`). Detach is a local waiting policy and is not sent to
-    /// the server or Provider.
+    /// `submit` is the response from a successful `chat_async` call — its
+    /// `run_id` is polled and its `session_id`/`bot_uuid` fill branches where
+    /// no status response is available (local timeout before first status).
+    /// `poll_wait_ms` controls each long-poll HTTP hop.
+    /// `overall_timeout` caps the total wall-clock spent polling; on expiry
+    /// the result carries `state="timeout"` with IDs from `submit` and the
+    /// server-side run keeps executing.
     ///
-    /// `overall_timeout_ms` caps the total wall-clock spent waiting for the
-    /// detach acknowledgement. On overflow the run is left running on the
-    /// server side and an error is returned.
-    /// `poll_wait_ms` controls each long-poll HTTP hop (default 15 s).
-    pub async fn chat_polling_detach(
+    /// Returns `Ok(ChatRunOutcome)` on every path — terminal, timeout, and
+    /// poll errors are all structured outcomes, never bare `Err`.
+    pub async fn chat_poll_run(
         &self,
-        bot_id: &str,
-        message: &str,
-        from: Option<&str>,
-        session_id: Option<&str>,
-        tags: &[String],
-        response_mode: Option<&str>,
-        overall_timeout_ms: Option<u64>,
-        poll_wait_ms: Option<u64>,
-        organization_code: Option<&str>,
-    ) -> Result<serde_json::Value> {
-        let client_wait_timeout_ms = overall_timeout_ms.unwrap_or(30 * 60 * 1_000);
-        let overall_timeout = Duration::from_millis(client_wait_timeout_ms);
-        let poll_wait_ms = poll_wait_ms.unwrap_or(15_000);
-
-        let submit = self
-            .chat_async(
-                bot_id,
-                message,
-                from,
-                session_id,
-                tags,
-                response_mode,
-                organization_code,
-                client_wait_timeout_ms,
-                true,
-            )
-            .await?;
-        let run_id = submit.run_id.clone();
-        let reported_session = submit.session_id.clone();
-        debug!(
-            run_id = %run_id,
-            session_id = %reported_session,
-            "chat_polling_detach: submitted"
-        );
-
+        submit: &ChatRunSubmitResponse,
+        poll_wait_ms: u64,
+        overall_timeout: Duration,
+    ) -> Result<ChatRunOutcome> {
         let deadline = tokio::time::Instant::now() + overall_timeout;
         let mut since_version: u64 = 0;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
             if remaining.is_zero() {
                 warn!(
-                    run_id = %run_id,
-                    "chat_polling_detach: local timeout before first ack"
+                    run_id = %submit.run_id,
+                    "chat_poll_run: local polling timeout; run left active"
                 );
-                return Err(anyhow!(
-                    "chat_polling_detach: timed out after {} ms waiting for detach ack; run {} is still active",
-                    overall_timeout.as_millis(),
-                    run_id,
-                ));
+                return Ok(Self::timeout_outcome(submit, overall_timeout));
             }
             let wait_ms = remaining.as_millis().min(poll_wait_ms as u128) as u64;
-            let status = self
-                .chat_run_status(&run_id, Some(since_version), Some(wait_ms))
-                .await?;
-
-            let state_str = status.state.as_str();
-            match status.state {
-                ChatRunState::Completed | ChatRunState::Running => {
-                    return Ok(serde_json::json!({
-                        "submitted": true,
-                        "bot_uuid": status.bot_uuid,
-                        "run_id": status.run_id,
-                        "session_id": status.session_id,
-                        "state": state_str,
-                    }));
-                }
-                ChatRunState::Failed | ChatRunState::Cancelled => {
-                    return Err(anyhow!(
-                        "chat_polling_detach: run {} ended in state {}: {}",
-                        run_id,
-                        state_str,
-                        status
-                            .error_message
-                            .as_deref()
-                            .unwrap_or("<no error message>"),
-                    ));
-                }
-                ChatRunState::Pending | ChatRunState::Submitted | ChatRunState::Unknown => {
+            match self
+                .chat_run_status(&submit.run_id, Some(since_version), Some(wait_ms))
+                .await
+            {
+                Ok(status) => {
+                    since_version = status.version;
                     if status.is_terminal() {
-                        return Err(anyhow!(
-                            "chat_polling_detach: run {} ended in state {}: {}",
-                            run_id,
-                            state_str,
-                            status
-                                .error_message
-                                .as_deref()
-                                .unwrap_or("<no error message>"),
-                        ));
+                        return Ok(Self::terminal_outcome(&status));
                     }
                 }
+                Err(err) => {
+                    return Ok(Self::poll_error_outcome(submit, &err.to_string()));
+                }
             }
-            since_version = status.version;
+        }
+    }
+
+    /// Poll a chat run until BCS reports it as `running` (detach mode).
+    /// Accepts `Running` or `Completed` as success — mirrors the legacy
+    /// `chat_polling_detach` that treated `Completed | Running` as detach-ack
+    /// (a run may complete before the first status response arrives).
+    ///
+    /// Same signature contract as [`Self::chat_poll_run`]: `submit` metadata
+    /// fills ID-bearing branches that lack a status response.
+    pub async fn chat_poll_run_until_running(
+        &self,
+        submit: &ChatRunSubmitResponse,
+        poll_wait_ms: u64,
+        overall_timeout: Duration,
+    ) -> Result<ChatRunOutcome> {
+        let deadline = tokio::time::Instant::now() + overall_timeout;
+        let mut since_version: u64 = 0;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                warn!(
+                    run_id = %submit.run_id,
+                    "chat_poll_run_until_running: local timeout before detach ack"
+                );
+                return Ok(Self::timeout_outcome(submit, overall_timeout));
+            }
+            let wait_ms = remaining.as_millis().min(poll_wait_ms as u128) as u64;
+            match self
+                .chat_run_status(&submit.run_id, Some(since_version), Some(wait_ms))
+                .await
+            {
+                Ok(status) => {
+                    match status.state {
+                        ChatRunState::Completed | ChatRunState::Running => {
+                            return Ok(Self::running_outcome(&status));
+                        }
+                        ChatRunState::Failed | ChatRunState::Cancelled => {
+                            return Ok(Self::terminal_outcome(&status));
+                        }
+                        ChatRunState::Pending | ChatRunState::Submitted
+                        | ChatRunState::Unknown => {
+                            if status.is_terminal() {
+                                return Ok(Self::terminal_outcome(&status));
+                            }
+                        }
+                    }
+                    since_version = status.version;
+                }
+                Err(err) => {
+                    return Ok(Self::poll_error_outcome(submit, &err.to_string()));
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers for building ChatRunOutcome from known state
+    // ------------------------------------------------------------------
+
+    /// Terminal outcome from a status response. `delivered` is true only for
+    /// `Completed`; `Failed`/`Cancelled`/terminal-`Unknown` yield
+    /// `delivered=false`. IDs come from the status response (the run has
+    /// been created and a terminal status was received).
+    fn terminal_outcome(status: &ChatRunStatusResponse) -> ChatRunOutcome {
+        let delivered = matches!(status.state, ChatRunState::Completed);
+        ChatRunOutcome {
+            delivered,
+            submitted: true,
+            run_id: Some(status.run_id.clone()),
+            session_id: Some(status.session_id.clone()),
+            bot_uuid: Some(status.bot_uuid.clone()),
+            state: status.state.as_str().to_string(),
+            response_content: Some(status.response.content.clone()),
+            error_message: status.error_message.clone(),
+            content_truncated: status.content_truncated,
+        }
+    }
+
+    /// Detach success outcome: `delivered=true`, no response content (detach
+    /// does not wait for completion). State is `running` or `completed`. IDs
+    /// come from the status response (the run has been created and a status
+    /// response was received — unlike timeout/poll_error which use submit).
+    fn running_outcome(status: &ChatRunStatusResponse) -> ChatRunOutcome {
+        ChatRunOutcome {
+            delivered: true,
+            submitted: true,
+            run_id: Some(status.run_id.clone()),
+            session_id: Some(status.session_id.clone()),
+            bot_uuid: Some(status.bot_uuid.clone()),
+            state: status.state.as_str().to_string(),
+            response_content: None,
+            error_message: None,
+            content_truncated: false,
+        }
+    }
+
+    /// Local polling deadline hit. IDs come from the submit response so the
+    /// outcome is non-empty even with a zero-length timeout before any status
+    /// response arrived.
+    fn timeout_outcome(
+        submit: &ChatRunSubmitResponse,
+        overall_timeout: Duration,
+    ) -> ChatRunOutcome {
+        ChatRunOutcome {
+            delivered: false,
+            submitted: true,
+            run_id: Some(submit.run_id.clone()),
+            session_id: Some(submit.session_id.clone()),
+            bot_uuid: Some(submit.bot_uuid.clone()),
+            state: "timeout".to_string(),
+            response_content: None,
+            error_message: Some(format!(
+                "local polling timeout after {} ms; run {} is still active",
+                overall_timeout.as_millis(),
+                submit.run_id
+            )),
+            content_truncated: false,
+        }
+    }
+
+    /// `chat_run_status` error during polling. IDs come from the submit
+    /// response (already known); the error is preserved in `error_message`.
+    fn poll_error_outcome(submit: &ChatRunSubmitResponse, error: &str) -> ChatRunOutcome {
+        ChatRunOutcome {
+            delivered: false,
+            submitted: true,
+            run_id: Some(submit.run_id.clone()),
+            session_id: Some(submit.session_id.clone()),
+            bot_uuid: Some(submit.bot_uuid.clone()),
+            state: "poll_error".to_string(),
+            response_content: None,
+            error_message: Some(format!("chat_run_status failed: {}", error)),
+            content_truncated: false,
         }
     }
 
@@ -3720,7 +3755,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_chat_polling_detach_waits_through_submitted_until_running() {
+    async fn test_chat_poll_run_until_running_waits_through_submitted_until_running() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
         use std::sync::{
@@ -3817,31 +3852,33 @@ mod tests {
         });
 
         let client = BcsClient::new(format!("http://{}", addr));
-        let result = client
-            .chat_polling_detach(
-                "bot-target",
-                "hello",
-                None,
-                None,
-                &[],
-                None,
-                Some(2_000),
-                Some(10),
-                None,
-            )
-            .await;
+        let submit = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 2_000, true)
+            .await
+            .expect("chat_async submit should succeed");
+        let outcome = client
+            .chat_poll_run_until_running(&submit, 10, Duration::from_millis(2_000))
+            .await
+            .expect("poll should return an outcome");
         // Signal the worker to exit whether or not the call succeeded so the
         // join below never waits on the backstop deadline.
         shutdown.store(true, Ordering::SeqCst);
-        let result = result.unwrap();
 
         server.join().unwrap();
-        assert_eq!(get_count.load(Ordering::SeqCst), 2);
-        assert_eq!(result["state"], "running");
+        assert_eq!(
+            get_count.load(Ordering::SeqCst),
+            2,
+            "detach should poll twice: submitted then running"
+        );
+        assert!(outcome.delivered, "running should be delivered");
+        assert_eq!(outcome.state, "running");
+        assert_eq!(outcome.run_id.as_deref(), Some("run-1"));
+        assert_eq!(outcome.session_id.as_deref(), Some("session-1"));
+        assert!(outcome.submitted);
     }
 
     #[tokio::test]
-    async fn test_chat_polling_timeout_leaves_server_run_active() {
+    async fn test_chat_poll_run_times_out_with_ids_from_submit() {
         use wiremock::{
             Mock, MockServer, ResponseTemplate,
             matchers::{method, path},
@@ -3882,55 +3919,228 @@ mod tests {
         client
             .set_traceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
             .unwrap();
-        let error = client
-            .chat_polling(
-                "bot-target",
-                "hello",
-                None,
-                None,
-                &[],
-                None,
-                Some(20),
-                Some(5),
-                None,
-            )
+        let submit = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 20, false)
             .await
-            .expect_err("local polling should time out");
+            .expect("chat_async submit should succeed");
+        let outcome = client
+            .chat_poll_run(&submit, 5, Duration::from_millis(20))
+            .await
+            .expect("poll should return a timeout outcome");
 
-        assert!(error.to_string().contains("local polling timeout"));
-        assert!(error.to_string().contains("run-local-timeout is still active"));
+        assert!(!outcome.delivered, "timeout should not be delivered");
+        assert_eq!(outcome.state, "timeout");
+        assert_eq!(
+            outcome.run_id.as_deref(),
+            Some("run-local-timeout"),
+            "IDs should come from submit response"
+        );
+        assert_eq!(outcome.session_id.as_deref(), Some("session-1"));
+        assert!(outcome.submitted);
         let requests = server.received_requests().await.unwrap();
-        let submit = requests
+        let submit_req = requests
             .iter()
             .find(|request| request.url.path() == "/bots/bot-target/chat-async")
             .expect("chat submit request");
         assert_eq!(
-            submit
+            submit_req
                 .headers
                 .get("traceparent")
                 .and_then(|value| value.to_str().ok()),
             Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
         );
         assert_eq!(
-            submit
+            submit_req
                 .headers
                 .get("x-bcs-client-detach")
                 .and_then(|value| value.to_str().ok()),
             Some("false")
         );
         assert_eq!(
-            submit
+            submit_req
                 .headers
                 .get("x-bcs-client-wait-timeout-ms")
                 .and_then(|value| value.to_str().ok()),
             Some("20")
         );
-        let payload: serde_json::Value = serde_json::from_slice(&submit.body).unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&submit_req.body).unwrap();
         assert!(payload.get("timeout_ms").is_none());
         assert!(payload.get("caller_wait_mode").is_none());
         assert!(requests
             .iter()
             .all(|request| request.url.path() != "/chat/runs/run-local-timeout/cancel"));
+    }
+
+    #[tokio::test]
+    async fn test_chat_poll_run_until_running_accepts_completed_as_success() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/bots/bot-target/chat-async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "run_id": "run-1",
+                "bot_uuid": "bot-target",
+                "session_id": "session-1",
+                "status": "submitted",
+                "expires_at_ms": 9_999_999_u64,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chat/runs/run-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "run_id": "run-1",
+                "bot_uuid": "bot-target",
+                "from_bot_id": "bot-source",
+                "session_id": "session-1",
+                "state": "completed",
+                "response": {"content": "done"},
+                "created_at_ms": 1_u64,
+                "updated_at_ms": 2_u64,
+                "expires_at_ms": 9_999_999_u64,
+                "version": 2_u64,
+                "content_truncated": false,
+                "is_terminal": true,
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::new(server.uri());
+        let submit = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 60_000, true)
+            .await
+            .expect("chat_async submit should succeed");
+        let outcome = client
+            .chat_poll_run_until_running(&submit, 10, Duration::from_millis(5_000))
+            .await
+            .expect("poll should accept completed as detach success");
+
+        assert!(outcome.delivered, "completed should be detach-delivered");
+        assert_eq!(outcome.state, "completed");
+        assert_eq!(outcome.run_id.as_deref(), Some("run-1"));
+    }
+
+    #[tokio::test]
+    async fn test_chat_async_returns_transport_error_on_non_listening_port() {
+        // Port 1 is unlikely to be listening; connection should fail.
+        let client = BcsClient::new("http://127.0.0.1:1");
+        let result = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 2_000, false)
+            .await;
+        assert!(
+            matches!(result, Err(ChatAsyncError::Transport(_))),
+            "expected Transport error on non-listening port, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chat_poll_run_returns_poll_error_on_http_500() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/bots/bot-target/chat-async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "run_id": "run-1",
+                "bot_uuid": "bot-target",
+                "session_id": "session-1",
+                "status": "submitted",
+                "expires_at_ms": 9_999_999_u64,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chat/runs/run-1"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(serde_json::json!({"error": "internal"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::new(server.uri());
+        let submit = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 5_000, false)
+            .await
+            .expect("chat_async submit should succeed");
+        let outcome = client
+            .chat_poll_run(&submit, 10, Duration::from_millis(5_000))
+            .await
+            .expect("poll error should return a structured outcome");
+
+        assert!(!outcome.delivered);
+        assert_eq!(outcome.state, "poll_error");
+        assert_eq!(
+            outcome.run_id.as_deref(),
+            Some("run-1"),
+            "IDs should come from submit response"
+        );
+        assert_eq!(outcome.session_id.as_deref(), Some("session-1"));
+        assert!(outcome.submitted);
+    }
+
+    #[tokio::test]
+    async fn test_chat_poll_run_returns_failed_on_terminal_failed_state() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path},
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/bots/bot-target/chat-async"))
+            .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+                "run_id": "run-1",
+                "bot_uuid": "bot-target",
+                "session_id": "session-1",
+                "status": "submitted",
+                "expires_at_ms": 9_999_999_u64,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/chat/runs/run-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "run_id": "run-1",
+                "bot_uuid": "bot-target",
+                "from_bot_id": "bot-source",
+                "session_id": "session-1",
+                "state": "failed",
+                "response": {"content": ""},
+                "created_at_ms": 1_u64,
+                "updated_at_ms": 2_u64,
+                "expires_at_ms": 9_999_999_u64,
+                "version": 2_u64,
+                "content_truncated": false,
+                "is_terminal": true,
+                "error_message": "provider returned error: timeout"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BcsClient::new(server.uri());
+        let submit = client
+            .chat_async("bot-target", "hello", None, None, &[], None, None, 5_000, false)
+            .await
+            .expect("chat_async submit should succeed");
+        let outcome = client
+            .chat_poll_run(&submit, 10, Duration::from_millis(5_000))
+            .await
+            .expect("poll should return a failed terminal outcome");
+
+        assert!(!outcome.delivered);
+        assert_eq!(outcome.state, "failed");
+        assert!(outcome.submitted);
+        assert_eq!(outcome.run_id.as_deref(), Some("run-1"));
+        assert_eq!(outcome.session_id.as_deref(), Some("session-1"));
     }
 
     #[test]

--- a/src/bcs/crates/tools/bcs-cli/src/lib.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/lib.rs
@@ -15,8 +15,8 @@ mod client;
 pub mod oauth;
 
 pub use client::{
-    BcsClient, BotGroupListPage, CreateCustomGroupOptions, CurrentActorGroupListPage,
-    RunSessionCollaborationOptions,
+    BcsClient, BotGroupListPage, ChatAsyncError, ChatRunOutcome, CreateCustomGroupOptions,
+    CurrentActorGroupListPage, RunSessionCollaborationOptions,
 };
 
 const COMPILED_PRE_BCS_URL: Option<&str> = option_env!("BCS_CLI_DEFAULT_PRE_URL");

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -3547,9 +3547,12 @@ pub async fn run() -> Result<()> {
                     run_id: None,
                     session_id: None,
                     bot_uuid: Some(bot_uuid.clone()),
-                    state: "submit_failed".to_string(),
+                    state: "submit_indeterminate".to_string(),
                     response_content: None,
-                    error_message: Some(msg),
+                    error_message: Some(format!(
+                        "chat_async response unreadable: {}; run may have been created server-side, ID unknown",
+                        msg
+                    )),
                     content_truncated: false,
                 },
             };

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -68,7 +68,8 @@ use tracing::{Level, debug, info, warn};
 use tracing_subscriber::FmtSubscriber;
 
 use bcs_cli::{
-    BcsClient, CreateCustomGroupOptions, RunSessionCollaborationOptions,
+    BcsClient, ChatAsyncError, ChatRunOutcome, CreateCustomGroupOptions,
+    RunSessionCollaborationOptions,
 };
 use bcs_protocol::{BCS_PROTOCOL_VERSION, BotConnectParams};
 
@@ -3448,6 +3449,7 @@ pub async fn run() -> Result<()> {
             } else {
                 1_800_000
             });
+            let json_mode = structured_mode;
 
             debug_request!(
                 debug,
@@ -3462,61 +3464,158 @@ pub async fn run() -> Result<()> {
                     "organization_code": &organization_code,
                 })
             );
-            let result = if detach {
-                client
-                    .chat_polling_detach(
-                        &bot_uuid,
-                        &message,
-                        None,
-                        session_id.as_deref(),
-                        &tags,
-                        response_mode.as_deref(),
-                        Some(client_wait_timeout_ms),
-                        Some(poll_wait_ms),
-                        organization_code.as_deref(),
-                    )
-                    .await?
-            } else {
-                client
-                    .chat_polling(
-                        &bot_uuid,
-                        &message,
-                        None,
-                        session_id.as_deref(),
-                        &tags,
-                        response_mode.as_deref(),
-                        Some(client_wait_timeout_ms),
-                        Some(poll_wait_ms),
-                        organization_code.as_deref(),
-                    )
-                    .await?
+            let outcome: ChatRunOutcome = match client
+                .chat_async(
+                    &bot_uuid,
+                    &message,
+                    None,
+                    session_id.as_deref(),
+                    &tags,
+                    response_mode.as_deref(),
+                    organization_code.as_deref(),
+                    client_wait_timeout_ms,
+                    detach,
+                )
+                .await
+            {
+                Ok(submit) => {
+                    // Early ack: timestamped plain-text log line. json mode →
+                    // stderr (keep stdout as a single JSON object); non-json
+                    // mode → stdout, before the Response / Message block.
+                    let ack = format!(
+                        "{} [chat] submitted run_id={} session_id={}",
+                        chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f%:z"),
+                        submit.run_id,
+                        submit.session_id
+                    );
+                    if json_mode {
+                        use std::io::Write as _;
+                        eprintln!("{}", ack);
+                        let _ = std::io::stderr().flush();
+                    } else {
+                        use std::io::Write as _;
+                        println!("{}", ack);
+                        let _ = std::io::stdout().flush();
+                    }
+
+                    if detach {
+                        client
+                            .chat_poll_run_until_running(
+                                &submit,
+                                poll_wait_ms,
+                                std::time::Duration::from_millis(client_wait_timeout_ms),
+                            )
+                            .await?
+                    } else {
+                        client
+                            .chat_poll_run(
+                                &submit,
+                                poll_wait_ms,
+                                std::time::Duration::from_millis(client_wait_timeout_ms),
+                            )
+                            .await?
+                    }
+                }
+                Err(ChatAsyncError::Transport(msg)) => ChatRunOutcome {
+                    delivered: false,
+                    submitted: false,
+                    run_id: None,
+                    session_id: None,
+                    bot_uuid: Some(bot_uuid.clone()),
+                    state: "submit_indeterminate".to_string(),
+                    response_content: None,
+                    error_message: Some(format!(
+                        "chat_async transport error: {}; run may have been created server-side, ID unknown",
+                        msg
+                    )),
+                    content_truncated: false,
+                },
+                Err(ChatAsyncError::NotSuccessful { status, body }) => ChatRunOutcome {
+                    delivered: false,
+                    submitted: false,
+                    run_id: None,
+                    session_id: None,
+                    bot_uuid: Some(bot_uuid.clone()),
+                    state: "submit_failed".to_string(),
+                    response_content: None,
+                    error_message: Some(format!("chat_async failed ({}): {}", status, body)),
+                    content_truncated: false,
+                },
+                Err(ChatAsyncError::InvalidResponse(msg)) => ChatRunOutcome {
+                    delivered: false,
+                    submitted: false,
+                    run_id: None,
+                    session_id: None,
+                    bot_uuid: Some(bot_uuid.clone()),
+                    state: "submit_failed".to_string(),
+                    response_content: None,
+                    error_message: Some(msg),
+                    content_truncated: false,
+                },
             };
 
-            debug_response!(debug, "200", &result);
+            debug!(
+                state = %outcome.state,
+                delivered = outcome.delivered,
+                "chat outcome"
+            );
 
-            if cli.json {
-                println!("{}", serde_json::to_string(&result)?);
-            } else if detach {
-                println!("Message submitted to {}", bot_uuid);
-                if let Some(rid) = result.get("run_id").and_then(|v| v.as_str()) {
-                    println!("Run: {}", rid);
-                }
-                if let Some(sid) = result.get("session_id").and_then(|v| v.as_str()) {
-                    println!("Session: {}", sid);
-                }
-                if let Some(state) = result.get("state").and_then(|v| v.as_str()) {
-                    println!("State: {}", state);
-                }
-            } else {
-                if let Some(response) = result.get("response") {
-                    println!("Response from {}:", bot_uuid);
-                    println!("{}", serde_json::to_string_pretty(response)?);
+            if json_mode {
+                // stdout = EXACTLY one JSON object (jq-parseable).
+                let json_value = if detach {
+                    serde_json::json!({
+                        "delivered": outcome.delivered,
+                        "submitted": outcome.submitted,
+                        "bot_uuid": outcome.bot_uuid,
+                        "run_id": outcome.run_id,
+                        "session_id": outcome.session_id,
+                        "state": outcome.state,
+                        "error_message": outcome.error_message,
+                    })
                 } else {
-                    println!("Result: {}", serde_json::to_string_pretty(&result)?);
+                    serde_json::json!({
+                        "delivered": outcome.delivered,
+                        "submitted": outcome.submitted,
+                        "bot_uuid": outcome.bot_uuid,
+                        "run_id": outcome.run_id,
+                        "session_id": outcome.session_id,
+                        "state": outcome.state,
+                        "response": {"content": outcome.response_content.unwrap_or_default()},
+                        "error_message": outcome.error_message,
+                        "content_truncated": outcome.content_truncated,
+                    })
+                };
+                println!("{}", serde_json::to_string(&json_value)?);
+            } else {
+                // Human text on stdout.
+                if outcome.delivered {
+                    if detach {
+                        println!("Message submitted to {}", bot_uuid);
+                    } else {
+                        println!("Response from {}:", bot_uuid);
+                        let content = outcome.response_content.unwrap_or_default();
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({"content": content}))?
+                        );
+                    }
                 }
-                if let Some(sid) = result.get("session_id").and_then(|v| v.as_str()) {
-                    println!("Session: {}", sid);
+                println!(
+                    "Run: {}",
+                    outcome.run_id.as_deref().unwrap_or("none")
+                );
+                println!(
+                    "Session: {}",
+                    outcome.session_id.as_deref().unwrap_or("none")
+                );
+                println!("State: {}", outcome.state);
+                if let Some(err) = &outcome.error_message {
+                    println!("Error: {}", err);
                 }
+            }
+
+            if !outcome.delivered {
+                std::process::exit(1);
             }
         }
 

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/chat_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/chat_test.rs
@@ -1,0 +1,149 @@
+//! E2E tests for `bcs-cli chat` output rendering.
+//!
+//! These exercise the binary-level output contracts from the v4 design spec:
+//! - Default (no-flag) mode emits a single JSON object on stdout + ack on stderr
+//! - `--no-json` mode emits human text including a `Run:` line on stdout
+//!
+//! Both paths assert `run_id` + `session_id` are surfaced.
+
+use crate::common::{assert_success, TestContext};
+use wiremock::{matchers::method, Mock, ResponseTemplate};
+
+/// Set up the mock for a sync `completed` chat run.
+async fn mock_chat_completed(ctx: &TestContext) {
+    Mock::given(method("POST"))
+        .and(wiremock::matchers::path("/bots/bot-target/chat-async"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+            "run_id": "run-1",
+            "bot_uuid": "bot-target",
+            "session_id": "session-1",
+            "status": "submitted",
+            "expires_at_ms": 9_999_999_u64,
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(wiremock::matchers::path("/chat/runs/run-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "run_id": "run-1",
+            "bot_uuid": "bot-target",
+            "from_bot_id": "bot-source",
+            "session_id": "session-1",
+            "state": "completed",
+            "response": {"content": "hello back"},
+            "created_at_ms": 1_u64,
+            "updated_at_ms": 2_u64,
+            "expires_at_ms": 9_999_999_u64,
+            "version": 2_u64,
+            "content_truncated": false,
+            "is_terminal": true,
+        })))
+        .mount(&ctx.mock_server)
+        .await;
+}
+
+#[tokio::test]
+async fn chat_default_mode_emits_single_json_on_stdout_with_ack_on_stderr() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    // Write session with a token so `get_token` doesn't fail.
+    std::fs::write(
+        ctx.session_path(),
+        serde_json::to_vec(&serde_json::json!({
+            "token": ctx.session.token,
+            "bcs_url": ctx.session.bcs_url,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    mock_chat_completed(&ctx).await;
+
+    let output = ctx
+        .cmd()
+        .arg("chat")
+        .arg("--bot-uuid")
+        .arg("bot-target")
+        .arg("--message")
+        .arg("hello")
+        .arg("--timeout-ms")
+        .arg("10000")
+        .output()
+        .expect("Failed to execute command");
+
+    assert_success(&output);
+
+    // stdout: exactly one JSON object (jq-parseable)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|err| {
+        panic!(
+            "stdout should be a single JSON object, got: {:?}\nError: {}",
+            stdout, err
+        )
+    });
+    assert_eq!(json["delivered"], serde_json::json!(true));
+    assert_eq!(json["submitted"], serde_json::json!(true));
+    assert_eq!(json["run_id"], serde_json::json!("run-1"));
+    assert_eq!(json["session_id"], serde_json::json!("session-1"));
+    assert_eq!(json["state"], serde_json::json!("completed"));
+    assert_eq!(json["response"]["content"], serde_json::json!("hello back"));
+
+    // stderr: ack line with run_id + session_id
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[chat] submitted run_id=run-1 session_id=session-1"),
+        "stderr should contain ack line, got: {:?}",
+        stderr
+    );
+}
+
+#[tokio::test]
+async fn chat_no_json_mode_prints_run_line_on_stdout() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    std::fs::write(
+        ctx.session_path(),
+        serde_json::to_vec(&serde_json::json!({
+            "token": ctx.session.token,
+            "bcs_url": ctx.session.bcs_url,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    mock_chat_completed(&ctx).await;
+
+    let output = ctx
+        .cmd()
+        .arg("--no-json")
+        .arg("chat")
+        .arg("--bot-uuid")
+        .arg("bot-target")
+        .arg("--message")
+        .arg("hello")
+        .arg("--timeout-ms")
+        .arg("10000")
+        .output()
+        .expect("Failed to execute command");
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Regression: sync non-json success MUST include `Run:` (issue 1 fix)
+    assert!(
+        stdout.contains("Run: run-1"),
+        "stdout should contain 'Run: run-1', got: {:?}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Session: session-1"),
+        "stdout should contain 'Session: session-1', got: {:?}",
+        stdout
+    );
+    assert!(
+        stdout.contains("State: completed"),
+        "stdout should contain 'State: completed', got: {:?}",
+        stdout
+    );
+    // ack also on stdout in non-json mode
+    assert!(
+        stdout.contains("[chat] submitted run_id=run-1 session_id=session-1"),
+        "stdout should contain ack line in non-json mode, got: {:?}",
+        stdout
+    );
+}

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/main.rs
@@ -1,5 +1,6 @@
 //! E2E test suite for bcs-cli
 
+mod chat_test;
 mod common;
 mod custom_collaboration_test;
 mod discover_test;

--- a/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
@@ -1,0 +1,186 @@
+# bcs-cli chat 透出 run_id / session_id 设计
+
+- 日期：2026-08-10
+- 状态：设计已确认，待实现
+- 范围：`crates/tools/bcs-cli`（`main.rs` + `client.rs`），仅 CLI 侧输出契约
+
+## 背景
+
+`bcs-cli chat` 走 `POST /bots/{id}/chat-async` 提交 + 长轮询 `GET /chat/runs/{run_id}` 的流程，分两种模式：
+
+- `--detach`：run 进入 `running` 即返回（`chat_polling_detach`）。
+- 同步默认：阻塞到 run 终态（`chat_polling`）。
+
+两类问题经核对属真实：
+
+1. **同步等待模式下 agent 不知道 run_id**：`chat_polling` 成功返回的 JSON 内含 `run_id`/`session_id`，但 `main.rs` 的同步分支只打印 `Session:`，不打印 `Run:`；`--detach` 分支则有 `Run:`。整个阻塞等待期间 agent 也拿不到任何标识符。
+2. **同步失败时响应里没有 run_id/session_id**：失败时 `chat_polling` 返回 `Err(anyhow!(...))`，经 `main.rs` 的 `?` 直接冒泡，结构化结果块（含 `--json` 分支）完全跳过，最终由 `fn main() -> Result<()>` 以纯文本打到 stderr。其中 `run_id` 只是混在错误串里（`run {}`），`session_id` 完全缺失——即便 `reported_session` 在提交后已经拿到（`client.rs:1350`）。`--detach` 失败路径同样丢失 `session_id`。
+
+## 决策
+
+### 1. 架构：submit → ack → poll → print，由 `main.rs` 驱动打印
+
+当前 `chat_polling` / `chat_polling_detach` 把「提交 + 轮询 + 失败即 Err」揉在 `client.rs` 中，导致 `main.rs` 没有机会在提交后、轮询前介入打印。改为把流程切分，让 `main.rs`（交付层，按 CLAUDE.md 分层负责 CLI 打印）显式驱动：
+
+1. `client.chat_async(...)` → `ChatRunSubmitResponse { run_id, session_id, bot_uuid, ... }`（已存在）。
+2. `main.rs` 打印早 ack（见 §3）。
+3. 新增轮询方法返回结构化结果 `ChatRunOutcome`（见 §5），不再返回裸 `Err`：
+   - 同步：`chat_poll_run(run_id, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到终态）。
+   - detach：`chat_poll_run_until_running(run_id, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到 `running`）。
+4. `main.rs` 用 `ChatRunOutcome` 决定最终输出与退出码。
+
+`client.rs` 继续保持纯传输层，不做任何 stdout/stderr 打印；所有打印仍在 `main.rs`。
+
+### 2. run_id / session_id 透出位置
+
+run_id + session_id 必须在两处出现：早 ack（提交后立刻）与最终块（成功与失败都含），覆盖 sync/detach × json/non-json 全部分支。
+
+### 3. 早 ack：带时间戳的纯文本日志行（非 JSON）
+
+格式（时间戳为本地时区 RFC3339，含毫秒）：
+
+```
+2026-08-10T14:23:01.123+08:00 [chat] submitted run_id=run-9f3a session_id=bcs-cli:default:197262:a9c8432f
+```
+
+通道按模式分流（混合策略，对 `--json` stdout 保持纯净）：
+
+- non-json：ack 打到 **stdout**，在 `Response from <bot>` 块之前。
+- json：ack 打到 **stderr**，stdout 保持单个 JSON 对象（`jq` 可直接解析）。
+
+> 备选：统一 stderr / 统一 stdout，实现时如需调整以该决策为准；当前选混合是为了同时满足「non-json 在 Response 块前可见」与「json stdout 纯净」。
+
+### 4. 输出契约
+
+统一规则：早 ack → 见 §3；最终结果 → stdout 恰一个实体；退出码 → 成败。
+
+| 模式 | 早 ack（提交后） | 最终结果（stdout） | Exit |
+|---|---|---|---|
+| sync non-json | stdout，在 Response 块前：`<ts> [chat] submitted run_id=<rid> session_id=<sid>` | 成功：`Response from <bot>`+content+`Session:`；失败：`Run:`+`Session:`+`State: failed`+`Error: <msg>` | 0/1 |
+| sync json | stderr：`<ts> [chat] submitted run_id=<rid> session_id=<sid>` | 成功见下方 §6；失败见下方 §6 | 0/1 |
+| detach non-json | stdout，在 Response 块前 | 成功：`Run:`+`Session:`+`State: running`（现有）；失败：`Run:`+`Session:`+`State: failed`+`Error: <msg>` | 0/1 |
+| detach json | stderr 同上 | 成功/失败见 §6 | 0/1 |
+
+### 5. `ChatRunOutcome`（替代裸 `Result<Value>` / Err）
+
+```rust
+struct ChatRunOutcome {
+    delivered: bool,          // Completed（sync）/ 进入 Running（detach）
+    submitted: bool,          // 仅当提交本身失败时为 false
+    run_id: Option<String>,   // 仅提交失败时为 None
+    session_id: Option<String>,
+    state: String,            // running|completed|failed|cancelled|timeout|submitted|submit_failed
+    bot_uuid: Option<String>,
+    response_content: Option<String>,
+    error_message: Option<String>,
+    content_truncated: bool,
+}
+```
+
+- 提交成功后轮询方法返回 `Ok(ChatRunOutcome)`；`delivered=false` 表示未交付。
+- 提交级 HTTP 错误（非 2xx / 反序列化失败）返回 `Err`，由 `main.rs` 转成 `submit_failed` 的 `ChatRunOutcome` 再打印。
+- `ChatRunOutcome` 是 `bcs-cli` crate 内部结构（位于 `client.rs`），不是 bcs-protocol 线上 DTO；由现有 `ChatRunSubmitResponse` / `ChatRunStatusResponse` 的既有字段组装，不引入任何新的线上字段。
+
+### 6. 最终 stdout JSON 显式字段
+
+run_id 与 session_id 始终为顶层字段；仅提交失败（服务器未创建 run）时为 `null`。sync 与 detach 的 JSON 顶层布尔字段不同：sync 以 `delivered` 表成败并携带 `response` / `content_truncated`；detach 以 `submitted` 表成败，因 run 未等到完成故省略 `response` / `content_truncated`。两者均始终包含 `run_id` 与 `session_id`。
+
+sync json 成功（exit 0）：
+```json
+{
+  "delivered": true,
+  "bot_uuid": "default:197262",
+  "run_id": "run-9f3a",
+  "session_id": "bcs-cli:default:197262:a9c8432f",
+  "state": "completed",
+  "response": { "content": "嘿，我是元歌的分身 …" },
+  "error_message": null,
+  "content_truncated": false
+}
+```
+
+sync json 失败（exit 1）：
+```json
+{
+  "delivered": false,
+  "bot_uuid": "default:197262",
+  "run_id": "run-9f3a",
+  "session_id": "bcs-cli:default:197262:a9c8432f",
+  "state": "failed",
+  "response": { "content": "" },
+  "error_message": "provider returned error: …",
+  "content_truncated": false
+}
+```
+超时变体：`"state": "timeout"`、`"error_message": "local polling timeout after 1800000 ms; run run-9f3a still active"`。
+
+detach json 成功（exit 0）/ 失败（exit 1）：
+```json
+{ "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "running", "error_message": null }
+{ "submitted": false, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "failed", "error_message": "…" }
+```
+
+提交本身失败（如 404 bot 不存在，未创建 run）（exit 1）：
+```json
+{
+  "delivered": false,
+  "submitted": false,
+  "bot_uuid": "default:197262",
+  "run_id": null,
+  "session_id": null,
+  "state": "submit_failed",
+  "response": { "content": "" },
+  "error_message": "chat_async failed (404): Bot not found"
+}
+```
+
+### 7. 失败语义
+
+- `Failed` / `Cancelled`：`delivered=false`、`state=failed/cancelled`、`error_message` 取自 status。结构化 stdout 输出，exit 1。
+- 本地轮询超时（deadline 到，run 在服务端仍活动）：`delivered=false`、`state="timeout"`、`error_message="local polling timeout after N ms; run <rid> still active"`。结构化输出，exit 1。透出的 run_id 允许 agent 自行后续查询/取消。
+- 提交本身失败（非 2xx 或反序列化失败）：无 run_id/session_id，`state="submit_failed"`，`error_message=body`，结构化输出，exit 1。
+
+### 8. 兼容性与退出码
+
+- 退出码：成功 0，任何失败 1（与现状一致，仅输出内容改善）。
+- `--json` stdout 在所有情况下都恰为一个 JSON 对象（成功或失败）；失败路径为严格增量修复（现状打印空）。
+- `chat_polling` / `chat_polling_detach` 被 `chat_async` + `chat_poll_run(_until_running)` 取代；`client.rs` 内现有 `test_chat_polling_*` 测试需更新为断言新的结构化结果，而非自由文本 `Err`。
+- 该 `client.rs` 为 `bcs-cli` crate 内部，无外部 crate 依赖其 `chat_polling`，API 变更影响面仅在 crate 内及 crate 内测试。
+
+## 跨版本兼容（无服务端变更）
+
+本设计仅改动 `bcs-cli` crate，不触达服务端、端点、或线上 DTO：
+
+- 不改 `POST /bots/{id}/chat-async`、`GET /chat/runs/{run_id}`，不改 `ChatRunSubmitResponse` / `ChatRunStatusResponse`；这些 DTO 已含 `run_id`、`session_id`、`state`、`response`、`error_message` 字段，CLI 今日已解析，只是未打印 / 在失败时丢弃。本设计只改打印与失败结构化。
+- 因此本功能**不需要服务端升级**，也不引入 CLI↔Server 新版本耦合。
+- 双向兼容：
+  - 老存量 CLI ↔ 当前/未来 Server：不受本改动影响（服务端无任何变化），行为与今天一致。
+  - 新 CLI ↔ 老 Server：可用。新 CLI 只读老 Server 已发送的既有字段；不新增请求字段、不新增/不提升 `X-BCS-CHAT-VERSION`（仍为 `2`）。
+- 失败时 run_id 取自提交响应、session_id 取自提交时的 `reported_session`，因此即便某 Server 的失败状态体遗漏这些字段，CLI 仍可透出，不依赖 Server 状态体形状。
+- 仓库已有 `BCS_CHAT_VERSION` / `X-BCS-CHAT-VERSION` 版本协商用于任何真实的线上协议变更；本设计不触碰它。
+
+## 验收标准
+
+- 同步 non-json 成功时，stdout 出现 `Run:`（修复问题 1 的 run_id）。
+- 同步与 detach 在提交后立刻输出带时间戳的纯文本 ack，行内含 `run_id` 与 `session_id`；non-json 走 stdout 且在 `Response from` 块之前，json 走 stderr。
+- 同步失败（run failed / local timeout）时，stdout（json：单 JSON 对象；non-json：`Run/Session/State/Error` 行）包含 run_id 与 session_id，且 exit 1。
+- detach 成功与失败均输出 run_id 与 session_id；失败时 exit 1。
+- 提交级失败（如 404）输出结构化失败（json：单对象，`run_id/session_id=null`；non-json：`Error:` 行），exit 1，无 panic。
+- `--json` 模式下，stdout 成功与失败均为且仅为一个 JSON 对象，`jq '.'` 可解析。
+- run_id 与 session_id 同时出现在早 ack 与最终 stdout 块（除提交级失败外，最终块均为非 null 顶层字段）。
+
+## 测试
+
+- 更新 `test_chat_polling_timeout_leaves_server_run_active`：断言 `outcome.delivered==false`、`state=="timeout"`、含 `run_id` 与 `session_id`，而非断言自由文本 `Err` 含 `run-local-timeout is still active`。
+- 新增：同步 non-json 成功打印 `Run:`（问题 1 回归）。
+- 新增：同步 json 失败在 stdout 打印单个失败 JSON 对象且 exit 1（问题 2）。
+- 新增：提交后立刻在正确通道（non-json→stdout，json→stderr）输出带时间戳的纯文本 ack（含 run_id+session_id），覆盖 sync 与 detach。
+- 新增：detach 失败在 stdout 输出 run_id 与 session_id 且 exit 1。
+- 新增：提交级失败（404）输出结构化失败、exit 1、ID 为 null、无 panic。
+
+## 非目标
+
+- 不改服务端 run 生命周期、端点、或 `chat_run_status` 长轮询协议。
+- 不新增 CLI 子命令用于复轮询（透出的 run_id 允许 agent 直接打 `GET /chat/runs/{run_id}`，另行跟进）。
+- 不动 `wait_for_service_completion`（群组 / state-machine 流程，已打印 `StateRun:`）。
+- 不改 `client.rs` 之外 crate 的对外 API。

--- a/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
@@ -1,14 +1,14 @@
 # bcs-cli chat 透出 run_id / session_id 设计
 
 - 日期：2026-08-10
-- 状态：设计已确认，待实现（v2：据 Codex PR #927 review 修订）
+- 状态：设计已确认，待实现（v3：据 Codex PR #927 第二轮 review 修订——detach 接受 `completed`）
 - 范围：`crates/tools/bcs-cli`（`main.rs` + `client.rs`），仅 CLI 侧输出契约
 
 ## 背景
 
 `bcs-cli chat` 走 `POST /bots/{id}/chat-async` 提交 + 长轮询 `GET /chat/runs/{run_id}` 的流程，分两种模式：
 
-- `--detach`：run 进入 `running` 即返回（`chat_polling_detach`）。
+- `--detach`：run 进入 `running`（或 legacy 直接 `completed`，见 §6）即返回（`chat_polling_detach`）。
 - 同步默认：阻塞到 run 终态（`chat_polling`）。
 
 两类问题经核对属真实：
@@ -79,7 +79,7 @@ run_id + session_id 必须在两处出现：早 ack（提交后立刻）与最�
 
 ```rust
 struct ChatRunOutcome {
-    delivered: bool,          // 成败：Completed（sync）/ 进入 Running（detach）
+    delivered: bool,          // 成败：sync=Completed；detach=Running 或 Completed（含 legacy 直接 completed）
     submitted: bool,          // run 是否被创建（chat_async 返回了 run_id）；仅提交级失败为 false
     run_id: Option<String>,   // 仅提交失败时为 None
     session_id: Option<String>,
@@ -92,7 +92,7 @@ struct ChatRunOutcome {
 ```
 
 - 提交成功后轮询方法返回 `Ok(ChatRunOutcome)`；`delivered=false` 表示未交付。
-- `submitted` 仅表示「run 是否被创建」，**不**用于表达成败；退出码由 `state` 推导（成功 = `completed`（sync）或 `running`（detach）；其余 = 失败）。
+- `submitted` 仅表示「run 是否被创建」，**不**用于表达成败；退出码由 `state` 推导（成功 = sync 下 `completed`，或 detach 下 `running`/`completed`——含 run 在首次状态响应前已完成，对齐现有 `chat_polling_detach` 接受 `Completed|Running` `client.rs:1469`；其余 = 失败）。
 - 错误映射（`main.rs` 统一做，确保 stdout 在「run 已创建」时绝不空）：
   - 提交级 HTTP 错误（非 2xx / 反序列化失败） → `submit_failed`（`submitted=false`、`run_id/session_id=null`）。
   - 轮询期 `chat_run_status` 错误（传输 / 非 2xx / 反序列化，发生在 run 已创建后） → `poll_error`（`submitted=true`、IDs 取自提交响应，见 §7）。
@@ -100,7 +100,7 @@ struct ChatRunOutcome {
 
 ### 6. 最终 stdout JSON 显式字段
 
-run_id 与 session_id 始终为顶层字段；仅提交失败（服务器未创建 run）时为 `null`。sync 与 detach **均以 `delivered` 表成败**（detach：`delivered`↔`state=running`）。`submitted` 仅表示 run 是否被创建（`chat_async` 返回了 `run_id`），仅在提交级失败时为 false——**不**用于表达成败，退出码由 `state` 推导。sync 因等待到完成携带 `response` / `content_truncated`；detach 因不等到完成故省略 `response` / `content_truncated`。两者均始终包含 `run_id` 与 `session_id`。
+run_id 与 session_id 始终为顶层字段；仅提交失败（服务器未创建 run）时为 `null`。sync 与 detach **均以 `delivered` 表成败**（sync：`delivered`↔`state=completed`；detach：`delivered`↔`state∈{running, completed}`，含 run 在首次状态响应前已完成的快/legacy 情况）。`submitted` 仅表示 run 是否被创建（`chat_async` 返回了 `run_id`），仅在提交级失败时为 false——**不**用于表达成败，退出码由 `state` 推导。sync 因等待到完成携带 `response` / `content_truncated`；detach 因不等到完成故省略 `response` / `content_truncated`。两者均始终包含 `run_id` 与 `session_id`。
 
 sync json 成功（exit 0）：
 ```json
@@ -137,9 +137,10 @@ sync json 失败（exit 1）：
 detach json 成功（exit 0）/ 失败（exit 1）：
 ```json
 { "delivered": true, "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "running", "error_message": null }
+{ "delivered": true, "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "completed", "error_message": null }
 { "delivered": false, "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "failed", "error_message": "…" }
 ```
-注意 detach 失败时 `submitted=true`（run 已被创建，只是后来 failed/cancelled），区别于提交级失败的 `submitted:false`（见下方）。
+注意：detach 下 `state=completed` 同样算成功（`delivered:true`、exit 0）—— run 可能在首次状态响应前已完成（快 run 或 legacy server 跳过 `running`），对齐现有 `chat_polling_detach` 接受 `Completed|Running`（`client.rs:1469`）。detach 失败时 `submitted=true`（run 已被创建，只是后来 failed/cancelled），区别于提交级失败的 `submitted:false`（见下方）。
 
 提交本身失败（如 404 bot 不存在，未创建 run）（exit 1）：
 ```json
@@ -188,7 +189,7 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 - 同步 non-json 成功时，stdout 出现 `Run:`（修复问题 1 的 run_id）。
 - 同步与 detach 在提交后立刻输出带时间戳的纯文本 ack，行内含 `run_id` 与 `session_id`；non-json 走 stdout 且在 `Response from` 块之前，json 走 stderr。
 - 同步失败（run failed / local timeout / 轮询请求错误）时，stdout（json：单 JSON 对象；non-json：`Run/Session/State/Error` 行）包含 run_id 与 session_id，且 exit 1。
-- detach 成功与失败均输出 run_id 与 session_id；失败时 `submitted=true`、`state=failed/cancelled`、exit 1。
+- detach 成功与失败均输出 run_id 与 session_id；成功接受 `state=running` **或** `state=completed`（run 在首次状态前已完成的快/legacy 情况），均 `delivered:true`、exit 0；失败时 `submitted=true`、`state=failed/cancelled`、exit 1。
 - 提交级失败（如 404）输出结构化失败（json：单对象，`run_id/session_id=null`、`submitted=false`；non-json：`Error:` 行），exit 1，无 panic。
 - 轮询期 `chat_run_status` 错误映射为 `state="poll_error"` 的结构化结果（含来自提交的 run_id+session_id），exit 1，stdout 非空。
 - `--json` 模式下，stdout 成功与失败均为且仅为一个 JSON 对象，`jq '.'` 可解析。
@@ -202,6 +203,7 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 - 新增：同步 json 失败在 stdout 打印单个失败 JSON 对象且 exit 1（问题 2）。
 - 新增：提交后立刻在正确通道（non-json→stdout，json→stderr）输出带时间戳的纯文本 ack（含 run_id+session_id），覆盖 sync 与 detach。
 - 新增：detach 失败在 stdout 输出 `submitted=true`、`state=failed`、run_id 与 session_id 且 exit 1。
+- 新增：detach 首个状态为 `completed`（快/legacy run）→ `delivered=true`、`state=completed`、exit 0（兼容回归，对齐 `chat_polling_detach` 的 `Completed` 接受）。
 - 新增：提交级失败（404）输出结构化失败、`submitted=false`、ID=null、exit 1、无 panic。
 - 新增：轮询期 `chat_run_status` 返回 500 → `state="poll_error"` 结构化结果，含 run_id+session_id（取自提交响应），exit 1，stdout 非空。
 

--- a/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
@@ -1,7 +1,7 @@
 # bcs-cli chat 透出 run_id / session_id 设计
 
 - 日期：2026-08-10
-- 状态：设计已确认，待实现（v3：据 Codex PR #927 第二轮 review 修订——detach 接受 `completed`）
+- 状态：设计已确认，待实现（v4：据 Codex PR #927 第三轮 review 修订——poll 签名携带 submit 元数据；新增 `submit_indeterminate`。spec 实现就绪，其余边缘场景归实现 PR）
 - 范围：`crates/tools/bcs-cli`（`main.rs` + `client.rs`），仅 CLI 侧输出契约
 
 ## 背景
@@ -25,8 +25,8 @@
 1. `client.chat_async(...)` → `ChatRunSubmitResponse { run_id, session_id, bot_uuid, ... }`（已存在）。
 2. `main.rs` 打印早 ack（见 §3）。
 3. 新增轮询方法返回结构化结果 `ChatRunOutcome`（见 §5），不再返回裸 `Err`：
-   - 同步：`chat_poll_run(run_id, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到终态）。
-   - detach：`chat_poll_run_until_running(run_id, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到 `running`）。
+   - 同步：`chat_poll_run(submit: &ChatRunSubmitResponse, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到终态；用 `submit.run_id` 轮询，`submit.session_id`/`bot_uuid` 填充无 status 响应的 timeout/poll_error 结果）。
+   - detach：`chat_poll_run_until_running(submit: &ChatRunSubmitResponse, poll_wait_ms, deadline) -> Result<ChatRunOutcome>`（轮询到 `running`/`completed`；同样用 submit 元数据填充无 status 的结果）。
 4. `main.rs` 用 `ChatRunOutcome` 决定最终输出与退出码。
 
 `client.rs` 继续保持纯传输层，不做任何 stdout/stderr 打印；所有打印仍在 `main.rs`。
@@ -83,7 +83,7 @@ struct ChatRunOutcome {
     submitted: bool,          // run 是否被创建（chat_async 返回了 run_id）；仅提交级失败为 false
     run_id: Option<String>,   // 仅提交失败时为 None
     session_id: Option<String>,
-    state: String,            // running|completed|failed|cancelled|timeout|submitted|submit_failed|poll_error
+    state: String,            // running|completed|failed|cancelled|timeout|submitted|submit_failed|poll_error|submit_indeterminate
     bot_uuid: Option<String>,
     response_content: Option<String>,
     error_message: Option<String>,
@@ -94,7 +94,8 @@ struct ChatRunOutcome {
 - 提交成功后轮询方法返回 `Ok(ChatRunOutcome)`；`delivered=false` 表示未交付。
 - `submitted` 仅表示「run 是否被创建」，**不**用于表达成败；退出码由 `state` 推导（成功 = sync 下 `completed`，或 detach 下 `running`/`completed`——含 run 在首次状态响应前已完成，对齐现有 `chat_polling_detach` 接受 `Completed|Running` `client.rs:1469`；其余 = 失败）。
 - 错误映射（`main.rs` 统一做，确保 stdout 在「run 已创建」时绝不空）：
-  - 提交级 HTTP 错误（非 2xx / 反序列化失败） → `submit_failed`（`submitted=false`、`run_id/session_id=null`）。
+  - 提交级非 2xx / 反序列化失败（服务器明确拒绝或响应不可读） → `submit_failed`（`submitted=false`、`run_id/session_id=null`）。
+  - 提交级传输错误（连接 reset / 10s 客户端超时等，`chat_async` 的 `.send()` 失败，见 §7） → `submit_indeterminate`（`submitted=false`、`run_id/session_id=null`、`error_message` 注明「run 可能在服务端已创建但 CLI 未知其 ID」）。不加分类地塞进 `submit_failed` 不安全——run 可能已存在但 202 未抵达。
   - 轮询期 `chat_run_status` 错误（传输 / 非 2xx / 反序列化，发生在 run 已创建后） → `poll_error`（`submitted=true`、IDs 取自提交响应，见 §7）。
 - `ChatRunOutcome` 是 `bcs-cli` crate 内部结构（位于 `client.rs`），不是 bcs-protocol 线上 DTO；由现有 `ChatRunSubmitResponse` / `ChatRunStatusResponse` 的既有字段组装，不引入任何新的线上字段。
 
@@ -156,12 +157,15 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 }
 ```
 
+提交传输错误变体：`state="submit_indeterminate"`（与上方结构相同，`run_id/session_id=null`、`submitted=false`）、`error_message="chat_async transport error: ...; run may have been created server-side, ID unknown"`——run 是否已创建未知，见 §7。`submit_failed` = 服务器明确未接受（非 2xx）/ 响应不含可读 run（deser）；两者 IDs 均为 null，仅语义不同。
+
 ### 7. 失败语义
 
 - `Failed` / `Cancelled`：`delivered=false`、`submitted=true`、`state=failed/cancelled`、`error_message` 取自 status。结构化 stdout 输出，exit 1。
-- 本地轮询超时（deadline 到，run 在服务端仍活动）：`delivered=false`、`submitted=true`、`state="timeout"`、`error_message="local polling timeout after N ms; run <rid> still active"`。结构化输出，exit 1。透出的 run_id 允许 agent 自行后续查询/取消。
+- 本地轮询超时（deadline 到，run 在服务端仍活动）：`delivered=false`、`submitted=true`、`state="timeout"`、`error_message="local polling timeout after N ms; run <rid> still active"`。结构化输出，exit 1。透出的 run_id 允许 agent 自行后续查询/取消。`run_id`/`session_id`/`bot_uuid` 取自提交响应（由 `chat_poll_run`/`chat_poll_run_until_running` 接收的 submit 元数据填充），即便因零/极短 `--timeout-ms` 在首次状态响应前超时、从未拿到 `ChatRunStatusResponse` 也保留。
 - **轮询请求错误**（修复 Codex P2）：`chat_run_status` 在 run 已创建后的传输错误 / 非 2xx / 反序列化失败：`delivered=false`、`submitted=true`、`state="poll_error"`、`run_id`+`session_id` 取自提交响应（已知）、`error_message="<err>"`。结构化输出，exit 1。`main.rs` 将该 Err 映射为 `poll_error` 的 `ChatRunOutcome`，**不**作为裸 Err 冒泡——避免「stdout 空 + 已知 ID 丢失」的原缺陷。
 - 提交本身失败（非 2xx 或反序列化失败）：`submitted=false`、`run_id/session_id=null`、`state="submit_failed"`、`error_message=body`，结构化输出，exit 1。
+- 提交传输不确定（修复 Codex #3b）：`chat_async` 的 `.send()` 报连接 reset / 10s 客户端超时等：`submitted=false`、`run_id/session_id=null`、`state="submit_indeterminate"`、`error_message` 注明「run 可能在服务端已创建但 CLI 未知其 ID」。结构化输出，exit 1。区别于 `submit_failed`（非 2xx/deser = 服务器明确未接受）；本态表示「不确定是否已创建」，agent 不应假设无 run 残留。
 
 ### 8. 兼容性与退出码
 
@@ -190,7 +194,9 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 - 同步与 detach 在提交后立刻输出带时间戳的纯文本 ack，行内含 `run_id` 与 `session_id`；non-json 走 stdout 且在 `Response from` 块之前，json 走 stderr。
 - 同步失败（run failed / local timeout / 轮询请求错误）时，stdout（json：单 JSON 对象；non-json：`Run/Session/State/Error` 行）包含 run_id 与 session_id，且 exit 1。
 - detach 成功与失败均输出 run_id 与 session_id；成功接受 `state=running` **或** `state=completed`（run 在首次状态前已完成的快/legacy 情况），均 `delivered:true`、exit 0；失败时 `submitted=true`、`state=failed/cancelled`、exit 1。
-- 提交级失败（如 404）输出结构化失败（json：单对象，`run_id/session_id=null`、`submitted=false`；non-json：`Error:` 行），exit 1，无 panic。
+- 提交级失败（如 404 非 2xx / 反序列化）输出结构化失败 `state="submit_failed"`（json：单对象，`run_id/session_id=null`、`submitted=false`；non-json：`Error:` 行），exit 1，无 panic。
+- 提交级传输错误（`chat_async` `.send()` reset/超时）映射为 `state="submit_indeterminate"` 结构化结果（IDs null、`submitted=false`、`error_message` 注明可能已创建），exit 1，stdout 非空；agent 不应假设无 run 残留。
+- 本地轮询在首次状态响应前超时（零/极短 `--timeout-ms`）时，结果仍含 `run_id`+`session_id`（取自提交响应），`state="timeout"`，exit 1。
 - 轮询期 `chat_run_status` 错误映射为 `state="poll_error"` 的结构化结果（含来自提交的 run_id+session_id），exit 1，stdout 非空。
 - `--json` 模式下，stdout 成功与失败均为且仅为一个 JSON 对象，`jq '.'` 可解析。
 - run_id 与 session_id 同时出现在早 ack 与最终 stdout 块（除提交级失败外，最终块均为非 null 顶层字段）。
@@ -206,6 +212,8 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 - 新增：detach 首个状态为 `completed`（快/legacy run）→ `delivered=true`、`state=completed`、exit 0（兼容回归，对齐 `chat_polling_detach` 的 `Completed` 接受）。
 - 新增：提交级失败（404）输出结构化失败、`submitted=false`、ID=null、exit 1、无 panic。
 - 新增：轮询期 `chat_run_status` 返回 500 → `state="poll_error"` 结构化结果，含 run_id+session_id（取自提交响应），exit 1，stdout 非空。
+- 新增：`chat_async` `.send()` 连接重置/超时 → `state="submit_indeterminate"` 结构化结果（IDs null、`submitted=false`、`error_message` 注明可能已创建），exit 1，stdout 非空。
+- 新增：零/极短 `--timeout-ms` 在首次状态响应前超时 → 结果仍含 `run_id`+`session_id`（取自提交响应），`state="timeout"`，exit 1。
 
 ## 非目标
 

--- a/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md
@@ -1,7 +1,7 @@
 # bcs-cli chat 透出 run_id / session_id 设计
 
 - 日期：2026-08-10
-- 状态：设计已确认，待实现
+- 状态：设计已确认，待实现（v2：据 Codex PR #927 review 修订）
 - 范围：`crates/tools/bcs-cli`（`main.rs` + `client.rs`），仅 CLI 侧输出契约
 
 ## 背景
@@ -31,6 +31,18 @@
 
 `client.rs` 继续保持纯传输层，不做任何 stdout/stderr 打印；所有打印仍在 `main.rs`。
 
+### 1.5 默认输出模式（修复 Codex P1）
+
+实现中 Chat 分支的输出决策**必须**使用 `is_structured_mode(cli)`（= `!cli.no_json`，见 `main.rs:107`），而**不是**当前的 `if cli.json`（`main.rs:3497`）。即：
+
+- no-flag → **JSON**（匹配仓库文档 `main.rs:741`「default: enabled」与 `is_structured_mode` 语义）。
+- `--json` 保留为向后兼容（仍出 JSON，因 `no_json` 保持 false；OpenClaw 显式传 `--json` 不受影响）。
+- `--no-json` → 人类文本。
+
+**行为变更**：no-flag `bcs-cli chat` 由人类文本改为 JSON。背景：当前 `main.rs:3497` 用 `if cli.json`（显式 flag，默认 false），导致 no-flag 走 non-json 分支，与仓库「JSON 默认开启」文档不一致；本修复纠正之。
+
+> 注：`json` 字段（`main.rs:743`）保留但仅作向后兼容的接受旗标；输出判定一律走 `is_structured_mode`。
+
 ### 2. run_id / session_id 透出位置
 
 run_id + session_id 必须在两处出现：早 ack（提交后立刻）与最终块（成功与失败都含），覆盖 sync/detach × json/non-json 全部分支。
@@ -43,20 +55,22 @@ run_id + session_id 必须在两处出现：早 ack（提交后立刻）与最�
 2026-08-10T14:23:01.123+08:00 [chat] submitted run_id=run-9f3a session_id=bcs-cli:default:197262:a9c8432f
 ```
 
-通道按模式分流（混合策略，对 `--json` stdout 保持纯净）：
+通道按模式分流（混合策略，对 json stdout 保持纯净）：
 
-- non-json：ack 打到 **stdout**，在 `Response from <bot>` 块之前。
-- json：ack 打到 **stderr**，stdout 保持单个 JSON 对象（`jq` 可直接解析）。
+- **json 模式（默认，或显式 `--json`）**：ack 打到 **stderr**，stdout 保持单个 JSON 对象（`jq` 可直接解析）。
+- **non-json 模式（`--no-json`）**：ack 打到 **stdout**，在 `Response from <bot>` 块之前。
 
 > 备选：统一 stderr / 统一 stdout，实现时如需调整以该决策为准；当前选混合是为了同时满足「non-json 在 Response 块前可见」与「json stdout 纯净」。
 
+**早送达范围（澄清）**：主流 agent（OpenClaw / Codex / Claude Code）执行工具时都会消费 stderr（OpenClaw 结果契约 `openclaw-channel-bcn/src/typings/openclaw.d.ts:87-88` 即含 `stderr: Buffer`）。但**前台阻塞调用只在命令退出后才返回输出**，且前台执行有 ~10min 上限 → 长 sync 跑不动前台，agent 须用 `--detach` 或后台流式。因此 stderr 早 ack 的实际受益方是：`--detach`（秒级 ID，比 detach 返回的 ~60s 更早）、流式/后台消费、人类直连。前台阻塞 agent 无论如何都在最终 stdout JSON 拿到 ID（成功+失败都含，见 §6），即完成/失败时拿到而非等待期间——此为已确认取舍以换取 stdout 保持单个 `jq` 可解析对象。
+
 ### 4. 输出契约
 
-统一规则：早 ack → 见 §3；最终结果 → stdout 恰一个实体；退出码 → 成败。
+统一规则：早 ack → 见 §3；最终结果 → stdout 恰一个实体；退出码 → 由 `state` 推导成败。注：json 模式＝默认（或 `--json`），non-json 模式＝`--no-json`（见 §1.5）。
 
 | 模式 | 早 ack（提交后） | 最终结果（stdout） | Exit |
 |---|---|---|---|
-| sync non-json | stdout，在 Response 块前：`<ts> [chat] submitted run_id=<rid> session_id=<sid>` | 成功：`Response from <bot>`+content+`Session:`；失败：`Run:`+`Session:`+`State: failed`+`Error: <msg>` | 0/1 |
+| sync non-json | stdout，在 Response 块前：`<ts> [chat] submitted run_id=<rid> session_id=<sid>` | 成功：`Response from <bot>`+content+`Run:`+`Session:`+`State: completed`；失败：`Run:`+`Session:`+`State: failed`+`Error: <msg>` | 0/1 |
 | sync json | stderr：`<ts> [chat] submitted run_id=<rid> session_id=<sid>` | 成功见下方 §6；失败见下方 §6 | 0/1 |
 | detach non-json | stdout，在 Response 块前 | 成功：`Run:`+`Session:`+`State: running`（现有）；失败：`Run:`+`Session:`+`State: failed`+`Error: <msg>` | 0/1 |
 | detach json | stderr 同上 | 成功/失败见 §6 | 0/1 |
@@ -65,11 +79,11 @@ run_id + session_id 必须在两处出现：早 ack（提交后立刻）与最�
 
 ```rust
 struct ChatRunOutcome {
-    delivered: bool,          // Completed（sync）/ 进入 Running（detach）
-    submitted: bool,          // 仅当提交本身失败时为 false
+    delivered: bool,          // 成败：Completed（sync）/ 进入 Running（detach）
+    submitted: bool,          // run 是否被创建（chat_async 返回了 run_id）；仅提交级失败为 false
     run_id: Option<String>,   // 仅提交失败时为 None
     session_id: Option<String>,
-    state: String,            // running|completed|failed|cancelled|timeout|submitted|submit_failed
+    state: String,            // running|completed|failed|cancelled|timeout|submitted|submit_failed|poll_error
     bot_uuid: Option<String>,
     response_content: Option<String>,
     error_message: Option<String>,
@@ -78,17 +92,21 @@ struct ChatRunOutcome {
 ```
 
 - 提交成功后轮询方法返回 `Ok(ChatRunOutcome)`；`delivered=false` 表示未交付。
-- 提交级 HTTP 错误（非 2xx / 反序列化失败）返回 `Err`，由 `main.rs` 转成 `submit_failed` 的 `ChatRunOutcome` 再打印。
+- `submitted` 仅表示「run 是否被创建」，**不**用于表达成败；退出码由 `state` 推导（成功 = `completed`（sync）或 `running`（detach）；其余 = 失败）。
+- 错误映射（`main.rs` 统一做，确保 stdout 在「run 已创建」时绝不空）：
+  - 提交级 HTTP 错误（非 2xx / 反序列化失败） → `submit_failed`（`submitted=false`、`run_id/session_id=null`）。
+  - 轮询期 `chat_run_status` 错误（传输 / 非 2xx / 反序列化，发生在 run 已创建后） → `poll_error`（`submitted=true`、IDs 取自提交响应，见 §7）。
 - `ChatRunOutcome` 是 `bcs-cli` crate 内部结构（位于 `client.rs`），不是 bcs-protocol 线上 DTO；由现有 `ChatRunSubmitResponse` / `ChatRunStatusResponse` 的既有字段组装，不引入任何新的线上字段。
 
 ### 6. 最终 stdout JSON 显式字段
 
-run_id 与 session_id 始终为顶层字段；仅提交失败（服务器未创建 run）时为 `null`。sync 与 detach 的 JSON 顶层布尔字段不同：sync 以 `delivered` 表成败并携带 `response` / `content_truncated`；detach 以 `submitted` 表成败，因 run 未等到完成故省略 `response` / `content_truncated`。两者均始终包含 `run_id` 与 `session_id`。
+run_id 与 session_id 始终为顶层字段；仅提交失败（服务器未创建 run）时为 `null`。sync 与 detach **均以 `delivered` 表成败**（detach：`delivered`↔`state=running`）。`submitted` 仅表示 run 是否被创建（`chat_async` 返回了 `run_id`），仅在提交级失败时为 false——**不**用于表达成败，退出码由 `state` 推导。sync 因等待到完成携带 `response` / `content_truncated`；detach 因不等到完成故省略 `response` / `content_truncated`。两者均始终包含 `run_id` 与 `session_id`。
 
 sync json 成功（exit 0）：
 ```json
 {
   "delivered": true,
+  "submitted": true,
   "bot_uuid": "default:197262",
   "run_id": "run-9f3a",
   "session_id": "bcs-cli:default:197262:a9c8432f",
@@ -103,6 +121,7 @@ sync json 失败（exit 1）：
 ```json
 {
   "delivered": false,
+  "submitted": true,
   "bot_uuid": "default:197262",
   "run_id": "run-9f3a",
   "session_id": "bcs-cli:default:197262:a9c8432f",
@@ -113,12 +132,14 @@ sync json 失败（exit 1）：
 }
 ```
 超时变体：`"state": "timeout"`、`"error_message": "local polling timeout after 1800000 ms; run run-9f3a still active"`。
+轮询请求错误变体：`"state": "poll_error"`、`"error_message": "chat_run_status failed: <err>"`（`run_id`/`session_id` 来自提交响应）。
 
 detach json 成功（exit 0）/ 失败（exit 1）：
 ```json
-{ "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "running", "error_message": null }
-{ "submitted": false, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "failed", "error_message": "…" }
+{ "delivered": true, "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "running", "error_message": null }
+{ "delivered": false, "submitted": true, "bot_uuid": "…", "run_id": "…", "session_id": "…", "state": "failed", "error_message": "…" }
 ```
+注意 detach 失败时 `submitted=true`（run 已被创建，只是后来 failed/cancelled），区别于提交级失败的 `submitted:false`（见下方）。
 
 提交本身失败（如 404 bot 不存在，未创建 run）（exit 1）：
 ```json
@@ -136,14 +157,16 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 
 ### 7. 失败语义
 
-- `Failed` / `Cancelled`：`delivered=false`、`state=failed/cancelled`、`error_message` 取自 status。结构化 stdout 输出，exit 1。
-- 本地轮询超时（deadline 到，run 在服务端仍活动）：`delivered=false`、`state="timeout"`、`error_message="local polling timeout after N ms; run <rid> still active"`。结构化输出，exit 1。透出的 run_id 允许 agent 自行后续查询/取消。
-- 提交本身失败（非 2xx 或反序列化失败）：无 run_id/session_id，`state="submit_failed"`，`error_message=body`，结构化输出，exit 1。
+- `Failed` / `Cancelled`：`delivered=false`、`submitted=true`、`state=failed/cancelled`、`error_message` 取自 status。结构化 stdout 输出，exit 1。
+- 本地轮询超时（deadline 到，run 在服务端仍活动）：`delivered=false`、`submitted=true`、`state="timeout"`、`error_message="local polling timeout after N ms; run <rid> still active"`。结构化输出，exit 1。透出的 run_id 允许 agent 自行后续查询/取消。
+- **轮询请求错误**（修复 Codex P2）：`chat_run_status` 在 run 已创建后的传输错误 / 非 2xx / 反序列化失败：`delivered=false`、`submitted=true`、`state="poll_error"`、`run_id`+`session_id` 取自提交响应（已知）、`error_message="<err>"`。结构化输出，exit 1。`main.rs` 将该 Err 映射为 `poll_error` 的 `ChatRunOutcome`，**不**作为裸 Err 冒泡——避免「stdout 空 + 已知 ID 丢失」的原缺陷。
+- 提交本身失败（非 2xx 或反序列化失败）：`submitted=false`、`run_id/session_id=null`、`state="submit_failed"`、`error_message=body`，结构化输出，exit 1。
 
 ### 8. 兼容性与退出码
 
-- 退出码：成功 0，任何失败 1（与现状一致，仅输出内容改善）。
+- 退出码：成功 0，任何失败 1（与现状一致，仅输出内容改善）；退出码由 `state` 推导，非布尔字段。
 - `--json` stdout 在所有情况下都恰为一个 JSON 对象（成功或失败）；失败路径为严格增量修复（现状打印空）。
+- 默认行为变更（见 §1.5）：no-flag 输出由人类文本改为 JSON；人类交互使用 `--no-json`。
 - `chat_polling` / `chat_polling_detach` 被 `chat_async` + `chat_poll_run(_until_running)` 取代；`client.rs` 内现有 `test_chat_polling_*` 测试需更新为断言新的结构化结果，而非自由文本 `Err`。
 - 该 `client.rs` 为 `bcs-cli` crate 内部，无外部 crate 依赖其 `chat_polling`，API 变更影响面仅在 crate 内及 crate 内测试。
 
@@ -161,22 +184,26 @@ detach json 成功（exit 0）/ 失败（exit 1）：
 
 ## 验收标准
 
+- 裸调用 `bcs-cli chat`（无 flag）默认输出 JSON：stdout 为单个 JSON 对象，stderr 为带时间戳的 ack（覆盖 §1.5 默认切换）。
 - 同步 non-json 成功时，stdout 出现 `Run:`（修复问题 1 的 run_id）。
 - 同步与 detach 在提交后立刻输出带时间戳的纯文本 ack，行内含 `run_id` 与 `session_id`；non-json 走 stdout 且在 `Response from` 块之前，json 走 stderr。
-- 同步失败（run failed / local timeout）时，stdout（json：单 JSON 对象；non-json：`Run/Session/State/Error` 行）包含 run_id 与 session_id，且 exit 1。
-- detach 成功与失败均输出 run_id 与 session_id；失败时 exit 1。
-- 提交级失败（如 404）输出结构化失败（json：单对象，`run_id/session_id=null`；non-json：`Error:` 行），exit 1，无 panic。
+- 同步失败（run failed / local timeout / 轮询请求错误）时，stdout（json：单 JSON 对象；non-json：`Run/Session/State/Error` 行）包含 run_id 与 session_id，且 exit 1。
+- detach 成功与失败均输出 run_id 与 session_id；失败时 `submitted=true`、`state=failed/cancelled`、exit 1。
+- 提交级失败（如 404）输出结构化失败（json：单对象，`run_id/session_id=null`、`submitted=false`；non-json：`Error:` 行），exit 1，无 panic。
+- 轮询期 `chat_run_status` 错误映射为 `state="poll_error"` 的结构化结果（含来自提交的 run_id+session_id），exit 1，stdout 非空。
 - `--json` 模式下，stdout 成功与失败均为且仅为一个 JSON 对象，`jq '.'` 可解析。
 - run_id 与 session_id 同时出现在早 ack 与最终 stdout 块（除提交级失败外，最终块均为非 null 顶层字段）。
 
 ## 测试
 
 - 更新 `test_chat_polling_timeout_leaves_server_run_active`：断言 `outcome.delivered==false`、`state=="timeout"`、含 `run_id` 与 `session_id`，而非断言自由文本 `Err` 含 `run-local-timeout is still active`。
+- 新增：裸 `bcs-cli chat`（无 flag）默认 JSON——stdout 单 JSON 对象、stderr 含 ack（覆盖 §1.5）。
 - 新增：同步 non-json 成功打印 `Run:`（问题 1 回归）。
 - 新增：同步 json 失败在 stdout 打印单个失败 JSON 对象且 exit 1（问题 2）。
 - 新增：提交后立刻在正确通道（non-json→stdout，json→stderr）输出带时间戳的纯文本 ack（含 run_id+session_id），覆盖 sync 与 detach。
-- 新增：detach 失败在 stdout 输出 run_id 与 session_id 且 exit 1。
-- 新增：提交级失败（404）输出结构化失败、exit 1、ID 为 null、无 panic。
+- 新增：detach 失败在 stdout 输出 `submitted=true`、`state=failed`、run_id 与 session_id 且 exit 1。
+- 新增：提交级失败（404）输出结构化失败、`submitted=false`、ID=null、exit 1、无 panic。
+- 新增：轮询期 `chat_run_status` 返回 500 → `state="poll_error"` 结构化结果，含 run_id+session_id（取自提交响应），exit 1，stdout 非空。
 
 ## 非目标
 

--- a/src/bcs/scripts/e2e-test/cli.sh
+++ b/src/bcs/scripts/e2e-test/cli.sh
@@ -247,9 +247,10 @@ test_cli_chat() {
             TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return
         fi
     fi
-    # chat --detach prints "Run: <uuid>" / "Session: ..." / "State: running"
-    # (capital). Assert a run/session handle is present (no unasserted pass).
-    if _cli_contains "$BCS_CLI_STDOUT" "Run:" || _cli_contains "$BCS_CLI_STDOUT" "Session:"; then
+    # chat --detach prints a run/session handle. The default (no --json) now
+    # returns a single JSON object with lowercase "run_id"/"session_id" keys;
+    # --no-json still prints the human "Run:"/"Session:" lines. Accept either.
+    if _cli_contains "$BCS_CLI_STDOUT" "Run:" || _cli_contains "$BCS_CLI_STDOUT" "Session:" || _cli_contains "$BCS_CLI_STDOUT" '"run_id"' || _cli_contains "$BCS_CLI_STDOUT" '"session_id"'; then
         pass "bcs-cli chat returned a run/session handle"
         TESTS_PASSED=$((TESTS_PASSED+1))
     else


### PR DESCRIPTION
## Problem

`bcs-cli chat` did not surface the run/session identifiers to its agent callers reliably:

- In the default sync (blocking) mode, the success output printed `Session:` but never `Run:`, so the agent never learned the `run_id`; during the long blocking wait (up to 30 min) no identifier was exposed at all. `--detach` printed `Run:`; sync did not.
- On failure, `chat_polling` returned a bare `anyhow::Error` that propagated through `main.rs`'s `?`, so the structured result block was skipped entirely — even with `--json`, nothing reached stdout. The `run_id` survived only inside free-text stderr, and the `session_id` was dropped despite being captured right after submit (`reported_session`, `client.rs:1350`). `--detach` failure lost `session_id` the same way.

Net effect: an agent driving `bcs-cli chat` could not reliably obtain the `run_id`/`session_id` needed to track, re-query, or cancel a run — the original issues this PR fixes.

## Solution

Implements the v4 design spec (see the **Spec** section below). Scope is strictly `crates/tools/bcs-cli`; no server, endpoint, or wire-DTO change. The CLI already parses `run_id`/`session_id` from `ChatRunSubmitResponse` / `ChatRunStatusResponse` — this change only restructures what it prints and how it handles failures.

- **`client.rs`** — new CLI-internal `ChatRunOutcome` (typed outcome replacing the bare `Result<Value>`/`Err`) and a typed `ChatAsyncError` (`Transport` / `NotSuccessful` / `InvalidResponse`) so submit-level failures can be distinguished. `chat_async` returns the typed error. New `chat_poll_run` / `chat_poll_run_until_running` take `&ChatRunSubmitResponse`, so the `timeout` and `poll_error` outcomes retain `run_id`+`session_id` even when no `ChatRunStatusResponse` was ever received (e.g. a zero or very short `--timeout-ms`). Removed `chat_polling` / `chat_polling_detach`. Detach accepts `Completed` | `Running` (the legacy `chat_polling_detach` contract), so fast/legacy runs that complete before the first status are success, not failure.
- **`main.rs` Chat arm** — submit → ack → poll → structured outcome → exit (`exit` derived from `state`): print the run_id/session_id ack right after submit, then call `chat_poll_run` / `chat_poll_run_until_running`, then render the `ChatRunOutcome`. The output decision is now `is_structured_mode(cli)` (`!no_json`) instead of `cli.json`, so no-flag defaults to JSON. A timestamped plain-text ack is emitted right after submit — to **stderr** in JSON mode (keeping stdout a single `jq`-parseable JSON object), and to **stdout** before the `Response from` block in `--no-json` mode.
- **Failure semantics** — every path is a structured outcome, never a bare propagating `Err`: `terminal` (`completed`/`failed`/`cancelled`), `timeout` (local deadline, run still active server-side), `poll_error` (`chat_run_status` transport/non-2xx/deser after submit — IDs kept), `submit_failed` (non-2xx/deser — IDs null), `submit_indeterminate` (transport reset/timeout at submit — a run may have been created server-side; IDs null; agents must not assume no lingering run). `submitted` means "run was created" only; exit code is derived from `state`.

Deferred to follow-up: surfacing response content on a `completed`-in-detach (matches the existing detach contract, which never returns the response) and in-session retry/re-query on an indeterminate submit.

## Validation

- `cargo test -p bcs-cli` at commit `78331008`: **183 passed / 0 failed / 2 ignored** (both ignored are pre-existing). Re-run independently after the implementation to confirm.
- New tests: 2 rewritten polling tests + 4 unit (`detach-completed` success, transport → `submit_indeterminate`, HTTP 500 → `poll_error`, terminal-`failed` structured) + 2 e2e (`chat_default_mode_emits_single_json_on_stdout_with_ack_on_stderr`; `chat_no_json_mode_prints_run_line_on_stdout`).
- Nothing skipped: all new tests use wiremock or a raw TCP harness; no live BCS server is required.

## Compatibility and risk

- **Behavior change (user-facing):** no-flag `bcs-cli chat` now emits JSON to stdout (previously human text). The output decision moved from `cli.json` (default `false`) to `is_structured_mode(cli)` = `!no_json`, to honor the repo's documented "JSON default: enabled" (`main.rs:741`). Interactive users restore the old human view with `--no-json`; `--json` stays accepted as a no-op-for-compat flag (OpenClaw unaffected).
- **No server / wire compatibility impact:** no endpoint, DTO, or `X-BCS-CHAT-VERSION` change → old CLI ↔ any server is unaffected; new CLI ↔ old server works.
- **API surface (crate-local):** `chat_polling` / `chat_polling_detach` are removed and replaced by `chat_async` + `chat_poll_run(_until_running)`; these are internal to the `bcs-cli` crate (no external consumer). `ChatRunOutcome` / `ChatAsyncError` are re-exported from the crate lib.
- **Rollback:** revert the commits on this branch; no migrations, schema, config, or persisted state to undo.

## Spec

`src/bcs/docs/superpowers/specs/2026-08-10-bcs-cli-chat-run-id-surfacing-design.md` (v4) — included in this PR. Codex reviewed the spec across three rounds (7 inline threads total, all addressed and replied-to + resolved in-thread); the new implementation is fresh and is awaiting Codex/human review.

## Related issues

None tracked externally. This addresses the two internally-reported CLI gaps: sync mode never prints `Run:`; sync failure drops `run_id`/`session_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
