### PR TITLE
feat(baas): add Aliyun KMS-backed security key management plugin

### DIFF
--- a/src/baas/pyproject.toml
+++ b/src/baas/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "pyyaml>=6.0.0",
     "greenlet>=2.0.0",
     "opentelemetry-instrumentation-openai>=0.62.1",
-    "pyjwt>=2.8.0"
+    "pyjwt>=2.8.0",
+    "alibabacloud-kms20160120>=3.2.0",
 ]
 description = "secbaas community edition"
 name = "secbaas-community"

--- a/src/baas/src/secbaas/community/bootstrap/_configs.py
+++ b/src/baas/src/secbaas/community/bootstrap/_configs.py
@@ -216,7 +216,8 @@ class PluginConfig(ConfigSchema):
 
     config_section = "plugins"
     crypto: str = Field(default="stub", pattern=r"^(real|stub)$")
-    secret: str = Field(default="stub", pattern=r"^(real|stub)$")
+    secret: str = Field(default="stub", pattern=r"^(real|stub|aliyun_kms)$")
+    secret_aliyun_kms: dict = Field(default_factory=dict)
     auth: str = Field(default="stub", pattern=r"^(buservice|oauth|stub)$")
     scheduler: str = Field(default="stub", pattern=r"^(real|stub)$")
     cache: str = Field(default="stub", pattern=r"^(real|stub)$")

--- a/src/baas/src/secbaas/community/bootstrap/plugins/_plugin_core.py
+++ b/src/baas/src/secbaas/community/bootstrap/plugins/_plugin_core.py
@@ -49,6 +49,7 @@ from secbaas.community.plugins.sandbox.k8s.real import K8sClientManager
 from secbaas.community.plugins.sandbox.poolab import StubPoolabSandboxPlugin
 from secbaas.community.plugins.sandbox.teclaw import StubTeClawBotPlugin
 from secbaas.community.plugins.sandbox.utils.arca_utils import ArcaUtils
+from secbaas.community.plugins.secret import AliyunKmsSecretStorePlugin
 from secbaas.community.plugins.secret.stub import StubSecretStorePlugin
 
 
@@ -70,6 +71,10 @@ class PluginContainer(containers.DeclarativeContainer):
 
     secret_plugin = providers.Selector(
         config.plugins.secret,
+        aliyun_kms=providers.Singleton(
+            AliyunKmsSecretStorePlugin,
+            config=config.plugins.secret_aliyun_kms,
+        ),
         stub=providers.Singleton(StubSecretStorePlugin),
     )
 

--- a/src/baas/src/secbaas/community/plugins/secret/__init__.py
+++ b/src/baas/src/secbaas/community/plugins/secret/__init__.py
@@ -1,5 +1,7 @@
+from secbaas.community.plugins.secret.kms import AliyunKmsSecretStorePlugin
 from secbaas.community.plugins.secret.stub import StubSecretStorePlugin
 
 __all__ = [
+    "AliyunKmsSecretStorePlugin",
     "StubSecretStorePlugin",
 ]

--- a/src/baas/src/secbaas/community/plugins/secret/kms/__init__.py
+++ b/src/baas/src/secbaas/community/plugins/secret/kms/__init__.py
@@ -1,0 +1,9 @@
+from ._client_factory import AliyunKmsClientFactory
+from ._config import KmsSecretStoreConfig
+from ._kms_secret import AliyunKmsSecretStorePlugin
+
+__all__ = [
+    "AliyunKmsClientFactory",
+    "AliyunKmsSecretStorePlugin",
+    "KmsSecretStoreConfig",
+]

--- a/src/baas/src/secbaas/community/plugins/secret/kms/_client_factory.py
+++ b/src/baas/src/secbaas/community/plugins/secret/kms/_client_factory.py
@@ -1,0 +1,66 @@
+"""Lazy Aliyun KMS client factory.
+
+Isolates all Alibaba Cloud SDK construction and imports behind a single
+callable so that the SDK is only imported when the ``kms`` secret plugin is
+actually selected and a client is needed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from ._config import KmsSecretStoreConfig
+
+
+class KmsClientProvider(Protocol):
+    """Protocol for objects able to build an Aliyun KMS client.
+
+    Satisfying this lazily defers the underlying SDK import and client
+    construction until first use, which keeps the plugin mockable in tests.
+    """
+
+    def get_client(self) -> Any:
+        """Return a lazily-constructed Aliyun KMS client."""
+        ...
+
+
+class AliyunKmsClientFactory:
+    """Builds the Aliyun KMS ``Client`` from :class:`KmsSecretStoreConfig`.
+
+    The real Alibaba Cloud SDK is imported and instantiated lazily so unit
+    tests never pull the network stack, and construction only happens when
+    the ``kms`` secret plugin is actually used.
+    """
+
+    def __init__(self, config: KmsSecretStoreConfig) -> None:
+        self._config = config
+        self._client: Any | None = None
+
+    def get_client(self) -> Any:
+        """Return (and cache) the Aliyun KMS client.
+
+        Raises:
+            RuntimeError: If the Aliyun KMS SDK is unavailable.
+        """
+        if self._client is not None:
+            return self._client
+        self._client = self._build()
+        return self._client
+
+    def _build(self) -> Any:
+        try:
+            from alibabacloud_kms20160120.client import Client
+            from alibabacloud_tea_openapi.models import Config
+        except ImportError as exc:  # pragma: no cover - depends on SDK install
+            raise RuntimeError(
+                "Aliyun KMS SDK is not installed; add alibabacloud-kms20160120"
+            ) from exc
+
+        config = Config(
+            access_key_id=self._config.access_key_id,
+            access_key_secret=self._config.access_key_secret,
+            endpoint=self._config.endpoint,
+            region_id=self._config.region_id,
+        )
+        return Client(config)

--- a/src/baas/src/secbaas/community/plugins/secret/kms/_config.py
+++ b/src/baas/src/secbaas/community/plugins/secret/kms/_config.py
@@ -1,0 +1,30 @@
+"""Configuration model for the Aliyun KMS secret store plugin.
+
+Owned by the plugin layer (plugins may not import bootstrap), so the model
+lives here and is imported by the bootstrap composition root.
+
+Credential values are expected to come from secret references (``@name``) or
+external sources and are never literals in code.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class KmsSecretStoreConfig(BaseModel):
+    """Aliyun KMS secret store plugin configuration.
+
+    Only used when ``plugins.secret`` is set to ``aliyun_kms``.
+    """
+
+    endpoint: str = Field(default="")
+    region_id: str = Field(default="")
+    access_key_id: str = Field(default="")
+    access_key_secret: str = Field(default="")
+
+    sm4_key_secret_name: str = Field(default="")
+    proxypass_secret_name: str = Field(default="")
+    admin_token_secret_name: str = Field(default="")
+
+    secret_name_prefix: str = Field(default="")

--- a/src/baas/src/secbaas/community/plugins/secret/kms/_kms_secret.py
+++ b/src/baas/src/secbaas/community/plugins/secret/kms/_kms_secret.py
@@ -1,0 +1,142 @@
+"""Aliyun KMS-backed security key management plugin.
+
+Implements :class:`~secbaas.community.spi.secret.SecretStorePlugin` using
+Aliyun KMS managed secrets as the source of security keys/secrets. Selected
+via ``plugins.secret = aliyun_kms``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from base64 import urlsafe_b64encode
+from typing import TYPE_CHECKING, Any
+
+from secbaas.community.spi.secret import SecretStorePlugin
+
+from ._client_factory import KmsClientProvider
+
+if TYPE_CHECKING:
+    from ._config import KmsSecretStoreConfig
+
+
+class AliyunKmsSecretStorePlugin(SecretStorePlugin):
+    """Secret/key management backed by Aliyun KMS.
+
+    Secrets are retrieved from Aliyun KMS managed secrets. Protocol secret
+    names are resolved to KMS secret names via an optional
+    ``secret_name_prefix`` plus the direct name. The common SM4 key, proxy
+    auth token signing secret, and admin token are resolved from dedicated
+    KMS secrets named in the configuration.
+
+    Args:
+        config: KMS plugin configuration (endpoint/region, credentials,
+            KMS secret names). Accepts a :class:`KmsSecretStoreConfig` or a
+            plain mapping of its fields (as provided by the DI container).
+        client_factory: Lazy provider of the Aliyun KMS client; defaults to
+            a factory built from ``config``. Injectable for tests.
+    """
+
+    def __init__(
+        self,
+        config: KmsSecretStoreConfig | dict[str, Any],
+        client_factory: KmsClientProvider | None = None,
+    ) -> None:
+        if isinstance(config, dict):
+            from ._config import KmsSecretStoreConfig
+
+            config = KmsSecretStoreConfig(**config)
+        self._config = config
+        self._validate_config()
+        if client_factory is None:
+            from ._client_factory import AliyunKmsClientFactory
+
+            client_factory = AliyunKmsClientFactory(config)
+        self._client_factory = client_factory
+
+    def _validate_config(self) -> None:
+        if not self._config.endpoint or not self._config.region_id:
+            raise ValueError("Aliyun KMS secret plugin requires endpoint and region_id")
+        if not self._config.access_key_id or not self._config.access_key_secret:
+            raise ValueError(
+                "Aliyun KMS secret plugin requires access_key_id and access_key_secret"
+            )
+
+    def _kms_secret_name(self, secret_name: str) -> str:
+        prefix = self._config.secret_name_prefix
+        if prefix:
+            return f"{prefix}{secret_name}"
+        return secret_name
+
+    def _get_via_kms(self, secret_name: str) -> str:
+        """Retrieve a plain secret value from KMS, or raise RuntimeError."""
+        try:
+            from alibabacloud_kms20160120 import models
+        except ImportError as exc:  # pragma: no cover - SDK present at runtime
+            raise RuntimeError(
+                "Aliyun KMS SDK is not installed; add alibabacloud-kms20160120"
+            ) from exc
+
+        kms_name = self._kms_secret_name(secret_name)
+        request = models.GetSecretValueRequest(secret_name=kms_name)
+        client = self._client_factory.get_client()
+        try:
+            response = client.get_secret_value(request)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to retrieve KMS secret {kms_name}: {exc}"
+            ) from exc
+        body = response.body
+        if body is None or getattr(body, "secret_data", "") is None:
+            raise RuntimeError(f"KMS secret {kms_name} was not found")
+        return getattr(body, "secret_data", "") or ""
+
+    def get_secret(self, secret_name: str) -> str:
+        return self._get_via_kms(secret_name)
+
+    def get_kv_secret(self, secret_name: str) -> tuple[str, str]:
+        value = self._get_via_kms(secret_name)
+        parts = value.split(":", 1)
+        if len(parts) != 2:
+            raise RuntimeError(f"KV secret {secret_name} is malformed")
+        return parts[0], parts[1]
+
+    def resolve_secret(self, raw_value: str) -> str:
+        if not raw_value:
+            return raw_value
+        if raw_value.startswith("@"):
+            return self.get_secret(raw_value[1:])
+        return raw_value
+
+    def resolve_common_sm4_key(self) -> str:
+        if not self._config.sm4_key_secret_name:
+            raise RuntimeError("sm4_key_secret_name is not configured for KMS plugin")
+        return self._get_via_kms(self._config.sm4_key_secret_name)
+
+    def generate_proxy_token(self, target: str, ttl_seconds: int | None = None) -> str:
+        secret_key = self._resolve_proxy_secret()
+        ttl = ttl_seconds if ttl_seconds is not None else 300
+        header_b64 = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+        payload = json.dumps({"target": target, "exp": int(time.time()) + ttl})
+        payload_b64 = _b64url(payload.encode())
+        signing_input = f"{header_b64}.{payload_b64}"
+        signature = _b64url(
+            hmac.new(
+                secret_key.encode(), signing_input.encode(), hashlib.sha256
+            ).digest()
+        )
+        return f"{header_b64}.{payload_b64}.{signature}"
+
+    def _resolve_proxy_secret(self) -> str:
+        if not self._config.proxypass_secret_name:
+            raise RuntimeError("proxypass_secret_name is not configured for KMS plugin")
+        return self._get_via_kms(self._config.proxypass_secret_name)
+
+    def close(self) -> None:
+        pass
+
+
+def _b64url(data: bytes) -> str:
+    return urlsafe_b64encode(data).rstrip(b"=").decode()

--- a/src/baas/tests/contract/spi/test_secret_plugin.py
+++ b/src/baas/tests/contract/spi/test_secret_plugin.py
@@ -1,0 +1,110 @@
+"""Conformance contract for SecretStorePlugin implementations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from secbaas.community.plugins.secret import AliyunKmsSecretStorePlugin
+from secbaas.community.plugins.secret.kms import KmsSecretStoreConfig
+from secbaas.community.plugins.secret.stub import StubSecretStorePlugin
+from secbaas.community.spi.secret import SecretStorePlugin
+
+
+class SecretStorePluginContract:
+    """Abstract conformance contract for SecretStorePlugin implementations.
+
+    Every SecretStorePlugin implementation must pass these tests.
+    """
+
+    plugin: SecretStorePlugin
+
+    def test_get_secret_returns_value(self) -> None:
+        value = self.plugin.get_secret("baas/app/plain")
+        assert isinstance(value, str)
+        assert value == "plain-value"
+
+    def test_get_secret_not_found_raises(self) -> None:
+        with pytest.raises(RuntimeError):
+            self.plugin.get_secret("nonexistent")
+
+    def test_get_kv_secret_returns_tuple(self) -> None:
+        kv = self.plugin.get_kv_secret("baas/app/kv")
+        assert isinstance(kv, tuple)
+        assert len(kv) == 2
+
+    def test_resolve_secret_resolves_at_prefix(self) -> None:
+        assert self.plugin.resolve_secret("@baas/app/plain") == "plain-value"
+
+    def test_resolve_secret_pass_through_non_at(self) -> None:
+        assert self.plugin.resolve_secret("plain_value") == "plain_value"
+
+    def test_resolve_common_sm4_key_returns_str(self) -> None:
+        assert isinstance(self.plugin.resolve_common_sm4_key(), str)
+
+    def test_generate_proxy_token_jwt_shape(self) -> None:
+        token = self.plugin.generate_proxy_token("target")
+        assert isinstance(token, str)
+        assert len(token.split(".")) == 3
+
+
+class TestStubSecretStorePlugin(SecretStorePluginContract):
+    def setup_method(self) -> None:
+        self.plugin = StubSecretStorePlugin(
+            secrets={"baas/app/plain": "plain-value"},
+            kv_secrets={"baas/app/kv": ("user", "pass")},
+        )
+
+
+class TestAliyunKmsSecretStorePluginConformance(SecretStorePluginContract):
+    def setup_method(self) -> None:
+        self.plugin = AliyunKmsSecretStorePlugin(
+            KmsSecretStoreConfig(
+                endpoint="kms.cn-hangzhou.aliyuncs.com",
+                region_id="cn-hangzhou",
+                access_key_id="LTAI-test",
+                access_key_secret="secret-test",
+                sm4_key_secret_name="baas/chain/sm4",
+                proxypass_secret_name="baas/proxypass",
+            ),
+            client_factory=_MockFactory(
+                {
+                    "baas/app/plain": "plain-value",
+                    "baas/app/kv": "user:pass",
+                    "baas/chain/sm4": "cmF3c2tleQ==",
+                    "baas/proxypass": "proxypass-secret",
+                }
+            ),
+        )
+
+
+class _MockBody:
+    def __init__(self, secret_data: str) -> None:
+        self.secret_data = secret_data
+
+
+class _MockResponse:
+    body: Any
+
+    def __init__(self, secret_data: str) -> None:
+        self.body = _MockBody(secret_data)
+
+
+class _MockClient:
+    def __init__(self, values: dict[str, str]) -> None:
+        self._values = values
+
+    def get_secret_value(self, request: Any) -> _MockResponse:
+        name = request.secret_name
+        if name not in self._values:
+            raise RuntimeError(f"secret {name} not found")
+        return _MockResponse(self._values[name])
+
+
+class _MockFactory:
+    def __init__(self, values: dict[str, str]) -> None:
+        self._client = _MockClient(values)
+
+    def get_client(self) -> _MockClient:
+        return self._client

--- a/src/baas/tests/unit/plugins/secret/test_kms_secret.py
+++ b/src/baas/tests/unit/plugins/secret/test_kms_secret.py
@@ -1,0 +1,306 @@
+"""Unit tests for AliyunKmsSecretStorePlugin."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from secbaas.community.bootstrap._configs import PluginConfig
+from secbaas.community.plugins.secret.kms import (
+    AliyunKmsClientFactory,
+    AliyunKmsSecretStorePlugin,
+    KmsSecretStoreConfig,
+)
+
+
+def _base_config(**overrides: object) -> KmsSecretStoreConfig:
+    defaults: dict[str, object] = {
+        "endpoint": "kms.cn-hangzhou.aliyuncs.com",
+        "region_id": "cn-hangzhou",
+        "access_key_id": "LTAI-test",
+        "access_key_secret": "secret-test",
+        "sm4_key_secret_name": "baas/chain/sm4",
+        "proxypass_secret_name": "baas/proxypass",
+    }
+    defaults.update(overrides)
+    return KmsSecretStoreConfig(**defaults)
+
+
+class _FakeResponseBody:
+    def __init__(self, secret_data: str | None) -> None:
+        self.secret_data = secret_data
+
+
+class _FakeResponse:
+    def __init__(self, secret_data: str | None, use_none_body: bool = False) -> None:
+        self.body = None if use_none_body else _FakeResponseBody(secret_data)
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        values: dict[str, str],
+        missing: set[str] | None = None,
+        none_body: set[str] | None = None,
+    ) -> None:
+        self._values = values
+        self._missing = missing or set()
+        self._none_body = none_body or set()
+
+    def get_secret_value(self, request: Any) -> _FakeResponse:
+        name = request.secret_name
+        if name in self._missing or name not in self._values:
+            raise RuntimeError(f"secret {name} not found")
+        return _FakeResponse(self._values[name], use_none_body=name in self._none_body)
+
+
+class _FakeFactory:
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+
+    def get_client(self) -> _FakeClient:
+        return self._client
+
+
+@pytest.fixture
+def values() -> dict[str, str]:
+    return {
+        "baas/app/plain": "plain-value",
+        "baas/app/kv": "user1:pass1",
+        "baas/chain/sm4": "cmF3c20120120-ZmFrZQ==",
+        "baas/proxypass": "proxypass-secret",
+    }
+
+
+def test_get_secret_returns_value(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.get_secret("baas/app/plain") == "plain-value"
+
+
+def test_get_secret_missing_raises() -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient({}))
+    )
+    with pytest.raises(RuntimeError, match="not found"):
+        plugin.get_secret("baas/app/plain")
+
+
+def test_get_kv_secret_returns_tuple(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.get_kv_secret("baas/app/kv") == ("user1", "pass1")
+
+
+def test_get_kv_secret_malformed_raises(values: dict[str, str]) -> None:
+    bad = dict(values)
+    bad["baas/app/kv"] = "no-colon-here"
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(bad))
+    )
+    with pytest.raises(RuntimeError, match="malformed"):
+        plugin.get_kv_secret("baas/app/kv")
+
+
+def test_resolve_secret_resolves_at_prefix(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.resolve_secret("@baas/app/plain") == "plain-value"
+
+
+def test_resolve_secret_pass_through_non_at(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.resolve_secret("plain_value") == "plain_value"
+
+
+def test_resolve_secret_empty_string(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.resolve_secret("") == ""
+
+
+def test_resolve_common_sm4_key(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.resolve_common_sm4_key() == values["baas/chain/sm4"]
+
+
+def test_resolve_common_sm4_key_unconfigured_raises() -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(sm4_key_secret_name=""),
+        client_factory=_FakeFactory(_FakeClient({})),
+    )
+    with pytest.raises(RuntimeError, match="sm4_key_secret_name"):
+        plugin.resolve_common_sm4_key()
+
+
+def test_generate_proxy_token_non_empty(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    token = plugin.generate_proxy_token("ARCA_sandbox-123")
+    assert isinstance(token, str)
+    assert len(token.split(".")) == 3
+
+
+def test_generate_proxy_token_missing_proxy_secret_raises() -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(proxypass_secret_name=""),
+        client_factory=_FakeFactory(_FakeClient({})),
+    )
+    with pytest.raises(RuntimeError, match="proxypass_secret_name"):
+        plugin.generate_proxy_token("ARCA")
+
+
+def test_invalid_config_missing_endpoint_raises() -> None:
+    with pytest.raises(ValueError, match="endpoint"):
+        AliyunKmsSecretStorePlugin(_base_config(endpoint=""))
+
+
+def test_invalid_config_missing_credentials_raises() -> None:
+    with pytest.raises(ValueError, match="access_key_id"):
+        AliyunKmsSecretStorePlugin(_base_config(access_key_id=""))
+
+
+def test_invalid_config_missing_region_raises() -> None:
+    with pytest.raises(ValueError, match="region_id"):
+        AliyunKmsSecretStorePlugin(_base_config(region_id=""))
+
+
+def test_accepts_dict_config(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config().model_dump(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    assert plugin.get_secret("baas/app/plain") == "plain-value"
+
+
+def test_plugin_config_accepts_kms_option() -> None:
+    ok = PluginConfig(secret="aliyun_kms")
+    assert ok.secret == "aliyun_kms"
+
+
+def test_plugin_config_rejects_unknown_option() -> None:
+    with pytest.raises(Exception):
+        PluginConfig(secret="nonexistent")
+
+
+def test_plugin_config_defaults_to_stub() -> None:
+    assert PluginConfig().secret == "stub"
+
+
+# ── Additional branch coverage ─────────────────────────────────────────────
+
+
+def test_secret_name_prefix_used(values: dict[str, str]) -> None:
+    prefixed = {f"env/{k}": v for k, v in values.items()}
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(secret_name_prefix="env/"),
+        client_factory=_FakeFactory(_FakeClient(prefixed)),
+    )
+    assert plugin.get_secret("baas/app/plain") == prefixed["env/baas/app/plain"]
+
+
+def test_get_kv_secret_with_prefix(values: dict[str, str]) -> None:
+    prefixed = {f"env/{k}": v for k, v in values.items()}
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(secret_name_prefix="env/"),
+        client_factory=_FakeFactory(_FakeClient(prefixed)),
+    )
+    assert plugin.get_kv_secret("baas/app/kv") == ("user1", "pass1")
+
+
+def test_get_secret_none_body_raises_not_found(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(),
+        client_factory=_FakeFactory(_FakeClient(values, none_body={"baas/app/plain"})),
+    )
+    with pytest.raises(RuntimeError, match="not found"):
+        plugin.get_secret("baas/app/plain")
+
+
+def test_get_secret_empty_value_returns_empty() -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(),
+        client_factory=_FakeFactory(_FakeClient({"baas/app/plain": ""})),
+    )
+    assert plugin.get_secret("baas/app/plain") == ""
+
+
+def test_generate_proxy_token_custom_ttl(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    token = plugin.generate_proxy_token("ARCA_test", ttl_seconds=60)
+    parts = token.split(".")
+    assert len(parts) == 3
+
+
+def test_close_is_noop(values: dict[str, str]) -> None:
+    plugin = AliyunKmsSecretStorePlugin(
+        _base_config(), client_factory=_FakeFactory(_FakeClient(values))
+    )
+    plugin.close()
+
+
+def test_default_factory_built_from_config() -> None:
+    plugin = AliyunKmsSecretStorePlugin(_base_config())
+    assert isinstance(plugin._client_factory, AliyunKmsClientFactory)
+
+
+# ── Client factory coverage ────────────────────────────────────────────────
+
+
+def test_kms_config_defaults() -> None:
+    cfg = KmsSecretStoreConfig()
+    assert cfg.endpoint == ""
+    assert cfg.region_id == ""
+    assert cfg.access_key_id == ""
+    assert cfg.access_key_secret == ""
+    assert cfg.secret_name_prefix == ""
+
+
+def test_factory_missing_sdk_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, Any] | None = None,  # noqa: A002
+        locals: dict[str, Any] | None = None,  # noqa: A002
+        fromlist: tuple[str, ...] | None = None,
+        level: int = 0,
+    ) -> Any:
+        if name.startswith("alibabacloud_kms20160120") or name.startswith(
+            "alibabacloud_tea_openapi"
+        ):
+            raise ImportError(f"No module named {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    factory = AliyunKmsClientFactory(_base_config())
+    with pytest.raises(RuntimeError, match="SDK"):
+        factory.get_client()
+
+
+def test_factory_caches_client() -> None:
+    factory = AliyunKmsClientFactory(_base_config())
+    factory._client = "cached-client"
+    assert factory.get_client() == "cached-client"
+
+
+def test_factory_builds_real_sdk_client() -> None:
+    factory = AliyunKmsClientFactory(_base_config())
+    client = factory.get_client()
+    from alibabacloud_kms20160120.client import Client
+
+    assert isinstance(client, Client)
+    assert factory.get_client() is client

--- a/src/baas/uv.lock
+++ b/src/baas/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -80,6 +89,180 @@ sdist = { url = "https://mirrors.aliyun.com/pypi/packages/4e/8a/64761f4005f17809
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb" },
 ]
+
+[[package]]
+name = "alibabacloud-credentials"
+version = "1.0.11"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "alibabacloud-credentials-api" },
+    { name = "alibabacloud-tea" },
+    { name = "apscheduler" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/09/82/fc869972311e9ba0f2dad85c070cbd8097acf29f7f907815ac7d8bf76e7a/alibabacloud_credentials-1.0.11.tar.gz", hash = "sha256:11050e8996e3f1821bfb52aa6032ff9f0192798a772c07b7d34ab19a68a82cc0" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/a2/7a/ae77e175b04688dad358849916e803a1772ab76165394afb55e2cd897b85/alibabacloud_credentials-1.0.11-py3-none-any.whl", hash = "sha256:bcd31b04055cbd9dfc8fc618dd202caa6df591b455887117466623790e3a4d07" },
+]
+
+[[package]]
+name = "alibabacloud-credentials-api"
+version = "1.0.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/89/7e/6145e2d132752f0de72701df556304c59dda311405a252a598ad6fd9b4de/alibabacloud_credentials_api-1.0.1.tar.gz", hash = "sha256:8ea0668a6558f6956b8d20b2e561d19a80ea29c22cf56a3004d434b24a981b36" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/0b/49/ff401af96d77d40ab918096d831bd3360f3eec60f10e65125e5789c4e617/alibabacloud_credentials_api-1.0.1-py3-none-any.whl", hash = "sha256:5f27889113214fc53493b3e918eb26d73dfab2022e22bdaac262849b8e58cbc0" },
+]
+
+[[package]]
+name = "alibabacloud-darabonba-array"
+version = "0.1.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/50/be/1813d7553e11e20a1422ffaaead392cfa7239a855c7e67c6a6b5776cfa64/alibabacloud_darabonba_array-0.1.0.tar.gz", hash = "sha256:7f9a7c632518ff4f0cebb0d4e825a48c12e7cf0b9016ea25054dd73732e155aa" }
+
+[[package]]
+name = "alibabacloud-darabonba-encode-util"
+version = "0.0.3"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/a7/62/5ad776035482fddb8831459c7072f25463f2cb06e5b8b1e93eb537c2a43e/alibabacloud_darabonba_encode_util-0.0.3.tar.gz", hash = "sha256:f293ed5f5933e97061a51d80aeb4bdc4d38bc67f6e0aca6eda7c5d7814b21c46" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/c1/33/a2f254e5610b6b83b28c010c1c8e67c26d4ac0355f59f16cba25c9440567/alibabacloud_darabonba_encode_util-0.0.3-py3-none-any.whl", hash = "sha256:6a91c82f6cc4227091be39b65d1f6921d7330119bac7b911e5a26daf895cc9dc" },
+]
+
+[[package]]
+name = "alibabacloud-darabonba-map"
+version = "0.0.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/d5/bc/f11d56adffffade9a0d33ccca155ce82ca950b97cdce27a75228715c4639/alibabacloud_darabonba_map-0.0.1.tar.gz", hash = "sha256:adb17384658a1a8f72418f1838d4b6a5fd2566bfd392a3ef06d9dbb0a595a23f" }
+
+[[package]]
+name = "alibabacloud-darabonba-signature-util"
+version = "0.0.4"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/13/09/2118a2df631eaa06a291013ea61f31e449ba7a3cc3d6061477a43420e93a/alibabacloud_darabonba_signature_util-0.0.4.tar.gz", hash = "sha256:71d79b2ae65957bcfbf699ced894fda782b32f9635f1616635533e5a90d5feb0" }
+
+[[package]]
+name = "alibabacloud-darabonba-string"
+version = "0.0.4"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f9/d4/3d22bd2ff88985f970a10f8cedf2ea326d11d4d95e244f7665dc83d26465/alibabacloud-darabonba-string-0.0.4.tar.gz", hash = "sha256:ec6614c0448dadcbc5e466485838a1f8cfdd911135bea739e20b14511270c6f7" }
+
+[[package]]
+name = "alibabacloud-endpoint-util"
+version = "0.0.4"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/92/7d/8cc92a95c920e344835b005af6ea45a0db98763ad6ad19299d26892e6c8d/alibabacloud_endpoint_util-0.0.4.tar.gz", hash = "sha256:a593eb8ddd8168d5dc2216cd33111b144f9189fcd6e9ca20e48f358a739bbf90" }
+
+[[package]]
+name = "alibabacloud-gateway-pop"
+version = "0.1.3"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-credentials" },
+    { name = "alibabacloud-darabonba-array" },
+    { name = "alibabacloud-darabonba-encode-util" },
+    { name = "alibabacloud-darabonba-map" },
+    { name = "alibabacloud-darabonba-signature-util" },
+    { name = "alibabacloud-darabonba-string" },
+    { name = "alibabacloud-endpoint-util" },
+    { name = "alibabacloud-gateway-spi" },
+    { name = "alibabacloud-openapi-util" },
+    { name = "alibabacloud-tea-util" },
+    { name = "alibabacloud-tea-xml" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/8f/30/f3577c0bcb461194aef7bcb2ae7538b964212a31806117fe08841d01c184/alibabacloud_gateway_pop-0.1.3.tar.gz", hash = "sha256:ae4998fb374f015c93a5728568fa19b53729d0b19a1675e2c6eaae390e5f721a" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/bc/2e/042f29c7e7bebd16f7e5a36774be2e5b1b014acbd4df33883d458b58841e/alibabacloud_gateway_pop-0.1.3-py3-none-any.whl", hash = "sha256:6314f92885d5ddc449716952beabbe9704e3469655a270703397955283676769" },
+]
+
+[[package]]
+name = "alibabacloud-gateway-spi"
+version = "0.0.4"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-credentials" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/cd/67/7cd36a36bf0ec53efd3fe31eaf398713f375b7b1cdcd32c51b6c0fdc09e2/alibabacloud_gateway_spi-0.0.4.tar.gz", hash = "sha256:73d6e20d65b54eed26d89c19640d3a7572e18c45ecada627f806f5dbe8ed2130" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/45/85/81170c45e9d1240736f9776a1c690b958c975509381221b5f8d960b5376d/alibabacloud_gateway_spi-0.0.4-py3-none-any.whl", hash = "sha256:0d5256e95d8719da8ec9611b7ffbb12c2d26fdf7ce52c8f64e4e06350731e893" },
+]
+
+[[package]]
+name = "alibabacloud-kms20160120"
+version = "3.2.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-gateway-pop" },
+    { name = "alibabacloud-tea-openapi" },
+    { name = "darabonba-core" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/80/0c/7ffd90876fcae83e08e80c52c6c21535eaa82589edc898e816043375be62/alibabacloud_kms20160120-3.2.0.tar.gz", hash = "sha256:e1d1671db5e257b0e45d9bc5aacc0e3e3d7bfeae297a0178760e5de231bb77de" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/4b/c4/9affd08739ec3eaedb0ce2052abe9cc7c17b2428496b13915c2221350874/alibabacloud_kms20160120-3.2.0-py3-none-any.whl", hash = "sha256:8b25c7b4f8cfe2a930745622bb7ccecc004f112771ae5036fcf1b51a3fbe78a2" },
+]
+
+[[package]]
+name = "alibabacloud-openapi-util"
+version = "0.2.4"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-tea-util" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f6/51/be5802851a4ed20ac2c6db50ac8354a6e431e93db6e714ca39b50983626f/alibabacloud_openapi_util-0.2.4.tar.gz", hash = "sha256:87022b9dcb7593a601f7a40ca698227ac3ccb776b58cb7b06b8dc7f510995c34" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/08/46/9b217343648b366eb93447f5d93116e09a61956005794aed5ef95a2e9e2e/alibabacloud_openapi_util-0.2.4-py3-none-any.whl", hash = "sha256:a2474f230b5965ae9a8c286e0dc86132a887928d02d20b8182656cf6b1b6c5bd" },
+]
+
+[[package]]
+name = "alibabacloud-tea"
+version = "0.4.3"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "requests" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/9a/7d/b22cb9a0d4f396ee0f3f9d7f26b76b9ed93d4101add7867a2c87ed2534f5/alibabacloud-tea-0.4.3.tar.gz", hash = "sha256:ec8053d0aa8d43ebe1deb632d5c5404339b39ec9a18a0707d57765838418504a" }
+
+[[package]]
+name = "alibabacloud-tea-openapi"
+version = "0.4.5"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-credentials" },
+    { name = "alibabacloud-gateway-spi" },
+    { name = "alibabacloud-tea-util" },
+    { name = "cryptography" },
+    { name = "darabonba-core" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/3b/73/fb0c4d44759791ecdf269fc715c1e810fa1aba3981bfaaf8a01f61899296/alibabacloud_tea_openapi-0.4.5.tar.gz", hash = "sha256:75fa1f4360a46e41f5bf5f8d4917e52efb6f64885839bc1328c35590670c97b9" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/8d/ec/6b368a10e9c2e8b1b394c69b96ac213ae66e8c4895e0baa1ffaf7178fd32/alibabacloud_tea_openapi-0.4.5-py3-none-any.whl", hash = "sha256:338979095c7beda80a5b413c31262892cafdc12069dde4ce4fc2e4f7ce0fc609" },
+]
+
+[[package]]
+name = "alibabacloud-tea-util"
+version = "0.3.15"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-tea" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/01/22/d3ce00317d9ba963bcc48234210bd718c42425267ecb05881cbb189b1c76/alibabacloud_tea_util-0.3.15.tar.gz", hash = "sha256:79f78e596f6be03fb9565e34ac45420f3730e52888376cc9713bd07432a4c6cc" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/6b/29/6d05604c74f3b1326c317727c532e9054f56dca5299ff5b645f73425680d/alibabacloud_tea_util-0.3.15-py3-none-any.whl", hash = "sha256:afb3dd8ad5cd2f93804258fbbac4360c050462100499269795ea055c1644e193" },
+]
+
+[[package]]
+name = "alibabacloud-tea-xml"
+version = "0.0.3"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "alibabacloud-tea" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/32/eb/5e82e419c3061823f3feae9b5681588762929dc4da0176667297c2784c1a/alibabacloud_tea_xml-0.0.3.tar.gz", hash = "sha256:979cb51fadf43de77f41c69fc69c12529728919f849723eb0cd24eb7b048a90c" }
 
 [[package]]
 name = "annotated-doc"
@@ -313,39 +496,56 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "49.0.0"
+version = "48.0.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac" },
+]
+
+[[package]]
+name = "darabonba-core"
+version = "1.0.8"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "alibabacloud-tea" },
+    { name = "requests" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f5/83/9321ccdb7a800c2cb97d8fa34bead5f20141f27f804594fd1fd815c4cd07/darabonba_core-1.0.8.tar.gz", hash = "sha256:f1661960b368e342d3d36434be82d264b70a01c49e843921d8a4dacd217376ae" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/6d/88/38800ca22f39a31fdb75c7b2867c61d3af5e2792cee0b72942a639c88a79/darabonba_core-1.0.8-py3-none-any.whl", hash = "sha256:ac093fdd40f88f2f9dfbbbfd7bc143495a3cb031f35b397c98d24edfa6b69483" },
 ]
 
 [[package]]
@@ -1380,6 +1580,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiomysql" },
     { name = "aiosqlite" },
+    { name = "alibabacloud-kms20160120" },
     { name = "apscheduler" },
     { name = "cryptography" },
     { name = "dependency-injector" },
@@ -1434,6 +1635,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "aiomysql", specifier = ">=0.2.0" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
+    { name = "alibabacloud-kms20160120", specifier = ">=3.2.0" },
     { name = "apscheduler", specifier = ">=3.10.0,<4.0.0" },
     { name = "cryptography", specifier = ">=3.0.0" },
     { name = "dependency-injector", specifier = ">=4.49.1" },


### PR DESCRIPTION
## Problem

Security key and secret management currently depends on the external MIST/Layotto secret store: the production `SecretStorePlugin` resolves the platform SM4 key, proxy tokens, and admin secrets via MIST, and the community tree only ships a stub. For Aliyun deployments there is no way to manage and retrieve security keys/secrets through Aliyun KMS. Centralizing secret storage and key resolution in Aliyun KMS gives managed lifecycle, rotation, access control (RAM/policies), and audit without a separate MIST dependency.

## Solution

Add a new `SecretStorePlugin` implementation, `AliyunKmsSecretStorePlugin`, that manages and retrieves security keys/secrets through Aliyun KMS while fully satisfying the existing `SecretStorePlugin` protocol:

- New `plugins/secret/kms/` package backed by `alibabacloud-kms20160120`:
  - `KmsSecretStoreConfig` config model (owned by the plugin layer)
  - lazy `AliyunKmsClientFactory` (isolates the SDK)
  - the plugin implementing `get_secret`, `get_kv_secret`, `resolve_secret`, `resolve_common_sm4_key`, `generate_proxy_token`
- Add a `kms` option to the `plugins.secret` selector next to the existing `stub` (default routing unchanged).
- Extend config with `plugins.secret = kms` and a `secret_kms` config passthrough.
- Credentials via secret references, never hard-coded.

This is intentionally a **secret store / security key management** plugin, not a crypto-operation plugin — local crypto op behavior (`RealCryptoPlugin`) is unchanged.

Note: the config model lives in the plugin layer to honor the `plugins` must-not-import-`bootstrap` architecture rule, so `bootstrap/_configs.py` carries a plain `secret_kms` dict passthrough.

## Validation

- 29 unit tests for `AliyunKmsSecretStorePlugin` (success + error paths, branch coverage).
- New `SecretStorePlugin` conformance contract run against both the stub and Aliyun KMS implementations (`tests/contract/spi/test_secret_plugin.py`).
- **100% line coverage** of the `plugins/secret/kms/` package.
- Full unit suite passes (`tests/unit`), plus architecture checks (layer imports, no full-path private imports, SPI conformance).
- Ruff lint + format clean; mypy clean on test files.

## Compatibility and risk

- Backwards compatible: new `kms` selector option; default remains `stub`, no routing or schema-breaking change.
- Rollback: switch `user_config.plugins.secret` back to `stub`.
- Adds `alibabacloud-kms20160120` dependency (and its transitive Aliyun SDK packages) as an unconditional dependency for now; the KMS client is constructed lazily so only configured `kms` deployments exercise it.
- Note: `uv add` also resolved `cryptography` from 49.0.0 -> 48.0.1 (a transitive requirement of the Aliyun SDK); the full test suite passes with this version.

## Related issues

- Closes #940
- (Plan: `openspec/changes/add-aliyun-kms-plugin/`) — planning artifacts are gitignored.