### PR TITLE
fix: resolve aicoding template mcp defaults

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
@@ -12,8 +12,8 @@ class AicodingMcpDefaultsResolver:
     """Resolve effective default MCPs for AICoding bots.
 
     AICoding templates may preset MCP capabilities at
-    ``ext_info.aicoding.template_config.template_config.bot_template_config.preset_capabilities.mcp``. These are
-    merged by ``server_code`` onto the AICoding engine default MCP list.
+    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities.mcp``.
+    These are merged by ``server_code`` onto the AICoding engine default MCP list.
     """
 
     def resolve(
@@ -49,10 +49,7 @@ class AicodingMcpDefaultsResolver:
         ).template_config
         if template_config is None:
             return []
-        template_body = template_config.get("template_config")
-        if not isinstance(template_body, Mapping):
-            return []
-        bot_template_config = template_body.get("bot_template_config")
+        bot_template_config = template_config.get("bot_template_config")
         if not isinstance(bot_template_config, Mapping):
             return []
         preset_capabilities = bot_template_config.get("preset_capabilities")

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -285,22 +285,20 @@ def test_default_cli_items_returns_copy():
 
 def test_template_config_mcps_append_and_override_defaults():
     template_config = {
-        "template_config": {
-            "bot_template_config": {
-                "preset_capabilities": {
-                    "mcp": [
-                        {
-                            "server_code": "mcp.ant.arkai.dimamcpserver",
-                            "name": "Template Dima",
-                            "description": "template override",
-                        },
-                        {
-                            "server_code": "mcp.ant.custom.template.server",
-                            "name": "Template Custom",
-                            "description": "template appended",
-                        },
-                    ]
-                }
+        "bot_template_config": {
+            "preset_capabilities": {
+                "mcp": [
+                    {
+                        "server_code": "mcp.ant.arkai.dimamcpserver",
+                        "name": "Template Dima",
+                        "description": "template override",
+                    },
+                    {
+                        "server_code": "mcp.ant.custom.template.server",
+                        "name": "Template Custom",
+                        "description": "template appended",
+                    },
+                ]
             }
         }
     }
@@ -316,6 +314,36 @@ def test_template_config_mcps_append_and_override_defaults():
     assert overridden["description"] == "template override"
     appended = next(s for s in servers if s["server_code"] == "mcp.ant.custom.template.server")
     assert appended["name"] == "Template Custom"
+
+
+def test_resolved_template_config_mcps_append_defaults():
+    template_config = {
+        "template_key": "mcptest",
+        "bot_template_config": {
+            "preset_capabilities": {
+                "mcp": [
+                    {
+                        "server_code": "mcp.ant.agentix.112858.baishitong",
+                        "name": "Aix 安全百事通",
+                        "description": "Aix 安全百事通",
+                    },
+                    {
+                        "server_code": "mcp.ant.productai.product-query-tool",
+                        "name": "找产品、找人、找服务、找文档",
+                        "description": "产品星球提供的：找产品、找人、找服务、找文档(语雀)、语雀文档URL解析等。",
+                    },
+                ]
+            }
+        },
+    }
+
+    codes = get_default_mcp_server_codes(
+        "aicoding",
+        ext_info={"aicoding": {"template_config": template_config}},
+    )
+
+    assert "mcp.ant.agentix.112858.baishitong" in codes
+    assert "mcp.ant.productai.product-query-tool" in codes
 
 
 def test_template_config_top_level_mcp_presets_are_ignored():
@@ -335,7 +363,7 @@ def test_template_config_top_level_mcp_presets_are_ignored():
     )
 
 
-def test_template_config_without_bot_template_config_mcp_presets_are_ignored():
+def test_legacy_wrapped_template_config_mcp_presets_are_ignored():
     template_config = {
         "template_config": {
             "preset_capabilities": {
@@ -356,17 +384,15 @@ def test_template_config_without_bot_template_config_mcp_presets_are_ignored():
 
 def test_template_config_mcp_presets_are_aicoding_specific():
     template_config = {
-        "template_config": {
-            "bot_template_config": {
-                "preset_capabilities": {
-                    "mcp": [
-                        {
-                            "server_code": "mcp.ant.custom.template.server",
-                            "name": "Template Custom",
-                            "description": "template appended",
-                        }
-                    ]
-                }
+        "bot_template_config": {
+            "preset_capabilities": {
+                "mcp": [
+                    {
+                        "server_code": "mcp.ant.custom.template.server",
+                        "name": "Template Custom",
+                        "description": "template appended",
+                    }
+                ]
             }
         }
     }
@@ -384,16 +410,14 @@ def test_template_config_mcp_presets_are_aicoding_specific():
 
 def test_claude_code_coding_template_uses_aicoding_mcp_bucket():
     template_config = {
-        "template_config": {
-            "bot_template_config": {
-                "preset_capabilities": {
-                    "mcp": [
-                        {
-                            "server_code": "mcp.ant.custom.template.server",
-                            "name": "Template Custom",
-                        }
-                    ]
-                }
+        "bot_template_config": {
+            "preset_capabilities": {
+                "mcp": [
+                    {
+                        "server_code": "mcp.ant.custom.template.server",
+                        "name": "Template Custom",
+                    }
+                ]
             }
         }
     }
@@ -412,16 +436,14 @@ def test_claude_code_coding_template_uses_aicoding_mcp_bucket():
 
 def test_claude_code_template_factory_non_normal_uses_aicoding_mcp_bucket():
     template_config = {
-        "template_config": {
-            "bot_template_config": {
-                "preset_capabilities": {
-                    "mcp": [
-                        {
-                            "server_code": "mcp.ant.custom.template.server",
-                            "name": "Template Custom",
-                        }
-                    ]
-                }
+        "bot_template_config": {
+            "preset_capabilities": {
+                "mcp": [
+                    {
+                        "server_code": "mcp.ant.custom.template.server",
+                        "name": "Template Custom",
+                    }
+                ]
             }
         }
     }


### PR DESCRIPTION
## Summary
- read AICoding template MCP defaults from resolved template_config.bot_template_config.preset_capabilities.mcp
- remove legacy nested template_config lookup
- add coverage for the resolved upstream template_config payload

## Tests
- uv run pytest tests/community/core/mcp/test_defaults_per_engine.py -q