### PR TITLE
feat(expert-chat): support multiple sessions per bot

### DIFF
--- a/scripts/ci/singlebox_coverage_modules.yaml
+++ b/scripts/ci/singlebox_coverage_modules.yaml
@@ -199,6 +199,10 @@ modules:
         - DELETE /api/v1/expert-chats/{bot_id}/{owner_id}
         - POST /api/v1/expert-chats/{bot_id}/{owner_id}/session
         - DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/session
+        - GET /api/v1/expert-chats/{bot_id}/{owner_id}/sessions
+        - POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions
+        - POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions/connect
+        - DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/sessions
         - POST /api/v1/expert-chats/caller-connection
     plugin_api:
       status: not_applicable

--- a/src/backend/specs/2026-08-10-expert-chat-multi-session/api.md
+++ b/src/backend/specs/2026-08-10-expert-chat-multi-session/api.md
@@ -30,7 +30,7 @@ Backend 接口统一前缀：
 
 ## 2. 发布前置
 
-1. 执行同目录下的 `ddl.sql`，创建 `ac_expert_chat_sessions` 表。
+1. 执行同目录下的 `ddl.sql`，创建 `ac_expert_chat_owned_sessions` 表。
 2. 发布 Backend。
 3. Adapter 无需随本需求升级，本实现复用现有 `/api/sessions` 和
    `/api/session-favorites` 接口。

--- a/src/backend/specs/2026-08-10-expert-chat-multi-session/api.md
+++ b/src/backend/specs/2026-08-10-expert-chat-multi-session/api.md
@@ -1,0 +1,416 @@
+# 我的互动多会话前端接入说明
+
+## 1. 功能范围
+
+本次改造支持同一个登录用户与同一个公开 Bot 创建和管理多个会话。
+
+- Backend 新增多会话列表、新建、连接和删除接口。
+- 搜索只支持按完整 `session_key` 精确查询。
+- “全部”和“已收藏”列表均由新的 Backend 会话列表接口提供。
+- 收藏和取消收藏继续复用现有 Engine Proxy 接口。
+- 消息历史加载、WebSocket 连接和消息发送继续沿用现有聊天链路。
+- OpenClaw、Hermes、AI Coding、Claude Code 在本次支持范围内。
+- Teclaw 不在本次需求范围内。
+
+Backend 接口统一前缀：
+
+```text
+/api/v1/expert-chats/{bot_id}/{owner_id}
+```
+
+路径参数：
+
+| 参数 | 说明 |
+| --- | --- |
+| `bot_id` | 当前 Bot ID |
+| `owner_id` | Bot 所有者工号，不一定是当前登录用户 |
+
+当前用户身份由 Backend 从登录态获取，多会话 Backend 接口不接受前端传入
+`user_id` 覆盖当前用户身份。
+
+## 2. 发布前置
+
+1. 执行同目录下的 `ddl.sql`，创建 `ac_expert_chat_sessions` 表。
+2. 发布 Backend。
+3. Adapter 无需随本需求升级，本实现复用现有 `/api/sessions` 和
+   `/api/session-favorites` 接口。
+
+旧版前端继续调用单数 `/session` 接口时，行为保持不变。Backend 会将旧接口
+当前使用的 session key 自动登记到新表，因此新旧前端可以并行使用。
+
+## 3. 查询会话列表
+
+```http
+GET /api/v1/expert-chats/{bot_id}/{owner_id}/sessions
+```
+
+### 3.1 查询参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `session_key` | 否 | - | 按完整 session key 精确查询，长度不超过 255 |
+| `favorite_only` | 否 | `false` | `true` 时只返回已收藏会话 |
+| `limit` | 否 | `20` | 每页数量，范围 1～100 |
+| `offset` | 否 | `0` | 分页偏移量，必须大于或等于 0 |
+
+查询全部会话：
+
+```http
+GET /api/v1/expert-chats/20260807_ks811fu2/165137/sessions?limit=20&offset=0
+```
+
+按 session key 精确搜索：
+
+```http
+GET /api/v1/expert-chats/20260807_ks811fu2/165137/sessions?session_key=agent%3Amain%3Asession%3Axxx%3Auser%3A165137
+```
+
+查询已收藏会话：
+
+```http
+GET /api/v1/expert-chats/20260807_ks811fu2/165137/sessions?favorite_only=true&limit=20&offset=0
+```
+
+`session_key` 作为 query 参数时，应交给请求库进行 URL 编码，不要修改、截断或
+按引擎类型转换原始值。
+
+### 3.2 成功响应
+
+```json
+{
+  "success": true,
+  "message": "获取成功",
+  "error_code": 0,
+  "data": {
+    "total": 2,
+    "items": [
+      {
+        "id": "agent:main:session:2d20edc1:user:165137",
+        "title": "代码审计与优化",
+        "user_id": "165137",
+        "agent_id": "20260807_ks811fu2",
+        "model": "claude-sonnet-4-5",
+        "permission_mode": "default",
+        "cwd": "/home/admin/workspace",
+        "gmt_created": "2026-08-10T10:00:00Z",
+        "gmt_modified": "2026-08-10T10:30:00Z",
+        "message_count": 8,
+        "runtime": "openclaw",
+        "last_message": {
+          "id": "message-001",
+          "session_id": "agent:main:session:2d20edc1:user:165137",
+          "role": "assistant",
+          "content": "审计完成，发现两个可优化点。",
+          "metadata": {
+            "model": "claude-sonnet-4-5"
+          },
+          "gmt_created": "2026-08-10T10:30:00Z",
+          "history_meta": {
+            "summary": "会话摘要"
+          }
+        },
+        "ext_info": {
+          "source": "web"
+        }
+      }
+    ]
+  }
+}
+```
+
+字段说明：
+
+| 字段 | 说明 |
+| --- | --- |
+| `data.total` | 当前筛选条件下的会话总数，不是当前页数量 |
+| `data.items[].id` | 原始 session key，后续连接、删除和收藏操作均以此为准 |
+| `title` | 会话标题 |
+| `user_id` | 会话所属用户 |
+| `agent_id` | 会话所属 Bot/Agent |
+| `model` | 会话模型，可能为 `null` |
+| `permission_mode` | 权限模式，可能为 `null` |
+| `cwd` | 会话工作目录，可能为 `null` |
+| `gmt_created` | 会话创建时间 |
+| `gmt_modified` | 会话最近更新时间，用于列表倒序展示 |
+| `message_count` | 消息数量 |
+| `runtime` | 引擎类型，仅在引擎返回时存在 |
+| `last_message` | 最后一条消息，无消息或引擎不可用时为 `null` |
+| `ext_info` | 引擎扩展信息，仅在引擎返回时存在 |
+
+不同引擎返回的扩展字段可能不同。前端应依赖上述公共字段进行列表渲染，并允许
+`runtime`、`ext_info`、`last_message` 的扩展字段缺失。
+
+### 3.3 容器不可用时的占位数据
+
+当 Backend 中仍存在合法会话归属，但容器正在启动或 Adapter 暂不可用时，
+会话不会从列表中消失，而是返回字段完整的占位数据：
+
+```json
+{
+  "id": "agent:main:session:xxx:user:165137",
+  "title": "新会话",
+  "user_id": "165137",
+  "agent_id": "20260807_ks811fu2",
+  "model": null,
+  "permission_mode": null,
+  "cwd": null,
+  "gmt_created": "2026-08-10T10:00:00Z",
+  "gmt_modified": "2026-08-10T10:00:00Z",
+  "message_count": 0,
+  "last_message": null
+}
+```
+
+前端不要因为收到占位数据而删除本地会话。后续重新查询时，Backend 会继续尝试
+从 Adapter 补齐会话元数据。
+
+当 Caller 独立容器仍在启动时，列表响应的 `data` 中还可能包含：
+
+```json
+{
+  "total": 2,
+  "items": [],
+  "need_poll": true
+}
+```
+
+此时前端应沿用现有 Bot 启动轮询逻辑。
+
+## 4. 新建会话
+
+```http
+POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions
+```
+
+无需请求体。每次调用都会创建一个全新的会话，不会删除或覆盖之前的会话；新会话
+同时会成为旧版单会话接口的默认会话。
+
+### 4.1 成功响应
+
+```json
+{
+  "success": true,
+  "message": "创建成功",
+  "error_code": 0,
+  "data": {
+    "session_key": "agent:main:session:xxx:user:165137",
+    "is_new": true,
+    "connection": {
+      "type": "websocket",
+      "target": "127.0.0.1:20003",
+      "token": null,
+      "engine_type": "openclaw",
+      "url": "wss://example.com/ws",
+      "headers": null,
+      "use_proxy": false,
+      "sandbox_id": "ARCA-SANDBOX-xxx"
+    }
+  }
+}
+```
+
+`connection` 的具体字段随现有 Bot 连接类型变化，前端继续使用当前聊天页面已有的
+连接逻辑处理该对象。
+
+### 4.2 容器启动中
+
+```json
+{
+  "success": true,
+  "message": "创建成功",
+  "error_code": 0,
+  "data": {
+    "session_key": null,
+    "is_new": true,
+    "connection": {},
+    "need_poll": true
+  }
+}
+```
+
+收到 `need_poll=true` 时，尚未创建 session。前端应等待容器就绪后重新调用新建
+接口，不能将 `session_key=null` 加入会话列表。
+
+## 5. 进入已有会话
+
+```http
+POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions/connect
+Content-Type: application/json
+```
+
+请求体：
+
+```json
+{
+  "session_key": "agent:main:session:xxx:user:165137"
+}
+```
+
+成功响应：
+
+```json
+{
+  "success": true,
+  "message": "获取成功",
+  "error_code": 0,
+  "data": {
+    "session_key": "agent:main:session:xxx:user:165137",
+    "is_new": false,
+    "connection": {
+      "type": "websocket",
+      "target": "127.0.0.1:20003",
+      "token": null,
+      "engine_type": "openclaw",
+      "url": "wss://example.com/ws",
+      "headers": null,
+      "use_proxy": false,
+      "sandbox_id": "ARCA-SANDBOX-xxx"
+    }
+  }
+}
+```
+
+Backend 会先校验该 session key 是否属于当前登录用户，再返回连接信息。前端选择
+已有会话时，应调用本接口获取连接，不能只根据列表中的 session key 直接建立连接。
+
+Caller 独立容器启动中时，响应可能包含 `need_poll=true`。此时前端应完成现有
+轮询流程后，再次调用本接口。
+
+## 6. 删除指定会话
+
+```http
+DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/sessions?session_key={session_key}
+```
+
+成功响应：
+
+```json
+{
+  "success": true,
+  "message": "Session 已删除",
+  "error_code": 0,
+  "data": null
+}
+```
+
+删除会同步清理：
+
+- Adapter 中的真实会话；
+- Adapter 中的收藏记录；
+- Backend 中当前用户的会话归属记录；
+- 旧版默认会话指针。
+
+如果删除的是旧版默认会话，Backend 会将默认指针切换到剩余会话；如果没有剩余
+会话，则清空默认指针。
+
+前端应等待接口返回成功后再从列表移除该项。删除失败时不要只在前端隐藏会话，应
+保留该项并允许用户重试。
+
+## 7. 收藏与取消收藏
+
+收藏写操作继续通过当前 Bot 的 Engine Proxy 调用现有接口：
+
+### 7.1 收藏
+
+```http
+PUT /api/session-favorites/{encoded_session_id}?user_id={current_user_id}
+```
+
+成功响应：
+
+```json
+{
+  "success": true,
+  "data": null,
+  "message": "Session favorited",
+  "warning": null,
+  "total": null
+}
+```
+
+### 7.2 取消收藏
+
+```http
+DELETE /api/session-favorites/{encoded_session_id}?user_id={current_user_id}
+```
+
+成功响应：
+
+```json
+{
+  "success": true,
+  "data": null,
+  "message": "Session unfavorited",
+  "warning": null,
+  "total": null
+}
+```
+
+`encoded_session_id` 必须使用当前项目已有的 URL-safe Base64 编码方法生成，原始值
+直接取会话列表返回的 `item.id`：
+
+```ts
+const encodedSessionId = encodeToUrlSafeBase64(session.id);
+```
+
+不要手工截断、拼接或按引擎类型转换 session key。收藏和取消收藏均为幂等操作。
+
+“已收藏”标签页不要直接使用 Adapter 收藏列表接口渲染，而是调用新的 Backend
+列表接口：
+
+```http
+GET /api/v1/expert-chats/{bot_id}/{owner_id}/sessions?favorite_only=true
+```
+
+这样 Backend 会再次按照当前登录用户、Bot、Bot Owner 和 session key 校验会话归属。
+
+## 8. 统一错误响应
+
+Backend 多会话接口使用统一响应结构。业务错误通常也通过该结构返回，前端不能只
+判断 HTTP 状态码，还必须判断 `success` 和 `error_code`：
+
+```json
+{
+  "success": false,
+  "message": "Session不存在或不属于当前用户",
+  "error_code": 404,
+  "data": null
+}
+```
+
+常见错误码：
+
+| `error_code` | 说明 |
+| --- | --- |
+| `0` | 成功 |
+| `400` | Bot 状态不可用或请求不符合要求 |
+| `4001` | Bot 尚未发布 |
+| `403` | 当前用户没有访问权限 |
+| `404` | Bot/session 不存在，或 session 不属于当前用户 |
+| `5001` | Bot 连接不可用或仍在启动 |
+| `5003` | 创建 session 失败 |
+| `5999` | Backend 未预期异常 |
+
+身份认证失败仍可能由统一认证中间件直接返回 HTTP `401` 或 `403`。
+
+## 9. 推荐前端调用流程
+
+1. 用户选择左侧 Bot，调用会话列表接口加载“全部”会话。
+2. 用户切换“已收藏”，调用同一列表接口并传 `favorite_only=true`。
+3. 用户输入完整 session key，调用同一列表接口并传 `session_key`。
+4. 用户点击“新建会话”，调用新建接口。
+5. 新建成功后，使用响应中的 `session_key` 和 `connection` 进入聊天。
+6. 用户点击已有会话，调用 `sessions/connect` 获取连接信息后进入聊天。
+7. 消息历史加载、WebSocket 建连和消息发送沿用当前聊天实现。
+8. 用户收藏或取消收藏时，调用现有 Engine Proxy 收藏写接口。
+9. 用户删除会话时，调用 Backend 指定会话删除接口；成功后再刷新列表。
+
+## 10. 兼容性说明
+
+- 原有 `POST /api/v1/expert-chats/{bot_id}/{owner_id}/session` 保留，旧前端不修改
+  时行为不变。
+- 原有 `DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/session` 保留。
+- 新旧前端并行期间，旧接口当前使用的 session key 会自动登记到多会话表。
+- 新建或进入会话时，Backend 会更新旧版默认会话指针，避免回到旧页面后打开错误
+  会话。
+- 前端不需要修改 Adapter 的调用协议，也不需要为不同引擎实现不同的多会话逻辑。

--- a/src/backend/specs/2026-08-10-expert-chat-multi-session/ddl.sql
+++ b/src/backend/specs/2026-08-10-expert-chat-multi-session/ddl.sql
@@ -1,0 +1,16 @@
+-- Production DDL for the expert-chat multi-session ownership index.
+-- Apply before deploying Backend code that exposes the plural /sessions APIs.
+CREATE TABLE IF NOT EXISTS `ac_expert_chat_sessions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `user_id` varchar(64) NOT NULL,
+  `bot_id` varchar(64) NOT NULL,
+  `owner_id` varchar(64) NOT NULL,
+  `session_key` varchar(255) NOT NULL,
+  `status` varchar(20) NOT NULL DEFAULT 'ACTIVE',
+  `env` varchar(50) NOT NULL,
+  `gmt_create` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `gmt_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_user_bot_owner_env_session`
+    (`user_id`, `bot_id`, `owner_id`, `env`, `session_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/backend/specs/2026-08-10-expert-chat-multi-session/ddl.sql
+++ b/src/backend/specs/2026-08-10-expert-chat-multi-session/ddl.sql
@@ -1,16 +1,21 @@
 -- Production DDL for the expert-chat multi-session ownership index.
 -- Apply before deploying Backend code that exposes the plural /sessions APIs.
-CREATE TABLE IF NOT EXISTS `ac_expert_chat_sessions` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
-  `user_id` varchar(64) NOT NULL,
-  `bot_id` varchar(64) NOT NULL,
-  `owner_id` varchar(64) NOT NULL,
-  `session_key` varchar(255) NOT NULL,
-  `status` varchar(20) NOT NULL DEFAULT 'ACTIVE',
-  `env` varchar(50) NOT NULL,
-  `gmt_create` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `gmt_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+-- Do not reuse the historical ac_expert_chat_sessions table: its schema and
+-- single-session unique key are incompatible with this ownership index.
+CREATE TABLE `ac_expert_chat_owned_sessions` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `user_id` varchar(64) NOT NULL COMMENT '当前会话所属用户ID',
+  `bot_id` varchar(64) NOT NULL COMMENT '互动Bot ID',
+  `owner_id` varchar(64) NOT NULL COMMENT '互动Bot所有者ID',
+  `session_key` varchar(255) NOT NULL COMMENT 'Engine会话唯一标识',
+  `status` varchar(20) NOT NULL DEFAULT 'ACTIVE'
+    COMMENT '会话归属记录状态：ACTIVE或DELETED',
+  `env` varchar(50) NOT NULL COMMENT '运行环境标识',
+  `gmt_create` timestamp NULL DEFAULT CURRENT_TIMESTAMP COMMENT '记录创建时间',
+  `gmt_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP
+    ON UPDATE CURRENT_TIMESTAMP COMMENT '记录最后修改时间',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_user_bot_owner_env_session`
     (`user_id`, `bot_id`, `owner_id`, `env`, `session_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+  COMMENT='互动Bot多会话归属关系表';

--- a/src/backend/src/agentclaw/community/adapters/http/expert_chat/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/expert_chat/router.py
@@ -7,6 +7,10 @@ ExpertChat Router — HTTP接口入口
 - DELETE /api/v1/expert-chats/{bot_id}/{owner_id} - 从对话列表移除
 - POST /api/v1/expert-chats/{bot_id}/{owner_id}/session - 获取/创建 Session
 - DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/session - 删除 Session
+- GET /api/v1/expert-chats/{bot_id}/{owner_id}/sessions - 获取多会话列表
+- POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions - 新建会话
+- POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions/connect - 连接已有会话
+- DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/sessions - 删除指定会话
 - POST /api/v1/expert-chats/caller-connection - 获取 caller 独立容器连接(管理员接口)
 
 依赖规则：
@@ -22,6 +26,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from agentclaw.community.adapters.http.expert_chat.schemas import (
     AddChatBotRequest,
     ApiResponse,
+    SessionKeyRequest,
 )
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.adapters.http.auth.dependencies import get_current_user
@@ -35,6 +40,7 @@ from agentclaw.community.core.expert_chat.errors import (
     BotNotFoundError,
     BotNotActiveError,
     BotNotPublishedError,
+    ChatPermissionError,
     SessionCreateError,
     ConnectionError,
 )
@@ -130,6 +136,10 @@ async def remove_chat_bot(
         else:
             return ApiResponse(success=False, message="专家Bot不存在或不在对话列表中", error_code=404)
 
+    except ConnectionError as e:
+        # Runtime cleanup is intentionally retryable: the service preserves local
+        # session ownership until every Adapter session has been deleted.
+        return ApiResponse(success=False, message=str(e), error_code=int(e.error_code))
     except Exception as e:
         logger.error(f"[expert_chats.remove_chat_bot] Error: {e}")
         logger.error(f"[expert_chats.remove_chat_bot] Traceback: {traceback.format_exc()}")
@@ -215,8 +225,250 @@ async def delete_chat_session(
 
     except Exception as e:
         logger.error(f"[expert_chats.delete_chat_session] Error: {e}")
-        logger.error(f"[expert_chats.delete_chat_session] Traceback: {traceback.format_exc()}")
-        return ApiResponse(success=False, message="删除 Session 失败，请稍后重试", error_code=5999)
+        logger.error(
+            f"[expert_chats.delete_chat_session] Traceback: {traceback.format_exc()}"
+        )
+        return ApiResponse(
+            success=False, message="删除 Session 失败，请稍后重试", error_code=5999
+        )
+
+
+@router.get("/{bot_id}/{owner_id}/sessions", response_model=ApiResponse)
+async def list_chat_sessions(
+    request: Request,
+    bot_id: str,
+    owner_id: str,
+    session_key: str | None = Query(
+        None,
+        min_length=1,
+        max_length=255,
+        description="Exact session key filter",
+    ),
+    favorite_only: bool = Query(False, description="Return favorite sessions only"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: ExpertChatServiceProtocol = Injected(ExpertChatServiceProtocol),
+):
+    """List the authenticated user's sessions for one expert Bot."""
+    try:
+        result = await service.list_chat_sessions(
+            user_id=user.staffId,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            session_key=session_key,
+            favorite_only=favorite_only,
+            limit=limit,
+            offset=offset,
+            iam_token=request.cookies.get("IAM_TOKEN") or None,
+        )
+        return ApiResponse(
+            success=True,
+            message="获取成功",
+            error_code=0,
+            data=result,
+        )
+    except (BotNotFoundError, BotNotActiveError) as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=404 if isinstance(error, BotNotFoundError) else 400,
+        )
+    except BotNotPublishedError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=4001
+        )
+    except ChatPermissionError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=403
+        )
+    except ConnectionError as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=int(error.error_code) if error.error_code else 5001,
+        )
+    except Exception as error:
+        logger.error(
+            "[expert_chats.list_chat_sessions] Unexpected error: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        logger.error(traceback.format_exc())
+        return ApiResponse(
+            success=False,
+            message="获取会话列表失败，请稍后重试",
+            error_code=5999,
+        )
+
+
+@router.post("/{bot_id}/{owner_id}/sessions", response_model=ApiResponse)
+async def create_chat_session(
+    request: Request,
+    bot_id: str,
+    owner_id: str,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: ExpertChatServiceProtocol = Injected(ExpertChatServiceProtocol),
+):
+    """Create a new session without replacing older session mappings."""
+    try:
+        result = await service.create_chat_session(
+            user_id=user.staffId,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            iam_token=request.cookies.get("IAM_TOKEN") or None,
+        )
+        return ApiResponse(
+            success=True,
+            message="创建成功",
+            error_code=0,
+            data=result,
+        )
+    except (BotNotFoundError, BotNotActiveError) as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=404 if isinstance(error, BotNotFoundError) else 400,
+        )
+    except BotNotPublishedError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=4001
+        )
+    except ChatPermissionError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=403
+        )
+    except (ConnectionError, SessionCreateError) as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=int(error.error_code) if error.error_code else 5003,
+        )
+    except Exception as error:
+        logger.error(
+            "[expert_chats.create_chat_session] Unexpected error: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        logger.error(traceback.format_exc())
+        return ApiResponse(
+            success=False,
+            message="创建 Session 失败，请稍后重试",
+            error_code=5999,
+        )
+
+
+@router.post("/{bot_id}/{owner_id}/sessions/connect", response_model=ApiResponse)
+async def connect_chat_session(
+    request: Request,
+    bot_id: str,
+    owner_id: str,
+    body: SessionKeyRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: ExpertChatServiceProtocol = Injected(ExpertChatServiceProtocol),
+):
+    """Return connection data for one session owned by the caller."""
+    try:
+        result = await service.connect_chat_session(
+            user_id=user.staffId,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            session_key=body.session_key,
+            iam_token=request.cookies.get("IAM_TOKEN") or None,
+        )
+        return ApiResponse(
+            success=True,
+            message="获取成功",
+            error_code=0,
+            data=result,
+        )
+    except (BotNotFoundError, BotNotActiveError) as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=404 if isinstance(error, BotNotFoundError) else 400,
+        )
+    except BotNotPublishedError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=4001
+        )
+    except ChatPermissionError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=403
+        )
+    except ConnectionError as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=int(error.error_code) if error.error_code else 5001,
+        )
+    except Exception as error:
+        logger.error(
+            "[expert_chats.connect_chat_session] Unexpected error: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        logger.error(traceback.format_exc())
+        return ApiResponse(
+            success=False,
+            message="连接 Session 失败，请稍后重试",
+            error_code=5999,
+        )
+
+
+@router.delete("/{bot_id}/{owner_id}/sessions", response_model=ApiResponse)
+async def delete_owned_chat_session(
+    bot_id: str,
+    owner_id: str,
+    session_key: str = Query(..., min_length=1, max_length=255),
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: ExpertChatServiceProtocol = Injected(ExpertChatServiceProtocol),
+):
+    """Delete one session after checking its Backend-owned mapping."""
+    try:
+        await service.delete_owned_chat_session(
+            user_id=user.staffId,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            session_key=session_key,
+        )
+        return ApiResponse(
+            success=True,
+            message="Session 已删除",
+            error_code=0,
+        )
+    except BotNotFoundError as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=404,
+        )
+    except BotNotActiveError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=400
+        )
+    except ChatPermissionError as error:
+        return ApiResponse(
+            success=False, message=str(error), error_code=403
+        )
+    except ConnectionError as error:
+        return ApiResponse(
+            success=False,
+            message=str(error),
+            error_code=int(error.error_code) if error.error_code else 5001,
+        )
+    except Exception as error:
+        logger.error(
+            "[expert_chats.delete_owned_chat_session] Unexpected error: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        logger.error(traceback.format_exc())
+        return ApiResponse(
+            success=False,
+            message="删除 Session 失败，请稍后重试",
+            error_code=5999,
+        )
 
 
 @router.post("/caller-connection", response_model=ApiResponse)

--- a/src/backend/src/agentclaw/community/adapters/http/expert_chat/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/expert_chat/schemas.py
@@ -27,6 +27,12 @@ class GrtChatRequest(BaseModel):
     session_id: str = Field(..., description="session:uuid 格式")
 
 
+class SessionKeyRequest(BaseModel):
+    """Select an existing expert-chat session."""
+
+    session_key: str = Field(..., min_length=1, max_length=255)
+
+
 # ============ Response Models ============
 
 class AddChatBotResponse(BaseModel):

--- a/src/backend/src/agentclaw/community/api/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/api/expert_chat_service.py
@@ -25,3 +25,40 @@ class ExpertChatServiceProtocol(Protocol):
     async def delete_chat_session(
         self, user_id: str, bot_id: str, owner_id: str
     ) -> bool: ...
+
+    async def list_chat_sessions(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: Optional[str] = None,
+        favorite_only: bool = False,
+        limit: int = 20,
+        offset: int = 0,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
+
+    async def create_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
+
+    async def connect_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: str,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
+
+    async def delete_owned_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: str,
+    ) -> bool: ...

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -12,10 +12,13 @@ ExpertChat Service — 用户与专家Bot对话业务逻辑层
 - BotInfoProvider: Bot信息查询
 - DeviceConnectionProvider: 设备连接服务
 """
+
 from __future__ import annotations
 
 import traceback
+from datetime import datetime
 from typing import Dict, Any, List, Optional, Protocol, runtime_checkable
+from urllib.parse import quote
 
 from injector import inject
 
@@ -47,9 +50,18 @@ from agentclaw.community.core.bot_management.engines.registry import (
     resolve_provisioning,
 )
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.device_adapter_transport import DeviceAdapterTransport
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+    DeviceAdapterTransport,
+)
 
 logger = get_logger()
+
+_ADAPTER_SESSION_PAGE_SIZE = 500
+_EXACT_SESSION_LOOKUP_ENGINES = {"openclaw", "hermes", "claude_code"}
+_LEGACY_LOCAL_SESSION_ENGINES = {"aicoding", "claude_code"}
+_RELAY_SESSION_CREATE_TIMEOUT_SECONDS = 330.0
 
 
 # ============ Protocol Definitions ============
@@ -239,7 +251,7 @@ class ExpertChatService:
         return result
 
     async def remove_chat_bot(self, user_id: str, bot_id: str, owner_id: str) -> bool:
-        """从对话列表移除专家Bot并清理 session
+        """从对话列表移除专家Bot并清理全部 session
 
         Args:
             user_id: 用户ID（使用人）
@@ -249,21 +261,79 @@ class ExpertChatService:
         Returns:
             是否成功
         """
-        # 1. 尝试删除 session（包括 Adapter 和本地）
-        try:
-            await self.delete_chat_session(user_id, bot_id, owner_id)
-        except BotNotFoundError:
-            # Bot 不存在，继续移除
-            pass
-        except Exception as e:
-            logger.warning(f"[ExpertChatService] Failed to delete session during remove: {e}")
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        legacy_session_key = self._repo.get_session(user_id, bot_id, owner_id)
+        if legacy_session_key:
+            self._repo.add_owned_session(
+                user_id, bot_id, owner_id, legacy_session_key
+            )
+        owned_sessions = self._repo.list_owned_sessions(user_id, bot_id, owner_id)
 
-        # 2. 移除记录
+        if bot and owned_sessions:
+            connection, need_poll = await self._prepare_chat_connection(
+                bot, user_id, owner_id, None
+            )
+            if need_poll or connection is None:
+                raise ConnectionError(
+                    "Bot服务正在启动，请稍后重试",
+                    error_code="5001",
+                )
+
+            remaining_session_keys = [row["session_key"] for row in owned_sessions]
+            for row in owned_sessions:
+                session_key = row["session_key"]
+                await self._delete_adapter_session(
+                    bot,
+                    session_key,
+                    user_id,
+                    connection=connection,
+                )
+                await self._remove_session_favorite(
+                    connection, session_key, user_id
+                )
+                # Persist progress after each confirmed runtime deletion. If a
+                # later deletion fails, retrying must not revisit a session that
+                # the Engine has already removed.
+                self._repo.delete_owned_session(
+                    user_id, bot_id, owner_id, session_key
+                )
+                remaining_session_keys.remove(session_key)
+                if legacy_session_key == session_key:
+                    if remaining_session_keys:
+                        legacy_session_key = remaining_session_keys[0]
+                        self._repo.save_session(
+                            user_id,
+                            bot_id,
+                            owner_id,
+                            legacy_session_key,
+                        )
+                    else:
+                        self._repo.delete_session(user_id, bot_id, owner_id)
+                        legacy_session_key = None
+        elif not bot and owned_sessions:
+            logger.warning(
+                "[ExpertChatService] Bot missing during removal; runtime session "
+                "cleanup is unavailable: bot=%s owner=%s sessions=%s",
+                bot_id,
+                owner_id,
+                len(owned_sessions),
+            )
+
+        # Runtime cleanup is complete (or impossible because the Bot no longer
+        # exists), so the local indexes can now be removed together.
+        self._repo.delete_all_owned_sessions(user_id, bot_id, owner_id)
+        if legacy_session_key:
+            self._repo.delete_session(user_id, bot_id, owner_id)
+
         result = self._repo.remove_chat_bot(user_id, bot_id, owner_id)
-        logger.info(f"[ExpertChatService] Removed chat bot: user={user_id}, bot={bot_id}, owner={owner_id}")
+        logger.info(
+            f"[ExpertChatService] Removed chat bot: user={user_id}, bot={bot_id}, owner={owner_id}"
+        )
         return result
 
-    async def get_chat_session(self, user_id: str, bot_id: str, owner_id: str, iam_token: Optional[str] = None) -> Dict[str, Any]:
+    async def get_chat_session(
+        self, user_id: str, bot_id: str, owner_id: str, iam_token: Optional[str] = None
+    ) -> Dict[str, Any]:
         """获取/创建与专家Bot的 chat session
 
         Authorization order (all checks BEFORE expensive operations):
@@ -295,105 +365,267 @@ class ExpertChatService:
             BotNotActiveError: Bot 状态不是 ACTIVE
             ChatPermissionError: 用户无聊天权限
         """
-        # 1. 校验 bot 是否存在且属于该 owner（通过 bot_id + owner_id 唯一定位）
-        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
-        if not bot:
-            raise BotNotFoundError(f"Bot不存在: {bot_id}")
-
-        if bot.get("status") != "ACTIVE":
-            raise BotNotActiveError(f"Bot未激活: {bot_id}")
-
-        # 2. 【安全前置】校验 bot 是否在用户的对话列表中
-        #    必须在任何昂贵操作（容器创建/升级）之前执行，防止未授权用户触发副作用
-        chat_bots = self._repo.list_chat_bots(user_id)
-        bot_in_list = any(
-            entry["bot_id"] == bot_id and entry["owner_id"] == owner_id
-            for entry in chat_bots
+        bot = self._get_authorized_chat_bot(user_id, bot_id, owner_id)
+        connection, need_poll = await self._prepare_chat_connection(
+            bot, user_id, owner_id, iam_token
         )
-        if not bot_in_list:
-            raise BotNotFoundError(f"Bot不在对话列表中: {bot_id}")
-
-        # 3. 【安全前置】校验用户是否有聊天权限
-        #    必须在任何昂贵操作（容器创建/升级）之前执行，防止未授权用户触发副作用
-        self._check_chat_access(bot, user_id)
-
-        # 4. 根据 call_type 决定连接获取方式（授权检查之后）
-        # Caller 模式：为每个 caller 分配独立的 baas 容器
-        bot_call_type = McpCallType.parse(bot.get("call_type") or None)
-        logger.info("[ExpertChatService] Bot call_type: bot=%s, call_type=%s, parsed=%s", bot_id, bot.get("call_type"), bot_call_type)
-        if bot_call_type == McpCallType.CALLER:
-            logger.info("[ExpertChatService] Caller mode: bot=%s, owner=%s, user=%s", bot_id, owner_id, user_id)
-            result = await self._instance_service.get_caller_connection(
-                user_id=user_id,
-                bot_id=bot_id,
-                owner_id=owner_id,
-                iam_token=iam_token
-            )
-            connection = result.get("connection")
-            need_poll = result.get("need_poll", False)
-
-            # 容器还在创建中，直接返回
-            if need_poll:
-                logger.info("[ExpertChatService] Caller instance not ready: bot=%s, user=%s, need_poll=%s", bot_id, user_id, need_poll)
-                return {
-                    "session_key": None,
-                    "is_new": True,
-                    "connection": connection,
-                    "need_poll": need_poll,
-                }
-
-            # 从 result 中获取 binding_id 并设置到 bot 对象
-            instance = result.get("instance", {})
-            ext = instance.get("ext") or {}
-            bot["binding_id"] = ext.get("binding_id")
-        else:
-            # Owner 模式：使用原有的 binding_id 方式
-            # 根据 bot_type 获取 binding_id
-            # 服务型 Bot：通过 BaasService 获取发布成功的发布单
-            bot_type = bot.get("bot_type", "personal")
-            if bot_type == "service":
-                from agentclaw.community.core.service_bot.repository.models import PublishStatus
-                binding_id = self._baas_service.get_bind_id(
-                    bot_id=bot_id,
-                    owner_id=owner_id,
-                    bot_type=bot_type,
-                    publish_status=PublishStatus.SUCCESS.value,
-                )
-                # 将 binding_id 设置到 bot 对象中，供后续 _get_connection 使用
-                bot["binding_id"] = binding_id
+        if need_poll:
+            return {
+                "session_key": None,
+                "is_new": True,
+                "connection": connection,
+                "need_poll": True,
+            }
 
         # 5. 查是否已有 session
         session_key = self._repo.get_session(user_id, bot_id, owner_id)
 
         # 6. 有则校验有效性
         if session_key:
-            exists = await self._check_session_exists(bot, session_key, user_id)
+            exists = await self._check_session_exists(
+                bot, session_key, user_id, connection=connection
+            )
             if exists:
-                conn = self._get_connection(bot, user_id)
-                logger.info(f"[ExpertChatService] Reusing session: user={user_id}, bot={bot_id}, session={session_key}")
+                self._repo.add_owned_session(user_id, bot_id, owner_id, session_key)
+                logger.info(
+                    f"[ExpertChatService] Reusing session: user={user_id}, bot={bot_id}, session={session_key}"
+                )
                 return {
                     "session_key": session_key,
                     "is_new": False,
-                    "connection": conn
+                    "connection": connection,
                 }
             else:
                 # Session 已失效，删除旧记录
+                self._repo.delete_owned_session(
+                    user_id, bot_id, owner_id, session_key
+                )
                 self._repo.delete_session(user_id, bot_id, owner_id)
 
         # 7. 没有或无效则创建新 session
-        session_key = await self._create_session(bot, user_id)
+        session_key = await self._create_session(
+            bot, user_id, connection=connection
+        )
         self._repo.save_session(user_id, bot_id, owner_id, session_key)
+        self._repo.add_owned_session(user_id, bot_id, owner_id, session_key)
 
-        conn = self._get_connection(bot, user_id)
-        logger.info(f"[ExpertChatService] Created new session: user={user_id}, bot={bot_id}, session={session_key}")
+        logger.info(
+            f"[ExpertChatService] Created new session: user={user_id}, bot={bot_id}, session={session_key}"
+        )
 
         return {
             "session_key": session_key,
             "is_new": True,
-            "connection": conn
+            "connection": connection,
         }
 
-    async def delete_chat_session(self, user_id: str, bot_id: str, owner_id: str) -> bool:
+    async def list_chat_sessions(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: Optional[str] = None,
+        favorite_only: bool = False,
+        limit: int = 20,
+        offset: int = 0,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List one user's sessions for one expert Bot.
+
+        The Backend-owned index is authoritative for ownership. Adapter data is
+        only used to enrich those already-authorized keys with live metadata.
+        """
+        bot = self._get_authorized_chat_bot(user_id, bot_id, owner_id)
+        legacy_session_key = self._repo.get_session(user_id, bot_id, owner_id)
+        if legacy_session_key:
+            self._repo.add_owned_session(user_id, bot_id, owner_id, legacy_session_key)
+
+        rows = self._repo.list_owned_sessions(
+            user_id=user_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            session_key=session_key,
+        )
+        if not rows:
+            return {"total": 0, "items": []}
+
+        connection, need_poll = await self._prepare_chat_connection(
+            bot, user_id, owner_id, iam_token
+        )
+        if favorite_only and need_poll:
+            return {"total": 0, "items": [], "need_poll": True}
+
+        if favorite_only and connection is not None:
+            favorite_items = await self._list_favorite_sessions(
+                connection, user_id, bot_id
+            )
+            rows_by_key = {row["session_key"]: row for row in rows}
+            items = []
+            for favorite in favorite_items:
+                favorite_key = favorite.get("id")
+                row = rows_by_key.get(favorite_key)
+                if row is None:
+                    continue
+                item = dict(favorite)
+                for key, value in self._placeholder_session(row).items():
+                    item.setdefault(key, value)
+                items.append(item)
+            total = len(items)
+            return {
+                "total": total,
+                "items": items[offset : offset + limit],
+            }
+
+        adapter_items = {}
+        if not need_poll and connection is not None:
+            adapter_items = await self._list_owned_adapter_sessions(
+                connection=connection,
+                rows=rows,
+                user_id=user_id,
+            )
+
+        items = []
+        engine_type = connection.get("engine_type", "openclaw") if connection else None
+        for row in rows:
+            item = adapter_items.get(row["session_key"])
+            if item is None:
+                items.append(self._placeholder_session(row))
+                continue
+            enriched = dict(item)
+            for key, value in self._placeholder_session(row).items():
+                enriched.setdefault(key, value)
+            if engine_type == "openclaw":
+                # OpenClaw currently synthesizes Session updated_at at conversion
+                # time. Prefer the real message timestamp, then the stable Backend
+                # ownership creation time, so repeated reads cannot reorder rows.
+                last_message = enriched.get("last_message")
+                last_message_at = (
+                    last_message.get("gmt_created")
+                    if isinstance(last_message, dict)
+                    else None
+                )
+                stable_modified = last_message_at or row.get("gmt_create")
+                if stable_modified:
+                    enriched["gmt_modified"] = stable_modified
+            items.append(enriched)
+
+        items.sort(key=self._session_sort_key, reverse=True)
+        total = len(items)
+        return {
+            "total": total,
+            "items": items[offset : offset + limit],
+            **({"need_poll": True} if need_poll else {}),
+        }
+
+    async def create_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Always create a new session and make it the legacy default."""
+        bot = self._get_authorized_chat_bot(user_id, bot_id, owner_id)
+        connection, need_poll = await self._prepare_chat_connection(
+            bot, user_id, owner_id, iam_token
+        )
+        if need_poll:
+            return {
+                "session_key": None,
+                "is_new": True,
+                "connection": connection,
+                "need_poll": True,
+            }
+
+        created_session_key = await self._create_session(
+            bot,
+            user_id,
+            connection=connection,
+            prefer_adapter_for_relay=True,
+        )
+        self._repo.add_owned_session(user_id, bot_id, owner_id, created_session_key)
+        # Legacy clients resume the latest session created by the new UI.
+        self._repo.save_session(user_id, bot_id, owner_id, created_session_key)
+        return {
+            "session_key": created_session_key,
+            "is_new": True,
+            "connection": connection,
+        }
+
+    async def connect_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: str,
+        iam_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return connection data for one session owned by the caller."""
+        bot = self._get_authorized_chat_bot(user_id, bot_id, owner_id)
+        # 以下为安全注释COSEC：会话归属必须在建立容器连接前由登录用户维度校验。
+        owned = self._repo.get_owned_session(user_id, bot_id, owner_id, session_key)
+        if not owned:
+            raise BotNotFoundError("Session不存在或不属于当前用户")
+
+        connection, need_poll = await self._prepare_chat_connection(
+            bot, user_id, owner_id, iam_token
+        )
+        if not need_poll:
+            self._repo.save_session(user_id, bot_id, owner_id, session_key)
+        return {
+            "session_key": session_key,
+            "is_new": False,
+            "connection": connection,
+            **({"need_poll": True} if need_poll else {}),
+        }
+
+    async def delete_owned_chat_session(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: str,
+    ) -> bool:
+        """Delete one authorized multi-session entry and its favorite marker."""
+        bot = self._get_authorized_chat_bot(user_id, bot_id, owner_id)
+        # 以下为安全注释COSEC：禁止仅凭前端提供的 session_key 删除会话。
+        owned = self._repo.get_owned_session(user_id, bot_id, owner_id, session_key)
+        if not owned:
+            raise BotNotFoundError("Session不存在或不属于当前用户")
+
+        connection, need_poll = await self._prepare_chat_connection(
+            bot, user_id, owner_id, None
+        )
+        if need_poll or connection is None:
+            raise ConnectionError(
+                "Bot服务正在启动，请稍后重试",
+                error_code="5001",
+            )
+
+        # Keep the ownership row until runtime deletion is confirmed. Otherwise
+        # a transient Adapter failure would make the session impossible to retry.
+        await self._delete_adapter_session(
+            bot, session_key, user_id, connection=connection
+        )
+        await self._remove_session_favorite(connection, session_key, user_id)
+        self._repo.delete_owned_session(user_id, bot_id, owner_id, session_key)
+
+        if self._repo.get_session(user_id, bot_id, owner_id) == session_key:
+            remaining = self._repo.list_owned_sessions(user_id, bot_id, owner_id)
+            if remaining:
+                self._repo.save_session(
+                    user_id,
+                    bot_id,
+                    owner_id,
+                    remaining[0]["session_key"],
+                )
+            else:
+                self._repo.delete_session(user_id, bot_id, owner_id)
+        return True
+
+    async def delete_chat_session(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> bool:
         """删除用户与专家Bot的 chat session
 
         Args:
@@ -415,15 +647,17 @@ class ExpertChatService:
             logger.warning(f"[ExpertChatService] No session found for user={user_id}, bot={bot_id}, owner={owner_id}")
             return True  # 本来就没有，也算成功
 
-        # 3. 调用 Adapter 删除 session
+        # 3. 调用 Adapter 删除 session。运行时删除失败时保留新的 ownership，
+        # 让新旧前端都能重试，而不是制造 Engine 孤儿会话。
         try:
             await self._delete_adapter_session(bot, session_key, user_id)
             logger.info(f"[ExpertChatService] Deleted adapter session: {session_key}")
         except Exception as e:
             logger.error(f"[ExpertChatService] Failed to delete adapter session {session_key}: {e}")
-            # Adapter 删除失败也要继续删除本地记录
+            raise
 
         # 4. 删除本地 session 映射
+        self._repo.delete_owned_session(user_id, bot_id, owner_id, session_key)
         self._repo.delete_session(user_id, bot_id, owner_id)
         logger.info(
             "[ExpertChatService] Deleted local session mapping: user=%s, bot=%s, owner=%s",
@@ -436,7 +670,271 @@ class ExpertChatService:
 
     # ============ Private Methods ============
 
-    def _get_connection(self, bot: Dict[str, Any], user_id: Optional[str] = None) -> Dict[str, Any]:
+    def _get_authorized_chat_bot(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> Dict[str, Any]:
+        """Resolve and authorize a Bot before any container-side operation."""
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if not bot:
+            raise BotNotFoundError(f"Bot不存在: {bot_id}")
+        if bot.get("status") != "ACTIVE":
+            raise BotNotActiveError(f"Bot未激活: {bot_id}")
+
+        # 以下为安全注释COSEC：互动列表归属和 Bot 访问权均使用服务端登录身份校验。
+        bot_in_list = any(
+            entry["bot_id"] == bot_id and entry["owner_id"] == owner_id
+            for entry in self._repo.list_chat_bots(user_id)
+        )
+        if not bot_in_list:
+            raise BotNotFoundError(f"Bot不在对话列表中: {bot_id}")
+        self._check_chat_access(bot, user_id)
+        return bot
+
+    async def _prepare_chat_connection(
+        self,
+        bot: Dict[str, Any],
+        user_id: str,
+        owner_id: str,
+        iam_token: Optional[str],
+    ) -> tuple[Optional[Dict[str, Any]], bool]:
+        """Resolve caller/owner binding and return Adapter connection data."""
+        bot_id = bot["bot_id"]
+        bot_call_type = McpCallType.parse(bot.get("call_type") or None)
+        logger.info(
+            "[ExpertChatService] Bot call_type: bot=%s, call_type=%s, parsed=%s",
+            bot_id,
+            bot.get("call_type"),
+            bot_call_type,
+        )
+        if bot_call_type == McpCallType.CALLER:
+            result = await self._instance_service.get_caller_connection(
+                user_id=user_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                iam_token=iam_token,
+            )
+            if result.get("need_poll", False):
+                logger.info(
+                    "[ExpertChatService] Caller instance not ready: bot=%s, user=%s",
+                    bot_id,
+                    user_id,
+                )
+                return result.get("connection"), True
+            instance = result.get("instance", {})
+            ext = instance.get("ext") or {}
+            bot["binding_id"] = ext.get("binding_id")
+        elif bot.get("bot_type", "personal") == "service":
+            from agentclaw.community.core.service_bot.repository.models import (
+                PublishStatus,
+            )
+
+            bot["binding_id"] = self._baas_service.get_bind_id(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                bot_type="service",
+                publish_status=PublishStatus.SUCCESS.value,
+            )
+
+        return self._get_connection(bot, user_id), False
+
+    async def _list_owned_adapter_sessions(
+        self,
+        connection: Dict[str, Any],
+        rows: List[Dict[str, Any]],
+        user_id: str,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Batch-read Adapter metadata until every owned session is resolved.
+
+        The Adapter may host sessions for multiple Bots or legacy keys that do
+        not encode an ``agent_id``. We therefore omit the agent filter and make
+        the Backend ownership index the final authorization boundary.
+        """
+        remaining_keys = {row["session_key"] for row in rows}
+        matched: Dict[str, Dict[str, Any]] = {}
+        engine_type = connection.get("engine_type", "openclaw")
+        if engine_type in _EXACT_SESSION_LOOKUP_ENGINES:
+            await self._lookup_remaining_adapter_sessions(
+                connection=connection,
+                remaining_keys=remaining_keys,
+                matched=matched,
+            )
+            return matched
+
+        seen_adapter_ids: set[str] = set()
+        offset = 0
+        list_unavailable = False
+
+        while remaining_keys:
+            try:
+                response = await self._transport.invoke(
+                    connection,
+                    "GET",
+                    "/api/sessions",
+                    params={
+                        "user_id": user_id,
+                        "limit": _ADAPTER_SESSION_PAGE_SIZE,
+                        "offset": offset,
+                    },
+                )
+            except Exception as error:
+                list_unavailable = True
+                logger.warning(
+                    "[ExpertChatService] Adapter session list unavailable; "
+                    "unresolved sessions will use placeholders: offset=%s error=%s",
+                    offset,
+                    error,
+                )
+                break
+
+            data = response.get("data")
+            if not isinstance(data, list) or not data:
+                break
+
+            page_ids: set[str] = set()
+            for raw_item in data:
+                if not isinstance(raw_item, dict):
+                    continue
+                session_id = raw_item.get("id")
+                if not isinstance(session_id, str) or not session_id:
+                    continue
+                page_ids.add(session_id)
+                # 以下为安全注释COSEC：Adapter 结果必须与已授权的 Backend ownership 取交集。
+                if session_id in remaining_keys:
+                    matched[session_id] = raw_item
+                    remaining_keys.remove(session_id)
+
+            unseen_ids = page_ids - seen_adapter_ids
+            if not unseen_ids:
+                logger.warning(
+                    "[ExpertChatService] Adapter session pagination made no progress; "
+                    "stopping at offset=%s",
+                    offset,
+                )
+                break
+            seen_adapter_ids.update(unseen_ids)
+            offset += len(data)
+
+        if remaining_keys and not list_unavailable:
+            await self._lookup_remaining_adapter_sessions(
+                connection=connection,
+                remaining_keys=remaining_keys,
+                matched=matched,
+            )
+
+        return matched
+
+    async def _lookup_remaining_adapter_sessions(
+        self,
+        connection: Dict[str, Any],
+        remaining_keys: set[str],
+        matched: Dict[str, Dict[str, Any]],
+    ) -> None:
+        """Resolve keys hidden by engines that filter after pagination."""
+        for session_key in sorted(remaining_keys):
+            encoded_session_key = quote(session_key, safe="")
+            try:
+                response = await self._transport.invoke(
+                    connection,
+                    "GET",
+                    f"/api/sessions/{encoded_session_key}",
+                )
+            except Exception as error:
+                if self._is_adapter_not_found(error):
+                    continue
+                logger.warning(
+                    "[ExpertChatService] Exact session lookup unavailable; "
+                    "remaining sessions will use placeholders: session=%s error=%s",
+                    session_key,
+                    error,
+                )
+                break
+
+            item = response.get("data")
+            # The session key comes from the authorized Backend index, and the
+            # Adapter response must still match it exactly before enrichment.
+            if isinstance(item, dict) and item.get("id") == session_key:
+                matched[session_key] = item
+
+    @staticmethod
+    def _placeholder_session(row: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the complete list shape for an empty or unavailable session."""
+        return {
+            "id": row["session_key"],
+            "title": "新会话",
+            "user_id": row["user_id"],
+            "agent_id": row["bot_id"],
+            "model": None,
+            "permission_mode": None,
+            "cwd": None,
+            "gmt_created": row.get("gmt_create") or "",
+            "gmt_modified": row.get("gmt_modified") or "",
+            "message_count": 0,
+            "last_message": None,
+        }
+
+    @staticmethod
+    def _session_sort_key(item: Dict[str, Any]) -> float:
+        value = item.get("gmt_modified") or item.get("gmt_created")
+        if not value:
+            return 0.0
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+        except (TypeError, ValueError):
+            return 0.0
+
+    async def _remove_session_favorite(
+        self,
+        connection: Dict[str, Any],
+        session_key: str,
+        user_id: str,
+    ) -> None:
+        """Best-effort favorite cleanup for engines whose delete is deferred."""
+        encoded_session_key = quote(session_key, safe="")
+        try:
+            await self._transport.invoke(
+                connection,
+                "DELETE",
+                f"/api/session-favorites/{encoded_session_key}",
+                params={"user_id": user_id},
+            )
+        except Exception as error:
+            logger.warning(
+                "[ExpertChatService] Favorite cleanup skipped: session=%s error=%s",
+                session_key,
+                error,
+            )
+
+    async def _list_favorite_sessions(
+        self,
+        connection: Dict[str, Any],
+        user_id: str,
+        bot_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Read existing Adapter favorites; old Adapters degrade to an empty tab."""
+        try:
+            response = await self._transport.invoke(
+                connection,
+                "GET",
+                "/api/session-favorites",
+                params={
+                    "user_id": user_id,
+                    "limit": 10_000,
+                    "offset": 0,
+                },
+            )
+            data = response.get("data")
+            return data if isinstance(data, list) else []
+        except Exception as error:
+            logger.warning(
+                "[ExpertChatService] Favorite list unavailable: bot=%s error=%s",
+                bot_id,
+                error,
+            )
+            return []
+
+    def _get_connection(
+        self, bot: Dict[str, Any], user_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """获取 Bot 的连接信息
 
         分流:
@@ -596,45 +1094,13 @@ class ExpertChatService:
             f"User {user_id} has no chat access to bot {bot_id}"
         )
 
-    def _resolve_chat_engine_type(self, bot: Dict[str, Any], conn: Dict[str, Any]) -> str:
-        """Resolve effective chat engine from authoritative bot metadata.
-
-        ``conn["engine_type"]`` may be a resolver fallback when a historical
-        runtime binding cannot reverse-resolve the business bot, for example
-        caller-instance BaaS bindings created before ``device_props.bolt_id`` was
-        persisted. ExpertChat already has the authoritative bot row, so prefer it
-        and apply the public BaaS bucket normalization used by runtime routing.
-        """
-        template_config = bot.get("template_config") or {}
-        if not isinstance(template_config, dict):
-            template_config = {}
-        raw_engine_type = (
-            bot.get("active_engine")
-            or template_config.get("active_runtime_engine_type")
-            or conn.get("engine_type")
-            or "openclaw"
-        )
-        return resolve_baas_engine_bucket(
-            engine_type=raw_engine_type,
-            template_type=bot.get("template_type") or "",
-        )
-
-    def _resolve_chat_engine_strategy(self, bot: Dict[str, Any], conn: Dict[str, Any]):
-        """Resolve normalized chat engine plus its registered strategy."""
-        engine_type = self._resolve_chat_engine_type(bot, conn)
-        template_config = bot.get("template_config")
-        if not isinstance(template_config, dict):
-            template_config = None
-        return resolve_provisioning(
-            bot_id=str(bot.get("bot_id") or ""),
-            owner_id=str(bot.get("owner_id") or ""),
-            bot_type=str(bot.get("bot_type") or ""),
-            active_engine=engine_type,
-            template_type=bot.get("template_type") or None,
-            template_config=template_config,
-        )
-
-    async def _create_session(self, bot: Dict[str, Any], user_id: str) -> str:
+    async def _create_session(
+        self,
+        bot: Dict[str, Any],
+        user_id: str,
+        connection: Optional[Dict[str, Any]] = None,
+        prefer_adapter_for_relay: bool = False,
+    ) -> str:
         """调用 Adapter 创建 session
 
         Args:
@@ -644,27 +1110,54 @@ class ExpertChatService:
         Returns:
             session_key
         """
-        conn = self._get_connection(bot, user_id)
-        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
-        conn["engine_type"] = ctx.active_engine
+        conn = connection or self._get_connection(bot, user_id)
+        engine_type = conn.get("engine_type", "openclaw")
 
-        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
-            session_key = strategy.build_local_chat_session_key(ctx, user_id=user_id)
-            logger.info(
-                "[ExpertChatService] Relay-managed chat session: bot=%s, user=%s, engine=%s, session=%s",
-                bot.get("bot_id"), user_id, ctx.active_engine, session_key,
-            )
-            return session_key
+        # Preserve the legacy singular /session behavior. Only the new plural
+        # /sessions flow opts into persisted, canonical relay session keys.
+        if (
+            engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+            and not prefer_adapter_for_relay
+        ):
+            return await self._create_aicoding_session(conn, bot, user_id)
 
-        return await self._create_openclaw_session(conn, bot, user_id)
+        try:
+            return await self._create_openclaw_session(conn, bot, user_id)
+        except Exception as error:
+            if (
+                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+                and self._is_adapter_endpoint_unsupported(error)
+            ):
+                logger.warning(
+                    "[ExpertChatService] Adapter session creation unsupported; "
+                    "using legacy local key: engine=%s bot=%s",
+                    engine_type,
+                    bot.get("bot_id"),
+                )
+                return await self._create_aicoding_session(conn, bot, user_id)
+            raise
 
-    async def _create_openclaw_session(self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str) -> str:
-        """调用 Adapter 创建 OpenClaw session，返回带前缀的完整 session ID"""
+    async def _create_aicoding_session(
+        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
+    ) -> str:
+        """
+        AI Coding 引擎：teamclaw-aicoding-relay 按需建 session，本地生成 key，不调 Adapter。
+        """
+        import uuid
+
+        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
+        logger.info(f"[aicoding] local session key generated: {session_key}")
+        return session_key
+
+    async def _create_openclaw_session(
+        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
+    ) -> str:
+        """Create a session through the active Adapter and return its full ID."""
         payload = {
             "title": f"Chat with {bot.get('bot_name', bot['bot_id'])}",
             "user_id": user_id,
             "agent_id": bot["bot_id"],
-            "engine": "openclaw",
+            "engine": conn.get("engine_type", "openclaw"),
         }
         use_proxy = conn.get("use_proxy", False)
         logger.info(
@@ -676,11 +1169,19 @@ class ExpertChatService:
         )
 
         try:
+            create_timeout = (
+                _RELAY_SESSION_CREATE_TIMEOUT_SECONDS
+                if conn.get("engine_type") in _LEGACY_LOCAL_SESSION_ENGINES
+                else None
+            )
+            invoke_kwargs: Dict[str, Any] = {"body": payload}
+            if create_timeout is not None:
+                invoke_kwargs["timeout"] = create_timeout
             data = await self._transport.invoke(
                 conn,
                 "POST",
                 "/api/sessions",
-                body=payload,
+                **invoke_kwargs,
             )
             logger.info(f"[ExpertChatService] Adapter POST response {data}")
             raw_session_key = data.get("data", {}).get("id") or data.get("id")
@@ -762,24 +1263,34 @@ class ExpertChatService:
             original_error=error_msg,
         )
 
-    async def _check_session_exists(self, bot: Dict[str, Any], session_key: str, user_id: Optional[str] = None) -> bool:
+    async def _check_session_exists(
+        self,
+        bot: Dict[str, Any],
+        session_key: str,
+        user_id: Optional[str] = None,
+        connection: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """
         调用 Adapter 校验 session 是否还存在。
         AI Coding 引擎：teamclaw-aicoding-relay 按需创建 session，始终返回 True。
         """
-        conn = self._get_connection(bot, user_id)
-        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
-        conn["engine_type"] = ctx.active_engine
+        conn = connection or self._get_connection(bot, user_id)
 
-        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
+        if conn.get("engine_type") == "aicoding":
+            return True
+        if conn.get("engine_type") == "claude_code":
             logger.info(
-                "[ExpertChatService] Relay-managed chat session check: skipping adapter pre-check for session=%s, engine=%s",
-                session_key, ctx.active_engine,
+                "[ExpertChatService] claude_code session check: skipping "
+                "adapter pre-check for session=%s",
+                session_key,
             )
             return True
 
         try:
-            await self._transport.invoke(conn, "GET", f"/api/sessions/{session_key}")
+            encoded_session_key = quote(session_key, safe="")
+            await self._transport.invoke(
+                conn, "GET", f"/api/sessions/{encoded_session_key}"
+            )
             return True
         except Exception as e:
             if self._is_adapter_not_found(e):
@@ -799,37 +1310,44 @@ class ExpertChatService:
         bot: Dict[str, Any],
         session_key: str,
         user_id: Optional[str] = None,
+        connection: Optional[Dict[str, Any]] = None,
     ) -> None:
         """调用 Adapter 删除 session"""
-        # Relay-managed sessions do not require Adapter deletion. Resolve from bot
-        # first so historical caller-instance bindings with conn_engine=openclaw do
-        # not accidentally call the OpenClaw adapter endpoint.
-        bot_ctx, bot_strategy = self._resolve_chat_engine_strategy(bot, {})
-        if not bot_strategy.uses_adapter_chat_session_lifecycle(bot_ctx):
-            logger.info(
-                "[ExpertChatService] Skipping adapter session deletion for relay-managed engine: bot=%s, session=%s, engine=%s",
-                bot.get("bot_id"), session_key, bot_ctx.active_engine,
-            )
-            return
-
-        conn = self._get_connection(bot, user_id)
-        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
-        conn["engine_type"] = ctx.active_engine
-        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
-            logger.info(
-                "[ExpertChatService] Skipping adapter session deletion for relay-managed engine: bot=%s, session=%s, engine=%s",
-                bot.get("bot_id"), session_key, ctx.active_engine,
-            )
-            return
+        conn = connection or self._get_connection(bot, user_id)
+        engine_type = conn.get("engine_type", "openclaw")
 
         logger.info(f"[ExpertChatService] Deleting adapter session via transport: session={session_key}")
 
         try:
-            await self._transport.invoke(conn, "DELETE", f"/api/sessions/{session_key}")
+            encoded_session_key = quote(session_key, safe="")
+            await self._transport.invoke(
+                conn, "DELETE", f"/api/sessions/{encoded_session_key}"
+            )
             logger.info(f"[ExpertChatService] Successfully deleted adapter session: {session_key}")
         except Exception as e:
             if self._is_adapter_not_found(e):
+                if self._is_ambiguous_adapter_delete_not_found(e):
+                    # Engine's generic DELETE endpoint uses this 404 for both a
+                    # missing session and an operational deletion failure. The
+                    # Backend ownership index must remain retryable on ambiguity.
+                    logger.error(
+                        "[ExpertChatService] Adapter returned ambiguous delete "
+                        "result; preserving ownership: session=%s",
+                        session_key,
+                    )
+                    raise
                 logger.warning(f"[ExpertChatService] Session not found in adapter: {session_key}")
+                return
+            if (
+                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+                and self._is_adapter_endpoint_unsupported(e)
+            ):
+                logger.warning(
+                    "[ExpertChatService] Adapter session deletion unsupported; "
+                    "keeping legacy metadata-only behavior: engine=%s session=%s",
+                    engine_type,
+                    session_key,
+                )
                 return
             logger.error(
                 "[ExpertChatService] Unexpected error when DELETE session via transport: %s: %s",
@@ -841,5 +1359,29 @@ class ExpertChatService:
 
     @staticmethod
     def _is_adapter_not_found(error: Exception) -> bool:
+        if isinstance(error, DeviceAdapterEndpointNotFoundError):
+            return True
+        if isinstance(error, DeviceAdapterHTTPStatusError):
+            return error.status_code == 404
         error_msg = str(error)
         return "Adapter returned" in error_msg and "404" in error_msg
+
+    @staticmethod
+    def _is_ambiguous_adapter_delete_not_found(error: Exception) -> bool:
+        """Identify the Engine 404 that also represents runtime delete failure."""
+        return "Session not found or delete failed" in str(error)
+
+    @staticmethod
+    def _is_adapter_endpoint_unsupported(error: Exception) -> bool:
+        if isinstance(error, DeviceAdapterEndpointNotFoundError):
+            return True
+        if isinstance(error, DeviceAdapterHTTPStatusError):
+            return error.status_code in {404, 405}
+        error_msg = (
+            error.original_error
+            if isinstance(error, SessionCreateError) and error.original_error
+            else str(error)
+        )
+        return "Adapter returned" in error_msg and (
+            "404" in error_msg or "405" in error_msg
+        )

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -484,7 +484,6 @@ class ExpertChatService(ExpertChatSessionRuntimeMixin):
             )
 
         items = []
-        engine_type = connection.get("engine_type", "openclaw") if connection else None
         for row in rows:
             item = adapter_items.get(row["session_key"])
             if item is None:
@@ -493,19 +492,18 @@ class ExpertChatService(ExpertChatSessionRuntimeMixin):
             enriched = dict(item)
             for key, value in self._placeholder_session(row).items():
                 enriched.setdefault(key, value)
-            if engine_type == "openclaw":
-                # OpenClaw currently synthesizes Session updated_at at conversion
-                # time. Prefer the real message timestamp, then the stable Backend
-                # ownership creation time, so repeated reads cannot reorder rows.
-                last_message = enriched.get("last_message")
-                last_message_at = (
-                    last_message.get("gmt_created")
-                    if isinstance(last_message, dict)
-                    else None
-                )
-                stable_modified = last_message_at or row.get("gmt_create")
-                if stable_modified:
-                    enriched["gmt_modified"] = stable_modified
+            # Adapter timestamps may be synthesized during reads. Prefer the real
+            # last-message timestamp and fall back to the stable ownership time so
+            # repeated list requests cannot reorder any engine's sessions.
+            last_message = enriched.get("last_message")
+            last_message_at = (
+                last_message.get("gmt_created")
+                if isinstance(last_message, dict)
+                else None
+            )
+            stable_modified = last_message_at or row.get("gmt_create")
+            if stable_modified:
+                enriched["gmt_modified"] = stable_modified
             items.append(enriched)
 
         items.sort(key=self._session_sort_key, reverse=True)
@@ -540,7 +538,6 @@ class ExpertChatService(ExpertChatSessionRuntimeMixin):
             bot,
             user_id,
             connection=connection,
-            prefer_adapter_for_relay=True,
         )
         self._repo.add_owned_session(user_id, bot_id, owner_id, created_session_key)
         # Legacy clients resume the latest session created by the new UI.

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -15,14 +15,12 @@ ExpertChat Service — 用户与专家Bot对话业务逻辑层
 
 from __future__ import annotations
 
-import traceback
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Protocol, runtime_checkable
 from urllib.parse import quote
 
 from injector import inject
 
-from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
     CollaboratorService,
 )
@@ -37,22 +35,17 @@ from agentclaw.community.core.expert_chat.errors import (
     BotNotFoundError,
     BotNotActiveError,
     BotNotPublishedError,
-    ChatPermissionError,
-    SessionCreateError,
     ConnectionError,
 )
 from agentclaw.community.core.repository.protocols.chat import ExpertChatRepository
 from agentclaw.community.core.expert_chat.services.expert_chat_instance_service import (
     ExpertChatInstanceService,
 )
-from agentclaw.community.core.bot_management.engines.registry import (
-    resolve_baas_engine_bucket,
-    resolve_provisioning,
+from agentclaw.community.core.expert_chat.services.expert_chat_session_runtime import (
+    ExpertChatSessionRuntimeMixin,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import (
-    DeviceAdapterEndpointNotFoundError,
-    DeviceAdapterHTTPStatusError,
     DeviceAdapterTransport,
 )
 
@@ -60,11 +53,10 @@ logger = get_logger()
 
 _ADAPTER_SESSION_PAGE_SIZE = 500
 _EXACT_SESSION_LOOKUP_ENGINES = {"openclaw", "hermes", "claude_code"}
-_LEGACY_LOCAL_SESSION_ENGINES = {"aicoding", "claude_code"}
-_RELAY_SESSION_CREATE_TIMEOUT_SECONDS = 330.0
 
 
 # ============ Protocol Definitions ============
+
 
 @runtime_checkable
 class DeviceConnectionProvider(Protocol):
@@ -72,6 +64,7 @@ class DeviceConnectionProvider(Protocol):
 
     Decoupled from old device service to avoid circular dependencies.
     """
+
     def get_device_connection_v2(
         self, binding_id: str, user_id: str, nick_name: str
     ) -> Dict[str, Any]:
@@ -92,7 +85,9 @@ class DeviceConnectionProvider(Protocol):
 class BotInfoProvider(Protocol):
     """Protocol for bot info provider."""
 
-    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> Optional[Dict[str, Any]]:
+    def get_by_id_and_owner(
+        self, bot_id: str, owner_id: str
+    ) -> Optional[Dict[str, Any]]:
         """通过bot_id和owner_id获取Bot信息
 
         Args:
@@ -107,7 +102,8 @@ class BotInfoProvider(Protocol):
 
 # ============ Service Implementation ============
 
-class ExpertChatService:
+
+class ExpertChatService(ExpertChatSessionRuntimeMixin):
     """用户与专家Bot对话业务逻辑"""
 
     @inject
@@ -172,11 +168,15 @@ class ExpertChatService:
         # 1. 校验 bot 是否存在且 ACTIVE（通过 bot_id + owner_id 唯一定位）
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if not bot:
-            logger.warning(f"[ExpertChatService] Bot not found: {bot_id}, owner={owner_id}")
+            logger.warning(
+                f"[ExpertChatService] Bot not found: {bot_id}, owner={owner_id}"
+            )
             raise BotNotFoundError(f"Bot不存在: {bot_id}")
 
         if bot.get("status") != "ACTIVE":
-            logger.warning(f"[ExpertChatService] Bot not active: {bot_id}, status={bot.get('status')}")
+            logger.warning(
+                f"[ExpertChatService] Bot not active: {bot_id}, status={bot.get('status')}"
+            )
             raise BotNotActiveError(f"Bot未激活: {bot_id}")
 
         # 2. 校验 Bot 是否已绑定设备
@@ -214,7 +214,9 @@ class ExpertChatService:
             # 使用 get_by_id_and_owner 唯一定位 bot
             bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
             if not bot:
-                logger.warning(f"[ExpertChatService] Bot not found in list: {bot_id}, owner={owner_id}")
+                logger.warning(
+                    f"[ExpertChatService] Bot not found in list: {bot_id}, owner={owner_id}"
+                )
                 continue
 
             # 检查是否有 binding_id（即是否绑定了设备）
@@ -222,7 +224,10 @@ class ExpertChatService:
             bot_type = bot.get("bot_type", "personal")
             if bot_type == "service":
                 # 服务型 Bot：通过 BaasService 获取 bind_id
-                from agentclaw.community.core.service_bot.repository.models import PublishStatus
+                from agentclaw.community.core.service_bot.repository.models import (
+                    PublishStatus,
+                )
+
                 binding_id = self._baas_service.get_bind_id(
                     bot_id=bot_id,
                     owner_id=owner_id,
@@ -234,20 +239,24 @@ class ExpertChatService:
                 binding_id = bot.get("binding_id")
             binding_available = bool(binding_id)
 
-            result.append({
-                "bot_id": bot_id,
-                "owner_id": owner_id,
-                "bot_name": bot.get("bot_name") or bot_id,
-                "owner_name": bot.get("owner_name", "未知"),
-                "status": bot.get("status", "UNKNOWN"),
-                # 设备绑定相关字段
-                "binding_available": binding_available,
-                "binding_id": binding_id,
-                # Bot 扩展信息
-                "ext": bot.get("ext"),
-            })
+            result.append(
+                {
+                    "bot_id": bot_id,
+                    "owner_id": owner_id,
+                    "bot_name": bot.get("bot_name") or bot_id,
+                    "owner_name": bot.get("owner_name", "未知"),
+                    "status": bot.get("status", "UNKNOWN"),
+                    # 设备绑定相关字段
+                    "binding_available": binding_available,
+                    "binding_id": binding_id,
+                    # Bot 扩展信息
+                    "ext": bot.get("ext"),
+                }
+            )
 
-        logger.info(f"[ExpertChatService] Listed {len(result)} chat bots for user={user_id}")
+        logger.info(
+            f"[ExpertChatService] Listed {len(result)} chat bots for user={user_id}"
+        )
         return result
 
     async def remove_chat_bot(self, user_id: str, bot_id: str, owner_id: str) -> bool:
@@ -264,9 +273,7 @@ class ExpertChatService:
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         legacy_session_key = self._repo.get_session(user_id, bot_id, owner_id)
         if legacy_session_key:
-            self._repo.add_owned_session(
-                user_id, bot_id, owner_id, legacy_session_key
-            )
+            self._repo.add_owned_session(user_id, bot_id, owner_id, legacy_session_key)
         owned_sessions = self._repo.list_owned_sessions(user_id, bot_id, owner_id)
 
         if bot and owned_sessions:
@@ -288,15 +295,11 @@ class ExpertChatService:
                     user_id,
                     connection=connection,
                 )
-                await self._remove_session_favorite(
-                    connection, session_key, user_id
-                )
+                await self._remove_session_favorite(connection, session_key, user_id)
                 # Persist progress after each confirmed runtime deletion. If a
                 # later deletion fails, retrying must not revisit a session that
                 # the Engine has already removed.
-                self._repo.delete_owned_session(
-                    user_id, bot_id, owner_id, session_key
-                )
+                self._repo.delete_owned_session(user_id, bot_id, owner_id, session_key)
                 remaining_session_keys.remove(session_key)
                 if legacy_session_key == session_key:
                     if remaining_session_keys:
@@ -397,15 +400,11 @@ class ExpertChatService:
                 }
             else:
                 # Session 已失效，删除旧记录
-                self._repo.delete_owned_session(
-                    user_id, bot_id, owner_id, session_key
-                )
+                self._repo.delete_owned_session(user_id, bot_id, owner_id, session_key)
                 self._repo.delete_session(user_id, bot_id, owner_id)
 
         # 7. 没有或无效则创建新 session
-        session_key = await self._create_session(
-            bot, user_id, connection=connection
-        )
+        session_key = await self._create_session(bot, user_id, connection=connection)
         self._repo.save_session(user_id, bot_id, owner_id, session_key)
         self._repo.add_owned_session(user_id, bot_id, owner_id, session_key)
 
@@ -644,7 +643,9 @@ class ExpertChatService:
         # 2. 获取本地 session_key
         session_key = self._repo.get_session(user_id, bot_id, owner_id)
         if not session_key:
-            logger.warning(f"[ExpertChatService] No session found for user={user_id}, bot={bot_id}, owner={owner_id}")
+            logger.warning(
+                f"[ExpertChatService] No session found for user={user_id}, bot={bot_id}, owner={owner_id}"
+            )
             return True  # 本来就没有，也算成功
 
         # 3. 调用 Adapter 删除 session。运行时删除失败时保留新的 ownership，
@@ -653,7 +654,9 @@ class ExpertChatService:
             await self._delete_adapter_session(bot, session_key, user_id)
             logger.info(f"[ExpertChatService] Deleted adapter session: {session_key}")
         except Exception as e:
-            logger.error(f"[ExpertChatService] Failed to delete adapter session {session_key}: {e}")
+            logger.error(
+                f"[ExpertChatService] Failed to delete adapter session {session_key}: {e}"
+            )
             raise
 
         # 4. 删除本地 session 映射
@@ -931,457 +934,3 @@ class ExpertChatService:
                 error,
             )
             return []
-
-    def _get_connection(
-        self, bot: Dict[str, Any], user_id: Optional[str] = None
-    ) -> Dict[str, Any]:
-        """获取 Bot 的连接信息
-
-        分流:
-        - service bot:caller 链路(``list_chat_bots`` / ``get_chat_session``)已通过
-          ``baas_service.get_bind_id(SUCCESS)`` 把发布单 ``ext.binding.online`` 的
-          binding_id 塞到 ``bot["binding_id"]``。直接走 ``resolve_for_binding``。
-          **不能走 by-bot 入口** — 它会反查 ``ac_bots.binding_id``,那是 DRAFT
-          binding,与 SUCCESS binding 数据上是两条不同记录。
-        - personal bot:``bot.get("binding_id")`` 为 None,走 ``resolve_for_bot``
-          (按 (bot_id, owner_id) 反查 ``ac_bots.binding_id``)。
-          owner_id 显式从 ``bot["owner_id"]`` 取,**不再用 user_id 当 owner_id**:
-          public bot 被他人调用 / collaborator 调用时,user_id 是 caller 工号,
-          binding 仍在 owner 名下,用 caller id 必查不到。
-
-        权限上移:caller 显式调 ``_check_chat_access``,失败 ``ChatPermissionError``,
-        resolver 不被调(早失败语义)。
-
-        Args:
-            bot: Bot 信息字典(必须含 ``bot_id`` / ``owner_id`` / ``public``;
-                service bot 链路下还含 ``binding_id``)
-            user_id: 用户ID（caller 身份,权限校验 + builder device_affinity 用）
-
-        Returns:
-            连接信息，含 url、headers、use_proxy、engine_type 等字段
-
-        Raises:
-            ChatPermissionError: 非 owner / 非 public / 非 collaborator
-            BotNotPublishedError: Bot 未绑定设备(resolver 抛 DeviceNotBoundError 翻译而来)
-            ConnectionError: 底层连接失败
-        """
-        from agentclaw.community.core.devices.services.device_context import (
-            DeviceNotBoundError,
-        )
-
-        bot_id = bot["bot_id"]
-        owner_id = bot.get("owner_id")
-        binding_id = bot.get("binding_id")
-
-        # 1. 权限校验 — Defense-in-depth: primary check in get_chat_session
-        #    保持此检查作为安全网，确保其他调用路径（如 refresh_connection）也有权限保护
-        self._check_chat_access(bot, user_id)
-
-        # 2. 走 resolver (全仓唯一 provider 解析点,替代 v2)
-        if not binding_id:
-            raise ConnectionError(
-                "(binding_id 未提供)服务未发布",
-                error_code="5002",
-            )
-        logger.info(
-            f"[ExpertChatService] Resolving device context: bot={bot_id}, "
-            f"owner={owner_id}, user={user_id}, binding_id={binding_id}"
-        )
-        try:
-            ctx = self._resolver.resolve_for_binding(binding_id, user_id, bot_id=bot_id)
-        except DeviceNotBoundError as e:
-            logger.warning(f"[ExpertChatService] Bot has no active binding: {bot_id}: {e}")
-            raise BotNotPublishedError(f"Bot未绑定设备: {bot_id}")
-        except Exception as e:
-            error_msg = str(e)
-            logger.error(
-                "[ExpertChatService] Failed to resolve device context for bot=%s: %s: %s",
-                bot_id,
-                type(e).__name__,
-                e,
-            )
-            logger.error(f"[ExpertChatService] Resolver error traceback: {traceback.format_exc()}")
-            raise ConnectionError(
-                "无法连接到Bot服务",
-                error_code="5001",
-                original_error=error_msg
-            )
-
-        conn = ctx.conn_info
-
-        logger.info(
-            "[ExpertChatService] Resolved device context: bot=%s binding_id=%s "
-            "provider=%s conn_engine=%s active_engine=%s template_type=%s "
-            "runtime_engine=%s",
-            bot_id,
-            binding_id,
-            ctx.provider,
-            conn.get("engine_type"),
-            bot.get("active_engine"),
-            bot.get("template_type"),
-            (bot.get("template_config") or {}).get("active_runtime_engine_type"),
-        )
-
-        if conn.get("use_proxy"):
-            logger.info(
-                "[ExpertChatService] Got proxy connection: bot=%s, provider=%s, sandbox_id=%s",
-                bot_id,
-                ctx.provider,
-                conn.get("sandbox_id"),
-            )
-        else:
-            logger.info(f"[ExpertChatService] Got direct connection: bot={bot_id}, target={conn.get('target')}")
-
-        return conn
-
-    def _check_chat_access(self, bot: Dict[str, Any], user_id: Optional[str]) -> None:
-        """权限上移 — 沿用 device_service.py:804-839 旧 v2 内 4 分支语义。
-
-        改造前: 权限校验藏在 ``get_device_connection`` 副作用里,经由
-        ``get_device_connection_v2`` 间接触发,raise ``InvalidDeviceStatusError``。
-        改造后: caller 显式调,失败时 resolver 不被调到。
-
-        放行规则(与旧 v2 等价):
-        - bot owner 本人 → 放行
-        - 非 owner 但 bot.public='1' → 放行
-        - 协作者 (PermissionLevel.MEMBER 及以上) → 放行
-        - 否则 → raise ChatPermissionError
-
-        Args:
-            bot: Bot 信息字典(必须含 ``bot_id`` / ``owner_id`` / ``public``)
-            user_id: caller 身份
-
-        Raises:
-            ChatPermissionError: 不满足上述任何分支
-        """
-        bot_id = bot["bot_id"]
-        owner_id = bot.get("owner_id")
-
-        # 分支 1: owner 本人
-        if owner_id == user_id:
-            return
-
-        # 分支 2: 公开 bot
-        if bot.get("public") == "1":
-            return
-
-        # 分支 3: 协作者
-        try:
-            result = self._collaborator_service.check_collaborator_permission(
-                bot_id=bot_id,
-                owner_id=owner_id,
-                user_id=user_id,
-                required_level=PermissionLevel.MEMBER,
-            )
-        except Exception as e:
-            # 兜底 — collaborator 查询失败按拒绝处理,日志告警
-            logger.warning(
-                f"[ExpertChatService] check_collaborator_permission failed for "
-                f"bot={bot_id}, user={user_id}: {e}"
-            )
-            raise ChatPermissionError(
-                f"User {user_id} has no chat access to bot {bot_id} (collaborator check failed)"
-            )
-
-        if result.get("has_permission", False):
-            return
-
-        # 分支 4: 拒绝
-        logger.warning(
-            f"[ExpertChatService] ChatPermissionError: user={user_id} not allowed to chat with bot={bot_id}"
-        )
-        raise ChatPermissionError(
-            f"User {user_id} has no chat access to bot {bot_id}"
-        )
-
-    async def _create_session(
-        self,
-        bot: Dict[str, Any],
-        user_id: str,
-        connection: Optional[Dict[str, Any]] = None,
-        prefer_adapter_for_relay: bool = False,
-    ) -> str:
-        """调用 Adapter 创建 session
-
-        Args:
-            bot: Bot 信息字典
-            user_id: 用户ID
-
-        Returns:
-            session_key
-        """
-        conn = connection or self._get_connection(bot, user_id)
-        engine_type = conn.get("engine_type", "openclaw")
-
-        # Preserve the legacy singular /session behavior. Only the new plural
-        # /sessions flow opts into persisted, canonical relay session keys.
-        if (
-            engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-            and not prefer_adapter_for_relay
-        ):
-            return await self._create_aicoding_session(conn, bot, user_id)
-
-        try:
-            return await self._create_openclaw_session(conn, bot, user_id)
-        except Exception as error:
-            if (
-                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-                and self._is_adapter_endpoint_unsupported(error)
-            ):
-                logger.warning(
-                    "[ExpertChatService] Adapter session creation unsupported; "
-                    "using legacy local key: engine=%s bot=%s",
-                    engine_type,
-                    bot.get("bot_id"),
-                )
-                return await self._create_aicoding_session(conn, bot, user_id)
-            raise
-
-    async def _create_aicoding_session(
-        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
-    ) -> str:
-        """
-        AI Coding 引擎：teamclaw-aicoding-relay 按需建 session，本地生成 key，不调 Adapter。
-        """
-        import uuid
-
-        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
-        logger.info(f"[aicoding] local session key generated: {session_key}")
-        return session_key
-
-    async def _create_openclaw_session(
-        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
-    ) -> str:
-        """Create a session through the active Adapter and return its full ID."""
-        payload = {
-            "title": f"Chat with {bot.get('bot_name', bot['bot_id'])}",
-            "user_id": user_id,
-            "agent_id": bot["bot_id"],
-            "engine": conn.get("engine_type", "openclaw"),
-        }
-        use_proxy = conn.get("use_proxy", False)
-        logger.info(
-            "[ExpertChatService] Creating OpenClaw session via transport: "
-            "user_id=%s, bot_id=%s, use_proxy=%s",
-            user_id,
-            bot["bot_id"],
-            use_proxy,
-        )
-
-        try:
-            create_timeout = (
-                _RELAY_SESSION_CREATE_TIMEOUT_SECONDS
-                if conn.get("engine_type") in _LEGACY_LOCAL_SESSION_ENGINES
-                else None
-            )
-            invoke_kwargs: Dict[str, Any] = {"body": payload}
-            if create_timeout is not None:
-                invoke_kwargs["timeout"] = create_timeout
-            data = await self._transport.invoke(
-                conn,
-                "POST",
-                "/api/sessions",
-                **invoke_kwargs,
-            )
-            logger.info(f"[ExpertChatService] Adapter POST response {data}")
-            raw_session_key = data.get("data", {}).get("id") or data.get("id")
-            if not raw_session_key:
-                logger.error(f"[ExpertChatService] No session key in adapter response: {data}")
-                raise Exception(f"Invalid response from adapter: {data}")
-        except Exception as e:
-            self._raise_session_create_error(e, "POST /api/sessions")
-
-        # 创建成功后，通过 list 获取带前缀的完整 session ID
-        logger.info(f"[ExpertChatService] Looking for prefixed session ID for: {raw_session_key}")
-        try:
-            list_data = await self._transport.invoke(conn, "GET", "/api/sessions")
-            sessions = list_data.get("data", [])
-            if not isinstance(sessions, list):
-                sessions = []
-            logger.info(f"[ExpertChatService] Got {len(sessions)} sessions from list")
-            for s in sessions:
-                session_id = s.get("id", "")
-                if (
-                    session_id.lower().endswith(raw_session_key.lower())
-                    or raw_session_key.lower() in session_id.lower()
-                ):
-                    logger.info(
-                        "[ExpertChatService] Found prefixed session ID: %s (raw: %s)",
-                        session_id,
-                        raw_session_key,
-                    )
-                    return session_id
-            logger.warning(f"[ExpertChatService] No matching prefixed session found for: {raw_session_key}")
-        except Exception as e:
-            logger.warning(f"[ExpertChatService] Failed to get prefixed session ID, using raw: {e}")
-
-        logger.info(f"[ExpertChatService] Created OpenClaw session via adapter: {raw_session_key}")
-        return raw_session_key
-
-    def _raise_session_create_error(self, error: Exception, operation: str) -> None:
-        logger.error(
-            "[ExpertChatService] Unexpected error when %s: %s: %s",
-            operation,
-            type(error).__name__,
-            error,
-        )
-        logger.error(f"[ExpertChatService] Unexpected error traceback: {traceback.format_exc()}")
-        error_msg = str(error)
-        if "Connection refused" in error_msg or "Cannot connect to host" in error_msg:
-            raise SessionCreateError(
-                "Bot服务暂不可用，请稍后重试",
-                error_code="50201",
-                original_error=error_msg,
-            )
-        if "Failed to connect" in error_msg:
-            raise SessionCreateError(
-                "连接Bot服务失败",
-                error_code="5002",
-                original_error=error_msg,
-            )
-        if "Adapter returned" in error_msg:
-            if "404" in error_msg:
-                raise SessionCreateError(
-                    "Bot服务暂不可用，请稍后重试",
-                    error_code="40402",
-                    original_error=error_msg,
-                )
-            if (
-                "500" in error_msg
-                or "502" in error_msg
-                or "503" in error_msg
-                or "gateway" in error_msg.lower()
-            ):
-                raise SessionCreateError(
-                    "Bot服务暂不可用，请稍后重试",
-                    error_code="50201",
-                    original_error=error_msg,
-                )
-        raise SessionCreateError(
-            f"创建 Session 失败: {error_msg[:100]}",
-            error_code="5003",
-            original_error=error_msg,
-        )
-
-    async def _check_session_exists(
-        self,
-        bot: Dict[str, Any],
-        session_key: str,
-        user_id: Optional[str] = None,
-        connection: Optional[Dict[str, Any]] = None,
-    ) -> bool:
-        """
-        调用 Adapter 校验 session 是否还存在。
-        AI Coding 引擎：teamclaw-aicoding-relay 按需创建 session，始终返回 True。
-        """
-        conn = connection or self._get_connection(bot, user_id)
-
-        if conn.get("engine_type") == "aicoding":
-            return True
-        if conn.get("engine_type") == "claude_code":
-            logger.info(
-                "[ExpertChatService] claude_code session check: skipping "
-                "adapter pre-check for session=%s",
-                session_key,
-            )
-            return True
-
-        try:
-            encoded_session_key = quote(session_key, safe="")
-            await self._transport.invoke(
-                conn, "GET", f"/api/sessions/{encoded_session_key}"
-            )
-            return True
-        except Exception as e:
-            if self._is_adapter_not_found(e):
-                logger.warning(f"[ExpertChatService] Session not found in adapter: {session_key}")
-                return False
-            # 网络错误或其他状态，保守起见认为存在
-            logger.warning(
-                "[ExpertChatService] Error checking session %s via transport: %s: %s",
-                session_key,
-                type(e).__name__,
-                e,
-            )
-            return True
-
-    async def _delete_adapter_session(
-        self,
-        bot: Dict[str, Any],
-        session_key: str,
-        user_id: Optional[str] = None,
-        connection: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """调用 Adapter 删除 session"""
-        conn = connection or self._get_connection(bot, user_id)
-        engine_type = conn.get("engine_type", "openclaw")
-
-        logger.info(f"[ExpertChatService] Deleting adapter session via transport: session={session_key}")
-
-        try:
-            encoded_session_key = quote(session_key, safe="")
-            await self._transport.invoke(
-                conn, "DELETE", f"/api/sessions/{encoded_session_key}"
-            )
-            logger.info(f"[ExpertChatService] Successfully deleted adapter session: {session_key}")
-        except Exception as e:
-            if self._is_adapter_not_found(e):
-                if self._is_ambiguous_adapter_delete_not_found(e):
-                    # Engine's generic DELETE endpoint uses this 404 for both a
-                    # missing session and an operational deletion failure. The
-                    # Backend ownership index must remain retryable on ambiguity.
-                    logger.error(
-                        "[ExpertChatService] Adapter returned ambiguous delete "
-                        "result; preserving ownership: session=%s",
-                        session_key,
-                    )
-                    raise
-                logger.warning(f"[ExpertChatService] Session not found in adapter: {session_key}")
-                return
-            if (
-                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-                and self._is_adapter_endpoint_unsupported(e)
-            ):
-                logger.warning(
-                    "[ExpertChatService] Adapter session deletion unsupported; "
-                    "keeping legacy metadata-only behavior: engine=%s session=%s",
-                    engine_type,
-                    session_key,
-                )
-                return
-            logger.error(
-                "[ExpertChatService] Unexpected error when DELETE session via transport: %s: %s",
-                type(e).__name__,
-                e,
-            )
-            logger.error(f"[ExpertChatService] Delete session traceback: {traceback.format_exc()}")
-            raise
-
-    @staticmethod
-    def _is_adapter_not_found(error: Exception) -> bool:
-        if isinstance(error, DeviceAdapterEndpointNotFoundError):
-            return True
-        if isinstance(error, DeviceAdapterHTTPStatusError):
-            return error.status_code == 404
-        error_msg = str(error)
-        return "Adapter returned" in error_msg and "404" in error_msg
-
-    @staticmethod
-    def _is_ambiguous_adapter_delete_not_found(error: Exception) -> bool:
-        """Identify the Engine 404 that also represents runtime delete failure."""
-        return "Session not found or delete failed" in str(error)
-
-    @staticmethod
-    def _is_adapter_endpoint_unsupported(error: Exception) -> bool:
-        if isinstance(error, DeviceAdapterEndpointNotFoundError):
-            return True
-        if isinstance(error, DeviceAdapterHTTPStatusError):
-            return error.status_code in {404, 405}
-        error_msg = (
-            error.original_error
-            if isinstance(error, SessionCreateError) and error.original_error
-            else str(error)
-        )
-        return "Adapter returned" in error_msg and (
-            "404" in error_msg or "405" in error_msg
-        )

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
@@ -7,6 +7,10 @@ from typing import Any, Dict, Optional
 from urllib.parse import quote
 
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_baas_engine_bucket,
+    resolve_provisioning,
+)
 from agentclaw.community.core.expert_chat.errors import (
     BotNotPublishedError,
     ChatPermissionError,
@@ -20,9 +24,6 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 )
 
 logger = get_logger()
-
-_LEGACY_LOCAL_SESSION_ENGINES = {"aicoding", "claude_code"}
-_RELAY_SESSION_CREATE_TIMEOUT_SECONDS = 330.0
 
 
 class ExpertChatSessionRuntimeMixin:
@@ -110,10 +111,24 @@ class ExpertChatSessionRuntimeMixin:
             )
 
         conn = ctx.conn_info
+        logger.info(
+            "[ExpertChatService] Resolved device context: bot=%s binding_id=%s "
+            "provider=%s conn_engine=%s active_engine=%s template_type=%s "
+            "runtime_engine=%s",
+            bot_id,
+            binding_id,
+            ctx.provider,
+            conn.get("engine_type"),
+            bot.get("active_engine"),
+            bot.get("template_type"),
+            (bot.get("template_config") or {}).get("active_runtime_engine_type"),
+        )
         if conn.get("use_proxy"):
             logger.info(
-                "[ExpertChatService] Got ARCA proxy connection: bot=%s, sandbox_id=%s",
+                "[ExpertChatService] Got proxy connection: bot=%s, provider=%s, "
+                "sandbox_id=%s",
                 bot_id,
+                ctx.provider,
                 conn.get("sandbox_id"),
             )
         else:
@@ -167,50 +182,65 @@ class ExpertChatSessionRuntimeMixin:
         )
         raise ChatPermissionError(f"User {user_id} has no chat access to bot {bot_id}")
 
+    def _resolve_chat_engine_type(
+        self, bot: Dict[str, Any], conn: Dict[str, Any]
+    ) -> str:
+        """Resolve the effective chat engine from authoritative Bot metadata."""
+        template_config = bot.get("template_config") or {}
+        if not isinstance(template_config, dict):
+            template_config = {}
+        raw_engine_type = (
+            bot.get("active_engine")
+            or template_config.get("active_runtime_engine_type")
+            or conn.get("engine_type")
+            or "openclaw"
+        )
+        return resolve_baas_engine_bucket(
+            engine_type=raw_engine_type,
+            template_type=bot.get("template_type") or "",
+        )
+
+    def _resolve_chat_engine_strategy(
+        self, bot: Dict[str, Any], conn: Dict[str, Any]
+    ):
+        """Resolve the normalized chat engine and its registered strategy."""
+        engine_type = self._resolve_chat_engine_type(bot, conn)
+        template_config = bot.get("template_config")
+        if not isinstance(template_config, dict):
+            template_config = None
+        return resolve_provisioning(
+            bot_id=str(bot.get("bot_id") or ""),
+            owner_id=str(bot.get("owner_id") or ""),
+            bot_type=str(bot.get("bot_type") or ""),
+            active_engine=engine_type,
+            template_type=bot.get("template_type") or None,
+            template_config=template_config,
+        )
+
     async def _create_session(
         self,
         bot: Dict[str, Any],
         user_id: str,
         connection: Optional[Dict[str, Any]] = None,
-        prefer_adapter_for_relay: bool = False,
     ) -> str:
         """Create a session through the current runtime strategy."""
         conn = connection or self._get_connection(bot, user_id)
-        engine_type = conn.get("engine_type", "openclaw")
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
 
-        # Preserve the legacy singular /session behavior. Only the plural
-        # /sessions flow opts into persisted, canonical relay session keys.
-        if (
-            engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-            and not prefer_adapter_for_relay
-        ):
-            return await self._create_aicoding_session(conn, bot, user_id)
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
+            session_key = strategy.build_local_chat_session_key(ctx, user_id=user_id)
+            logger.info(
+                "[ExpertChatService] Relay-managed chat session: bot=%s, user=%s, "
+                "engine=%s, session=%s",
+                bot.get("bot_id"),
+                user_id,
+                ctx.active_engine,
+                session_key,
+            )
+            return session_key
 
-        try:
-            return await self._create_openclaw_session(conn, bot, user_id)
-        except Exception as error:
-            if (
-                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-                and self._is_adapter_endpoint_unsupported(error)
-            ):
-                logger.warning(
-                    "[ExpertChatService] Adapter session creation unsupported; "
-                    "using legacy local key: engine=%s bot=%s",
-                    engine_type,
-                    bot.get("bot_id"),
-                )
-                return await self._create_aicoding_session(conn, bot, user_id)
-            raise
-
-    async def _create_aicoding_session(
-        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
-    ) -> str:
-        """Generate the legacy local relay session key."""
-        import uuid
-
-        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
-        logger.info("[aicoding] local session key generated: %s", session_key)
-        return session_key
+        return await self._create_openclaw_session(conn, bot, user_id)
 
     async def _create_openclaw_session(
         self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
@@ -231,19 +261,11 @@ class ExpertChatSessionRuntimeMixin:
         )
 
         try:
-            create_timeout = (
-                _RELAY_SESSION_CREATE_TIMEOUT_SECONDS
-                if conn.get("engine_type") in _LEGACY_LOCAL_SESSION_ENGINES
-                else None
-            )
-            invoke_kwargs: Dict[str, Any] = {"body": payload}
-            if create_timeout is not None:
-                invoke_kwargs["timeout"] = create_timeout
             data = await self._transport.invoke(
                 conn,
                 "POST",
                 "/api/sessions",
-                **invoke_kwargs,
+                body=payload,
             )
             logger.info("[ExpertChatService] Adapter POST response %s", data)
             raw_session_key = data.get("data", {}).get("id") or data.get("id")
@@ -354,14 +376,15 @@ class ExpertChatSessionRuntimeMixin:
     ) -> bool:
         """Check whether a session still exists in the active Adapter."""
         conn = connection or self._get_connection(bot, user_id)
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
 
-        if conn.get("engine_type") == "aicoding":
-            return True
-        if conn.get("engine_type") == "claude_code":
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
             logger.info(
-                "[ExpertChatService] claude_code session check: skipping "
-                "adapter pre-check for session=%s",
+                "[ExpertChatService] Relay-managed chat session check: skipping "
+                "adapter pre-check for session=%s, engine=%s",
                 session_key,
+                ctx.active_engine,
             )
             return True
 
@@ -394,8 +417,25 @@ class ExpertChatSessionRuntimeMixin:
         connection: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Delete a session through the active Adapter."""
+        # Resolve from Bot metadata before opening a connection. Historical
+        # caller-instance bindings can report a fallback engine that must not
+        # override the Bot's authoritative relay strategy.
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, connection or {})
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
+            logger.info(
+                "[ExpertChatService] Skipping adapter session deletion for "
+                "relay-managed engine: bot=%s, session=%s, engine=%s",
+                bot.get("bot_id"),
+                session_key,
+                ctx.active_engine,
+            )
+            return
+
         conn = connection or self._get_connection(bot, user_id)
-        engine_type = conn.get("engine_type", "openclaw")
+        ctx, strategy = self._resolve_chat_engine_strategy(bot, conn)
+        conn["engine_type"] = ctx.active_engine
+        if not strategy.uses_adapter_chat_session_lifecycle(ctx):
+            return
 
         logger.info(
             "[ExpertChatService] Deleting adapter session via transport: session=%s",
@@ -427,17 +467,6 @@ class ExpertChatSessionRuntimeMixin:
                     session_key,
                 )
                 return
-            if (
-                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
-                and self._is_adapter_endpoint_unsupported(error)
-            ):
-                logger.warning(
-                    "[ExpertChatService] Adapter session deletion unsupported; "
-                    "keeping legacy metadata-only behavior: engine=%s session=%s",
-                    engine_type,
-                    session_key,
-                )
-                return
             logger.error(
                 "[ExpertChatService] Unexpected error when DELETE session via "
                 "transport: %s: %s",
@@ -463,18 +492,3 @@ class ExpertChatSessionRuntimeMixin:
     def _is_ambiguous_adapter_delete_not_found(error: Exception) -> bool:
         """Identify the Engine 404 that also represents runtime delete failure."""
         return "Session not found or delete failed" in str(error)
-
-    @staticmethod
-    def _is_adapter_endpoint_unsupported(error: Exception) -> bool:
-        if isinstance(error, DeviceAdapterEndpointNotFoundError):
-            return True
-        if isinstance(error, DeviceAdapterHTTPStatusError):
-            return error.status_code in {404, 405}
-        error_msg = (
-            error.original_error
-            if isinstance(error, SessionCreateError) and error.original_error
-            else str(error)
-        )
-        return "Adapter returned" in error_msg and (
-            "404" in error_msg or "405" in error_msg
-        )

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
@@ -1,0 +1,480 @@
+"""Runtime connection and Adapter session operations for expert chat."""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.expert_chat.errors import (
+    BotNotPublishedError,
+    ChatPermissionError,
+    ConnectionError,
+    SessionCreateError,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+)
+
+logger = get_logger()
+
+_LEGACY_LOCAL_SESSION_ENGINES = {"aicoding", "claude_code"}
+_RELAY_SESSION_CREATE_TIMEOUT_SECONDS = 330.0
+
+
+class ExpertChatSessionRuntimeMixin:
+    """Connection authorization and Adapter session lifecycle operations."""
+
+    def _get_connection(
+        self, bot: Dict[str, Any], user_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """获取 Bot 的连接信息
+
+        分流:
+        - service bot:caller 链路(``list_chat_bots`` / ``get_chat_session``)已通过
+          ``baas_service.get_bind_id(SUCCESS)`` 把发布单 ``ext.binding.online`` 的
+          binding_id 塞到 ``bot["binding_id"]``。直接走 ``resolve_for_binding``。
+          **不能走 by-bot 入口** — 它会反查 ``ac_bots.binding_id``,那是 DRAFT
+          binding,与 SUCCESS binding 数据上是两条不同记录。
+        - personal bot:``bot.get("binding_id")`` 为 None,走 ``resolve_for_bot``
+          (按 (bot_id, owner_id) 反查 ``ac_bots.binding_id``)。
+          owner_id 显式从 ``bot["owner_id"]`` 取,**不再用 user_id 当 owner_id**:
+          public bot 被他人调用 / collaborator 调用时,user_id 是 caller 工号,
+          binding 仍在 owner 名下,用 caller id 必查不到。
+
+        权限上移:caller 显式调 ``_check_chat_access``,失败 ``ChatPermissionError``,
+        resolver 不被调(早失败语义)。
+
+        Args:
+            bot: Bot 信息字典(必须含 ``bot_id`` / ``owner_id`` / ``public``;
+                service bot 链路下还含 ``binding_id``)
+            user_id: 用户ID（caller 身份,权限校验 + builder device_affinity 用）
+
+        Returns:
+            连接信息，含 url、headers、use_proxy、engine_type 等字段
+
+        Raises:
+            ChatPermissionError: 非 owner / 非 public / 非 collaborator
+            BotNotPublishedError: Bot 未绑定设备(resolver 抛 DeviceNotBoundError 翻译而来)
+            ConnectionError: 底层连接失败
+        """
+        from agentclaw.community.core.devices.services.device_context import (
+            DeviceNotBoundError,
+        )
+
+        bot_id = bot["bot_id"]
+        owner_id = bot.get("owner_id")
+        binding_id = bot.get("binding_id")
+
+        # Defense in depth: every path resolving a runtime connection must
+        # enforce the same owner/public/collaborator authorization boundary.
+        self._check_chat_access(bot, user_id)
+
+        if not binding_id:
+            raise ConnectionError(
+                "(binding_id 未提供)服务未发布",
+                error_code="5002",
+            )
+        logger.info(
+            f"[ExpertChatService] Resolving device context: bot={bot_id}, "
+            f"owner={owner_id}, user={user_id}, binding_id={binding_id}"
+        )
+        try:
+            ctx = self._resolver.resolve_for_binding(binding_id, user_id, bot_id=bot_id)
+        except DeviceNotBoundError as error:
+            logger.warning(
+                "[ExpertChatService] Bot has no active binding: %s: %s",
+                bot_id,
+                error,
+            )
+            raise BotNotPublishedError(f"Bot未绑定设备: {bot_id}")
+        except Exception as error:
+            error_msg = str(error)
+            logger.error(
+                "[ExpertChatService] Failed to resolve device context for bot=%s: %s: %s",
+                bot_id,
+                type(error).__name__,
+                error,
+            )
+            logger.error(
+                "[ExpertChatService] Resolver error traceback: %s",
+                traceback.format_exc(),
+            )
+            raise ConnectionError(
+                "无法连接到Bot服务",
+                error_code="5001",
+                original_error=error_msg,
+            )
+
+        conn = ctx.conn_info
+        if conn.get("use_proxy"):
+            logger.info(
+                "[ExpertChatService] Got ARCA proxy connection: bot=%s, sandbox_id=%s",
+                bot_id,
+                conn.get("sandbox_id"),
+            )
+        else:
+            logger.info(
+                "[ExpertChatService] Got direct connection: bot=%s, target=%s",
+                bot_id,
+                conn.get("target"),
+            )
+        return conn
+
+    def _check_chat_access(self, bot: Dict[str, Any], user_id: Optional[str]) -> None:
+        """Apply the existing owner/public/collaborator chat access policy.
+
+        Access is granted to the owner, callers of public bots, and members
+        registered as collaborators. Collaborator lookup failures fail closed.
+        """
+        bot_id = bot["bot_id"]
+        owner_id = bot.get("owner_id")
+
+        if owner_id == user_id:
+            return
+        if bot.get("public") == "1":
+            return
+
+        try:
+            result = self._collaborator_service.check_collaborator_permission(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                user_id=user_id,
+                required_level=PermissionLevel.MEMBER,
+            )
+        except Exception as error:
+            logger.warning(
+                "[ExpertChatService] collaborator check failed for bot=%s, user=%s: %s",
+                bot_id,
+                user_id,
+                error,
+            )
+            raise ChatPermissionError(
+                f"User {user_id} has no chat access to bot {bot_id} "
+                "(collaborator check failed)"
+            )
+
+        if result.get("has_permission", False):
+            return
+
+        logger.warning(
+            "[ExpertChatService] ChatPermissionError: user=%s not allowed to chat with bot=%s",
+            user_id,
+            bot_id,
+        )
+        raise ChatPermissionError(f"User {user_id} has no chat access to bot {bot_id}")
+
+    async def _create_session(
+        self,
+        bot: Dict[str, Any],
+        user_id: str,
+        connection: Optional[Dict[str, Any]] = None,
+        prefer_adapter_for_relay: bool = False,
+    ) -> str:
+        """Create a session through the current runtime strategy."""
+        conn = connection or self._get_connection(bot, user_id)
+        engine_type = conn.get("engine_type", "openclaw")
+
+        # Preserve the legacy singular /session behavior. Only the plural
+        # /sessions flow opts into persisted, canonical relay session keys.
+        if (
+            engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+            and not prefer_adapter_for_relay
+        ):
+            return await self._create_aicoding_session(conn, bot, user_id)
+
+        try:
+            return await self._create_openclaw_session(conn, bot, user_id)
+        except Exception as error:
+            if (
+                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+                and self._is_adapter_endpoint_unsupported(error)
+            ):
+                logger.warning(
+                    "[ExpertChatService] Adapter session creation unsupported; "
+                    "using legacy local key: engine=%s bot=%s",
+                    engine_type,
+                    bot.get("bot_id"),
+                )
+                return await self._create_aicoding_session(conn, bot, user_id)
+            raise
+
+    async def _create_aicoding_session(
+        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
+    ) -> str:
+        """Generate the legacy local relay session key."""
+        import uuid
+
+        session_key = f"session:{uuid.uuid4()}:user:{user_id}"
+        logger.info("[aicoding] local session key generated: %s", session_key)
+        return session_key
+
+    async def _create_openclaw_session(
+        self, conn: Dict[str, Any], bot: Dict[str, Any], user_id: str
+    ) -> str:
+        """Create a session through the active Adapter and return its full ID."""
+        payload = {
+            "title": f"Chat with {bot.get('bot_name', bot['bot_id'])}",
+            "user_id": user_id,
+            "agent_id": bot["bot_id"],
+            "engine": conn.get("engine_type", "openclaw"),
+        }
+        logger.info(
+            "[ExpertChatService] Creating OpenClaw session via transport: "
+            "user_id=%s, bot_id=%s, use_proxy=%s",
+            user_id,
+            bot["bot_id"],
+            conn.get("use_proxy", False),
+        )
+
+        try:
+            create_timeout = (
+                _RELAY_SESSION_CREATE_TIMEOUT_SECONDS
+                if conn.get("engine_type") in _LEGACY_LOCAL_SESSION_ENGINES
+                else None
+            )
+            invoke_kwargs: Dict[str, Any] = {"body": payload}
+            if create_timeout is not None:
+                invoke_kwargs["timeout"] = create_timeout
+            data = await self._transport.invoke(
+                conn,
+                "POST",
+                "/api/sessions",
+                **invoke_kwargs,
+            )
+            logger.info("[ExpertChatService] Adapter POST response %s", data)
+            raw_session_key = data.get("data", {}).get("id") or data.get("id")
+            if not raw_session_key:
+                logger.error(
+                    "[ExpertChatService] No session key in adapter response: %s",
+                    data,
+                )
+                raise Exception(f"Invalid response from adapter: {data}")
+        except Exception as error:
+            self._raise_session_create_error(error, "POST /api/sessions")
+
+        logger.info(
+            "[ExpertChatService] Looking for prefixed session ID for: %s",
+            raw_session_key,
+        )
+        try:
+            list_data = await self._transport.invoke(conn, "GET", "/api/sessions")
+            sessions = list_data.get("data", [])
+            if not isinstance(sessions, list):
+                sessions = []
+            logger.info(
+                "[ExpertChatService] Got %s sessions from list",
+                len(sessions),
+            )
+            for session in sessions:
+                session_id = session.get("id", "")
+                if (
+                    session_id.lower().endswith(raw_session_key.lower())
+                    or raw_session_key.lower() in session_id.lower()
+                ):
+                    logger.info(
+                        "[ExpertChatService] Found prefixed session ID: %s (raw: %s)",
+                        session_id,
+                        raw_session_key,
+                    )
+                    return session_id
+            logger.warning(
+                "[ExpertChatService] No matching prefixed session found for: %s",
+                raw_session_key,
+            )
+        except Exception as error:
+            logger.warning(
+                "[ExpertChatService] Failed to get prefixed session ID, using raw: %s",
+                error,
+            )
+
+        logger.info(
+            "[ExpertChatService] Created OpenClaw session via adapter: %s",
+            raw_session_key,
+        )
+        return raw_session_key
+
+    def _raise_session_create_error(self, error: Exception, operation: str) -> None:
+        logger.error(
+            "[ExpertChatService] Unexpected error when %s: %s: %s",
+            operation,
+            type(error).__name__,
+            error,
+        )
+        logger.error(
+            "[ExpertChatService] Unexpected error traceback: %s",
+            traceback.format_exc(),
+        )
+        error_msg = str(error)
+        if "Connection refused" in error_msg or "Cannot connect to host" in error_msg:
+            raise SessionCreateError(
+                "Bot服务暂不可用，请稍后重试",
+                error_code="50201",
+                original_error=error_msg,
+            )
+        if "Failed to connect" in error_msg:
+            raise SessionCreateError(
+                "连接Bot服务失败",
+                error_code="5002",
+                original_error=error_msg,
+            )
+        if "Adapter returned" in error_msg:
+            if "404" in error_msg:
+                raise SessionCreateError(
+                    "Bot服务暂不可用，请稍后重试",
+                    error_code="40402",
+                    original_error=error_msg,
+                )
+            if (
+                "500" in error_msg
+                or "502" in error_msg
+                or "503" in error_msg
+                or "gateway" in error_msg.lower()
+            ):
+                raise SessionCreateError(
+                    "Bot服务暂不可用，请稍后重试",
+                    error_code="50201",
+                    original_error=error_msg,
+                )
+        raise SessionCreateError(
+            f"创建 Session 失败: {error_msg[:100]}",
+            error_code="5003",
+            original_error=error_msg,
+        )
+
+    async def _check_session_exists(
+        self,
+        bot: Dict[str, Any],
+        session_key: str,
+        user_id: Optional[str] = None,
+        connection: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Check whether a session still exists in the active Adapter."""
+        conn = connection or self._get_connection(bot, user_id)
+
+        if conn.get("engine_type") == "aicoding":
+            return True
+        if conn.get("engine_type") == "claude_code":
+            logger.info(
+                "[ExpertChatService] claude_code session check: skipping "
+                "adapter pre-check for session=%s",
+                session_key,
+            )
+            return True
+
+        try:
+            encoded_session_key = quote(session_key, safe="")
+            await self._transport.invoke(
+                conn, "GET", f"/api/sessions/{encoded_session_key}"
+            )
+            return True
+        except Exception as error:
+            if self._is_adapter_not_found(error):
+                logger.warning(
+                    "[ExpertChatService] Session not found in adapter: %s",
+                    session_key,
+                )
+                return False
+            logger.warning(
+                "[ExpertChatService] Error checking session %s via transport: %s: %s",
+                session_key,
+                type(error).__name__,
+                error,
+            )
+            return True
+
+    async def _delete_adapter_session(
+        self,
+        bot: Dict[str, Any],
+        session_key: str,
+        user_id: Optional[str] = None,
+        connection: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Delete a session through the active Adapter."""
+        conn = connection or self._get_connection(bot, user_id)
+        engine_type = conn.get("engine_type", "openclaw")
+
+        logger.info(
+            "[ExpertChatService] Deleting adapter session via transport: session=%s",
+            session_key,
+        )
+        try:
+            encoded_session_key = quote(session_key, safe="")
+            await self._transport.invoke(
+                conn, "DELETE", f"/api/sessions/{encoded_session_key}"
+            )
+            logger.info(
+                "[ExpertChatService] Successfully deleted adapter session: %s",
+                session_key,
+            )
+        except Exception as error:
+            if self._is_adapter_not_found(error):
+                if self._is_ambiguous_adapter_delete_not_found(error):
+                    # The generic Engine DELETE endpoint uses this 404 for both
+                    # a missing session and an operational deletion failure.
+                    # Preserve ownership so the latter remains retryable.
+                    logger.error(
+                        "[ExpertChatService] Adapter returned ambiguous delete "
+                        "result; preserving ownership: session=%s",
+                        session_key,
+                    )
+                    raise
+                logger.warning(
+                    "[ExpertChatService] Session not found in adapter: %s",
+                    session_key,
+                )
+                return
+            if (
+                engine_type in _LEGACY_LOCAL_SESSION_ENGINES
+                and self._is_adapter_endpoint_unsupported(error)
+            ):
+                logger.warning(
+                    "[ExpertChatService] Adapter session deletion unsupported; "
+                    "keeping legacy metadata-only behavior: engine=%s session=%s",
+                    engine_type,
+                    session_key,
+                )
+                return
+            logger.error(
+                "[ExpertChatService] Unexpected error when DELETE session via "
+                "transport: %s: %s",
+                type(error).__name__,
+                error,
+            )
+            logger.error(
+                "[ExpertChatService] Delete session traceback: %s",
+                traceback.format_exc(),
+            )
+            raise
+
+    @staticmethod
+    def _is_adapter_not_found(error: Exception) -> bool:
+        if isinstance(error, DeviceAdapterEndpointNotFoundError):
+            return True
+        if isinstance(error, DeviceAdapterHTTPStatusError):
+            return error.status_code == 404
+        error_msg = str(error)
+        return "Adapter returned" in error_msg and "404" in error_msg
+
+    @staticmethod
+    def _is_ambiguous_adapter_delete_not_found(error: Exception) -> bool:
+        """Identify the Engine 404 that also represents runtime delete failure."""
+        return "Session not found or delete failed" in str(error)
+
+    @staticmethod
+    def _is_adapter_endpoint_unsupported(error: Exception) -> bool:
+        if isinstance(error, DeviceAdapterEndpointNotFoundError):
+            return True
+        if isinstance(error, DeviceAdapterHTTPStatusError):
+            return error.status_code in {404, 405}
+        error_msg = (
+            error.original_error
+            if isinstance(error, SessionCreateError) and error.original_error
+            else str(error)
+        )
+        return "Adapter returned" in error_msg and (
+            "404" in error_msg or "405" in error_msg
+        )

--- a/src/backend/src/agentclaw/community/core/expert_chat/sqlite_models.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/sqlite_models.py
@@ -71,6 +71,63 @@ class AcExpertChatBotSession(Base):
         }
 
 
+class AcExpertChatSession(Base):
+    """One user-owned session in an expert-chat Bot conversation list.
+
+    ``AcExpertChatBotSession`` remains the legacy Bot-list row and default
+    session pointer. Keeping the multi-session index separate preserves its
+    unique-key and removal semantics for clients that still use ``/session``.
+    """
+
+    __tablename__ = "ac_expert_chat_sessions"
+
+    id = Column(
+        AutoIncrementBigInteger,
+        primary_key=True,
+        autoincrement=True,
+        nullable=False,
+    )
+    user_id = Column(String(64), nullable=False)
+    bot_id = Column(String(64), nullable=False)
+    owner_id = Column(String(64), nullable=False)
+    session_key = Column(String(255), nullable=False)
+    status = Column(String(20), nullable=False, server_default="ACTIVE")
+    env = Column(String(50), nullable=False)
+    gmt_create = Column(DateTime, server_default=func.now(), nullable=True)
+    gmt_modified = Column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "bot_id",
+            "owner_id",
+            "env",
+            "session_key",
+            name="uk_user_bot_owner_env_session",
+        ),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "bot_id": self.bot_id,
+            "owner_id": self.owner_id,
+            "session_key": self.session_key,
+            "status": self.status,
+            "env": self.env,
+            "gmt_create": self.gmt_create.isoformat() if self.gmt_create else None,
+            "gmt_modified": self.gmt_modified.isoformat()
+            if self.gmt_modified
+            else None,
+        }
+
+
 class AcExpertChatInstance(Base):
     """ac_expert_chat_instance — per-caller baas container instance.
 

--- a/src/backend/src/agentclaw/community/core/expert_chat/sqlite_models.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/sqlite_models.py
@@ -71,15 +71,17 @@ class AcExpertChatBotSession(Base):
         }
 
 
-class AcExpertChatSession(Base):
+class AcExpertChatOwnedSession(Base):
     """One user-owned session in an expert-chat Bot conversation list.
 
     ``AcExpertChatBotSession`` remains the legacy Bot-list row and default
     session pointer. Keeping the multi-session index separate preserves its
     unique-key and removal semantics for clients that still use ``/session``.
+    The historical ``ac_expert_chat_sessions`` table has an incompatible
+    single-session schema and must not be reused for this ownership index.
     """
 
-    __tablename__ = "ac_expert_chat_sessions"
+    __tablename__ = "ac_expert_chat_owned_sessions"
 
     id = Column(
         AutoIncrementBigInteger,
@@ -121,7 +123,9 @@ class AcExpertChatSession(Base):
             "session_key": self.session_key,
             "status": self.status,
             "env": self.env,
-            "gmt_create": self.gmt_create.isoformat() if self.gmt_create else None,
+            "gmt_create": self.gmt_create.isoformat()
+            if self.gmt_create
+            else None,
             "gmt_modified": self.gmt_modified.isoformat()
             if self.gmt_modified
             else None,
@@ -196,9 +200,7 @@ class AcExpertChatInstance(Base):
             "status": self.status,
             "ext": ext,
             "env": self.env,
-            "gmt_create": self.gmt_create.isoformat()
-            if self.gmt_create
-            else None,
+            "gmt_create": self.gmt_create.isoformat() if self.gmt_create else None,
             "gmt_modified": self.gmt_modified.isoformat()
             if self.gmt_modified
             else None,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/chat/expert_chat.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/chat/expert_chat.py
@@ -55,14 +55,14 @@ class ExpertChatRepository(
     def __init__(self, db: DatabasePlugin) -> None:
         from agentclaw.community.core.expert_chat.sqlite_models import (
             AcExpertChatBotSession,
+            AcExpertChatSession,
         )
 
         self._db = db
         self.Model = AcExpertChatBotSession
+        self.SessionModel = AcExpertChatSession
 
-    def add_chat_bot(
-        self, user_id: str, bot_id: str, owner_id: str
-    ) -> Dict[str, Any]:
+    def add_chat_bot(self, user_id: str, bot_id: str, owner_id: str) -> Dict[str, Any]:
         """Atomic upsert on uk_user_bot_owner_env (prod parity)."""
         env = get_current_env()
         with self._db.orm_session() as db:
@@ -254,3 +254,142 @@ class ExpertChatRepository(
                 )
             )
             return rowcount > 0
+
+    def add_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> Dict[str, Any]:
+        """Atomically add or reactivate one multi-session index row."""
+        env = get_current_env()
+        with self._db.orm_session() as db:
+            dialect = db.get_bind().dialect.name
+            table = self.SessionModel.__table__
+            values = {
+                "user_id": user_id,
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "session_key": session_key,
+                "status": "ACTIVE",
+                "env": env,
+            }
+            if dialect == "sqlite":
+                from sqlalchemy.dialects.sqlite import insert as _insert
+
+                stmt = _insert(table).values(**values)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=[
+                        "user_id",
+                        "bot_id",
+                        "owner_id",
+                        "env",
+                        "session_key",
+                    ],
+                    set_={"status": "ACTIVE", "gmt_modified": func.now()},
+                )
+                db.execute(stmt)
+                db.flush()
+                row = (
+                    db.query(self.SessionModel)
+                    .filter(
+                        self.SessionModel.user_id == user_id,
+                        self.SessionModel.bot_id == bot_id,
+                        self.SessionModel.owner_id == owner_id,
+                        self.SessionModel.env == env,
+                        self.SessionModel.session_key == session_key,
+                    )
+                    .one()
+                )
+            else:
+                from sqlalchemy.dialects.mysql import insert as _insert
+
+                stmt = _insert(table).values(**values)
+                stmt = stmt.on_duplicate_key_update(
+                    id=func.LAST_INSERT_ID(self.SessionModel.id),
+                    status="ACTIVE",
+                    gmt_modified=func.now(),
+                )
+                row_id = db.execute(stmt).lastrowid
+                row = db.get(self.SessionModel, row_id)
+            return row.to_dict()
+
+    def list_owned_sessions(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        env = get_current_env()
+        with self._db.orm_session() as db:
+            query = db.query(self.SessionModel).filter(
+                self.SessionModel.user_id == user_id,
+                self.SessionModel.bot_id == bot_id,
+                self.SessionModel.owner_id == owner_id,
+                self.SessionModel.status == "ACTIVE",
+                self.SessionModel.env == env,
+            )
+            if session_key is not None:
+                query = query.filter(self.SessionModel.session_key == session_key)
+            rows = query.order_by(
+                self.SessionModel.gmt_modified.desc(),
+                self.SessionModel.id.desc(),
+            ).all()
+            return [row.to_dict() for row in rows]
+
+    def get_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> Optional[Dict[str, Any]]:
+        rows = self.list_owned_sessions(
+            user_id=user_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            session_key=session_key,
+        )
+        return rows[0] if rows else None
+
+    def delete_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> bool:
+        env = get_current_env()
+        with self._db.orm_session() as db:
+            rowcount = (
+                db.query(self.SessionModel)
+                .filter(
+                    self.SessionModel.user_id == user_id,
+                    self.SessionModel.bot_id == bot_id,
+                    self.SessionModel.owner_id == owner_id,
+                    self.SessionModel.session_key == session_key,
+                    self.SessionModel.status == "ACTIVE",
+                    self.SessionModel.env == env,
+                )
+                .update(
+                    {
+                        self.SessionModel.status: "DELETED",
+                        self.SessionModel.gmt_modified: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+            return rowcount > 0
+
+    def delete_all_owned_sessions(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> int:
+        env = get_current_env()
+        with self._db.orm_session() as db:
+            return (
+                db.query(self.SessionModel)
+                .filter(
+                    self.SessionModel.user_id == user_id,
+                    self.SessionModel.bot_id == bot_id,
+                    self.SessionModel.owner_id == owner_id,
+                    self.SessionModel.status == "ACTIVE",
+                    self.SessionModel.env == env,
+                )
+                .update(
+                    {
+                        self.SessionModel.status: "DELETED",
+                        self.SessionModel.gmt_modified: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/chat/expert_chat.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/chat/expert_chat.py
@@ -55,12 +55,12 @@ class ExpertChatRepository(
     def __init__(self, db: DatabasePlugin) -> None:
         from agentclaw.community.core.expert_chat.sqlite_models import (
             AcExpertChatBotSession,
-            AcExpertChatSession,
+            AcExpertChatOwnedSession,
         )
 
         self._db = db
         self.Model = AcExpertChatBotSession
-        self.SessionModel = AcExpertChatSession
+        self.OwnedSessionModel = AcExpertChatOwnedSession
 
     def add_chat_bot(self, user_id: str, bot_id: str, owner_id: str) -> Dict[str, Any]:
         """Atomic upsert on uk_user_bot_owner_env (prod parity)."""
@@ -262,7 +262,7 @@ class ExpertChatRepository(
         env = get_current_env()
         with self._db.orm_session() as db:
             dialect = db.get_bind().dialect.name
-            table = self.SessionModel.__table__
+            table = self.OwnedSessionModel.__table__
             values = {
                 "user_id": user_id,
                 "bot_id": bot_id,
@@ -288,13 +288,13 @@ class ExpertChatRepository(
                 db.execute(stmt)
                 db.flush()
                 row = (
-                    db.query(self.SessionModel)
+                    db.query(self.OwnedSessionModel)
                     .filter(
-                        self.SessionModel.user_id == user_id,
-                        self.SessionModel.bot_id == bot_id,
-                        self.SessionModel.owner_id == owner_id,
-                        self.SessionModel.env == env,
-                        self.SessionModel.session_key == session_key,
+                        self.OwnedSessionModel.user_id == user_id,
+                        self.OwnedSessionModel.bot_id == bot_id,
+                        self.OwnedSessionModel.owner_id == owner_id,
+                        self.OwnedSessionModel.env == env,
+                        self.OwnedSessionModel.session_key == session_key,
                     )
                     .one()
                 )
@@ -303,12 +303,12 @@ class ExpertChatRepository(
 
                 stmt = _insert(table).values(**values)
                 stmt = stmt.on_duplicate_key_update(
-                    id=func.LAST_INSERT_ID(self.SessionModel.id),
+                    id=func.LAST_INSERT_ID(self.OwnedSessionModel.id),
                     status="ACTIVE",
                     gmt_modified=func.now(),
                 )
                 row_id = db.execute(stmt).lastrowid
-                row = db.get(self.SessionModel, row_id)
+                row = db.get(self.OwnedSessionModel, row_id)
             return row.to_dict()
 
     def list_owned_sessions(
@@ -320,18 +320,18 @@ class ExpertChatRepository(
     ) -> List[Dict[str, Any]]:
         env = get_current_env()
         with self._db.orm_session() as db:
-            query = db.query(self.SessionModel).filter(
-                self.SessionModel.user_id == user_id,
-                self.SessionModel.bot_id == bot_id,
-                self.SessionModel.owner_id == owner_id,
-                self.SessionModel.status == "ACTIVE",
-                self.SessionModel.env == env,
+            query = db.query(self.OwnedSessionModel).filter(
+                self.OwnedSessionModel.user_id == user_id,
+                self.OwnedSessionModel.bot_id == bot_id,
+                self.OwnedSessionModel.owner_id == owner_id,
+                self.OwnedSessionModel.status == "ACTIVE",
+                self.OwnedSessionModel.env == env,
             )
             if session_key is not None:
-                query = query.filter(self.SessionModel.session_key == session_key)
+                query = query.filter(self.OwnedSessionModel.session_key == session_key)
             rows = query.order_by(
-                self.SessionModel.gmt_modified.desc(),
-                self.SessionModel.id.desc(),
+                self.OwnedSessionModel.gmt_modified.desc(),
+                self.OwnedSessionModel.id.desc(),
             ).all()
             return [row.to_dict() for row in rows]
 
@@ -352,19 +352,19 @@ class ExpertChatRepository(
         env = get_current_env()
         with self._db.orm_session() as db:
             rowcount = (
-                db.query(self.SessionModel)
+                db.query(self.OwnedSessionModel)
                 .filter(
-                    self.SessionModel.user_id == user_id,
-                    self.SessionModel.bot_id == bot_id,
-                    self.SessionModel.owner_id == owner_id,
-                    self.SessionModel.session_key == session_key,
-                    self.SessionModel.status == "ACTIVE",
-                    self.SessionModel.env == env,
+                    self.OwnedSessionModel.user_id == user_id,
+                    self.OwnedSessionModel.bot_id == bot_id,
+                    self.OwnedSessionModel.owner_id == owner_id,
+                    self.OwnedSessionModel.session_key == session_key,
+                    self.OwnedSessionModel.status == "ACTIVE",
+                    self.OwnedSessionModel.env == env,
                 )
                 .update(
                     {
-                        self.SessionModel.status: "DELETED",
-                        self.SessionModel.gmt_modified: func.now(),
+                        self.OwnedSessionModel.status: "DELETED",
+                        self.OwnedSessionModel.gmt_modified: func.now(),
                     },
                     synchronize_session=False,
                 )
@@ -377,18 +377,18 @@ class ExpertChatRepository(
         env = get_current_env()
         with self._db.orm_session() as db:
             return (
-                db.query(self.SessionModel)
+                db.query(self.OwnedSessionModel)
                 .filter(
-                    self.SessionModel.user_id == user_id,
-                    self.SessionModel.bot_id == bot_id,
-                    self.SessionModel.owner_id == owner_id,
-                    self.SessionModel.status == "ACTIVE",
-                    self.SessionModel.env == env,
+                    self.OwnedSessionModel.user_id == user_id,
+                    self.OwnedSessionModel.bot_id == bot_id,
+                    self.OwnedSessionModel.owner_id == owner_id,
+                    self.OwnedSessionModel.status == "ACTIVE",
+                    self.OwnedSessionModel.env == env,
                 )
                 .update(
                     {
-                        self.SessionModel.status: "DELETED",
-                        self.SessionModel.gmt_modified: func.now(),
+                        self.OwnedSessionModel.status: "DELETED",
+                        self.OwnedSessionModel.gmt_modified: func.now(),
                     },
                     synchronize_session=False,
                 )

--- a/src/backend/src/agentclaw/community/core/repository/protocols/chat.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/chat.py
@@ -111,6 +111,45 @@ class ExpertChatRepository(Protocol):
         """
         ...
 
+    @abstractmethod
+    def add_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> Dict[str, Any]:
+        """Idempotently add one user-owned session to the multi-session index."""
+        ...
+
+    @abstractmethod
+    def list_owned_sessions(
+        self,
+        user_id: str,
+        bot_id: str,
+        owner_id: str,
+        session_key: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List active sessions owned by one user for one expert Bot."""
+        ...
+
+    @abstractmethod
+    def get_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return one active owned-session row, or ``None`` when unauthorized."""
+        ...
+
+    @abstractmethod
+    def delete_owned_session(
+        self, user_id: str, bot_id: str, owner_id: str, session_key: str
+    ) -> bool:
+        """Soft-delete one user-owned session mapping."""
+        ...
+
+    @abstractmethod
+    def delete_all_owned_sessions(
+        self, user_id: str, bot_id: str, owner_id: str
+    ) -> int:
+        """Soft-delete every active session mapping for one user and Bot."""
+        ...
+
 
 @runtime_checkable
 class ExpertChatInstanceRepository(Protocol):

--- a/src/backend/tests/community/_flows/expert_chat/api_lifecycle.py
+++ b/src/backend/tests/community/_flows/expert_chat/api_lifecycle.py
@@ -29,6 +29,35 @@ EXPERT_CHAT_FLOWS: list[FlowCase] = [
                 extract={"expert_session_reused": "data.session_key"},
             ),
             FlowStep(
+                method="POST",
+                path="/api/v1/expert-chats/{bot_id}/{owner_id}/sessions",
+                expect={"success": True, "data": {"is_new": True}},
+                extract={"expert_session_second": "data.session_key"},
+            ),
+            FlowStep(
+                method="GET",
+                path="/api/v1/expert-chats/{bot_id}/{owner_id}/sessions",
+                expect={"success": True, "data": {"total": 2}},
+            ),
+            FlowStep(
+                method="POST",
+                path="/api/v1/expert-chats/{bot_id}/{owner_id}/sessions/connect",
+                body={"session_key": "{expert_session_second}"},
+                expect={"success": True, "data": {"is_new": False}},
+                extract={"expert_session_connected": "data.session_key"},
+            ),
+            FlowStep(
+                method="DELETE",
+                path="/api/v1/expert-chats/{bot_id}/{owner_id}/sessions",
+                query={"session_key": "{expert_session_second}"},
+                expect={"success": True},
+            ),
+            FlowStep(
+                method="GET",
+                path="/api/v1/expert-chats/{bot_id}/{owner_id}/sessions",
+                expect={"success": True, "data": {"total": 1}},
+            ),
+            FlowStep(
                 method="DELETE",
                 path="/api/v1/expert-chats/{bot_id}/{owner_id}/session",
                 expect={"success": True},

--- a/src/backend/tests/community/acceptance/expert_chat/test_chat_session_lifecycle.py
+++ b/src/backend/tests/community/acceptance/expert_chat/test_chat_session_lifecycle.py
@@ -48,3 +48,5 @@ def test_expert_chat_session_reaches_live_singlebox_engine(live_backend, accepta
         raise
 
     assert result_ctx["expert_session_reused"] == result_ctx["expert_session"]
+    assert result_ctx["expert_session_second"] != result_ctx["expert_session"]
+    assert result_ctx["expert_session_connected"] == result_ctx["expert_session_second"]

--- a/src/backend/tests/community/api/expert_chat/test_router.py
+++ b/src/backend/tests/community/api/expert_chat/test_router.py
@@ -9,34 +9,78 @@ from injector import Injector, Module
 from agentclaw.community.core.expert_chat.errors import (
     BotNotFoundError,
     BotNotActiveError,
+    BotNotPublishedError,
+    ChatPermissionError,
     ConnectionError,
+    SessionCreateError,
 )
-from agentclaw.community.core.expert_chat.services.expert_chat_service import ExpertChatService
+from agentclaw.community.core.expert_chat.services.expert_chat_service import (
+    ExpertChatService,
+)
 
 
 @pytest.fixture
 def mock_expert_chat_service():
     """Mock ExpertChatService for testing."""
     service = MagicMock(spec=ExpertChatService)
-    service.add_chat_bot = MagicMock(return_value={
-        "id": 1,
-        "user_id": "test_user",
-        "bot_id": "test_bot",
-        "owner_id": "test_owner",
-        "status": "ACTIVE"
-    })
+    service.add_chat_bot = MagicMock(
+        return_value={
+            "id": 1,
+            "user_id": "test_user",
+            "bot_id": "test_bot",
+            "owner_id": "test_owner",
+            "status": "ACTIVE",
+        }
+    )
     service.list_chat_bots = MagicMock(return_value=[])
     service.remove_chat_bot = AsyncMock(return_value=True)
-    service.get_chat_session = AsyncMock(return_value={
-        "session_key": "session:test",
-        "is_new": True,
-        "connection": {
-            "type": "websocket",
-            "url": "http://localhost:8080",
-            "engine_type": "openclaw"
+    service.get_chat_session = AsyncMock(
+        return_value={
+            "session_key": "session:test",
+            "is_new": True,
+            "connection": {
+                "type": "websocket",
+                "url": "http://localhost:8080",
+                "engine_type": "openclaw",
+            },
         }
-    })
+    )
     service.delete_chat_session = AsyncMock(return_value=True)
+    service.list_chat_sessions = AsyncMock(
+        return_value={
+            "total": 1,
+            "items": [
+                {
+                    "id": "session:test",
+                    "title": "Test session",
+                    "user_id": "test_user",
+                    "agent_id": "test_bot",
+                    "model": None,
+                    "permission_mode": None,
+                    "cwd": None,
+                    "gmt_created": "2026-08-10T10:00:00Z",
+                    "gmt_modified": "2026-08-10T10:01:00Z",
+                    "message_count": 1,
+                    "last_message": {"role": "user", "content": "hello"},
+                }
+            ],
+        }
+    )
+    service.create_chat_session = AsyncMock(
+        return_value={
+            "session_key": "session:new",
+            "is_new": True,
+            "connection": {"type": "local"},
+        }
+    )
+    service.connect_chat_session = AsyncMock(
+        return_value={
+            "session_key": "session:test",
+            "is_new": False,
+            "connection": {"type": "local"},
+        }
+    )
+    service.delete_owned_chat_session = AsyncMock(return_value=True)
     return service
 
 
@@ -167,6 +211,24 @@ class TestRemoveChatBot:
         assert data["success"] is True
         mock_service.remove_chat_bot.assert_called_once()
 
+    def test_remove_chat_bot_connection_error_is_retryable(self, client_with_mock):
+        """Keep runtime cleanup failures distinguishable from generic errors."""
+        client, mock_service = client_with_mock
+        mock_service.remove_chat_bot.side_effect = ConnectionError(
+            "Bot服务正在启动，请稍后重试",
+            error_code="5001",
+        )
+
+        response = client.delete("/api/v1/expert-chats/test_bot/test_owner")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": False,
+            "message": "Bot服务正在启动，请稍后重试",
+            "error_code": 5001,
+            "data": None,
+        }
+
 
 class TestGetChatSession:
     """Tests for POST /api/v1/expert-chats/{bot_id}/{owner_id}/session endpoint."""
@@ -212,3 +274,225 @@ class TestDeleteChatSession:
         data = response.json()
         assert data["success"] is True
         mock_service.delete_chat_session.assert_called_once()
+
+    def test_delete_chat_session_maps_unexpected_error(self, client_with_mock):
+        client, mock_service = client_with_mock
+        mock_service.delete_chat_session.side_effect = RuntimeError("unexpected")
+
+        response = client.delete("/api/v1/expert-chats/test_bot/test_owner/session")
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == 5999
+
+
+class TestMultiChatSessions:
+    """Tests for the multi-session expert-chat endpoints."""
+
+    def test_list_sessions_passes_filters_and_authenticated_user(
+        self, client_with_mock
+    ):
+        client, mock_service = client_with_mock
+        client.cookies.set("IAM_TOKEN", "test-iam-token")
+
+        response = client.get(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions",
+            params={
+                "session_key": "session:test",
+                "favorite_only": "true",
+                "limit": 10,
+                "offset": 2,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["data"]["items"][0]["last_message"]["content"] == "hello"
+        mock_service.list_chat_sessions.assert_awaited_once_with(
+            user_id="test_user",
+            bot_id="test_bot",
+            owner_id="test_owner",
+            session_key="session:test",
+            favorite_only=True,
+            limit=10,
+            offset=2,
+            iam_token="test-iam-token",
+        )
+
+    def test_list_sessions_rejects_invalid_limit(self, client_with_mock):
+        client, mock_service = client_with_mock
+
+        response = client.get(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions?limit=101"
+        )
+
+        assert response.status_code == 422
+        mock_service.list_chat_sessions.assert_not_awaited()
+
+    def test_create_session(self, client_with_mock):
+        client, mock_service = client_with_mock
+
+        response = client.post("/api/v1/expert-chats/test_bot/test_owner/sessions")
+
+        assert response.status_code == 200
+        assert response.json()["data"]["session_key"] == "session:new"
+        mock_service.create_chat_session.assert_awaited_once_with(
+            user_id="test_user",
+            bot_id="test_bot",
+            owner_id="test_owner",
+            iam_token=None,
+        )
+
+    def test_connect_session(self, client_with_mock):
+        client, mock_service = client_with_mock
+
+        response = client.post(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions/connect",
+            json={"session_key": "session:test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["is_new"] is False
+        mock_service.connect_chat_session.assert_awaited_once_with(
+            user_id="test_user",
+            bot_id="test_bot",
+            owner_id="test_owner",
+            session_key="session:test",
+            iam_token=None,
+        )
+
+    def test_delete_session(self, client_with_mock):
+        client, mock_service = client_with_mock
+
+        response = client.delete(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions",
+            params={"session_key": "session:test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_service.delete_owned_chat_session.assert_awaited_once_with(
+            user_id="test_user",
+            bot_id="test_bot",
+            owner_id="test_owner",
+            session_key="session:test",
+        )
+
+    def test_delete_unowned_session_returns_not_found(self, client_with_mock):
+        client, mock_service = client_with_mock
+        mock_service.delete_owned_chat_session.side_effect = BotNotFoundError(
+            "Session不存在或不属于当前用户"
+        )
+
+        response = client.delete(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions",
+            params={"session_key": "session:other"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is False
+        assert data["error_code"] == 404
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (BotNotFoundError("missing"), 404),
+            (BotNotActiveError("inactive"), 400),
+            (BotNotPublishedError("unpublished"), 4001),
+            (ChatPermissionError("forbidden"), 403),
+            (ConnectionError("offline", error_code="5001"), 5001),
+            (RuntimeError("unexpected"), 5999),
+        ],
+    )
+    def test_list_sessions_maps_service_errors(
+        self, client_with_mock, error, expected_code
+    ):
+        client, mock_service = client_with_mock
+        mock_service.list_chat_sessions.side_effect = error
+
+        response = client.get("/api/v1/expert-chats/test_bot/test_owner/sessions")
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == expected_code
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (BotNotFoundError("missing"), 404),
+            (BotNotActiveError("inactive"), 400),
+            (BotNotPublishedError("unpublished"), 4001),
+            (ChatPermissionError("forbidden"), 403),
+            (SessionCreateError("failed", error_code="5003"), 5003),
+            (RuntimeError("unexpected"), 5999),
+        ],
+    )
+    def test_create_session_maps_service_errors(
+        self, client_with_mock, error, expected_code
+    ):
+        client, mock_service = client_with_mock
+        mock_service.create_chat_session.side_effect = error
+
+        response = client.post("/api/v1/expert-chats/test_bot/test_owner/sessions")
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == expected_code
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (BotNotFoundError("missing"), 404),
+            (BotNotActiveError("inactive"), 400),
+            (BotNotPublishedError("unpublished"), 4001),
+            (ChatPermissionError("forbidden"), 403),
+            (ConnectionError("offline", error_code="5001"), 5001),
+            (RuntimeError("unexpected"), 5999),
+        ],
+    )
+    def test_connect_session_maps_service_errors(
+        self, client_with_mock, error, expected_code
+    ):
+        client, mock_service = client_with_mock
+        mock_service.connect_chat_session.side_effect = error
+
+        response = client.post(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions/connect",
+            json={"session_key": "session:test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == expected_code
+
+    def test_delete_session_maps_unexpected_error(self, client_with_mock):
+        client, mock_service = client_with_mock
+        mock_service.delete_owned_chat_session.side_effect = RuntimeError("unexpected")
+
+        response = client.delete(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions",
+            params={"session_key": "session:test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == 5999
+
+    @pytest.mark.parametrize(
+        ("error", "expected_code"),
+        [
+            (BotNotActiveError("inactive"), 400),
+            (ChatPermissionError("forbidden"), 403),
+            (ConnectionError("offline", error_code="5001"), 5001),
+        ],
+    )
+    def test_delete_session_maps_access_errors(
+        self, client_with_mock, error, expected_code
+    ):
+        client, mock_service = client_with_mock
+        mock_service.delete_owned_chat_session.side_effect = error
+
+        response = client.delete(
+            "/api/v1/expert-chats/test_bot/test_owner/sessions",
+            params={"session_key": "session:test"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["error_code"] == expected_code

--- a/src/backend/tests/community/core/expert_chat/conftest.py
+++ b/src/backend/tests/community/core/expert_chat/conftest.py
@@ -19,6 +19,11 @@ def mock_repository():
     repo.get_session = MagicMock(return_value=None)
     repo.save_session = MagicMock()
     repo.delete_session = MagicMock(return_value=True)
+    repo.add_owned_session = MagicMock()
+    repo.list_owned_sessions = MagicMock(return_value=[])
+    repo.get_owned_session = MagicMock(return_value=None)
+    repo.delete_owned_session = MagicMock(return_value=True)
+    repo.delete_all_owned_sessions = MagicMock(return_value=0)
     return repo
 
 

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
@@ -1,6 +1,6 @@
 """Tests for ExpertChatService."""
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from agentclaw.community.core.expert_chat.services.expert_chat_service import ExpertChatService
 from agentclaw.community.core.expert_chat.errors import (
@@ -10,6 +10,10 @@ from agentclaw.community.core.expert_chat.errors import (
     SessionCreateError,
     ConnectionError,
     ChatPermissionError,
+)
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
 )
 
 
@@ -219,38 +223,181 @@ class TestRemoveChatBot:
     async def test_success(self, mock_repository, mock_bot_repo, mock_device_provider):
         mock_repository.remove_chat_bot.return_value = True
         svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
-        svc.delete_chat_session = AsyncMock(return_value=True)
 
         result = await svc.remove_chat_bot("user1", "bot1", "owner1")
 
         assert result is True
         mock_repository.remove_chat_bot.assert_called_once_with("user1", "bot1", "owner1")
+        mock_repository.delete_all_owned_sessions.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
 
     @pytest.mark.asyncio
     async def test_bot_not_found_during_session_delete_is_ignored(
         self, mock_repository, mock_bot_repo, mock_device_provider
     ):
-        """BotNotFoundError from delete_chat_session should not propagate."""
+        """A missing Bot cannot expose runtime cleanup, but local removal works."""
+        mock_bot_repo.get_by_id_and_owner.return_value = None
+        mock_repository.get_session.return_value = "session:orphan"
+        mock_repository.list_owned_sessions.return_value = [
+            {"session_key": "session:orphan"}
+        ]
         mock_repository.remove_chat_bot.return_value = True
         svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
-        svc.delete_chat_session = AsyncMock(side_effect=BotNotFoundError("not found"))
 
         result = await svc.remove_chat_bot("user1", "bot1", "owner1")
 
         assert result is True
+        mock_repository.delete_all_owned_sessions.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        mock_repository.delete_session.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
 
     @pytest.mark.asyncio
-    async def test_generic_exception_during_session_delete_is_logged_not_raised(
+    async def test_runtime_delete_failure_preserves_local_ownership(
         self, mock_repository, mock_bot_repo, mock_device_provider
     ):
-        """Non-BotNotFoundError exceptions should be caught and logged."""
-        mock_repository.remove_chat_bot.return_value = True
+        """A runtime cleanup failure must keep local ownership retryable."""
+        mock_bot_repo.get_by_id_and_owner.return_value = dict(ACTIVE_BOT)
+        mock_repository.list_owned_sessions.return_value = [
+            {"session_key": "session:one"}
+        ]
         svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
-        svc.delete_chat_session = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch.object(
+            svc,
+            "_delete_adapter_session",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await svc.remove_chat_bot("user1", "bot1", "owner1")
 
-        result = await svc.remove_chat_bot("user1", "bot1", "owner1")
+        mock_repository.delete_all_owned_sessions.assert_not_called()
+        mock_repository.delete_session.assert_not_called()
+        mock_repository.remove_chat_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remove_while_caller_instance_is_starting_is_retryable(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_bot_repo.get_by_id_and_owner.return_value = dict(ACTIVE_BOT)
+        mock_repository.list_owned_sessions.return_value = [
+            {"session_key": "session:one"}
+        ]
+        svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
+
+        with patch.object(
+            svc,
+            "_prepare_chat_connection",
+            new=AsyncMock(return_value=(None, True)),
+        ):
+            with pytest.raises(ConnectionError, match="正在启动"):
+                await svc.remove_chat_bot("user1", "bot1", "owner1")
+
+        mock_repository.delete_owned_session.assert_not_called()
+        mock_repository.delete_all_owned_sessions.assert_not_called()
+        mock_repository.remove_chat_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_partial_runtime_delete_failure_retries_only_remaining_sessions(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_bot_repo.get_by_id_and_owner.return_value = dict(ACTIVE_BOT)
+        mock_repository.get_session.side_effect = [
+            "session:first",
+            "session:second",
+        ]
+        mock_repository.list_owned_sessions.side_effect = [
+            [
+                {"session_key": "session:first"},
+                {"session_key": "session:second"},
+            ],
+            [{"session_key": "session:second"}],
+        ]
+        svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
+        delete_attempts = {"session:second": 0}
+
+        async def delete_with_one_transient_failure(
+            _bot, session_key, _user_id, connection=None
+        ):
+            if session_key == "session:second":
+                delete_attempts[session_key] += 1
+                if delete_attempts[session_key] == 1:
+                    raise RuntimeError("transient")
+
+        with patch.object(
+            svc,
+            "_delete_adapter_session",
+            new=AsyncMock(side_effect=delete_with_one_transient_failure),
+        ) as delete_adapter, patch.object(
+            svc, "_remove_session_favorite", new=AsyncMock()
+        ):
+            with pytest.raises(RuntimeError, match="transient"):
+                await svc.remove_chat_bot("user1", "bot1", "owner1")
+
+            result = await svc.remove_chat_bot("user1", "bot1", "owner1")
 
         assert result is True
+        assert [call.args[1] for call in delete_adapter.await_args_list] == [
+            "session:first",
+            "session:second",
+            "session:second",
+        ]
+        assert mock_repository.delete_owned_session.call_args_list == [
+            call("user1", "bot1", "owner1", "session:first"),
+            call("user1", "bot1", "owner1", "session:second"),
+        ]
+        mock_repository.save_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:second"
+        )
+        mock_repository.delete_session.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        mock_repository.delete_all_owned_sessions.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        mock_repository.remove_chat_bot.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_owned_sessions_are_deleted_before_bot_is_removed(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_bot_repo.get_by_id_and_owner.return_value = dict(ACTIVE_BOT)
+        mock_repository.get_session.return_value = "session:default"
+        mock_repository.list_owned_sessions.return_value = [
+            {"session_key": "session:default"},
+            {"session_key": "session:second"},
+        ]
+        svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
+
+        with patch.object(
+            svc, "_delete_adapter_session", new=AsyncMock()
+        ) as delete_adapter, patch.object(
+            svc, "_remove_session_favorite", new=AsyncMock()
+        ) as remove_favorite:
+            result = await svc.remove_chat_bot("user1", "bot1", "owner1")
+
+        assert result is True
+        assert [call.args[1] for call in delete_adapter.await_args_list] == [
+            "session:default",
+            "session:second",
+        ]
+        assert [call.args[1] for call in remove_favorite.await_args_list] == [
+            "session:default",
+            "session:second",
+        ]
+        mock_repository.delete_all_owned_sessions.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        mock_repository.delete_session.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        mock_repository.remove_chat_bot.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +460,9 @@ class TestGetChatSession:
 
         assert result["session_key"] == "session:new-456"
         assert result["is_new"] is True
+        mock_repository.delete_owned_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:stale"
+        )
         mock_repository.delete_session.assert_called_once()
 
     @pytest.mark.asyncio
@@ -426,8 +576,684 @@ class TestGetChatSession:
             user_id="user1", bot_id="bot1", owner_id="owner1", iam_token=None
         )
 
+
+class TestExpertChatMultiSession:
+    @staticmethod
+    def _authorized_service(
+        mock_repository,
+        mock_bot_repo,
+        mock_device_provider,
+        *,
+        mock_transport=None,
+    ):
+        mock_bot_repo.get_by_id_and_owner.return_value = dict(ACTIVE_BOT)
+        mock_repository.list_chat_bots.return_value = [
+            {"bot_id": "bot1", "owner_id": "owner1"}
+        ]
+        return _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=mock_transport,
+        )
+
     @pytest.mark.asyncio
-    async def test_caller_mode_container_ready_creates_new_session(self, mock_repository, mock_bot_repo, mock_device_provider):
+    async def test_list_migrates_legacy_session_enriches_and_sorts(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_session.return_value = "session:legacy"
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:old",
+                "gmt_create": "2026-08-10T08:00:00",
+                "gmt_modified": "2026-08-10T08:00:00",
+            },
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:new",
+                "gmt_create": "2026-08-10T09:00:00",
+                "gmt_modified": "2026-08-10T09:00:00",
+            },
+        ]
+        transport = MagicMock()
+        adapter_sessions = {
+            "/api/sessions/session%3Aold": {
+                "data": {
+                    "id": "session:old",
+                    "title": "Old",
+                    # OpenClaw currently synthesizes this value at read time.
+                    "gmt_modified": "2026-08-10T12:00:00Z",
+                    "last_message": {
+                        "content": "older",
+                        "gmt_created": "2026-08-10T10:00:00Z",
+                    },
+                }
+            },
+            "/api/sessions/session%3Anew": {
+                "data": {
+                    "id": "session:new",
+                    "title": "New",
+                    "gmt_modified": "2026-08-10T11:59:59Z",
+                    "last_message": {
+                        "content": "latest",
+                        "gmt_created": "2026-08-10T11:00:00Z",
+                    },
+                }
+            },
+        }
+        transport.invoke = AsyncMock(
+            side_effect=lambda _connection, _method, path: adapter_sessions[path]
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1", limit=1)
+
+        assert result["total"] == 2
+        assert [item["id"] for item in result["items"]] == ["session:new"]
+        assert result["items"][0]["gmt_modified"] == "2026-08-10T11:00:00Z"
+        assert result["items"][0]["message_count"] == 0
+        expected_conn = mock_device_provider.get_device_connection_v2.return_value
+        assert all(
+            call.args[:2] == (expected_conn, "GET")
+            for call in transport.invoke.await_args_list
+        )
+        assert {call.args[2] for call in transport.invoke.await_args_list} == {
+            "/api/sessions/session%3Aold",
+            "/api/sessions/session%3Anew",
+        }
+        mock_repository.add_owned_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:legacy"
+        )
+
+    @pytest.mark.asyncio
+    async def test_aicoding_list_finds_owned_session_beyond_first_adapter_page(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        target_key = "user:user1:session:target:agent:bot1"
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": target_key,
+                "gmt_create": "2026-08-10T09:00:00",
+                "gmt_modified": "2026-08-10T09:00:00",
+            }
+        ]
+        first_page = [
+            {
+                "id": f"user:user1:session:{index}:agent:other",
+                "title": f"Other {index}",
+            }
+            for index in range(500)
+        ]
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=[
+                {"data": first_page},
+                {
+                    "data": [
+                        {
+                            "id": target_key,
+                            "title": "Target beyond the first page",
+                            "gmt_modified": "2026-08-10T12:00:00Z",
+                        }
+                    ]
+                },
+            ]
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+        mock_device_provider.get_device_connection_v2.return_value[
+            "engine_type"
+        ] = "aicoding"
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1")
+
+        assert result["items"][0]["id"] == target_key
+        assert result["items"][0]["title"] == "Target beyond the first page"
+        assert transport.invoke.await_count == 2
+        assert transport.invoke.await_args_list[1].kwargs["params"] == {
+            "user_id": "user1",
+            "limit": 500,
+            "offset": 500,
+        }
+
+    @pytest.mark.asyncio
+    async def test_aicoding_list_transport_failure_returns_no_metadata(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(side_effect=ConnectionError("offline"))
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc._list_owned_adapter_sessions(
+            connection=dict(DEVICE_CONN, engine_type="aicoding"),
+            rows=[{"session_key": "session:owned"}],
+            user_id="user1",
+        )
+
+        assert result == {}
+        transport.invoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aicoding_list_ignores_invalid_rows_and_stops_on_repeated_page(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        target_key = "session:target"
+        repeated_page = [None, {}, {"id": ""}, {"id": "session:other"}]
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=[
+                {"data": repeated_page},
+                {"data": repeated_page},
+                {"data": {"id": target_key, "title": "Target"}},
+            ]
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc._list_owned_adapter_sessions(
+            connection=dict(DEVICE_CONN, engine_type="aicoding"),
+            rows=[{"session_key": target_key}],
+            user_id="user1",
+        )
+
+        assert result[target_key]["title"] == "Target"
+        assert transport.invoke.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_aicoding_empty_list_and_missing_exact_lookup_use_placeholder(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=[
+                {"data": []},
+                DeviceAdapterEndpointNotFoundError("missing"),
+            ]
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc._list_owned_adapter_sessions(
+            connection=dict(DEVICE_CONN, engine_type="aicoding"),
+            rows=[{"session_key": "session:missing"}],
+            user_id="user1",
+        )
+
+        assert result == {}
+        assert transport.invoke.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_openclaw_list_uses_exact_lookup_without_scanning_pages(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        target_key = "agent:bot1:session:target:user:user1"
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": target_key,
+                "gmt_create": "2026-08-10T09:00:00",
+                "gmt_modified": "2026-08-10T09:00:00",
+            }
+        ]
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            return_value={
+                "data": {
+                    "id": target_key,
+                    "title": "Visible after exact lookup",
+                    "gmt_modified": "2026-08-10T12:00:00Z",
+                }
+            }
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1")
+
+        assert result["items"][0]["title"] == "Visible after exact lookup"
+        assert result["items"][0]["gmt_modified"] == "2026-08-10T09:00:00"
+        transport.invoke.assert_awaited_once()
+        assert transport.invoke.await_args.args[1:] == (
+            "GET",
+            "/api/sessions/agent%3Abot1%3Asession%3Atarget%3Auser%3Auser1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_returns_placeholder_when_adapter_metadata_fails(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:empty",
+                "gmt_create": "2026-08-10T09:00:00",
+                "gmt_modified": "2026-08-10T09:00:00",
+            }
+        ]
+        transport = MagicMock()
+        transport.invoke = AsyncMock(side_effect=ConnectionError("offline"))
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1")
+
+        assert result["items"][0]["id"] == "session:empty"
+        assert result["items"][0]["title"] == "新会话"
+        assert result["items"][0]["last_message"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_before_resolving_connection(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = []
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1")
+
+        assert result == {"total": 0, "items": []}
+        svc._resolver.resolve_for_binding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_returns_placeholders_while_caller_is_starting(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        bot = dict(ACTIVE_BOT, call_type="caller")
+        mock_bot_repo.get_by_id_and_owner.return_value = bot
+        mock_repository.list_chat_bots.return_value = [
+            {"bot_id": "bot1", "owner_id": "owner1"}
+        ]
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:waiting",
+                "gmt_create": None,
+                "gmt_modified": None,
+            }
+        ]
+        mock_instance = MagicMock()
+        mock_instance.get_caller_connection = AsyncMock(
+            return_value={
+                "connection": None,
+                "need_poll": True,
+            }
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_instance_service=mock_instance,
+        )
+
+        result = await svc.list_chat_sessions("user1", "bot1", "owner1")
+
+        assert result["need_poll"] is True
+        assert result["items"][0]["id"] == "session:waiting"
+
+    @pytest.mark.asyncio
+    async def test_favorite_list_stays_filtered_while_caller_is_starting(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        bot = dict(ACTIVE_BOT, call_type="caller")
+        mock_bot_repo.get_by_id_and_owner.return_value = bot
+        mock_repository.list_chat_bots.return_value = [
+            {"bot_id": "bot1", "owner_id": "owner1"}
+        ]
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:not-confirmed-favorite",
+            }
+        ]
+        mock_instance = MagicMock()
+        mock_instance.get_caller_connection = AsyncMock(
+            return_value={"connection": None, "need_poll": True}
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_instance_service=mock_instance,
+        )
+
+        result = await svc.list_chat_sessions(
+            "user1", "bot1", "owner1", favorite_only=True
+        )
+
+        assert result == {"total": 0, "items": [], "need_poll": True}
+
+    @pytest.mark.asyncio
+    async def test_create_returns_poll_state_without_writing_mapping(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+        with patch.object(
+            svc,
+            "_prepare_chat_connection",
+            new=AsyncMock(return_value=(None, True)),
+        ):
+            result = await svc.create_chat_session("user1", "bot1", "owner1")
+
+        assert result["need_poll"] is True
+        mock_repository.add_owned_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_favorite_list_filters_unowned_sessions(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_session.return_value = None
+        mock_repository.list_owned_sessions.return_value = [
+            {
+                "user_id": "user1",
+                "bot_id": "bot1",
+                "owner_id": "owner1",
+                "session_key": "session:owned",
+                "gmt_create": None,
+                "gmt_modified": None,
+            }
+        ]
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            return_value={
+                "data": [
+                    {"id": "session:not-owned", "title": "Hidden"},
+                    {"id": "session:owned", "title": "Favorite"},
+                ]
+            }
+        )
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc.list_chat_sessions(
+            "user1", "bot1", "owner1", favorite_only=True
+        )
+
+        assert result["total"] == 1
+        assert result["items"][0]["id"] == "session:owned"
+        assert result["items"][0]["user_id"] == "user1"
+        assert transport.invoke.await_args.kwargs["params"] == {
+            "user_id": "user1",
+            "limit": 10_000,
+            "offset": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_adds_mapping_and_updates_legacy_default(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+        with patch.object(
+            svc, "_create_session", new=AsyncMock(return_value="session:new")
+        ) as create_session:
+            result = await svc.create_chat_session("user1", "bot1", "owner1")
+
+        assert result["session_key"] == "session:new"
+        assert create_session.await_args.kwargs["prefer_adapter_for_relay"] is True
+        mock_repository.add_owned_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:new"
+        )
+        mock_repository.save_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:new"
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_rejects_unowned_key_before_connection(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+
+        with pytest.raises(BotNotFoundError):
+            await svc.connect_chat_session("user1", "bot1", "owner1", "session:other")
+
+        mock_repository.save_session.assert_not_called()
+        svc._resolver.resolve_for_binding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connect_owned_session_updates_legacy_default(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_owned_session.return_value = {
+            "session_key": "session:owned"
+        }
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+
+        result = await svc.connect_chat_session(
+            "user1", "bot1", "owner1", "session:owned"
+        )
+
+        assert result["session_key"] == "session:owned"
+        mock_repository.save_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:owned"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_cleans_mapping_favorite_and_legacy_default(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_owned_session.return_value = {
+            "session_key": "session:owned"
+        }
+        mock_repository.get_session.return_value = "session:owned"
+        mock_repository.list_owned_sessions.return_value = []
+        transport = MagicMock()
+        transport.invoke = AsyncMock(return_value={"success": True})
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        with patch.object(
+            svc, "_delete_adapter_session", new=AsyncMock()
+        ) as delete_adapter:
+            assert (
+                await svc.delete_owned_chat_session(
+                    "user1", "bot1", "owner1", "session:owned"
+                )
+                is True
+            )
+
+        delete_adapter.assert_awaited_once()
+        mock_repository.delete_owned_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:owned"
+        )
+        mock_repository.delete_session.assert_called_once_with(
+            "user1", "bot1", "owner1"
+        )
+        favorite_call = transport.invoke.await_args
+        assert favorite_call.args[1:] == (
+            "DELETE",
+            "/api/session-favorites/session%3Aowned",
+        )
+        assert favorite_call.kwargs == {"params": {"user_id": "user1"}}
+
+    @pytest.mark.asyncio
+    async def test_delete_rejects_unowned_session(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+
+        with pytest.raises(BotNotFoundError):
+            await svc.delete_owned_chat_session(
+                "user1", "bot1", "owner1", "session:other"
+            )
+
+        mock_repository.delete_owned_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_selects_next_session_when_default_is_removed(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_owned_session.return_value = {
+            "session_key": "session:owned"
+        }
+        mock_repository.get_session.return_value = "session:owned"
+        mock_repository.list_owned_sessions.return_value = [
+            {"session_key": "session:next"}
+        ]
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+        with patch.object(
+            svc,
+            "_delete_adapter_session",
+            new=AsyncMock(),
+        ), patch.object(svc, "_remove_session_favorite", new=AsyncMock()):
+            assert await svc.delete_owned_chat_session(
+                "user1", "bot1", "owner1", "session:owned"
+            )
+
+        mock_repository.save_session.assert_called_once_with(
+            "user1", "bot1", "owner1", "session:next"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_failure_preserves_mapping_and_default_pointer(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_owned_session.return_value = {
+            "session_key": "session:owned"
+        }
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+        with patch.object(
+            svc,
+            "_delete_adapter_session",
+            new=AsyncMock(side_effect=ConnectionError("offline")),
+        ):
+            with pytest.raises(ConnectionError, match="offline"):
+                await svc.delete_owned_chat_session(
+                    "user1", "bot1", "owner1", "session:owned"
+                )
+
+        mock_repository.delete_owned_session.assert_not_called()
+        mock_repository.save_session.assert_not_called()
+        mock_repository.delete_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_during_caller_startup_preserves_mapping(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        mock_repository.get_owned_session.return_value = {
+            "session_key": "session:owned"
+        }
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+        with patch.object(
+            svc,
+            "_prepare_chat_connection",
+            new=AsyncMock(return_value=(None, True)),
+        ):
+            with pytest.raises(ConnectionError, match="正在启动"):
+                await svc.delete_owned_chat_session(
+                    "user1", "bot1", "owner1", "session:owned"
+                )
+
+        mock_repository.delete_owned_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_favorite_helpers_degrade_on_old_adapter(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(side_effect=ConnectionError("offline"))
+        svc = self._authorized_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        await svc._remove_session_favorite(DEVICE_CONN, "session:test", "user1")
+        favorites = await svc._list_favorite_sessions(DEVICE_CONN, "user1", "bot1")
+
+        assert favorites == []
+
+    def test_session_sort_key_handles_missing_and_invalid_timestamps(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        svc = self._authorized_service(
+            mock_repository, mock_bot_repo, mock_device_provider
+        )
+
+        assert svc._session_sort_key({}) == 0.0
+        assert svc._session_sort_key({"gmt_modified": "not-a-date"}) == 0.0
+
+
+class TestGetChatSessionCallerMode:
+    @pytest.mark.asyncio
+    async def test_caller_mode_container_ready_creates_new_session(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
         """Caller 模式：容器就绪，创建新 session"""
         caller_bot = {
             "bot_id": "bot1",
@@ -628,18 +1454,23 @@ class TestDeleteChatSession:
         mock_repository.delete_session.assert_called_once_with("user1", "bot1", "owner1")
 
     @pytest.mark.asyncio
-    async def test_adapter_delete_failure_still_deletes_local(
+    async def test_adapter_delete_failure_preserves_local_indexes(
         self, mock_repository, mock_bot_repo, mock_device_provider
     ):
         mock_bot_repo.get_by_id_and_owner.return_value = ACTIVE_BOT
         mock_repository.get_session.return_value = "session:abc"
         svc = _make_service(mock_repository, mock_bot_repo, mock_device_provider)
 
-        with patch.object(svc, "_delete_adapter_session", new=AsyncMock(side_effect=RuntimeError("adapter down"))):
-            result = await svc.delete_chat_session("user1", "bot1", "owner1")
+        with patch.object(
+            svc,
+            "_delete_adapter_session",
+            new=AsyncMock(side_effect=RuntimeError("adapter down")),
+        ):
+            with pytest.raises(RuntimeError, match="adapter down"):
+                await svc.delete_chat_session("user1", "bot1", "owner1")
 
-        assert result is True
-        mock_repository.delete_session.assert_called_once()
+        mock_repository.delete_owned_session.assert_not_called()
+        mock_repository.delete_session.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -836,7 +1667,9 @@ class TestCheckSessionExists:
 
         assert result is True
         expected_conn = mock_device_provider.get_device_connection_v2.return_value
-        transport.invoke.assert_awaited_once_with(expected_conn, "GET", "/api/sessions/session:abc")
+        transport.invoke.assert_awaited_once_with(
+            expected_conn, "GET", "/api/sessions/session%3Aabc"
+        )
 
     @pytest.mark.asyncio
     async def test_returns_false_on_404(self, mock_repository, mock_bot_repo, mock_device_provider):
@@ -930,7 +1763,9 @@ class TestDeleteAdapterSession:
         await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
 
         expected_conn = mock_device_provider.get_device_connection_v2.return_value
-        transport.invoke.assert_awaited_once_with(expected_conn, "DELETE", "/api/sessions/session:abc")
+        transport.invoke.assert_awaited_once_with(
+            expected_conn, "DELETE", "/api/sessions/session%3Aabc"
+        )
 
     @pytest.mark.asyncio
     async def test_404_is_silently_ignored(self, mock_repository, mock_bot_repo, mock_device_provider):
@@ -944,6 +1779,26 @@ class TestDeleteAdapterSession:
         )
 
         await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_delete_404_is_retryable(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=ValueError(
+                "Adapter returned HTTP 404: Session not found or delete failed"
+            )
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        with pytest.raises(ValueError, match="delete failed"):
+            await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
 
     @pytest.mark.asyncio
     async def test_4xx_raises_exception(self, mock_repository, mock_bot_repo, mock_device_provider):
@@ -960,10 +1815,15 @@ class TestDeleteAdapterSession:
             await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
 
     @pytest.mark.asyncio
-    async def test_resolved_aicoding_connection_skips_transport_call(
-        self, mock_repository, mock_bot_repo, mock_device_provider
+    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
+    async def test_relay_engine_connection_uses_generic_delete_endpoint(
+        self,
+        engine_type,
+        mock_repository,
+        mock_bot_repo,
+        mock_device_provider,
     ):
-        conn = dict(DEVICE_CONN, engine_type="aicoding")
+        conn = dict(DEVICE_CONN, engine_type=engine_type)
         resolver = MagicMock()
         ctx = MagicMock()
         ctx.conn_info = conn
@@ -980,6 +1840,179 @@ class TestDeleteAdapterSession:
 
         await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
 
+        transport.invoke.assert_awaited_once_with(
+            conn,
+            "DELETE",
+            "/api/sessions/session%3Aabc",
+        )
+
+    @pytest.mark.asyncio
+    async def test_relay_engine_ignores_unsupported_delete_endpoint(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        conn = dict(DEVICE_CONN, engine_type="aicoding")
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=DeviceAdapterHTTPStatusError(405, "Method Not Allowed")
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        await svc._delete_adapter_session(
+            ACTIVE_BOT,
+            "session:abc",
+            "user1",
+            connection=conn,
+        )
+
+    def test_structured_adapter_errors_are_classified(self):
+        endpoint_missing = DeviceAdapterEndpointNotFoundError("missing")
+        not_found = DeviceAdapterHTTPStatusError(404, "Not Found")
+        method_not_allowed = DeviceAdapterHTTPStatusError(
+            405, "Method Not Allowed"
+        )
+
+        assert ExpertChatService._is_adapter_not_found(endpoint_missing) is True
+        assert ExpertChatService._is_adapter_not_found(not_found) is True
+        assert ExpertChatService._is_adapter_endpoint_unsupported(
+            endpoint_missing
+        ) is True
+        assert ExpertChatService._is_adapter_endpoint_unsupported(
+            method_not_allowed
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# _create_session engine dispatch
+# ---------------------------------------------------------------------------
+
+class TestCreateSessionDispatch:
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
+    async def test_relay_engines_use_generic_adapter_create(
+        self,
+        engine_type,
+        mock_repository,
+        mock_bot_repo,
+        mock_device_provider,
+    ):
+        canonical_key = f"agent:bot1:session:new:user:user1:{engine_type}"
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=[
+                {"data": {"id": canonical_key}},
+                {"data": [{"id": canonical_key}]},
+            ]
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+        conn = dict(DEVICE_CONN, engine_type=engine_type)
+
+        result = await svc._create_session(
+            {"bot_id": "bot1", "bot_name": "Bot"},
+            "user1",
+            connection=conn,
+            prefer_adapter_for_relay=True,
+        )
+
+        assert result == canonical_key
+        assert transport.invoke.await_args_list[0].kwargs["body"]["engine"] == engine_type
+        assert transport.invoke.await_args_list[0].kwargs["timeout"] == 330.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
+    @pytest.mark.parametrize("status_code", [404, 405])
+    async def test_relay_engines_fall_back_only_when_create_endpoint_is_missing(
+        self,
+        engine_type,
+        status_code,
+        mock_repository,
+        mock_bot_repo,
+        mock_device_provider,
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=ValueError(
+                f"Adapter returned HTTP {status_code}: Endpoint unavailable"
+            )
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+        conn = dict(DEVICE_CONN, engine_type=engine_type)
+
+        result = await svc._create_session(
+            {"bot_id": "bot1", "bot_name": "Bot"},
+            "user1",
+            connection=conn,
+            prefer_adapter_for_relay=True,
+        )
+
+        assert result.startswith("session:")
+        assert result.endswith(":user:user1")
+        assert transport.invoke.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_relay_engine_does_not_fall_back_on_adapter_failure(
+        self, mock_repository, mock_bot_repo, mock_device_provider
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock(
+            side_effect=ValueError("Adapter returned HTTP 500: Broken")
+        )
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        with pytest.raises(SessionCreateError):
+            await svc._create_session(
+                {"bot_id": "bot1", "bot_name": "Bot"},
+                "user1",
+                connection=dict(DEVICE_CONN, engine_type="aicoding"),
+                prefer_adapter_for_relay=True,
+            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
+    async def test_legacy_singular_flow_keeps_local_session_key_behavior(
+        self,
+        engine_type,
+        mock_repository,
+        mock_bot_repo,
+        mock_device_provider,
+    ):
+        transport = MagicMock()
+        transport.invoke = AsyncMock()
+        svc = _make_service(
+            mock_repository,
+            mock_bot_repo,
+            mock_device_provider,
+            mock_transport=transport,
+        )
+
+        result = await svc._create_session(
+            {"bot_id": "bot1", "bot_name": "Bot"},
+            "user1",
+            connection=dict(DEVICE_CONN, engine_type=engine_type),
+        )
+
+        assert result.startswith("session:")
+        assert result.endswith(":user:user1")
         transport.invoke.assert_not_awaited()
 
 

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
@@ -1048,7 +1048,7 @@ class TestExpertChatMultiSession:
             result = await svc.create_chat_session("user1", "bot1", "owner1")
 
         assert result["session_key"] == "session:new"
-        assert create_session.await_args.kwargs["prefer_adapter_for_relay"] is True
+        assert create_session.await_args.kwargs["connection"] is result["connection"]
         mock_repository.add_owned_session.assert_called_once_with(
             "user1", "bot1", "owner1", "session:new"
         )
@@ -1816,7 +1816,7 @@ class TestDeleteAdapterSession:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
-    async def test_relay_engine_connection_uses_generic_delete_endpoint(
+    async def test_relay_engine_skips_adapter_delete(
         self,
         engine_type,
         mock_repository,
@@ -1838,52 +1838,21 @@ class TestDeleteAdapterSession:
             mock_transport=transport,
         )
 
-        await svc._delete_adapter_session(ACTIVE_BOT, "session:abc", "user1")
-
-        transport.invoke.assert_awaited_once_with(
-            conn,
-            "DELETE",
-            "/api/sessions/session%3Aabc",
-        )
-
-    @pytest.mark.asyncio
-    async def test_relay_engine_ignores_unsupported_delete_endpoint(
-        self, mock_repository, mock_bot_repo, mock_device_provider
-    ):
-        conn = dict(DEVICE_CONN, engine_type="aicoding")
-        transport = MagicMock()
-        transport.invoke = AsyncMock(
-            side_effect=DeviceAdapterHTTPStatusError(405, "Method Not Allowed")
-        )
-        svc = _make_service(
-            mock_repository,
-            mock_bot_repo,
-            mock_device_provider,
-            mock_transport=transport,
-        )
-
         await svc._delete_adapter_session(
-            ACTIVE_BOT,
+            {**ACTIVE_BOT, "active_engine": engine_type},
             "session:abc",
             "user1",
             connection=conn,
         )
 
+        transport.invoke.assert_not_awaited()
+
     def test_structured_adapter_errors_are_classified(self):
         endpoint_missing = DeviceAdapterEndpointNotFoundError("missing")
         not_found = DeviceAdapterHTTPStatusError(404, "Not Found")
-        method_not_allowed = DeviceAdapterHTTPStatusError(
-            405, "Method Not Allowed"
-        )
 
         assert ExpertChatService._is_adapter_not_found(endpoint_missing) is True
         assert ExpertChatService._is_adapter_not_found(not_found) is True
-        assert ExpertChatService._is_adapter_endpoint_unsupported(
-            endpoint_missing
-        ) is True
-        assert ExpertChatService._is_adapter_endpoint_unsupported(
-            method_not_allowed
-        ) is True
 
 
 # ---------------------------------------------------------------------------
@@ -1894,102 +1863,7 @@ class TestCreateSessionDispatch:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
-    async def test_relay_engines_use_generic_adapter_create(
-        self,
-        engine_type,
-        mock_repository,
-        mock_bot_repo,
-        mock_device_provider,
-    ):
-        canonical_key = f"agent:bot1:session:new:user:user1:{engine_type}"
-        transport = MagicMock()
-        transport.invoke = AsyncMock(
-            side_effect=[
-                {"data": {"id": canonical_key}},
-                {"data": [{"id": canonical_key}]},
-            ]
-        )
-        svc = _make_service(
-            mock_repository,
-            mock_bot_repo,
-            mock_device_provider,
-            mock_transport=transport,
-        )
-        conn = dict(DEVICE_CONN, engine_type=engine_type)
-
-        result = await svc._create_session(
-            {"bot_id": "bot1", "bot_name": "Bot"},
-            "user1",
-            connection=conn,
-            prefer_adapter_for_relay=True,
-        )
-
-        assert result == canonical_key
-        assert transport.invoke.await_args_list[0].kwargs["body"]["engine"] == engine_type
-        assert transport.invoke.await_args_list[0].kwargs["timeout"] == 330.0
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
-    @pytest.mark.parametrize("status_code", [404, 405])
-    async def test_relay_engines_fall_back_only_when_create_endpoint_is_missing(
-        self,
-        engine_type,
-        status_code,
-        mock_repository,
-        mock_bot_repo,
-        mock_device_provider,
-    ):
-        transport = MagicMock()
-        transport.invoke = AsyncMock(
-            side_effect=ValueError(
-                f"Adapter returned HTTP {status_code}: Endpoint unavailable"
-            )
-        )
-        svc = _make_service(
-            mock_repository,
-            mock_bot_repo,
-            mock_device_provider,
-            mock_transport=transport,
-        )
-        conn = dict(DEVICE_CONN, engine_type=engine_type)
-
-        result = await svc._create_session(
-            {"bot_id": "bot1", "bot_name": "Bot"},
-            "user1",
-            connection=conn,
-            prefer_adapter_for_relay=True,
-        )
-
-        assert result.startswith("session:")
-        assert result.endswith(":user:user1")
-        assert transport.invoke.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_relay_engine_does_not_fall_back_on_adapter_failure(
-        self, mock_repository, mock_bot_repo, mock_device_provider
-    ):
-        transport = MagicMock()
-        transport.invoke = AsyncMock(
-            side_effect=ValueError("Adapter returned HTTP 500: Broken")
-        )
-        svc = _make_service(
-            mock_repository,
-            mock_bot_repo,
-            mock_device_provider,
-            mock_transport=transport,
-        )
-
-        with pytest.raises(SessionCreateError):
-            await svc._create_session(
-                {"bot_id": "bot1", "bot_name": "Bot"},
-                "user1",
-                connection=dict(DEVICE_CONN, engine_type="aicoding"),
-                prefer_adapter_for_relay=True,
-            )
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("engine_type", ["aicoding", "claude_code"])
-    async def test_legacy_singular_flow_keeps_local_session_key_behavior(
+    async def test_relay_engines_use_strategy_without_adapter_create(
         self,
         engine_type,
         mock_repository,
@@ -2004,15 +1878,24 @@ class TestCreateSessionDispatch:
             mock_device_provider,
             mock_transport=transport,
         )
+        conn = dict(DEVICE_CONN, engine_type=engine_type)
 
         result = await svc._create_session(
-            {"bot_id": "bot1", "bot_name": "Bot"},
+            {
+                "bot_id": "bot1",
+                "bot_name": "Bot",
+                "active_engine": engine_type,
+            },
             "user1",
-            connection=dict(DEVICE_CONN, engine_type=engine_type),
+            connection=conn,
         )
 
-        assert result.startswith("session:")
-        assert result.endswith(":user:user1")
+        if engine_type == "aicoding":
+            assert result.startswith("user:user1:session:")
+            assert result.endswith(":agent:bot1")
+        else:
+            assert result.startswith("session:")
+            assert result.endswith(":user:user1")
         transport.invoke.assert_not_awaited()
 
 

--- a/src/backend/tests/community/core/expert_chat/test_sqlite_models.py
+++ b/src/backend/tests/community/core/expert_chat/test_sqlite_models.py
@@ -5,7 +5,7 @@ Focuses on edge cases like JSON deserialization error handling.
 from agentclaw.community.core.expert_chat.sqlite_models import (
     AcExpertChatBotSession,
     AcExpertChatInstance,
-    AcExpertChatSession,
+    AcExpertChatOwnedSession,
 )
 
 
@@ -51,7 +51,7 @@ def test_owned_session_to_dict_exposes_complete_index_row():
     from datetime import datetime
 
     now = datetime(2026, 8, 10, 12, 0, 0)
-    session = AcExpertChatSession(
+    session = AcExpertChatOwnedSession(
         id=7,
         user_id="u1",
         bot_id="b1",
@@ -74,6 +74,13 @@ def test_owned_session_to_dict_exposes_complete_index_row():
         "gmt_create": "2026-08-10T12:00:00",
         "gmt_modified": "2026-08-10T12:00:00",
     }
+
+
+def test_owned_session_uses_dedicated_non_legacy_table():
+    assert AcExpertChatOwnedSession.__tablename__ == (
+        "ac_expert_chat_owned_sessions"
+    )
+    assert AcExpertChatOwnedSession.__tablename__ != "ac_expert_chat_sessions"
 
 
 class TestAcExpertChatInstanceToDict:

--- a/src/backend/tests/community/core/expert_chat/test_sqlite_models.py
+++ b/src/backend/tests/community/core/expert_chat/test_sqlite_models.py
@@ -2,11 +2,10 @@
 
 Focuses on edge cases like JSON deserialization error handling.
 """
-import pytest
-
 from agentclaw.community.core.expert_chat.sqlite_models import (
     AcExpertChatBotSession,
     AcExpertChatInstance,
+    AcExpertChatSession,
 )
 
 
@@ -46,6 +45,35 @@ class TestAcExpertChatBotSessionToDict:
         result = session.to_dict()
         assert result["gmt_create"] == "2024-01-15T10:30:00"
         assert result["gmt_modified"] == "2024-01-15T10:30:00"
+
+
+def test_owned_session_to_dict_exposes_complete_index_row():
+    from datetime import datetime
+
+    now = datetime(2026, 8, 10, 12, 0, 0)
+    session = AcExpertChatSession(
+        id=7,
+        user_id="u1",
+        bot_id="b1",
+        owner_id="o1",
+        session_key="session:one",
+        status="ACTIVE",
+        env="test",
+        gmt_create=now,
+        gmt_modified=now,
+    )
+
+    assert session.to_dict() == {
+        "id": 7,
+        "user_id": "u1",
+        "bot_id": "b1",
+        "owner_id": "o1",
+        "session_key": "session:one",
+        "status": "ACTIVE",
+        "env": "test",
+        "gmt_create": "2026-08-10T12:00:00",
+        "gmt_modified": "2026-08-10T12:00:00",
+    }
 
 
 class TestAcExpertChatInstanceToDict:

--- a/src/backend/tests/community/endpoints/test_expert_chat_multi_session.py
+++ b/src/backend/tests/community/endpoints/test_expert_chat_multi_session.py
@@ -1,0 +1,216 @@
+"""Endpoint coverage for the expert-chat multi-session API."""
+
+from agentclaw.community.api.expert_chat_service import ExpertChatServiceProtocol
+from agentclaw.community.core.expert_chat.errors import BotNotFoundError
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    bind_overrides,
+    endpoint_test,
+)
+
+
+_PATH = "/api/v1/expert-chats/{bot_id}/{owner_id}/sessions"
+_CONNECT_PATH = f"{_PATH}/connect"
+_PATH_PARAMS = {"bot_id": "multi-session-bot", "owner_id": "multi-session-owner"}
+_HEADERS = {"x-user-id": "multi-session-user"}
+_SESSION_KEY = "agent:main:session:endpoint:user:multi-session-user"
+
+
+def _seed_happy_service(world) -> None:
+    """Bind the thin router boundary to deterministic successful outcomes."""
+
+    async def list_sessions(_self, *_args, **_kwargs):
+        return {
+            "total": 1,
+            "items": [
+                {
+                    "id": _SESSION_KEY,
+                    "title": "Endpoint session",
+                    "user_id": "multi-session-user",
+                    "agent_id": "multi-session-bot",
+                    "gmt_created": "2026-08-11T00:00:00Z",
+                    "gmt_modified": "2026-08-11T00:00:00Z",
+                    "message_count": 0,
+                    "last_message": None,
+                }
+            ],
+        }
+
+    async def create_session(_self, *_args, **_kwargs):
+        return {
+            "session_key": _SESSION_KEY,
+            "is_new": True,
+            "connection": {"type": "websocket"},
+        }
+
+    async def connect_session(_self, *_args, **_kwargs):
+        return {
+            "session_key": _SESSION_KEY,
+            "is_new": False,
+            "connection": {"type": "websocket"},
+        }
+
+    async def delete_session(_self, *_args, **_kwargs):
+        return True
+
+    bind_overrides(
+        world,
+        ExpertChatServiceProtocol,
+        {
+            "list_chat_sessions": list_sessions,
+            "create_chat_session": create_session,
+            "connect_chat_session": connect_session,
+            "delete_owned_chat_session": delete_session,
+        },
+    )
+
+
+def _seed_create_not_found(world) -> None:
+    """Drive the create route's domain-error mapping through DI."""
+
+    async def create_session(_self, *_args, **_kwargs):
+        raise BotNotFoundError("Bot不存在")
+
+    bind_overrides(
+        world,
+        ExpertChatServiceProtocol,
+        {"create_chat_session": create_session},
+    )
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="happy",
+    seed=_seed_happy_service,
+    input=CaseInput(path_params=_PATH_PARAMS, headers=_HEADERS),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "error_code": 0,
+            "data": {"total": 1, "items": [{"id": _SESSION_KEY}]},
+        },
+    ),
+)
+def list_sessions_happy():
+    """The plural list route returns the service result."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="invalid_limit",
+    input=CaseInput(
+        path_params=_PATH_PARAMS,
+        query_params={"limit": 0},
+        headers=_HEADERS,
+    ),
+    expect=ExpectError(status=422),
+)
+def list_sessions_invalid_limit():
+    """The list route rejects an invalid page size."""
+
+
+@endpoint_test(
+    method="POST",
+    path=_PATH,
+    scenario="happy",
+    seed=_seed_happy_service,
+    input=CaseInput(path_params=_PATH_PARAMS, headers=_HEADERS),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "error_code": 0,
+            "data": {"session_key": _SESSION_KEY, "is_new": True},
+        },
+    ),
+)
+def create_session_happy():
+    """The create route returns a newly-created session."""
+
+
+@endpoint_test(
+    method="POST",
+    path=_PATH,
+    scenario="bot_not_found",
+    seed=_seed_create_not_found,
+    input=CaseInput(path_params=_PATH_PARAMS, headers=_HEADERS),
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 404},
+    ),
+)
+def create_session_bot_not_found():
+    """The create route maps a missing Bot to its error envelope."""
+
+
+@endpoint_test(
+    method="POST",
+    path=_CONNECT_PATH,
+    scenario="happy",
+    seed=_seed_happy_service,
+    input=CaseInput(
+        path_params=_PATH_PARAMS,
+        headers=_HEADERS,
+        json_body={"session_key": _SESSION_KEY},
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "error_code": 0,
+            "data": {"session_key": _SESSION_KEY, "is_new": False},
+        },
+    ),
+)
+def connect_session_happy():
+    """The connect route returns an existing session connection."""
+
+
+@endpoint_test(
+    method="POST",
+    path=_CONNECT_PATH,
+    scenario="missing_session_key",
+    input=CaseInput(
+        path_params=_PATH_PARAMS,
+        headers=_HEADERS,
+        json_body={},
+    ),
+    expect=ExpectError(status=422),
+)
+def connect_session_missing_key():
+    """The connect route requires a session key."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path=_PATH,
+    scenario="happy",
+    seed=_seed_happy_service,
+    input=CaseInput(
+        path_params=_PATH_PARAMS,
+        query_params={"session_key": _SESSION_KEY},
+        headers=_HEADERS,
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True, "error_code": 0},
+    ),
+)
+def delete_session_happy():
+    """The delete route returns success after the service completes."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path=_PATH,
+    scenario="missing_session_key",
+    input=CaseInput(path_params=_PATH_PARAMS, headers=_HEADERS),
+    expect=ExpectError(status=422),
+)
+def delete_session_missing_key():
+    """The delete route requires a session key."""

--- a/src/backend/tests/community/repository/chat/test_expert_chat_unified.py
+++ b/src/backend/tests/community/repository/chat/test_expert_chat_unified.py
@@ -23,7 +23,7 @@ def _create_schema(engine):
     """Create private copies of both expert-chat session tables."""
     from agentclaw.community.core.expert_chat.sqlite_models import (
         AcExpertChatBotSession,
-        AcExpertChatSession,
+        AcExpertChatOwnedSession,
     )
 
     md = MetaData()
@@ -34,7 +34,7 @@ def _create_schema(engine):
             "uk_user_bot_owner_env",
         ),
         (
-            AcExpertChatSession,
+            AcExpertChatOwnedSession,
             ("user_id", "bot_id", "owner_id", "env", "session_key"),
             "uk_user_bot_owner_env_session",
         ),
@@ -211,7 +211,7 @@ def test_owned_session_uses_mysql_atomic_upsert_contract():
     statement = db_session.execute.call_args.args[0]
     compiled = str(statement.compile(dialect=db_session.get_bind().dialect))
     assert "ON DUPLICATE KEY UPDATE" in compiled
-    db_session.get.assert_called_once_with(repository.SessionModel, 42)
+    db_session.get.assert_called_once_with(repository.OwnedSessionModel, 42)
     assert result == stored_row.to_dict.return_value
 
 

--- a/src/backend/tests/community/repository/chat/test_expert_chat_unified.py
+++ b/src/backend/tests/community/repository/chat/test_expert_chat_unified.py
@@ -7,9 +7,11 @@ against the real ``SqliteDB.orm_session``. No ZDAS-skipped test — the
 prod round-trip is a manual Pre acceptance gate.
 """
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import Column, MetaData, Table, UniqueConstraint, create_engine
+from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.repository.implementations.chat.expert_chat import ExpertChatRepository
@@ -18,36 +20,44 @@ pytestmark = pytest.mark.integration
 
 
 def _create_schema(engine):
-    """Private MetaData copy of AcExpertChatBotSession — copies
-    server_default (DB-side timestamps) and the uk_user_bot_owner_env
-    unique constraint (the upsert's conflict target)."""
+    """Create private copies of both expert-chat session tables."""
     from agentclaw.community.core.expert_chat.sqlite_models import (
         AcExpertChatBotSession,
+        AcExpertChatSession,
     )
 
-    src = AcExpertChatBotSession.__table__
     md = MetaData()
-    Table(
-        src.name,
-        md,
-        *[
-            Column(
-                c.name,
-                c.type,
-                primary_key=c.primary_key,
-                nullable=c.nullable,
-                autoincrement=c.autoincrement,
-                server_default=c.server_default.arg
-                if c.server_default is not None
-                else None,
-            )
-            for c in src.columns
-        ],
-        UniqueConstraint(
-            "user_id", "bot_id", "owner_id", "env",
-            name="uk_user_bot_owner_env",
+    for model, unique_columns, unique_name in (
+        (
+            AcExpertChatBotSession,
+            ("user_id", "bot_id", "owner_id", "env"),
+            "uk_user_bot_owner_env",
         ),
-    )
+        (
+            AcExpertChatSession,
+            ("user_id", "bot_id", "owner_id", "env", "session_key"),
+            "uk_user_bot_owner_env_session",
+        ),
+    ):
+        src = model.__table__
+        Table(
+            src.name,
+            md,
+            *[
+                Column(
+                    c.name,
+                    c.type,
+                    primary_key=c.primary_key,
+                    nullable=c.nullable,
+                    autoincrement=c.autoincrement,
+                    server_default=c.server_default.arg
+                    if c.server_default is not None
+                    else None,
+                )
+                for c in src.columns
+            ],
+            UniqueConstraint(*unique_columns, name=unique_name),
+        )
     md.create_all(engine)
 
 
@@ -149,6 +159,70 @@ def test_delete_session_rowcount(repo):
     assert repo.delete_session("u1", "b1", "o1") is True
     assert repo.get_session("u1", "b1", "o1") is None
     assert repo.delete_session("u1", "missing", "o1") is False
+
+
+def test_owned_sessions_are_isolated_and_searchable(repo):
+    first = repo.add_owned_session("u1", "b1", "o1", "session:first")
+    second = repo.add_owned_session("u1", "b1", "o1", "session:second")
+    repo.add_owned_session("u2", "b1", "o1", "session:other-user")
+
+    assert first["id"] != second["id"]
+    assert [
+        row["session_key"] for row in repo.list_owned_sessions("u1", "b1", "o1")
+    ] == ["session:second", "session:first"]
+    assert (
+        repo.get_owned_session("u1", "b1", "o1", "session:second")["session_key"]
+        == "session:second"
+    )
+    assert repo.get_owned_session("u1", "b1", "o1", "session:other-user") is None
+
+
+def test_owned_session_upsert_reactivates_soft_deleted_row(repo):
+    original = repo.add_owned_session("u1", "b1", "o1", "session:one")
+    assert repo.delete_owned_session("u1", "b1", "o1", "session:one") is True
+    assert repo.list_owned_sessions("u1", "b1", "o1") == []
+
+    restored = repo.add_owned_session("u1", "b1", "o1", "session:one")
+    assert restored["id"] == original["id"]
+    assert restored["status"] == "ACTIVE"
+
+
+def test_owned_session_uses_mysql_atomic_upsert_contract():
+    db_session = MagicMock()
+    db_session.get_bind.return_value.dialect = mysql.dialect()
+    db_session.execute.return_value.lastrowid = 42
+    stored_row = MagicMock()
+    stored_row.to_dict.return_value = {
+        "id": 42,
+        "session_key": "session:one",
+        "status": "ACTIVE",
+    }
+    db_session.get.return_value = stored_row
+
+    class _MysqlDB:
+        @contextmanager
+        def orm_session(self):
+            yield db_session
+
+    repository = ExpertChatRepository(_MysqlDB())
+
+    result = repository.add_owned_session("u1", "b1", "o1", "session:one")
+
+    statement = db_session.execute.call_args.args[0]
+    compiled = str(statement.compile(dialect=db_session.get_bind().dialect))
+    assert "ON DUPLICATE KEY UPDATE" in compiled
+    db_session.get.assert_called_once_with(repository.SessionModel, 42)
+    assert result == stored_row.to_dict.return_value
+
+
+def test_delete_all_owned_sessions_only_affects_requested_bot(repo):
+    repo.add_owned_session("u1", "b1", "o1", "session:one")
+    repo.add_owned_session("u1", "b1", "o1", "session:two")
+    repo.add_owned_session("u1", "b2", "o1", "session:three")
+
+    assert repo.delete_all_owned_sessions("u1", "b1", "o1") == 2
+    assert repo.list_owned_sessions("u1", "b1", "o1") == []
+    assert len(repo.list_owned_sessions("u1", "b2", "o1")) == 1
 
 
 def test_real_sqlitedb_orm_session_commits(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add a Backend-owned session ownership index so one user can keep multiple sessions with the same public Bot
- add plural session APIs for paginated listing, exact session-key lookup, creation, connection, deletion, and favorite-only filtering
- validate session ownership against the authenticated caller and preserve sessions while the runtime container is temporarily unavailable
- keep the legacy singular `/session` APIs compatible by synchronizing their default session pointer with the new multi-session records

## API changes

- `GET /api/v1/expert-chats/{bot_id}/{owner_id}/sessions`
- `POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions`
- `POST /api/v1/expert-chats/{bot_id}/{owner_id}/sessions/connect`
- `DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/sessions`

Existing Engine Adapter session and favorite APIs are reused, so this change does not require an Adapter upgrade.

## Compatibility and rollout

- existing clients that continue using the singular `/session` endpoints retain their current behavior
- new and legacy clients can run in parallel; selected or newly created sessions update the legacy default pointer
- deploy `src/backend/specs/2026-08-10-expert-chat-multi-session/ddl.sql` before rolling out the Backend
- OpenClaw, Hermes, AI Coding, and Claude Code use the existing runtime session capabilities; Teclaw is outside this change

## Testing

- targeted expert-chat suites: **163 passed**
- changed-line coverage: **96.75% (298/308)**
- rebase onto the latest `origin/dev` completed without conflicts; `range-diff` confirmed an equivalent feature patch