### PR TITLE
fix(bcs-message-flow): persist raw mention text for human-facing history

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -345,17 +345,35 @@ pub(crate) async fn try_persist_group_message(
     }
 }
 
-fn persisted_inbound_content(content: &str, attachments: Option<&[Attachment]>) -> Value {
-    let Some(attachments) = attachments.filter(|items| !items.is_empty()) else {
+/// Persist the sender's original text verbatim so human-facing history keeps
+/// `@mention` markers visible (mention tokens are only stripped from bot-bound
+/// deliveries, via `RoutingDecision::cleaned_message`). Non-empty `mentions`
+/// ride along so frontends can render mention chips after a history reload.
+fn persisted_inbound_content(
+    content: &str,
+    attachments: Option<&[Attachment]>,
+    mentions: &[String],
+) -> Value {
+    let attachments = attachments.filter(|items| !items.is_empty());
+    if attachments.is_none() && mentions.is_empty() {
         return Value::String(content.to_string());
-    };
-    serde_json::json!({
-        "text": content,
-        "attachments": attachments
+    }
+    let mut stored = serde_json::json!({ "text": content });
+    if let Some(attachments) = attachments {
+        stored["attachments"] = attachments
             .iter()
             .map(Attachment::stable_metadata)
-            .collect::<Vec<_>>(),
-    })
+            .collect::<Vec<_>>()
+            .into();
+    }
+    if !mentions.is_empty() {
+        stored["mentions"] = mentions
+            .iter()
+            .map(|mention| Value::String(mention.clone()))
+            .collect::<Vec<_>>()
+            .into();
+    }
+    stored
 }
 
 #[cfg(test)]
@@ -377,12 +395,32 @@ mod attachment_persistence_tests {
             expires_at: None,
         };
 
-        let persisted = persisted_inbound_content("look", Some(&[attachment]));
+        let persisted = persisted_inbound_content("look", Some(&[attachment]), &[]);
 
         assert_eq!(persisted["text"], "look");
         assert_eq!(persisted["attachments"][0]["attachment_id"], "att-1");
         assert!(persisted["attachments"][0].get("url").is_none());
         assert!(!persisted.to_string().contains("token=temporary"));
+    }
+
+    #[test]
+    fn mention_text_is_persisted_verbatim_with_structured_mentions() {
+        let persisted = persisted_inbound_content(
+            "@Driver please review",
+            None,
+            &["bot-driver".to_string()],
+        );
+
+        assert_eq!(persisted["text"], "@Driver please review");
+        assert_eq!(persisted["mentions"][0], "bot-driver");
+        assert!(persisted.get("attachments").is_none());
+    }
+
+    #[test]
+    fn plain_text_without_attachments_or_mentions_stays_a_string() {
+        let persisted = persisted_inbound_content("plain chat", None, &[]);
+
+        assert_eq!(persisted, serde_json::Value::String("plain chat".to_string()));
     }
 }
 
@@ -516,7 +554,7 @@ pub async fn handle_web_send(
         &cmd.from_actor_id,
         sender_type,
         "chat",
-        persisted_inbound_content(&decision.cleaned_message, cmd.attachments.as_deref()),
+        persisted_inbound_content(&cmd.message, cmd.attachments.as_deref(), &cmd.mentions),
         cmd.idempotency_key.as_deref(),
         None,
         "", // run_id: user messages don't associate with bot runs
@@ -2612,7 +2650,9 @@ fn log_routing_digest(
     mode: MessageLogMode,
     route_source: &'static str,
 ) {
-    let content = MessageLogContent::from_text(&decision.cleaned_message);
+    // Log the sender's original text so the digest joins with `message_received`;
+    // the @-stripped `cleaned_message` only applies to bot-bound deliveries.
+    let content = MessageLogContent::from_text(&cmd.message);
     let targets_summary: Vec<MessageLogTargetSummary> = decision
         .targets
         .iter()

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -3688,3 +3688,71 @@ async fn web_send_event_omits_attachments_key_for_empty_attachment_list() {
         "event: {event}"
     );
 }
+
+#[tokio::test]
+async fn web_send_persists_raw_mention_text_while_bots_receive_cleaned_text() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let repo = Arc::new(RecordingMessageRepo::default());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_message_repo(repo.clone());
+
+    flow.handle_web_send(WebSendCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_1".to_string(),
+            staff_no: "1".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        session_id: None,
+        from_actor_id: "human_1".to_string(),
+        from_name: Some("Human One".to_string()),
+        message: "@Driver please review".to_string(),
+        mentions: vec!["bot-driver".to_string()],
+        attachments: None,
+        thinking: None,
+        idempotency_key: None,
+        source_im_message_id: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    // Human-facing history keeps the sender's text verbatim and stores the
+    // structured mention targets for rendering.
+    let appended = repo.appended().await;
+    assert_eq!(appended.len(), 1);
+    assert_eq!(appended[0].content["text"], "@Driver please review");
+    assert_eq!(appended[0].content["mentions"][0], "bot-driver");
+    assert!(appended[0].content.get("attachments").is_none());
+
+    // Bot-bound deliveries still get the @-stripped routing text.
+    let frames = support.bot_delivery.frames().await;
+    assert_eq!(frames.len(), 2);
+    for frame in frames {
+        let BcsFrame::Request(req) = frame else {
+            panic!("expected request frame");
+        };
+        let params = req.params.as_ref().expect("params");
+        let text = params["message"]["content"][0]["text"]
+            .as_str()
+            .expect("text");
+        assert!(text.contains("Driver please review"), "text: {text}");
+        assert!(!text.contains("@Driver"), "text: {text}");
+    }
+
+    // The realtime workbench event already echoes the raw text and mentions.
+    let events = support.frontend_delivery.events().await;
+    assert_eq!(events.len(), 1);
+    let event: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+    assert_eq!(
+        event["payload"]["message"]["content"][0]["text"],
+        "@Driver please review"
+    );
+    assert_eq!(event["payload"]["message"]["mentions"][0], "bot-driver");
+}


### PR DESCRIPTION
## Problem

Web sends build the routing decision by regex-stripping `@name` tokens into `decision.cleaned_message` (for bot-bound deliveries). That same stripped text was also fed to `persisted_inbound_content`, so message history lost the `@mention` markers: the realtime workbench event shows `@Driver ...`, but after a page reload the history renders `Driver ...`. The stripping also mangles non-mention text such as email addresses (`user@gmail.com` → `usergmail.com`).

## Solution

Split text by consumer:

- `persisted_inbound_content` now takes the original `cmd.message` and non-empty `cmd.mentions`, storing `{"text": ..., "mentions": [...]}` (plain `Value::String` preserved when there are neither attachments nor mentions, so legacy content shape is unchanged for other traffic). Attachment handling is unchanged (`stable_metadata`, temporary URLs still dropped).
- Bot-bound deliveries keep using `decision.cleaned_message`, preserving the anti-abuse property that injected messages cannot re-trigger mention routing.
- The routing-digest log now records the original `cmd.message`, so `route_decided` content joins with `message_received`.

Rejected alternative: stop text-parsing mentions entirely (structured mentions end-to-end). Cleaner long-term direction, but it touches the routing port and bot-ecosystem conventions; kept as a follow-up.

## Validation

- `cargo test -p bcs-message-flow` (offline): 64 passed, 0 failed. Includes a new contract test asserting history keeps `@Driver please review` + `mentions` while delivered frames carry `Driver please review` with no `@`, plus unit tests for the new `persisted_inbound_content` shapes (raw text + mentions, plain string when neither attachments nor mentions).

## Compatibility and risk

- Content shape only changes where attachments already forced the object shape or mentions are present; plain text-only messages stay `Value::String`.
- Known gap (deferred issue #4 family): the V1 facade (`bcs-app-session project_content`) renders object-shaped content as a raw JSON string; mention messages without attachments now hit that known issue, same as attachment messages already do. The fix belongs with the V1 facade follow-up.
- Rollback: revert this commit; rows written in the interim remain valid JSON and readable by history readers.
