### PR TITLE
feat(baas): unify Arca sandbox info model in the community SPI

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
@@ -20,7 +20,11 @@ from secbaas.community.api.device_manage import (
     Storage,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
+from secbaas.community.spi.sandbox.arca import (
+    ArcaSandbox,
+    ArcaSandboxInfo,
+    ArcaSandboxPlugin,
+)
 
 if TYPE_CHECKING:
     from secbaas.community.api.device_manage import ArcaCredentials
@@ -28,20 +32,26 @@ if TYPE_CHECKING:
 logger = get_logger("plugin-sandbox-arca")
 
 
-class StubSandboxInfo:
-    """Mimics the Arca SDK SandboxInfo object returned by SyncSandbox.get_info()."""
+class StubSandboxInfo(ArcaSandboxInfo):
+    """Backward-compatible alias of :class:`~secbaas.community.spi.sandbox.arca.ArcaSandboxInfo`.
+
+    Retained so existing imports and ``isinstance`` checks keep working. Offers the same
+    attribute surface as the unified model.
+    """
 
     def __init__(self, sandbox_id: str, template_id: str) -> None:
-        self.sandbox_id = sandbox_id
-        self.status = "RUNNING"
-        self.template_id = template_id
-        self.resources = None
-        self.ttl_in_minutes = None
-        self.ttl_timestamp = None
-        self.envs = None
-        self.snapshot_id = None
-        self.metadata = None
-        self.outbound_operation_rule = None
+        super().__init__(
+            sandbox_id=sandbox_id,
+            status="RUNNING",
+            template_id=template_id,
+            resources=None,
+            ttl_in_minutes=None,
+            ttl_timestamp=None,
+            envs=None,
+            snapshot_id=None,
+            metadata=None,
+            outbound_operation_rule=None,
+        )
 
 
 class StubArcaSandbox(ArcaSandbox):
@@ -59,7 +69,7 @@ class StubArcaSandbox(ArcaSandbox):
     def sandbox_id(self) -> str:
         return self._sandbox_id
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         return StubSandboxInfo(self._sandbox_id, self._template_id)
 
     def destroy(self) -> Any:

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
@@ -9,7 +9,7 @@ from secbaas.community.api.device_manage import (
     OutBoundOperationRuleUpdatedMode,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxInfo
 
 logger = get_logger("plugin-sandbox-arca-local-docker")
 
@@ -47,20 +47,20 @@ class LocalDockerArcaSandbox(ArcaSandbox):
         """沙箱唯一标识符。"""
         return self._sandbox_id
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         """获取沙箱信息。
 
         Returns:
-            包含沙箱信息的字典，包括 sandbox_id, status, template_id 等。
+            返回统一 :class:`ArcaSandboxInfo`，包含 sandbox_id, status, template_id；
+            local-docker 专属字段（container_id, is_ready）附加为额外属性。
         """
-        # TODO: 从 Docker 容器获取实际状态
-        return {
-            "sandbox_id": self._sandbox_id,
-            "status": self._status,
-            "template_id": self._template_id,
-            "container_id": self._container_id,
-            "is_ready": self._is_ready,
-        }
+        return ArcaSandboxInfo(
+            sandbox_id=self._sandbox_id,
+            status=self._status,
+            template_id=self._template_id,
+            container_id=self._container_id,
+            is_ready=self._is_ready,
+        )
 
     def destroy(self) -> Any:
         """销毁沙箱（停止并删除 Docker 容器）。

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
@@ -10,7 +10,7 @@ from secbaas.community.api.device_manage import (
     OutBoundOperationRuleUpdatedMode,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxInfo
 
 if TYPE_CHECKING:
     from ._process_manager import ProcessEntry
@@ -18,13 +18,13 @@ if TYPE_CHECKING:
 logger = get_logger("plugin-sandbox-arca-local-proc")
 
 
-class LocalProcessSandboxInfo:
-    """本地进程沙箱信息对象。
+class LocalProcessSandboxInfo(ArcaSandboxInfo):
+    """Backward-compatible subclass of the unified :class:`ArcaSandboxInfo`.
 
-    支持属性访问（info.status），与 Arca SDK 的 SandboxInfo 接口对齐。
-    ArcaPaasService 通过属性访问以下字段：
-    status, template_id, sandbox_id, resources, ttl_in_minutes, envs,
-    snapshot_id, metadata, outbound_operation_rule, ttl_timestamp。
+    Retained so existing imports, ``isinstance`` checks, and the extra local-process
+    fields keep working. The SDK-common fields align to the unified model; the local-only
+    fields (``bot_id``, ports, pids, config/workspace dirs, ``is_ready``) are carried as
+    attributes.
     """
 
     def __init__(
@@ -48,24 +48,27 @@ class LocalProcessSandboxInfo:
         metadata: dict[str, str] | None = None,
         outbound_operation_rule: Any = None,
     ) -> None:
-        self.sandbox_id = sandbox_id
-        self.status = status
-        self.template_id = template_id
-        self.is_ready = is_ready
-        self.ttl_in_minutes = ttl_in_minutes
-        self.ttl_timestamp = ttl_timestamp
-        self.bot_id = bot_id
-        self.adapter_port = adapter_port
-        self.adapter_pid = adapter_pid
-        self.engine_port = engine_port
-        self.engine_pid = engine_pid
-        self.config_dir = config_dir
-        self.workspace_dir = workspace_dir
-        self.resources = resources
-        self.envs = envs
-        self.snapshot_id = snapshot_id
-        self.metadata = metadata
-        self.outbound_operation_rule = outbound_operation_rule
+        super().__init__(
+            sandbox_id=sandbox_id,
+            status=status,
+            template_id=template_id,
+            resources=resources,
+            ttl_in_minutes=ttl_in_minutes,
+            ttl_timestamp=ttl_timestamp,
+            envs=envs,
+            snapshot_id=snapshot_id,
+            metadata=metadata,
+            outbound_operation_rule=outbound_operation_rule,
+            storage=None,
+            is_ready=is_ready,
+            bot_id=bot_id,
+            adapter_port=adapter_port,
+            adapter_pid=adapter_pid,
+            engine_port=engine_port,
+            engine_pid=engine_pid,
+            config_dir=config_dir,
+            workspace_dir=workspace_dir,
+        )
 
     def __repr__(self) -> str:
         """返回结构化、日志友好的字符串表示。
@@ -135,12 +138,13 @@ class LocalProcessArcaSandbox(ArcaSandbox):
     def _ttl_minutes(self, value: int | None) -> None:
         self.__ttl_minutes = value
 
-    def get_info(self) -> LocalProcessSandboxInfo:
+    def get_info(self) -> ArcaSandboxInfo:
         """获取沙箱信息。
 
         Returns:
-            LocalProcSandboxInfo 对象，包含 sandbox_id, status, template_id 等属性。
+            ArcaSandboxInfo 对象，包含 sandbox_id, status, template_id 等属性。
             返回对象支持属性访问（info.status），与 Arca SDK 的 SandboxInfo 接口对齐。
+            本地进程模式额外字段（bot_id/端口/pid/目录）也会附加到返回对象上。
         """
         entry = self._process_entry
         return LocalProcessSandboxInfo(

--- a/src/baas/src/secbaas/community/spi/sandbox/__init__.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/__init__.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
+from secbaas.community.spi.sandbox.arca import (
+    ArcaSandbox,
+    ArcaSandboxInfo,
+    ArcaSandboxPlugin,
+)
 from secbaas.community.spi.sandbox.desktop import DesktopSandbox, DesktopSandboxPlugin
 from secbaas.community.spi.sandbox.docker import DockerSandbox, DockerSandboxPlugin
 from secbaas.community.spi.sandbox.k8s import K8sSandbox, K8sSandboxPlugin
@@ -53,6 +57,7 @@ class PaasSandboxPlugins:
 __all__ = [
     "ArcaSandboxPlugin",
     "ArcaSandbox",
+    "ArcaSandboxInfo",
     "DesktopSandboxPlugin",
     "DesktopSandbox",
     "DockerSandbox",

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/__init__.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/__init__.py
@@ -1,5 +1,6 @@
 """Arca device SPI — Protocol for Arca sandbox lifecycle."""
 
+from ._arca_sandbox_info import ArcaSandboxInfo
 from ._errors import (
     ArcaSandboxError,
     ArcaSandboxNotFoundError,
@@ -10,6 +11,7 @@ from ._protocols import ArcaSandbox, ArcaSandboxPlugin
 __all__ = [
     "ArcaSandbox",
     "ArcaSandboxError",
+    "ArcaSandboxInfo",
     "ArcaSandboxNotFoundError",
     "ArcaSandboxPlugin",
     "ArcaSandboxTimeoutError",

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/_arca_sandbox_info.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/_arca_sandbox_info.py
@@ -1,0 +1,143 @@
+"""Unified Arca sandbox info model.
+
+Single, community-owned model for ``ArcaSandbox.get_info()`` return values,
+derived from the Arca SDK ``SandboxInfo`` surface. All Arca sandbox
+implementations (enterprise SDK-backed, community stub, community
+local-process, community local-docker) return this model so the SPI has one
+source of truth for the sandbox info shape.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        ResourceSpecification,
+        Storage,
+    )
+
+
+class ArcaSandboxInfo:
+    """Unified Arca sandbox information container.
+
+    ``status`` may be an enum-like value exposing ``.value`` or a plain string;
+    consumers normalize via
+    ``str(status.value) if hasattr(status, "value") else str(status)``.
+
+    Field ownership / optionality:
+
+    ``sandbox_id`` (always set; owned by all backends)
+        ``str``. Arca sandbox ID.
+
+    ``status`` (always set; owned by all backends)
+        ``Any`` enum-like (``.value``) or plain ``str``. Current sandbox status.
+
+    ``template_id`` (optional; owned by all backends)
+        ``str | None``. Platform template ID; ``None`` when the backend does not
+        report a template.
+
+    ``resources`` (optional; owned by all backends)
+        ``ResourceSpecification | None``. CPU/memory/disk; ``None`` when unset.
+
+    ``ttl_in_minutes`` (optional; owned by all backends)
+        ``float | int | None``. Remaining/set TTL in minutes; ``None`` when unset.
+
+    ``ttl_timestamp`` (optional; owned by all backends)
+        ``int | None``. Expiry timestamp (ms); ``None`` when unavailable.
+
+    ``envs`` (optional; owned by all backends)
+        ``dict[str, Any] | None``. Environment variables; ``None`` when unset.
+
+    ``snapshot_id`` (optional; owned by all backends)
+        ``str | None``. Snapshot ID; ``None`` when unset.
+
+    ``metadata`` (optional; owned by all backends)
+        ``dict[str, Any] | None``. Arbitrary metadata; ``None`` when unset.
+
+    ``outbound_operation_rule`` (optional; owned by all backends)
+        ``OutBoundOperationRule | None``. Outbound rule; ``None`` when unset.
+
+    ``storage`` (optional; owned by all backends)
+        ``Storage | None``. NAS storage binding; ``None`` when unset.
+
+    ``is_ready`` (optional; owned by local-process + local-docker)
+        ``bool``. Ready flag; ``False`` on backends that do not model it.
+
+    ``container_id`` (optional; owned by local-docker)
+        ``str | None``. Docker container ID; ``None`` elsewhere.
+
+    ``bot_id`` (optional; owned by local-process)
+        ``str``. Bot ID; ``""`` on backends that do not model it.
+
+    ``adapter_port`` (optional; owned by local-process)
+        ``int``. Adapter port; ``0`` on backends that do not model it.
+
+    ``adapter_pid`` (optional; owned by local-process)
+        ``int | None``. Adapter PID; ``None`` when no adapter process.
+
+    ``engine_port`` (optional; owned by local-process)
+        ``int``. Engine port; ``0`` on backends that do not model it.
+
+    ``engine_pid`` (optional; owned by local-process)
+        ``int | None``. Engine PID; ``None`` when no engine process.
+
+    ``config_dir`` (optional; owned by local-process)
+        ``str``. Config directory; ``""`` on backends that do not model it.
+
+    ``workspace_dir`` (optional; owned by local-process)
+        ``str``. Workspace directory; ``""`` on backends that do not model it.
+
+    NOTE: Core logic that consumes an optional field MUST treat it as
+    ``None`` (or its unset default) — only the owning backend guarantees a
+    value. Do not assume presence without checking.
+    """
+
+    def __init__(
+        self,
+        sandbox_id: str,
+        status: Any = None,
+        template_id: str | None = None,
+        resources: ResourceSpecification | None = None,
+        ttl_in_minutes: float | int | None = None,
+        ttl_timestamp: int | None = None,
+        envs: dict[str, Any] | None = None,
+        snapshot_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        outbound_operation_rule: OutBoundOperationRule | None = None,
+        storage: Storage | None = None,
+        is_ready: bool = False,
+        container_id: str | None = None,
+        bot_id: str = "",
+        adapter_port: int = 0,
+        adapter_pid: int | None = None,
+        engine_port: int = 0,
+        engine_pid: int | None = None,
+        config_dir: str = "",
+        workspace_dir: str = "",
+        **extra: Any,
+    ) -> None:
+        self.sandbox_id = sandbox_id
+        self.status = status
+        self.template_id = template_id
+        self.resources = resources
+        self.ttl_in_minutes = ttl_in_minutes
+        self.ttl_timestamp = ttl_timestamp
+        self.envs = envs
+        self.snapshot_id = snapshot_id
+        self.metadata = metadata
+        self.outbound_operation_rule = outbound_operation_rule
+        self.storage = storage
+        self.is_ready = is_ready
+        self.container_id = container_id
+        self.bot_id = bot_id
+        self.adapter_port = adapter_port
+        self.adapter_pid = adapter_pid
+        self.engine_port = engine_port
+        self.engine_pid = engine_pid
+        self.config_dir = config_dir
+        self.workspace_dir = workspace_dir
+        # Unknown/forward-compatible extras remain available as dynamic attributes.
+        for name, value in extra.items():
+            setattr(self, name, value)

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/_protocols.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/_protocols.py
@@ -12,6 +12,8 @@ from secbaas.community.api.device_manage import (
     Storage,
 )
 
+from ._arca_sandbox_info import ArcaSandboxInfo
+
 if TYPE_CHECKING:
     from secbaas.community.api.bot_runtime import HttpConnectionInfo, WsConnectionInfo
 
@@ -26,12 +28,12 @@ class ArcaSandbox(Protocol):
     is_ready: bool
     sandbox_id: str
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         """Get sandbox info including status, template_id, resources, ttl, etc.
 
         Returns:
-            An info object with at minimum: sandbox_id, status, template_id.
-            Optional fields depend on the implementation.
+            An ``ArcaSandboxInfo`` with at minimum: sandbox_id, status, template_id.
+            Backends may attach backend-specific optional attributes.
         """
         ...
 

--- a/src/baas/tests/unit/plugins/sandbox/arca/local_docker/test_docker_sandbox_get_info.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/local_docker/test_docker_sandbox_get_info.py
@@ -1,0 +1,60 @@
+"""Coverage tests for LocalDockerArcaSandbox.get_info().
+
+Verifies the local-docker Arca sandbox returns the unified ArcaSandboxInfo model
+with its backend-specific extras (container_id, is_ready).
+"""
+
+from __future__ import annotations
+
+from secbaas.community.plugins.sandbox.arca.local_docker._sandbox import (
+    LocalDockerArcaSandbox,
+)
+from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+
+class TestLocalDockerSandboxGetInfo:
+    def test_returns_unified_sandbox_info_with_extras(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-1", "tpl-1", container_id="cid-1")
+        info = sandbox.get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert info.sandbox_id == "sb-docker-1"
+        assert info.template_id == "tpl-1"
+        assert info.status == "PENDING"
+        assert info.container_id == "cid-1"
+        assert info.is_ready is False
+
+    def test_after_mark_ready_status_is_running(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-2", "tpl-1")
+        sandbox.mark_ready("cid-2")
+
+        info = sandbox.get_info()
+
+        assert info.container_id == "cid-2"
+        assert info.is_ready is True
+        assert info.status == "RUNNING"
+
+    def test_unified_attribute_surface(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-3", "tpl-1")
+        info = sandbox.get_info()
+
+        for attr in (
+            "sandbox_id",
+            "status",
+            "template_id",
+            "resources",
+            "ttl_in_minutes",
+            "ttl_timestamp",
+            "envs",
+            "snapshot_id",
+            "metadata",
+            "outbound_operation_rule",
+            "storage",
+        ):
+            assert hasattr(info, attr), f"missing attribute: {attr}"
+
+    def test_destroy_marks_status(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-4", "tpl-1")
+        assert sandbox.destroy() is True
+        assert sandbox.get_info().status == "DESTROYED"
+        assert sandbox.get_info().is_ready is False

--- a/src/baas/tests/unit/plugins/sandbox/arca/local_proc/test_sandbox_get_info.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/local_proc/test_sandbox_get_info.py
@@ -1,0 +1,123 @@
+"""Coverage tests for LocalProcessArcaSandbox.get_info().
+
+Verifies that the local-process sandbox returns the unified ArcaSandboxInfo model
+while preserving the backend-specific extra fields, covering both
+process-present and process-absent branches for adapter and engine processes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from secbaas.community.plugins.sandbox.arca.local_proc._process_manager import (
+    ProcessEntry,
+)
+from secbaas.community.plugins.sandbox.arca.local_proc._sandbox import (
+    LocalProcessArcaSandbox,
+    LocalProcessSandboxInfo,
+)
+from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+
+def _fake_process() -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 12345
+    return proc
+
+
+def _entry(
+    *,
+    adapter_process=None,
+    openclaw_process=None,
+    hermes_process=None,
+    openclaw_port: int = 0,
+    hermes_port: int = 0,
+) -> ProcessEntry:
+    return ProcessEntry(
+        sandbox_id="sb-local-1",
+        device_id="dev-1",
+        bot_id="bot-1",
+        adapter_process=adapter_process,
+        adapter_port=9001,
+        openclaw_process=openclaw_process,
+        openclaw_port=openclaw_port,
+        hermes_process=hermes_process,
+        hermes_port=hermes_port,
+        config_dir=Path("/tmp/sb-local-1/config"),
+        workspace_dir=Path("/tmp/sb-local-1/workspace"),
+    )
+
+
+def _sandbox(entry: ProcessEntry) -> LocalProcessArcaSandbox:
+    return LocalProcessArcaSandbox(
+        sandbox_id="sb-local-1", template_id="openclaw", process_entry=entry
+    )
+
+
+class TestLocalProcessSandboxGetInfo:
+    def test_returns_unified_sandbox_info_with_extras(self) -> None:
+        info = _sandbox(_entry(adapter_process=_fake_process())).get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert isinstance(info, LocalProcessSandboxInfo)
+        assert info.sandbox_id == "sb-local-1"
+        assert info.status == "RUNNING"
+        assert info.template_id == "openclaw"
+        assert info.is_ready is True
+        assert info.bot_id == "bot-1"
+        assert info.adapter_port == 9001
+        assert info.adapter_pid == 12345
+        assert info.engine_port == 0
+        assert info.engine_pid is None
+        assert info.config_dir == "/tmp/sb-local-1/config"
+        assert info.workspace_dir == "/tmp/sb-local-1/workspace"
+        assert info.resources is None
+        assert info.envs is None
+        assert info.snapshot_id is None
+        assert info.metadata is None
+        assert info.outbound_operation_rule is None
+        assert info.storage is None
+        assert info.ttl_in_minutes is None
+        assert info.ttl_timestamp is None
+
+    def test_engine_port_from_openclaw(self) -> None:
+        entry = _entry(
+            adapter_process=_fake_process(),
+            openclaw_process=_fake_process(),
+            openclaw_port=9200,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.engine_port == 9200
+        assert info.engine_pid == 12345
+
+    def test_engine_port_from_hermes(self) -> None:
+        entry = _entry(
+            adapter_process=_fake_process(),
+            hermes_process=_fake_process(),
+            hermes_port=9300,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.engine_port == 9300
+        assert info.engine_pid == 12345
+
+    def test_missing_adapter_process_pid_none(self) -> None:
+        entry = _entry(
+            adapter_process=None,
+            openclaw_process=None,
+            hermes_process=None,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.adapter_pid is None
+        assert info.engine_pid is None
+
+    def test_repr_includes_local_fields(self) -> None:
+        info = _sandbox(_entry(adapter_process=_fake_process())).get_info()
+        text = repr(info)
+
+        assert "LocalProcessSandboxInfo(" in text
+        assert "sb-local-1" in text
+        assert "9001" in text

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_stub.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_stub.py
@@ -77,6 +77,50 @@ class TestStubArcaSandboxGetInfo:
         info = device.get_info()
         assert info.template_id == "mock-template"
 
+    def test_returns_unified_sandbox_info(self) -> None:
+        from secbaas.community.plugins.sandbox.arca._stub import StubSandboxInfo
+        from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+        device = StubArcaSandbox("sb-unified", template_id="tpl-unified")
+        info = device.get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert isinstance(info, StubSandboxInfo)
+        # Full SDK-aligned surface with optional fields defaulted
+        for attr in (
+            "sandbox_id",
+            "status",
+            "template_id",
+            "resources",
+            "ttl_in_minutes",
+            "ttl_timestamp",
+            "envs",
+            "snapshot_id",
+            "metadata",
+            "outbound_operation_rule",
+            "storage",
+        ):
+            assert hasattr(info, attr)
+        assert info.resources is None
+        assert info.storage is None
+        assert info.outbound_operation_rule is None
+        # status is a plain string; consumer normalize convention works
+        assert (
+            str(info.status.value)
+            if hasattr(info.status, "value")
+            else str(info.status) == "RUNNING"
+        )
+
+    def test_stub_sandbox_info_is_backward_compatible_alias(self) -> None:
+        from secbaas.community.plugins.sandbox.arca._stub import StubSandboxInfo
+        from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+        info = StubSandboxInfo("sb-alias", "tpl-alias")
+        assert isinstance(info, ArcaSandboxInfo)
+        assert info.sandbox_id == "sb-alias"
+        assert info.template_id == "tpl-alias"
+        assert info.status == "RUNNING"
+
 
 class TestStubArcaSandboxDestroy:
     """Test StubArcaSandbox.destroy()."""


### PR DESCRIPTION
## Problem

The Arca sandbox SPI declared `ArcaSandbox.get_info() -> Any`, so each `ArcaSandbox`
implementation produced its own, differently-shaped info object that independently
re-declared the same Arca-SDK-aligned field set:

| Backend | Before |
|---------|--------|
| Enterprise `ArcaSdkSandbox` | anonymous `_ConvertedSandboxInfo` class |
| Community `StubArcaSandbox` | `StubSandboxInfo` |
| Community `LocalProcessArcaSandbox` | `LocalProcessSandboxInfo` |
| Community `LocalDockerArcaSandbox` | plain `dict` |

Consumers (e.g. `ArcaPaasService._get_info_sync`, `ArcaCreationResult` construction) read
the same loose attribute surface (`sandbox_id`, `status`, `template_id`, `resources`,
`ttl_in_minutes`, `ttl_timestamp`, `envs`, `snapshot_id`, `metadata`,
`outbound_operation_rule`, `storage`) from four divergent types. This made the SPI contract
implicit and type-unsafe, and let `local_docker` silently diverge by returning a plain `dict`
that attribute-style consumers could not read.

## Solution

- Introduce a single, community-owned `SandboxInfo` model in
  `secbaas.community.spi.sandbox.arca`, mirroring the Arca SDK `SyncSandbox.get_info()`
  surface.
- Type `ArcaSandbox.get_info() -> SandboxInfo` in the SPI protocol.
- Migrate all four Arca backends to return the unified model, preserving the SDK-to-project
  conversions (enterprise) and backend-specific extra fields as optional attributes
  (stub, local-proc, local-docker).
- Retain the prior per-backend info types (`StubSandboxInfo`, `LocalProcessSandboxInfo`) as
  backward-compatible subclasses so existing imports and `isinstance` checks keep working.
- Add contract + branch coverage for the `get_info` paths, targeted at ≥90% change coverage
  across the enterprise SDK, stub, local-process, and local-docker backends.

## Validation

- Community sandbox + SPI suite: **650 passed, 3 skipped**.
- Enterprise `src/baas` arca unit + contract tests: **193 passed** (run against the
  frozen-synced env; the `just test` bootstrap hits a pre-existing, unrelated workspace
  `aiofiles` dependency-resolution conflict).
- ruff check + format clean on all changed files.
- Coverage: model and stub 100%; enterprise `_arca_sdk` ~92% branch; local-proc and
  local-docker `get_info` paths fully covered.

## Compatibility and risk

- Backward-compatible: `StubSandboxInfo` / `LocalProcessSandboxInfo` are retained as
  subclasses of the unified model; the previously-returned attribute surface is preserved.
- The enterprise `ArcaSdkSandbox` conversion keeps all existing fields; `sandbox_id` /
  `status` / `template_id` etc. are unchanged at the `ArcaPaasService` boundary.
- No schema, config, or migration impact. The commit in the main `ocb` repo
  (`feat(baas): return unified sandbox info model from enterprise Arca SDK`) is the matching
  enterprise-side change; this community PR must land with it.

## Related issues

- Closes https://github.com/inclusionAI/Avernet/issues/964