### PR TITLE
fix(bcs-system-message): source 目标 from input/context/label, drop 协作任务 default

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
@@ -168,10 +168,12 @@ pub async fn post_invocation(
                 let gid = group_id.clone();
                 let sid = outcome.session.id.clone();
                 let session_participants = outcome.session.participants.clone();
-                let reason = group
-                    .label
-                    .clone()
-                    .unwrap_or_else(|| "协作任务".to_string());
+                let reason = bcs_service_api::resolve_session_topic(
+                    session_input.as_ref(),
+                    group.context.as_deref(),
+                    group.label.as_deref(),
+                )
+                .unwrap_or_default();
                 let _task = tokio::spawn(async move {
                     let _ = notify
                         .notify(

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/sessions.rs
@@ -597,10 +597,12 @@ pub async fn create_session_for_group(
                 let session_input = sess.input.clone();
                 let session_participants = sess.participants.clone();
                 let driver_delivery = body.group_context_delivery;
-                let reason = group
-                    .label
-                    .clone()
-                    .unwrap_or_else(|| "协作任务".to_string());
+                let reason = bcs_service_api::resolve_session_topic(
+                    session_input.as_ref(),
+                    group.context.as_deref(),
+                    group.label.as_deref(),
+                )
+                .unwrap_or_default();
                 let _task = tokio::spawn(async move {
                     let _ = notify
                         .notify(
@@ -877,7 +879,45 @@ pub async fn list_sessions_for_group(
                     .create_or_reactivate(cmd)
                     .await
                 {
-                    Ok(outcome) => vec![session_to_json(&outcome.session)],
+                    Ok(outcome) => {
+                        let items = vec![session_to_json(&outcome.session)];
+                        // A new legacy session was materialized for a sessionless
+                        // group; emit the session-context system message so bots
+                        // receive their `<GroupContext>` injection, mirroring the
+                        // create-session path. Skipped when the legacy row already
+                        // existed (`created == false`, a reactivation).
+                        if outcome.created {
+                            let notify = state.services.system_message.clone();
+                            let gid = group_id.clone();
+                            let sid = legacy_sid.clone();
+                            let session_input = outcome.session.input.clone();
+                            let session_participants = outcome.session.participants.clone();
+                            let reason = bcs_service_api::resolve_session_topic(
+                                session_input.as_ref(),
+                                group.context.as_deref(),
+                                group.label.as_deref(),
+                            )
+                            .unwrap_or_default();
+                            let _task = tokio::spawn(async move {
+                                let _ = notify
+                                    .notify(
+                                        &gid,
+                                        SystemMessageEvent::SessionContext {
+                                            group_id: gid.clone(),
+                                            session_id: sid.clone(),
+                                            reason,
+                                            session_input,
+                                            task_ledger: None,
+                                            driver_delivery: None,
+                                        },
+                                        &sid,
+                                        &session_participants,
+                                    )
+                                    .await;
+                            });
+                        }
+                        items
+                    }
                     Err(e) => {
                         tracing::warn!(
                             group_id = %group_id,
@@ -1246,6 +1286,7 @@ pub async fn add_session_participant(
                 group_id: sess.group_id.clone(),
                 actor: participant.into(),
                 session_id: sid.clone(),
+                session_input: s.input.clone(),
             };
             let _ = state
                 .services

--- a/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/system_message.rs
@@ -14,6 +14,10 @@ pub enum SystemMessageEvent {
         /// serialized events deserializable.
         #[serde(default)]
         session_id: String,
+        /// Session input (the task/goal) used to populate the `目标` line of the
+        /// join context message when non-empty. `#[serde(default)]` for old data.
+        #[serde(default)]
+        session_input: Option<serde_json::Value>,
     },
     BotLeft {
         group_id: String,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/system_message.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/system_message.rs
@@ -15,3 +15,66 @@ pub trait SystemMessageService: Send + Sync {
         session_participants: &[Participant],
     ) -> ServiceResult<usize>;
 }
+
+/// Resolves the `目标` (topic/reason) line for a session-context system message
+/// from the first non-empty of: the session `input` (when it is a text value),
+/// the group `context`, or the group `label`. Returns `None` when all are
+/// empty/absent, in which case the `目标` line is omitted. Non-string input
+/// values (objects/arrays) are ignored, falling through to `context`/`label`.
+pub fn resolve_session_topic(
+    input: Option<&serde_json::Value>,
+    context: Option<&str>,
+    label: Option<&str>,
+) -> Option<String> {
+    input
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .or_else(|| context.filter(|s| !s.is_empty()))
+        .or_else(|| label.filter(|s| !s.is_empty()))
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_session_topic;
+    use serde_json::json;
+
+    #[test]
+    fn resolve_session_topic_prefers_input() {
+        assert_eq!(
+            resolve_session_topic(Some(&json!("input goal")), Some("ctx"), Some("lbl")),
+            Some("input goal".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_session_topic_falls_back_to_context() {
+        assert_eq!(
+            resolve_session_topic(None, Some("ctx"), Some("lbl")),
+            Some("ctx".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_session_topic_falls_back_to_label() {
+        assert_eq!(
+            resolve_session_topic(None, None, Some("lbl")),
+            Some("lbl".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_session_topic_none_when_all_empty() {
+        assert_eq!(resolve_session_topic(None, None, None), None);
+        // empty strings are treated as absent
+        assert_eq!(
+            resolve_session_topic(Some(&json!("")), Some(""), Some("")),
+            None
+        );
+        // non-string input value is ignored, falls through to label
+        assert_eq!(
+            resolve_session_topic(Some(&json!({"q": 1})), None, Some("lbl")),
+            Some("lbl".to_string())
+        );
+    }
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -31,6 +31,7 @@ pub use actors::{
     WorkerRecommendCommand, WorkerRecommendResult, WorkerRecommendation,
 };
 pub use application::SystemMessageService;
+pub use application::system_message::resolve_session_topic;
 pub use application::channel::{
     ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
     CreateBindingCommand, InboundMessage, OutboundMessage,

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -344,10 +344,12 @@ impl BcsChannelService {
             )
             .await?;
         if ctx.context_projection == "group" {
-            let reason = group
-                .label
-                .clone()
-                .unwrap_or_else(|| "协作任务".to_string());
+            // bcs-channel's session reason is the group's label (purpose); its
+            // `session.input` is the inbound chat message and `group.context`
+            // is not used as the reason here, so input/context are passed as
+            // None. Empty label → no `目标` line.
+            let reason = bcs_service_api::resolve_session_topic(None, None, group.label.as_deref())
+                .unwrap_or_default();
             match self
                 .system_message
                 .notify(

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -1059,10 +1059,6 @@ impl GroupManagementService for GroupManagement {
                 .await;
         }
 
-        let topic = cmd
-            .topic
-            .as_deref()
-            .unwrap_or_else(|| group.label.as_deref().unwrap_or(""));
         let initial_session_kind = match requested_strategy {
             GroupStrategy::StateMachine => SessionKind::ServiceInvocation,
             GroupStrategy::Chat | GroupStrategy::ManagerWorker => SessionKind::Chat,
@@ -1089,6 +1085,16 @@ impl GroupManagementService for GroupManagement {
             participant.mode = Some(ParticipantMode::Present);
             initial_session_participants.push(participant);
         }
+        // `目标` (reason) sourcing mirrors the create-session HTTP path:
+        // session input (as text) → group.context → group.label, empty when
+        // all are absent (the `目标` line is then omitted). Computed before the
+        // create call because `initial_session_input` is moved into it below.
+        let reason = bcs_service_api::resolve_session_topic(
+            initial_session_input.as_ref(),
+            group.context.as_deref(),
+            group.label.as_deref(),
+        )
+        .unwrap_or_default();
         let initial_session_id;
         let context_injected = match self
             .session_management
@@ -1122,7 +1128,6 @@ impl GroupManagementService for GroupManagement {
                     let sid = outcome.session.id.clone();
                     let gid = group.id.clone();
                     let session_participants = outcome.session.participants.clone();
-                    let reason = topic.to_string();
                     self.system_message
                         .notify(
                             &gid,

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -1557,6 +1557,7 @@ mod tests {
             group_id: group_id.to_string(),
             actor: Participant::bot(&new_bot_id, ParticipantRole::Consultant),
             session_id: session_id.clone(),
+            session_input: None,
         };
         dispatcher
             .dispatch(event, &group_fixture(group_id, &existing_id), &session_id, &participants)

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -247,6 +247,7 @@ async fn dispatch_bot_joined_delivers_to_all_participants() {
             mode: Some(ParticipantMode::Auto),
         },
         session_id: "session-test".to_string(),
+        session_input: None,
     };
 
     let registry = Arc::new(ProviderTargetRegistry::default());
@@ -327,6 +328,7 @@ async fn dispatch_bot_joined_persists_per_recipient_and_ws_shows_notification_on
             mode: Some(ParticipantMode::Auto),
         },
         session_id: "session-test".to_string(),
+        session_input: None,
     };
 
     let registry = Arc::new(ProviderTargetRegistry::default());

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined.rs
@@ -55,6 +55,7 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         let SystemMessageEvent::BotJoined {
             actor,
             session_id,
+            session_input,
             ..
         } = event
         else {
@@ -62,6 +63,13 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
         };
 
         let new_bot_uuid = actor.bot_uuid.clone();
+        // `目标` (topic) sourcing: session input → group.context → group.label,
+        // empty when all are absent (the `目标` line is then omitted).
+        let topic = bcs_service_api::resolve_session_topic(
+            session_input.as_ref(),
+            group.context.as_deref(),
+            group.label.as_deref(),
+        );
         let mut messages = Vec::new();
 
         // 1. Full context injection to the newly joined bot (personalized,
@@ -71,6 +79,7 @@ impl SystemMessageProducerService for BotJoinedMessageProducer {
             participants,
             &new_bot_uuid,
             session_id,
+            topic.as_deref(),
             registry,
             &*self.history,
         )
@@ -155,13 +164,16 @@ fn truncate_utf8(s: &str, max_chars: usize) -> String {
 ///
 /// Mirrors the unified `<GroupContext>` block used by the session-context
 /// producer, with a `你已加入` opening and a trailing `## 群历史消息` section.
-/// The `BotJoined` event carries no session/reason/task, so `## 群聊信息`
-/// omits `会话ID`/`目标` and there is no `## 任务说明` section.
+/// `会话ID` comes from the `BotJoined` event; `目标` is sourced from the
+/// session input → group.context → group.label, omitted when all are empty.
+/// There is no `## 任务说明` section (the joining bot is not re-injected with
+/// the original task).
 async fn build_context_injection_message(
     group: &Group,
     participants: &[Participant],
     new_bot_uuid: &str,
     session_id: &str,
+    topic: Option<&str>,
     registry: &dyn BotRegistryCoreService,
     history: &dyn GroupMessageHistoryService,
 ) -> String {
@@ -202,7 +214,7 @@ async fn build_context_injection_message(
     let history_messages = fetch_history(group, session_id, participants, history).await;
 
     let sections = vec![
-        group_info_section(&render_group, None, None, &recipient, mode),
+        group_info_section(&render_group, Some(session_id), topic, &recipient, mode),
         format!("## 参与者:\n{}", participant_table(&render_group)),
         format!(
             "## 工具说明 ({})\n{}",

--- a/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/bot_joined_test.rs
@@ -178,6 +178,7 @@ async fn bot_joined_produces_context_injection_and_notification() {
         group_id: "group-1".to_string(),
         actor: new_bot,
         session_id: "group-1:session".to_string(),
+        session_input: None,
     };
 
     let (messages, user_message) = producer.produce(&event, &group, &registry, &group.participants).await;
@@ -278,6 +279,7 @@ async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
         group_id: "group-1".to_string(),
         actor: new_bot.clone(),
         session_id: "group-1:session".to_string(),
+        session_input: None,
     };
 
     let (messages, user_message) = producer.produce(&event, &group, &registry, &[driver, new_bot]).await;
@@ -293,4 +295,5 @@ async fn bot_joined_emits_user_message_even_when_only_new_bot_present() {
         Some("NewBot(new-bot-id) 已加入协作群 - 能力集: {name: \"coding\"}")
     );
 }
+
 

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -185,7 +185,13 @@ fn initial_group_context_message(
     };
 
     let sections = vec![
-        group_info_section(group, Some(session_id), Some(topic), recipient, "自由聊天"),
+        group_info_section(
+            group,
+            Some(session_id),
+            Some(topic).filter(|t| !t.is_empty()),
+            recipient,
+            "自由聊天",
+        ),
         format!("## 参与者:\n{}", participant_table(group)),
         format!(
             "## 工具说明 ({})\n{}",
@@ -227,7 +233,13 @@ fn manager_worker_initial_message(
     let task = if is_manager { task_input } else { None };
 
     let sections = vec![
-        group_info_section(group, Some(session_id), Some(topic), recipient, "manager_worker"),
+        group_info_section(
+            group,
+            Some(session_id),
+            Some(topic).filter(|t| !t.is_empty()),
+            recipient,
+            "manager_worker",
+        ),
         format!("## 参与者:\n{}", participant_table(group)),
         skill_section(),
         task_section(task),


### PR DESCRIPTION
## Problem

The `目标` (topic/reason) line of the `<GroupContext>` system message is sourced inconsistently across the producers that build it. Three construction sites defaulted the reason to the hard-coded string `"协作任务"` when nothing else was available; `bcs-channel` used `group.label` directly (which carries the `"Group: "` prefix); `create_group`'s auto-created session took `reason` straight from `cmd.topic`; and `list_sessions_for_group`'s legacy auto-create path materialized a session for a sessionless group without emitting any `SessionContext` system message, so bots never received their `<GroupContext>` injection in that case.

## Solution

Unify `目标` sourcing to `input → group.context → group.label → empty`, and omit the `目标` line entirely when all sources are empty. The `"协作任务"` default is removed, and session-creation paths now consistently fire the `SessionContext` system message.

- **`session_context.rs`**: `group_info_section` treats an empty `topic` as `None`, so the `目标` line is omitted when empty (applies to every construction path).
- **`http/sessions.rs`** (`CreateSessionRequest`) and **`http/services.rs`**: `reason = input(as str) → group.context → group.label → ""`.
- **`bcs-channel/lib.rs`**: `session.input` is the inbound chat message (not a goal) and existing semantics use `group.label` (a test that sets both `context` and `label` expects `label`), so only the `"协作任务"` default is dropped here; `label` remains the source.
- **`BotJoined` event** gains `session_id` + `session_input` fields, populated at the HTTP call site from the joined session; `bot_joined` now computes `topic` via `input → context → label`, fills the previously-omitted `会话ID` line, and fetches session-scoped history via `get_session_history` (replacing the deprecated `get_history`).
- **`management.rs` (`create_group`)**: the auto-created initial session's `reason` now follows `input → context → label → empty` instead of `cmd.topic` directly, matching the create-session HTTP path.
- **`list_sessions_for_group` (legacy auto-create)**: when a legacy session is newly created for a sessionless group (`outcome.created`), fire the `SessionContext` system message (async `tokio::spawn` notify, not blocking the list response); `reactivation` of an existing legacy row is skipped.
- Test construction sites (`dispatcher_test`, `bot_joined_test`, `bcs-message` lib) updated.

The `proposal.rs` path (`proposal.reason`) has no `"协作任务"` default and was left unchanged.

## Validation

- `cargo build --workspace`: no warnings, no errors.
- `cargo test` for `bcs-system-message` / `bcs-message` / `bcs-http` / `bcs-channel` / `bcs-group` / `bcs-proposal` / `bcs-ws` / `bcs-rule-bot`: all green.
- Spot-checked `BotJoined` `目标` sourcing across three cases: input present → from input; input empty + context present → from context; all empty → `目标` omitted (会话ID still shown).