### PR TITLE
fix(backend): stop reactivation rollback from stranding RECYCLED bots

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_dormant/activate_service.py
@@ -7,21 +7,35 @@ Flow:
   4. RECYCLED      → update_status(REACTIVATING) + spawn background thread
                       that calls passport unfreeze, verifies the runtime token,
                       then starts the bot;
-                      on failure rolls back: passport freeze + RECYCLED.
+                      on failure rolls back to RECYCLED, and re-freezes the
+                      passport only when the unfreeze itself is not the step
+                      that must survive for the next attempt (see
+                      ``_reactivate_async``).
 """
 from __future__ import annotations
 
 import threading
+import time
 
 from injector import inject
 
 from agentclaw.community.core.bot_dormant.protocols import BotServiceProtocol
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.passport import PassportError, PassportPlugin
+from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 
 
 logger = get_logger()
+
+# ``unfreeze_agent_passport`` brings the credential online, but the runtime
+# token only becomes queryable once that change has propagated through the
+# passport provider. The plugin protocol asks implementations to return after
+# that postcondition holds; providers that resolve it asynchronously make the
+# first ``query_token`` race the propagation. Poll instead of trusting a single
+# read: the caller already returned REACTIVATING, so this wait is off the
+# request path.
+TOKEN_VERIFY_ATTEMPTS = 5
+TOKEN_VERIFY_BACKOFF_SECONDS = (1.0, 2.0, 4.0, 8.0)
 
 
 class InvalidBotStateError(Exception):
@@ -127,23 +141,31 @@ class ActivateBotService:
             )
             return
 
+        token = self._verify_token(bot_id=bot_id, user_id=user_id)
+        if not token:
+            # The credential is online — only the token read failed. Re-freezing
+            # here would undo the one step that succeeded and hand the next
+            # attempt the same cold start, turning a propagation delay into a
+            # bot that can never be activated no matter how often the user
+            # retries. Leave it online so a retry resumes from settled state;
+            # this is the same state the ops ``unfreeze-passport-one`` endpoint
+            # produces deliberately. Cost: a RECYCLED bot is never re-scanned
+            # (filter_candidates takes ACTIVE only), so nothing re-freezes this
+            # credential automatically — grep the marker below to reconcile.
+            logger.error(
+                "[activate] passport token unavailable after %d attempts, "
+                "leaving credential online for retry "
+                "event=token_verify_exhausted bot_id=%s user_id=%s",
+                TOKEN_VERIFY_ATTEMPTS,
+                bot_id,
+                user_id,
+            )
+            self._bot_service.update_status(
+                bot_id=bot_id, user_id=user_id, status="RECYCLED"
+            )
+            return
+
         try:
-            logger.info(
-                "[activate] passport token verify start bot_id=%s user_id=%s",
-                bot_id,
-                user_id,
-            )
-            token = self._passport.query_token(
-                bot_id=bot_id,
-                owner_workno=user_id,
-            )
-            if not token:
-                raise PassportError("passport token is unavailable after unfreeze")
-            logger.info(
-                "[activate] passport token verify success bot_id=%s user_id=%s",
-                bot_id,
-                user_id,
-            )
             # start_bot internally calls apply_device; on success sets status=ACTIVE.
             logger.info(
                 "[activate] start_bot start bot_id=%s user_id=%s nick_name=%s",
@@ -180,3 +202,48 @@ class ActivateBotService:
             self._bot_service.update_status(
                 bot_id=bot_id, user_id=user_id, status="RECYCLED"
             )
+
+    def _verify_token(self, *, bot_id: str, user_id: str) -> str | None:
+        """Poll ``query_token`` until the unfrozen credential yields a token.
+
+        Returns the token, or None once every attempt is exhausted. A raising
+        provider is treated the same as an empty answer — both mean "not usable
+        yet", and only the final outcome decides whether the bot starts.
+        """
+        logger.info(
+            "[activate] passport token verify start bot_id=%s user_id=%s attempts=%d",
+            bot_id,
+            user_id,
+            TOKEN_VERIFY_ATTEMPTS,
+        )
+        for attempt in range(1, TOKEN_VERIFY_ATTEMPTS + 1):
+            try:
+                token = self._passport.query_token(
+                    bot_id=bot_id,
+                    owner_workno=user_id,
+                )
+            except Exception as e:
+                token = None
+                logger.warning(
+                    "[activate] passport token query raised "
+                    "bot_id=%s user_id=%s attempt=%d/%d: %s",
+                    bot_id, user_id, attempt, TOKEN_VERIFY_ATTEMPTS, e,
+                )
+            if token:
+                logger.info(
+                    "[activate] passport token verify success "
+                    "bot_id=%s user_id=%s attempt=%d",
+                    bot_id, user_id, attempt,
+                )
+                return token
+            if attempt < TOKEN_VERIFY_ATTEMPTS:
+                delay = TOKEN_VERIFY_BACKOFF_SECONDS[
+                    min(attempt - 1, len(TOKEN_VERIFY_BACKOFF_SECONDS) - 1)
+                ]
+                logger.info(
+                    "[activate] passport token not ready, retrying "
+                    "bot_id=%s user_id=%s attempt=%d/%d delay=%.1fs",
+                    bot_id, user_id, attempt, TOKEN_VERIFY_ATTEMPTS, delay,
+                )
+                time.sleep(delay)
+        return None

--- a/src/backend/tests/community/core/bot_dormant/test_activate.py
+++ b/src/backend/tests/community/core/bot_dormant/test_activate.py
@@ -1,23 +1,33 @@
 """Tests for ActivateBotService (Task 6).
 
-Six scenarios:
+Scenarios:
   1. reject_active_bot          — ACTIVE → InvalidBotStateError
   2. reactivating_friendly      — REACTIVATING → friendly dict (no update_status call)
   3. recycled_kicks_async       — RECYCLED → update_status(REACTIVATING) + start_bot called
   4. rollback_on_passport_error — passport unfreeze raises → status=RECYCLED,
                                    start_bot NOT called
   5. rollback_on_start_bot_fail — start_bot raises → passport freeze + status=RECYCLED
-  6. missing_token_after_unfreeze — token absent → freeze + RECYCLED before start
+  6. missing_token_after_unfreeze — token never queryable → RECYCLED before start,
+                                   passport left online so a retry can converge
+  7. token_settles_on_retry     — token empty then present → bot starts, no freeze
 """
 from unittest.mock import MagicMock
 
 import pytest
 
+from agentclaw.community.core.bot_dormant import activate_service
 from agentclaw.community.core.bot_dormant.activate_service import (
+    TOKEN_VERIFY_ATTEMPTS,
     ActivateBotService,
     BotNotFoundError,
     InvalidBotStateError,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_token_verify_sleep(monkeypatch):
+    """Collapse the token-verify backoff so tests exercise it without waiting."""
+    monkeypatch.setattr(activate_service.time, "sleep", lambda _seconds: None)
 
 
 def test_activate_reports_missing_bot_through_dormant_contract():
@@ -204,17 +214,47 @@ def test_missing_token_after_unfreeze_rolls_back_before_start(monkeypatch):
 
     result = svc.activate(bot_id="b1", user_id="u1")
 
-    passport_mock.query_token.assert_called_once_with(
+    # Every attempt is spent before the bot is declared un-startable.
+    assert passport_mock.query_token.call_count == TOKEN_VERIFY_ATTEMPTS
+    passport_mock.query_token.assert_called_with(
         bot_id="b1",
         owner_workno="u1",
     )
     bot_service.start_bot.assert_not_called()
-    passport_mock.freeze_agent_passport.assert_called_once_with(
-        bot_id="b1",
-        owner_workno="u1",
-        reason="reactivate rollback",
-    )
+    # The credential stays online: re-freezing would reset the next attempt to
+    # the same cold start and strand the bot in RECYCLED forever.
+    passport_mock.freeze_agent_passport.assert_not_called()
     bot_service.update_status.assert_called_with(
         bot_id="b1", user_id="u1", status="RECYCLED"
     )
     assert result["status"] == "REACTIVATING"
+
+
+def test_token_settling_after_unfreeze_starts_the_bot(monkeypatch):
+    """A token that only becomes queryable on a later read still activates."""
+    passport_mock = MagicMock()
+    passport_mock.unfreeze_agent_passport.return_value = None
+    # First read races the unfreeze propagation, second one raises, third wins.
+    passport_mock.query_token.side_effect = [
+        None,
+        RuntimeError("passport gateway timeout"),
+        "token-b1",
+    ]
+
+    svc, bot_service = _make_svc_with_passport("RECYCLED", passport_mock)
+    monkeypatch.setattr(
+        "agentclaw.community.core.bot_dormant.activate_service.threading.Thread",
+        _SyncThread,
+    )
+
+    svc.activate(bot_id="b1", user_id="u1")
+
+    assert passport_mock.query_token.call_count == 3
+    bot_service.start_bot.assert_called_once_with(
+        bot_id="b1", user_id="u1", nick_name="u1"
+    )
+    passport_mock.freeze_agent_passport.assert_not_called()
+    # No rollback: the last status write is the synchronous REACTIVATING one.
+    bot_service.update_status.assert_called_once_with(
+        bot_id="b1", user_id="u1", status="REACTIVATING"
+    )


### PR DESCRIPTION
## Problem

A user whose dormant `default` bot had been recycled could not get past step 5
of bot initialization. Every "重新唤醒Bot" click produced the same backend log
chain, repeated at 16:36 / 16:39 / 16:44 / 16:48 / 16:58:

```
activate → status RECYCLED → update to REACTIVATING   ✅
passport unfreeze → success                            ✅
passport token verify → start                          ✅
passport rollback freeze → success                     ⚠️   ← no "verify success"
bot_service.update_status → RECYCLED                   ⚠️
```

The chain ends in the rollback with no `token verify success` in between, so
the failure was inside the token check in `ActivateBotService._reactivate_async`.

`unfreeze_agent_passport` brings the credential online, but the runtime token
only becomes queryable once that change has propagated through the passport
provider. `PassportPlugin.unfreeze_agent_passport` asks implementations to
return only after that postcondition holds; a provider that resolves it
asynchronously leaves the immediate `query_token` racing the propagation. The
code read the token exactly once, with no retry and no settle window.

Losing that race was recoverable in principle. What made it permanent was the
rollback: it re-froze the passport, undoing the one step that had succeeded. The
next attempt therefore started from the same cold credential and lost the same
race, which is why five retries over 22 minutes produced five identical traces.
A propagation delay became a bot that could never be activated, and the owner
was left on an infinite loading state on first use of the product.

## Solution

Two changes in `activate_service.py`:

1. **Poll instead of trusting a single read.** `_verify_token` calls
   `query_token` up to `TOKEN_VERIFY_ATTEMPTS` (5) times with 1/2/4/8s backoff,
   about 15s total. A raising provider is treated the same as an empty answer —
   both mean "not usable yet" — and only the final outcome decides whether the
   bot starts. The wait costs nothing on the request path: `activate` has
   already returned `REACTIVATING` and this runs in the background thread.

2. **Do not re-freeze when only the token read failed.** On exhaustion the
   status still rolls back to `RECYCLED`, but the credential is left online so
   the next attempt resumes from settled state rather than repeating the cold
   start. The `start_bot` failure path keeps its existing freeze rollback —
   that failure is not evidence about the credential, and the bot genuinely did
   not start.

Rejected: re-freezing on exhaustion but retrying more aggressively. It keeps the
trap intact — however wide the window, a lost race still resets the credential
and dooms the next attempt.

## Validation

- `tests/community/core/bot_dormant/test_activate.py` — 8 passed. Updated
  `test_missing_token_after_unfreeze_rolls_back_before_start` to assert all
  attempts are spent and that `freeze_agent_passport` is **not** called; added
  `test_token_settling_after_unfreeze_starts_the_bot`, covering an empty first
  read, a raising second read, and a successful third that starts the bot with
  no rollback. An autouse fixture stubs `time.sleep`, so the backoff path is
  exercised without the wall-clock cost.
- `tests/community/core/bot_dormant`, `tests/community/endpoints/test_bot_dormant_ops_router.py`,
  `tests/community/di/test_bot_dormant_module_wiring.py` — 158 passed.
- `ruff check` on the changed files — clean.
- Not run: the acceptance E2E (`test_dormant_lifecycle.py`) needs a live backend,
  unavailable in this environment. It drives the same public
  `POST /api/bots/{bot_id}/activate` path and should be run before merge.

## Compatibility and risk

No contract, schema, or config change; no new endpoint, so
`singlebox_coverage_modules.yaml` is untouched. The API response and the
observable status transitions are unchanged.

One deliberate trade-off: after an exhausted token verify, the passport stays
online while the bot sits in `RECYCLED`. Nothing re-freezes it automatically,
because `filter_candidates` only ever selects `ACTIVE` bots, so the dormant scan
will not revisit this row. This is the same state the ops
`POST /api/internal/dormant/unfreeze-passport-one` endpoint produces on purpose,
and it is what lets a retry converge. The terminal log line carries
`event=token_verify_exhausted` so the affected bots can be listed and
reconciled; the alternative — keeping the re-freeze — is what caused this bug.

Rollback path: revert the commit. Behavior returns to a single token read with
a re-freezing rollback.

## Related issues

Backend issue: 首次打开 TeamClaw，Bot 初始化卡在第 5 步「等待Bot就绪」
(bot_id=default, user_id=424949).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVirEFxsYLjFQA8FGhG77r)_