### PR TITLE
fix(backend): seed collaborator admins into the running teclaw co…

### DIFF
--- a/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/plan.md
+++ b/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/plan.md
@@ -1,0 +1,228 @@
+# Plan: Teclaw Service-Bot Publish — seed admins into the running container's `.credentials`
+
+## Approach
+
+Both gaps share one root: the admins write reaches the wrong (or no) binding for
+a teclaw service bot. Close both by routing the write through the **online**
+binding:
+
+- **Publish-time seed.** `TeclawPublishTaskHandler` already polls the online
+  teclaw binding (its `binding_id`). At publish SUCCESS, after the agentpass token
+  is delivered, resolve that binding via `resolve_for_binding` and read-modify-
+  write the `ADMINS=` line into the existing `.credentials`. Retried on failure,
+  idempotent under replay.
+- **Runtime sync.** `on_collaboration_changed` currently resolves the device via
+  `resolve_for_bot` → `ac_bots.binding_id` (the DRAFT for service bots). Replace
+  with: look up the online binding id from the publish record
+  (`get_latest_success_by_source_bot_id` → `ext.binding.online`) and use
+  `resolve_for_binding`; fall back to `resolve_for_bot` when there is no publish
+  record (ARCA/personal/desktop, unchanged).
+
+Extract the `.credentials` admins write into a reusable
+`DeviceCredentialsAdminsWriter` that both paths call. Read-modify-write only
+(file exists; engine rejects ADMINS-only) — **no `create_if_missing`**. The
+engine hot-reloads `.credentials`, so runtime writes take effect immediately.
+
+## Affected Components
+
+- `core/bot_collaborator/services/credentials_admins_writer.py` (NEW) —
+  `DeviceCredentialsAdminsWriter`.
+- `core/bot_collaborator/services/collaborator_service.py` — replace inline
+  `_sync_admins_to_credentials` / `_rewrite_credentials_admins` with the injected
+  writer; move `_DEVICE_CREDENTIALS_PATH` + `_replace_admins_line` into the
+  writer module (import back if still referenced).
+- `core/bot_management/services/teclaw_publish_task_handler.py` — inject the
+  writer; call `seed_for_publish` after token delivery.
+- `di/modules/bot_collaborator_module.py` — bind
+  `DeviceCredentialsAdminsWriter` (deps: collaborator_repo, bot_publish_repo,
+  resolver thunk, dispatcher thunk).
+- `di/modules/bot_management_module.py` — `teclaw_publish_task_lifecycle`
+  injects the writer.
+- `tests/community/core/bot_collaborator/test_credentials_admins_writer.py`
+  (NEW).
+- `tests/community/core/bot_management/services/test_teclaw_publish_task_handler.py`
+  — extend.
+
+Unchanged (deliberately): `BotConfigArtifact`, `create_teclaw_bot` /
+`_build_teclaw_payload`, `BotBuildService.release` teclaw branch, the ARCA /
+personal / desktop paths.
+
+## API / Interface Changes
+
+- NEW `DeviceCredentialsAdminsWriter`:
+  - `seed_for_publish(binding_id: int, bot_id: str, owner_id: str) -> None` —
+    query admins, then `_write_for_binding(binding_id, ...)`.
+  - `sync_on_change(bot_id: str, owner_id: str, admins: list[str]) -> None` —
+    resolve online binding id from the publish record; if found, `_write_for_binding`;
+    else `_write_for_bot` (today's behavior).
+  - private `_write_for_binding(binding_id, bot_id, owner_id, admins)` —
+    `resolver.resolve_for_binding(binding_id, owner_id, bot_id=bot_id)` →
+    `_do_write`.
+  - private `_write_for_bot(bot_id, owner_id, admins)` —
+    `resolver.resolve_for_bot(bot_id, owner_id)` → `_do_write`.
+  - private `_resolve_online_binding_id(bot_id) -> int | None` —
+    `bot_publish_repo.get_latest_success_by_source_bot_id(bot_id, env)` →
+    `(record.ext.get("binding") or {}).get("online")`.
+  - private `_do_write(ctx, admins)` — dispatch fs; read-modify-write `ADMINS=`.
+
+No changes to existing protocols. The writer is a new internal collaborator.
+
+## Key Files & Functions
+
+- `credentials_admins_writer.py` (NEW):
+  - module constants: `_DEVICE_CREDENTIALS_PATH = "/home/admin/.credentials"`,
+    `_replace_admins_line(content, admins)` (moved, unchanged — line-preserving
+    replace/append of `ADMINS=`).
+  - `__init__(collaborator_repo, bot_publish_repo, resolver_provider,
+    device_fs_dispatcher_provider)`.
+  - `_do_write(ctx, admins)`:
+    ```
+    fs = device_fs_dispatcher_provider().dispatch(ctx)
+    _run_coro_blocking(_rewrite_credentials_admins(fs, admins))
+    ```
+  - `_rewrite_credentials_admins(fs, admins)` (moved, **no `create_if_missing`**):
+    `raw = await fs.read_file(_DEVICE_CREDENTIALS_PATH)`; if `raw is None` → log
+    info, skip (file should exist; defensive); else
+    `await fs.write_file(..., _replace_admins_line(raw.decode(), admins))`.
+  - `DeviceNotBoundError` / `UnknownProviderError` → log info, skip (no raise).
+    `write_file` / transport error → **raise** (publish handler turns into Retry);
+    `sync_on_change` warns and swallows (never break the collab-change flow).
+- `collaborator_service.py`:
+  - `__init__`: drop `resolver_provider` / `device_fs_dispatcher_provider` **iff**
+    Task 1 / Open Q2 confirms no other caller; accept `credentials_admins_writer`.
+  - `on_collaboration_changed` (`:767`): replace
+    `self._sync_admins_to_credentials(...)` with
+    `self._creds_writer.sync_on_change(bot_id, owner_id_from_bot, admins)`.
+  - delete `_sync_admins_to_credentials` and `_rewrite_credentials_admins`
+    (moved); import `_replace_admins_line` / `_DEVICE_CREDENTIALS_PATH` back only
+    if still referenced.
+- `teclaw_publish_task_handler.py`:
+  - `__init__` (`:96`): add `credentials_admins_writer`.
+  - `_seed_admins(bot_id, owner_id, binding) -> TaskOutcome`:
+    ```
+    try:
+        self._writer.seed_for_publish(binding.id, bot_id, owner_id)
+    except (DeviceNotBoundError, UnknownProviderError):
+        return Complete()          # nothing to write to
+    except Exception as exc:
+        return Retry(f"seed admins failed: {exc}")
+    return Complete()
+    ```
+  - Wire it so it runs **after** the container is ACTIVE and the device is
+    reachable. Concretely: in `_persist_terminal` (`:181`) on
+    `applied and status == ACTIVE`, and in the crash-resume path (`:143-148`,
+    ACTIVE re-enter), both routes go through `_deliver_outbound_rule`; the seed
+    fires in its **device-ready success tail** (the `len(updated) > 0` branch,
+    `:326`) — i.e. the same device-readiness signal as the token delivery. The
+    `updated is None` (no-egress-provider) branch completes without seeding: it
+    is unreachable for standard teclaw (the agentpass rule is always built) and
+    does not confirm device readiness. Token Reschedule / Retry short-circuits
+    seed. Seed failure → Retry (re-enter ACTIVE, replay token [idempotent
+    REPLACE] + seed [idempotent read-modify-write]). `binding` is the record
+    loaded at `:126`; `binding.id` is the online teclaw binding;
+    `owner_id = binding.entity_id`.
+  - `TeclawPublishTaskLifecycle.bootstrap` (`:352`): forward the writer into the
+    handler.
+- DI:
+  - `bot_collaborator_module.py`: `@provider @singleton` for
+    `DeviceCredentialsAdminsWriter` (deps collaborator_repo, bot_publish_repo,
+    `Callable[[], DeviceContextResolver]`, `Callable[[], DeviceFilesystemDispatcher]`).
+  - `CollaboratorService` provider: inject the writer (drop resolver / dispatcher
+    thunks per Task 1).
+  - `bot_management_module.py:389` `teclaw_publish_task_lifecycle`: inject +
+    forward the writer.
+
+## Dependencies
+
+None new. Reuses `DeviceContextResolver.resolve_for_binding`,
+`DeviceFilesystemDispatcher`, `TeclawDeviceFileSystem`,
+`BotCollaboratorRepository.list_by_bot`,
+`BotPublishRepository.get_latest_success_by_source_bot_id`, the durable task
+queue.
+
+## Risks & Mitigations
+
+- **Risk:** "Prefer online binding" changes ARCA behavior. **Mitigation:** ARCA
+  has no publish record → falls back to `resolve_for_bot` (unchanged). Verify in
+  Task 1 (Open Q3); if an ARCA publish also yields a divergent `ext.binding.online`,
+  scope the online path to teclaw.
+- **Risk:** `get_latest_success_by_source_bot_id` returns a stale online binding
+  after a re-publish/rollback. **Mitigation:** it returns the **latest** success
+  record; re-publish writes a new `ext.binding.online`. Confirm the binding id is
+  current for the running container (Task 1 / Task 6 test).
+- **Risk:** Seed runs before the container file API is reachable → noisy Retries.
+  **Mitigation:** gate on the same device-readiness signal as token delivery;
+  transient failures Retry within the task deadline.
+- **Risk:** Folding seed into the replay path breaks token-delivery idempotency.
+  **Mitigation:** seed is a read-modify-write (idempotent); token push is a
+  REPLACE (idempotent). Replaying both converges. Test crash-resume explicitly.
+- **Risk:** Moving `_resolver_provider` / `_device_fs_dispatcher_provider` off
+  `CollaboratorService` breaks another caller. **Mitigation:** grep-verify (Task
+  1); keep as-is if any other caller exists.
+
+## Alternatives Considered
+
+- **Carry admins in `BotConfigArtifact` (SCHEMA_VERSION 5).** Rejected: the
+  engine reads admins from `.credentials`, not the artifact; a contract bump +
+  engine-side change is unnecessary scope.
+- **Create `.credentials` with only `ADMINS=`.** Rejected: engine owner confirms
+  the engine rejects an ADMINS-only file; the file already exists anyway, so
+  read-modify-write is both sufficient and required.
+- **Keep `resolve_for_bot` at runtime and only add publish-seed.** Rejected: the
+  runtime path resolves the DRAFT binding for service bots, so post-publish
+  collaborator changes would never reach the running container — the user's
+  follow-up concern. The runtime resolver fix is necessary for a complete fix.
+- **Inject `CollaboratorService` directly into the handler** instead of a narrow
+  writer. Rejected: fat dep, wider test surface, drags the collab-change path's
+  concerns into the publish handler. The narrow writer keeps the seam testable
+  and matches the repo's composition-seam discipline.
+- **Seed inline at `BotBuildService.release` teclaw branch.** Rejected: the
+  container is not ready at that instant (BaaS create is async; device not yet
+  provisioned) — `TeclawPublishTaskHandler` exists precisely because post-publish
+  delivery must wait for readiness.
+
+## Rollout
+
+- No schema migration, no feature flag. The fix activates for teclaw service bots
+  on next publish. Already-published teclaw containers self-heal on the next
+  collaborator change (the runtime `on_collaboration_changed` fix now resolves the
+  online binding); a manual re-publish also seeds.
+- ARCA / personal / desktop byte-for-byte unchanged.
+- Backward compat: the writer's non-service branch is identical to today's
+  `_sync_admins_to_credentials` (`resolve_for_bot` + read-modify-write +
+  skip-if-missing).
+
+## Test Strategy
+
+Unit (`tests/community/core/bot_collaborator/test_credentials_admins_writer.py`,
+in-memory fake `DeviceFileSystem` + fake collaborator repo + fake publish repo):
+- `seed_for_publish(binding_id, …)` → `resolve_for_binding` used (not
+  `resolve_for_bot`); admins = repo `role=ADMIN` for current env; `.credentials`
+  read-modify-write preserves TOKEN/CLIENT_ID, changes only `ADMINS=`.
+- `sync_on_change` for a service bot (publish repo returns a record with
+  `ext.binding.online`) → `_write_for_binding(online)`; the running container's
+  `.credentials` `ADMINS=` updated; `resolve_for_bot` NOT used.
+- `sync_on_change` for a bot with no publish record → `_write_for_bot` (today's
+  behavior); ARCA-style `.credentials` read-modify-write.
+- `.credentials` present with TOKEN/CLIENT_ID → only `ADMINS=` changed.
+- `admins=[]` → writes `ADMINS=` (clears); other lines preserved.
+- `.credentials` missing → skip (no create), no raise (defensive).
+- no device bound (`DeviceNotBoundError`) → skip silently.
+- `write_file` raises → `seed_for_publish` propagates (handler Retry);
+  `sync_on_change` swallows (warn).
+- online binding lookup stale-missing (`ext.binding.online` absent) → falls back
+  to `_write_for_bot`.
+
+Handler (`test_teclaw_publish_task_handler.py`, no mocks — real fakes):
+- publish SUCCESS + device ready → `seed_for_publish` called once with the online
+  `binding.id`; task Completes.
+- `seed_for_publish` raises a transient error → Retry; next attempt replays
+  token + seed; converges.
+- crash-resume (binding already ACTIVE) → replays seed; idempotent (read-modify-
+  write, no clobber).
+- `updated is None` (no egress rule provider) → still seeds admins; Completes.
+
+Regression:
+- existing `collaborator_service` tests green (non-service sync unchanged);
+  existing handler tests green (token delivery unchanged); full `tests/community`
+  green.

--- a/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/spec.md
+++ b/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/spec.md
@@ -1,0 +1,166 @@
+# Teclaw Service-Bot Publish: seed collaborator admins into the running container's `.credentials`
+
+## Summary
+
+After a service bot (a **teclaw** container) is published, the running container
+has no collaborator-admins information. The teclaw engine reads admins from
+`/home/admin/.credentials` (the `ADMINS=` line). The file **already exists** in a
+freshly published teclaw container (engine-created at boot, containing
+TOKEN/CLIENT_ID/etc.) — only the `ADMINS=` line is missing. Two backend gaps
+leave it missing forever:
+
+1. **No publish-time seed.** The teclaw publish path never writes `ADMINS=` after
+   the container is up. ARCA seeds via `start_service.sh --admins` at boot;
+   teclaw has no such step.
+2. **Runtime sync resolves the wrong binding.** `on_collaboration_changed` →
+   `_sync_admins_to_credentials` resolves the device via `resolve_for_bot`, which
+   looks up `ac_bots.binding_id` (`get_active_by_bot_and_owner`). For a service
+   bot that is the **DRAFT** binding, not the online teclaw container (whose
+   binding id lives in the publish record's `ext.binding.online`). So even adding
+   a collaborator after publish writes to the draft (or no-ops) — it never
+   reaches the running teclaw container.
+
+Fix: resolve the **online** binding for both paths and read-modify-write the
+`ADMINS=` line into the existing `.credentials` (never create a bare file —
+confirmed the engine rejects an ADMINS-only file). At publish SUCCESS, the
+`TeclawPublishTaskHandler` already holds the online `binding_id` — use
+`resolve_for_binding`. At runtime, resolve the online binding id from
+`ext.binding.online` (`get_latest_success_by_source_bot_id`) and use
+`resolve_for_binding`; fall back to `resolve_for_bot` for bots with no publish
+record (ARCA/personal/desktop, unchanged). The engine hot-reloads `.credentials`
+(confirmed), so runtime collaborator changes take effect immediately — no
+restart/re-publish needed.
+
+## Motivation
+
+- `bot_service.py:4479` states the intent verbatim: *"服务型 bot 实例化时，复用
+  source bot 的 admin 协作者作为沙箱启动 admins."* ARCA honors it
+  (`apply_device(admins=...)` → `--admins` at `baas_container_init.py:156`).
+  The teclaw publish branch (`bot_build_service.py:517-534` → `create_teclaw_bot`)
+  does not — `create_teclaw_bot` / `_build_teclaw_payload`
+  (`baas_service.py:893-1038`) have no admins field.
+- The teclaw container boots only from `config_artifact` (no NAS, no
+  `start_service.sh`, no boot hooks; `baas_service.py:904-910`). Its only
+  post-publish reach-in today is the agentpass token egress rule
+  (`teclaw_publish_task_handler.py:213-334`). Admins are neither in the artifact
+  nor delivered otherwise.
+- `CollaboratorService._sync_admins_to_credentials` already does the right
+  read-modify-write on `.credentials` (`collaborator_service.py:775-842`) and the
+  plumbing reaches teclaw (`DeviceContextResolver` routes teclaw via binding;
+  `TeclawDeviceFileSystem.read_file`/`write_file` work). But it resolves the
+  device with `resolve_for_bot` → `get_active_by_bot_and_owner`, which JOINs
+  `ac_bots.binding_id` (`device_repository.py:220-248`). For a service bot that
+  is the draft binding; `resolve_for_binding`'s own docstring
+  (`device_context_resolver.py:113-115`) calls out that service bots must use
+  `ext.binding.online`, not the by-bot entry. `get_latest_success_by_source_bot_id`
+  (`bot_publish_repository.py:181-200`) exists precisely to read that online
+  binding id.
+
+## Confirmed engine contract (from the engine owner)
+
+- **`.credentials` already exists** in a freshly published teclaw container, with
+  TOKEN/CLIENT_ID/etc.; only `ADMINS=` is missing.
+- **The engine rejects an ADMINS-only `.credentials`** → the backend must
+  read-modify-write the existing file, never create a bare one.
+- **The engine hot-reloads `.credentials`** → runtime writes take effect
+  immediately; no restart/re-publish required for collaborator changes.
+
+## User Stories
+
+- As a service-bot owner, after I publish, the running container must know my
+  admin collaborators so admin-gated actions work in-session.
+- As a collaborator admin added to a service bot *after* it is already published,
+  my admin role must reach the running container immediately, without a
+  re-publish or restart.
+- As an operator, if the publish pod dies between token delivery and the admins
+  seed, the durable task must replay both and converge — no container left with a
+  token but no admins.
+
+## Acceptance Criteria
+
+- [ ] After a teclaw service-bot first publish reaches SUCCESS and the container
+      is ready, `/home/admin/.credentials` in the **online** container contains an
+      `ADMINS=` line listing the bot's current admin collaborators (worknos,
+      comma-joined), sourced from `ac_bot_collaborator` (`role=admin`) for the
+      current env. The seed resolves the online binding (the one the
+      `TeclawPublishTaskHandler` is polling), not the draft.
+- [ ] The seed is read-modify-write only: it preserves TOKEN/CLIENT_ID/etc. and
+      changes only the `ADMINS=` line. It never creates a bare `.credentials`
+      (engine rejects ADMINS-only). Empty admins → writes `ADMINS=` (clears),
+      never deletes the line.
+- [ ] The seed is part of the `teclaw.create.publish_poll` durable task, gated on
+      the same device-readiness signal as the agentpass token delivery, retried on
+      transient failure up to the task deadline. A crash between token delivery
+      and seed replay-converges: re-entering the ACTIVE binding replays both, and
+      both are idempotent (token = REPLACE; `.credentials` = read-modify-write).
+- [ ] When a collaborator admin is added/removed on an already-published teclaw
+      service bot, `on_collaboration_changed` resolves the bot's **online**
+      binding (`get_latest_success_by_source_bot_id` → `ext.binding.online` →
+      `resolve_for_binding`) and updates the running container's `.credentials`
+      `ADMINS=` line. Because the engine hot-reloads `.credentials`, the change
+      takes effect immediately — no restart/re-publish.
+- [ ] Bots with no publish record (ARCA / personal / desktop) keep today's
+      `resolve_for_bot` resolution and are byte-for-byte unchanged.
+- [ ] No mocking in the new/extended tests (per commit `da9bf087`); use real
+      fakes. Full `tests/community` suite green.
+
+## In Scope
+
+- `TeclawPublishTaskHandler` post-publish step: seed `ADMINS=` via the online
+  binding (`resolve_for_binding`).
+- `on_collaboration_changed` runtime sync: resolve the online binding for service
+  bots (via the publish record's `ext.binding.online`) and write via
+  `resolve_for_binding`; fall back to `resolve_for_bot` for bots without a
+  publish record.
+- Extract the `.credentials` admins write into a reusable
+  `DeviceCredentialsAdminsWriter` used by both paths (needs `bot_publish_repo`
+  for the online-binding lookup).
+- DI wiring for the writer into `TeclawPublishTaskHandler` and
+  `CollaboratorService`.
+
+## Out of Scope
+
+- Changing the `BotConfigArtifact` contract (admins do not ride in the artifact).
+- Creating `.credentials` from scratch / `create_if_missing` (engine rejects
+  ADMINS-only; the file already exists).
+- ARCA/baas/personal/desktop paths (unchanged — they have no `ext.binding.online`
+  and keep `resolve_for_bot`).
+- Version-scoping collaborators. `ac_bot_collaborator` has no `version`/`status`
+  field — a source bot has a single collaborator set shared across all its
+  publish versions. So editing collaborators (in draft or anytime) takes effect
+  on the **currently online** instance immediately (matching ARCA's existing
+  `on_collaboration_changed` behavior); there is no "draft-only collaborators
+  that apply only when the new version publishes." If that isolation is ever
+  required, it is a separate model change (version column + migration + UI) and
+  stays out of this fix.
+- Re-publish/upgrade re-seed: covered automatically if it routes through the same
+  publish-poll task; verify, do not special-case unless needed.
+- BaaS-server-side changes.
+- Backfilling already-published teclaw containers (the runtime-sync fix
+  self-heals them on the next collaborator edit; a manual re-publish also seeds).
+
+## Open Questions
+
+1. ~~`.credentials` minimal-file tolerance.~~ **Resolved (engine owner):** cannot
+   tolerate ADMINS-only → read-modify-write the existing file, never create a
+   bare one. (Confirmed the file already exists, engine-created.)
+2. ~~**`CollaboratorService` dep narrowing.**~~ **Resolved (Task 1):** confirmed
+   `_resolver_provider` / `_device_fs_dispatcher_provider` are used only in
+   `_sync_admins_to_credentials` (`collaborator_service.py:800,809`). Move both
+   onto the writer.
+3. ~~**ARCA-unaffected verification.**~~ **Resolved (Task 1):** non-service bots
+   (ARCA/personal/desktop) produce no publish record, so
+   `get_latest_success_by_source_bot_id` returns `None` → the writer falls back to
+   `resolve_for_bot` (unchanged). Desktop additionally sets `ac_bots.binding_id`
+   to the active binding itself. The "prefer online binding" rule only activates
+   for bots with a success publish record (service bots), so no teclaw-only
+   scoping is needed.
+4. ~~Engine hot-reload of `.credentials`.~~ **Resolved (engine owner):** yes,
+   runtime writes take effect immediately.
+5. ~~**`ac_bots.binding_id` stays draft for service bots.**~~ **Resolved (Task 1):**
+   the service/teclaw publish flow never writes the online binding into
+   `ac_bots.binding_id` (only desktop / bot creation writes that column;
+   `caller_identity`'s `binding_id` is a caller-credential runtime update, not an
+   `ac_bots` write; publish-flow `update_by_owner` touches `bot_type` etc., not
+   `binding_id`). So `ac_bots.binding_id` stays the draft for service bots and
+   `resolve_for_bot` mis-resolves — the online-binding fix is necessary.

--- a/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/tasks.md
+++ b/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/tasks.md
@@ -1,0 +1,132 @@
+# Tasks: Teclaw Service-Bot Publish — seed admins into the running `.credentials`
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: [ ] Verify preconditions (deps, ARCA-unaffected, binding stays draft)
+- **Goal:** Confirm the three open assumptions before coding, so the fix shape is
+  sound.
+- **Files:** `core/bot_collaborator/services/collaborator_service.py` (grep
+  `self._resolver_provider`, `self._device_fs_dispatcher_provider`);
+  `core/service_bot/services/publish_flow/` + `baas_service.py` (does anything
+  overwrite `ac_bots.binding_id` to the online binding post-publish?);
+  `core/service_bot/repository/bot_publish_repository.py`
+  (`get_latest_success_by_source_bot_id` + `ext.binding.online` shape); whether
+  ARCA publish produces a divergent `ext.binding.online`.
+- **Done when:**
+  - [ ] Open Q2: `_resolver_provider` / `_device_fs_dispatcher_provider` are used
+        only by `_sync_admins_to_credentials` (→ move to writer) OR another
+        caller exists (→ keep, also inject writer).
+  - [ ] Open Q3: ARCA has no `ext.binding.online` (→ fallback path unchanged) OR
+        its online binding == `ac_bots.binding_id` (→ same target). Else scope the
+        online-binding path to teclaw only.
+  - [ ] Open Q5: confirm `ac_bots.binding_id` is NOT overwritten to the online
+        binding after teclaw publish (so `resolve_for_bot` is definitively wrong
+        for service bots). Document findings in plan.
+- **Depends on:** —
+
+## Task 2: [ ] Add `DeviceCredentialsAdminsWriter` (online-binding aware)
+- **Goal:** Reusable `.credentials` ADMINS writer that resolves the **online**
+  binding for service bots and reads-modify-writes the existing file (no create).
+- **Files:** NEW `core/bot_collaborator/services/credentials_admins_writer.py`;
+  move `_DEVICE_CREDENTIALS_PATH` + `_replace_admins_line` here (import back into
+  `collaborator_service` if still referenced).
+- **Done when:**
+  - [ ] `__init__(collaborator_repo, bot_publish_repo, resolver_provider,
+        device_fs_dispatcher_provider)`.
+  - [ ] `seed_for_publish(binding_id, bot_id, owner_id)`: query
+        `collaborator_repo.list_by_bot(role=ADMIN, env=current)` →
+        `_write_for_binding(binding_id, bot_id, owner_id, admins)`.
+  - [ ] `sync_on_change(bot_id, owner_id, admins)`: if
+        `_resolve_online_binding_id(bot_id)` found → `_write_for_binding(online,
+        …)`; else `_write_for_bot(bot_id, owner_id, admins)`.
+  - [ ] `_resolve_online_binding_id(bot_id)`:
+        `bot_publish_repo.get_latest_success_by_source_bot_id(bot_id, env)` →
+        `(record.ext.get("binding") or {}).get("online")` (or None).
+  - [ ] `_write_for_binding` → `resolver.resolve_for_binding(binding_id, owner_id,
+        bot_id=bot_id)` → `_do_write`. `_write_for_bot` →
+        `resolver.resolve_for_bot(bot_id, owner_id)` → `_do_write`.
+  - [ ] `_do_write(ctx, admins)`: dispatch fs; `_rewrite_credentials_admins(fs,
+        admins)`.
+  - [ ] `_rewrite_credentials_admins(fs, admins)` (moved, **no create**):
+        `read_file` None → log info, skip; else write
+        `_replace_admins_line(raw.decode(), admins)`.
+  - [ ] `DeviceNotBoundError` / `UnknownProviderError` → log info, skip. Transport
+        error → raise out of `seed_for_publish` (handler Retry) / warn+swallow in
+        `sync_on_change`.
+- **Depends on:** Task 1
+
+## Task 3: [ ] Route `on_collaboration_changed` through the writer
+- **Goal:** Runtime collaborator-change sync resolves the online binding for
+  service bots; non-service unchanged.
+- **Files:** `core/bot_collaborator/services/collaborator_service.py`.
+- **Done when:**
+  - [ ] `__init__` injects `credentials_admins_writer` (drop/keep resolver deps
+        per Task 1).
+  - [ ] `on_collaboration_changed` calls `writer.sync_on_change(...)` instead of
+        inline `_sync_admins_to_credentials`.
+  - [ ] removed `_sync_admins_to_credentials` / `_rewrite_credentials_admins`
+        (moved).
+  - [ ] existing `collaborator_service` tests green (non-service: read
+        `.credentials`, preserve TOKEN, empty→`ADMINS=`).
+- **Depends on:** Task 2
+
+## Task 4: [ ] Seed admins in `TeclawPublishTaskHandler` post-publish
+- **Goal:** teclaw publish SUCCESS writes `ADMINS=` into the **online** container;
+  idempotent, replay-safe.
+- **Files:** `core/bot_management/services/teclaw_publish_task_handler.py`.
+- **Done when:**
+  - [ ] `__init__` accepts `credentials_admins_writer`.
+  - [ ] `_seed_admins(bot_id, owner_id, binding)`: call
+        `writer.seed_for_publish(binding.id, bot_id, owner_id)`; DeviceNotBound/
+        UnknownProvider → Complete; other exception → Retry.
+  - [ ] post-publish flow runs token-then-seed after device-ready success (both
+        the `len(updated) > 0` and `updated is None` branches); token
+        Reschedule/Retry short-circuits seed.
+  - [ ] crash-resume (ACTIVE re-enter) replays seed; token + seed both idempotent.
+  - [ ] `TeclawPublishTaskLifecycle.bootstrap` forwards the writer.
+- **Depends on:** Task 2, Task 3
+
+## Task 5: [ ] DI wiring
+- **Goal:** Bind the writer; inject into the lifecycle/handler/service.
+- **Files:** `di/modules/bot_collaborator_module.py`,
+  `di/modules/bot_management_module.py`.
+- **Done when:**
+  - [ ] `@provider @singleton` for `DeviceCredentialsAdminsWriter` (deps
+        collaborator_repo, bot_publish_repo, resolver thunk, dispatcher thunk).
+  - [ ] `teclaw_publish_task_lifecycle` injects + forwards the writer.
+  - [ ] `CollaboratorService` provider injects the writer.
+  - [ ] app boots; existing DI tests green.
+- **Depends on:** Task 2, Task 3, Task 4
+
+## Task 6: [ ] Tests & Verification (TDD, no mocks)
+- **Goal:** Prove every acceptance criterion; write red first.
+- **Files:** NEW
+  `tests/community/core/bot_collaborator/test_credentials_admins_writer.py`;
+  `tests/community/core/bot_management/services/test_teclaw_publish_task_handler.py`.
+- **Done when:**
+  - [ ] writer: `seed_for_publish` uses `resolve_for_binding`; service-bot
+        `sync_on_change` uses the online binding (not `resolve_for_bot`); no-
+        publish-record bot uses `resolve_for_bot`; `.credentials` present→preserve
+        TOKEN/CLIENT_ID, change only `ADMINS=`; `admins=[]`→`ADMINS=`; missing
+        file→skip (no create); no-device→skip; write-raise→seed propagates /
+        sync swallows; missing `ext.binding.online`→fallback.
+  - [ ] handler: SUCCESS+ready→seed once with online `binding.id`; seed
+        raise→Retry→converges; ACTIVE resume→replay idempotent; no-egress→still
+        seeds.
+  - [ ] regression: collaborator_service + handler existing tests green; full
+        `tests/community` green.
+  - [ ] SAST + changed-line coverage pass pre-push.
+- **Depends on:** Task 1–5
+
+---
+
+## Groups
+
+- **Group A — Preconditions (Task 1):** confirm dep-narrowing, ARCA-unaffected,
+  binding-stays-draft. De-risks the shape.
+- **Group B — Writer (Task 2):** the reusable, online-binding-aware `.credentials`
+  admins writer. Self-contained; no behavior change yet.
+- **Group C — Wire-up (Tasks 3, 4, 5):** runtime sync + publish seed + DI.
+  Behavior changes land here.
+- **Group D — Verification (Task 6):** TDD coverage of every acceptance
+  criterion.

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -4,7 +4,7 @@
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, List, Optional, Dict, Any
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
 from agentclaw.community.core.bot_collaborator.models import (
     CollaboratorRecord,
@@ -16,82 +16,21 @@ from agentclaw.community.core.bot_collaborator.services.member_management_capabi
     MemberManagementCapabilityService,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
     from agentclaw.community.plugins.passport import PassportPlugin
-    from agentclaw.community.core.devices.services.device_context_resolver import DeviceContextResolver
-    from agentclaw.community.di.modules.skill_center_module import DeviceFilesystemDispatcher
-    from agentclaw.community.core.devices.services.device_filesystem import DeviceFileSystem
+    from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
+        DeviceCredentialsAdminsWriter,
+    )
 
 logger = get_logger()
 
-# 运行设备上 .credentials 的固定路径(prod 容器内 start_service.sh 写入处,
-# 与 engine ``CredentialsService.DEFAULT_CREDENTIALS_PATH`` 一致)。
-_DEVICE_CREDENTIALS_PATH = "/home/admin/.credentials"
-
-
-def _run_coro_blocking(coro: Any) -> Any:
-    """在独立线程里跑协程并阻塞等待结果。
-
-    ``on_collaboration_changed`` 是同步方法，但被 ``async def`` 路由**直接同步调用**，
-    运行在事件循环线程上。此处：
-      - 不能用 ``asyncio.run``(当前线程已有 running loop → 抛错);
-      - 不能用 ``run_coroutine_threadsafe(coro, 当前loop)``(当前线程被阻塞 → 死锁)。
-    所以起一个新线程、用全新的 ``asyncio.run`` 跑，再 ``join`` 取结果/异常。
-    协作者变更频率低，每次起线程的开销可接受。
-    """
-    import asyncio
-    import threading
-
-    box: Dict[str, Any] = {}
-
-    def _runner() -> None:
-        try:
-            box["result"] = asyncio.run(coro)
-        except BaseException as e:  # noqa: BLE001 - 透传给调用线程统一处理
-            box["error"] = e
-
-    thread = threading.Thread(
-        target=bind_current_avernet_tenant(_runner), daemon=True
-    )
-    thread.start()
-    thread.join()
-
-    if "error" in box:
-        raise box["error"]
-    return box.get("result")
-
-
-def _replace_admins_line(content: str, admins: List[str]) -> str:
-    """逐行替换/追加 ``ADMINS=`` 行，其它行原样保留。
-
-    镜像 engine ``CredentialsService.update_fields`` 的逐行替换思路(不引入 engine 依赖)。
-    ``admins`` 为空 → 写 ``ADMINS=``(空值)以清空，而非删除行——保证设备端能读到“无 admin”。
-    """
-    admins_value = ",".join(admins)
-    new_line = f"ADMINS={admins_value}"
-
-    lines = content.splitlines()
-    replaced = False
-    out: List[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#") and "=" in stripped:
-            key = stripped.partition("=")[0].strip().upper()
-            if key == "ADMINS":
-                out.append(new_line)
-                replaced = True
-                continue
-        out.append(line)
-
-    if not replaced:
-        out.append(new_line)
-
-    # 保持末尾换行(与 ``_write_credentials`` 写出的文件一致)。
-    return "\n".join(out) + "\n"
+# 运行设备 .credentials 的 ADMINS= 同步由 ``DeviceCredentialsAdminsWriter`` 负责
+# (``core/bot_collaborator/services/credentials_admins_writer.py``):对 service bot 解析
+# 在线 binding (ext.binding.online)、对其它 bot 回退 resolve_for_bot,read-modify-write
+# 既有文件。本模块不再直接解析设备 / 读写 .credentials。
 
 
 # ============================================================================
@@ -146,8 +85,7 @@ class CollaboratorService:
         collaborator_repo: CollaboratorRepositoryProtocol,
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
-        resolver_provider: "Callable[[], DeviceContextResolver]",
-        device_fs_dispatcher_provider: "Callable[[], DeviceFilesystemDispatcher]",
+        credentials_admins_writer: "DeviceCredentialsAdminsWriter",
         member_management_capability_service: MemberManagementCapabilityService | None = None,
     ) -> None:
         """初始化服务。
@@ -156,18 +94,15 @@ class CollaboratorService:
             collaborator_repo: 协作者数据访问接口
             bot_repo: Bot 数据访问接口
             passport_plugin: Passport 插件，用于协作者变更时同步 admins 到 Passport 服务
-            resolver_provider: 惰性 thunk，返回 ``DeviceContextResolver``（按 bot 解析
-                运行设备）。lazy 是为了打断构造期 DI 循环
-                （device 图反向依赖 ``BotService``）。
-            device_fs_dispatcher_provider: 惰性 thunk，返回 ``DeviceFilesystemDispatcher``
-                （按 ``DeviceContext`` 派发 per-bot 文件读写插件）。
+            credentials_admins_writer: 把 admin 工号同步到运行设备 ``.credentials`` 的
+                写入器（对 service bot 解析在线 binding、对其它 bot 回退
+                ``resolve_for_bot``）。read-modify-write 既有文件，失败只 warning。
             member_management_capability_service: 成员管理能力服务，用于协调通用能力与各引擎定制逻辑。
         """
         self._collaborator_repo = collaborator_repo
         self._bot_repo = bot_repo
         self._passport_plugin = passport_plugin
-        self._resolver_provider = resolver_provider
-        self._device_fs_dispatcher_provider = device_fs_dispatcher_provider
+        self._creds_writer = credentials_admins_writer
         self._member_management_capability_service = (
             member_management_capability_service or MemberManagementCapabilityService()
         )
@@ -763,80 +698,9 @@ class CollaboratorService:
             )
 
         # 5. 同步 admin 工号到运行设备的 .credentials 文件（ADMINS= 行）。
-        # 失败只 warning，不影响协作者变更主流程，也不回滚已完成的 Passport 服务同步。
-        self._sync_admins_to_credentials(bot_id, owner_id_from_bot, admins)
+        # 委托给 DeviceCredentialsAdminsWriter:对 service bot 解析在线 binding
+        # (ext.binding.online)、对其它 bot 回退 resolve_for_bot;失败只 warning，
+        # 不影响协作者变更主流程，也不回滚已完成的 Passport 服务同步。
+        self._creds_writer.sync_on_change(bot_id, owner_id_from_bot, admins)
 
         return results
-
-    # ========================================================================
-    # 同步 admins 到运行设备 .credentials
-    # ========================================================================
-
-    def _sync_admins_to_credentials(
-        self,
-        bot_id: str,
-        owner_id: str,
-        admins: List[str],
-    ) -> None:
-        """把最新的 ADMIN 工号写回运行设备的 ``/home/admin/.credentials``。
-
-        走 ``DeviceContextResolver`` 解析 bot 的运行设备，再用
-        ``DeviceFilesystemDispatcher`` 派发 per-bot 文件读写插件做 read-modify-write，
-        只改 ``ADMINS=`` 一行，保留 TOKEN/CLIENT_ID 等其它字段。
-
-        注意：``admins`` 为空列表（最后一个 admin 被移除）时仍要写 ``ADMINS=``（空值）
-        以清空设备端旧值——不能因 falsy 短路跳过。
-
-        bot 无运行设备 / 文件不存在 / 任何异常 → 跳过并记日志，
-        绝不抛出影响主流程。
-        """
-        try:
-            from agentclaw.community.core.devices.services.device_context import (
-                DeviceNotBoundError,
-                UnknownProviderError,
-            )
-
-            try:
-                ctx = self._resolver_provider().resolve_for_bot(bot_id, owner_id)
-            except (DeviceNotBoundError, UnknownProviderError) as e:
-                logger.info(
-                    "[_sync_admins_to_credentials] bot 无运行设备，跳过 credentials 同步: "
-                    "bot_id=%s, reason=%s",
-                    bot_id, e,
-                )
-                return
-
-            fs = self._device_fs_dispatcher_provider().dispatch(ctx)
-            _run_coro_blocking(self._rewrite_credentials_admins(fs, admins))
-            logger.info(
-                "[_sync_admins_to_credentials] Synced admins to .credentials: "
-                "bot_id=%s, admins=%s",
-                bot_id, admins,
-            )
-        except Exception as e:
-            logger.warning(
-                "[_sync_admins_to_credentials] Failed to sync admins to .credentials: "
-                "bot_id=%s, error=%s",
-                bot_id, e,
-            )
-
-    @staticmethod
-    async def _rewrite_credentials_admins(
-        fs: "DeviceFileSystem",
-        admins: List[str],
-    ) -> None:
-        """read-modify-write 设备 .credentials，只替换/追加 ``ADMINS=`` 行。
-
-        文件不存在（``read_file`` 返回 ``None``）→ 跳过：不凭空造文件，否则会丢失
-        TOKEN 等启动时写入的字段。
-        """
-        raw = await fs.read_file(_DEVICE_CREDENTIALS_PATH)
-        if raw is None:
-            logger.info(
-                "[_rewrite_credentials_admins] %s 不存在，跳过",
-                _DEVICE_CREDENTIALS_PATH,
-            )
-            return
-
-        new_content = _replace_admins_line(raw.decode("utf-8"), admins)
-        await fs.write_file(_DEVICE_CREDENTIALS_PATH, new_content.encode("utf-8"))

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/credentials_admins_writer.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/credentials_admins_writer.py
@@ -1,0 +1,245 @@
+"""``DeviceCredentialsAdminsWriter`` — seed/sync the ``ADMINS=`` line of a
+running container's ``/home/admin/.credentials``.
+
+Two entry points share one read-modify-write:
+
+* :meth:`seed_for_publish` — called from the teclaw publish handler once the
+  online container is up. Takes the **online** ``binding_id`` the handler already
+  holds (it polled that binding to SUCCESS) and resolves it via
+  ``resolve_for_binding``. Transport / binding errors **propagate** so the
+  durable task can ``Retry`` (publish-seed is load-bearing; a silent skip would
+  strand the container without admins).
+* :meth:`sync_on_change` — called from ``CollaboratorService.on_collaboration_changed``
+  on every collaborator add/update/remove. For a service bot it resolves the
+  bot's **online** binding from the publish record's ``ext.binding.online``
+  (``ac_bots.binding_id`` is the draft for service bots, so ``resolve_for_bot``
+  would mis-resolve — see ``device_context_resolver.resolve_for_binding``
+  docstring); for bots without a publish record it falls back to
+  ``resolve_for_bot`` (today's ARCA/personal/desktop behavior). It **swallows**
+  every error (warns) — a collaborator change must never break the main flow.
+
+The engine reads admins from ``.credentials`` and the file already exists in a
+running container (engine-created at boot with TOKEN/CLIENT_ID/etc.), so the
+writer **read-modify-writes** the existing file (preserving every other line)
+and never creates a bare ADMINS-only file (the engine rejects one). The engine
+hot-reloads ``.credentials``, so a runtime write takes effect immediately.
+"""
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any, Callable, Dict, List
+
+from agentclaw.community.core.bot_collaborator.models import CollaboratorRole
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceContext,
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.bot_collaborator.models import CollaboratorRecord
+    from agentclaw.community.core.repository.protocols.bot import (
+        CollaboratorRepositoryProtocol,
+    )
+    from agentclaw.community.core.repository.protocols.publishing import (
+        BotPublishRepositoryProtocol,
+    )
+    from agentclaw.community.core.devices.services.device_context_resolver import (
+        DeviceContextResolver,
+    )
+    from agentclaw.community.core.devices.services.device_filesystem_dispatcher import (
+        DeviceFilesystemDispatcher,
+    )
+    from agentclaw.community.core.devices.services.device_filesystem import (
+        DeviceFileSystem,
+    )
+
+logger = get_logger()
+
+# 运行设备上 .credentials 的固定路径(prod 容器内 start_service.sh 写入处,
+# 与 engine ``CredentialsService.DEFAULT_CREDENTIALS_PATH`` 一致)。
+_DEVICE_CREDENTIALS_PATH = "/home/admin/.credentials"
+
+
+def _run_coro_blocking(coro: Any) -> Any:
+    """在独立线程里跑协程并阻塞等待结果。
+
+    ``on_collaboration_changed`` / publish handler 调本 writer 时运行在事件循环
+    线程上(同步入口)。此处:
+      - 不能用 ``asyncio.run``(当前线程已有 running loop → 抛错);
+      - 不能用 ``run_coroutine_threadsafe(coro, 当前loop)``(当前线程被阻塞 → 死锁)。
+    所以起一个新线程、用全新的 ``asyncio.run`` 跑,再 ``join`` 取结果/异常。
+    """
+    import asyncio
+
+    from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
+
+    box: Dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            box["result"] = asyncio.run(coro)
+        except BaseException as e:  # noqa: BLE001 - 透传给调用线程统一处理
+            box["error"] = e
+
+    thread = threading.Thread(
+        target=bind_current_avernet_tenant(_runner), daemon=True
+    )
+    thread.start()
+    thread.join()
+
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
+
+
+def _replace_admins_line(content: str, admins: List[str]) -> str:
+    """逐行替换/追加 ``ADMINS=`` 行，其它行原样保留。
+
+    镜像 engine ``CredentialsService.update_fields`` 的逐行替换思路(不引入 engine 依赖)。
+    ``admins`` 为空 → 写 ``ADMINS=``(空值)以清空，而非删除行——保证设备端能读到“无 admin”。
+    """
+    admins_value = ",".join(admins)
+    new_line = f"ADMINS={admins_value}"
+
+    lines = content.splitlines()
+    replaced = False
+    out: List[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key = stripped.partition("=")[0].strip().upper()
+            if key == "ADMINS":
+                out.append(new_line)
+                replaced = True
+                continue
+        out.append(line)
+
+    if not replaced:
+        out.append(new_line)
+
+    # 保持末尾换行(与 ``_write_credentials`` 写出的文件一致)。
+    return "\n".join(out) + "\n"
+
+
+async def _rewrite_credentials_admins(
+    fs: "DeviceFileSystem", admins: List[str]
+) -> None:
+    """read-modify-write 设备 ``.credentials``，只替换/追加 ``ADMINS=`` 行。
+
+    文件不存在(``read_file`` 返回 ``None``) → 跳过：不凭空造文件。引擎拒绝只含
+    ``ADMINS=`` 的 ``.credentials``(会丢 TOKEN/CLIENT_ID 等启动字段)，而运行容器里
+    该文件由引擎在 boot 时创建，理应存在;真不存在属异常态,记日志不写。
+    """
+    raw = await fs.read_file(_DEVICE_CREDENTIALS_PATH)
+    if raw is None:
+        logger.info(
+            "[credentials_admins_writer] %s 不存在，跳过(不创建)",
+            _DEVICE_CREDENTIALS_PATH,
+        )
+        return
+
+    new_content = _replace_admins_line(raw.decode("utf-8"), admins)
+    await fs.write_file(_DEVICE_CREDENTIALS_PATH, new_content.encode("utf-8"))
+
+
+class DeviceCredentialsAdminsWriter:
+    """Write the ``ADMINS=`` line of a running container's ``.credentials``.
+
+    Resolves the **online** binding for service bots (via the publish record's
+    ``ext.binding.online``); falls back to ``resolve_for_bot`` for bots without a
+    publish record. Read-modify-write only — never creates a bare file.
+    """
+
+    def __init__(
+        self,
+        *,
+        collaborator_repo: "CollaboratorRepositoryProtocol",
+        bot_publish_repo: "BotPublishRepositoryProtocol",
+        resolver_provider: "Callable[[], DeviceContextResolver]",
+        device_fs_dispatcher_provider: "Callable[[], DeviceFilesystemDispatcher]",
+    ) -> None:
+        self._collaborator_repo = collaborator_repo
+        self._bot_publish_repo = bot_publish_repo
+        self._resolver_provider = resolver_provider
+        self._device_fs_dispatcher_provider = device_fs_dispatcher_provider
+
+    # ── public entry points ────────────────────────────────────────────────
+
+    def seed_for_publish(self, binding_id: int, bot_id: str, owner_id: str) -> None:
+        """Seed ``ADMINS=`` into the ONLINE container right after publish.
+
+        ``binding_id`` is the online binding the publish handler just polled to
+        SUCCESS; admins are read from the collaborator repo (current env,
+        ``role=admin``). Errors **propagate**: the handler turns a transport
+        failure into ``Retry`` and a missing binding into ``Complete``.
+        """
+        admins = self._query_admins(bot_id, owner_id)
+        self._write_for_binding(binding_id, bot_id, owner_id, admins)
+
+    def sync_on_change(self, bot_id: str, owner_id: str, admins: List[str]) -> None:
+        """Update the running container's ``ADMINS=`` on a collaborator change.
+
+        Service bot → resolve the online binding (``ext.binding.online``) and
+        write via ``resolve_for_binding``; otherwise fall back to
+        ``resolve_for_bot`` (ARCA/personal/desktop). All errors are swallowed
+        (warned) — a collaborator change must never break the main flow.
+        """
+        try:
+            online_binding_id = self._resolve_online_binding_id(bot_id)
+            if online_binding_id is not None:
+                self._write_for_binding(online_binding_id, bot_id, owner_id, admins)
+            else:
+                self._write_for_bot(bot_id, owner_id, admins)
+        except (DeviceNotBoundError, UnknownProviderError) as e:
+            logger.info(
+                "[credentials_admins_writer] bot 无运行设备，跳过 credentials 同步: "
+                "bot_id=%s, reason=%s",
+                bot_id, e,
+            )
+        except Exception as e:  # noqa: BLE001 - 协作者变更主流程不可因写 .credentials 失败而中断
+            logger.warning(
+                "[credentials_admins_writer] 同步 .credentials 失败(已忽略): "
+                "bot_id=%s, error=%s",
+                bot_id, e,
+            )
+
+    # ── internals ──────────────────────────────────────────────────────────
+
+    def _query_admins(self, bot_id: str, owner_id: str) -> List[str]:
+        env = get_current_env()
+        collaborators: List["CollaboratorRecord"] = self._collaborator_repo.list_by_bot(
+            bot_id=bot_id, owner_id=owner_id, env=env, role=CollaboratorRole.ADMIN,
+        )
+        return [c.user_id for c in collaborators]
+
+    def _resolve_online_binding_id(self, bot_id: str) -> int | None:
+        """Read the bot's online binding id from its latest success publish record."""
+        env = get_current_env()
+        record = self._bot_publish_repo.get_latest_success_by_source_bot_id(bot_id, env)
+        if record is None:
+            return None
+        return (record.ext or {}).get("binding", {}).get("online")
+
+    def _write_for_binding(
+        self, binding_id: int, bot_id: str, owner_id: str, admins: List[str]
+    ) -> None:
+        ctx = self._resolver_provider().resolve_for_binding(
+            binding_id, owner_id, bot_id=bot_id
+        )
+        self._do_write(ctx, admins)
+
+    def _write_for_bot(self, bot_id: str, owner_id: str, admins: List[str]) -> None:
+        ctx = self._resolver_provider().resolve_for_bot(bot_id, owner_id)
+        self._do_write(ctx, admins)
+
+    def _do_write(self, ctx: DeviceContext, admins: List[str]) -> None:
+        fs = self._device_fs_dispatcher_provider().dispatch(ctx)
+        _run_coro_blocking(_rewrite_credentials_admins(fs, admins))
+        logger.info(
+            "[credentials_admins_writer] synced ADMINS to .credentials: "
+            "bot_id=%s provider=%s admins=%s",
+            ctx.bot_id, ctx.provider, admins,
+        )

--- a/src/backend/src/agentclaw/community/core/bot_management/services/teclaw_publish_task_handler.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/teclaw_publish_task_handler.py
@@ -4,6 +4,10 @@ import time
 from typing import TYPE_CHECKING, Callable
 
 from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceNotBoundError,
+    UnknownProviderError,
+)
 from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
     TECLAW_DEVICE_PROVIDER,
 )
@@ -19,6 +23,9 @@ from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
+    from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
+        DeviceCredentialsAdminsWriter,
+    )
     from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
     from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
     from agentclaw.community.core.service_bot.services.baas_service import BaasService
@@ -97,12 +104,14 @@ class TeclawPublishTaskHandler:
         baas_service: BaasService,
         device_binding_repo: DeviceBindingRepository,
         passport_plugin: PassportPlugin,
+        credentials_admins_writer: "DeviceCredentialsAdminsWriter",
         poll_delay_seconds: float = 5.0,
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._baas = baas_service
         self._device_binding_repo = device_binding_repo
         self._passport_plugin = passport_plugin
+        self._creds_writer = credentials_admins_writer
         self._poll_delay_seconds = poll_delay_seconds
         self._clock = clock
 
@@ -329,6 +338,45 @@ class TeclawPublishTaskHandler:
             publish_id,
             len(updated),
         )
+        # Token delivered to a ready device → now seed admins into the same
+        # online container's .credentials. Runs in the success tail of every
+        # entry into _deliver_outbound_rule (first publish AND crash-resume
+        # replay), is idempotent (read-modify-write), and a transient failure
+        # keeps the task recoverable (Retry) without rolling back the token push.
+        return self._seed_admins(bot_id=bot_id, binding=binding)
+
+    def _seed_admins(self, *, bot_id: str, binding: "DeviceBindingRecord") -> TaskOutcome:
+        """Seed collaborator admins into the just-started container's ``.credentials``.
+
+        Reached only after the agentpass token was delivered to a ready device,
+        so the container's file API is reachable. A transient write failure →
+        ``Retry`` (the queue re-drives token + seed; both are idempotent — token
+        is a REPLACE, ``.credentials`` is a read-modify-write). A missing /
+        unknown binding → ``Complete`` (nothing to write to).
+        """
+        try:
+            self._creds_writer.seed_for_publish(
+                binding.id, bot_id, binding.entity_id
+            )
+        except (DeviceNotBoundError, UnknownProviderError) as exc:
+            logger.info(
+                "[TeclawPublishTaskHandler] admins seed skipped (no running device): "
+                "bot_id=%s binding_id=%s reason=%s",
+                bot_id, binding.id, exc,
+            )
+            return Complete()
+        except Exception as exc:  # noqa: BLE001 - keep the task recoverable, don't strand the container
+            logger.warning(
+                "[TeclawPublishTaskHandler] admins seed failed (will retry): "
+                "bot_id=%s binding_id=%s error=%s",
+                bot_id, binding.id, exc,
+            )
+            return Retry(f"seed admins to .credentials failed: {exc}")
+        logger.info(
+            "[TeclawPublishTaskHandler] admins seeded to .credentials: "
+            "bot_id=%s binding_id=%s",
+            bot_id, binding.id,
+        )
         return Complete()
 
 
@@ -341,11 +389,13 @@ class TeclawPublishTaskLifecycle(LifecycleBase):
         baas_service: BaasService,
         device_binding_repo: DeviceBindingRepository,
         passport_plugin: PassportPlugin,
+        credentials_admins_writer: "DeviceCredentialsAdminsWriter",
     ) -> None:
         self._registry = registry
         self._baas_service = baas_service
         self._device_binding_repo = device_binding_repo
         self._passport_plugin = passport_plugin
+        self._creds_writer = credentials_admins_writer
 
     async def bootstrap(self) -> None:
         self._registry.register(
@@ -353,5 +403,6 @@ class TeclawPublishTaskLifecycle(LifecycleBase):
                 baas_service=self._baas_service,
                 device_binding_repo=self._device_binding_repo,
                 passport_plugin=self._passport_plugin,
+                credentials_admins_writer=self._creds_writer,
             )
         )

--- a/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
@@ -26,6 +26,12 @@ from agentclaw.community.core.repository.protocols.bot import CollaboratorReposi
 from agentclaw.community.core.repository.protocols.bot import BotCollabLogRepositoryProtocol
 from agentclaw.community.core.repository.protocols.bot import BotCollabLockRepositoryProtocol
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import CollaboratorService
+from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
+    DeviceCredentialsAdminsWriter,
+)
+from agentclaw.community.core.repository.protocols.publishing import (
+    BotPublishRepositoryProtocol,
+)
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
 )
@@ -95,26 +101,48 @@ class BotCollaboratorModule(Module):
     @singleton
     @provider
     @inject
+    def credentials_admins_writer(
+        self,
+        collaborator_repo: CollaboratorRepositoryProtocol,
+        bot_publish_repo: BotPublishRepositoryProtocol,
+        injector: Injector,
+    ) -> DeviceCredentialsAdminsWriter:
+        """Construct ``DeviceCredentialsAdminsWriter``.
+
+        ``resolver`` / ``device_fs_dispatcher`` 走 lazy ``Callable`` thunk 注入,打断
+        构造期 DI 循环(device 图反向依赖 ``BotService``);collaborator_repo /
+        bot_publish_repo 直接注入(均为 singleton repository)。被 ``CollaboratorService``
+        (运行时协作者变更同步) 和 ``TeclawPublishTaskHandler`` (发布后 seed) 共用。
+        """
+        return DeviceCredentialsAdminsWriter(
+            collaborator_repo=collaborator_repo,
+            bot_publish_repo=bot_publish_repo,
+            resolver_provider=lambda: injector.get(DeviceContextResolver),
+            device_fs_dispatcher_provider=lambda: injector.get(DeviceFilesystemDispatcher),
+        )
+
+    @singleton
+    @provider
+    @inject
     def collaborator_service(
         self,
         collaborator_repo: CollaboratorRepositoryProtocol,
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
+        credentials_admins_writer: DeviceCredentialsAdminsWriter,
         member_management_capability_service: MemberManagementCapabilityService,
-        injector: Injector,
     ) -> CollaboratorService:
         """Construct ``CollaboratorService``.
 
-        ``resolver`` / ``device_fs_dispatcher`` 走 lazy ``Callable`` thunk 注入，
-        打断构造期 DI 循环(device 图反向依赖 ``BotService``)。同手法见
-        ``di/modules/mcp_module.py`` 的 ``mcp_sync_service``。
+        ``.credentials`` 的 ADMINS= 同步委托给 ``DeviceCredentialsAdminsWriter`` (对
+        service bot 解析在线 binding、对其它 bot 回退 resolve_for_bot)。设备解析/读写
+        的 DI 循环由 writer 内部的 lazy thunk 打断。
         """
         return CollaboratorService(
             collaborator_repo=collaborator_repo,
             bot_repo=bot_repo,
             passport_plugin=passport_plugin,
-            resolver_provider=lambda: injector.get(DeviceContextResolver),
-            device_fs_dispatcher_provider=lambda: injector.get(DeviceFilesystemDispatcher),
+            credentials_admins_writer=credentials_admins_writer,
             member_management_capability_service=member_management_capability_service,
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -44,6 +44,9 @@ from agentclaw.community.core.bot_collaborator.protocols import (
 )
 from agentclaw.community.core.repository.protocols.bot import CollaboratorRepositoryProtocol
 from agentclaw.community.core.repository.protocols.bot import RenderScreenRepository
+from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
+    DeviceCredentialsAdminsWriter,
+)
 from agentclaw.community.core.bot_management.render_screen.services.render_screen_service import (
     RenderScreenService,
 )
@@ -382,12 +385,14 @@ class BotManagementModule(Module):
         baas_service: BaasService,
         device_binding_repo: DeviceBindingRepository,
         passport_plugin: PassportPlugin,
+        credentials_admins_writer: DeviceCredentialsAdminsWriter,
     ) -> TeclawPublishTaskLifecycle:
         return TeclawPublishTaskLifecycle(
             registry=registry,
             baas_service=baas_service,
             device_binding_repo=device_binding_repo,
             passport_plugin=passport_plugin,
+            credentials_admins_writer=credentials_admins_writer,
         )
 
     @singleton

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -55,8 +55,7 @@ def service(collaborator_repo, bot_repo, template_service):
         collaborator_repo=collaborator_repo,
         bot_repo=bot_repo,
         passport_plugin=Mock(),
-        resolver_provider=lambda: Mock(),
-        device_fs_dispatcher_provider=lambda: Mock(),
+        credentials_admins_writer=Mock(),
         member_management_capability_service=MemberManagementCapabilityService(
             engine_capabilities=(AICodingMemberManagementCapability(template_service),),
         ),
@@ -187,14 +186,11 @@ def test_add_collaborator_bot_not_found(service, bot_repo):
 # credentials-sync leg is a clean no-op and we stay focused on the passport leg.
 
 def _service_for_sync(passport):
-    resolver = Mock()
-    resolver.resolve_for_bot.side_effect = RuntimeError("no device in test")
     return CollaboratorService(
         collaborator_repo=Mock(),
         bot_repo=Mock(),
         passport_plugin=passport,
-        resolver_provider=lambda: resolver,
-        device_fs_dispatcher_provider=lambda: Mock(),
+        credentials_admins_writer=Mock(),
     )
 
 
@@ -229,6 +225,42 @@ def test_on_collaboration_changed_passport_failure_is_swallowed():
     svc.on_collaboration_changed("bot1", "owner1", env="dev")
 
     passport.update_passport.assert_called_once()
+
+
+# ── on_collaboration_changed: delegates the .credentials admins write to the
+#    DeviceCredentialsAdminsWriter (the teclaw service-bot admins-sync fix) ──
+
+
+class _RecordingWriter:
+    """Records sync_on_change calls — stands in for the credentials writer."""
+
+    def __init__(self) -> None:
+        self.sync_calls: list[tuple[str, str, list[str]]] = []
+
+    def sync_on_change(self, bot_id: str, owner_id: str, admins: list[str]) -> None:
+        self.sync_calls.append((bot_id, owner_id, list(admins)))
+
+
+def test_on_collaboration_changed_delegates_admins_to_credentials_writer():
+    writer = _RecordingWriter()
+    collaborator_repo = Mock()
+    collaborator_repo.list_by_bot.return_value = [
+        _admin_record("admin001"),
+        _admin_record("admin002"),
+    ]
+    bot_repo = Mock()
+    bot_repo.get_by_id_and_owner.return_value = {"bot_id": "bot1", "owner_id": "owner1"}
+    svc = CollaboratorService(
+        collaborator_repo=collaborator_repo,
+        bot_repo=bot_repo,
+        passport_plugin=Mock(),
+        credentials_admins_writer=writer,
+    )
+
+    svc.on_collaboration_changed("bot1", "owner1", env="dev")
+
+    # admins (role=admin) computed from the collaborator list are handed to the writer
+    assert writer.sync_calls == [("bot1", "owner1", ["admin001", "admin002"])]
 
 
 def _collaborator_record(user_id: str = MEMBER) -> CollaboratorRecord:

--- a/src/backend/tests/community/core/bot_collaborator/test_credentials_admins_writer.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_credentials_admins_writer.py
@@ -1,0 +1,346 @@
+"""Tests for ``DeviceCredentialsAdminsWriter``.
+
+Real fakes only (no mocks — per repo convention). The writer is the shared seam
+that seeds / syncs the ``ADMINS=`` line of a running container's
+``/home/admin/.credentials``. For a service bot it must resolve the **online**
+binding (``ext.binding.online`` via the publish record) and write via
+``resolve_for_binding``; for bots without a publish record it falls back to
+``resolve_for_bot`` (today's ARCA behavior). It read-modify-writes the existing
+file (engine rejects ADMINS-only) and never creates a bare file.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+)
+from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
+    _DEVICE_CREDENTIALS_PATH,
+    DeviceCredentialsAdminsWriter,
+)
+from agentclaw.community.core.devices.services.device_context import (
+    DeviceContext,
+    DeviceNotBoundError,
+)
+from agentclaw.community.core.devices.services.device_filesystem import (
+    DeviceFileSystem,
+)
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishRecord,
+    PublishStatus,
+)
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+class FakeDeviceFileSystem:
+    """In-memory dict-backed DeviceFileSystem. Records nothing but state."""
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self._files: dict[str, bytes] = dict(files or {})
+        self.write_calls: list[tuple[str, bytes]] = []
+
+    async def read_file(self, file_path: str, *, enforce_download_limit: bool = False) -> bytes | None:
+        return self._files.get(file_path)
+
+    async def write_file(self, file_path: str, content: bytes) -> None:
+        self._files[file_path] = content
+        self.write_calls.append((file_path, content))
+
+    async def delete_file(self, file_path: str) -> bool:
+        return self._files.pop(file_path, None) is not None
+
+    async def delete_tree(self, dir_path: str) -> bool:
+        return True
+
+    async def list_dir(self, dir_path: str, *, recursive: bool = False) -> list[dict[str, Any]] | None:
+        return []
+
+    async def exists(self, path: str) -> bool:
+        return path in self._files
+
+
+class RaisingDeviceFileSystem(FakeDeviceFileSystem):
+    """A fs whose write_file always raises — to test error propagation."""
+
+    async def write_file(self, file_path: str, content: bytes) -> None:
+        raise RuntimeError("write failed (fake)")
+
+
+class FakeDispatcher:
+    def __init__(self, fs: DeviceFileSystem) -> None:
+        self._fs = fs
+        self.dispatched: list[DeviceContext] = []
+
+    def dispatch(self, ctx: DeviceContext) -> DeviceFileSystem:
+        self.dispatched.append(ctx)
+        return self._fs
+
+
+class FakeResolver:
+    """Records which entry (resolve_for_bot vs resolve_for_binding) was used."""
+
+    def __init__(self, provider: str = "teclaw") -> None:
+        self._provider = provider
+        self.resolve_for_bot_calls: list[tuple[str, str]] = []
+        self.resolve_for_binding_calls: list[tuple[int, str, str]] = []
+
+    def resolve_for_bot(self, bot_id: str, user_id: str, *, device_uuid: str | None = None) -> DeviceContext:
+        self.resolve_for_bot_calls.append((bot_id, user_id))
+        return DeviceContext(
+            provider=self._provider,  # type: ignore[arg-type]
+            conn_info={},
+            binding_id=0,
+            bot_id=bot_id,
+            user_id=user_id,
+        )
+
+    def resolve_for_binding(
+        self, binding_id: int, operator_id: str, *, bot_id: str, device_uuid: str | None = None
+    ) -> DeviceContext:
+        self.resolve_for_binding_calls.append((binding_id, operator_id, bot_id))
+        return DeviceContext(
+            provider=self._provider,  # type: ignore[arg-type]
+            conn_info={},
+            binding_id=binding_id,
+            bot_id=bot_id,
+            user_id=operator_id,
+        )
+
+
+class FakeCollaboratorRepo:
+    def __init__(self, admins: list[str]) -> None:
+        self._admins = admins
+
+    def list_by_bot(self, bot_id: str, owner_id: str, env: str, role: str | None = None) -> list[CollaboratorRecord]:
+        return [
+            CollaboratorRecord(
+                id=i,
+                bot_pk=1,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                user_id=uid,
+                user_name=None,
+                role=CollaboratorRole.ADMIN,
+                operator_id=owner_id,
+                env=env,
+            )
+            for i, uid in enumerate(self._admins)
+        ]
+
+
+class FakePublishRepo:
+    def __init__(self, online_binding_id: int | None) -> None:
+        self._online_binding_id = online_binding_id
+
+    def get_latest_success_by_source_bot_id(self, source_bot_id: str, env: str) -> BotPublishRecord | None:
+        if self._online_binding_id is None:
+            return None
+        return BotPublishRecord(
+            id=1,
+            source_bot_pk=1,
+            source_bot_id=source_bot_id,
+            publish_bot_id=f"{source_bot_id}pub1",
+            name="n",
+            description=None,
+            owner_id="owner",
+            owner_name=None,
+            status=PublishStatus.SUCCESS,
+            version=1,
+            last_pub_id=0,
+            env=env,
+            ext={"binding": {"online": self._online_binding_id}},
+            permission_owner="owner",
+        )
+
+
+def _make_writer(
+    *,
+    fs: DeviceFileSystem,
+    admins: list[str] | None = None,
+    online_binding_id: int | None = None,
+    provider: str = "teclaw",
+) -> tuple[DeviceCredentialsAdminsWriter, FakeResolver, FakeDispatcher]:
+    resolver = FakeResolver(provider=provider)
+    dispatcher = FakeDispatcher(fs)
+    writer = DeviceCredentialsAdminsWriter(
+        collaborator_repo=FakeCollaboratorRepo(admins=admins or []),
+        bot_publish_repo=FakePublishRepo(online_binding_id=online_binding_id),
+        resolver_provider=lambda: resolver,
+        device_fs_dispatcher_provider=lambda: dispatcher,
+    )
+    return writer, resolver, dispatcher
+
+
+def _credentials(token: str = "TOK", client_id: str = "CID", admins: str = "") -> bytes:
+    return f"TOKEN={token}\nCLIENT_ID={client_id}\nADMINS={admins}\n".encode()
+
+
+# ── seed_for_publish ─────────────────────────────────────────────────────────
+
+
+def test_seed_for_publish_uses_resolve_for_binding_and_writes_admins():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, resolver, dispatcher = _make_writer(fs=fs, admins=["u1", "u2"], online_binding_id=42)
+
+    writer.seed_for_publish(binding_id=42, bot_id="bot-1", owner_id="owner-1")
+
+    # online binding resolved via resolve_for_binding, NOT resolve_for_bot
+    assert resolver.resolve_for_binding_calls == [(42, "owner-1", "bot-1")]
+    assert resolver.resolve_for_bot_calls == []
+    # only the ADMINS= line changed; TOKEN/CLIENT_ID preserved
+    written = fs.write_calls[-1][1].decode()
+    assert "TOKEN=TOK" in written
+    assert "CLIENT_ID=CID" in written
+    assert "ADMINS=u1,u2" in written
+
+
+def test_seed_for_publish_empty_admins_clears_line_preserves_others():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials(admins="old")})
+    writer, *_ = _make_writer(fs=fs, admins=[], online_binding_id=7)
+
+    writer.seed_for_publish(binding_id=7, bot_id="bot-1", owner_id="o")
+
+    written = fs.write_calls[-1][1].decode()
+    assert "ADMINS=\n" in written
+    assert "TOKEN=TOK" in written
+    assert "CLIENT_ID=CID" in written
+
+
+def test_seed_for_publish_missing_credentials_skips_no_create():
+    fs = FakeDeviceFileSystem({})  # no .credentials present
+    writer, *_ = _make_writer(fs=fs, admins=["u1"], online_binding_id=7)
+
+    writer.seed_for_publish(binding_id=7, bot_id="bot-1", owner_id="o")
+
+    # engine rejects ADMINS-only → never create a bare file
+    assert fs.write_calls == []
+    assert _DEVICE_CREDENTIALS_PATH not in fs._files
+
+
+def test_seed_for_publish_write_failure_propagates():
+    fs = RaisingDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, *_ = _make_writer(fs=fs, admins=["u1"], online_binding_id=7)
+
+    # propagates so the publish handler can Retry
+    with pytest.raises(RuntimeError, match="write failed"):
+        writer.seed_for_publish(binding_id=7, bot_id="bot-1", owner_id="o")
+
+
+# ── sync_on_change ───────────────────────────────────────────────────────────
+
+
+def test_sync_on_change_service_bot_uses_online_binding():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, resolver, dispatcher = _make_writer(fs=fs, admins=["u1"], online_binding_id=99)
+
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+
+    # online binding resolved via resolve_for_binding (service bot has a publish record)
+    assert resolver.resolve_for_binding_calls == [(99, "owner-1", "bot-1")]
+    assert resolver.resolve_for_bot_calls == []
+    assert "ADMINS=u1" in fs.write_calls[-1][1].decode()
+
+
+def test_sync_on_change_no_publish_record_falls_back_to_resolve_for_bot():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, resolver, _ = _make_writer(fs=fs, online_binding_id=None, provider="baas")
+
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+
+    # ARCA/personal/desktop: no online binding → today's resolve_for_bot path
+    assert resolver.resolve_for_bot_calls == [("bot-1", "owner-1")]
+    assert resolver.resolve_for_binding_calls == []
+    assert "ADMINS=u1" in fs.write_calls[-1][1].decode()
+
+
+def test_sync_on_change_missing_ext_binding_online_falls_back():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    resolver = FakeResolver(provider="baas")
+    dispatcher = FakeDispatcher(fs)
+    # publish record present but ext has no online binding id
+    class _NoOnlineRepo:
+        def get_latest_success_by_source_bot_id(self, source_bot_id, env):
+            return BotPublishRecord(
+                id=1, source_bot_pk=1, source_bot_id=source_bot_id, publish_bot_id="p",
+                name="n", description=None, owner_id="o", owner_name=None,
+                status=PublishStatus.SUCCESS, version=1, last_pub_id=0, env=env,
+                ext={"binding": {}}, permission_owner="o",
+            )
+    writer = DeviceCredentialsAdminsWriter(
+        collaborator_repo=FakeCollaboratorRepo(["u1"]),
+        bot_publish_repo=_NoOnlineRepo(),
+        resolver_provider=lambda: resolver,
+        device_fs_dispatcher_provider=lambda: dispatcher,
+    )
+
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+
+    assert resolver.resolve_for_bot_calls == [("bot-1", "owner-1")]
+    assert resolver.resolve_for_binding_calls == []
+
+
+def test_sync_on_change_no_device_bound_swallows():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    resolver = FakeResolver(provider="teclaw")
+    resolver.resolve_for_bot = lambda bot_id, user_id, *, device_uuid=None: (_ for _ in ()).throw(
+        DeviceNotBoundError("no active binding")
+    )
+    # for the service-bot branch it uses resolve_for_binding; make that raise too:
+    resolver.resolve_for_binding = lambda binding_id, operator_id, *, bot_id, device_uuid=None: (
+        _ for _ in ()
+    ).throw(DeviceNotBoundError("no active binding"))
+    dispatcher = FakeDispatcher(fs)
+    writer = DeviceCredentialsAdminsWriter(
+        collaborator_repo=FakeCollaboratorRepo(["u1"]),
+        bot_publish_repo=FakePublishRepo(online_binding_id=99),
+        resolver_provider=lambda: resolver,
+        device_fs_dispatcher_provider=lambda: dispatcher,
+    )
+
+    # must NOT raise — a collab change must never break the main flow
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+    assert fs.write_calls == []
+
+
+def test_sync_on_change_write_failure_swallows():
+    fs = RaisingDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, *_ = _make_writer(fs=fs, admins=["u1"], online_binding_id=99)
+
+    # must NOT raise — collab change flow stays intact
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+
+
+def test_sync_on_change_empty_admins_clears_line():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials(admins="old")})
+    writer, *_ = _make_writer(fs=fs, online_binding_id=99)
+
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=[])
+
+    written = fs.write_calls[-1][1].decode()
+    assert "ADMINS=\n" in written
+    assert "TOKEN=TOK" in written
+
+
+def test_seed_for_publish_no_device_bound_propagates():
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    resolver = FakeResolver(provider="teclaw")
+    resolver.resolve_for_binding = lambda binding_id, operator_id, *, bot_id, device_uuid=None: (
+        _ for _ in ()
+    ).throw(DeviceNotBoundError("no active binding"))
+    dispatcher = FakeDispatcher(fs)
+    writer = DeviceCredentialsAdminsWriter(
+        collaborator_repo=FakeCollaboratorRepo(["u1"]),
+        bot_publish_repo=FakePublishRepo(online_binding_id=99),
+        resolver_provider=lambda: resolver,
+        device_fs_dispatcher_provider=lambda: dispatcher,
+    )
+
+    # seed_for_publish propagates DeviceNotBound so the handler can decide (Complete)
+    with pytest.raises(DeviceNotBoundError):
+        writer.seed_for_publish(binding_id=99, bot_id="bot-1", owner_id="owner-1")

--- a/src/backend/tests/community/core/bot_management/services/test_teclaw_publish_task_handler.py
+++ b/src/backend/tests/community/core/bot_management/services/test_teclaw_publish_task_handler.py
@@ -147,6 +147,7 @@ def _handler(*, clock=lambda: 200.0):
         baas_service=baas,
         device_binding_repo=binding_repo,
         passport_plugin=passport,
+        credentials_admins_writer=MagicMock(),
         poll_delay_seconds=10.0,
         clock=clock,
     )
@@ -414,6 +415,7 @@ def test_terminal_publish_does_not_overwrite_binding_released_during_poll(sqlite
         baas_service=baas,
         device_binding_repo=binding_repo,
         passport_plugin=MagicMock(),
+        credentials_admins_writer=MagicMock(),
     )
 
     assert handler.handle(_payload(binding_id=binding_id)) == Complete()
@@ -438,6 +440,7 @@ def test_terminal_publish_does_not_overwrite_new_publish_id_during_poll(sqlite_d
         baas_service=baas,
         device_binding_repo=binding_repo,
         passport_plugin=MagicMock(),
+        credentials_admins_writer=MagicMock(),
     )
 
     assert handler.handle(_payload(binding_id=binding_id)) == Complete()
@@ -503,6 +506,7 @@ def test_lifecycle_registers_handler():
         baas_service=MagicMock(),
         device_binding_repo=MagicMock(),
         passport_plugin=MagicMock(),
+        credentials_admins_writer=MagicMock(),
     )
 
     asyncio.run(lifecycle.bootstrap())
@@ -566,3 +570,94 @@ def test_binding_read_failure_returns_retry():
     assert isinstance(outcome, Retry)
     assert "binding db down" in outcome.error
     baas.get_publish_progress.assert_not_called()
+
+
+# ── post-publish admins seed into the online container's .credentials ────────
+
+
+class _RecordingCredsWriter:
+    """Records seed_for_publish calls; optionally raises to test Retry."""
+
+    def __init__(self, *, raise_on_seed: BaseException | None = None) -> None:
+        self.seed_calls: list[tuple[int, str, str]] = []
+        self._raise = raise_on_seed
+
+    def seed_for_publish(self, binding_id: int, bot_id: str, owner_id: str) -> None:
+        self.seed_calls.append((binding_id, bot_id, owner_id))
+        if self._raise is not None:
+            raise self._raise
+
+
+def _handler_with_writer(writer, *, clock=lambda: 200.0):
+    baas = MagicMock()
+    binding_repo = MagicMock()
+    binding_repo.get_by_id.return_value = _binding()
+    binding_repo.transition_teclaw_publish_terminal.return_value = True
+    passport = MagicMock()
+    passport.query_token.return_value = "passport-token"
+    baas.update_teclaw_outbound_rule_by_bot_uuid.return_value = [
+        {"device_uuid": "DEVICE-1", "paas_device_id": "TECLAW_1@4"}
+    ]
+    handler = TeclawPublishTaskHandler(
+        baas_service=baas,
+        device_binding_repo=binding_repo,
+        passport_plugin=passport,
+        credentials_admins_writer=writer,
+        poll_delay_seconds=10.0,
+        clock=clock,
+    )
+    return handler, baas, binding_repo, passport, writer
+
+
+def test_success_seeds_admins_into_the_started_container():
+    writer = _RecordingCredsWriter()
+    handler, baas, binding_repo, passport, writer = _handler_with_writer(writer)
+    baas.get_publish_progress.return_value = {"status": "SUCCESS"}
+
+    assert handler.handle(_payload()) == Complete()
+
+    # token delivered, then admins seeded into the ONLINE binding (id=77, owner staff-1)
+    baas.update_teclaw_outbound_rule_by_bot_uuid.assert_called_once_with(
+        "BOT-x", agent_pass_token="passport-token"
+    )
+    assert writer.seed_calls == [(77, "b1", "staff-1")]
+
+
+def test_active_binding_replays_admins_seed_after_crash():
+    writer = _RecordingCredsWriter()
+    handler, baas, binding_repo, passport, writer = _handler_with_writer(writer)
+    binding_repo.get_by_id.return_value = _binding(status="ACTIVE")
+
+    assert handler.handle(_payload()) == Complete()
+
+    # crash-resume replays both token delivery and admins seed (both idempotent)
+    baas.update_teclaw_outbound_rule_by_bot_uuid.assert_called_once_with(
+        "BOT-x", agent_pass_token="passport-token"
+    )
+    assert writer.seed_calls == [(77, "b1", "staff-1")]
+
+
+def test_admins_seed_failure_retries_without_losing_token_delivery():
+    writer = _RecordingCredsWriter(raise_on_seed=RuntimeError("credentials write down"))
+    handler, baas, binding_repo, passport, writer = _handler_with_writer(writer)
+    baas.get_publish_progress.return_value = {"status": "SUCCESS"}
+
+    outcome = handler.handle(_payload())
+
+    assert isinstance(outcome, Retry)
+    assert "seed admins" in outcome.error
+    # token was still delivered (its own durability); seed failure does not roll it back
+    baas.update_teclaw_outbound_rule_by_bot_uuid.assert_called_once_with(
+        "BOT-x", agent_pass_token="passport-token"
+    )
+
+
+def test_admins_seed_not_run_when_devices_not_ready():
+    writer = _RecordingCredsWriter()
+    handler, baas, binding_repo, passport, writer = _handler_with_writer(writer)
+    baas.get_publish_progress.return_value = {"status": "SUCCESS"}
+    baas.update_teclaw_outbound_rule_by_bot_uuid.return_value = []  # devices not ready
+
+    assert handler.handle(_payload()) == Reschedule(10.0)
+    # never seed before the device is ready
+    assert writer.seed_calls == []

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -309,6 +309,7 @@ def test_teclaw_publish_task_is_reclaimed_after_worker_restart():
             baas_service=baas,
             device_binding_repo=binding_repo,
             passport_plugin=MagicMock(),
+            credentials_admins_writer=MagicMock(),
         )
     )
     record = w.enqueue(


### PR DESCRIPTION
After a teclaw service-bot publish the running container had no collaborator admins: the publish path never wrote ADMINS=, and the runtime sync resolved the DRAFT binding (ac_bots.binding_id) instead of the online one. Add a DeviceCredentialsAdminsWriter that, for service bots, resolves the online binding (ext.binding.online) via resolve_for_binding and read-modify-writes ADMINS= into the existing .credentials (engine rejects an ADMINS-only file and hot-reloads it). Seed at publish SUCCESS after the agentpass token is delivered to a ready device (idempotent, retried, replay-safe), and sync on every collaborator change. ARCA/personal/desktop keep resolve_for_bot.

- new DeviceCredentialsAdminsWriter (seed_for_publish / sync_on_change)
- CollaboratorService delegates on_collaboration_changed to the writer
- TeclawPublishTaskHandler seeds admins after token delivery (+ replay-safe)
- DI: bind the writer; inject into CollaboratorService + the publish lifecycle

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
