### PR TITLE
chore(baas): change logger name

### DIFF
--- a/src/baas/src/secbaas/community/plugins/sandbox/utils/arca_utils.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/utils/arca_utils.py
@@ -14,7 +14,7 @@ from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.secret import SecretStorePlugin
 
-logger = get_logger(__name__)
+logger = get_logger("plugin-sandbox-arca")
 
 _ARCA_PROXY_HOST_MAP: dict[str, ConfigPath] = {
     "dev": ConfigPath.AGENTCLAW_PROXY_HOST_DEV,


### PR DESCRIPTION
## Problem

The Arca sandbox utils logger uses the module name (`__name__`), which produces a verbose, caller-relative log name that is inconsistent with the fixed, meaningful logger names used elsewhere in the BaaS plugin sandbox code.

## Solution

Set the logger name to a stable identifier, `"plugin-sandbox-arca"`, instead of the module path, so log filtering and correlation in the sandbox plugin are consistent and reliable.

## Validation

- BaaS SAST/lint gate passes locally (lint-only mode).
- No behavior change beyond the emitted logger name; no tests affected.

## Compatibility and risk

- No contract, schema, config, or migration impact. Rollback is a revert of the single-line change.