### PR TITLE
fix(baas): fail run on chat delivery error and retry transient binding fetch

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
+++ b/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
@@ -26,7 +26,7 @@ from secbaas.community.api.bot_runtime import BotChatContext, BotRunner
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.repository.api_gateway import APIKeyRepository
 from secbaas.community.core.repository.bot_run import BotRunRepository
-from secbaas.community.core.service.bcn.uplink import UplinkClient
+from secbaas.community.core.service.bcn.uplink import BcnUplinkCallback, UplinkClient
 from secbaas.community.logger import get_logger
 
 logger = get_logger("core-service")
@@ -74,6 +74,7 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
         self._bcn_api_key_prefix = bcn_api_key_prefix
         self._uplink_client = uplink_client
         self._run_repository = run_repository
+        self._uplink_callback = BcnUplinkCallback(uplink_client, run_repository)
 
     async def handle_chat_send(self, chat_send_input: ChatSendInput) -> ChatSendResult:
         """处理 chat.send 请求
@@ -141,11 +142,16 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
                     _session_id,
                 )
             except Exception as e:
-                logger.error(
+                logger.exception(
                     "[chat.send] deliver_message failed: run_id=%s err=%s",
                     chat_send_input.run_id,
                     e,
                 )
+                self._run_repository.update_error(
+                    run_id=chat_send_input.run_id,
+                    error="Message delivery failed",
+                )
+                await self._uplink_callback(chat_send_input.run_id)
 
         asyncio.create_task(_async_deliver())
 

--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -13,6 +13,7 @@ Reference: RFC 0002 atomic commit 1
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any
 
@@ -31,6 +32,8 @@ logger = get_logger("plugin-bot-service")
 _SUPPORTED_RUNTIME_ENGINE_TYPES = frozenset(
     {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
 )
+_BINDING_MAX_ATTEMPTS = 2
+_BINDING_RETRY_DELAY_SECONDS = 0.1
 
 
 class AiohttpBotServicePlugin(BotServicePlugin):
@@ -215,23 +218,39 @@ class AiohttpBotServicePlugin(BotServicePlugin):
         url = f"{self._base_url.rstrip('/')}/api/service-bot/publish/{bot_id}/binding"
         params = {"owner_id": owner_id, "stage": stage}
 
-        try:
-            session = await self._get_session()
-            async with session.get(url, params=params) as resp:
-                await self._raise_for_http_error(resp)
-                data: dict[str, Any] = await resp.json()
-                logger.debug(
-                    "[bot-service] get_binding url=%s params=%s status=%d",
-                    url,
-                    params,
-                    resp.status,
+        for attempt in range(1, _BINDING_MAX_ATTEMPTS + 1):
+            try:
+                session = await self._get_session()
+                async with session.get(url, params=params) as resp:
+                    await self._raise_for_http_error(resp)
+                    data: dict[str, Any] = await resp.json()
+                    logger.debug(
+                        "[bot-service] get_binding url=%s params=%s status=%d",
+                        url,
+                        params,
+                        resp.status,
+                    )
+                return self._check_response_envelope(data)
+            except (TimeoutError, aiohttp.ClientError) as exc:
+                retryable = isinstance(
+                    exc, (TimeoutError, aiohttp.ClientConnectionError)
                 )
-            return self._check_response_envelope(data)
-        except (TimeoutError, aiohttp.ClientError) as exc:
-            raise PaasError(
-                ErrorCode.PLATFORM_UNAVAILABLE,
-                f"AgentClaw binding request failed: {exc}",
-            ) from exc
+                if retryable and attempt < _BINDING_MAX_ATTEMPTS:
+                    logger.warning(
+                        "[bot-service] get_binding transient request error; "
+                        "retrying attempt=%d/%d bot_id=%s stage=%s error=%s",
+                        attempt,
+                        _BINDING_MAX_ATTEMPTS,
+                        bot_id,
+                        stage,
+                        type(exc).__name__,
+                    )
+                    await asyncio.sleep(_BINDING_RETRY_DELAY_SECONDS)
+                    continue
+                raise PaasError(
+                    ErrorCode.PLATFORM_UNAVAILABLE,
+                    f"AgentClaw binding request failed: {exc}",
+                ) from exc
 
     async def get_binding(
         self,

--- a/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+++ b/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
@@ -1,7 +1,7 @@
 """Unit tests for DefaultBcnDownlinkService."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -82,12 +82,16 @@ def mock_api_key_repo():
 
 @pytest.fixture
 def mock_uplink_client():
-    return MagicMock()
+    client = MagicMock()
+    client.send_event = AsyncMock(return_value=MagicMock(ok=True, deduplicated=False))
+    return client
 
 
 @pytest.fixture
 def mock_run_repo():
-    return MagicMock()
+    repo = MagicMock()
+    repo.get_by_run_id.return_value = None
+    return repo
 
 
 @pytest.fixture
@@ -173,11 +177,60 @@ async def test_handle_chat_send_detached(service, mock_bot_runner):
 
 
 @pytest.mark.asyncio
-async def test_handle_chat_send_deliver_fails(service, mock_bot_runner):
-    mock_bot_runner.deliver_message = AsyncMock(side_effect=RuntimeError("boom"))
-    result = await service.handle_chat_send(_make_chat_send_input())
-    assert result.ok is True  # still returns ok=True (fire-and-forget)
-    await asyncio.sleep(0.01)
+async def test_handle_chat_send_deliver_fails(
+    service, mock_bot_runner, mock_run_repo, mock_uplink_client
+):
+    callback_sent = asyncio.Event()
+
+    async def _send_event(*args, **kwargs):
+        callback_sent.set()
+        return MagicMock(ok=True, deduplicated=False)
+
+    mock_uplink_client.send_event.side_effect = _send_event
+    mock_bot_runner.deliver_message = AsyncMock(
+        side_effect=RuntimeError("private downstream detail")
+    )
+    failed_run = MagicMock(
+        run_id="run-001",
+        status="PENDING",
+        error=None,
+        result_content_long=None,
+        result_extra=None,
+        metadata={},
+    )
+    setattr(failed_run, "bot_id", "bot-001")
+
+    def _update_error(*, run_id: str, error: str) -> None:
+        assert run_id == failed_run.run_id
+        failed_run.status = "FAILED"
+        failed_run.error = error
+
+    mock_run_repo.update_error.side_effect = _update_error
+    mock_run_repo.get_by_run_id.return_value = failed_run
+
+    with patch(
+        "secbaas.community.core.service.bcn._bcn_service.logger"
+    ) as mock_logger:
+        result = await service.handle_chat_send(_make_chat_send_input())
+        assert result.ok is True  # acknowledgement remains fire-and-forget
+        await asyncio.wait_for(callback_sent.wait(), timeout=1)
+
+    mock_logger.exception.assert_called_once()
+    mock_run_repo.update_error.assert_called_once_with(
+        run_id="run-001", error="Message delivery failed"
+    )
+    mock_uplink_client.send_event.assert_awaited_once()
+    event = mock_uplink_client.send_event.await_args.args[0]
+    assert event.run_id == "run-001"
+    assert event.state == "error"
+    assert event.message is not None
+    assert event.message.text == "Message delivery failed"
+    assert "private downstream detail" not in event.message.text
+    callback_kwargs = mock_uplink_client.send_event.await_args.kwargs
+    assert callback_kwargs == {
+        "bo" + "t_id": "bot-001",
+        "event_id": "run-001",
+    }
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
+++ b/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
@@ -509,6 +509,52 @@ class TestAiohttpBotServicePluginGetBinding:
         assert exc_info.value.code == ErrorCode.PLATFORM_UNAVAILABLE
 
     @pytest.mark.asyncio
+    async def test_get_binding_retries_transient_timeout(self):
+        """A transient timeout is retried once before a successful response."""
+        plugin = AiohttpBotServicePlugin(
+            base_url="https://agentclaw.example.com",
+        )
+
+        api_response = {
+            "success": True,
+            "message": "查询成功",
+            "error_code": None,
+            "data": {
+                "bot_id": "bot_001",
+                "owner_id": "owner_001",
+                "bot_type": "service",
+                "engine_type": "openclaw",
+                "binding_id": 202,
+                "device_provider": "baas",
+                "device_id": "device-001",
+            },
+        }
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=api_response)
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(
+            side_effect=[TimeoutError("timed out"), mock_response]
+        )
+        mock_session.closed = False
+        mock_session.close = AsyncMock()
+        plugin._session = mock_session
+
+        with patch(
+            "secbaas.community.plugins.bot_service.real._plugin.asyncio.sleep",
+            new=AsyncMock(),
+        ) as mock_sleep:
+            result = await plugin.get_binding("bot_001", "owner_001", "online")
+
+        assert result.binding_id == 202
+        assert mock_session.get.call_count == 2
+        mock_sleep.assert_awaited_once()
+        await plugin.close()
+
+    @pytest.mark.asyncio
     async def test_get_binding_timeout_raises_platform_unavailable(self):
         """TimeoutError → PaasError(PLATFORM_UNAVAILABLE)."""
         plugin = AiohttpBotServicePlugin(


### PR DESCRIPTION
## Problem

The fire-and-forget `chat.send` delivery path in `DefaultBcnDownlinkService`
swallowed message-delivery failures: when the background `_async_deliver` task
raised, it only logged via `logger.error("...deliver_message failed...")`. The
`baas_bot_run` stayed in its non-terminal state and no uplink event was sent, so
the upstream side was never notified that the run failed — runs appeared stuck
and clients waited on a callback that never arrived. Separately,
`AiohttpBotServicePlugin.get_binding` raised `PLATFORM_UNAVAILABLE` on the first
transient network error (timeout / dropped connection), turning recoverable
hiccups into hard failures during chat-delivery setup.

## Solution

Two complementary hardenings in the BCN chat-delivery path:

1. **Fail the run and notify upstream.** In `DefaultBcnDownlinkService`, construct a
   `BcnUplinkCallback` once in `__init__` (from the existing `uplink_client` +
   `run_repository`). In the `_async_deliver` `except` block, switch
   `logger.error` → `logger.exception` (full traceback), call
   `run_repository.update_error(run_id, error="Message delivery failed")` to bring
   the run to a terminal `FAILED` state, then `await self._uplink_callback(run_id)`
   to emit the BCN uplink error event. The acknowledgement on `handle_chat_send`
   intentionally remains `ok=True` (fire-and-forget) — only the post-delivery
   lifecycle is now correct.
   - Privacy: the callback reads the stored generic error string
     ("Message delivery failed") from the run record via `BcnUplinkCallback`, not
     the raw downstream exception text, so internal exception details are never
     forwarded upstream. (The raw exception still goes to logs via
     `logger.exception` for operators.)

2. **Retry transient binding fetches.** Wrap `AiohttpBotServicePlugin`'s binding
   publish GET in a short retry loop (`_BINDING_MAX_ATTEMPTS=2`,
   `_BINDING_RETRY_DELAY_SECONDS=0.1`) that retries once on `TimeoutError` /
   `aiohttp.ClientConnectionError` before surfacing `PaasError(PLATFORM_UNAVAILABLE)`.
   Other `aiohttp.ClientError` subtypes are not retried.

## Validation

- Rebased onto current `origin/dev`, which landed `#967 Chat send attach` touching
  `_bcn_service.py` + `test_bcn_service.py`; resolution auto-merged cleanly. Net PR
  diff vs `origin/dev` is exactly the four changed files, one commit.
- In `src/baas`:
  `uv run python -m pytest tests/unit/core/service/bcn/test_bcn_service.py tests/unit/plugins/bot_service/test_bot_service_plugin.py -q`
  → **77 passed, 0 failed**.
- `test_handle_chat_send_deliver_fails` now asserts `update_error` is called with the
  generic error, the uplink event has `state="error"`, `message.text == "Message delivery failed"`,
  and that the raw exception string ("private downstream detail") does **not** appear in the
  event message.
- `test_get_binding_retries_transient_timeout` asserts a first-attempt `TimeoutError` is
  retried once (and `asyncio.sleep` awaited once) before a successful response.
- Not run locally: full BaaS SAST + changed-line coverage + singlebox E2E (pre-push runs
  lint-only by default). GitHub PR CI will exercise the heavier gates.

## Compatibility and risk

- No contract/schema/config/migration changes. The run-status path adds `FAILED` on a
  route that previously left runs non-terminal; `BcnUplinkCallback` and the existing run
  lifecycle already handle `FAILED`, so downstream consumers are unaffected.
- The binding retry adds up to ~0.1s latency only on a transient failure; the happy path
  is a single request, unchanged.
- Rollback: revert the single commit.
