### PR TITLE
fix(expert-chat): align local session keys

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/schemas.py
@@ -117,9 +117,10 @@ class SessionCreate(BaseModel):
 
     # Only fields every engine on this surface actually persists — the same
     # ruling `cwd` got on SessionUpdate, for the same reason. An agent was
-    # offered here and withdrawn: `claude_code` encodes it into the session key
-    # (`agent:{agent_id}:session:…`) so later reads recover it, while `openclaw`
-    # builds `session:{uuid}:user:{user_id}` and never sends the agent at all,
+    # offered here and withdrawn: these local engines build
+    # `session:{uuid}:user:{user_id}` / related local session keys and do not send
+    # the agent through this request body, while `openclaw` also builds
+    # `session:{uuid}:user:{user_id}` and never sends the agent at all,
     # then synthesises a 201 echoing the value it dropped. The association would
     # exist or not depending on the bot's engine, and the response would claim
     # it either way. `extra="forbid"` makes a caller still sending `agent_id` a

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -594,21 +594,34 @@ class ExpertChatService:
         if engine_type == "aicoding":
             return await self._create_aicoding_session(conn, bot, user_id)
         elif engine_type == "claude_code":
-            logger.info(
-                "[ExpertChatService] claude_code session: delegating to aicoding session for bot=%s, user=%s",
-                bot.get("bot_id"), user_id,
-            )
-            return await self._create_aicoding_session(conn, bot, user_id)
+            return await self._create_claude_code_session(conn, bot, user_id)
 
         return await self._create_openclaw_session(conn, bot, user_id)
 
+    async def _create_claude_code_session(self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str) -> str:
+        """Claude Code/GeneralCC 引擎：本地生成旧格式 session key，不调 Adapter。"""
+        import uuid
+
+        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
+        logger.info(f"[claude_code] local session key generated: {session_key}")
+        return session_key
+
     async def _create_aicoding_session(self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str) -> str:
         """
-        AI Coding 引擎：teamclaw-aicoding-relay 按需建 session，本地生成 key，不调 Adapter。
+        AI Coding/Claude Code 引擎：relay 按需建 session，本地生成 key，不调 Adapter。
+
+        session key 需要同时携带 caller user 与 agent 维度。
         """
         import uuid
-        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
-        logger.info(f"[aicoding] local session key generated: {session_key}")
+
+        bot_id = str(bot["bot_id"])
+        session_key = f"user:{user_id}:session:{uuid.uuid4()}:agent:{bot_id}"
+        logger.info(
+            "[aicoding] local session key generated: bot=%s caller=%s session=%s",
+            bot_id,
+            user_id,
+            session_key,
+        )
         return session_key
 
     async def _create_openclaw_session(self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str) -> str:

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
@@ -984,6 +984,81 @@ class TestDeleteAdapterSession:
 
 
 # ---------------------------------------------------------------------------
+# _create_aicoding_session / _create_claude_code_session
+# ---------------------------------------------------------------------------
+
+class TestCreateLocalSession:
+
+    @pytest.mark.asyncio
+    async def test_aicoding_session_key_uses_caller_and_agent(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
+        bot = {
+            "bot_id": "20260714_ysjxmqfy",
+            "owner_id": "382716",
+            "bot_name": "GeneralCC Bot",
+        }
+
+        result = await svc._create_aicoding_session(
+            {"engine_type": "aicoding"},
+            bot,
+            "136677",
+        )
+
+        assert result.startswith("user:136677:session:")
+        assert result.endswith(":agent:20260714_ysjxmqfy")
+
+    @pytest.mark.asyncio
+    async def test_claude_code_session_key_uses_legacy_user_suffix(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
+
+        result = await svc._create_claude_code_session(
+            {"engine_type": "claude_code"},
+            {"bot_id": "20260714_ysjxmqfy"},
+            "136677",
+        )
+
+        assert result.startswith("session:")
+        assert result.endswith(":user:136677")
+        assert ":agent:" not in result
+
+    @pytest.mark.asyncio
+    async def test_create_session_routes_claude_code_to_legacy_user_suffix(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        conn = dict(DEVICE_CONN, engine_type="claude_code")
+        resolver = MagicMock()
+        ctx = MagicMock()
+        ctx.conn_info = conn
+        resolver.resolve_for_binding = MagicMock(return_value=ctx)
+        transport = MagicMock()
+        transport.invoke = AsyncMock()
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_resolver=resolver,
+            mock_transport=transport,
+        )
+        bot = {
+            "bot_id": "20260714_ysjxmqfy",
+            "owner_id": "382716",
+            "public": "1",
+            "binding_id": "binding-1",
+        }
+
+        result = await svc._create_session(bot, "136677")
+
+        assert result.startswith("session:")
+        assert result.endswith(":user:136677")
+        assert ":agent:" not in result
+        transport.invoke.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # _create_openclaw_session
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- keep claude_code local sessions on legacy session:{uuid}:user:{user_id} keys
- change aicoding local sessions to user:{user_id}:session:{uuid}:agent:{bot_id}
- add regression tests for both session key formats

## Test
- uv run pytest tests/community/core/expert_chat/services/test_expert_chat_service.py -q
- git diff --check