### PR TITLE
fix(baas): serialize distributed-lock acquire against renew thread

### DIFF
--- a/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
+++ b/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
@@ -292,6 +292,17 @@ class DistributedLockService:
         委托仓储的 ``try_acquire_lock`` 在单一事务中完成原子加锁：
         SELECT → DELETE expired → INSERT，唯一索引冲突视为并发竞争。
 
+        通过 ``_renew_lock`` 串行化加锁路径与自动续期守护线程的
+        ``update_expire_time``：两者都在同一个仓储单例上调用
+        ``orm_session()``，共享连接下并发的提交/回滚会破坏 SQLAlchemy
+        会话的事务栈，间歇性抛出 “Transaction ... is not on the active
+        transaction list”。该约定由 #441 引入，#460 重写为本方法委托
+        ``try_acquire_lock`` 时被误删，此处恢复。
+
+        ``_renew_lock`` 是独立于 ``_local_lock`` 的专用锁：``_stop_renew_thread``
+        在持有 ``_local_lock`` 时 ``join`` 续期线程，续期线程只竞争
+        ``_renew_lock`` 而不持有 ``_local_lock``，故不会死锁。
+
         Args:
             lock_name: 锁名称
             lock_holder: 锁持有者
@@ -302,11 +313,12 @@ class DistributedLockService:
         """
         try:
             expire_time = datetime.now() + timedelta(seconds=expire_seconds)
-            return self._repository.try_acquire_lock(
-                lock_name=lock_name,
-                lock_holder=lock_holder,
-                expire_time=expire_time,
-            )
+            with self._renew_lock:
+                return self._repository.try_acquire_lock(
+                    lock_name=lock_name,
+                    lock_holder=lock_holder,
+                    expire_time=expire_time,
+                )
         except Exception as e:
             if _is_unique_constraint_violation(e):
                 logger.info(

--- a/src/baas/tests/unit/core/service/distributed_lock/test_service.py
+++ b/src/baas/tests/unit/core/service/distributed_lock/test_service.py
@@ -748,6 +748,85 @@ class TestGetLockInfo:
 # ── Helpers ──────────────────────────────────────────────────────
 
 
+# ── Renew/acquire serialization tests ───────────────────────────
+
+
+class TestAcquireRenewSerialization:
+    """Pin the `_renew_lock` contract between acquire and the renew thread.
+
+    #441 serialised the acquire path against the auto-renew daemon thread with
+    `_renew_lock` because both reach `orm_session()` on the same repository
+    singleton and, under a shared connection, concurrent commit/rollback
+    corrupts the SQLAlchemy session. #460 dropped the guard from the acquire
+    path while rewriting it to delegate to `repository.try_acquire_lock`;
+    these tests fail if that regression returns.
+    """
+
+    def test_acquire_lock_holds_renew_lock_during_repo_call(
+        self, lock_service, repository
+    ):
+        """The acquire DB call must run while `_renew_lock` is held."""
+        seen: dict = {}
+
+        def record(*, lock_name, lock_holder, expire_time):
+            seen["renew_lock_held"] = lock_service._renew_lock.locked()
+            return True
+
+        repository.try_acquire_lock.side_effect = record
+
+        ctx = lock_service.acquire_lock("mylock", lock_holder="h1")
+
+        assert ctx.acquired is True
+        assert seen.get("renew_lock_held") is True, (
+            "acquire path ran without holding _renew_lock — the renew thread can "
+            "race it on the shared repository connection"
+        )
+
+    def test_acquire_blocks_while_renew_lock_is_held(self, lock_service, repository):
+        """Acquire must wait for the renew thread to release `_renew_lock`."""
+        repository.try_acquire_lock.return_value = True
+
+        held = threading.Event()
+        release = threading.Event()
+
+        def renew_in_flight() -> None:
+            with lock_service._renew_lock:
+                held.set()
+                release.wait(timeout=5.0)
+
+        renew_thread = threading.Thread(
+            target=renew_in_flight, daemon=True, name="renew-in-flight"
+        )
+        renew_thread.start()
+        assert held.wait(timeout=2.0), "renew thread did not acquire _renew_lock"
+        assert lock_service._renew_lock.locked() is True
+
+        done = threading.Event()
+
+        def acquire() -> None:
+            ctx = lock_service.acquire_lock("mylock", lock_holder="h1")
+            ctx and _stop_thread(ctx)
+            done.set()
+
+        acquirer = threading.Thread(target=acquire, daemon=True, name="acquire-waiter")
+        acquirer.start()
+
+        # While the renew thread holds _renew_lock, acquire must not complete.
+        assert not done.wait(timeout=0.3), (
+            "acquire completed while renew held _renew_lock — serialization broken"
+        )
+
+        release.set()
+        assert done.wait(timeout=2.0), (
+            "acquire did not complete after renew released _renew_lock"
+        )
+        acquirer.join(timeout=2.0)
+        renew_thread.join(timeout=2.0)
+
+
+# ── Helpers ──────────────────────────────────────────────
+
+
 def _stop_thread(ctx: LockContext) -> None:
     """Stop a renew thread and wait for it to finish."""
     ctx.stop_renew.set()


### PR DESCRIPTION
## Problem
The distributed lock service's internal acquire path intermittently raised a SQLAlchemy session error (`Transaction ... is not on the active transaction list`) when acquiring a lock whose auto-renew daemon thread was running.

## Solution
Restore the `_renew_lock` serialization around the acquire database flow.

`DistributedLockService` starts an auto-renew daemon thread per held lock that calls `OrmDistributedLockRepository.update_expire_time` (serialized with `_renew_lock`). The renew thread and the acquire path both reach `orm_session()` on the same repository singleton; under a shared-connection engine (e.g. the SQLite `StaticPool` plugin, or any single-connection engine) their concurrent commit/rollback finalizations corrupt the SQLAlchemy `SessionTransaction` stack and raise the observed error intermittently.

This serialization was originally added to close the same renew/acquire race (#441), then dropped when `_try_acquire_lock_internal` was rewritten to delegate to the repository's atomic `try_acquire_lock` (#460). This change restores the wrapper around that delegated call and documents why it must stay, so it is not silently removed again.

The source change is one method: wrap the `self._repository.try_acquire_lock(...)` call in `_try_acquire_lock_internal` with `with self._renew_lock:`. No public API, schema, or config change; `_renew_lock` already existed on the service.

## Validation
- New regression tests `TestAcquireRenewSerialization` pin the contract: the acquire DB call runs while `_renew_lock` is held, and acquire blocks while the renew thread holds `_renew_lock`. Verified both tests FAIL without the fix and PASS with it.
- Existing distributed-lock unit suite (94 tests) and the distributed-lock integration suite on the real SQLite plugin (19 tests) pass.
- A standalone reproduction against the public SQLite plugin (StaticPool, short renew interval, concurrent acquire) reproduced shared-connection corruption before the fix and is clean after.
- `ruff check` and `ruff format --check` pass on the changed files.

Not run: the full `src/baas` module CI (`scripts/ci_test.sh`, which runs `uv sync` + coverage + singlebox coverage); the targeted unit and integration layers above cover the changed code path, and the default pre-push hook runs SAST-only for `src/baas/`. Singlebox was not required — this is a pure in-process concurrency fix with no gateway/plugin/HTTP-contract change.

## Compatibility and risk
- No contract, schema, or config change. Rollback is a single-file revert with no state to clean up.
- Lock ordering is `local -> renew` with no reverse nesting. `_stop_renew_thread` joins the renew worker, which never takes the local lock, so there is no join deadlock.
- This minimal fix targets the proven acquire-path defect. The same race class also affects sibling read / manual-renew / delete paths that reach `orm_session()` on the shared connection; serializing those consistently (or revisiting single-connection engine usage) is recommended as a separate follow-up rather than bundling.
