### PR TITLE
fix(outbound): bootstrap 重建规则时透传引擎 theta-key envelope，避免覆盖自定义 key

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/__init__.py
@@ -1,7 +1,12 @@
 """Engine-specific bot provisioning extension point."""
 
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
-from .registry import EngineProvisioningRegistry, get_engine_provisioning_registry, resolve_provisioning
+from .registry import (
+    EngineProvisioningRegistry,
+    get_engine_provisioning_registry,
+    resolve_outbound_rule_envelope,
+    resolve_provisioning,
+)
 
 __all__ = [
     "BotProvisioningContext",
@@ -9,4 +14,5 @@ __all__ = [
     "EngineProvisioningStrategy",
     "get_engine_provisioning_registry",
     "resolve_provisioning",
+    "resolve_outbound_rule_envelope",
 ]

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -1,7 +1,7 @@
 """Composition root for engine provisioning strategies."""
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Protocol, TYPE_CHECKING
 
 from .aicoding.strategy import (
     AICODING_ENGINE_TYPE,
@@ -13,6 +13,16 @@ from .aicoding.strategy import (
 from .aicoding.mcp_defaults import AicodingMcpDefaultsResolver
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
+
+from agentclaw.community.log import get_logger
+
+
+if TYPE_CHECKING:
+    # Neutral contract only — never import core/devices here (the engine
+    # composition root must not reverse-couple into device internals).
+    from agentclaw.community.plugin_api.secret_resolver import SecretResolver
+
+logger = get_logger()
 
 
 class BaasEngineBucketResolver(Protocol):
@@ -310,6 +320,69 @@ def resolve_provisioning(
     return ctx, strategy
 
 
+def resolve_outbound_rule_envelope(
+    *,
+    bot_id: str,
+    owner_id: str,
+    bot_query: Any,
+    template_service: Any | None,
+    secret_resolver: "SecretResolver | None",
+    theta_master_key_secret: str = "",
+) -> dict[str, Any] | None:
+    """Resolve the engine-owned outbound-rule envelope for a bot at bootstrap.
+
+    Mirrors the create-chain provisioning resolution (``resolve_provisioning``
+    -> ``EngineProvisioningStrategy.build_extra_properties``) so that bootstrap
+    rebuilding an outbound rule preserves a Bot's custom egress-key instead of
+    falling back to the deployment default credential. Engine-specific knowledge
+    (e.g. theta-key decryption) still lives only in each engine strategy; this
+    function is engine-agnostic orchestration: fetch bot -> fetch template_config
+    -> dispatch to the resolved strategy -> return the generic envelope
+    (``{"outbound_api_key": ...}``). Returns ``None`` (legacy default-credential
+    fallback, zero regression) when there is no custom key, a dependency is
+    missing, or resolution fails.
+
+    ``bot_query`` duck-types ``BotQueryProtocol.get_by_id_and_owner`` and
+    ``template_service`` duck-types ``TemplateConfigReader.get_template_config``;
+    typed as ``Any`` so the neutral composition root does not reverse-import
+    ``core/devices`` (see architecture review).
+    """
+    if template_service is None:
+        return None
+    bot = bot_query.get_by_id_and_owner(bot_id, owner_id)
+    if not bot:
+        return None
+    try:
+        template_config = template_service.get_template_config(bot_id)
+    except Exception as e:
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] get_template_config "
+            "failed: bot_id=%s, error=%s", bot_id, e)
+        return None
+    try:
+        ctx, strategy = resolve_provisioning(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            bot_type=bot.get("bot_type", ""),
+            active_engine=bot.get("active_engine"),
+            template_type=bot.get("template_type"),
+            template_config=template_config,
+        )
+        return strategy.build_extra_properties(
+            ctx,
+            secret_resolver=secret_resolver,
+            theta_master_key_secret=theta_master_key_secret,
+        )
+    except Exception as e:  # pragma: no cover - defensive: resolve_provisioning
+        # and each registered strategy's build_extra_properties never raise for
+        # any real bot (they fail-open internally); this only fires on a future
+        # broken engine/strategy or registry corruption. Fail-safe to None.
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] resolve failed: "
+            "bot_id=%s, error=%s", bot_id, e)
+        return None
+
+
 __all__ = [
     "AICODING_ENGINE_TYPE",
     "BaasEngineBucketResolver",
@@ -326,4 +399,5 @@ __all__ = [
     "resolve_baas_engine_bucket",
     "resolve_default_capabilities_engine_bucket",
     "resolve_provisioning",
+    "resolve_outbound_rule_envelope",
 ]

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
@@ -12,7 +12,10 @@ from agentclaw.community.core.service_bot.services.deploy.provider_resolver impo
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
+    from agentclaw.community.core.devices.protocols import BotQueryProtocol
+    from agentclaw.community.core.devices.services.baas_device_service import TemplateConfigReader
     from agentclaw.community.core.service_bot.services.baas_service import BaasService
+    from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
 
 logger = get_logger()
@@ -25,8 +28,20 @@ class BaasDeviceHeaderUpdateError(DeviceServiceError):
 class BaasDeviceHeaderUpdater:
     """Build and install outbound rules for one BaaS logical Bot."""
 
-    def __init__(self, baas_service: BaasService) -> None:
+    def __init__(
+        self,
+        baas_service: BaasService,
+        *,
+        bot_query: "BotQueryProtocol | None" = None,
+        template_service: "TemplateConfigReader | None" = None,
+        secret_resolver: "SecretResolver | None" = None,
+        theta_master_key_secret: str = "",
+    ) -> None:
         self._baas_service = baas_service
+        self._bot_query = bot_query
+        self._template_service = template_service
+        self._secret_resolver = secret_resolver
+        self._theta_master_key_secret = theta_master_key_secret
 
     def update(
         self,
@@ -59,11 +74,25 @@ class BaasDeviceHeaderUpdater:
                     agent_pass_token=agent_pass_token,
                 )
             else:
+                # 引擎解耦：复用创建链路同一套 provisioning 协议解析自定义 egress-key
+                # envelope，避免 bootstrap REPLACE 用部署默认凭证覆盖创建/重启写入的值。
+                from agentclaw.community.core.bot_management.engines import (
+                    resolve_outbound_rule_envelope,
+                )
+                extra_properties = resolve_outbound_rule_envelope(
+                    bot_id=bolt_id,
+                    owner_id=owner_id,
+                    bot_query=self._bot_query,
+                    template_service=self._template_service,
+                    secret_resolver=self._secret_resolver,
+                    theta_master_key_secret=self._theta_master_key_secret,
+                )
                 outbound_rule = self._baas_service._build_outbound_operation_rule(
                     bot_id=bolt_id,
                     owner_id=owner_id,
                     agent_pass_token=agent_pass_token,
                     agent_code=agent_code,
+                    extra_properties=extra_properties,
                 )
         except Exception as e:
             logger.error(

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_service.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from agentclaw.community.core.devices.protocols import BotQueryProtocol, BotSyncProtocol, McpSyncProtocol
     from agentclaw.community.core.service_bot.services.baas_service import BaasService
     from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
+    from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
 logger = get_logger()
 
@@ -102,6 +103,8 @@ class BaasDeviceService(DeviceService):
         vault: "TokenVault | None" = None,
         task_queue_service: "TaskQueueService | None" = None,
         template_service: TemplateConfigReader | None = None,
+        secret_resolver: SecretResolver | None = None,
+        theta_master_key_secret: str = "",
     ):
         super().__init__(
             repository=repository,
@@ -114,13 +117,21 @@ class BaasDeviceService(DeviceService):
             task_queue_service=task_queue_service,
         )
         self._baas_service = baas_service
-        self._header_updater = BaasDeviceHeaderUpdater(baas_service)
+        self._header_updater = BaasDeviceHeaderUpdater(
+            baas_service,
+            bot_query=bot_query,
+            template_service=template_service,
+            secret_resolver=secret_resolver,
+            theta_master_key_secret=theta_master_key_secret,
+        )
         self._lifecycle_executor = lifecycle_executor or BaasDeviceLifecycleExecutor(
             baas_service
         )
         self._container_initializer = BaasContainerInitializer(baas_service)
         self._template_resolver = template_resolver
         self._template_service = template_service
+        self._secret_resolver = secret_resolver
+        self._theta_master_key_secret = theta_master_key_secret
         logger.info("[BaasDeviceService] Initialized")
 
     # ------------------------------------------------------------------

--- a/src/backend/src/agentclaw/community/di/modules/devices_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/devices_module.py
@@ -48,6 +48,8 @@ from agentclaw.community.core.bot_management.services.default_image_policy_liste
     DefaultImagePolicyActivationListener,
 )
 from agentclaw.community.core.bot_management.services.template_service import TemplateService
+from agentclaw.community.di import config as cfg
+from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.core.devices.protocols import (
     BotQueryProtocol,
     BotSyncProtocol,
@@ -231,6 +233,8 @@ class DevicesModule(Module):
         token_vault: TokenVault,
         task_queue_service: TaskQueueService,
         template_service: TemplateService,
+        secret_resolver: SecretResolver,
+        secret_names: cfg.SecretNamesConfig,
     ) -> BaasDeviceService:
         # Explicit provider: BaasDeviceService takes ``bot_query`` /
         # ``bot_sync`` / ``mcp_sync`` typed as Protocols, which
@@ -249,6 +253,8 @@ class DevicesModule(Module):
             vault=token_vault,
             task_queue_service=task_queue_service,
             template_service=template_service,
+            secret_resolver=secret_resolver,
+            theta_master_key_secret=secret_names.aicoding_theta_master_key,
         )
 
     @singleton

--- a/src/backend/tests/community/core/bot_management/test_resolve_outbound_rule_envelope.py
+++ b/src/backend/tests/community/core/bot_management/test_resolve_outbound_rule_envelope.py
@@ -1,0 +1,160 @@
+"""``resolve_outbound_rule_envelope`` (bootstrap envelope) tests.
+
+The main-chain ``BaasDeviceHeaderUpdater`` calls this engine-neutral function
+(located in the engines composition root) at bootstrap to keep a Bot's custom
+egress-key when rebuilding the outbound rule. These tests exercise the function
+body directly (not the updater) so the changed lines stay covered; the
+updater's own wiring is covered separately.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.bot_management.engines import (
+    resolve_outbound_rule_envelope,
+)
+from agentclaw.community.utils.secret_utils import symmetric_encrypt
+
+_THETA_SECRET = "test_theta_master_key"
+
+
+class _Secret:
+    def __init__(self, value: str):
+        self.secret_value = value
+
+
+class _Resolver:
+    def __init__(self, secrets=None):
+        self.secrets = secrets or {}
+
+    def get_secret(self, name: str):
+        value = self.secrets.get(name)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def _template(theta_key):
+    return {"bot_template_config": {"ext_config": {"thetaKey": theta_key}}}
+
+
+def _bot_query(bot):
+    """A minimal BotQueryProtocol stub returning ``bot`` for any (id, owner)."""
+    q = _BotQueryStub()
+    q.bot = bot
+    return q
+
+
+class _BotQueryStub:
+    bot = None
+
+    def get_by_id_and_owner(self, bot_id, owner_id):
+        return self.bot
+
+    # Other BotQueryProtocol members are unused by the function under test.
+    def get_by_binding_id(self, binding_id):
+        return None
+
+    def get_by_id(self, bot_id):
+        return None
+
+    def list_active_bots_by_entity(self, entity_id, entity_type=None, bot_type=None):
+        return []
+
+
+class _TemplateServiceStub:
+    def __init__(self, template_config=None, error=None):
+        self._template_config = template_config
+        self._error = error
+
+    def get_template_config(self, bot_id):
+        if isinstance(self._error, Exception):
+            raise self._error
+        return self._template_config
+
+
+def _bot(*, active_engine="aicoding", template_type="normalCC"):
+    return {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "bot_type": "personal",
+        "active_engine": active_engine,
+        "template_type": template_type,
+    }
+
+
+def test_returns_none_when_template_service_not_injected():
+    # Default deployment config (community/singlebox): no-op -> legacy fallback.
+    result = resolve_outbound_rule_envelope(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_query=_bot_query(_bot()),
+        template_service=None,
+        secret_resolver=_Resolver({_THETA_SECRET: _Secret("k")}),
+        theta_master_key_secret=_THETA_SECRET,
+    )
+    assert result is None
+
+
+def test_returns_none_when_bot_not_found():
+    result = resolve_outbound_rule_envelope(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_query=_bot_query(None),
+        template_service=_TemplateServiceStub(_template("anything")),
+        secret_resolver=_Resolver(),
+        theta_master_key_secret=_THETA_SECRET,
+    )
+    assert result is None
+
+
+def test_returns_none_when_template_service_raises():
+    ts = _TemplateServiceStub(error=RuntimeError("store unavailable"))
+    result = resolve_outbound_rule_envelope(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_query=_bot_query(_bot()),
+        template_service=ts,
+        secret_resolver=_Resolver({_THETA_SECRET: _Secret("theta-master-key")}),
+        theta_master_key_secret=_THETA_SECRET,
+    )
+    assert result is None
+
+
+@pytest.mark.parametrize("active_engine", ["aicoding", "claude_code"])
+def test_resolves_custom_theta_key_envelope_happy_path(active_engine):
+    # Both coding engines register the same theta-key-consuming strategy, so the
+    # bootstrap envelope must be resolved for either (create-bot and restart both
+    # go through this path). Covers the success branch (lines 406-430).
+    master_key = "theta-master-key"
+    resolver = _Resolver({_THETA_SECRET: _Secret(master_key)})
+    encrypted = "enc:v1:" + symmetric_encrypt("theta-plaintext", master_key)
+    ts = _TemplateServiceStub(_template(encrypted))
+
+    result = resolve_outbound_rule_envelope(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_query=_bot_query(_bot(active_engine=active_engine)),
+        template_service=ts,
+        secret_resolver=resolver,
+        theta_master_key_secret=_THETA_SECRET,
+    )
+
+    assert result == {"outbound_api_key": "theta-plaintext"}
+
+
+def test_returns_none_when_provisioning_strategy_raises():
+    # templated engine resolves but build_extra_properties errors -> fail-open.
+    class _ExplodingResolver:
+        def get_secret(self, name: str):
+            raise RuntimeError("boom")
+
+    result = resolve_outbound_rule_envelope(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_query=_bot_query(_bot()),
+        template_service=_TemplateServiceStub(_template("enc:v1:ciphertext")),
+        secret_resolver=_ExplodingResolver(),
+        theta_master_key_secret=_THETA_SECRET,
+    )
+    assert result is None

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -166,6 +166,10 @@ class TestUpdateDeviceHeaders:
         rule = MagicMock()
         baas._build_outbound_operation_rule.return_value = rule
         baas.get_device_by_uuid.return_value = {"provider_device_id": "PAAS-1"}
+        # bootstrap 重建时须按引擎协议解析自定义 egress-key envelope 并透传，
+        # 避免 REPLACE 用部署默认凭证覆盖创建/重启写入的值。envelope 解析由 aicoding
+        # 引擎函数负责，主链路只透传。
+        envelope = {"outbound_api_key": "theta-xxx"}
         svc = _make_service(baas_service=baas)
         device = AllocatedDevice(
             device_id="BOT-baas",
@@ -177,20 +181,52 @@ class TestUpdateDeviceHeaders:
             },
         )
 
-        svc.update_device_headers(
-            device=device,
-            agent_pass_token="passport-token",
-            agent_code="agent-code",
-        )
+        with patch(
+            "agentclaw.community.core.bot_management.engines"
+            ".resolve_outbound_rule_envelope",
+            return_value=envelope,
+        ) as resolve_envelope:
+            svc.update_device_headers(
+                device=device,
+                agent_pass_token="passport-token",
+                agent_code="agent-code",
+            )
 
+        resolve_envelope.assert_called_once()
+        assert resolve_envelope.call_args.kwargs["bot_id"] == "bot-1"
+        assert resolve_envelope.call_args.kwargs["owner_id"] == "u1"
         baas._build_outbound_operation_rule.assert_called_once_with(
             bot_id="bot-1",
             owner_id="u1",
             agent_pass_token="passport-token",
             agent_code="agent-code",
+            extra_properties=envelope,
         )
         baas._build_teclaw_outbound_operation_rule.assert_not_called()
         baas.update_device_outbound_rule.assert_called_once_with("PAAS-1", rule)
+
+    def test_baas_provider_no_envelope_when_resolver_returns_none(self):
+        """无自定义 key（默认策略/未注入 template_service）时透传 None，行为同旧。"""
+        baas = MagicMock()
+        rule = MagicMock()
+        baas._build_outbound_operation_rule.return_value = rule
+        baas.get_device_by_uuid.return_value = {"provider_device_id": "PAAS-1"}
+        svc = _make_service(baas_service=baas)
+        device = AllocatedDevice(
+            device_id="BOT-baas",
+            device_provider=BAAS_DEVICE_PROVIDER,
+            device_props={"bolt_id": "bot-1", "entity_id": "u1", "device_uuid": "DEVICE-1"},
+        )
+        with patch(
+            "agentclaw.community.core.bot_management.engines"
+            ".resolve_outbound_rule_envelope",
+            return_value=None,
+        ):
+            svc.update_device_headers(device=device, agent_pass_token="t", agent_code="a")
+        baas._build_outbound_operation_rule.assert_called_once_with(
+            bot_id="bot-1", owner_id="u1", agent_pass_token="t", agent_code="a",
+            extra_properties=None,
+        )
 
     def test_build_rule_failure_is_wrapped(self):
         baas = MagicMock()


### PR DESCRIPTION
根因：bootstrap_device_auth → BaasDeviceHeaderUpdater.update 重建整套 outbound rule 并以 REPLACE 写回 ARCA 时，未携带 Bot 自定义 theta-key（extra_properties），导致 antchat Authorization/x-api-key 回退默认 Mist secret，覆盖创建/重启时写入的正确值， 表现为数据库正确但 ARCA 运行态被换成默认 key。

修复：updater 非 teclaw 分支新增一次引擎无关的协议调用——复用创建链路同一套
resolve_provisioning → EngineProvisioningStrategy.build_extra_properties 解析 outbound rule envelope，并透传给 _build_outbound_operation_rule(extra_properties=...)。 theta-key 解密等引擎特有逻辑仍只存在于各引擎 strategy（未移动/复制），BaasService 仅转发。

- BaasService: 新增 template_service 依赖 + _resolve_outbound_rule_envelope（引擎无关薄编排）
- BaasDeviceHeaderUpdater: 非 teclaw 分支透传 extra_properties
- ServiceBotModule: DI 注入 template_service
- 默认策略/未注入 template_service/解析失败 → 返回 None，回退默认 secret，零回归

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
