### PR TITLE
chore(outbound): add theta-key bootstrap diagnostics

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -4,6 +4,7 @@ All knowledge about coding template types, relay default envs and CodeFuse token
 provisioning lives here instead of being duplicated in bot/device/template
 services.
 """
+
 from __future__ import annotations
 
 import json
@@ -157,7 +158,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             template_config.get("template_key") and template_config.get("template_uid")
         )
         normalized_engine = cls.normalize_engine_type(active_engine, default="")
-        return normalized_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES and has_template_identity
+        return (
+            normalized_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES
+            and has_template_identity
+        )
 
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type
@@ -174,9 +178,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         # template-factory templates expose their template_type verbatim so new
         # template types do not require backend enum/map changes.
         if template_type:
-            envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(
-                template_type, template_type
-            )
+            envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(template_type, template_type)
 
         devflow_workflow = template_config.get("devflow_workflow", "")
         if isinstance(devflow_workflow, dict):
@@ -199,7 +201,11 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             if not isinstance(repos, list):
                 continue
             for repo in repos:
-                if isinstance(repo, str) and repo_key not in legacy_repo_keys and repo.strip():
+                if (
+                    isinstance(repo, str)
+                    and repo_key not in legacy_repo_keys
+                    and repo.strip()
+                ):
                     repo_list.append(repo.strip())
                 elif isinstance(repo, dict):
                     for url_key in ("repo_url", "url", "git_url", "ssh_url"):
@@ -252,30 +258,99 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             ctx.active_engine not in TEMPLATE_CONFIG_CONSUMING_ENGINES
             and ctx.template_type not in CODING_TEMPLATE_TYPES
         ):
+            logger.info(
+                "[AicodingProvisioningStrategy.build_extra_properties] skipped: "
+                "bot_id=%s, active_engine=%s, template_type=%s, "
+                "reason=unsupported_engine_or_template",
+                ctx.bot_id,
+                ctx.active_engine,
+                ctx.template_type,
+            )
             return None
 
         stored = self._get_template_value(ctx.template_config, _THETA_KEY_PATH)
-        if (
-            secret_resolver is None
-            or not theta_master_key_secret
-            or not isinstance(stored, str)
-            or not stored.startswith(_ENCRYPTED_VALUE_PREFIX)
-        ):
+        has_theta_key = isinstance(stored, str) and bool(stored)
+        has_encrypted_theta_key = isinstance(stored, str) and stored.startswith(
+            _ENCRYPTED_VALUE_PREFIX
+        )
+        logger.info(
+            "[AicodingProvisioningStrategy.build_extra_properties] input: "
+            "bot_id=%s, active_engine=%s, template_type=%s, "
+            "has_template_config=%s, has_theta_key=%s, "
+            "has_encrypted_theta_key=%s, has_secret_resolver=%s, "
+            "has_theta_master_key_secret=%s",
+            ctx.bot_id,
+            ctx.active_engine,
+            ctx.template_type,
+            isinstance(ctx.template_config, dict),
+            has_theta_key,
+            has_encrypted_theta_key,
+            secret_resolver is not None,
+            bool(theta_master_key_secret),
+        )
+        if secret_resolver is None:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=secret_resolver_missing",
+                ctx.bot_id,
+            )
             return None
-        ciphertext = stored[len(_ENCRYPTED_VALUE_PREFIX):]
+        if not theta_master_key_secret:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_master_key_secret_name_missing",
+                ctx.bot_id,
+            )
+            return None
+        if not has_encrypted_theta_key:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=encrypted_theta_key_missing_or_invalid",
+                ctx.bot_id,
+            )
+            return None
+
+        ciphertext = stored[len(_ENCRYPTED_VALUE_PREFIX) :]
         if not ciphertext:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_ciphertext_empty",
+                ctx.bot_id,
+            )
             return None
 
         try:
             secret = secret_resolver.get_secret(theta_master_key_secret)
             master_key = getattr(secret, "secret_value", secret) if secret else None
             if not master_key:
+                logger.warning(
+                    "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                    "bot_id=%s, reason=theta_master_secret_empty",
+                    ctx.bot_id,
+                )
                 return None
             api_key = secret_utils.symmetric_decrypt(ciphertext, str(master_key))
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_key_decrypt_failed, error_type=%s",
+                ctx.bot_id,
+                type(exc).__name__,
+            )
             return None
         if not isinstance(api_key, str) or not api_key:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=decrypted_theta_key_empty",
+                ctx.bot_id,
+            )
             return None
+
+        logger.info(
+            "[AicodingProvisioningStrategy.build_extra_properties] resolved: "
+            "bot_id=%s, custom_outbound_key_resolved=True",
+            ctx.bot_id,
+        )
         return {"outbound_api_key": api_key}
 
     def should_encrypt_template_token(self, ctx: BotProvisioningContext) -> bool:
@@ -361,7 +436,9 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         logger.info(
             "[aicoding.restart] persisted newer template snapshot: "
             "bot_id=%s old_version=%s new_version=%s",
-            ctx.bot_id, stored_version, incoming_version,
+            ctx.bot_id,
+            stored_version,
+            incoming_version,
         )
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -1,4 +1,5 @@
 """Composition root for engine provisioning strategies."""
+
 from __future__ import annotations
 
 from typing import Any, Protocol, TYPE_CHECKING
@@ -68,8 +69,6 @@ class BaasEngineBucketResolverRegistry:
         return normalized_engine
 
 
-
-
 class DefaultCapabilitiesEngineBucketResolver(Protocol):
     """Resolver that may map an engine context to a default-capabilities bucket."""
 
@@ -127,11 +126,14 @@ class McpDefaultsResolverRegistry:
 
     def register(self, engine_bucket: str, resolver: McpDefaultsResolver) -> None:
         if engine_bucket in self._resolvers:
-            raise ValueError(f"MCP defaults resolver already registered: {engine_bucket}")
+            raise ValueError(
+                f"MCP defaults resolver already registered: {engine_bucket}"
+            )
         self._resolvers[engine_bucket] = resolver
 
     def resolve(self, engine_bucket: str) -> McpDefaultsResolver | None:
         return self._resolvers.get(engine_bucket)
+
 
 class EngineProvisioningRegistry:
     def __init__(self) -> None:
@@ -205,7 +207,9 @@ def get_engine_provisioning_registry() -> EngineProvisioningRegistry:
     return _REGISTRY
 
 
-def _build_default_baas_engine_bucket_resolver_registry() -> BaasEngineBucketResolverRegistry:
+def _build_default_baas_engine_bucket_resolver_registry() -> (
+    BaasEngineBucketResolverRegistry
+):
     """Assemble the process-wide BaaS bucket resolver registry."""
     registry = BaasEngineBucketResolverRegistry()
     registry.register(AicodingBaasEngineBucketResolver())
@@ -244,7 +248,9 @@ def resolve_baas_engine_bucket(
     )
 
 
-def _build_default_capabilities_engine_bucket_resolver_registry() -> DefaultCapabilitiesEngineBucketResolverRegistry:
+def _build_default_capabilities_engine_bucket_resolver_registry() -> (
+    DefaultCapabilitiesEngineBucketResolverRegistry
+):
     """Assemble the process-wide default MCP/CLI bucket resolver registry."""
     registry = DefaultCapabilitiesEngineBucketResolverRegistry()
     registry.register(AicodingBaasEngineBucketResolver())
@@ -256,7 +262,9 @@ _DEFAULT_CAPABILITIES_ENGINE_BUCKET_RESOLVER_REGISTRY = (
 )
 
 
-def get_default_capabilities_engine_bucket_resolver_registry() -> DefaultCapabilitiesEngineBucketResolverRegistry:
+def get_default_capabilities_engine_bucket_resolver_registry() -> (
+    DefaultCapabilitiesEngineBucketResolverRegistry
+):
     """Return the process-wide default-capabilities bucket resolver registry."""
     return _DEFAULT_CAPABILITIES_ENGINE_BUCKET_RESOLVER_REGISTRY
 
@@ -347,39 +355,111 @@ def resolve_outbound_rule_envelope(
     typed as ``Any`` so the neutral composition root does not reverse-import
     ``core/devices`` (see architecture review).
     """
+    logger.info(
+        "[engines.resolve_outbound_rule_envelope] start: "
+        "bot_id=%s, owner_id=%s, has_template_service=%s, "
+        "has_secret_resolver=%s, has_theta_master_key_secret=%s",
+        bot_id,
+        owner_id,
+        template_service is not None,
+        secret_resolver is not None,
+        bool(theta_master_key_secret),
+    )
     if template_service is None:
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] fallback: "
+            "bot_id=%s, owner_id=%s, reason=template_service_missing",
+            bot_id,
+            owner_id,
+        )
         return None
+
     bot = bot_query.get_by_id_and_owner(bot_id, owner_id)
     if not bot:
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] fallback: "
+            "bot_id=%s, owner_id=%s, reason=bot_not_found",
+            bot_id,
+            owner_id,
+        )
         return None
+
+    active_engine = bot.get("active_engine")
+    template_type = bot.get("template_type")
     try:
         template_config = template_service.get_template_config(bot_id)
     except Exception as e:
         logger.warning(
             "[engines.resolve_outbound_rule_envelope] get_template_config "
-            "failed: bot_id=%s, error=%s", bot_id, e)
+            "failed: bot_id=%s, owner_id=%s, error=%s",
+            bot_id,
+            owner_id,
+            e,
+        )
         return None
+
+    logger.info(
+        "[engines.resolve_outbound_rule_envelope] context: "
+        "bot_id=%s, owner_id=%s, active_engine=%s, template_type=%s, "
+        "has_template_config=%s",
+        bot_id,
+        owner_id,
+        active_engine,
+        template_type,
+        isinstance(template_config, dict),
+    )
+
     try:
         ctx, strategy = resolve_provisioning(
             bot_id=bot_id,
             owner_id=owner_id,
             bot_type=bot.get("bot_type", ""),
-            active_engine=bot.get("active_engine"),
-            template_type=bot.get("template_type"),
+            active_engine=active_engine,
+            template_type=template_type,
             template_config=template_config,
         )
-        return strategy.build_extra_properties(
+        extra_properties = strategy.build_extra_properties(
             ctx,
             secret_resolver=secret_resolver,
             theta_master_key_secret=theta_master_key_secret,
         )
+        custom_outbound_key_resolved = bool(
+            isinstance(extra_properties, dict)
+            and extra_properties.get("outbound_api_key")
+        )
+        logger.info(
+            "[engines.resolve_outbound_rule_envelope] result: "
+            "bot_id=%s, owner_id=%s, strategy=%s, "
+            "custom_outbound_key_resolved=%s",
+            bot_id,
+            owner_id,
+            type(strategy).__name__,
+            custom_outbound_key_resolved,
+        )
+        if not custom_outbound_key_resolved:
+            logger.warning(
+                "[engines.resolve_outbound_rule_envelope] fallback: "
+                "bot_id=%s, owner_id=%s, active_engine=%s, "
+                "template_type=%s, reason=strategy_returned_no_custom_key, "
+                "has_secret_resolver=%s, has_theta_master_key_secret=%s",
+                bot_id,
+                owner_id,
+                active_engine,
+                template_type,
+                secret_resolver is not None,
+                bool(theta_master_key_secret),
+            )
+        return extra_properties
     except Exception as e:  # pragma: no cover - defensive: resolve_provisioning
         # and each registered strategy's build_extra_properties never raise for
         # any real bot (they fail-open internally); this only fires on a future
         # broken engine/strategy or registry corruption. Fail-safe to None.
         logger.warning(
             "[engines.resolve_outbound_rule_envelope] resolve failed: "
-            "bot_id=%s, error=%s", bot_id, e)
+            "bot_id=%s, error=%s",
+            bot_id,
+            e,
+        )
         return None
 
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
@@ -13,7 +13,9 @@ from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.protocols import BotQueryProtocol
-    from agentclaw.community.core.devices.services.baas_device_service import TemplateConfigReader
+    from agentclaw.community.core.devices.services.baas_device_service import (
+        TemplateConfigReader,
+    )
     from agentclaw.community.core.service_bot.services.baas_service import BaasService
     from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
@@ -70,8 +72,10 @@ class BaasDeviceHeaderUpdater:
 
         try:
             if device.device_provider == TECLAW_DEVICE_PROVIDER:
-                outbound_rule = self._baas_service._build_teclaw_outbound_operation_rule(
-                    agent_pass_token=agent_pass_token,
+                outbound_rule = (
+                    self._baas_service._build_teclaw_outbound_operation_rule(
+                        agent_pass_token=agent_pass_token,
+                    )
                 )
             else:
                 # 引擎解耦：复用创建链路同一套 provisioning 协议解析自定义 egress-key
@@ -79,6 +83,7 @@ class BaasDeviceHeaderUpdater:
                 from agentclaw.community.core.bot_management.engines import (
                     resolve_outbound_rule_envelope,
                 )
+
                 extra_properties = resolve_outbound_rule_envelope(
                     bot_id=bolt_id,
                     owner_id=owner_id,
@@ -86,6 +91,18 @@ class BaasDeviceHeaderUpdater:
                     template_service=self._template_service,
                     secret_resolver=self._secret_resolver,
                     theta_master_key_secret=self._theta_master_key_secret,
+                )
+                logger.info(
+                    "[BaasDeviceHeaderUpdater.update] outbound envelope: "
+                    "device_id=%s, bolt_id=%s, owner_id=%s, "
+                    "custom_outbound_key_resolved=%s",
+                    device.device_id,
+                    bolt_id,
+                    owner_id,
+                    bool(
+                        isinstance(extra_properties, dict)
+                        and extra_properties.get("outbound_api_key")
+                    ),
                 )
                 outbound_rule = self._baas_service._build_outbound_operation_rule(
                     bot_id=bolt_id,
@@ -162,10 +179,12 @@ class BaasDeviceHeaderUpdater:
             f"device_id={device.device_id}, device_uuid={device_uuid}, "
             f"paas_device_id={paas_device_id}"
         )
-        return [{
-            "baas_device_uuid": device_uuid,
-            "paas_device_id": paas_device_id,
-        }]
+        return [
+            {
+                "baas_device_uuid": device_uuid,
+                "paas_device_id": paas_device_id,
+            }
+        ]
 
     def _update_bot_devices(
         self,
@@ -200,10 +219,12 @@ class BaasDeviceHeaderUpdater:
                 paas_device_id,
                 outbound_rule,
             )
-            updated_devices.append({
-                "device_uuid": device_uuid,
-                "paas_device_id": paas_device_id,
-            })
+            updated_devices.append(
+                {
+                    "device_uuid": device_uuid,
+                    "paas_device_id": paas_device_id,
+                }
+            )
             logger.info(
                 f"[BaasDeviceHeaderUpdater.update] Device updated: "
                 f"device_id={device.device_id}, device_uuid={device_uuid}, "


### PR DESCRIPTION
## Problem

The BaaS bootstrap flow rebuilds and replaces the full outbound rule after a sandbox starts. When a Bot has a custom encrypted theta-key, current logs only show the final `extra_api_key_applied` result and do not identify why the bootstrap envelope resolved to `None`.

This makes it difficult to distinguish among deployment/version drift, missing dependency injection, Bot/template lookup failure, unsupported engine metadata, missing encrypted template data, missing secret configuration, and decryption failure. The existing fail-open behavior then silently falls back to the deployment default credential.

## Solution

Add secret-safe diagnostics across the bootstrap outbound-key resolution path:

- log entry and dependency-presence flags in `resolve_outbound_rule_envelope`;
- log Bot/template context and the selected provisioning strategy;
- log explicit, machine-searchable fallback reasons for missing dependencies, missing Bot data, template failures, strategy fallback, missing encrypted theta-key, missing master secret, and decryption failure;
- log whether `BaasDeviceHeaderUpdater` received a resolved custom outbound key before rebuilding the outbound rule.

The logs only report booleans, engine/template metadata, strategy type, and exception type. They do not print the theta-key plaintext, encrypted value, master secret name/value, or resolved outbound API key.

## Validation

- `uv run pytest tests/community/core/bot_management/test_resolve_outbound_rule_envelope.py tests/community/core/devices/services/test_baas_device_service.py -q`
  - 87 passed
- `uv run ruff check` on the three changed Python files
  - passed
- `uv run ruff format --check` on the three changed Python files
  - passed
- `git diff --check`
  - passed

## Compatibility and risk

No API, persistence, configuration, outbound-rule, or secret-resolution behavior changes. This change only adds diagnostic logging around existing decisions. Rollback is a single commit revert.
