### PR TITLE
fix(gateway): key schema location on its source, name nested-domain configs

### DIFF
--- a/src/gateway/src/gateway/community/core/forwarding/_domains.py
+++ b/src/gateway/src/gateway/community/core/forwarding/_domains.py
@@ -253,10 +253,17 @@ class PathRewrite:
 
 @dataclass(frozen=True)
 class SchemaSource:
-    """Where a domain's published OpenAPI description is read from."""
+    """Where a domain's published OpenAPI description is read from.
 
-    source: str  # "file" (single-box) | "object_store" (any deployed edition)
-    location: str  # file path or object-store URL
+    ``source`` names the reader; ``location`` is the address that reader
+    understands, and parsing takes it from the key belonging to that source —
+    ``path`` for ``file``, ``url`` for the remote ones. The two are not
+    interchangeable: a ``path`` is resolved against the config directory, and
+    handing one to a remote reader produces a fetch that can never succeed.
+    """
+
+    source: str  # "file" (single-box) | "http" | "object_store" (deployed)
+    location: str  # config-relative file path, or the URL to fetch
     refresh_seconds: int = _DEFAULT_REFRESH_SECONDS
 
 
@@ -405,6 +412,11 @@ _SERVER_KEYS = frozenset({"base_url"})
 _REWRITE_KEYS = frozenset({"from", "to"})
 _SCHEMA_KEYS = frozenset({"source", "path", "url", "refresh_seconds"})
 
+#: The one schema source read from the local filesystem. Its location is a
+#: ``path``, resolved against the config directory; every other source names a
+#: remote document and takes a ``url``.
+_FILE_SOURCE = "file"
+
 
 def _reject_unknown_keys(
     what: str, spec: dict[str, Any], allowed: frozenset[str]
@@ -449,6 +461,7 @@ def _parse_domains(
     domains: dict[str, Domain] = {}
     for name, raw_spec in raw.items():
         spec = cast("dict[str, Any]", raw_spec or {})
+        _reject_nested_domain(name, spec)
         _reject_unknown_keys(f"domain {name!r}", spec, _DOMAIN_KEYS)
         server_name = str(spec.get("server", ""))
         server = servers.get(server_name)
@@ -467,6 +480,40 @@ def _parse_domains(
         )
     _reject_ambiguous(domains)
     return domains
+
+
+def _reject_nested_domain(name: str, spec: dict[str, Any]) -> None:
+    """Refuse a domain block with another domain indented inside it.
+
+    YAML has no way to tell that a block was meant as a sibling: a domain
+    written one level too deep simply becomes a *key* of the domain above it,
+    and the file still parses. The result is silent and asymmetric — the nested
+    domain claims no paths at all, while the one that swallowed it keeps
+    working — so nothing about the running gateway points at the mistake.
+
+    :func:`_reject_unknown_keys` already refuses the key, which is what turns
+    this into a boot failure rather than a missing route. But it reports a
+    misspelling, and the reader goes looking for a typo in a name that is
+    spelled correctly; the fault is the indentation and the fix is invisible
+    from that message. So the domain-shaped case is named for what it is.
+
+    The signal is deliberately narrow: the value must be a mapping whose keys
+    are all domain keys, which no misspelling of ``schema`` or ``rewrite``
+    satisfies — their contents (``source``/``path``, ``from``/``to``) are not
+    domain keys. Anything else falls through to the generic rejection.
+    """
+    for key, value in spec.items():
+        if str(key) in _DOMAIN_KEYS or not isinstance(value, dict):
+            continue
+        nested = cast("dict[str, Any]", value)
+        if nested and all(str(inner) in _DOMAIN_KEYS for inner in nested):
+            raise ValueError(
+                f"domain {name!r}: {str(key)!r} is indented inside it, but its "
+                f"keys {sorted(str(inner) for inner in nested)} make it a "
+                f"domain in its own right. Unindent it to sit beside "
+                f"{name!r} under 'domains:' — as written, YAML reads it as a "
+                f"key of {name!r} and it claims no paths at all"
+            )
 
 
 def _parse_pattern(name: str, raw: Any, base_path: str) -> PathPattern:
@@ -641,8 +688,30 @@ def _parse_rewrite(name: str, raw: Any, domain_prefix: str) -> PathRewrite | Non
 
 
 def _parse_schema(name: str, raw: dict[str, Any]) -> SchemaSource:
+    """Where this domain's published description is read from.
+
+    The location comes from the key belonging to the declared ``source`` —
+    ``path`` for ``file``, ``url`` for every remote reader — rather than from
+    whichever of the two happens to be present.
+
+    Reading ``path`` first is not merely untidy, because config overlays are
+    **deep-merged** (:func:`gateway.community.config._config_loader._merge`): an
+    overlay adds and replaces keys but can never *remove* one. A deployed
+    environment that moves a domain off its committed file and onto its
+    published URL writes ``source`` and ``url``, inherits the base's ``path``
+    whether it wants it or not, and — with ``path`` winning — keeps pointing at
+    the artifact it just moved away from while the URL it declared is dropped
+    without a word. The domain is then handed to the reader its ``source``
+    names, so the HTTP catalog receives a relative file path where it expects a
+    URL, fails every fetch, and the served document loses that domain entirely
+    for nothing louder than a warning.
+
+    Keying on ``source`` also makes the two spellings independent: the other
+    key is ignored rather than refused, so an overlay that inherits a stale
+    ``path`` still boots.
+    """
     _reject_unknown_keys(f"domain {name!r}: schema", raw, _SCHEMA_KEYS)
-    source = str(raw.get("source", "file"))
-    location = str(raw.get("path") or raw.get("url") or "")
+    source = str(raw.get("source", _FILE_SOURCE))
+    location = str(raw.get("path" if source == _FILE_SOURCE else "url") or "")
     refresh = int(raw.get("refresh_seconds", _DEFAULT_REFRESH_SECONDS))
     return SchemaSource(source=source, location=location, refresh_seconds=refresh)

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -822,6 +822,141 @@ def test_every_key_the_shipped_config_uses_is_recognised() -> None:
     assert domain_map.websocket_domain_for("/openapi/v1/bots/messages/t/api") is None
 
 
+# ── a domain indented inside another ─────────────────────────────────────────
+
+
+def test_a_domain_indented_inside_another_is_named_as_such() -> None:
+    """The generic "unknown key" message sends the reader hunting for a typo.
+
+    This is the shape that took a deployment down: a domain appended to the
+    config one level too deep. YAML reads it as a key of the domain above, the
+    file still parses, and the nested domain claims no paths — so the message
+    has to name the indentation, because the key it reports is spelled
+    correctly and nothing about it suggests where to look.
+    """
+    with pytest.raises(ValueError, match=r"'loadtest' is indented inside it"):
+        DomainMap.from_config(
+            {
+                "domains": {
+                    "messages": {
+                        "match": "/openapi/v1/bots/messages/**",
+                        "server": "proxy",
+                        "protocols": ["websocket"],
+                        "loadtest": {
+                            "match": "/openapi/v1/bots/loadtest/**",
+                            "server": "backend",
+                            "protocols": ["websocket"],
+                        },
+                    }
+                },
+                "servers": {
+                    "proxy": {"base_url": "https://proxy:20003"},
+                    "backend": {"base_url": "http://backend:8080"},
+                },
+            },
+            variables={},
+        )
+
+
+def test_a_misspelled_block_key_is_not_mistaken_for_a_nested_domain() -> None:
+    """The nested-domain signal must not swallow the generic one.
+
+    A mistyped `schema` still holds `source`/`path`, which are not domain keys,
+    so it stays a misspelling and keeps the message that says so.
+    """
+    with pytest.raises(ValueError, match=r"unknown key\(s\) \['schemaa'\]"):
+        DomainMap.from_config(
+            {
+                "domains": {
+                    "bots": {
+                        "server": "backend",
+                        "schemaa": {"source": "file", "path": "schemas/bots.json"},
+                    }
+                },
+                "servers": {"backend": {"base_url": "http://backend:8080"}},
+            },
+            variables={},
+        )
+
+
+# ── schema location follows the declared source ──────────────────────────────
+
+
+def test_a_remote_schema_source_reads_its_url_over_an_inherited_path() -> None:
+    """Config overlays are deep-merged, so a `path` can be inherited, not chosen.
+
+    An overlay adds and replaces keys but cannot remove one. An environment
+    moving a domain off its committed file onto its published URL writes
+    `source` and `url` and inherits the base's `path` whether it wants it or
+    not. Preferring `path` would keep pointing at the artifact the overlay just
+    moved away from, and hand the HTTP reader a relative file path for a URL —
+    every fetch fails and the domain drops out of the served doc silently.
+    """
+    domain_map = DomainMap.from_config(
+        {
+            "domains": {
+                "chat": {
+                    "server": "baas",
+                    "schema": {
+                        "source": "http",
+                        # Inherited from the base config by the deep merge.
+                        "path": "schemas/baas.openapi.json",
+                        "url": "https://baas-pre.example.com/openapi.json",
+                        "refresh_seconds": 300,
+                    },
+                }
+            },
+            "servers": {"baas": {"base_url": "http://baas:9090"}},
+        },
+        variables={},
+    )
+    schema = domain_map.domains["chat"].schema
+    assert schema.source == "http"
+    assert schema.location == "https://baas-pre.example.com/openapi.json"
+
+
+def test_a_file_schema_source_reads_its_path() -> None:
+    """The single-box default is unchanged: `file` still means `path`."""
+    domain_map = DomainMap.from_config(
+        {
+            "domains": {
+                "bots": {
+                    "server": "backend",
+                    "schema": {"source": "file", "path": "schemas/bots.openapi.json"},
+                }
+            },
+            "servers": {"backend": {"base_url": "http://backend:8080"}},
+        },
+        variables={},
+    )
+    schema = domain_map.domains["bots"].schema
+    assert schema.source == "file"
+    assert schema.location == "schemas/bots.openapi.json"
+
+
+def test_an_object_store_schema_source_reads_its_url() -> None:
+    """`file` is the only local source; every other reader takes a `url`."""
+    domain_map = DomainMap.from_config(
+        {
+            "domains": {
+                "bots": {
+                    "server": "backend",
+                    "schema": {
+                        "source": "object_store",
+                        "url": "https://bucket.example.com/bots/openapi-latest.json",
+                    },
+                }
+            },
+            "servers": {"backend": {"base_url": "http://backend:8080"}},
+        },
+        variables={},
+    )
+    assert (
+        domain_map.domains["bots"].schema.location
+        == "https://bucket.example.com/bots/openapi-latest.json"
+    )
+
+
 # ── path patterns: match first, then most specific ───────────────────────────
 
 


### PR DESCRIPTION
## Problem

A prepub gateway boot died in `_parse_domains` with `unknown key(s) ['bots-loadtest-ws']` reported against the domain *above* it. The deployed config had appended that domain one level too deep, so YAML read it as a key of `bots-messages-ws` rather than as its sibling. The strict unknown-key check caught it — correctly, since a dropped key silently takes a default — but reported it as a misspelling. The reader then goes hunting for a typo in a name that is spelled right, and the actual fix (unindent) is invisible from the message.

Fixing the indentation exposed a second fault. Config overlays are deep-merged (`_config_loader._merge`), so an overlay adds and replaces keys but can never *remove* one. An environment moving a domain off its committed file onto its published URL writes `source: http` and `url:`, and inherits the base's `path:` whether it wants it or not. `_parse_schema` read `path` before `url`, so:

```
overlay declares:  source: http, url: https://…/openapi.json
base contributes:  path: schemas/baas.openapi.json
parsed result:     SchemaSource(source='http', location='schemas/baas.openapi.json')
```

The domain is routed to a reader by `source`, so the HTTP catalog receives a relative file path where it expects a URL. Every fetch fails, `_refresh_async` swallows it as a warning, and the domain drops out of the served OpenAPI document with nothing to indicate why. The overlay cannot work around this — it has no way to unset the inherited `path`.

## Solution

**`_parse_schema` takes the location from the key belonging to the declared source** — `path` for `file`, `url` for every remote reader. `file` is the only source resolved against the config directory; a path means nothing to a remote reader, so any other source takes `url`. The other key is ignored rather than refused, so an overlay carrying an inherited `path` still boots. Rejecting the stale key was the alternative considered and dropped: it would turn today's silently-degraded deployments into failed boots, which is a worse trade for a fault the overlay cannot fix.

**`_reject_nested_domain` names the indentation fault for what it is.** The check runs before the generic unknown-key rejection and is deliberately narrow — the value must be a mapping whose keys are *all* domain keys. A mistyped `schema` or `rewrite` holds `source`/`path` or `from`/`to`, which are not domain keys, so those keep the generic message. This changes only the error text of a boot that already failed; no config that parsed before parses differently.

`SchemaSource` gains a docstring for the source/location pairing and drops a stale comment that omitted `http`.

## Validation

- New unit tests in `test_domain_map.py`: the nested-domain message, a misspelled block key keeping the generic message, and location resolution for `file`, `http`, and `object_store` — including the deep-merge shape that regressed.
- Reproduced both faults against the reported prepub config before the change, and confirmed each resolves after it. The first now reports `'bots-loadtest-ws' is indented inside it, but its keys ['match', 'protocols', 'server'] make it a domain in its own right`; the second now resolves `chat` to the overlay's `https://secbaas-pre.alipay.com/openapi.json` instead of the inherited `schemas/baas.openapi.json`.
- `pytest tests/unit tests/integration tests/architecture`: 650 passed, 3 skipped.
- `ruff check` and `ruff format --check` clean on both changed files.

Not run: the `tests/e2e` suites, which need a live gateway on `:8888` and fail the same way on this commit's parent.

Pre-existing and untouched: `test_ruff_formatting_passes` fails on `HEAD` because `tests/unit/core/forwarding/test_served_openapi.py` is unformatted. Verified against a clean tree; left out of this diff to keep the change reviewable.

## Compatibility and risk

No config that parses today changes meaning, with one intended exception: a schema block whose location sits under the key that does *not* match its `source`. Every such block is already broken — the location is handed to a reader that cannot use it — so the change is from a silent failed fetch to an empty location the caller skips. The shipped `application.yaml` is unaffected (all `file` + `path`).

Rollback is the revert; there is no state or schema migration.

## Related issues

The prepub startup failure this was reported from. The root cause is in the corp `application.yaml`, not this repo — that config needs `bots-loadtest-ws` unindented by two spaces to sit beside `bots-messages-ws`. This PR makes that mistake self-describing and fixes the schema-location bug it was masking.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3pAqQW65E6gbxAGaH2nte)_