### PR TITLE
feat(aicoding): preserve notify ui hints

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/notify_router.py
@@ -59,6 +59,7 @@ class NotifyEntry(BaseModel):
     subject: dict[str, Any] | None = None
     command: str | None = None
     cwd: str | None = None
+    uiHints: dict[str, Any] | None = None
     status: str
     createdAtMs: int
     expiresAtMs: int | None = None


### PR DESCRIPTION
## Summary
- Preserve Relay notify uiHints in the OCB AICoding notify entry model
- Allow open-claw 我的消息 to read uiHints.approvalComment and render approval comments

## Validation
- uv run pytest tests/community/api/aicoding/test_notify_router.py (34 passed)
- OCB pre-push gate passed in lint-only mode

## Related
- https://code.alipay.com/ASF-Service-Platform/open-claw/issues/49