### PR TITLE
fix(backend,baas): key service-bot multi-instance affinity on the caller, not the owner

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
@@ -20,8 +20,15 @@ if TYPE_CHECKING:
 
 logger = get_logger("core-service")
 
-# Virtual nodes per physical device for even hash distribution
-_VIRTUAL_NODES = 100
+# Virtual nodes per physical device for even hash distribution.
+#
+# Tuned from 100 → 200 to reduce the small-instance / small-key-set bias
+# observed in production (5 instances, 61 requests
+# spread 19/7/9/12/14). With 5 devices × 100 vnodes, MD5 landing variance
+# alone skews the per-device share enough to look like routing injustice; the
+# doubled ring averages out that variance without changing the algorithm or
+# its stateless contract.
+_VIRTUAL_NODES = 200
 
 
 def build_ring(
@@ -67,19 +74,28 @@ def select_by_affinity(
     """
     key = int(hashlib.md5(device_affinity.encode()).hexdigest(), 16)
     unique_devices = len(set(d.device_uuid for _, d in ring))
+    # First 8 hex chars of the affinity key hash — enough to correlate a
+    # selection across logs without publishing the key itself, which can be a
+    # user id. ``key`` is the full 128-bit int; render the prefix through hex
+    # so the width is stable across scales.
+    key_hash_prefix = f"{key:032x}"[:8]
     for h, d in ring:
         if key <= h:
             logger.info(
                 f"Affinity selection: key_hash={key}, "
+                f"key_hash_prefix={key_hash_prefix}, "
                 f"matched_device_uuid={d.device_uuid}, "
                 f"ring_size={len(ring)}, "
+                f"virtual_nodes_per_device={_VIRTUAL_NODES}, "
                 f"unique_devices={unique_devices}, "
                 f"device_affinity={device_affinity!r}"
             )
             return d
     logger.info(
         f"Affinity key wrapping around ring: key_hash={key}, "
-        f"ring_size={len(ring)}, unique_devices={unique_devices}, "
+        f"key_hash_prefix={key_hash_prefix}, "
+        f"ring_size={len(ring)}, virtual_nodes_per_device={_VIRTUAL_NODES}, "
+        f"unique_devices={unique_devices}, "
         f"selected_first={ring[0][1].device_uuid}"
     )
     return ring[0][1]

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
@@ -22,13 +22,12 @@ logger = get_logger("core-service")
 
 # Virtual nodes per physical device for even hash distribution.
 #
-# Tuned from 100 → 200 to reduce the small-instance / small-key-set bias
-# observed in production (5 instances, 61 requests
-# spread 19/7/9/12/14). With 5 devices × 100 vnodes, MD5 landing variance
-# alone skews the per-device share enough to look like routing injustice; the
-# doubled ring averages out that variance without changing the algorithm or
-# its stateless contract.
-_VIRTUAL_NODES = 200
+# Left at 100: changing the vnode count reshapes the entire ring, so a
+# rolling deploy with mixed old/new BaaS processes would remap a large
+# share of affinity keys to different instances mid-session. Any ring
+# change needs an explicit migration (ring version pin / atomic / dual
+# ring), not a bump hidden in an unrelated PR.
+_VIRTUAL_NODES = 100
 
 
 def build_ring(

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
@@ -194,12 +194,6 @@ class TestMultiInstanceDistribution:
             counts[selected.device_uuid] += 1
         return list(counts.values())
 
-    def test_virtual_nodes_was_bumped_to_two_hundred(self):
-        """The ring-width bump is the contract: a later tuning that reverts
-        it silently would re-open the defect. Pin the value here so the
-        algorithm lever cannot drift without a deliberate change."""
-        assert _VIRTUAL_NODES == 200
-
     def test_a_single_affinity_key_pins_everything_to_one_instance(self):
         """The "改造前" pathology: if every caller hashes under the same key
         (the pre-fix owner-keyed affinity), the consistent-hash ring selects
@@ -228,17 +222,16 @@ class TestMultiInstanceDistribution:
         # floor on a 60-key / 5-device run is at least 5 hits.
         assert min(counts) >= 5, f"starved device: {counts}"
         # No device takes more than 35% — the production report had 31.1%, and a
-        # 5-device / 60-key run on the 200-vnode ring stays comfortably
-        # below that on the realistic (per-caller) key set.
+        # 5-device / 60-key run stays comfortably below that on the realistic
+        # (per-caller) key set.
         assert max(counts) / self.N_KEYS < 0.35, f"hot device: {counts}"
 
     def test_per_caller_stddev_is_dramatically_lower_than_single_key(self):
         """The spec's "stddev 显著低于改造前" criterion. The single-key
         baseline (改造前: owner-keyed affinity) has stddev ~26.8 because all
-        60 hits pile onto one device. The per-caller distribution on the
-        200-vnode ring has stddev in the low single digits — a >5x
-        reduction, deterministic on the consistent-hash algorithm and the
-        60-key set the spec names."""
+        60 hits pile onto one device. The per-caller distribution has
+        stddev in the low single digits — a >5x reduction, deterministic
+        on the consistent-hash algorithm and the 60-key set the spec names."""
         devices = self._build_devices()
         single_key = self._distribution(devices, ["owner-1"] * self.N_KEYS)
         per_caller = self._distribution(

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
@@ -4,11 +4,13 @@ Tests select_available_device() with various device status scenarios
 and verifies select_active_device() remains unchanged (regression gate).
 """
 
+import statistics
 from unittest.mock import MagicMock
 
 import pytest
 
 from secbaas.community.core.service.bot_runtime.dispatcher._device_selector import (
+    _VIRTUAL_NODES,
     select_active_device,
     select_available_device,
 )
@@ -154,3 +156,92 @@ class TestSelectActiveDeviceRegression:
         ]
         result = select_active_device(devices)
         assert result is None
+
+
+# ==================== Multi-instance distribution Tests ====================
+
+
+class TestMultiInstanceDistribution:
+    """Statistical regression for the the production multi-instance distribution defect defect: 5
+    service-bot instances, 61 requests, distribution 19/7/9/12/14 (max
+    31.1%, min 11.5%).
+
+    The load-bearing fix lives in the backend (keying affinity on the
+    authenticated caller instead of the bot owner), and it is exercised
+    end-to-end in the backend tests. The BaaS ring is the algorithm the
+    affinity key feeds into, and these tests pin the invariants the
+    production replay needs to hold on the new ring:
+
+    * a single affinity key pins every request to one instance — the
+      "改造前" pathology the backend keying change exists to break;
+    * a realistic set of distinct affinity keys distributes across all
+      instances, with no instance starving and no instance dominating;
+    * the multi-key stddev is dramatically lower than the single-key one,
+      the spec's "stddev significantly lower than 改造前" criterion.
+    """
+
+    N_DEVICES = 5
+    N_KEYS = 60
+
+    def _build_devices(self):
+        return [_make_device(f"dev-{i:02d}", "ACTIVE") for i in range(self.N_DEVICES)]
+
+    def _distribution(self, devices, keys):
+        """Per-device hit counts over ``keys`` (callers)."""
+        counts = {d.device_uuid: 0 for d in devices}
+        for key in keys:
+            selected = select_active_device(devices, device_affinity=key)
+            counts[selected.device_uuid] += 1
+        return list(counts.values())
+
+    def test_virtual_nodes_was_bumped_to_two_hundred(self):
+        """The ring-width bump is the contract: a later tuning that reverts
+        it silently would re-open the defect. Pin the value here so the
+        algorithm lever cannot drift without a deliberate change."""
+        assert _VIRTUAL_NODES == 200
+
+    def test_a_single_affinity_key_pins_everything_to_one_instance(self):
+        """The "改造前" pathology: if every caller hashes under the same key
+        (the pre-fix owner-keyed affinity), the consistent-hash ring selects
+        exactly one device for every request and 100% of traffic lands on
+        it. The backend tests verify the routing layer no longer feeds such
+        a single key; here we pin the algorithm-level invariant that makes
+        that fix worth doing — same key ⇒ same device, never a spread."""
+        devices = self._build_devices()
+        counts = self._distribution(devices, ["owner-1"] * self.N_KEYS)
+        # One device receives every hit, the rest receive zero. The defect
+        # magnitudes: stddev ~ 26.8 on a 60-key / 5-device run.
+        assert max(counts) == self.N_KEYS
+        assert min(counts) == 0
+        assert statistics.stdev(counts) > 20
+
+    def test_distinct_caller_keys_distribute_across_every_instance(self):
+        """The "改造后" expectation: distinct affinity keys (per-caller,
+        when the backend routes on ``caller_id``) spread across all
+        instances. No instance starves and no single instance dominates
+        the way a pinned key would."""
+        devices = self._build_devices()
+        keys = [f"caller-{i}" for i in range(self.N_KEYS)]
+        counts = self._distribution(devices, keys)
+        # Every device gets a non-trivial share — the production replay
+        # target was "every instance receives traffic", and the new ring's
+        # floor on a 60-key / 5-device run is at least 5 hits.
+        assert min(counts) >= 5, f"starved device: {counts}"
+        # No device takes more than 35% — the production report had 31.1%, and a
+        # 5-device / 60-key run on the 200-vnode ring stays comfortably
+        # below that on the realistic (per-caller) key set.
+        assert max(counts) / self.N_KEYS < 0.35, f"hot device: {counts}"
+
+    def test_per_caller_stddev_is_dramatically_lower_than_single_key(self):
+        """The spec's "stddev 显著低于改造前" criterion. The single-key
+        baseline (改造前: owner-keyed affinity) has stddev ~26.8 because all
+        60 hits pile onto one device. The per-caller distribution on the
+        200-vnode ring has stddev in the low single digits — a >5x
+        reduction, deterministic on the consistent-hash algorithm and the
+        60-key set the spec names."""
+        devices = self._build_devices()
+        single_key = self._distribution(devices, ["owner-1"] * self.N_KEYS)
+        per_caller = self._distribution(
+            devices, [f"caller-{i}" for i in range(self.N_KEYS)]
+        )
+        assert statistics.stdev(per_caller) * 5 < statistics.stdev(single_key)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
@@ -109,6 +109,7 @@ async def get_approval_mode(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="POST",
         path="/api/approvals/mode/get",
         # The verified caller (never accepted from the body); the engine
@@ -142,6 +143,7 @@ async def set_approval_mode(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="POST",
         path="/api/approvals/mode/set",
         body={
@@ -193,6 +195,7 @@ async def list_approval_modes(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET",
         path="/api/engine/capabilities",
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
@@ -83,6 +83,7 @@ async def get_engine_status(
     # no `success` key and no `data` wrapper. The only such route wrapped here.
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET", path="/api/engine/status",
         enveloped=False,
     )
@@ -125,6 +126,7 @@ async def get_engine_capabilities(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET",
         path="/api/engine/capabilities",
     )
@@ -165,6 +167,7 @@ async def list_available_engines(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET", path="/api/engine/list",
     )
     raw = result.data

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
@@ -73,6 +73,7 @@ async def list_models(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET", path="/api/models",
     )
     # The engine wraps this one: data is {"models": [...], "total": n}, not a
@@ -122,6 +123,7 @@ async def get_model(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET",
         path=f"/api/models/{model_id}",
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -326,6 +326,7 @@ async def list_sessions(
         params["session_key"] = session_key
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET", path="/api/sessions",
         params=params,
     )
@@ -357,6 +358,7 @@ async def create_session(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="POST", path="/api/sessions",
         body={
             "title": body.title,
@@ -399,6 +401,7 @@ async def get_session(
     )
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET",
         path=f"/api/sessions/{session_id}",
     )
@@ -433,6 +436,7 @@ async def update_session(
     payload = {k: v for k, v in body.model_dump().items() if v is not None}
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="POST",
         # QUERY params, not a body. The engine declares this route's fields as
         # bare scalar arguments, which FastAPI binds from the query string —
@@ -468,6 +472,7 @@ async def delete_session(
     )
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="DELETE",
         path=f"/api/sessions/{session_id}",
     )
@@ -506,6 +511,7 @@ async def list_session_messages(
     _require_within_depth(page)
     result = await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="GET",
         path=f"/api/sessions/{session_id}/messages",
         # The history route tail-limits rather than paginating, so the offset is
@@ -542,6 +548,7 @@ async def clear_session_messages(
     )
     await relay.call(
         bot_id=bot_id, owner_id=owner_id, facts=facts, stage=stage.value,
+        caller_id=user_id,
         method="DELETE",
         path=f"/api/sessions/{session_id}/messages",
     )

--- a/src/backend/src/agentclaw/community/api/engine_runtime_service.py
+++ b/src/backend/src/agentclaw/community/api/engine_runtime_service.py
@@ -60,6 +60,7 @@ class EngineRuntimeRelayProtocol(Protocol):
         enveloped: bool = True,
         facts: BotFacts | None = None,
         stage: str,
+        caller_id: str | None = None,
     ) -> EngineResult:
         """Issue ``method path`` against the addressed bot's engine adapter.
 
@@ -77,6 +78,14 @@ class EngineRuntimeRelayProtocol(Protocol):
         handler gated on and the stage it forwards to cannot silently
         diverge. Ignored by a personal bot — refusing a published stage on
         one is the gate's job, before any device work.
+
+        ``caller_id`` is the authenticated principal when it differs from
+        ``owner_id`` (a collaborator operating a bot they do not own). It
+        flows into the BaaS multi-instance affinity key on the published-stage
+        path, so requests from different callers on one (bot, stage)
+        distribute across instances instead of pinning to the single instance
+        the owner's id would hash to. ``None`` keeps the historical
+        owner-keyed behavior for owner-scoped and ungated routes.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -209,20 +209,29 @@ class EngineConnectionService:
             bot_pk=bot_pk, bot_id=resolved_id, owner_id=owner_id, stage=stage
         )
 
-        # Composed as the **resolved owner**, deliberately, even when the
-        # admitted caller is a collaborator. The adjudication above is this
-        # surface's authorization; downstream, the operator id is routing and
-        # bookkeeping, and two provider behaviors make the owner the only
-        # correct value there: some device-service implementations apply
-        # permission models of their own that know nothing of collaborators
-        # (they would refuse a caller our gate admitted, as a misleading
-        # "not ready"), and the BaaS path feeds this id into instance
-        # affinity — keyed per caller, two operators of the same (bot, stage)
-        # could be pinned to different instances while the HTTP relay path
-        # resolves with the owner. Who actually held the channel is on the
-        # gate's log line and stamped into the sessions the caller creates.
+        # ``staff_id`` is keyed on the **authenticated caller**, deliberately,
+        # even when the request addresses a bot the caller does not own. The
+        # adjudication above is this surface's authorization; downstream, the
+        # BaaS path feeds ``operator.staff_id`` into multi-instance affinity
+        # (``BaasDeviceService.get_device_connection`` →
+        # ``device_affinity=operator.staff_id``), and keying that on the owner
+        # pinned every collaborator of one (bot, stage) onto the single
+        # instance the owner's id hashed to — the production multi-instance distribution defect The
+        # caller has already been admitted as the bot's operator by
+        # :func:`require_bot_operator`; using the caller id here distributes
+        # multi-instance requests per caller while keeping one caller sticky
+        # across reconnects.
+        #
+        # The audit / bookkeeping fields (``staff``, ``nick_name``,
+        # ``operator_name``) stay on the **resolved owner** — the bot is the
+        # owner's, the device permission row is the owner's, and the device
+        # service's collaborator-aware permission check uses ``staff_id`` (a
+        # collaborator falls through to ``check_collaborator_permission``,
+        # which our gate already proved them guilty of holding). Who actually
+        # held the channel is on the gate's log line and stamped into the
+        # sessions the caller creates.
         operator = OperatorContext(
-            staff_id=resolved_owner,
+            staff_id=caller_id,
             staff=resolved_owner,
             nick_name=resolved_owner,
             operator_name=resolved_owner,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -166,7 +166,12 @@ class EngineRuntimeRelay:
         return await asyncio.to_thread(self.resolve_bot, bot_id, owner_id, caller_id)
 
     def _resolve_device(
-        self, bot_id: str, owner_id: str, facts: BotFacts, stage: str
+        self,
+        bot_id: str,
+        owner_id: str,
+        facts: BotFacts,
+        stage: str,
+        caller_id: str | None = None,
     ) -> DeviceContext:
         """Resolve the bot's device, translating "not reachable" to one error.
 
@@ -181,6 +186,11 @@ resolve_stage_bind_id`. The draft lookup is the same owner-scoped
         the stage entirely — it has only its workspace, and the *refusal* of a
         published stage on one is the gate's job
         (``require_operable_bot``), before any device work.
+
+        ``caller_id`` flows into the published-stage device resolution as
+        the affinity key (see :meth:`_resolve_published_device`); ``None``
+        keeps the historical owner-keyed behavior for owner-scoped and
+        ungated routes.
 
         ``DeviceNotBoundError`` (never provisioned, released, or malformed
         publish data) and ``ConnInfoBuildError`` (the provider could not build
@@ -204,7 +214,9 @@ resolve_stage_bind_id`. The draft lookup is the same owner-scoped
             # bot, not an unmapped error from the record scan.
             require_stage_addressable(facts.bot_type, stage)
             if facts.bot_type == _SERVICE_BOT_TYPE and stage != STAGE_DRAFT:
-                return self._resolve_published_device(facts, owner_id, stage)
+                return self._resolve_published_device(
+                    facts, owner_id, stage, caller_id=caller_id
+                )
             return self._resolver.resolve_for_bot(bot_id, owner_id)
         except (DeviceNotBoundError, ConnInfoBuildError) as exc:
             raise EngineDeviceNotReadyError(
@@ -214,7 +226,12 @@ resolve_stage_bind_id`. The draft lookup is the same owner-scoped
             raise
 
     def _resolve_published_device(
-        self, facts: BotFacts, owner_id: str, stage: str
+        self,
+        facts: BotFacts,
+        owner_id: str,
+        stage: str,
+        *,
+        caller_id: str | None = None,
     ) -> DeviceContext:
         """Resolve a ``service`` bot through a published stage's runtime binding.
 
@@ -229,6 +246,16 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
         different devices. A stage with no live record raises
         ``EngineStageNotLiveError`` there; no fallback to the draft binding,
         and none between stages.
+
+        ``caller_id`` is used as the BaaS multi-instance affinity key on this
+        resolution path — the ``operator_id`` argument to
+        ``resolve_for_binding_invoke`` becomes ``conn_info["device_affinity"]``,
+        which ``BaasService.get_ws_info`` feeds into the consistent-hashing
+        ring. Keying on the caller (rather than the owner, as before) is what
+        distributes multi-instance requests across the live replicas instead
+        of pinning every collaborator onto the owner's single chosen instance
+        (the production multi-instance distribution defect). ``None`` keeps the historical
+        owner-keyed behavior.
         """
         bind_id = resolve_stage_bind_id(
             self._publish_repo,
@@ -238,16 +265,22 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
             stage=stage,
             env=get_current_env(),
         )
+        affinity_id = caller_id if caller_id is not None else owner_id
         # ``…_invoke`` rather than ``resolve_for_binding``: for the multi-instance
         # providers a published bot runs on, the transport fetches the address per
         # binding at call time and this only has to carry the routing fields. It
         # falls through to full resolution for the providers that need it.
         return self._resolver.resolve_for_binding_invoke(
-            bind_id, owner_id, bot_id=facts.bot_id
+            bind_id, affinity_id, bot_id=facts.bot_id
         )
 
     def _resolve_bot_and_device(
-        self, bot_id: str, owner_id: str, facts: BotFacts | None, stage: str
+        self,
+        bot_id: str,
+        owner_id: str,
+        facts: BotFacts | None,
+        stage: str,
+        caller_id: str | None = None,
     ) -> DeviceContext:
         """Prove ownership, then resolve the device — one worker-thread hop.
 
@@ -255,14 +288,17 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
         order is the isolation order: ``resolve_bot`` raises for a bot the
         caller may not operate, before any device is touched. On this path the
         caller *is* the owner: a route that serves someone other than the
-        bot's owner must adjudicate the real caller first and pass ``facts``.
+        bot's owner must adjudicate the real caller first and pass ``facts``
+        (and ``caller_id`` so the affinity key follows the actual caller).
         """
         resolved = (
             facts
             if facts is not None
             else self.resolve_bot(bot_id, owner_id, owner_id)
         )
-        return self._resolve_device(bot_id, owner_id, resolved, stage)
+        return self._resolve_device(
+            bot_id, owner_id, resolved, stage, caller_id=caller_id
+        )
 
     # ── forwarding ────────────────────────────────────────────────────────
 
@@ -279,6 +315,7 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
         enveloped: bool = True,
         facts: BotFacts | None = None,
         stage: str,
+        caller_id: str | None = None,
     ) -> EngineResult:
         """Issue ``method path`` against the addressed bot's engine adapter.
 
@@ -328,9 +365,23 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
         the whole body becomes the payload. It is an explicit per-route fact
         rather than sniffing for a ``success`` key, because a body that happens
         to lack one is exactly the malformed case that must still fail.
+
+        ``caller_id`` is the authenticated principal when it differs from
+        ``owner_id`` (a collaborator operating a bot they do not own). It
+        flows into the BaaS multi-instance affinity key on the
+        published-stage path, so requests from different callers on one
+        (bot, stage) distribute across instances instead of pinning to
+        the single instance the owner's id would hash to. ``None`` keeps
+        the historical owner-keyed behavior for owner-scoped and ungated
+        routes.
         """
         ctx = await asyncio.to_thread(
-            self._resolve_bot_and_device, bot_id, owner_id, facts, stage
+            self._resolve_bot_and_device,
+            bot_id,
+            owner_id,
+            facts,
+            stage,
+            caller_id,
         )
         raw = await self._invoke(ctx, method, path, body, params, timeout)
         return self._normalise(raw, bot_id=bot_id, path=path, enveloped=enveloped)

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/conftest.py
@@ -81,7 +81,7 @@ class FakeRelay:
     async def call(
         self, *, bot_id, owner_id, method, path,
         body=None, params=None, timeout=None, enveloped=True, facts=None,
-        stage,
+        stage, caller_id=None,
     ) -> EngineResult:
         # Record the ATTEMPT first, then resolve. Ordering it the other way
         # made "no device was touched" tautological: a foreign bot raises in
@@ -100,7 +100,7 @@ class FakeRelay:
                 "bot_id": bot_id, "owner_id": owner_id, "method": method,
                 "path": path, "body": body, "params": params,
                 "timeout": timeout, "enveloped": enveloped,
-                "stage": stage,
+                "stage": stage, "caller_id": caller_id,
             }
         )
         if self.raises is not None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_approvals.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_approvals.py
@@ -189,3 +189,41 @@ def test_a_collaborator_is_served_and_a_stranger_is_the_masked_404(
     )
     assert refused["message"] == "Not found"
     assert len(relay.calls) == 1
+
+
+def test_every_approval_route_threads_the_verified_caller_as_caller_id(
+    make_client, relay
+):
+    """Cross-route consistency (review P1-1): every approvals route forwards
+    the authenticated caller as ``caller_id`` — not the owner — so a
+    collaborator operating another owner's service bot sends its approval
+    request to the same instance its connection/session request landed on.
+    Without this the approval/state response could land on a different
+    instance than the event that created it. A handler that later drops the
+    kwarg fails this directly."""
+    relay.set_bot_type("service")
+    relay.add_operator("u-collab")
+    client = make_client(router, caller="u-collab")
+
+    relay.results = [EngineResult(data={"mode": "on-miss", "sessionKey": SESSION})]
+    ok(client.get(f"{BASE}/mode", params={"session_key": SESSION, "owner_id": OWNER}))
+
+    relay.results = [
+        EngineResult(data={"ok": True, "mode": "never", "sessionKey": SESSION})
+    ]
+    ok(
+        client.put(
+            f"{BASE}/mode",
+            json={"session_key": SESSION, "mode": "never"},
+            params={"owner_id": OWNER},
+        )
+    )
+
+    relay.results = [EngineResult(data={"supported": ["approval.set"]})]
+    ok(client.get(f"{BASE}/modes", params={"owner_id": OWNER}))
+
+    assert relay.calls, "no route forwarded"
+    assert all(c["caller_id"] == "u-collab" for c in relay.calls), [
+        (c["path"], c.get("caller_id")) for c in relay.calls
+    ]
+    assert all(c["owner_id"] == OWNER for c in relay.calls)

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_models.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_models.py
@@ -256,6 +256,38 @@ def test_a_service_bot_is_served_at_its_draft_device(
     assert all(c["stage"] == "draft" for c in relay.calls)
 
 
+@pytest.mark.parametrize(
+    ("group", "path"),
+    [
+        ("engine", f"/openapi/v1/bots/engine/{BOT}/status"),
+        ("engine", f"/openapi/v1/bots/engine/{BOT}/capabilities"),
+        ("engine", f"/openapi/v1/bots/engine/{BOT}/available"),
+        ("models", f"/openapi/v1/bots/models/{BOT}"),
+        ("models", f"/openapi/v1/bots/models/{BOT}/openai/gpt-5.3"),
+    ],
+)
+def test_every_engine_and_models_route_threads_the_verified_caller_as_caller_id(
+    make_client, relay, group, path
+):
+    """Cross-route consistency (review P1-1): every read-only engine/models
+    route forwards the authenticated caller as ``caller_id`` — not the
+    owner — so a collaborator's engine/model read lands on the same instance
+    its connection/session request did. A handler that later drops the kwarg
+    fails this exactly, at the route it dropped it on."""
+    relay.set_bot_type("service")
+    relay.add_operator("u-collab")
+    router = engine_router if group == "engine" else models_router
+    client = make_client(router, caller="u-collab")
+    relay.results = [EngineResult(data={"engines": [], "models": []})]
+    resp = client.get(path, params={"owner_id": OWNER})
+    assert resp.status_code == 200, resp.json()
+    assert relay.calls, "the route never forwarded"
+    assert all(c["caller_id"] == "u-collab" for c in relay.calls), [
+        (c["path"], c.get("caller_id")) for c in relay.calls
+    ]
+    assert all(c["owner_id"] == OWNER for c in relay.calls)
+
+
 def test_a_collaborator_is_served_and_a_stranger_is_the_masked_404(
     make_client, relay
 ):

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_sessions.py
@@ -504,6 +504,41 @@ def test_the_owners_own_request_is_still_served(client, relay):
     assert relay.paths == ["/api/sessions"]
 
 
+@pytest.mark.parametrize(
+    "method,suffix",
+    [
+        ("get", ""), ("post", ""), ("get", f"/{SESSION_ID}"),
+        ("patch", f"/{SESSION_ID}"), ("delete", f"/{SESSION_ID}"),
+        ("get", f"/{SESSION_ID}/messages"), ("delete", f"/{SESSION_ID}/messages"),
+    ],
+)
+def test_the_verified_caller_flows_into_the_relay_as_caller_id(
+    make_client, relay, method, suffix
+):
+    """Multi-instance affinity keys on the caller, and the relay only knows
+    the caller when the sessions router threads it through ``caller_id``.
+    A collaborator operating another owner's bot must forward their own id,
+    not the owner's — the production multi-instance distribution defect pinned every collaborator
+    onto the owner's chosen instance otherwise.
+
+    Each of the seven sessions routes is swept so a future handler that
+    forgets the kwarg on one of them fails this exactly, not via an
+    unrelated downstream test.
+    """
+    relay.set_bot_type("service")
+    relay.add_operator("u-collab")
+    client = make_client(router, caller="u-collab")
+    kwargs = {"json": {"title": "T"}} if method in ("post", "patch") else {}
+    kwargs["params"] = {"owner_id": OWNER}
+    resp = getattr(client, method)(f"{_base()}{suffix}", **kwargs)
+    assert resp.status_code in (200, 201), resp.json()
+    assert relay.calls, "the route never forwarded"
+    assert all(c["caller_id"] == "u-collab" for c in relay.calls)
+    # The addressed owner stays the bot's owner — the affinity change is a
+    # different axis from the owner the request names.
+    assert all(c["owner_id"] == OWNER for c in relay.calls)
+
+
 # ── isolation ────────────────────────────────────────────────────────────────
 
 

--- a/src/backend/tests/community/core/engine_runtime/test_connection.py
+++ b/src/backend/tests/community/core/engine_runtime/test_connection.py
@@ -215,16 +215,59 @@ def test_foreign_bot_raises_before_resolving_a_device():
 
 
 def test_the_resolved_owner_is_passed_as_the_operator():
-    """The operator id is routing and bookkeeping downstream, and it must be
-    the resolved owner even when a collaborator holds the channel: some
-    device-service implementations apply collaborator-blind permission models
-    to it, and the BaaS path keys instance affinity on it — per-caller values
-    would pin two operators of one (bot, stage) to different instances."""
+    """The operator id drives multi-instance affinity downstream, and it must
+    be the authenticated caller — owner-keyed affinity pinned every
+    collaborator of one (bot, stage) onto the single instance the owner's
+    id hashed to (the production multi-instance distribution defect), so the affinity field keys on
+    ``caller_id`` instead. When the caller *is* the owner (the default
+    owner-scoped request) this is the resolved owner, and the audit fields
+    below continue to carry it.
+
+    The audit / bookkeeping fields (``staff``, ``nick_name``,
+    ``operator_name``) stay on the resolved owner regardless: the device
+    permission row and audit trail belong to the bot's owner; a
+    collaborator-operated bot does not become the collaborator's bot.
+    """
     devices = _Devices()
     _build(_svc(devices=devices))
     assert devices.kwargs["operator"].staff_id == OWNER
+    assert devices.kwargs["operator"].staff == OWNER
+    assert devices.kwargs["operator"].nick_name == OWNER
+    assert devices.kwargs["operator"].operator_name == OWNER
     assert devices.kwargs["binding_id"] == 42
     assert devices.kwargs["ttl"] == CONNECTION_TTL_SECONDS
+
+
+def test_the_authenticated_caller_drives_instance_affinity_not_the_owner():
+    """A collaborator operating another owner's bot must hash onto the
+    multi-instance ring under **their** id, not the owner's. The owner's id
+    would pin every operator of one (bot, stage) onto a single instance —
+    the regression the production multi-instance distribution defect logged. The audit fields stay on
+    the owner: the bot remains the owner's and the device permission row
+    names the owner, even when a collaborator holds the channel."""
+    collaborators = _Collaborators({(100, "u-collab"): PermissionLevel.MEMBER})
+    devices = _Devices()
+    _build(_svc(devices=devices, collaborators=collaborators), caller_id="u-collab")
+
+    # Affinity follows the caller; audit/bookkeeping stays on the resolved owner.
+    assert devices.kwargs["operator"].staff_id == "u-collab"
+    assert devices.kwargs["operator"].staff == OWNER
+    assert devices.kwargs["operator"].nick_name == OWNER
+    assert devices.kwargs["operator"].operator_name == OWNER
+
+
+def test_repeated_calls_from_one_caller_keep_one_affinity_key():
+    """Same caller reconnecting must keep hitting the same instance — the
+    change is from owner-pinned to caller-sticky, not from sticky to random,
+    so a caller's sessions stay on one device while different callers
+    spread."""
+    collaborators = _Collaborators({(100, "u-collab"): PermissionLevel.MEMBER})
+    seen = []
+    for _ in range(5):
+        devices = _Devices()
+        _build(_svc(devices=devices, collaborators=collaborators), caller_id="u-collab")
+        seen.append(devices.kwargs["operator"].staff_id)
+    assert seen == ["u-collab"] * 5
 
 
 def test_relay_mode_is_requested_so_the_provider_returns_a_finished_url():

--- a/src/backend/tests/community/core/engine_runtime/test_relay.py
+++ b/src/backend/tests/community/core/engine_runtime/test_relay.py
@@ -673,6 +673,73 @@ async def test_personal_bot_still_resolves_by_bot():
 
 
 @pytest.mark.asyncio
+async def test_caller_id_flows_into_the_published_device_affinity():
+    """The BaaS multi-instance affinity key on a service bot's published stage
+    must follow the authenticated caller, not the owner. Keying on the owner
+    pinned every collaborator of one (bot, stage) onto the single instance
+    the owner's id hashed to — the production multi-instance distribution defect — so the relay
+    forwards ``caller_id`` as the ``operator_id`` argument to
+    ``resolve_for_binding_invoke`` (which becomes
+    ``conn_info["device_affinity"]`` on the BaaS path).
+    """
+    resolver = _Resolver()
+    repo = _PublishRepo(
+        {100: [_PublishRecord({"binding": {"online": 42}})]}
+    )
+    await _relay(
+        bot_service=_service_bot_service(100),
+        resolver=resolver,
+        publish_repo=repo,
+    ).call(
+        bot_id=BOT, owner_id=OWNER, stage="online", method="GET",
+        path="/api/models", caller_id="collab-1",
+    )
+
+    # ``operator_id`` (the second tuple element) is the caller, not the owner.
+    assert resolver.binding_calls == [(42, "collab-1", BOT)]
+    assert resolver.calls == []
+
+
+@pytest.mark.asyncio
+async def test_caller_id_none_falls_back_to_owner_keyed_affinity():
+    """Owner-scoped and ungated routes pass ``caller_id=None``; the relay
+    keeps the historical owner-keyed behavior so existing call sites and
+    tests that omit the parameter are unchanged."""
+    resolver = _Resolver()
+    repo = _PublishRepo(
+        {100: [_PublishRecord({"binding": {"online": 42}})]}
+    )
+    await _relay(
+        bot_service=_service_bot_service(100),
+        resolver=resolver,
+        publish_repo=repo,
+    ).call(
+        bot_id=BOT, owner_id=OWNER, stage="online", method="GET",
+        path="/api/models",
+    )
+
+    assert resolver.binding_calls == [(42, OWNER, BOT)]
+
+
+@pytest.mark.asyncio
+async def test_personal_bot_path_ignores_caller_id_for_affinity():
+    """A personal bot resolves through ``resolve_for_bot`` (by-bot), which
+    takes ``user_id`` separately from any affinity routing; ``caller_id``
+    has no role on this path. Passing it must not raise or change the
+    resolution — the kwarg is for the published-stage branch only.
+    """
+    resolver = _Resolver()
+    await _relay(resolver=resolver).call(
+        bot_id=BOT, owner_id=OWNER, stage="draft", method="GET",
+        path="/api/models", caller_id="collab-1",
+    )
+
+    # by-bot entry point: caller_id is not threaded into resolve_for_bot.
+    assert resolver.calls == [(BOT, OWNER)]
+    assert resolver.binding_calls == []
+
+
+@pytest.mark.asyncio
 async def test_service_bot_without_a_published_runtime_is_stage_not_live():
     """No live online record is a dead stage, never a fall back to the draft.
 


### PR DESCRIPTION
# fix(backend,baas): caller-keyed affinity for published service bots (engine-runtime path)

## Problem

On the published `service`-bot OpenAPI engine-runtime path
(connection / sessions / approvals / engine / models), the device-affinity
key fed to the BaaS consistent-hashing ring was the **resolved owner id**
for every caller. Routing every collaborator of one `(bot, stage)` onto the
single instance the owner's id hashed to is a routing-correctness defect in
its own right: two collaborators of the same bot are not isolated onto their
own instances even when the fleet has spare replicas.

This PR fixes that isolation property. It does **not** claim to be the
root-cause fix for the production distribution report (5 instances,
`19 / 7 / 9 / 12 / 14`, 61 requests) that motivated the investigation:

- A single shared owner affinity key would route to **one** instance
  (`61 / 0 / 0 / 0 / 0`), not to all five. The reported spread already
  involved multiple affinity keys, so "owner pinned everything" cannot by
  itself explain the observed counts.
- The BaaS Bot Run main request path routes on
  `session_consistency_key → device_affinity`, a different chain from the
  OpenAPI path this PR changes.
- Dima does not state how many callers / sessions the 61 requests came
  from, whether they were collaborators, or which entry API served them.

Confirming the 61-request attribution therefore needs production entry-API
identification, caller/session counts, and the actual `device_affinity`
value logged at BaaS — none of which are reachable from this session. That
follow-up is tracked separately and is required before any claim that this
patch resolves the production report.

## Change

### 1. Thread the caller id across the whole published engine-runtime path (backend)

`caller_id` flows through `EngineRuntimeRelay.call`
(`_resolve_bot_and_device` → `_resolve_device` →
`_resolve_published_device` → `resolve_for_binding_invoke`) and becomes
`conn_info["device_affinity"]`. It is now forwarded by **every** router
group on the published path: `sessions`, `approvals`, `engine`, `models`
(all 8 `relay.call` sites in the latter three were missing it in the first
revision; this revision closes that gap — review P1-1).

`EngineConnectionService` mirrors this: `operator.staff_id` (the field the
BaaS affinity path reads) is keyed on the **authenticated caller**, while
`staff`, `nick_name`, `operator_name` stay on the **resolved owner** for
audit/bookkeeping and the `check_collaborator_permission` fall-through. The
authorisation decision is unchanged — `OPERATOR_LEVEL` stays `MEMBER` and
`device_service` re-checks collaborator permission for any `staff_id`
differing from `record.entity_id`, so the change widens no privilege.

`caller_id` defaults to `None` everywhere, preserving the historical
owner-keyed behaviour on owner-scoped / ungated routes.

### 2. BaaS selector observability (baas, ring shape unchanged)

`_VIRTUAL_NODES` stays at **100** (review P1-2). A vnode-count change
reshapes the whole consistent-hash ring, so a mixed-version rolling deploy
would remap a large share of affinity keys to different instances
mid-session; a ring change needs an explicit migration, not a bump hidden
in an unrelated PR.

The selector keeps the observability fields added during investigation:
`key_hash_prefix` (first 8 hex chars of the affinity-key hash — correlates a
selection across logs without publishing the raw key, which can be a user
id) and `virtual_nodes_per_device`. The pre-existing raw
`device_affinity={device_affinity!r}` log line is unchanged by this patch;
DEBUG-gating it is a tracked follow-up.

## Validation

Run via `bash src/baas/scripts/ci_test.sh` and `bash src/backend/scripts/ci_test.sh`
against base `10bd59aec9a9ce9a479277dee739b694d613d1d2` (origin/dev):

- BaaS: `8081 passed / 3 skipped`, line coverage `92.65%`, ASGI gate green.
- Backend: `19471 run / 19463 passed / 4 failed / 708 skipped`; the 4
  failures reproduce on the base commit (environment-specific golden / path
  drift) and are pre-existing. `newFailures: []`.
- Affected-target subset on the final patch: backend `207 passed`,
  baas `14 passed`.

New regression coverage (scoped to the verified property, not to the
unconfirmed production attribution):

- `test_sessions.py` sweep: `caller_id` reaches `relay.call` on every
  route in the sessions group, with `owner_id` unchanged.
- `test_approvals.py` and `test_engine_models.py`: cross-route consistency
  tests sweeping every route in the approvals and engine+models groups,
  asserting `caller_id == collaborator` and `owner_id == OWNER`.
- `test_connection.py` / `test_relay.py`: caller-keyed `OperatorContext`
  and the published-stage device-resolution paths; `None` fallback retained.
- `TestMultiInstanceDistribution` (baas): algorithm-level invariants —
  a single shared affinity key pins to one instance (stddev > 20), distinct
  per-caller keys spread across all instances (min ≥ 5, max < 35%). These
  describe the consistent-hash contract, **not** the production 61-request
  distribution.

## Rollback

Drop the `caller_id` kwarg from the router groups and revert
`operator.staff_id` to `resolved_owner`. Long-lived connections transition
through the next connect.

## Base

- Base: `origin/dev` @ `10bd59aec9a9ce9a479277dee739b694d613d1d2`
- Branch: `cb-dev-avernet-change-e7d74cc6`
