### PR TITLE
fix(bot-collaborator): sync admins to both draft and online containers

### DIFF
--- a/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/spec.md
+++ b/src/backend/specs/2026-08-06-teclaw-publish-seed-admins-credentials/spec.md
@@ -94,11 +94,15 @@ restart/re-publish needed.
       and seed replay-converges: re-entering the ACTIVE binding replays both, and
       both are idempotent (token = REPLACE; `.credentials` = read-modify-write).
 - [ ] When a collaborator admin is added/removed on an already-published teclaw
-      service bot, `on_collaboration_changed` resolves the bot's **online**
-      binding (`get_latest_success_by_source_bot_id` → `ext.binding.online` →
-      `resolve_for_binding`) and updates the running container's `.credentials`
-      `ADMINS=` line. Because the engine hot-reloads `.credentials`, the change
-      takes effect immediately — no restart/re-publish.
+      service bot, `on_collaboration_changed` syncs `ADMINS=` to **every running
+      container** of the bot: the draft binding (`ac_bots.binding_id` via
+      `resolve_for_bot`) AND the online binding (`ext.binding.online` via
+      `resolve_for_binding`), independently (each error swallowed). A
+      published-then-re-drafted bot has both containers live at once, so syncing
+      only one regressed the other (draft-only → online had no admins;
+      online-only → draft edits didn't reach the draft container). Because the
+      engine hot-reloads `.credentials`, the change takes effect immediately on
+      each container — no restart/re-publish.
 - [ ] Bots with no publish record (ARCA / personal / desktop) keep today's
       `resolve_for_bot` resolution and are byte-for-byte unchanged.
 - [ ] No mocking in the new/extended tests (per commit `da9bf087`); use real

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/credentials_admins_writer.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/credentials_admins_writer.py
@@ -180,30 +180,56 @@ class DeviceCredentialsAdminsWriter:
         self._write_for_binding(binding_id, bot_id, owner_id, admins)
 
     def sync_on_change(self, bot_id: str, owner_id: str, admins: List[str]) -> None:
-        """Update the running container's ``ADMINS=`` on a collaborator change.
+        """Sync ``ADMINS=`` to EVERY running container of the bot on a change.
 
-        Service bot → resolve the online binding (``ext.binding.online``) and
-        write via ``resolve_for_binding``; otherwise fall back to
-        ``resolve_for_bot`` (ARCA/personal/desktop). All errors are swallowed
-        (warned) — a collaborator change must never break the main flow.
+        A published-then-re-drafted bot has two running containers at once: the
+        draft (``ac_bots.binding_id``, resolved via ``resolve_for_bot``) and the
+        online (``ext.binding.online``, resolved via ``resolve_for_binding``).
+        Syncing only one regresses the other: draft-only left the online container
+        without admins (the original bug), and online-only skipped the draft
+        container so draft-state admin edits didn't take effect. So write to both,
+        independently — each error is swallowed (a collaborator change must never
+        break the main flow).
+
+        For bots with no publish record (personal/desktop/ARCA-instance) there is
+        no online binding, so only the ``resolve_for_bot`` leg runs (today's
+        behavior).
+        """
+        self._write_safe(
+            "draft", lambda: self._write_for_bot(bot_id, owner_id, admins), bot_id
+        )
+        online_binding_id = self._resolve_online_binding_id(bot_id)
+        if online_binding_id is not None:
+            self._write_safe(
+                "online",
+                lambda: self._write_for_binding(
+                    online_binding_id, bot_id, owner_id, admins
+                ),
+                bot_id,
+            )
+
+    def _write_safe(
+        self, target: str, write: "Callable[[], None]", bot_id: str
+    ) -> None:
+        """Run one credentials write, swallowing any error.
+
+        info on no-running-device (draft/online binding not active), warn on
+        transport failure — never let a .credentials write break the collaborator
+        change main flow.
         """
         try:
-            online_binding_id = self._resolve_online_binding_id(bot_id)
-            if online_binding_id is not None:
-                self._write_for_binding(online_binding_id, bot_id, owner_id, admins)
-            else:
-                self._write_for_bot(bot_id, owner_id, admins)
+            write()
         except (DeviceNotBoundError, UnknownProviderError) as e:
             logger.info(
-                "[credentials_admins_writer] bot 无运行设备，跳过 credentials 同步: "
+                "[credentials_admins_writer] %s 绑定无运行设备，跳过 credentials 同步: "
                 "bot_id=%s, reason=%s",
-                bot_id, e,
+                target, bot_id, e,
             )
         except Exception as e:  # noqa: BLE001 - 协作者变更主流程不可因写 .credentials 失败而中断
             logger.warning(
-                "[credentials_admins_writer] 同步 .credentials 失败(已忽略): "
+                "[credentials_admins_writer] 同步 %s .credentials 失败(已忽略): "
                 "bot_id=%s, error=%s",
-                bot_id, e,
+                target, bot_id, e,
             )
 
     # ── internals ──────────────────────────────────────────────────────────

--- a/src/backend/tests/community/core/bot_collaborator/test_credentials_admins_writer.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_credentials_admins_writer.py
@@ -241,10 +241,32 @@ def test_sync_on_change_service_bot_uses_online_binding():
 
     writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
 
-    # online binding resolved via resolve_for_binding (service bot has a publish record)
-    assert resolver.resolve_for_binding_calls == [(99, "owner-1", "bot-1")]
-    assert resolver.resolve_for_bot_calls == []
+    # service bot has a publish record → online binding (99) IS resolved, alongside
+    # the draft binding (ac_bots.binding_id via resolve_for_bot). Both legs run; see
+    # test_sync_on_change_dual_syncs_draft_and_online_for_republished_bot for the
+    # full two-container assertion.
+    assert (99, "owner-1", "bot-1") in resolver.resolve_for_binding_calls
+    assert resolver.resolve_for_bot_calls == [("bot-1", "owner-1")]
     assert "ADMINS=u1" in fs.write_calls[-1][1].decode()
+
+
+def test_sync_on_change_dual_syncs_draft_and_online_for_republished_bot():
+    # A published-then-re-drafted bot has TWO running containers: the draft
+    # (ac_bots.binding_id, via resolve_for_bot) and the online (ext.binding.online,
+    # via resolve_for_binding). A collaborator change must reach BOTH — syncing
+    # only the online one regresses draft-state admin edits.
+    fs = FakeDeviceFileSystem({_DEVICE_CREDENTIALS_PATH: _credentials()})
+    writer, resolver, dispatcher = _make_writer(fs=fs, admins=["u1"], online_binding_id=99)
+
+    writer.sync_on_change(bot_id="bot-1", owner_id="owner-1", admins=["u1"])
+
+    # draft binding (ac_bots.binding_id) AND online binding (99) both resolved
+    assert resolver.resolve_for_bot_calls == [("bot-1", "owner-1")]
+    assert resolver.resolve_for_binding_calls == [(99, "owner-1", "bot-1")]
+    # two writes — one per container — each with the ADMINS line
+    assert len(fs.write_calls) == 2
+    for _path, content in fs.write_calls:
+        assert "ADMINS=u1" in content.decode()
 
 
 def test_sync_on_change_no_publish_record_falls_back_to_resolve_for_bot():


### PR DESCRIPTION
sync_on_change resolved only the ONLINE binding (ext.binding.online), so a published-then-re-drafted bot — which runs a draft container (ac_bots.binding_id) and an online container at once — only got the admin change on the online side; draft-state admin edits stopped reaching the draft container. Write to BOTH bindings (draft via resolve_for_bot, online via resolve_for_binding), each independently swallowing errors, so every running container stays current. Bots with no publish record keep the resolve_for_bot leg only (unchanged).

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
