### PR TITLE
refactor(bcs-system-message): unify group context into <GroupContext> block

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -180,7 +180,7 @@ pub struct CreateSessionRequest {
     pub created_by: Option<String>,
     #[serde(default)]
     pub caller_role: Option<String>,
-    /// Optional delivery override for the driver bot's `[GROUP CONTEXT]`
+    /// Optional delivery override for the driver bot's `<GroupContext>`
     /// message: `"send"` (default, driver is asked to respond) or
     /// `"inject"` (driver observes silently). Other participants always
     /// receive the context via `chat.inject`.
@@ -1245,6 +1245,7 @@ pub async fn add_session_participant(
             let event = SystemMessageEvent::BotJoined {
                 group_id: sess.group_id.clone(),
                 actor: participant.into(),
+                session_id: sid.clone(),
             };
             let _ = state
                 .services

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_create_request_dto.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_create_request_dto.rs
@@ -1,7 +1,7 @@
 //! Contract tests for the `group_context_delivery` field of
 //! `CreateSessionRequest` (`POST /groups/{id}/sessions`).
 //!
-//! The field chooses whether the driver bot's `[GROUP CONTEXT]` message is
+//! The field chooses whether the driver bot's `<GroupContext>` message is
 //! actively sent (`"send"`, default, asks the driver to respond) or silently
 //! injected (`"inject"`). Other participants always receive `chat.inject`.
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_structured_routing.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_structured_routing.rs
@@ -5,7 +5,7 @@
 //! → targets receive chat.send, non-targets receive chat.inject.
 //!
 //! Note: When a group is created via POST /groups, BCS automatically injects
-//! a [GROUP CONTEXT] message to all participants (chat.send to driver,
+//! a <GroupContext> message to all participants (chat.send to driver,
 //! chat.inject to others). Tests must drain these frames before proceeding.
 
 mod helpers;
@@ -76,7 +76,7 @@ async fn setup_group_and_send_message(
     group_id: &str,
     message: &str,
 ) -> String {
-    // Group creation injects [GROUP CONTEXT] to all participants.
+    // Group creation injects <GroupContext> to all participants.
     let _ = bot_a.recv_frame().await; // context chat.send for driver
     let _ = bot_b.recv_frame().await; // context chat.inject
     let _ = bot_c.recv_frame().await; // context chat.inject

--- a/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
@@ -9,6 +9,11 @@ pub enum SystemMessageEvent {
     BotJoined {
         group_id: String,
         actor: Participant,
+        /// Session the bot joined within; used to fetch session-scoped history
+        /// for the join context message. `#[serde(default)]` keeps old
+        /// serialized events deserializable.
+        #[serde(default)]
+        session_id: String,
     },
     BotLeft {
         group_id: String,
@@ -29,7 +34,7 @@ pub enum SystemMessageEvent {
         session_input: Option<serde_json::Value>,
         #[serde(default)]
         task_ledger: Option<crate::LedgerSummary>,
-        /// Delivery override for the driver bot's `[GROUP CONTEXT]` message.
+        /// Delivery override for the driver bot's `<GroupContext>` message.
         /// `None` keeps the default `DeliveryType::Send`; `Some(Inject)`
         /// delivers the context silently. Only applies to the driver;
         /// other participants always receive `DeliveryType::Inject`.
@@ -87,7 +92,7 @@ impl SystemMessageEvent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PersistMode {
     /// Persist one record per recipient with `owner_bot_id = recipient`
-    /// (personalized per-bot context such as `[GROUP CONTEXT]`, only
+    /// (personalized per-bot context such as `<GroupContext>`, only
     /// readable by that bot's history view).
     PerRecipient,
     /// Persist exactly one record with `owner_bot_id = None` so the notice

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -1556,6 +1556,7 @@ mod tests {
         let event = SystemMessageEvent::BotJoined {
             group_id: group_id.to_string(),
             actor: Participant::bot(&new_bot_id, ParticipantRole::Consultant),
+            session_id: session_id.clone(),
         };
         dispatcher
             .dispatch(event, &group_fixture(group_id, &existing_id), &session_id, &participants)
@@ -1580,7 +1581,7 @@ mod tests {
             1,
             "the shared notice is a single public record, not per-bot copies"
         );
-        assert!(existing_contents.iter().all(|c| !c.contains("你加入了 BCS 协作群.")),
+        assert!(existing_contents.iter().all(|c| !c.contains("<GroupContext>")),
             "new-bot's context injection (owner=new-bot) is hidden from mgr");
 
         // Viewer = new-bot: sees its own context injection (owner=new-bot) +
@@ -1593,7 +1594,7 @@ mod tests {
             res_new.messages.iter().map(|m| m.content.as_str()).collect();
         assert!(new_contents.contains(&"public-anchor"),
             "public owner=None records still visible to new-bot");
-        assert!(new_contents.iter().any(|c| c.contains("你加入了 BCS 协作群.")),
+        assert!(new_contents.iter().any(|c| c.contains("<GroupContext>")),
             "new-bot's own context injection (owner=new-bot) is returned");
         assert!(new_contents.iter().any(|c| c.contains("已加入协作群")),
             "public join notice (owner=None) is returned to new-bot");
@@ -1611,7 +1612,7 @@ mod tests {
             "public owner=None records visible to human viewers");
         assert!(human_contents.iter().any(|c| c.contains("已加入协作群")),
             "public join notice is visible to human viewers");
-        assert!(human_contents.iter().all(|c| !c.contains("你加入了 BCS 协作群.")),
+        assert!(human_contents.iter().all(|c| !c.contains("<GroupContext>")),
             "per-bot owned copies stay hidden from human viewers");
     }
 

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -246,6 +246,7 @@ async fn dispatch_bot_joined_delivers_to_all_participants() {
             actor_kind: ActorKind::Bot,
             mode: Some(ParticipantMode::Auto),
         },
+        session_id: "session-test".to_string(),
     };
 
     let registry = Arc::new(ProviderTargetRegistry::default());
@@ -325,6 +326,7 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
             role: ParticipantRole::Consultant, actor_kind: ActorKind::Bot,
             mode: Some(ParticipantMode::Auto),
         },
+        session_id: "session-test".to_string(),
     };
 
     let registry = Arc::new(ProviderTargetRegistry::default());
@@ -354,12 +356,12 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
         .expect("new-bot injection record");
     assert_eq!(injection.sender_id, "system");
     assert_eq!(injection.message_type, "system");
-    assert!(content_text(injection).contains("你加入了 BCS 协作群."),
+    assert!(content_text(injection).contains("<GroupContext>"),
         "new-bot context injection persisted under owner=new-bot");
     let notice = appended.iter().find(|m| m.owner_bot_id.is_none())
         .expect("public join notification record");
     assert!(content_text(notice).contains("已加入协作群"));
-    assert!(!content_text(notice).contains("你加入了 BCS 协作群."));
+    assert!(!content_text(notice).contains("<GroupContext>"));
     assert!(!appended.iter().any(|m| m.owner_bot_id.as_deref() == Some(&existing_bot_id)),
         "shared notice must not persist per-bot copies");
 
@@ -369,7 +371,7 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
     assert_eq!(published.len(), 1, "WS publishes a single user_message");
     let payload = &published[0].event_json;
     assert!(payload.contains("已加入协作群"));
-    assert!(!payload.contains("你加入了 BCS 协作群."),
+    assert!(!payload.contains("<GroupContext>"),
         "WS must not leak the new-bot context injection");
 }
 
@@ -647,7 +649,7 @@ async fn dispatch_non_manager_worker_session_context_persists_per_recipient_reco
         let rec = appended.iter()
             .find(|m| m.owner_bot_id.as_deref() == Some(owner))
             .unwrap_or_else(|| panic!("owner record for {owner}"));
-        assert!(content_text(rec).contains("[GROUP CONTEXT]"));
+        assert!(content_text(rec).contains("<GroupContext>"));
     }
 }
 
@@ -745,9 +747,9 @@ async fn dispatch_session_context_uses_bcs_route_when_group_has_no_provider_down
     let calls = dispatch_session_context_with_provider_registry(&group, "普通协作").await;
     let text = delivered_text_for(&calls, "bot-ws");
 
-    assert!(text.contains("路由工具 (bcs_route)"));
-    assert!(text.contains("使用 bcs_route 工具指定下一个响应者"));
-    assert!(!text.contains("路由工具 (@mention)"));
+    assert!(text.contains("## 工具说明 (bcs_route)"));
+    assert!(text.contains("使用 `bcs_route` 工具替代 @mention 指定下一个响应者可以提高路由准确率"));
+    assert!(!text.contains("## 工具说明 (@mention)"));
     assert!(!text.contains("可@:"));
 }
 
@@ -769,21 +771,15 @@ async fn dispatch_session_context_uses_at_mention_when_group_has_provider_downli
 
     for recipient in ["bot-ws", "bot-provider"] {
         let text = delivered_text_for(&calls, recipient);
-        assert!(text.contains("路由工具 (@mention)"));
+        assert!(text.contains("## 工具说明 (@mention)"));
         assert!(text.contains("消息中任何 @ 标识都会触发路由，让被 @ 的 Bot 收到消息并被要求响应。"));
         assert!(text.contains("只有希望某个 Bot 响应时才使用 @"));
         assert!(text.contains("不要用 @ 表示引用、收到或转述某个 Bot 的消息"));
         assert!(text.contains("优先使用名称；名称为空、重复或不确定时，使用 Bot ID。"));
-        assert!(text.contains(
-            "- 名称: Driver | ID: bot-ws | 角色: driver | 可@: @Driver / @bot-ws"
-        ));
-        assert!(text.contains(
-            "- 名称: Reviewer | ID: bot-provider | 角色: consultant | 可@: @bot-provider"
-        ));
-        assert!(text.contains(
-            "- 名称: Reviewer | ID: bot-peer | 角色: consultant | 可@: @bot-peer"
-        ));
-        assert!(!text.contains("路由工具 (bcs_route)"));
+        assert!(text.contains("|Driver|bot-ws|driver|"));
+        assert!(text.contains("|Reviewer|bot-provider|consultant|"));
+        assert!(text.contains("|Reviewer|bot-peer|consultant|"));
+        assert!(!text.contains("## 工具说明 (bcs_route)"));
         assert!(!text.contains("等待 @mention、bcs_route 或任务点名后再响应。"));
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
@@ -9,13 +9,21 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_domain::{
-    DeliveryType, Group, GroupMessage, Participant, PersistMode, Skill, SystemMessageEvent,
-    SystemMessageEventKind, SystemGroupMessage,
+    DeliveryType, Group, GroupMessage, GroupStrategy, Participant, ParticipantRole, PersistMode,
+    Skill, SystemMessageEvent, SystemMessageEventKind, SystemGroupMessage,
 };
 use bcs_service_api::{
-    BotRegistryCoreService, CallerContext, GroupHistoryCommand, GroupMessageHistoryService,
-    SystemMessageProducerService,
+    BotRegistryCoreService, CallerContext, GroupMessageHistoryService, SessionHistoryCommand,
+    SystemMessageProducerService, backfill_bot_names,
 };
+
+use super::session_context::{
+    contains_provider_downlink_bot, group_info_section, participant_table, render_group_context,
+    routing_instruction_block, skill_section,
+};
+
+/// Lead line for the `<GroupContext>` block delivered to a newly joined bot.
+const JOINED_OPENING: &str = "你已加入 bcn 群聊，群聊相关信息如下";
 
 const HISTORY_LIMIT: usize = 10;
 const HISTORY_MAX_LENGTH: usize = 200;
@@ -44,7 +52,12 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         registry: &dyn BotRegistryCoreService,
         participants: &[Participant],
     ) -> (Vec<SystemGroupMessage>, Option<String>) {
-        let SystemMessageEvent::BotJoined { actor, .. } = event else {
+        let SystemMessageEvent::BotJoined {
+            actor,
+            session_id,
+            ..
+        } = event
+        else {
             return (vec![], None);
         };
 
@@ -53,8 +66,15 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
 
         // 1. Full context injection to the newly joined bot (personalized,
         // persisted with owner = the new bot only).
-        let new_bot_content =
-            build_context_injection_message(group, participants, &new_bot_uuid, registry, &*self.history).await;
+        let new_bot_content = build_context_injection_message(
+            group,
+            participants,
+            &new_bot_uuid,
+            session_id,
+            registry,
+            &*self.history,
+        )
+        .await;
         messages.push(SystemGroupMessage {
             recipients: vec![new_bot_uuid.clone()],
             message: new_bot_content,
@@ -132,83 +152,111 @@ fn truncate_utf8(s: &str, max_chars: usize) -> String {
 }
 
 /// Compose a context-injection message for the newly joined bot.
+///
+/// Mirrors the unified `<GroupContext>` block used by the session-context
+/// producer, with a `你已加入` opening and a trailing `## 群历史消息` section.
+/// The `BotJoined` event carries no session/reason/task, so `## 群聊信息`
+/// omits `会话ID`/`目标` and there is no `## 任务说明` section.
 async fn build_context_injection_message(
     group: &Group,
     participants: &[Participant],
     new_bot_uuid: &str,
+    session_id: &str,
     registry: &dyn BotRegistryCoreService,
     history: &dyn GroupMessageHistoryService,
 ) -> String {
-    let mut parts = vec!["你加入了 BCS 协作群.".to_string()];
-    parts.push(format!("群 ID: {}", group.id));
-    parts.push(format!(
-        "主题: {}",
-        group.label.as_deref().unwrap_or("N/A")
-    ));
+    let mut render_group = group.clone();
+    render_group.participants = participants.to_vec();
+    backfill_bot_names(registry, &mut render_group).await;
 
-    parts.push("参与者:".to_string());
-    for p in participants {
-        let registered = registry.get(&p.bot_uuid).await;
-        let name = registered
-            .as_ref()
-            .and_then(|b| b.capabilities.name.as_deref())
-            .or(p.bot_name.as_deref())
-            .unwrap_or(&p.bot_uuid);
-        let skills: &[Skill] = registered
-            .as_ref()
-            .map(|b| b.capabilities.skills.as_slice())
-            .unwrap_or(&[]);
-        let line = if !skills.is_empty() {
-            format!(
-                "  - {}({}) - 能力集: {}",
-                name,
-                p.bot_uuid,
-                format_skills(skills)
-            )
-        } else {
-            format!("  - {}({})", name, p.bot_uuid)
-        };
-        parts.push(line);
+    let recipient = render_group
+        .participants
+        .iter()
+        .find(|p| p.bot_uuid == new_bot_uuid)
+        .cloned()
+        .unwrap_or_else(|| Participant::bot(new_bot_uuid, ParticipantRole::Consultant));
+
+    let mode = if render_group.group_strategy == GroupStrategy::ManagerWorker {
+        "manager_worker"
+    } else {
+        "自由聊天"
+    };
+
+    let bot_participants: Vec<&Participant> = render_group
+        .participants
+        .iter()
+        .filter(|p| p.is_bot())
+        .collect();
+    let use_at_mention_routing = contains_provider_downlink_bot(&bot_participants, registry).await;
+    let tool_kind = if use_at_mention_routing {
+        "@mention"
+    } else {
+        "bcs_route"
+    };
+    let role_instruction = if use_at_mention_routing {
+        "你当前通过 chat.inject 收到初始化上下文，应静默观察，不要主动回复；等待 @mention 或任务点名后再响应。"
+    } else {
+        "你当前通过 chat.inject 收到初始化上下文，应静默观察，不要主动回复；等待 @mention、bcs_route 或任务点名后再响应。"
+    };
+
+    let history_messages = fetch_history(group, session_id, participants, history).await;
+
+    let sections = vec![
+        group_info_section(&render_group, None, None, &recipient, mode),
+        format!("## 参与者:\n{}", participant_table(&render_group)),
+        format!(
+            "## 工具说明 ({})\n{}",
+            tool_kind,
+            routing_instruction_block(use_at_mention_routing)
+        ),
+        skill_section(),
+        format!("## 说明\n{}", role_instruction),
+        history_section(&history_messages),
+    ];
+    render_group_context(JOINED_OPENING, &sections)
+}
+
+/// Renders the `## 群历史消息 (最近 N 条)` section with the most recent
+/// messages (chronological, capped at `HISTORY_LIMIT`).
+fn history_section(messages: &[GroupMessage]) -> String {
+    let recent: Vec<&GroupMessage> = messages.iter().rev().take(HISTORY_LIMIT).rev().collect();
+    let mut section = format!("## 群历史消息 (最近 {} 条)", recent.len());
+    if recent.is_empty() {
+        section.push_str("\n暂无历史消息");
+    } else {
+        for msg in &recent {
+            let sender_name = msg.bot_name.as_deref().unwrap_or(&msg.sender);
+            let date = format_date(msg.timestamp);
+            let content = truncate_utf8(&msg.content, HISTORY_MAX_LENGTH);
+            section.push_str(&format!("\n[{}] {}\n{}\n---", date, sender_name, content));
+        }
     }
-
-    let history_messages = fetch_history(group, history).await;
-    parts.push(format!(
-        "群历史消息 (最近 {} 条):\n---\n",
-        history_messages.len()
-    ));
-    for msg in history_messages.iter().rev().take(HISTORY_LIMIT).rev() {
-        let sender_name = msg
-            .bot_name
-            .as_deref()
-            .unwrap_or(&msg.sender);
-        let date = format_date(msg.timestamp);
-        let content = truncate_utf8(&msg.content, HISTORY_MAX_LENGTH);
-        parts.push(format!("[{}] {}\n{}\n\n---\n", date, sender_name, content));
-    }
-
-    let _ = new_bot_uuid;
-
-    parts.join("\n")
+    section
 }
 
 async fn fetch_history(
     group: &Group,
-    history: &dyn GroupMessageHistoryService
+    session_id: &str,
+    session_participants: &[Participant],
+    history: &dyn GroupMessageHistoryService,
 ) -> Vec<GroupMessage> {
-    let cmd = GroupHistoryCommand {
+    let cmd = SessionHistoryCommand {
         caller: CallerContext::Bot(bcs_service_api::BotActor {
             bot_uuid: group.driver_bot.clone(),
         }),
         group_id: group.id.clone(),
+        session_id: session_id.to_string(),
+        session_participants: session_participants.to_vec(),
         view_bot_id: Some(group.driver_bot.clone()),
         limit: HISTORY_LIMIT as u64,
         before: None,
     };
-    match history.get_history(cmd).await {
+    match history.get_session_history(cmd).await {
         Ok(result) => result.messages,
         Err(error) => {
             tracing::warn!(
                 group_id = %group.id,
+                session_id = %session_id,
                 driver_bot = %group.driver_bot,
                 error = %error,
                 "fallback to group.messages for system message history"

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
@@ -177,6 +177,7 @@ async fn bot_joined_produces_context_injection_and_notification() {
     let event = SystemMessageEvent::BotJoined {
         group_id: "group-1".to_string(),
         actor: new_bot,
+        session_id: "group-1:session".to_string(),
     };
 
     let (messages, user_message) = producer.produce(&event, &group, &registry, &group.participants).await;
@@ -197,12 +198,16 @@ async fn bot_joined_produces_context_injection_and_notification() {
     );
     let injection = injection.unwrap();
     assert!(
-        injection.message.contains("你加入了 BCS 协作群."),
-        "context injection should contain '你加入了 BCS 协作群.'"
+        injection.message.contains("<GroupContext>"),
+        "context injection should use the unified <GroupContext> block"
     );
     assert!(
-        injection.message.contains("群 ID:"),
-        "context injection should contain '群 ID:'"
+        injection.message.contains("你已加入 bcn 群聊"),
+        "context injection should contain '你已加入 bcn 群聊'"
+    );
+    assert!(
+        injection.message.contains("群组ID:"),
+        "context injection should contain '群组ID:'"
     );
     assert!(
         injection.message.contains("参与者:"),
@@ -239,7 +244,7 @@ async fn bot_joined_produces_context_injection_and_notification() {
         Some("NewBot(new-bot-id) 已加入协作群 - 能力集: {name: \"coding\"}")
     );
     assert!(
-        !user_message.as_deref().unwrap().contains("你加入了 BCS 协作群"),
+        !user_message.as_deref().unwrap().contains("<GroupContext>"),
         "user_message must not leak the new-bot context injection"
     );
 }
@@ -272,6 +277,7 @@ async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
     let event = SystemMessageEvent::BotJoined {
         group_id: "group-1".to_string(),
         actor: new_bot.clone(),
+        session_id: "group-1:session".to_string(),
     };
 
     let (messages, user_message) = producer.produce(&event, &group, &registry, &[driver, new_bot]).await;
@@ -287,3 +293,4 @@ async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
         Some("NewBot(new-bot-id) 已加入协作群 - 能力集: {name: \"coding\"}")
     );
 }
+

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -1,14 +1,16 @@
 //! Producer for `SystemMessageEventKind::SessionContext`.
 //!
 //! When a session is created this producer generates the initial
-//! `[GROUP CONTEXT]` or `[SERVICE GROUP CONTEXT]` message delivered
-//! to all bot participants, with `chat.send` for the driver/manager
-//! and `chat.inject` for other participants. The driver's delivery
-//! can be overridden to `chat.inject` via the event's
-//! `driver_delivery` field (except in ManagerWorker groups, which
-//! always deliver to the manager via `chat.send`).
-
-use std::collections::HashMap;
+//! `<GroupContext>` message delivered to all bot participants, with
+//! `chat.send` for the driver/manager and `chat.inject` for other
+//! participants. The driver's delivery can be overridden to `chat.inject`
+//! via the event's `driver_delivery` field (except in ManagerWorker groups,
+//! which always deliver to the manager via `chat.send`).
+//!
+//! Free-chat (`Chat`) and manager-worker (`ManagerWorker`) groups share the
+//! same `<GroupContext>` shell and section order; the mode label and a few
+//! sections differ (free-chat has `## 工具说明` + `## 说明`; manager-worker
+//! has `## manager-worker 协同说明`).
 
 use async_trait::async_trait;
 use bcs_domain::{
@@ -16,9 +18,10 @@ use bcs_domain::{
     Participant, ParticipantRole, PersistMode, SystemMessageEvent, SystemMessageEventKind,
     SystemGroupMessage,
 };
-use bcs_service_api::{
-    BotRegistryCoreService, SystemMessageProducerService, backfill_bot_names,
-};
+use bcs_service_api::{BotRegistryCoreService, SystemMessageProducerService, backfill_bot_names};
+
+/// Lead line for the `<GroupContext>` block of a freshly created session.
+const CURRENT_IN_OPENING: &str = "当前你在 bcn 群聊中，群聊相关信息如下";
 
 pub struct SessionContextMessageProducer;
 
@@ -51,7 +54,6 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
         render_group.participants = participants.to_vec();
         backfill_bot_names(registry, &mut render_group).await;
 
-        let bot_summaries = build_bot_summaries(&render_group.participants, registry).await;
         let task_input_text = session_input
             .as_ref()
             .map(|v| v.as_str().map(str::to_string).unwrap_or_else(|| {
@@ -92,10 +94,9 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
                 manager_worker_initial_message(
                     &render_group,
                     session_id,
+                    reason,
                     participant,
-                    render_group.context.as_deref(),
                     delivery_type,
-                    &bot_summaries,
                     task_input_text.as_deref(),
                     task_ledger.as_ref(),
                     &coordination_surface,
@@ -104,9 +105,8 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
                 initial_group_context_message(
                     &render_group,
                     session_id,
-                    participant,
                     reason,
-                    render_group.context.as_deref(),
+                    participant,
                     delivery_type,
                     has_provider_downlink_bot,
                     task_input_text.as_deref(),
@@ -131,19 +131,7 @@ impl SystemMessageProducerService for SessionContextMessageProducer {
     }
 }
 
-async fn build_bot_summaries(participants: &[Participant], registry: &dyn BotRegistryCoreService) -> HashMap<String, String> {
-    let mut summaries = HashMap::new();
-    for participant in participants.iter().filter(|p| p.is_bot()) {
-        if let Some(bot) = registry.get(&participant.bot_uuid).await {
-            if let Some(summary) = bot.capabilities.summary.filter(|s| !s.is_empty()) {
-                summaries.insert(participant.bot_uuid.clone(), summary);
-            }
-        }
-    }
-    summaries
-}
-
-async fn contains_provider_downlink_bot(
+pub(super) async fn contains_provider_downlink_bot(
     participants: &[&Participant],
     registry: &dyn BotRegistryCoreService,
 ) -> bool {
@@ -169,18 +157,16 @@ fn is_lead_participant(group: &Group, participant: &Participant) -> bool {
     }
 }
 
+/// Renders the unified free-chat `<GroupContext>` block for one recipient.
 fn initial_group_context_message(
     group: &Group,
     session_id: &str,
-    recipient: &Participant,
     topic: &str,
-    user_context: Option<&str>,
+    recipient: &Participant,
     delivery_type: DeliveryType,
     use_at_mention_routing: bool,
     task_input: Option<&str>,
 ) -> String {
-    let base_context = base_context_block(user_context);
-    let task_line = task_block(task_input);
     let role_instruction = match delivery_type {
         DeliveryType::Send => {
             "你是本次协作的 Driver。请介绍协作目标，判断下一步需要谁参与，并开始协调。"
@@ -192,205 +178,168 @@ fn initial_group_context_message(
             "你当前通过 chat.inject 收到初始化上下文，应静默观察，不要主动回复；等待 @mention、bcs_route 或任务点名后再响应。"
         }
     };
-    let routing_instruction = routing_instruction_block(use_at_mention_routing);
-    let roster = if use_at_mention_routing {
-        format_roster_with_mentions(group)
+    let tool_kind = if use_at_mention_routing {
+        "@mention"
     } else {
-        format_roster(group)
+        "bcs_route"
     };
 
-    format!(
-        "[GROUP CONTEXT]\n\
-         群组ID: {}\n\
-         会话ID: {}\n\
-         主题: {}\n\
-         {}\
-         参与者:\n{}\n\
-         {}\
-         \n\
-         {}\n\
-         [/GROUP CONTEXT]\n\
-         \n\
-         你是: {}\n\
-         你的角色: {}\n\
-         \n\
-         {}",
-        group.id,
-        session_id,
-        topic,
-        base_context,
-        roster,
-        task_line,
-        routing_instruction,
-        display_participant(recipient),
-        role_slug(recipient.role),
-        role_instruction,
-    )
+    let sections = vec![
+        group_info_section(group, Some(session_id), Some(topic), recipient, "自由聊天"),
+        format!("## 参与者:\n{}", participant_table(group)),
+        format!(
+            "## 工具说明 ({})\n{}",
+            tool_kind,
+            routing_instruction_block(use_at_mention_routing)
+        ),
+        skill_section(),
+        task_section(task_input),
+        format!("## 说明\n{}", role_instruction),
+    ];
+    render_group_context(CURRENT_IN_OPENING, &sections)
 }
 
-/// Renders the `背景: ...` line for `[GROUP CONTEXT]` blocks, or an empty
-/// string when `user_context` is missing/blank.
-fn base_context_block(user_context: Option<&str>) -> String {
-    user_context
-        .filter(|ctx| !ctx.trim().is_empty())
-        .map(|ctx| format!("背景: {}\n", ctx.trim()))
-        .unwrap_or_default()
-}
-
-/// Renders the `[任务]...[/任务]` block, or an empty string when `task_input`
-/// is missing/blank.
-fn task_block(task_input: Option<&str>) -> String {
-    task_input
-        .filter(|task| !task.trim().is_empty())
-        .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
-        .unwrap_or_default()
-}
-
-/// Renders the routing instruction text (either `@mention` or `bcs_route`
-/// variant) used inside `[GROUP CONTEXT]` blocks.
-fn routing_instruction_block(use_at_mention_routing: bool) -> &'static str {
-    if use_at_mention_routing {
-        "路由工具 (@mention):\n\
-           消息中任何 @ 标识都会触发路由，让被 @ 的 Bot 收到消息并被要求响应。\n\
-           只有希望某个 Bot 响应时才使用 @，不要用 @ 表示引用、收到或转述某个 Bot 的消息。\n\
-           优先使用名称；名称为空、重复或不确定时，使用 Bot ID。"
-    } else {
-        "路由工具 (bcs_route):\n\
-           使用 bcs_route 工具指定下一个响应者（替代 @mention）。\n\
-           - to: 目标 Bot 列表，支持按名称或 bot_id 选择\n\
-             - 按名称: {\"type\": \"name\", \"value\": \"DBA\"}\n\
-             - 按ID: {\"type\": \"bot\", \"value\": \"bot_54123f4f\"}\n\
-           - reason: 路由原因"
-    }
-}
-
-fn format_roster_with_mentions(group: &Group) -> String {
-    let mut name_counts: HashMap<String, usize> = HashMap::new();
-    for participant in group.participants.iter().filter(|participant| participant.is_bot()) {
-        if let Some(name) = mentionable_name(participant) {
-            *name_counts.entry(name).or_insert(0) += 1;
-        }
-    }
-
-    group
-        .participants
-        .iter()
-        .filter(|participant| participant.is_bot())
-        .map(|participant| {
-            let display_name = participant
-                .bot_name
-                .as_deref()
-                .map(str::trim)
-                .filter(|name| !name.is_empty() && *name != participant.bot_uuid)
-                .unwrap_or("-");
-            let mention_name = mentionable_name(participant)
-                .filter(|name| name_counts.get(name).copied().unwrap_or(0) == 1);
-            let mention_hint = mention_name
-                .map(|name| format!("@{} / @{}", name, participant.bot_uuid))
-                .unwrap_or_else(|| format!("@{}", participant.bot_uuid));
-            format!(
-                "- 名称: {} | ID: {} | 角色: {} | 可@: {}",
-                display_name,
-                participant.bot_uuid,
-                role_slug(participant.role),
-                mention_hint
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn mentionable_name(participant: &Participant) -> Option<String> {
-    let name = participant.bot_name.as_deref()?.trim();
-    if name.is_empty() || name == participant.bot_uuid {
-        return None;
-    }
-    if name.chars().all(is_mention_token_char) {
-        Some(name.to_string())
-    } else {
-        None
-    }
-}
-
-fn is_mention_token_char(ch: char) -> bool {
-    ch == '_' || ch == ':' || ch.is_alphanumeric()
-}
-
+/// Renders the unified manager-worker `<GroupContext>` block for one recipient.
 fn manager_worker_initial_message(
     group: &Group,
     session_id: &str,
+    topic: &str,
     recipient: &Participant,
-    context: Option<&str>,
     delivery_type: DeliveryType,
-    bot_summaries: &HashMap<String, String>,
     task_input: Option<&str>,
     task_ledger: Option<&LedgerSummary>,
     coordination_surface: &CoordinationSurface,
 ) -> String {
     let is_manager = recipient.role == ParticipantRole::Manager;
-    let context_line = if is_manager { mw_context_block(context) } else { String::new() };
-    let task_line = if is_manager { mw_task_block(task_input) } else { String::new() };
-    let role_label = if is_manager { "manager" } else { "worker" };
-    let status_line = if is_manager { mw_status_block(task_ledger) } else { String::new() };
+    let status_line = if is_manager {
+        mw_status_block(task_ledger)
+    } else {
+        String::new()
+    };
     let instruction = manager_worker_coordination_instruction(
         is_manager,
         delivery_type,
         coordination_surface,
         &status_line,
     );
+    // `## 任务说明` is shown only to the manager; workers receive only the
+    // coordination instruction.
+    let task = if is_manager { task_input } else { None };
 
-    format!(
-        "[SERVICE GROUP CONTEXT]\n\
-         群组ID: {}\n\
-         会话ID: {}\n\
-         模式: manager_worker\n\
-         你的角色: {}\n\
-         参与者:\n{}\n\
-         {}\
-         {}\
-         {}\n\
-         [/SERVICE GROUP CONTEXT]\n\
-         \n\
-         你是: {}\n\
-         你的角色: {}",
-        group.id,
-        session_id,
-        role_label,
-        format_roster_with_role(group, bot_summaries),
-        context_line,
-        task_line,
-        instruction,
-        display_participant(recipient),
-        role_label,
-    )
+    let sections = vec![
+        group_info_section(group, Some(session_id), Some(topic), recipient, "manager_worker"),
+        format!("## 参与者:\n{}", participant_table(group)),
+        skill_section(),
+        task_section(task),
+        format!("## manager-worker 协同说明\n{}", instruction),
+    ];
+    render_group_context(CURRENT_IN_OPENING, &sections)
 }
 
-/// Renders the background block for `[SERVICE GROUP CONTEXT]` blocks:
-/// `\n{ctx}\n` when `context` is non-blank, else `""`.
-fn mw_context_block(context: Option<&str>) -> String {
-    context
-        .filter(|ctx| !ctx.trim().is_empty())
-        .map(|ctx| format!("\n{}\n", ctx.trim()))
-        .unwrap_or_default()
+/// Wraps non-empty section bodies in the `<GroupContext>` shell, joining
+/// sections with a blank line and placing a single newline before the close tag.
+/// `opening` is the lead line after `<GroupContext>` (it differs between a new
+/// session and a bot joining an existing group).
+pub(super) fn render_group_context(opening: &str, sections: &[String]) -> String {
+    let body = sections
+        .iter()
+        .filter(|section| !section.is_empty())
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    format!("<GroupContext>\n{}\n\n{}\n</GroupContext>", opening, body)
 }
 
-/// Renders the `[任务]...[/任务]` block for `[SERVICE GROUP CONTEXT]`
-/// blocks, or `""` when `task_input` is missing/blank.
-fn mw_task_block(task_input: Option<&str>) -> String {
+/// Renders the `## 群聊信息` section shared by both group modes. `session_id`
+/// and `topic` are omitted from the block when `None` (e.g. a bot joining a
+/// group has no session context attached to the event).
+pub(super) fn group_info_section(
+    group: &Group,
+    session_id: Option<&str>,
+    topic: Option<&str>,
+    recipient: &Participant,
+    mode: &str,
+) -> String {
+    let mut lines = vec![
+        "## 群聊信息".to_string(),
+        format!("* 群组ID: {}", group.id),
+    ];
+    if let Some(sid) = session_id {
+        lines.push(format!("* 会话ID: {}", sid));
+    }
+    lines.push(format!("* 群聊名称: {}", group_display_name(group)));
+    if let Some(topic) = topic {
+        lines.push(format!("* 目标: {}", topic));
+    }
+    lines.push(format!("* 模式: {}", mode));
+    lines.push(format!("* 你的身份: {}", display_participant(recipient)));
+    lines.push(format!("* 你的角色: {}", role_slug(recipient.role)));
+    lines.join("\n")
+}
+
+/// Group display name: `group.label` with any `"Group: "` prefix stripped;
+/// falls back to the group id when no label is set.
+pub(super) fn group_display_name(group: &Group) -> String {
+    group
+        .label
+        .as_deref()
+        .map(|label| label.strip_prefix("Group: ").unwrap_or(label).trim().to_string())
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| group.id.clone())
+}
+
+/// Renders the `## 参与者:` section as a 3-column markdown table
+/// (`name | bot_id | role`).
+pub(super) fn participant_table(group: &Group) -> String {
+    let mut rows = vec![
+        "| name | bot_id | role |".to_string(),
+        "|------|--------|------|".to_string(),
+    ];
+    for participant in group.participants.iter().filter(|p| p.is_bot()) {
+        let name = participant
+            .bot_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty() && *name != participant.bot_uuid)
+            .unwrap_or("-");
+        rows.push(format!(
+            "|{}|{}|{}|",
+            name,
+            participant.bot_uuid,
+            role_slug(participant.role)
+        ));
+    }
+    rows.join("\n")
+}
+
+/// Renders the `## 相关 SKILL` section shared by both group modes.
+pub(super) fn skill_section() -> String {
+    "## 相关 SKILL\nbcn 群聊相关操作可以参考 `bcs-coordination` 技能。".to_string()
+}
+
+/// Renders the `## 任务说明` section, or an empty string when `task_input`
+/// is missing/blank.
+pub(super) fn task_section(task_input: Option<&str>) -> String {
     task_input
         .filter(|task| !task.trim().is_empty())
-        .map(|task| format!("\n[任务]\n{}\n[/任务]\n", task.trim()))
+        .map(|task| format!("## 任务说明\n{}", task.trim()))
         .unwrap_or_default()
 }
 
-/// Renders the `[任务状态]` line for `[SERVICE GROUP CONTEXT]` blocks via
-/// `format_ledger_status_line`: non-empty → `\n{line}`, else `""`.
-fn mw_status_block(task_ledger: Option<&LedgerSummary>) -> String {
-    task_ledger
-        .map(format_ledger_status_line)
-        .filter(|line| !line.is_empty())
-        .map(|line| format!("\n{}", line))
-        .unwrap_or_default()
+/// Renders the routing instruction text (either `@mention` or `bcs_route`
+/// variant) used inside the `## 工具说明` section of free-chat groups.
+pub(super) fn routing_instruction_block(use_at_mention_routing: bool) -> &'static str {
+    if use_at_mention_routing {
+        "消息中任何 @ 标识都会触发路由，让被 @ 的 Bot 收到消息并被要求响应。\n\
+         只有希望某个 Bot 响应时才使用 @，不要用 @ 表示引用、收到或转述某个 Bot 的消息。\n\
+         优先使用名称；名称为空、重复或不确定时，使用 Bot ID。"
+    } else {
+        r#"使用 `bcs_route` 工具替代 @mention 指定下一个响应者可以提高路由准确率。
+* to: 目标 Bot 列表，支持按名称或 bot_id 选择
+  - 按名称: {"type": "name", "value": "DBA"}
+  - 按ID: {"type": "bot", "value": "bot_54123f4f"}
+* reason: 路由原因"#
+    }
 }
 
 fn manager_worker_coordination_instruction(
@@ -421,12 +370,12 @@ fn mcporter_mcp_instruction(
     let server = surface.mcp_server.as_deref().unwrap_or("bcs");
     if is_manager {
         return format!(
-            "\n[协同提醒] 本群为任务群，你是主 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。需要派发子任务时，使用 `{command} call {server}.bcs_assign_task target_bot=\"<目标Bot名称或ID>\" message=\"<任务内容>\"`；任务可以结束时，使用 `{command} call {server}.bcs_task_complete summary=\"<最终总结>\"`。不要直接调用原生发送工具来派发子任务，不要在普通回复中伪造工具结果。{}",
+            "本群为任务群，你是主 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。需要派发子任务时，使用 `{command} call {server}.bcs_assign_task target_bot=\"<目标Bot名称或ID>\" message=\"<任务内容>\"`；任务可以结束时，使用 `{command} call {server}.bcs_task_complete summary=\"<最终总结>\"`。不要直接调用原生发送工具来派发子任务，不要在普通回复中伪造工具结果。{}",
             status_line
         );
     }
     format!(
-        "\n[协同提醒] 本群为任务群，你是子 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。收到主 Bot 派发的任务后，使用 `{command} call {server}.bcs_send_task_message message=\"<结果、进展、问题或阻塞>\"`。不要直接面向用户输出最终答案；最终汇总由 manager 完成，不要在普通回复中伪造工具结果。"
+        "本群为任务群，你是子 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。收到主 Bot 派发的任务后，使用 `{command} call {server}.bcs_send_task_message message=\"<结果、进展、问题或阻塞>\"`。不要直接面向用户输出最终答案；最终汇总由 manager 完成，不要在普通回复中伪造工具结果。"
     )
 }
 
@@ -438,38 +387,45 @@ fn native_mcp_instruction(
     let server = surface.mcp_server.as_deref().unwrap_or("bcs");
     if is_manager {
         return format!(
-            "\n[协同提醒] 本群为任务群，你是主 Bot。你当前平台原生提供 BCS MCP 工具。需要派发子任务时，直接调用 MCP server `{server}` 上的 `bcs_assign_task`；任务可以结束时，直接调用 MCP server `{server}` 上的 `bcs_task_complete`。不要使用 mcporter、exec、bash，不要在普通回复中伪造工具结果。{}",
+            "本群为任务群，你是主 Bot。你当前平台原生提供 BCS MCP 工具。需要派发子任务时，直接调用 MCP server `{server}` 上的 `bcs_assign_task`；任务可以结束时，直接调用 MCP server `{server}` 上的 `bcs_task_complete`。不要使用 mcporter、exec、bash，不要在普通回复中伪造工具结果。{}",
             status_line
         );
     }
     format!(
-        "\n[协同提醒] 本群为任务群，你是子 Bot。你当前平台原生提供 BCS MCP 工具。收到 manager 派发的任务后，直接调用 MCP server `{server}` 上的 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要直接面向用户输出最终答案。"
+        "本群为任务群，你是子 Bot。你当前平台原生提供 BCS MCP 工具。收到 manager 派发的任务后，直接调用 MCP server `{server}` 上的 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要直接面向用户输出最终答案。"
     )
 }
 
 fn native_tool_instruction(is_manager: bool, status_line: &str) -> String {
     if is_manager {
         return format!(
-            "\n[协同提醒] 本群为任务群，你是主 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。需要派发子任务时，直接调用原生工具 `bcs_assign_task`；任务可以结束时，直接调用原生工具 `bcs_task_complete`。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要在普通回复中伪造工具结果。{}",
+            "本群为任务群，你是主 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。需要派发子任务时，直接调用原生工具 `bcs_assign_task`；任务可以结束时，直接调用原生工具 `bcs_task_complete`。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要在普通回复中伪造工具结果。{}",
             status_line
         );
     }
-    "\n[协同提醒] 本群为任务群，你是子 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。收到 manager 派发的任务后，直接调用原生工具 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要直接面向用户输出最终答案。".to_string()
+    "本群为任务群，你是子 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。收到 manager 派发的任务后，直接调用原生工具 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要直接面向用户输出最终答案。".to_string()
 }
 
-fn legacy_manager_worker_instruction(
-    delivery_type: DeliveryType,
-    status_line: &str,
-) -> String {
+fn legacy_manager_worker_instruction(delivery_type: DeliveryType, status_line: &str) -> String {
     match delivery_type {
         DeliveryType::Send => format!(
-            "\n[协同提醒] 本群为任务群，你是主 Bot。派发子任务用 bcs_assign_task(target_bot, message)，可并行派发多个；收齐所有子 Bot 回复、综合完毕后用 bcs_task_complete(summary) 收尾。不要用引擎自带的发送工具向群里发消息。{}",
+            "本群为任务群，你是主 Bot。派发子任务用 bcs_assign_task(target_bot, message)，可并行派发多个；收齐所有子 Bot 回复、综合完毕后用 bcs_task_complete(summary) 收尾。不要用引擎自带的发送工具向群里发消息。{}",
             status_line
         ),
         DeliveryType::Inject => {
-            "\n[协同提醒] 本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复；需要阶段性同步进展 / 说明阻塞时，用 bcs_send_task_message(message) 发给主 Bot。不要用引擎自带的发送工具向群里发消息。".to_string()
+            "本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复；需要阶段性同步进展 / 说明阻塞时，用 bcs_send_task_message(message) 发给主 Bot。不要用引擎自带的发送工具向群里发消息。".to_string()
         }
     }
+}
+
+/// Renders the `[任务状态]` line for manager-worker manager context via
+/// `format_ledger_status_line`: non-empty → `\n{line}`, else `""`.
+fn mw_status_block(task_ledger: Option<&LedgerSummary>) -> String {
+    task_ledger
+        .map(format_ledger_status_line)
+        .filter(|line| !line.is_empty())
+        .map(|line| format!("\n{}", line))
+        .unwrap_or_default()
 }
 
 fn format_ledger_status_line(summary: &LedgerSummary) -> String {
@@ -497,51 +453,7 @@ fn join_or_dash(items: &[String]) -> String {
     }
 }
 
-fn format_roster_with_role(group: &Group, bot_summaries: &HashMap<String, String>) -> String {
-    group
-        .participants
-        .iter()
-        .filter(|participant| participant.is_bot())
-        .map(|participant| {
-            let role = if participant.role == ParticipantRole::Manager {
-                "manager"
-            } else {
-                "worker"
-            };
-            let name = participant
-                .bot_name
-                .as_deref()
-                .unwrap_or(&participant.bot_uuid);
-            let summary = bot_summaries
-                .get(&participant.bot_uuid)
-                .map(|summary| format!(" — {}", summary))
-                .unwrap_or_default();
-            format!(
-                "- 名称: {} | ID: {} | 角色: {}{}",
-                name, participant.bot_uuid, role, summary
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn format_roster(group: &Group) -> String {
-    group
-        .participants
-        .iter()
-        .filter(|participant| participant.is_bot())
-        .map(|participant| {
-            format!(
-                "- {} ({})",
-                display_participant(participant),
-                role_slug(participant.role)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn display_participant(participant: &Participant) -> String {
+pub(super) fn display_participant(participant: &Participant) -> String {
     match participant.bot_name.as_deref() {
         Some(name) if !name.is_empty() && name != participant.bot_uuid => {
             format!("{}({})", name, participant.bot_uuid)
@@ -550,7 +462,7 @@ fn display_participant(participant: &Participant) -> String {
     }
 }
 
-fn role_slug(role: ParticipantRole) -> &'static str {
+pub(super) fn role_slug(role: ParticipantRole) -> &'static str {
     match role {
         ParticipantRole::Driver => "driver",
         ParticipantRole::Consultant => "consultant",

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -277,13 +277,13 @@ async fn manager_worker_session_context_backfills_placeholder_names() {
         .expect("manager receives context");
     assert_eq!(manager_message.delivery_type, DeliveryType::Send);
     assert!(manager_message.message.contains(
-        "- 名称: Demo Worker的分身 | ID: 20260416_a5clr6ig:12345678 | 角色: manager — Demo Worker的分身"
+        "|Demo Worker的分身|20260416_a5clr6ig:12345678|manager|"
     ));
     assert!(manager_message.message.contains(
-        "- 名称: Demo Worker测试0528 | ID: 20260528_vobmrqo6:12345678 | 角色: worker"
+        "|Demo Worker测试0528|20260528_vobmrqo6:12345678|worker|"
     ));
     assert!(!manager_message.message.contains(
-        "- 名称: 20260528_vobmrqo6:12345678 | ID: 20260528_vobmrqo6:12345678"
+        "|20260528_vobmrqo6:12345678|20260528_vobmrqo6:12345678|"
     ));
 }
 
@@ -299,7 +299,7 @@ async fn manager_worker_manager_reminder_lists_only_manager_tools() {
     assert!(manager_message.message.contains("bcs_assign_task"));
     assert!(manager_message.message.contains("bcs_task_complete"));
     assert!(manager_message.message.contains(
-        "[协同提醒] 本群为任务群，你是主 Bot。派发子任务用 bcs_assign_task(target_bot, message)"
+        "本群为任务群，你是主 Bot。派发子任务用 bcs_assign_task(target_bot, message)"
     ));
     assert!(manager_message.message.contains("不要用引擎自带的发送工具向群里发消息。"));
     assert!(!manager_message.message.contains("bcs_send_task_message"));
@@ -397,7 +397,7 @@ async fn manager_worker_worker_reminder_lists_only_worker_tool() {
 
     assert!(worker_message.message.contains("bcs_send_task_message"));
     assert!(worker_message.message.contains(
-        "[协同提醒] 本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复"
+        "本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复"
     ));
     assert!(worker_message.message.contains("不要用引擎自带的发送工具向群里发消息。"));
     assert!(!worker_message.message.contains("bcs_assign_task"));
@@ -604,3 +604,4 @@ async fn manager_worker_ignores_driver_delivery_override() {
         .expect("worker receives context");
     assert_eq!(worker_message.delivery_type, DeliveryType::Inject);
 }
+

--- a/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
+++ b/src/bcs/crates/tools/bcs-rule-bot/src/instance.rs
@@ -957,24 +957,20 @@ fn begin_supervisor_dispatch(
 }
 
 fn supervisor_system_task(message: &str) -> Option<String> {
-    tagged_task(message).or_else(|| manager_worker_group_goal(message))
+    tagged_task(message)
 }
 
+/// Extracts the `## 任务说明` section body from a `<GroupContext>` system
+/// message. The task body runs from the heading line up to the next `## `
+/// section or the closing `</GroupContext>` tag.
 fn tagged_task(message: &str) -> Option<String> {
-    let (_, after_open) = message.split_once("[任务]")?;
-    let (task, _) = after_open.split_once("[/任务]")?;
-    let task = task.trim();
+    let (_, after_heading) = message.split_once("## 任务说明\n")?;
+    let end = after_heading
+        .find("\n## ")
+        .or_else(|| after_heading.find("\n</GroupContext>"))
+        .unwrap_or(after_heading.len());
+    let task = after_heading[..end].trim();
     (!task.is_empty()).then(|| task.to_string())
-}
-
-fn manager_worker_group_goal(message: &str) -> Option<String> {
-    let (_, service_context) = message.split_once("[SERVICE GROUP CONTEXT]")?;
-    let (service_context, _) = service_context.split_once("[/SERVICE GROUP CONTEXT]")?;
-    let (_, participants_and_goal) = service_context.split_once("参与者:\n")?;
-    let (roster_and_goal, _) = participants_and_goal.rsplit_once("\n[协同提醒]")?;
-    let (_, goal) = roster_and_goal.split_once("\n\n")?;
-    let goal = goal.trim();
-    (!goal.is_empty()).then(|| goal.to_string())
 }
 
 fn parse_participant_identity(value: &str) -> ParticipantIdentity {
@@ -1776,10 +1772,11 @@ mod tests {
         assert_eq!(plain.name, "worker-id");
         assert_eq!(plain.target, "worker-id");
         assert_eq!(
-            tagged_task("context\n[任务]\n检查上线\n[/任务]\nend").as_deref(),
+            tagged_task("<GroupContext>\n## 任务说明\n检查上线\n\n## 说明\n静默\n</GroupContext>")
+                .as_deref(),
             Some("检查上线")
         );
-        assert!(tagged_task("[SERVICE GROUP CONTEXT]").is_none());
+        assert!(tagged_task("<GroupContext>\n## 群聊信息\n* 群组ID: g\n</GroupContext>").is_none());
     }
 
     #[tokio::test]
@@ -1898,52 +1895,50 @@ mod tests {
     }
 
     #[test]
-    fn system_supervisor_task_prefers_session_task_and_falls_back_to_group_goal() {
-        let goal_only = "\
-[SERVICE GROUP CONTEXT]\n\
-群组ID: group\n\
-会话ID: group:session\n\
-模式: manager_worker\n\
-你的角色: manager\n\
-参与者:\n\
-- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
-- 名称: 成员A | ID: worker-a | 角色: worker\n\
+    fn system_supervisor_task_extracts_session_task_from_group_context() {
+        let with_task = "\
+<GroupContext>\n\
+当前你在 bcn 群聊中，群聊相关信息如下\n\
 \n\
-测试协作目标\n\
+## 群聊信息\n\
+* 群组ID: group\n\
+* 会话ID: group:session\n\
+* 模式: manager_worker\n\
+* 你的角色: manager\n\
 \n\
-[协同提醒] 本群为任务群，你是主 Bot。\n\
-[/SERVICE GROUP CONTEXT]";
-        assert_eq!(
-            supervisor_system_task(goal_only).as_deref(),
-            Some("测试协作目标")
-        );
-
-        let goal_and_task = "\
-[SERVICE GROUP CONTEXT]\n\
-参与者:\n\
-- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+## 参与者:\n\
+| name | bot_id | role |\n\
+|------|--------|------|\n\
+|任务协调者|manager-id|manager|\n\
+|成员A|worker-a|worker|\n\
 \n\
-长期协作目标\n\
-\n\
-[任务]\n\
+## 任务说明\n\
 本次会话任务\n\
-[/任务]\n\
 \n\
-[协同提醒] 本群为任务群，你是主 Bot。\n\
-[/SERVICE GROUP CONTEXT]";
+## manager-worker 协同说明\n\
+本群为任务群，你是主 Bot。\n\
+</GroupContext>";
         assert_eq!(
-            supervisor_system_task(goal_and_task).as_deref(),
+            supervisor_system_task(with_task).as_deref(),
             Some("本次会话任务")
         );
 
-        let no_goal = "\
-[SERVICE GROUP CONTEXT]\n\
-参与者:\n\
-- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
+        let no_task = "\
+<GroupContext>\n\
+当前你在 bcn 群聊中，群聊相关信息如下\n\
 \n\
-[协同提醒] 本群为任务群，你是主 Bot。\n\
-[/SERVICE GROUP CONTEXT]";
-        assert!(supervisor_system_task(no_goal).is_none());
+## 群聊信息\n\
+* 群组ID: group\n\
+\n\
+## 参与者:\n\
+| name | bot_id | role |\n\
+|------|--------|------|\n\
+|任务协调者|manager-id|manager|\n\
+\n\
+## manager-worker 协同说明\n\
+本群为任务群，你是主 Bot。\n\
+</GroupContext>";
+        assert!(supervisor_system_task(no_task).is_none());
     }
 
     #[test]
@@ -2100,16 +2095,29 @@ mod tests {
         let mut input = supervisor_input();
         input.sender_name = "bcs-system-message".to_string();
         input.message_text = "\
-[SERVICE GROUP CONTEXT]\n\
-参与者:\n\
-- 名称: 任务协调者 | ID: manager-id | 角色: manager\n\
-- 名称: 成员A | ID: worker-a | 角色: worker\n\
-- 名称: 成员B | ID: worker-b | 角色: worker\n\
+<GroupContext>\n\
+当前你在 bcn 群聊中，群聊相关信息如下\n\
 \n\
+## 群聊信息\n\
+* 群组ID: group\n\
+* 会话ID: group:session\n\
+* 模式: manager_worker\n\
+* 你的身份: 任务协调者(manager-id)\n\
+* 你的角色: manager\n\
+\n\
+## 参与者:\n\
+| name | bot_id | role |\n\
+|------|--------|------|\n\
+|任务协调者|manager-id|manager|\n\
+|成员A|worker-a|worker|\n\
+|成员B|worker-b|worker|\n\
+\n\
+## 任务说明\n\
 初始化协作目标\n\
 \n\
-[协同提醒] 本群为任务群，你是主 Bot。\n\
-[/SERVICE GROUP CONTEXT]"
+## manager-worker 协同说明\n\
+本群为任务群，你是主 Bot。\n\
+</GroupContext>"
             .to_string();
         let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
         let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
@@ -2220,7 +2228,7 @@ mod tests {
         state.bot_uuid = Some("manager-id".to_string());
         let mut input = supervisor_input();
         input.sender_name = "bcs-system-message".to_string();
-        input.message_text = "[MANAGER-WORKER GROUP CONTEXT]".to_string();
+        input.message_text = "<GroupContext></GroupContext>".to_string();
         let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel();
         let (internal_tx, _internal_rx) = mpsc::unbounded_channel();
         let start = match BehaviorRuntime::new(&behavior)


### PR DESCRIPTION
## Problem

The group-context system messages injected at session creation are inconsistent: free-chat groups use `[GROUP CONTEXT]...[/GROUP CONTEXT]`, manager-worker groups use `[SERVICE GROUP CONTEXT]...[/SERVICE GROUP CONTEXT]`, with differing structure, field names, and participant-list styles. The `bot_joined` inject message to a newly added bot uses yet another free-text format (`你加入了 BCS 协作群.群 ID: ... 主题: ...`). The three message types are visually fragmented, and `bcs-rule-bot`'s supervisor extracts the task by parsing this text, so the format inconsistency raises maintenance cost.

## Solution

Unify all three into a single `<GroupContext>` structure sharing the same section order and rendering style; only a few sections differ by group mode.

- **session_context.rs**: rewrite both render functions into the unified `<GroupContext>`, extracting shared helpers (`group_display_name` strips the `Group: ` prefix; `participant_table` renders a 3-column markdown table; `render_group_context(opening, sections)`; `group_info_section` with optional session_id/topic). Coordination instructions drop the `\[协同提醒\]` prefix (now carried by the `## manager-worker 协同说明` heading); `group.context` (background) rendering is dropped.
- **bot_joined.rs**: the new-bot inject message reuses the shared helpers, opens with "你已加入 bcn 群聊", and appends a `## 群历史消息 (最近 N 条)` section.
- **bcs-rule-bot/instance.rs**: `tagged_task` now parses `## 任务说明`; `manager_worker_group_goal` is removed (its `group.context` source is no longer rendered), and `supervisor_system_task` calls `tagged_task` directly; tests updated in lockstep.
- Update format assertions in `dispatcher_test` / `session_context_test` / `bot_joined_test` / `bcs-message` lib and a few doc comments.

**Known gap (to confirm):** the `BotJoined` event carries only `{group_id, actor}` — no session_id / reason / session_input — so the new-bot message omits `会话ID` / `目标` / `## 任务说明`. Populating them requires plumbing these fields into the `BotJoined` event and its two call sites, plus giving the producer access to a session service.

## Validation

- `cargo build --workspace`: no warnings, no errors.
- `cargo test -p bcs-system-message`: 43 lib + 7 conformance, all green.
- `cargo test -p bcs-message` / `-p bcs-ws` / `-p bcs-rule-bot`: all green, no regression.
- Visual spot-check: the `<GroupContext>` output for all three scenarios (free-chat, manager-worker, bot-join) matches the intended format field-by-field.