### PR TITLE
fix(baas): route open API messages to the same instance by canonical session id

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -65,6 +65,23 @@ DEFAULT_ADAPTER_PORT = 20003
 DEFAULT_REQUEST_TIMEOUT = 30
 DEFAULT_CONNECT_TIMEOUT = 10
 
+# openclaw 给持久化 session id 加的固定前缀; 路由亲和键必须对有无该前缀不敏感,
+# 否则同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递会哈希到不同实例。
+_AGENT_MAIN_PREFIX = "agent:main:"
+
+
+def _strip_agent_main_prefix(session_id: str) -> str:
+    """剥离前导 ``agent:main:`` 前缀,使设备路由亲和键对前缀有无不敏感。
+
+    openclaw 会在持久化/返回 session id 时加上 ``agent:main:`` 前缀,而 DingTalk 入站
+    携带的是裸 id;若直接把调用方原样传入的 session_id 作为 ``device_affinity`` 哈希,
+    同一会话两次调用(裸 id vs 带前缀 id)会命中不同实例。在构造亲和键处统一剥离前缀,
+    使两种形式哈希到同一设备。循环剥离以对重复前缀幂等。
+    """
+    while session_id.startswith(_AGENT_MAIN_PREFIX):
+        session_id = session_id[len(_AGENT_MAIN_PREFIX) :]
+    return session_id
+
 
 def _safe_client_msg(exc: Exception) -> str:
     """返回可安全外抛给客户端的异常消息(剥离 aiohttp 请求 url 等内部信息)。
@@ -818,11 +835,16 @@ class BaasBotService(BotService):
         if not tenant and binding_info.device_props:
             tenant = binding_info.device_props.get("tenant", "")
 
+        # 与 create_session 路径一致:剥离前导 agent:main: 前缀,使 send/inject 等
+        # API 路径的 device 路由对前缀有无不敏感(同一会话跨通道落到同一实例)。
+        affinity = (
+            _strip_agent_main_prefix(session_id) if session_id is not None else None
+        )
         return await self._resolve_ws_connection(
             bot_uuid,
             tenant,
             engine_type=binding_info.engine_type,
-            session_consistency_key=session_id,
+            session_consistency_key=affinity,
         )
 
     @staticmethod
@@ -1095,9 +1117,17 @@ class BaasBotService(BotService):
         run_id: str,
         session_id: str | None = None,
     ) -> str | None:
-        """Create consistency key for session routing."""
+        """Create consistency key for session routing.
+
+        The affinity key drives consistent-hash device routing, so it must be
+        stable for a conversation regardless of whether the caller supplied the
+        ``agent:main:`` prefix. A caller-supplied ``session_id`` is therefore
+        canonicalized by stripping a leading ``agent:main:`` so the DingTalk
+        path (raw id) and the Open API path (prefixed id) hash to the same
+        device. The persisted/returned session id contract is unchanged.
+        """
         if session_id is not None:
-            return session_id
+            return _strip_agent_main_prefix(session_id)
 
         if engine_type == "openclaw":
             # Fixed prefix 'agent:main:'

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -190,6 +190,111 @@ class TestCreateSessionTenantValidation:
             )
 
 
+class TestSessionRoutingAffinityPrefix:
+    """device_affinity 必须对 ``agent:main:`` 前缀不敏感。
+
+    同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递必须哈希到同一实例,
+    因此 ``_create_session_consistency_key`` 对非 None session_id 剥离前导 ``agent:main:``。
+    """
+
+    def test_prefixed_and_raw_collapse_to_same_affinity(self, service):
+        raw = "bcs-sess-123"
+        prefixed = f"agent:main:{raw}"
+        kwargs = dict(
+            engine_type="openclaw",
+            tc_bot_id=BOT_UUID,
+            user_id="u-1",
+            run_id="run-1",
+        )
+        assert (
+            service._create_session_consistency_key(session_id=raw, **kwargs)
+            == service._create_session_consistency_key(session_id=prefixed, **kwargs)
+            == raw
+        )
+
+    def test_non_prefix_id_unchanged(self, service):
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="plain-sess",
+            )
+            == "plain-sess"
+        )
+
+    def test_none_branch_synthetic_key_unchanged(self, service):
+        """session_id=None 的合成键保持不变,不动既有 first-call 路由 stickiness。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id=None,
+            )
+            == "agent:main:session:run-1:user:u-1"
+        )
+
+    def test_double_prefix_stripped_to_idempotent_form(self, service):
+        """重复 agent:main: 前缀应被完全剥离,亲和键对前缀次数幂等。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="agent:main:agent:main:X",
+            )
+            == "X"
+        )
+
+    def test_empty_after_strip(self, service):
+        """仅含前缀的退化 id 剥离后为空串(不致崩溃,固定哈希到某设备)。"""
+        assert (
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="agent:main:",
+            )
+            == ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_path_routes_raw_and_prefixed_to_same_device(
+        self, service, wss_resolver
+    ):
+        """send/inject 路径(_resolve_ws_connection_for_binding): 裸 id 与带前缀 id
+        应使下游 resolver 收到相同 device_affinity —— 本缺陷的实际承重路径。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+        binding = _make_binding_info()
+
+        affinities = []
+        for sid in ("bcs-sess-123", "agent:main:bcs-sess-123"):
+            await service._resolve_ws_connection_for_binding(binding, session_id=sid)
+            affinities.append(
+                wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs["device_affinity"]
+            )
+        assert affinities == ["bcs-sess-123", "bcs-sess-123"]
+
+    @pytest.mark.asyncio
+    async def test_send_path_none_session_id_routes_with_none_affinity(
+        self, service, wss_resolver
+    ):
+        """session_id=None 时 send 路由亲和键为 None(回退随机/无粘性),不报错。"""
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+        await service._resolve_ws_connection_for_binding(
+            _make_binding_info(), session_id=None
+        )
+        assert (
+            wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs["device_affinity"]
+            is None
+        )
+
+
 class TestCreateSessionBotResolution:
     """Bot resolution error handling in create_session."""
 


### PR DESCRIPTION
## Problem

A service bot deployed across multiple instances could be addressed over two
channels for the same conversation: an inbound chat channel that supplies the
conversation's session id **without** the `agent:main:` prefix, and the Bot
Chat Open API (`POST /openapi/v1/messages`, `POST /openapi/v1/chat`) where the
caller re-passes the persisted session id **with** the `agent:main:` prefix.

Device/instance selection uses consistent hashing on the session id
(`select_by_affinity` hashes `device_affinity` verbatim), and
`_create_session_consistency_key` returned the caller-supplied session id
as-is. As a result, the two calls for the same conversation hashed two
different strings (`<raw>` vs `agent:main:<raw>`) and landed on **different**
bot instances, splitting the conversation context.

## Solution

Canonicalize the routing affinity key by stripping a leading `agent:main:`
prefix from a caller-supplied `session_id` via a shared `_strip_agent_main_prefix`
helper, applied at both seams where a caller session id becomes
`device_affinity`:

- `BaasBotService._create_session_consistency_key` (the `create_session` path);
- `BaasBotService._resolve_ws_connection_for_binding` (the load-bearing path
  used by `send_message`, `send_message_stream`, and `inject_message`), which
  previously passed the raw caller `session_id` straight through as
  `device_affinity`.

So both the create and the send path hash the raw and the prefixed form to the
same device. The generic consistent-hash selector is left untouched. The
persisted/returned session id contract is unchanged — only routing is made
prefix-insensitive. The `session_id is None` branch (synthetic first-call key
for openclaw) is intentionally left unchanged to avoid disturbing existing
first-call routing.

Engine scope: only openclaw is meaningfully affected (it is the only engine
that adds `agent:main:`). teclaw never uses the prefix, so the helper is a
no-op there. aicoding/hermes/claude_code use the adapter
`session_consistency_key` path and are not touched by this change.

Rejected alternative: normalizing at the inbound routers would require
duplicating the rule across the Open API and gateway entry points and would
still miss any other caller; centralizing at the affinity-key construction
seams covers every caller with one helper.

## Validation

- New unit tests `TestSessionRoutingAffinityPrefix` assert that
  `_create_session_consistency_key` returns the same key for `"<raw>"` and
  `"agent:main:<raw>"`, that a non-prefixed id is unchanged, that the `None`
  synthetic key is unchanged, that a double prefix is fully stripped, and that
  the empty-after-strip edge case is handled.
- A send-path regression test asserts that `_resolve_ws_connection_for_binding`
  (the path used by `send_message`/`inject_message`) yields the same
  `device_affinity` at the resolver for a raw and a prefixed session id — the
  actual bug invariant.
- Focused suite: `tests/unit/core/service/bot_run/test_baas_service.py::TestSessionRoutingAffinityPrefix`,
  `tests/unit/core/service/bot_run/test_engine_dispatch_integration.py`,
  `tests/unit/core/service/bot_runtime/dispatcher/test_device_selector.py` — 24 passed.
- Affected-module regression: `tests/unit/core/service/bot_run/`,
  `tests/unit/core/service/bcn/`, `tests/unit/adapters/web/test_routing_chain.py` —
  895 passed (no regressions).
- Not run: integration / E2E / Singlebox. The affected path is a stateless
  deterministic hash, exercised equivalently at the unit level; no
  cross-module or deployment-level behavior requires E2E.

## Compatibility and risk

- No contract/schema/config change; the persisted and returned session id
  format is unchanged.
- Existing conversations that happened to route on a prefixed id will, after
  rollout, hash to the canonical (unprefixed) form and may move to a
  different instance once — this is the intended correction of the
  misrouting.
- The `session_id is None` first-call scenario for openclaw is not covered by
  this change (it was not the reported symptom); tracked as an independent
  residual.
- Adapter-based engines (aicoding/hermes/claude_code) use a separate
  `session_consistency_key` path and are out of scope for this fix.

## Rollback

Revert the single-method change; routing reverts to the previous
prefix-sensitive behavior with no data migration.