### PR TITLE
perf(baas): raise virtual-node count on device routing ring

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_device_selector.py
@@ -10,6 +10,7 @@ Design decisions (per design.md):
 """
 
 import hashlib
+import os
 import random
 from typing import TYPE_CHECKING
 
@@ -20,28 +21,78 @@ if TYPE_CHECKING:
 
 logger = get_logger("core-service")
 
-# Virtual nodes per physical device for even hash distribution
-_VIRTUAL_NODES = 100
+# Virtual nodes per physical device for even hash distribution on the
+# consistent-hash ring. Bots typically run only a handful of replicas, and
+# consistent hashing with too few virtual nodes spreads load unevenly across
+# such small fleets. A higher virtual-node count reduces the per-node share
+# variance so each replica receives a closer-to-average slice of the hash
+# space. The ring still remaps keys when the active device set changes, as
+# expected from consistent hashing.
+#
+# Operators may tune the count per deployment without a code change via the
+# ``SECBAAS_DEVICE_SELECTOR_VIRTUAL_NODES`` environment variable; invalid or
+# sub-minimum values fall back to the default.
+_DEFAULT_VIRTUAL_NODES = 200
+_MIN_VIRTUAL_NODES = 1
+
+_ENV_VIRTUAL_NODES = "SECBAAS_DEVICE_SELECTOR_VIRTUAL_NODES"
+
+
+def _resolve_virtual_nodes(raw: str | None, default: int) -> int:
+    """Resolve and validate the configured virtual-node count.
+
+    Non-integer, empty, or sub-minimum values fall back to ``default`` so a
+    misconfiguration can never produce an empty or degenerate ring.
+
+    Args:
+        raw: The raw environment value, or ``None`` when unset.
+        default: The default count used when ``raw`` is absent or invalid.
+
+    Returns:
+        A validated virtual-node count of at least ``_MIN_VIRTUAL_NODES``.
+    """
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value < _MIN_VIRTUAL_NODES:
+        return default
+    return value
+
+
+# Resolved once at import time from the environment; ``build_ring`` also
+# accepts an explicit override so callers and tests can vary it in-process.
+_VIRTUAL_NODES = _resolve_virtual_nodes(
+    os.environ.get(_ENV_VIRTUAL_NODES), _DEFAULT_VIRTUAL_NODES
+)
 
 
 def build_ring(
     active_devices: list["DeviceRecord"],
+    virtual_nodes: int | None = None,
 ) -> list[tuple[int, "DeviceRecord"]]:
     """Build a consistent hash ring from active devices.
 
-    Each physical device is placed on the ring _VIRTUAL_NODES times
-    using different hash seeds (``{device_uuid}:{vnode_index}``) for
-    even distribution, especially with small device counts.
+    Each physical device is placed on the ring ``virtual_nodes`` times
+    (defaulting to the module-level ``_VIRTUAL_NODES``) using different hash
+    seeds (``{device_uuid}:{vnode_index}``) for even distribution, especially
+    with small device counts.
 
     Args:
         active_devices: List of ACTIVE device records
+        virtual_nodes: Optional override for virtual nodes per device;
+            defaults to the configured ``_VIRTUAL_NODES``.
 
     Returns:
         Sorted list of (hash_value, DeviceRecord) tuples forming the ring
     """
+    if virtual_nodes is None:
+        virtual_nodes = _VIRTUAL_NODES
     ring: list[tuple[int, DeviceRecord]] = []
     for d in active_devices:
-        for vnode in range(_VIRTUAL_NODES):
+        for vnode in range(virtual_nodes):
             seed = f"{d.device_uuid}:{vnode}"
             h = int(hashlib.md5(seed.encode()).hexdigest(), 16)
             ring.append((h, d))
@@ -88,6 +139,7 @@ def select_by_affinity(
 def select_active_device(
     devices: list["DeviceRecord"],
     device_affinity: str | None = None,
+    virtual_nodes: int | None = None,
 ) -> "DeviceRecord | None":
     """Select an ACTIVE device from the list.
 
@@ -101,6 +153,8 @@ def select_active_device(
     Args:
         devices: List of device records
         device_affinity: Optional affinity key for sticky device selection
+        virtual_nodes: Optional override for virtual nodes per device on the
+            consistent-hash ring; defaults to the configured ``_VIRTUAL_NODES``.
 
     Returns:
         A selected ACTIVE device, or None if no ACTIVE devices
@@ -109,7 +163,7 @@ def select_active_device(
     if not active_devices:
         return None
     if device_affinity is not None:
-        ring = build_ring(active_devices)
+        ring = build_ring(active_devices, virtual_nodes=virtual_nodes)
         return select_by_affinity(ring, device_affinity)
     return random.choice(active_devices)
 
@@ -117,6 +171,7 @@ def select_active_device(
 def select_available_device(
     devices: list["DeviceRecord"],
     device_affinity: str | None = None,
+    virtual_nodes: int | None = None,
 ) -> "DeviceRecord | None":
     """Select an available device from the list with a relaxed status filter.
 
@@ -149,6 +204,8 @@ def select_available_device(
     Args:
         devices: List of device records to select from.
         device_affinity: Optional affinity key for sticky device selection.
+        virtual_nodes: Optional override for virtual nodes per device on the
+            consistent-hash ring; defaults to the configured ``_VIRTUAL_NODES``.
 
     Returns:
         A selected available device, or ``None`` if no device matches the
@@ -160,6 +217,6 @@ def select_available_device(
     if not available_devices:
         return None
     if device_affinity is not None:
-        ring = build_ring(available_devices)
+        ring = build_ring(available_devices, virtual_nodes=virtual_nodes)
         return select_by_affinity(ring, device_affinity)
     return random.choice(available_devices)

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from secbaas.community.core.service.bot_runtime.dispatcher._device_selector import (
+    _resolve_virtual_nodes,
+    build_ring,
     select_active_device,
     select_available_device,
 )
@@ -154,3 +156,88 @@ class TestSelectActiveDeviceRegression:
         ]
         result = select_active_device(devices)
         assert result is None
+
+
+# ==================== Virtual Node Configuration Tests ====================
+
+
+class TestVirtualNodesConfig:
+    """Tests for the configurable virtual-node count on the routing ring."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, 200),
+            ("", 200),
+            ("not-an-int", 200),
+            ("0", 200),
+            ("-5", 200),
+            ("1", 1),
+            ("64", 64),
+            ("500", 500),
+        ],
+    )
+    def test_resolve_virtual_nodes_validation(self, raw, expected):
+        """Invalid/empty/sub-minimum values fall back to the default."""
+        assert _resolve_virtual_nodes(raw, default=200) == expected
+
+    def test_build_ring_size_scales_with_virtual_nodes(self):
+        """build_ring places each device on the ring virtual_nodes times."""
+        devices = [
+            _make_device("dev-a", "ACTIVE"),
+            _make_device("dev-b", "ACTIVE"),
+            _make_device("dev-c", "ACTIVE"),
+        ]
+        ring = build_ring(devices, virtual_nodes=64)
+        assert len(ring) == 3 * 64
+        # Ring is sorted by hash value.
+        hashes = [h for h, _ in ring]
+        assert hashes == sorted(hashes)
+
+    def test_build_ring_default_uses_module_constant(self):
+        """build_ring without an override uses the configured default count."""
+        from secbaas.community.core.service.bot_runtime.dispatcher import (
+            _device_selector as selector,
+        )
+
+        devices = [_make_device("dev-only", "ACTIVE")]
+        ring = build_ring(devices)
+        assert len(ring) == 1 * selector._VIRTUAL_NODES
+
+    def test_more_virtual_nodes_reduce_skew_on_small_fleet(self):
+        """A higher virtual-node count evens out load on a small device fleet.
+
+        This is the routing-algorithm property behind the reported uneven
+        multi-instance distribution: with only a few physical replicas the
+        consistent-hash ring partitions unevenly unless each device owns many
+        virtual nodes.
+        """
+        devices = [
+            _make_device(f"dev-{i}", "ACTIVE") for i in range(5)
+        ]
+        sample_size = 6000
+
+        def distribution(virtual_nodes: int) -> dict[str, int]:
+            counts = {d.device_uuid: 0 for d in devices}
+            for i in range(sample_size):
+                picked = select_active_device(
+                    devices,
+                    device_affinity=f"session-{i}",
+                    virtual_nodes=virtual_nodes,
+                )
+                counts[picked.device_uuid] += 1
+            return counts
+
+        few = distribution(virtual_nodes=1)
+        many = distribution(virtual_nodes=200)
+
+        def spread(counts: dict[str, int]) -> int:
+            return max(counts.values()) - min(counts.values())
+
+        # The all-replicas-identical degenerate ring (1 vnode per device) is
+        # far more skewed than the 200-vnode ring over the same keys.
+        assert spread(few) > spread(many)
+        # And the 200-vnode ring stays within a reasonable band of the mean.
+        mean = sample_size / len(devices)
+        assert max(many.values()) <= mean * 1.20
+        assert min(many.values()) >= mean * 0.80


### PR DESCRIPTION
## Problem
Service bots run only a handful of replicas. The consistent-hash ring that
selects a replica per request partitions the hash space unevenly when each
replica owns too few virtual nodes, so small fleets see skewed load across
replicas.

## Solution
Increase the default virtual nodes per physical device on the device-selector
consistent-hash ring from 100 to 200 and make the count configurable via the
`SECBAAS_DEVICE_SELECTOR_VIRTUAL_NODES` environment variable (invalid or
sub-minimum values fall back to the default). `build_ring`,
`select_active_device`, and `select_available_device` now accept an optional
`virtual_nodes` override so callers and tests can vary the ring size in-process.
The routing algorithm is otherwise unchanged.

## Validation
- `cd src/baas && uv run pytest tests/unit/core/service/bot_runtime/dispatcher/ -q`
  -> 193 passed, including new tests that verify env-value validation, ring-size
  scaling, and that 200 vnodes produces a strictly smaller max-min spread than a
  degenerate 1-vnode ring over 6000 affinity keys on a 5-replica fleet.
- `uv run ruff check` on the changed files -> clean.
- `uv run mypy` on the changed source -> clean.
