### PR TITLE
chore(baas): log TTL renewal failures in sandbox router

### DIFF
--- a/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
+++ b/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
@@ -308,6 +308,10 @@ class AcBindingSandboxHandler:
                     refresh_fail_count=0,
                 )
             else:
+                logger.warning(
+                    f"[AcBindingSandboxHandler] Renew TTL extension returned failure "
+                    f"for {sandbox_id}: {ttl_info.error or 'TTL extension failed'}"
+                )
                 return RenewTtlResult(
                     table_id=table_id,
                     table_type=TableType.AC_BINDING,
@@ -445,6 +449,9 @@ class BaasSandboxHandler:
         # STOPPED 状态不续期
         if row.get("status") == "STOPPED":
             dp = _parse_device_props(row.get("provider_device_props"))
+            logger.info(
+                f"[BaasSandboxHandler] Skip renew TTL for stopped device id={table_id}"
+            )
             return RenewTtlResult(
                 table_id=table_id,
                 table_type=TableType.BAAS,
@@ -487,6 +494,10 @@ class BaasSandboxHandler:
                     refresh_fail_count=0,
                 )
             else:
+                logger.warning(
+                    f"[BaasSandboxHandler] Renew TTL extension returned failure "
+                    f"for {sandbox_id}: {ttl_info.error or 'TTL extension failed'}"
+                )
                 return RenewTtlResult(
                     table_id=table_id,
                     table_type=TableType.BAAS,


### PR DESCRIPTION
## Problem

Failure paths in the sandbox device router's `renew_ttl` returned `RenewTtlResult(success=False)` silently. The STOPPED-guard and TTL-extension-failure branches emitted no log, making failures hard to observe without inspecting DB state or relying on the downstream scheduler's aggregated counts.

## Solution

Add logging at the previously silent `success=False` return paths in `_sandbox_device_router.py`, using the existing `"core-service"` logger:

- `BaasSandboxHandler`: `INFO` when skipping renewal for a `STOPPED` device; `WARNING` when the PaaS TTL extension returns failure.
- `AcBindingSandboxHandler`: `WARNING` when the PaaS TTL extension returns failure.

The exception branches already logged and are unchanged.

## Validation

- `py_compile` passes for the modified module.
- BaaS SAST/lint pre-push gate passes in lint-only mode.

## Compatibility and risk

- No contract, schema, config, or migration impact. Logging only; no behavior change. Rollback is a revert of the single-file change.