### PR TITLE
fix(bcs-message-flow): echo attachments in workbench ws user events

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -2525,7 +2525,7 @@ async fn build_workbench_user_event(flow: &BcsMessageFlow, cmd: &WebSendCommand)
         _ => "assistant",
     };
     let from_name = preferred_sender_display_name(flow, cmd).await;
-    let event = serde_json::json!({
+    let mut event = serde_json::json!({
         "run_id": run_id,
         "session_key": session_key,
         "bcs_session_id": cmd.session_id.as_deref(),
@@ -2539,6 +2539,9 @@ async fn build_workbench_user_event(flow: &BcsMessageFlow, cmd: &WebSendCommand)
             "mentions": cmd.mentions,
         },
     });
+    if let Some(attachments) = echo_event_attachments(cmd.attachments.as_deref()) {
+        event["message"]["attachments"] = attachments;
+    }
     let frame = serde_json::json!({
         "type": "event",
         "event": "chat",
@@ -2548,6 +2551,16 @@ async fn build_workbench_user_event(flow: &BcsMessageFlow, cmd: &WebSendCommand)
         "bot_name": from_name,
     });
     serde_json::to_string(&frame).unwrap_or_default()
+}
+
+/// Echo the inbound attachments verbatim (including the client-provided
+/// `url`/`expires_at`, which stays in **milliseconds**) so other frontends can
+/// render images without waiting for a history refresh. Returns `None` when
+/// there are no attachments, so the event omits the `attachments` key entirely
+/// (older frontends unaffected).
+fn echo_event_attachments(attachments: Option<&[Attachment]>) -> Option<Value> {
+    let attachments = attachments.filter(|items| !items.is_empty())?;
+    serde_json::to_value(attachments).ok()
 }
 
 fn effective_message_log_session_id<'a>(group_id: &'a str, session_id: Option<&'a str>) -> &'a str {

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -3568,3 +3568,123 @@ fn request_id_for_method(frames: &[BcsFrame], method: &str) -> String {
         })
         .unwrap_or_else(|| panic!("{method} request frame not found"))
 }
+
+// ==== Workbench realtime attachment echo ====
+
+fn image_attachment() -> bcs_domain::Attachment {
+    bcs_domain::Attachment {
+        attachment_id: "file_1".to_string(),
+        attachment_type: bcs_domain::AttachmentType::Image,
+        file_name: "a.png".to_string(),
+        mime_type: Some("image/png".to_string()),
+        size: Some(4),
+        sha256: Some("abcd".to_string()),
+        url: "https://bcs.test/sessions/shared-file/content?token=fromsender".to_string(),
+        expires_at: Some(1_786_346_756_000),
+    }
+}
+
+fn human_web_send(message: &str, attachments: Option<Vec<bcs_domain::Attachment>>) -> WebSendCommand {
+    WebSendCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_1".to_string(),
+            staff_no: "1".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        session_id: Some("session-1".to_string()),
+        from_actor_id: "human_1".to_string(),
+        from_name: Some("Human One".to_string()),
+        message: message.to_string(),
+        mentions: vec![],
+        attachments,
+        thinking: None,
+        idempotency_key: None,
+        source_im_message_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn web_send_event_echoes_attachments_verbatim() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_web_send(human_web_send("看图", Some(vec![image_attachment()])))
+        .await
+        .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 1);
+    let event: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    let atts = &event["payload"]["message"]["attachments"];
+    assert!(atts.is_array(), "event: {event}");
+    assert_eq!(atts[0]["attachment_id"], "file_1");
+    assert_eq!(atts[0]["type"], "image");
+    assert_eq!(atts[0]["file_name"], "a.png");
+    assert_eq!(atts[0]["mime_type"], "image/png");
+    assert_eq!(atts[0]["size"], 4);
+    assert_eq!(atts[0]["sha256"], "abcd");
+    // url and expires_at are echoed verbatim (expires_at in milliseconds).
+    assert_eq!(
+        atts[0]["url"],
+        "https://bcs.test/sessions/shared-file/content?token=fromsender"
+    );
+    assert_eq!(atts[0]["expires_at"], 1_786_346_756_000_u64);
+    // Existing content shape is untouched.
+    assert_eq!(event["payload"]["message"]["content"][0]["text"], "看图");
+}
+
+#[tokio::test]
+async fn web_send_event_without_attachments_has_no_attachments_key() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_web_send(human_web_send("plain", None))
+        .await
+        .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 1);
+    let event: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    assert!(
+        event["payload"]["message"].get("attachments").is_none(),
+        "event: {event}"
+    );
+}
+
+#[tokio::test]
+async fn web_send_event_omits_attachments_key_for_empty_attachment_list() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_web_send(human_web_send("plain", Some(Vec::new())))
+        .await
+        .unwrap();
+
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 1);
+    let event: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    assert!(
+        event["payload"]["message"].get("attachments").is_none(),
+        "event: {event}"
+    );
+}

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -57,11 +57,6 @@ impl NamedRegistry {
         self.surfaces.insert(bot_id.to_string(), surface);
         self
     }
-
-    fn with_http_provider(mut self, bot_id: &str) -> Self {
-        self.http_providers.insert(bot_id.to_string());
-        self
-    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Problem

Messages sent with file attachments are not visible to other frontends over the live WebSocket. The sender's `chat.send` carries `attachments`, and the realtime broadcast to other workbench pages for that message contains only the text:

- write path is fine: `persisted_inbound_content` stores `{"text":..., "attachments":[stable_metadata]}` (and #841 covered history echo);
- bot delivery is fine: `frame_for_target` maps `cmd.attachments` into the chat.send/chat.inject wire frames;
- but `build_workbench_user_event` (bcs-message-flow `group_flow.rs`) hardcodes `payload.message.content` to a single text part and never reads `cmd.attachments`.

Result: watching frontends can only render the image after a manual history refresh; the live event has no attachment data at all.

## Solution

Echo the inbound attachments verbatim into `payload.message.attachments` of the workbench realtime event:

- `build_workbench_user_event` now serializes `cmd.attachments` into the message object, keeping the client-provided `url` and `expires_at` (**milliseconds**, matching the inbound wire shape);
- messages with no attachments (or an empty attachment list) omit the `attachments` key entirely, so older frontends that only read `content` are unaffected;
- no DB/protocol change; group chat bots and persistence paths are untouched.

## Validation

- `bcs-message-flow` contract tests: 63/63 pass, including 3 new cases:
  - `web_send_event_echoes_attachments_verbatim` — event carries attachment metadata + url + millisecond `expires_at`, text content untouched;
  - `web_send_event_without_attachments_has_no_attachments_key`;
  - `web_send_event_omits_attachments_key_for_empty_attachment_list`.

## Compatibility and risk

Additive field on an event payload that did not carry attachments before; existing consumers ignoring unknown keys see no behavior change. The echoed `url` is the sender-provided share link (same one the sender's own page uses), so any watching member that could already fetch history via #841's minted urls gains no new access scope.