### PR TITLE
fix(baas): serialize distributed-lock acquire against renew thread

### DIFF
--- a/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
+++ b/src/baas/src/secbaas/community/core/service/distributed_lock/_service.py
@@ -292,6 +292,17 @@ class DistributedLockService:
         委托仓储的 ``try_acquire_lock`` 在单一事务中完成原子加锁：
         SELECT → DELETE expired → INSERT，唯一索引冲突视为并发竞争。
 
+        通过 ``_renew_lock`` 串行化加锁路径与自动续期守护线程的
+        ``update_expire_time``：两者都在同一个仓储单例上调用
+        ``orm_session()``，共享连接下并发的提交/回滚会破坏 SQLAlchemy
+        会话的事务栈，间歇性抛出 “Transaction ... is not on the active
+        transaction list”。该约定由 #441 引入，#460 重写为本方法委托
+        ``try_acquire_lock`` 时被误删，此处恢复。
+
+        ``_renew_lock`` 是独立于 ``_local_lock`` 的专用锁：``_stop_renew_thread``
+        在持有 ``_local_lock`` 时 ``join`` 续期线程，续期线程只竞争
+        ``_renew_lock`` 而不持有 ``_local_lock``，故不会死锁。
+
         Args:
             lock_name: 锁名称
             lock_holder: 锁持有者
@@ -302,11 +313,12 @@ class DistributedLockService:
         """
         try:
             expire_time = datetime.now() + timedelta(seconds=expire_seconds)
-            return self._repository.try_acquire_lock(
-                lock_name=lock_name,
-                lock_holder=lock_holder,
-                expire_time=expire_time,
-            )
+            with self._renew_lock:
+                return self._repository.try_acquire_lock(
+                    lock_name=lock_name,
+                    lock_holder=lock_holder,
+                    expire_time=expire_time,
+                )
         except Exception as e:
             if _is_unique_constraint_violation(e):
                 logger.info(

--- a/src/baas/tests/unit/core/service/distributed_lock/test_service.py
+++ b/src/baas/tests/unit/core/service/distributed_lock/test_service.py
@@ -748,6 +748,89 @@ class TestGetLockInfo:
 # ── Helpers ──────────────────────────────────────────────────────
 
 
+# ── Renew/acquire serialization tests ───────────────────────────
+
+
+class TestAcquireRenewSerialization:
+    """Pin the `_renew_lock` contract between acquire and the renew thread.
+
+    #441 serialised the acquire path against the auto-renew daemon thread with
+    `_renew_lock` because both reach `orm_session()` on the same repository
+    singleton and, under a shared connection, concurrent commit/rollback
+    corrupts the SQLAlchemy session. #460 dropped the guard from the acquire
+    path while rewriting it to delegate to `repository.try_acquire_lock`;
+    these tests fail if that regression returns.
+    """
+
+    def test_acquire_lock_holds_renew_lock_during_repo_call(
+        self, lock_service, repository
+    ):
+        """The acquire DB call must run while `_renew_lock` is held."""
+        seen: dict = {}
+
+        def record(*, lock_name, lock_holder, expire_time):
+            seen["renew_lock_held"] = lock_service._renew_lock.locked()
+            return True
+
+        repository.try_acquire_lock.side_effect = record
+
+        ctx = lock_service.acquire_lock("mylock", lock_holder="h1")
+
+        assert ctx.acquired is True
+        assert seen.get("renew_lock_held") is True, (
+            "acquire path ran without holding _renew_lock — the renew thread can "
+            "race it on the shared repository connection"
+        )
+
+    def test_acquire_blocks_while_renew_lock_is_held(self, lock_service, repository):
+        """Acquire must wait for the renew thread to release `_renew_lock`."""
+        repository.try_acquire_lock.return_value = True
+
+        held = threading.Event()
+        release = threading.Event()
+
+        def renew_in_flight() -> None:
+            with lock_service._renew_lock:
+                held.set()
+                release.wait(timeout=5.0)
+
+        renew_thread = threading.Thread(
+            target=renew_in_flight, daemon=True, name="renew-in-flight"
+        )
+        renew_thread.start()
+        assert held.wait(timeout=2.0), "renew thread did not acquire _renew_lock"
+        assert lock_service._renew_lock.locked() is True
+
+        done = threading.Event()
+
+        def acquire() -> None:
+            try:
+                ctx = lock_service.acquire_lock("mylock", lock_holder="h1")
+                _stop_thread(ctx)
+            finally:
+                done.set()
+
+        acquirer = threading.Thread(target=acquire, daemon=True, name="acquire-waiter")
+        acquirer.start()
+
+        # While the renew thread holds `_renew_lock`, acquire must not complete.
+        # `done` is set unconditionally in `finally`, so a DB-call exception or
+        # an early (unserialized) completion both surface here rather than hanging.
+        assert not done.wait(timeout=0.3), (
+            "acquire completed while renew held _renew_lock — serialization broken"
+        )
+
+        release.set()
+        assert done.wait(timeout=2.0), (
+            "acquire did not complete after renew released _renew_lock"
+        )
+        acquirer.join(timeout=2.0)
+        renew_thread.join(timeout=2.0)
+
+
+# ── Helpers ──────────────────────────────────────────────
+
+
 def _stop_thread(ctx: LockContext) -> None:
     """Stop a renew thread and wait for it to finish."""
     ctx.stop_renew.set()


### PR DESCRIPTION

## Problem

`DistributedLockService._try_acquire_lock_internal` performs its atomic
acquire (`repository.try_acquire_lock` → `orm_session()` commit) without
holding `_renew_lock`, while the auto-renew daemon thread concurrently calls
`repository.update_expire_time` → `orm_session()` commit under `_renew_lock`.
Both run on the same repository singleton and, under a shared-connection
engine, interleaved begin/commit/rollback can corrupt the SQLAlchemy
`SessionTransaction` stack and intermittently raise
"Transaction ... is not on the active transaction list".

This guard was introduced by #441 and **dropped** by #460 when that change
rewrote the acquire path to delegate to `repository.try_acquire_lock`. The
renew thread kept the guard (it still wraps `update_expire_time`), so #460
asymmetrically re-exposed the acquire side of the race #441 was written to
prevent — now on the faster, per-request `try_acquire_lock` path.

## Solution

Restore the `with self._renew_lock:` wrapper around
`repository.try_acquire_lock(...)` inside `_try_acquire_lock_internal`,
re-establishing #441's serialization invariant on the acquire path so it
matches the renew thread.

`_renew_lock` is intentionally separate from `_local_lock` (the in-memory
context-cache guard):
- The renew worker only ever holds `_renew_lock`, never `_local_lock`.
- `_stop_renew_thread` joins the renew thread while `_local_lock` is held;
  since the renew thread needs neither `_local_lock` to finish nor to hold it,
  this cannot self-deadlock.
- `acquire_lock` releases `_local_lock` before calling
  `_try_acquire_lock_internal`, so `_renew_lock` is never nested under
  `_local_lock` by the same thread.

Rejected alternatives: serializing the whole acquire (including the
context-cache bookkeeping) would mean holding `_local_lock` across the DB
call and across the `_local_lock`/`_renew_lock` nesting, re-introducing the
classic lock-ordering hazard; restoring only the DB-call window matches
#441's original, narrower contract.

## Validation

- New regression tests `TestAcquireRenewSerialization` pin the contract:
  - `test_acquire_lock_holds_renew_lock_during_repo_call` asserts the acquire
    DB call runs while `_renew_lock` is held.
  - `test_acquire_blocks_while_renew_lock_is_held` asserts acquire waits for
    the renew thread to release `_renew_lock`.
- Baseline repro: against the pre-fix (`origin/dev`) acquire path the two new
  tests fail with "acquire completed while renew held _renew_lock —
  serialization broken"; against this patch they pass.
- `src/baas` targeted runs (Python 3.12.10, SQLAlchemy 2.0.50, pytest 9.1.0):
  - `tests/unit/core/service/distributed_lock/test_service.py`: **54 passed**.
  - Downstream consumers of `DistributedLockService`
    (`tests/unit/core/service/bot_run`, `tests/unit/core/service/scheduler`):
    **843 passed, 8 xpassed** (the xpasses are pre-existing xfail-marked
    tests, not introduced by this change).

Not run this iteration: the full `src/baas/scripts/ci_test.sh` module gate
(requires `uv sync --frozen`) and SAST/coverage gates; the pre-push hook
runs lint/SAST by default and the full module CI only with
`OCB_PRE_PUSH_RUN_CI=1`.

## Compatibility and risk

- Behavior change is limited to restoring #441's invariant; no public API,
  config, schema, or error-surface change. Acquire may wait briefly while a
  renew write is in flight — that is the intended serialization, not a
  regression.
- Rollback: single self-contained commit; `git revert` suffices.
