### PR TITLE
feat: refresh template config before bot restart

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -2626,6 +2626,15 @@ async def restart_bot(
     Restart a bot by releasing current device and allocating a new one.
 
     POST /api/bots/{bot_id}/restart
+    Body (optional): {
+        "extra_configs": {
+            "<engine-owned-key>": {...}
+        }
+    }
+
+    ``extra_configs`` is an engine-agnostic extension envelope. Unknown or
+    malformed engine-owned values are ignored and do not block the historical
+    restart flow.
 
     This will:
     1. Release the current device bound to the bot
@@ -2652,10 +2661,27 @@ async def restart_bot(
 
         resolved_owner_id = owner_id or operator_id
 
+        # Keep the HTTP/core restart path engine-agnostic. Concrete engine
+        # strategies interpret their own keys inside this optional envelope.
+        extra_configs = None
+        try:
+            request_body = await request.json()
+            candidate = (
+                request_body.get("extra_configs")
+                if isinstance(request_body, dict)
+                else None
+            )
+            if isinstance(candidate, dict):
+                extra_configs = candidate
+        except Exception:
+            # Empty/non-JSON request bodies remain valid for legacy callers.
+            extra_configs = None
+
         result = bot_service.restart_bot(
             bot_id=bot_id,
             user_id=resolved_owner_id,
             nick_name=nick_name,
+            extra_configs=extra_configs,
         )
 
         if result.get("restart_in_progress"):

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.bot_management.capabilities import (
 
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils import secret_utils
+from agentclaw.community.log import get_logger
 
 from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 
@@ -38,6 +39,8 @@ LEGACY_BOT_TYPE_ENV_MAP = {
 }
 _THETA_KEY_PATH = ("bot_template_config", "ext_config", "thetaKey")
 _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
+
+logger = get_logger()
 
 
 class AicodingBaasEngineBucketResolver:
@@ -310,6 +313,56 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if self._engine_type == CLAUDE_CODE_ENGINE_TYPE:
             return f"session:{uuid.uuid4()}:user:{user_id}"
         return f"user:{user_id}:session:{uuid.uuid4()}:agent:{ctx.bot_id}"
+
+    @staticmethod
+    def _template_version_id(config: Any) -> int | None:
+        """Return a comparable template version id from a saved snapshot."""
+        if not isinstance(config, dict):
+            return None
+        value = config.get("template_version_id")
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def apply_restart_extra_configs(
+        self,
+        ctx: BotProvisioningContext,
+        extra_configs: dict[str, Any] | None,
+        *,
+        template_service: Any,
+    ) -> None:
+        """Apply AICoding/Claude Code values from generic restart extras."""
+        active_engine = self.normalize_engine_type(ctx.active_engine, default="")
+        if active_engine not in TEMPLATE_CONFIG_CONSUMING_ENGINES:
+            return
+        if not isinstance(extra_configs, dict):
+            return
+        candidate = extra_configs.get("template_config")
+        if not isinstance(candidate, dict):
+            return
+
+        stored_config = template_service.get_template_config(ctx.bot_id) or {}
+        incoming_version = self._template_version_id(candidate)
+        stored_version = self._template_version_id(stored_config)
+        if incoming_version is None or incoming_version < 0:
+            return
+        if stored_version is not None and incoming_version <= stored_version:
+            return
+
+        template_service.update_template(
+            bot_id=ctx.bot_id,
+            template_config=candidate,
+            template_type=ctx.template_type,
+            active_engine=ctx.active_engine,
+        )
+        logger.info(
+            "[aicoding.restart] persisted newer template snapshot: "
+            "bot_id=%s old_version=%s new_version=%s",
+            ctx.bot_id, stored_version, incoming_version,
+        )
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         # Application-only hooks (DIMA workspace/memory/cron) intentionally stay

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -44,6 +44,15 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
             f"engine {ctx.active_engine or self.engine_type} uses adapter chat session lifecycle"
         )
 
+    def apply_restart_extra_configs(
+        self,
+        ctx: BotProvisioningContext,
+        extra_configs: dict[str, object] | None,
+        *,
+        template_service: object,
+    ) -> None:
+        return None
+
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         return None
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -104,6 +104,21 @@ class EngineProvisioningStrategy(ABC):
         """
 
     @abstractmethod
+    def apply_restart_extra_configs(
+        self,
+        ctx: BotProvisioningContext,
+        extra_configs: Dict[str, Any] | None,
+        *,
+        template_service: Any,
+    ) -> None:
+        """Apply engine-owned values from the restart extension envelope.
+
+        Concrete engines own their keys, validation, and side effects.
+        Unsupported engines should no-op so the core restart path remains
+        engine-agnostic and backward compatible.
+        """
+
+    @abstractmethod
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         """Post-create hook. Default strategies should no-op."""
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3962,6 +3962,7 @@ class BotService:
         bot_id: str,
         user_id: str,
         nick_name: Optional[str] = None,
+        extra_configs: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Restart a bot by releasing current device and allocating a new one.
@@ -3970,6 +3971,7 @@ class BotService:
             bot_id: Bot ID
             user_id: User ID for permission check (must be the owner)
             nick_name: Nick name for device allocation (optional, defaults to user_id)
+            extra_configs: Optional engine-agnostic restart extension envelope
 
         Returns:
             Updated bot record with PENDING status (device allocation in progress)
@@ -4027,6 +4029,36 @@ class BotService:
             raise BotInvalidLifecycleStateError(
                 bot_id=bot_id,
                 current_status=bot_status or "UNKNOWN",
+            )
+
+        # Delegate optional engine-owned restart inputs after lifecycle guards
+        # pass and before device allocation consumes persisted configuration.
+        try:
+            from agentclaw.community.core.bot_management.engines import (
+                resolve_provisioning,
+            )
+
+            ctx, strategy = resolve_provisioning(
+                bot_id=bot_id,
+                owner_id=str(bot.get("owner_id") or ""),
+                bot_type=str(bot.get("bot_type") or ""),
+                active_engine=bot.get("active_engine"),
+                template_type=bot.get("template_type"),
+                template_config=None,
+            )
+            strategy.apply_restart_extra_configs(
+                ctx,
+                extra_configs,
+                template_service=self._template_service,
+            )
+        except Exception as exc:
+            # Optional engine extensions must never block the existing restart path.
+            logger.warning(
+                "[bot_service.restart_bot] applying restart extra configs failed; "
+                "continue with stored config: bot_id=%s error=%s",
+                bot_id,
+                exc,
+                exc_info=True,
             )
 
         env = get_current_env()

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -810,6 +810,44 @@ class TestRestartBot:
         assert resp.status_code == 200
         assert resp.json()["success"] is True
 
+    def test_forwards_engine_agnostic_extra_configs(self, client):
+        tc, svc, _ = client
+        extra_configs = {
+            "template_config": {
+                "template_key": "architect",
+                "template_version_id": 101,
+            }
+        }
+
+        resp = tc.post(
+            "/api/bots/default/restart",
+            json={"extra_configs": extra_configs},
+        )
+
+        assert resp.status_code == 200
+        svc.restart_bot.assert_called_once_with(
+            bot_id="default",
+            user_id="test_user",
+            nick_name="Test User",
+            extra_configs=extra_configs,
+        )
+
+    def test_ignores_unknown_legacy_body_fields(self, client):
+        tc, svc, _ = client
+
+        resp = tc.post(
+            "/api/bots/default/restart",
+            json={"template_config": {"template_version_id": 101}},
+        )
+
+        assert resp.status_code == 200
+        svc.restart_bot.assert_called_once_with(
+            bot_id="default",
+            user_id="test_user",
+            nick_name="Test User",
+            extra_configs=None,
+        )
+
     def test_bot_not_found(self, client):
         tc, svc, _ = client
         svc.restart_bot.side_effect = BotNotFoundError("nope")

--- a/src/backend/tests/community/core/bot_management/services/test_restart_template_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_template_refresh.py
@@ -1,0 +1,118 @@
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AicodingProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.engines.provisioning import (
+    BotProvisioningContext,
+)
+
+
+def _service(stored_config):
+    service = MagicMock()
+    service.get_template_config.return_value = stored_config
+    return service
+
+
+def _ctx(active_engine="claude_code"):
+    return BotProvisioningContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_type="personal",
+        active_engine=active_engine,
+        template_type="architect",
+    )
+
+
+def _refresh(stored_config, latest, *, active_engine="claude_code"):
+    template_service = _service(stored_config)
+    AicodingProvisioningStrategy(active_engine).apply_restart_extra_configs(
+        _ctx(active_engine),
+        {"template_config": latest} if latest is not None else None,
+        template_service=template_service,
+    )
+    return template_service
+
+
+def test_restart_persists_matching_newer_template_snapshot():
+    latest = {
+        "template_key": "architect",
+        "template_uid": "aicoding_bot_template",
+        "template_version_id": 101,
+        "template_version": "V2",
+        "bot_template_config": {"id": 101},
+    }
+
+    service = _refresh(
+        {
+            "template_key": "architect",
+            "template_uid": "aicoding_bot_template",
+            "template_version_id": 100,
+        },
+        latest,
+    )
+
+    service.update_template.assert_called_once_with(
+        bot_id="bot-1",
+        template_config=latest,
+        template_type="architect",
+        active_engine="claude_code",
+    )
+
+
+def test_restart_keeps_stored_snapshot_for_equal_or_lower_version():
+    for incoming_version in (99, 100):
+        service = _refresh(
+            {
+                "template_key": "architect",
+                "template_uid": "aicoding_bot_template",
+                "template_version_id": 100,
+            },
+            {
+                "template_key": "architect",
+                "template_version_id": incoming_version,
+            },
+        )
+
+        service.update_template.assert_not_called()
+
+
+def test_restart_ignores_missing_or_invalid_template_snapshot():
+    for latest in (None, {}, {"template_key": "architect"}):
+        service = _refresh(
+            {
+                "template_key": "architect",
+                "template_uid": "aicoding_bot_template",
+                "template_version_id": 100,
+            },
+            latest,
+        )
+
+        service.update_template.assert_not_called()
+
+
+def test_restart_uses_active_engine_without_template_type_matching():
+    service = _refresh(
+        {
+            "template_key": "architect",
+            "template_uid": "aicoding_bot_template",
+            "template_version_id": 100,
+        },
+        {
+            "template_key": "another-template",
+            "template_version_id": 101,
+        },
+    )
+
+    service.update_template.assert_called_once()
+
+
+def test_non_template_engine_does_not_refresh():
+    service = _refresh(
+        {"template_version_id": 100},
+        {"template_version_id": 101},
+        active_engine="openclaw",
+    )
+
+    service.get_template_config.assert_not_called()
+    service.update_template.assert_not_called()


### PR DESCRIPTION
<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
