### PR TITLE
fix(engine): isolate subagent announce events by session

### DIFF
--- a/src/engine/src/engine/community/openclaw/client/gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/gateway_client.py
@@ -629,6 +629,7 @@ class OpenClawGatewayClient:
         expected_run_id = idempotency_key or uuid.uuid4().hex
         run_id: Optional[str] = expected_run_id
         allowed_run_ids: set[str] = {expected_run_id}
+        trusted_parent_session_keys: set[str] = {session_key}
         pending_early_final: Optional[EventFrame] = None
         emitted_non_terminal = False
         early_final_grace_seconds = _get_early_final_grace_seconds()
@@ -671,6 +672,40 @@ class OpenClawGatewayClient:
                     return False
             return True
 
+        def is_announce_event(payload: Dict[str, Any]) -> bool:
+            payload_run_id = payload.get("runId")
+            # Caller-provided foreground IDs may use an announce-like prefix;
+            # correlated run identity takes precedence over prefix classification.
+            return (
+                isinstance(payload_run_id, str)
+                and payload_run_id.startswith("announce:")
+                and payload_run_id not in allowed_run_ids
+                and payload_run_id != run_id
+            )
+
+        def remember_trusted_parent_session(payload: Dict[str, Any]) -> None:
+            payload_run_id = payload.get("runId")
+            payload_session_key = payload.get("sessionKey")
+            if (
+                is_announce_event(payload)
+                or not isinstance(payload_run_id, str)
+                or not payload_run_id
+                or not isinstance(payload_session_key, str)
+                or not payload_session_key
+            ):
+                return
+            if payload_run_id in allowed_run_ids or payload_run_id == run_id:
+                # COSEC: Only the correlated foreground run may establish
+                # the canonical parent session used to isolate announce events.
+                trusted_parent_session_keys.add(payload_session_key)
+
+        def announce_matches_parent_session(payload: Dict[str, Any]) -> bool:
+            payload_session_key = payload.get("sessionKey")
+            return (
+                isinstance(payload_session_key, str)
+                and payload_session_key in trusted_parent_session_keys
+            )
+
         def matches_current_stream(payload: Dict[str, Any]) -> bool:
             payload_run_id = payload.get("runId")
             if isinstance(payload_run_id, str) and payload_run_id:
@@ -678,8 +713,8 @@ class OpenClawGatewayClient:
                     return True
                 if payload_run_id.startswith("inject-"):
                     return True
-                if payload_run_id.startswith("announce:") and pending_announces > 0:
-                    return True
+                if is_announce_event(payload) and pending_announces > 0:
+                    return announce_matches_parent_session(payload)
                 if pending_early_final is not None and payload.get("state") not in ("final", "error", "aborted"):
                     payload_session_key = payload.get("sessionKey")
                     return payload_session_key == session_key
@@ -695,6 +730,13 @@ class OpenClawGatewayClient:
             if done:
                 return
             payload = event.payload or {}
+            remember_trusted_parent_session(payload)
+            if is_announce_event(payload) and not announce_matches_parent_session(payload):
+                # COSEC: Reject cross-session completion events before any
+                # pending counter or stream terminal state can be changed.
+                filter_drop_count += 1
+                log.info("[chat_stream][foreign_announce_drop]")
+                return
             if not matches_current_stream(payload):
                 filter_drop_count += 1
                 log.info("[chat_stream][filter_drop] %s", event_summary(event, payload))
@@ -751,7 +793,7 @@ class OpenClawGatewayClient:
                     payload["_source_event"] = event.event
                     event_queue.put_nowait(event)
                 elif pending_announces > 0:
-                    is_announce = isinstance(payload_run_id, str) and payload_run_id.startswith("announce:")
+                    is_announce = is_announce_event(payload)
                     if is_announce:
                         pending_announces -= 1
                     if is_announce and pending_announces <= 0:

--- a/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
+++ b/src/engine/src/engine/community/openclaw/client/tests/test_gateway_client.py
@@ -587,3 +587,333 @@ async def test_chat_stream_timeout_waiting_subagent_final(monkeypatch):
     assert events[0].get("stream") == "tool"
     assert events[1]["state"] == "error"
     assert events[1]["errorMessage"] == "Chat stream timeout"
+
+
+@pytest.mark.parametrize("foreign_state", ["delta", "final", "error", "aborted"])
+@pytest.mark.asyncio
+async def test_chat_stream_drops_foreign_session_announce(
+    monkeypatch,
+    foreign_state: str,
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    canonical_session_key = "agent:main:gfr_sess-current"
+    own_announce_run_id = "announce:v1:child-current:child-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": canonical_session_key,
+            "runId": "run-1",
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": canonical_session_key,
+            "runId": "run-1",
+            "state": "final",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-foreign",
+            "runId": "announce:v1:child-foreign:child-run",
+            "state": foreign_state,
+            "text": "foreign",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": canonical_session_key,
+            "runId": own_announce_run_id,
+            "state": "final",
+            "text": "own completion",
+        })
+        return ResponseFrame.ok_response("rid", {"runId": "run-1"})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="gfr_sess-current",
+            message="hello",
+            idempotency_key="run-1",
+        )
+    )
+
+    assert [event["runId"] for event in events] == ["run-1", own_announce_run_id]
+    assert events[-1]["state"] == "final"
+    assert events[-1]["text"] == "own completion"
+
+
+@pytest.mark.parametrize(
+    "foreign_payload",
+    [{}, {"sessionKey": None}, {"sessionKey": 123}],
+)
+@pytest.mark.asyncio
+async def test_chat_stream_drops_announce_with_invalid_session_key(
+    monkeypatch,
+    foreign_payload: Dict[str, object],
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    own_announce_run_id = "announce:v1:child-current:child-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": "sk-1",
+            "runId": "run-1",
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            **foreign_payload,
+            "runId": "announce:v1:malformed:child-run",
+            "state": "error",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "sk-1",
+            "runId": own_announce_run_id,
+            "state": "final",
+        })
+        return ResponseFrame.ok_response("rid", {"runId": "run-1"})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="sk-1",
+            message="hello",
+            idempotency_key="run-1",
+        )
+    )
+
+    assert [event["runId"] for event in events] == ["run-1", own_announce_run_id]
+    assert events[-1]["state"] == "final"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_does_not_learn_parent_session_from_untrusted_run(monkeypatch):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    own_announce_run_id = "announce:v1:child-current:child-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": "sk-1",
+            "runId": "run-1",
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:foreign-session",
+            "runId": "untrusted-run",
+            "state": "delta",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:foreign-session",
+            "runId": "announce:v1:foreign-child:child-run",
+            "state": "final",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "sk-1",
+            "runId": own_announce_run_id,
+            "state": "final",
+        })
+        return ResponseFrame.ok_response("rid", {"runId": "run-1"})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="sk-1",
+            message="hello",
+            idempotency_key="run-1",
+        )
+    )
+
+    assert [event["runId"] for event in events] == ["run-1", own_announce_run_id]
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_does_not_treat_trusted_announce_prefixed_run_as_subagent_announce(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    foreground_run_id = "announce:caller-controlled-foreground-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": foreground_run_id,
+            "state": "final",
+            "text": "done",
+        })
+        return ResponseFrame.ok_response("rid", {"runId": foreground_run_id})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="gfr_sess-current",
+            message="hello",
+            idempotency_key=foreground_run_id,
+        )
+    )
+
+    assert len(events) == 1
+    assert events[0]["runId"] == foreground_run_id
+    assert events[0]["state"] == "final"
+
+
+@pytest.mark.asyncio
+async def test_announce_prefixed_foreground_final_does_not_consume_pending_subagent(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    foreground_run_id = "announce:caller-controlled-foreground-run"
+    own_announce_run_id = "announce:v1:child-current:child-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": foreground_run_id,
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": foreground_run_id,
+            "state": "final",
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": own_announce_run_id,
+            "state": "final",
+            "text": "subagent completion",
+        })
+        return ResponseFrame.ok_response("rid", {"runId": foreground_run_id})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="gfr_sess-current",
+            message="hello",
+            idempotency_key=foreground_run_id,
+        )
+    )
+
+    assert [event["runId"] for event in events] == [
+        foreground_run_id,
+        own_announce_run_id,
+    ]
+    assert events[-1]["text"] == "subagent completion"
+
+
+@pytest.mark.parametrize("terminal_state", ["error", "aborted"])
+@pytest.mark.asyncio
+async def test_chat_stream_accepts_current_session_announce_hard_stop(
+    monkeypatch,
+    terminal_state: str,
+):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+    own_announce_run_id = "announce:v1:child-current:child-run"
+
+    async def fake_send_request(*_args, **_kwargs) -> ResponseFrame:
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": "run-1",
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": "agent:main:gfr_sess-current",
+            "runId": own_announce_run_id,
+            "state": terminal_state,
+        })
+        return ResponseFrame.ok_response("rid", {"runId": "run-1"})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    events = await _collect(
+        client.chat_stream(
+            session_key="gfr_sess-current",
+            message="hello",
+            idempotency_key="run-1",
+        )
+    )
+
+    assert [event["runId"] for event in events] == ["run-1", own_announce_run_id]
+    assert events[-1]["state"] == terminal_state
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_isolates_concurrent_parent_sessions(monkeypatch):
+    monkeypatch.setenv("OPENCLAW_EARLY_FINAL_GRACE_SECONDS", "0")
+    client = _make_client()
+
+    async def fake_send_request(_method, params=None, **_kwargs) -> ResponseFrame:
+        return ResponseFrame.ok_response("rid", {"runId": params["idempotencyKey"]})
+
+    client.send_request = fake_send_request  # type: ignore[method-assign]
+
+    async def collect(session_key: str, run_id: str) -> list[Dict[str, Any]]:
+        return await _collect(
+            client.chat_stream(
+                session_key=session_key,
+                message="hello",
+                idempotency_key=run_id,
+                timeout_ms=1_000,
+            )
+        )
+
+    stream_a = asyncio.create_task(collect("short-a", "run-a"))
+    stream_b = asyncio.create_task(collect("short-b", "run-b"))
+    for _ in range(100):
+        if len(client._event_listeners.get("chat", [])) == 2:
+            break
+        await asyncio.sleep(0.001)
+    assert len(client._event_listeners.get("chat", [])) == 2
+
+    for session_key, run_id in (
+        ("agent:main:short-a", "run-a"),
+        ("agent:main:short-b", "run-b"),
+    ):
+        _fire_event(client, "chat", {
+            "sessionKey": session_key,
+            "runId": run_id,
+            "state": "delta",
+            "stream": "tool",
+            "data": {"name": "sessions_spawn", "phase": "result", "isError": False},
+        })
+        _fire_event(client, "chat", {
+            "sessionKey": session_key,
+            "runId": run_id,
+            "state": "final",
+        })
+
+    _fire_event(client, "chat", {
+        "sessionKey": "agent:main:short-a",
+        "runId": "announce:v1:child-a:child-run",
+        "state": "final",
+    })
+    _fire_event(client, "chat", {
+        "sessionKey": "agent:main:short-b",
+        "runId": "announce:v1:child-b:child-run",
+        "state": "final",
+    })
+
+    events_a, events_b = await asyncio.gather(stream_a, stream_b)
+
+    assert [event["runId"] for event in events_a] == [
+        "run-a",
+        "announce:v1:child-a:child-run",
+    ]
+    assert [event["runId"] for event in events_b] == [
+        "run-b",
+        "announce:v1:child-b:child-run",
+    ]


### PR DESCRIPTION
## Summary

- learn the canonical parent session identity from correlated foreground events
- reject foreign or malformed `announce:*` events before they can change pending counters or terminate the active stream
- preserve caller-supplied `announce:*` foreground run IDs and the existing valid announce/error semantics

## Problem

OpenClaw gateway events are broadcast to concurrent chat stream listeners. The adapter previously accepted any `announce:*` event whenever the current stream had pending subagents, so a different session's final, error, or aborted event could prematurely finish the current frontend stream.

## Scope

This PR is the P0 cross-session isolation fix. It keeps the existing legacy pending counter behavior; exact per-child announce correlation remains a separate protocol enhancement.

## Testing

- Engine CI: `2314 passed, 5 deselected`; line coverage `92.87%`; changed executable line coverage `100% (22/22)`
- Focused gateway client regression suite after rebasing latest `dev`: `27 passed`
- `git diff --check` passed
- security review found no medium/high-severity issues