### PR TITLE
fix(bcs): derive added member roles from group strategy

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -114,8 +114,6 @@ pub struct DeleteSessionQuery {
 #[derive(Debug, Deserialize)]
 pub struct AddMemberRequest {
     pub bot_uuid: String,
-    #[serde(default)]
-    pub role: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -757,7 +755,7 @@ pub async fn add_group_member(
     Json(req): Json<AddMemberRequest>,
 ) -> Result<Json<Value>, HttpAdapterError> {
     let requester_bot_id = resolve_group_member_caller(&state, &headers, &uri, &id).await?;
-    let AddMemberRequest { bot_uuid, role } = req;
+    let AddMemberRequest { bot_uuid } = req;
     let result = state
         .services
         .group_management
@@ -766,7 +764,6 @@ pub async fn add_group_member(
             human_actor_id: extract_human_actor_id(&state, &headers, &uri).await,
             group_id: id.clone(),
             bot_id: bot_uuid,
-            role,
         })
         .await
         .map_err(group_use_case_error_to_http)?;

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -512,7 +512,7 @@ impl GroupManagementService for RecordingGroupManagement {
     ) -> Result<GroupAddMemberResult, bcs_service_api::GroupUseCaseError> {
         let result = GroupAddMemberResult {
             group_id: cmd.group_id.clone(),
-            member: participant_view(&cmd.bot_id, cmd.role.as_deref().unwrap_or("consultant")),
+            member: participant_view(&cmd.bot_id, "consultant"),
         };
         self.add_member_calls.lock().await.push(cmd);
         Ok(result)
@@ -2259,62 +2259,7 @@ async fn put_group_status_delegates_to_group_management_status_and_preserves_res
 }
 
 #[tokio::test]
-async fn post_group_member_delegates_to_group_management_add_member() {
-    let temp_dir = TempDir::new().unwrap();
-    let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
-    register_bot(&registry, "driver-bot", "Driver").await;
-    registry
-        .store_token_mapping("driver-token".to_string(), "driver-bot".to_string())
-        .await;
-    let recorder = Arc::new(RecordingGroupManagement::default());
-    let services = Services::builder()
-        .registry(registry)
-        .group_management(recorder.clone())
-        .build_for_test();
-    let chain = static_auth_chain("alice", "Alice");
-    let app = build_router(
-        HttpAppState::new(services).with_user_identity(Arc::new(ChainUserIdentityPort::new(chain))),
-    );
-
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/groups/group-1/members")
-                .header("authorization", "Bearer driver-token")
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    serde_json::json!({
-                        "bot_uuid": "target-bot",
-                        "role": "observer"
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["added"], true);
-    assert_eq!(json["session_id"], "group-1");
-    assert_eq!(json["member"]["bot_uuid"], "target-bot");
-    assert_eq!(json["member"]["role"], "observer");
-
-    let calls = recorder.add_member_calls.lock().await;
-    assert_eq!(calls.len(), 1);
-    let cmd = &calls[0];
-    assert_eq!(cmd.caller_actor_id.as_deref(), Some("driver-bot"));
-    assert_eq!(cmd.human_actor_id.as_deref(), Some("human_alice"));
-    assert_eq!(cmd.group_id, "group-1");
-    assert_eq!(cmd.bot_id, "target-bot");
-    assert_eq!(cmd.role.as_deref(), Some("observer"));
-}
-
-#[tokio::test]
-async fn post_group_member_preserves_missing_role_for_group_policy() {
+async fn post_group_member_delegates_without_exposing_role() {
     let temp_dir = TempDir::new().unwrap();
     let registry = Arc::new(BotCore::with_base_dir(temp_dir.path().to_path_buf()));
     register_bot(&registry, "driver-bot", "Driver").await;
@@ -2347,9 +2292,20 @@ async fn post_group_member_preserves_missing_role_for_group_policy() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["added"], true);
+    assert_eq!(json["session_id"], "group-1");
+    assert_eq!(json["member"]["bot_uuid"], "target-bot");
+    assert_eq!(json["member"]["role"], "consultant");
+
     let calls = recorder.add_member_calls.lock().await;
     assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].role, None);
+    let cmd = &calls[0];
+    assert_eq!(cmd.caller_actor_id.as_deref(), Some("driver-bot"));
+    assert_eq!(cmd.human_actor_id.as_deref(), Some("human_alice"));
+    assert_eq!(cmd.group_id, "group-1");
+    assert_eq!(cmd.bot_id, "target-bot");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -1412,7 +1412,6 @@ impl GroupService for GroupServiceImpl {
                 human_actor_id: legacy_human_actor_id,
                 group_id: command.group_id.clone(),
                 bot_id,
-                role: Some(role_name(default_participant_role(group.group_strategy)).to_string()),
             })
             .await
             .map_err(map_group_error)?;
@@ -1635,13 +1634,6 @@ fn map_create_collaboration(
         CollaborationConfiguration::StateMachine(configuration) => {
             (GroupStrategy::StateMachine, None, Some(configuration))
         }
-    }
-}
-
-fn default_participant_role(strategy: GroupStrategy) -> bcs_service_api::ParticipantRole {
-    match strategy {
-        GroupStrategy::ManagerWorker => bcs_service_api::ParticipantRole::Worker,
-        _ => bcs_service_api::ParticipantRole::Consultant,
     }
 }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -542,7 +542,6 @@ fn group_add_member_cmd() -> GroupAddMemberCommand {
         human_actor_id: None,
         group_id: "group-wrapper".to_string(),
         bot_id: "bot-member".to_string(),
-        role: None,
     }
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/group_management.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/group_management.rs
@@ -71,7 +71,6 @@ pub struct GroupAddMemberCommand {
     pub human_actor_id: Option<String>,
     pub group_id: String,
     pub bot_id: String,
-    pub role: Option<String>,
 }
 
 /// Request for deleting a group.

--- a/src/bcs/crates/service-api/bcs-service-api/tests/group_use_cases_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/group_use_cases_contract.rs
@@ -126,7 +126,6 @@ fn group_status_and_history_commands_carry_route_inputs() {
         human_actor_id: Some("human_alice".to_string()),
         group_id: "group-1".to_string(),
         bot_id: "bot-a".to_string(),
-        role: Some("consultant".to_string()),
     };
     let history = GroupHistoryCommand {
         caller: CallerContext::Public,
@@ -141,7 +140,6 @@ fn group_status_and_history_commands_carry_route_inputs() {
     assert_eq!(add_member.caller_actor_id.as_deref(), Some("driver"));
     assert_eq!(add_member.group_id, "group-1");
     assert_eq!(add_member.bot_id, "bot-a");
-    assert_eq!(add_member.role.as_deref(), Some("consultant"));
     assert_eq!(history.group_id, "group-1");
     assert_eq!(history.view_bot_id.as_deref(), Some("bot-a"));
     assert_eq!(history.limit, 50);
@@ -348,7 +346,6 @@ async fn noop_group_management_service_fails_closed() {
             human_actor_id: None,
             group_id: "group-1".to_string(),
             bot_id: "bot-a".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await;
     assert_not_configured(added, "group management service is not configured");

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -1308,7 +1308,7 @@ impl GroupManagementService for GroupManagement {
             .get(&cmd.bot_id)
             .await
             .ok_or_else(|| ServiceError::BotNotFound(cmd.bot_id.clone()))?;
-        let role = member_role(cmd.role.as_deref(), group.group_strategy);
+        let role = default_added_member_role(group.group_strategy);
 
         if bot.actor_kind == ActorKind::Human {
             let allowed = match group.group_strategy {
@@ -2043,15 +2043,10 @@ fn validate_human_constraints(
     Ok(())
 }
 
-fn member_role(role: Option<&str>, strategy: GroupStrategy) -> ParticipantRole {
-    match role {
-        Some("driver") => ParticipantRole::Driver,
-        Some("manager") => ParticipantRole::Manager,
-        Some("worker") => ParticipantRole::Worker,
-        Some("observer") => ParticipantRole::Observer,
-        Some(_) => ParticipantRole::Consultant,
-        None if strategy == GroupStrategy::ManagerWorker => ParticipantRole::Worker,
-        None => ParticipantRole::Consultant,
+fn default_added_member_role(strategy: GroupStrategy) -> ParticipantRole {
+    match strategy {
+        GroupStrategy::ManagerWorker => ParticipantRole::Worker,
+        GroupStrategy::Chat | GroupStrategy::StateMachine => ParticipantRole::Consultant,
     }
 }
 

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -427,7 +427,6 @@ async fn add_member_allows_provider_downlink_bot_in_manager_worker_group() {
             human_actor_id: None,
             group_id: group.group_id,
             bot_id: "provider-worker".to_string(),
-            role: Some("worker".to_string()),
         })
         .await
         .expect("provider downlink bot can be added to manager_worker group");
@@ -435,7 +434,7 @@ async fn add_member_allows_provider_downlink_bot_in_manager_worker_group() {
 }
 
 #[tokio::test]
-async fn add_member_defaults_to_worker_in_manager_worker_group() {
+async fn add_member_assigns_worker_in_manager_worker_group() {
     let fixture = Fixture::new()
         .with_bot("manager", "Manager", "public", Some("alice"))
         .with_bot("existing-worker", "Existing Worker", "public", None)
@@ -462,10 +461,9 @@ async fn add_member_defaults_to_worker_in_manager_worker_group() {
             human_actor_id: None,
             group_id: group.group_id,
             bot_id: "new-worker".to_string(),
-            role: None,
         })
         .await
-        .expect("member without an explicit role should be added");
+        .expect("member should be added with the strategy-owned role");
 
     assert_eq!(result.member.role, "worker");
 }
@@ -884,7 +882,6 @@ async fn add_member_authorizes_coordinator_and_checks_reachability() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "friend".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await;
     assert!(matches!(
@@ -899,7 +896,6 @@ async fn add_member_authorizes_coordinator_and_checks_reachability() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "stranger".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await;
     assert!(matches!(
@@ -913,7 +909,6 @@ async fn add_member_authorizes_coordinator_and_checks_reachability() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "private-friend".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("private friend target is reachable");
@@ -925,7 +920,6 @@ async fn add_member_authorizes_coordinator_and_checks_reachability() {
             human_actor_id: Some("human_impostor".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "friend".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await;
     assert!(matches!(
@@ -940,13 +934,12 @@ async fn add_member_authorizes_coordinator_and_checks_reachability() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "friend".to_string(),
-            role: Some("driver".to_string()),
         })
         .await
         .expect("friend target is reachable");
     assert_eq!(added.group_id, "group-under-test");
     assert_eq!(added.member.bot_uuid, "friend");
-    assert_eq!(added.member.role, "driver");
+    assert_eq!(added.member.role, "consultant");
 
     let stored = fixture.group.get("group-under-test").await.unwrap();
     assert!(
@@ -985,7 +978,6 @@ async fn add_member_writes_subscription_edge_with_driver_identity_for_public_tar
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "public-helper".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("originator can add public helper");
@@ -995,7 +987,6 @@ async fn add_member_writes_subscription_edge_with_driver_identity_for_public_tar
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "protected-helper".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("originator can add protected friend of driver");
@@ -3000,41 +2991,12 @@ async fn add_member_human_consultant_ok() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "human_bob".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("adding human consultant should succeed");
     assert_eq!(result.member.actor_kind, ActorKind::Human);
     assert_eq!(result.member.mode, Some(ParticipantMode::Present));
     assert_eq!(result.member.role, "consultant");
-}
-
-#[tokio::test]
-async fn add_member_human_driver_rejected() {
-    let fixture = Fixture::new()
-        .with_bot("driver", "Driver", "public", Some("alice"))
-        .with_human("human_bob", "Bob");
-    let service = fixture.service_with_limits(5, 10, 10);
-    service
-        .create_group(create_cmd(
-            Some("driver"),
-            "driver",
-            vec![participant("driver", Some("driver"))],
-        ))
-        .await
-        .expect("create group");
-
-    let err = service
-        .add_member(GroupAddMemberCommand {
-            caller_actor_id: Some("driver".to_string()),
-            human_actor_id: Some("human_alice".to_string()),
-            group_id: "group-under-test".to_string(),
-            bot_id: "human_bob".to_string(),
-            role: Some("driver".to_string()),
-        })
-        .await
-        .expect_err("human driver via add_member should be rejected");
-    assert!(matches!(err, GroupUseCaseError::InvalidProposal(_)));
 }
 
 #[tokio::test]
@@ -3058,40 +3020,12 @@ async fn add_member_human_worker_in_manager_worker_ok() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "human_bob".to_string(),
-            role: Some("worker".to_string()),
         })
         .await
         .expect("adding human worker to mw group should succeed");
     assert_eq!(result.member.actor_kind, ActorKind::Human);
     assert_eq!(result.member.mode, Some(ParticipantMode::Present));
-}
-
-#[tokio::test]
-async fn add_member_human_manager_in_manager_worker_rejected() {
-    let fixture = Fixture::new()
-        .with_bot("mgr", "Manager", "public", Some("alice"))
-        .with_human("human_bob", "Bob");
-    let service = fixture.service_with_limits(5, 10, 10);
-
-    let mut cmd = create_cmd(
-        Some("mgr"),
-        "mgr",
-        vec![participant("mgr", Some("manager"))],
-    );
-    cmd.group_strategy = Some(bcs_service_api::GroupStrategy::ManagerWorker);
-    service.create_group(cmd).await.expect("create mw group");
-
-    let err = service
-        .add_member(GroupAddMemberCommand {
-            caller_actor_id: Some("mgr".to_string()),
-            human_actor_id: Some("human_alice".to_string()),
-            group_id: "group-under-test".to_string(),
-            bot_id: "human_bob".to_string(),
-            role: Some("manager".to_string()),
-        })
-        .await
-        .expect_err("human manager via add_member should be rejected");
-    assert!(matches!(err, GroupUseCaseError::InvalidProposal(_)));
+    assert_eq!(result.member.role, "worker");
 }
 
 #[tokio::test]
@@ -3142,7 +3076,6 @@ async fn originator_human_can_add_member() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "helper".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("human originator should be able to add member");
@@ -3223,7 +3156,6 @@ async fn originator_bot_self_driver_can_manage() {
             human_actor_id: Some("human_alice".to_string()),
             group_id: "group-under-test".to_string(),
             bot_id: "helper".to_string(),
-            role: Some("consultant".to_string()),
         })
         .await
         .expect("driver should still be able to add member");
@@ -3474,7 +3406,6 @@ async fn add_non_public_bot_to_public_group_rejected() {
         human_actor_id: None,
         group_id: "group-under-test".to_string(),
         bot_id: "bot_private".to_string(),
-        role: Some("consultant".to_string()),
     }).await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("Cannot add non-public bot"));
@@ -3498,7 +3429,6 @@ async fn add_human_to_public_group_succeeds() {
         human_actor_id: None,
         group_id: "group-under-test".to_string(),
         bot_id: "human_123".to_string(),
-        role: Some("consultant".to_string()),
     }).await;
     assert!(result.is_ok(), "error: {:?}", result.unwrap_err());
 }

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -1937,13 +1937,11 @@ impl BcsClient {
         &self,
         group_id: &str,
         bot_id: &str,
-        role: Option<&str>,
     ) -> Result<serde_json::Value> {
         let url = format!("{}/groups/{}/members", self.base_url, group_id);
 
         let payload = serde_json::json!({
-            "bot_uuid": bot_id,
-            "role": role.unwrap_or("consultant")
+            "bot_uuid": bot_id
         });
 
         let response = self

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -1205,10 +1205,6 @@ enum Commands {
         /// Bot UUID to add
         #[arg(long)]
         bot_uuid: String,
-
-        /// Role (driver/consultant)
-        #[arg(short, long)]
-        role: Option<String>,
     },
 
     /// Chat with another bot (1:1 message via BCS routing)
@@ -3391,7 +3387,6 @@ pub async fn run() -> Result<()> {
             token,
             group,
             bot_uuid,
-            role,
         } => {
             let token = get_token(token.as_deref())?;
             let client = create_client(
@@ -3406,21 +3401,24 @@ pub async fn run() -> Result<()> {
                 "POST",
                 &format!("/groups/{}/members", &group),
                 json!({
-                    "bot_id": &bot_uuid,
-                    "role": role.as_deref().unwrap_or("consultant")
+                    "bot_uuid": &bot_uuid,
                 })
             );
 
-            let result = client
-                .add_group_member(&group, &bot_uuid, role.as_deref())
-                .await?;
+            let result = client.add_group_member(&group, &bot_uuid).await?;
 
             debug_response!(debug, "200", &result);
 
             println!("✓ Member added to group:");
             println!("  Group: {}", group);
             println!("  Bot: {}", bot_uuid);
-            println!("  Role: {}", role.as_deref().unwrap_or("consultant"));
+            if let Some(role) = result
+                .get("member")
+                .and_then(|member| member.get("role"))
+                .and_then(|role| role.as_str())
+            {
+                println!("  Role: {}", role);
+            }
         }
 
         Commands::Chat {
@@ -4769,6 +4767,50 @@ mod tests {
         };
 
         assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn test_add_member_accepts_only_group_and_bot_uuid() {
+        let cli = Cli::try_parse_from([
+            "bcs-cli",
+            "add-member",
+            "--group",
+            "group-1",
+            "--bot-uuid",
+            "worker-1",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::AddMember {
+                group, bot_uuid, ..
+            } => {
+                assert_eq!(group, "group-1");
+                assert_eq!(bot_uuid, "worker-1");
+            }
+            _ => panic!("expected add-member command"),
+        }
+    }
+
+    #[test]
+    fn test_add_member_rejects_role_argument() {
+        let result = Cli::try_parse_from([
+            "bcs-cli",
+            "add-member",
+            "--group",
+            "group-1",
+            "--bot-uuid",
+            "worker-1",
+            "--role",
+            "worker",
+        ]);
+
+        let error = match result {
+            Ok(_) => panic!("group add-member must not expose role selection"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
     }
 
     #[test]

--- a/src/bcs/crates/tools/bcs-cli/tests/add_member_tests.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/add_member_tests.rs
@@ -1,0 +1,59 @@
+#[allow(dead_code)]
+#[path = "e2e/common/mod.rs"]
+mod common;
+
+use common::TestContext;
+use wiremock::{
+    matchers::{bearer_token, method, path},
+    Mock, ResponseTemplate,
+};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn add_group_member_sends_only_bot_uuid_and_prints_resolved_role() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    Mock::given(method("POST"))
+        .and(path("/groups/group-1/members"))
+        .and(bearer_token(&ctx.session.token))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "added": true,
+            "session_id": "group-1",
+            "member": {
+                "bot_uuid": "worker-1",
+                "role": "worker"
+            }
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("add-member")
+        .arg("--group")
+        .arg("group-1")
+        .arg("--bot-uuid")
+        .arg("worker-1")
+        .output()
+        .expect("Failed to execute add-member");
+
+    assert!(
+        output.status.success(),
+        "add-member failed with status {:?}: stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("Role: worker"));
+
+    let requests = ctx.mock_server.received_requests().await.unwrap();
+    let request = requests
+        .iter()
+        .find(|request| {
+            request.method.as_str() == "POST"
+                && request.url.path() == "/groups/group-1/members"
+        })
+        .expect("add-member request");
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+    assert_eq!(body, serde_json::json!({"bot_uuid": "worker-1"}));
+}

--- a/src/bcs/scripts/e2e-test/cli-stories.sh
+++ b/src/bcs/scripts/e2e-test/cli-stories.sh
@@ -306,7 +306,7 @@ for item in items:
     assert_json_eq "CLI group read keeps its driver" "$BCS_CLI_STDOUT" "driver_bot" "$BOT_PM_UUID"
 
     _cli_story_run "operator adds verification to the group" PM add-member \
-        --group "$group_id" --bot-uuid "$BOT_QA_UUID" --role consultant || return
+        --group "$group_id" --bot-uuid "$BOT_QA_UUID" || return
     _cli_story_run "operator reads the expanded group" PM get-group --id "$group_id" || return
     assert_contains "CLI group read contains the added specialist" "$BCS_CLI_STDOUT" "$BOT_QA_UUID"
 

--- a/src/bcs/scripts/e2e-test/group.sh
+++ b/src/bcs/scripts/e2e-test/group.sh
@@ -225,7 +225,7 @@ test_group_add_member_via_cli() {
     ensure_cli_token PM || { skip_case "no token"; TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
     local gid; gid="$(_cli_create_group)"
     [[ -z "$gid" ]] && { fail "setup create-group failed"; TESTS_FAILED=$((TESTS_FAILED+1)); TESTS_TOTAL=$((TESTS_TOTAL+1)); return; }
-    if bcs_cli PM add-member --group "$gid" --bot-uuid "$BOT_QA_UUID" --role consultant; then
+    if bcs_cli PM add-member --group "$gid" --bot-uuid "$BOT_QA_UUID"; then
         bcs_cli PM get-group --id "$gid" >/dev/null 2>&1 || true
         if _cli_contains "$BCS_CLI_STDOUT" "$BOT_QA_UUID"; then
             pass "add-member via CLI ok"; TESTS_PASSED=$((TESTS_PASSED+1))

--- a/src/bcs/scripts/test.sh
+++ b/src/bcs/scripts/test.sh
@@ -2049,7 +2049,7 @@ test_g4() {
     # New member will receive SessionContext with originator=张三
     print_info "Adding PM to project group..."
     local add_result
-    add_result=$(run_bcs_cli_as "张三" --json add-member --group "$group_id" --bot "PM" --role "consultant" 2>/dev/null)
+    add_result=$(run_bcs_cli_as "张三" --json add-member --group "$group_id" --bot "PM" 2>/dev/null)
 
     if [ -z "$add_result" ]; then
         print_error "Failed to add PM to project group"


### PR DESCRIPTION
## Problem
Group-level add-member exposed an optional role through the CLI, HTTP DTO, and application command. Callers could therefore select roles even though each group strategy has a fixed role for newly added members, leaking domain policy and allowing inconsistent requests.

## Solution
- remove group `add-member --role` from bcs-cli and send only `bot_uuid`
- remove role from the group HTTP/application add-member request contract
- derive new-member roles in BCS: `worker` for manager-worker groups and `consultant` for chat/state-machine groups
- update group add-member tests and E2E command invocations
- keep session-level add-member role handling unchanged

## Validation
- `cargo test -p bcs-group`
- `cargo test -p bcs-http --test groups_contract`
- `cargo test -p bcs-cli test_add_member_`
- `cargo test -p bcs-service-api --test group_use_cases_contract`
- `cargo test -p bcs-app-group`
- `cargo test -p bcs --test metrics_wrappers`
- `bash -n src/bcs/scripts/test.sh src/bcs/scripts/e2e-test/group.sh`
- `git diff --check`

Frontend companion branch validation:
- targeted Jest: 2 suites, 5 tests passed
- Prettier check passed for all changed frontend files
- Bigfish browser verification was not run because project setup is blocked by the internal metadata endpoint returning HTTP 400.

## Compatibility and risk
This intentionally removes caller-controlled roles from the group add-member contract. Existing JSON clients that still include `role` are tolerated by Serde but the field is ignored; the assigned role always follows group strategy. Session add-member APIs are unaffected. Rollback is to revert this PR.

## CI follow-up validation
- removed the stale group-level `--role consultant` invocation from `cli-stories.sh`
- added a real bcs-cli subprocess + wiremock regression test that verifies the request body is exactly `{"bot_uuid":"worker-1"}` and prints the server-resolved `worker` role
- `cargo test -p bcs-cli --test add_member_tests` passed three consecutive runs
- `cargo test -p bcs-cli test_add_member_` passed
- `bash -n scripts/e2e-test/cli-stories.sh` passed
- `git diff --check` passed
- the full local llvm-cov run could not complete because macOS SIGKILLed the instrumented test-list process under high memory/swap pressure; GitHub CI will re-run the authoritative coverage gate.