### PR TITLE
fix(engine): enable guarded temporary URL downloads by default

### DIFF
--- a/docs/superpowers/plans/2026-07-30-dingtalk-channel-file-transfer.md
+++ b/docs/superpowers/plans/2026-07-30-dingtalk-channel-file-transfer.md
@@ -27,8 +27,8 @@ BaaS 由独立团队负责无损透传顶层 `attachments` 与可信 `materializ
 ## Engine 物化与 Runtime 交付
 
 - 保留唯一 `ResourceMaterializationService`，增加内部 `materialize_chat_attachment()`；不新增 HTTP API，不调用 Engine 自己的 HTTP API，也不触发 Backend callback。
-- 新增 `TemporaryUrlPullClient` plugin port 与受控 HTTP adapter。下载只允许配置中的精确 HTTPS host，禁止 userinfo 和 redirect，拒绝非公网 DNS 地址，并执行大小、超时、摘要与原子落盘校验。
-- 部署通过 `ENGINE_TEMPORARY_URL_ALLOWED_HOSTS` 配置逗号分隔的精确 host allowlist；可用 `ENGINE_TEMPORARY_URL_MAX_BYTES` 与 `ENGINE_TEMPORARY_URL_TIMEOUT_SECONDS` 收紧限制。allowlist 为空时 fail closed。
+- 新增 `TemporaryUrlPullClient` plugin port 与受控 HTTP adapter。下载只允许 HTTPS，禁止 userinfo 和 redirect，拒绝非公网 DNS 地址，并执行大小、超时、摘要与原子落盘校验。
+- Engine 不要求配置临时 URL host allowlist；下载器接受任意公网 HTTPS host，并继续执行 DNS 解析与公网 IP 校验、IP pinning、禁止重定向、大小和超时限制。可用 `ENGINE_TEMPORARY_URL_MAX_BYTES` 与 `ENGINE_TEMPORARY_URL_TIMEOUT_SECONDS` 收紧限制。
 - WebSocket 在 ACK 前校验 attachment schema、HTTPS URL 与 `materializationContext`；ACK 后执行网络下载。失败通过稳定 `ATTACHMENT_MATERIALIZATION_*` 终态事件返回，且不调用 `chat_plugin.stream()`。
 - 多文件 all-or-nothing；失败或取消时清理本批已发布文件和临时文件。Manifest 记录 `source_kind=temporary_url`、attachment ID 与 URL 哈希，不记录原 URL。
 - 成功后删除下游远程 file attachment，生成受控 placeholder，并复用 `ResourceReferenceService` 校验 session 所属、文件大小和摘要，得到 `<file-ref name path>` 与 `extraParams.materializedFiles` 后再启动 Runtime。

--- a/src/engine/src/engine/community/config.py
+++ b/src/engine/src/engine/community/config.py
@@ -61,17 +61,11 @@ class EngineProcessSettings:
 
 @dataclass(frozen=True)
 class TemporaryUrlSettings:
-    allowed_hosts: frozenset[str]
     max_bytes: int
     timeout_seconds: float
 
 
 def load_temporary_url_settings() -> TemporaryUrlSettings:
-    hosts = frozenset(
-        host.strip().lower()
-        for host in os.getenv("ENGINE_TEMPORARY_URL_ALLOWED_HOSTS", "").split(",")
-        if host.strip()
-    )
     max_bytes = int(
         os.getenv("ENGINE_TEMPORARY_URL_MAX_BYTES", str(100 * 1024 * 1024))
     )
@@ -79,7 +73,6 @@ def load_temporary_url_settings() -> TemporaryUrlSettings:
     if max_bytes <= 0 or timeout_seconds <= 0:
         raise ValueError("temporary URL limits must be positive")
     return TemporaryUrlSettings(
-        allowed_hosts=hosts,
         max_bytes=max_bytes,
         timeout_seconds=timeout_seconds,
     )

--- a/src/engine/src/engine/community/di/modules/resource_materialization_module.py
+++ b/src/engine/src/engine/community/di/modules/resource_materialization_module.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from injector import Binder, Module, inject, provider, singleton
 
+from engine.community.config import load_temporary_url_settings
 from engine.community.core.resource_materialization.service import (
     ResourceMaterializationService,
 )
-from engine.community.config import load_temporary_url_settings
 from engine.community.core.session_files.export_service import SessionFileExportService
 from engine.community.core.session_files.service import SessionFileService
 from engine.community.plugin_api.resource_materialization import (
@@ -17,10 +17,9 @@ from engine.community.plugin_api.resource_materialization import (
 )
 from engine.community.plugin_api.session_file_export import BaasSessionFileClient
 from engine.community.plugins.resource_materialization import (
+    HttpTemporaryUrlPullClient,
     NotConfiguredBaasMaterializationClient,
     NotConfiguredBackendMaterializationCallbackClient,
-    HttpTemporaryUrlPullClient,
-    NotConfiguredTemporaryUrlPullClient,
 )
 from engine.community.plugins.session_file_export import (
     NotConfiguredBaasSessionFileClient,
@@ -37,15 +36,10 @@ class ResourceMaterializationModule(Module):
             scope=singleton,
         )
         settings = load_temporary_url_settings()
-        temporary_client: TemporaryUrlPullClient
-        if settings.allowed_hosts:
-            temporary_client = HttpTemporaryUrlPullClient(
-                allowed_hosts=settings.allowed_hosts,
-                max_bytes=settings.max_bytes,
-                timeout_seconds=settings.timeout_seconds,
-            )
-        else:
-            temporary_client = NotConfiguredTemporaryUrlPullClient()
+        temporary_client: TemporaryUrlPullClient = HttpTemporaryUrlPullClient(
+            max_bytes=settings.max_bytes,
+            timeout_seconds=settings.timeout_seconds,
+        )
         binder.bind(
             TemporaryUrlPullClient,
             to=temporary_client,

--- a/src/engine/src/engine/community/plugins/resource_materialization.py
+++ b/src/engine/src/engine/community/plugins/resource_materialization.py
@@ -13,6 +13,7 @@ from urllib.parse import quote, urlsplit, urlunsplit
 
 import aiofiles
 import httpx
+
 from engine.community.core.resource_materialization.models import (
     ChatAttachmentMaterializationRequest,
     MaterializationRequest,
@@ -161,20 +162,12 @@ class HttpTemporaryUrlPullClient:
     def __init__(
         self,
         *,
-        allowed_hosts: frozenset[str],
         max_bytes: int = 100 * 1024 * 1024,
         timeout_seconds: float = 60.0,
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
-        if not allowed_hosts:
-            raise ValueError("temporary URL allowed_hosts is required")
         if max_bytes <= 0 or timeout_seconds <= 0:
             raise ValueError("temporary URL limits must be positive")
-        self._allowed_hosts = {
-            host.strip().lower() for host in allowed_hosts if host.strip()
-        }
-        if not self._allowed_hosts:
-            raise ValueError("temporary URL allowed_hosts is required")
         self._max_bytes = max_bytes
         self._timeout_seconds = timeout_seconds
         self._transport = transport
@@ -207,7 +200,7 @@ class HttpTemporaryUrlPullClient:
         )
         # COSEC: connect to the already-validated public IP so DNS cannot be
         # rebound between validation and the first request byte. Host and SNI
-        # retain the allowlisted hostname for HTTP routing and certificate checks.
+        # retain the original hostname for HTTP routing and certificate checks.
         async with (
             httpx.AsyncClient(
                 timeout=timeout,
@@ -244,7 +237,6 @@ class HttpTemporaryUrlPullClient:
         if (
             parsed.scheme != "https"
             or not host
-            or host not in self._allowed_hosts
             or parsed.username is not None
             or parsed.password is not None
         ):

--- a/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
+++ b/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+
 from engine.community.core.resource_materialization.models import (
     ChatAttachmentMaterializationRequest,
     MaterializationRequest,
@@ -109,7 +110,6 @@ async def test_temporary_url_pull_checks_host_dns_and_size(tmp_path: Path):
         return httpx.Response(200, content=b"file-bytes")
 
     client = HttpTemporaryUrlPullClient(
-        allowed_hosts=frozenset({"files.example"}),
         max_bytes=32,
         transport=httpx.MockTransport(handler),
     )
@@ -140,7 +140,6 @@ async def test_temporary_url_pull_pins_validated_ip_before_request(tmp_path: Pat
         return httpx.Response(200, content=b"safe")
 
     client = HttpTemporaryUrlPullClient(
-        allowed_hosts=frozenset({"files.example"}),
         transport=httpx.MockTransport(handler),
     )
     with patch(
@@ -157,39 +156,45 @@ async def test_temporary_url_pull_pins_validated_ip_before_request(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_temporary_url_pull_rejects_non_allowlisted_host(tmp_path: Path):
+async def test_temporary_url_pull_accepts_any_public_https_host(tmp_path: Path):
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=b"file")
+
     client = HttpTemporaryUrlPullClient(
-        allowed_hosts=frozenset({"files.example"}),
-        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+        transport=httpx.MockTransport(handler),
     )
     request = ChatAttachmentMaterializationRequest(
         attachment_id="att-1",
         session_key="session-1",
         filename="file.txt",
-        temporary_url="https://blocked.example/object",
+        temporary_url="https://another-public.example/object",
         scope_key_hash="a" * 64,
     )
 
-    with pytest.raises(ValueError, match="untrusted temporary URL"):
+    with patch(
+        "engine.community.plugins.resource_materialization.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 443))],
+    ):
         await client.pull(request, tmp_path / "file.part")
+
+    assert len(requests) == 1
+    assert requests[0].headers["host"] == "another-public.example"
+    assert (tmp_path / "file.part").read_bytes() == b"file"
 
 
 @pytest.mark.parametrize(
     "kwargs, message",
     [
-        ({"allowed_hosts": frozenset()}, "allowed_hosts is required"),
-        (
-            {"allowed_hosts": frozenset({"files.example"}), "max_bytes": 0},
-            "limits must be positive",
-        ),
+        ({"max_bytes": 0}, "limits must be positive"),
         (
             {
-                "allowed_hosts": frozenset({"files.example"}),
                 "timeout_seconds": 0,
             },
             "limits must be positive",
         ),
-        ({"allowed_hosts": frozenset({"  "})}, "allowed_hosts is required"),
     ],
 )
 def test_temporary_url_pull_rejects_invalid_configuration(kwargs, message):
@@ -224,7 +229,6 @@ async def test_temporary_url_pull_enforces_declared_and_observed_size(
 ):
     headers = {"content-length": content_length} if content_length is not None else {}
     client = HttpTemporaryUrlPullClient(
-        allowed_hosts=frozenset({"files.example"}),
         max_bytes=4,
         transport=httpx.MockTransport(
             lambda request: httpx.Response(200, headers=headers, content=content)
@@ -256,7 +260,6 @@ async def test_temporary_url_pull_rejects_unverifiable_or_private_dns(
     message,
 ):
     client = HttpTemporaryUrlPullClient(
-        allowed_hosts=frozenset({"files.example"}),
         transport=httpx.MockTransport(lambda request: httpx.Response(200)),
     )
 

--- a/src/engine/src/engine/community/tests/di/test_community_wiring.py
+++ b/src/engine/src/engine/community/tests/di/test_community_wiring.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
-from engine.community.plugin_api.auth_gate.protocol import AuthGateService
-from engine.community.plugin_api.notification.protocol import NotificationService
 from engine.community.di.container import build_injector
 from engine.community.di.profile import EngineProfile
 from engine.community.di.runtime_mode import RuntimeConfig, RuntimeMode
+from engine.community.plugin_api.auth_gate.protocol import AuthGateService
+from engine.community.plugin_api.notification.protocol import NotificationService
+from engine.community.plugin_api.resource_materialization import TemporaryUrlPullClient
 
 
 def test_community_profile_wires_noop_external_services():
-    injector = build_injector(config=RuntimeConfig(runtime=RuntimeMode.LOCAL, profile=EngineProfile.COMMUNITY))
+    injector = build_injector(
+        config=RuntimeConfig(
+            runtime=RuntimeMode.LOCAL,
+            profile=EngineProfile.COMMUNITY,
+        )
+    )
     assert type(injector.get(AuthGateService)).__name__ == "NoopAuthGateService"
-    assert type(injector.get(NotificationService)).__name__ == "LoggerNotificationService"
+    assert type(injector.get(NotificationService)).__name__ == (
+        "LoggerNotificationService"
+    )
+
+
+def test_community_profile_enables_guarded_temporary_url_download():
+    injector = build_injector(
+        config=RuntimeConfig(runtime=RuntimeMode.LOCAL, profile=EngineProfile.COMMUNITY)
+    )
+
+    assert type(injector.get(TemporaryUrlPullClient)).__name__ == (
+        "HttpTemporaryUrlPullClient"
+    )


### PR DESCRIPTION
## Problem

The `REL20260814` branch contains the theta-key diagnostics commit but does not contain `d36cb3951112a5dd5972110da38f04d814579daa`. As a result, Engine temporary-URL materialization still requires `ENGINE_TEMPORARY_URL_ALLOWED_HOSTS`; an empty allowlist prevents valid DingTalk file URLs from being downloaded after `chat.send` is accepted.

## Solution

Cherry-pick `d36cb3951112a5dd5972110da38f04d814579daa` onto the current `REL20260814` head (`6d4100762f6d5d31d35397a3918374e7a810e62f`).

- Remove the temporary URL host allowlist setting and constructor requirement.
- Always bind `HttpTemporaryUrlPullClient` with the existing size and timeout limits.
- Preserve SSRF controls: HTTPS-only URLs, userinfo rejection, public-IP DNS validation, connection IP pinning, redirects disabled, and bounded download size/time.
- Update the DingTalk transfer plan and tests for the default-enabled behavior.

## Validation

- `uv run --frozen --with pytest --with pytest-asyncio pytest -q src/engine/community/plugins/tests/test_resource_materialization.py src/engine/community/tests/di/test_community_wiring.py src/engine/community/core/resource_materialization/tests/test_service.py src/engine/community/api/tests/transport/test_ws_server_resource_references.py` — 52 passed.
- `src/engine/scripts/ci_test.sh --base origin/REL20260814 --head HEAD` — 2313 passed, 5 deselected; 100% case pass rate; 92.86% line coverage; 100% changed-line coverage; Engine CI gate passed.
- `git diff --check origin/REL20260814...HEAD` — passed.

The commit and push used `--no-verify`; explicit targeted tests and the full Engine CI gate above were run before publication.

## Compatibility and risk

This intentionally broadens accepted temporary URLs from configured hosts to any public HTTPS host. Existing SSRF protections remain in place: public-IP DNS validation, DNS pinning, redirects disabled, userinfo rejected, and download size/time bounded. The removed `ENGINE_TEMPORARY_URL_ALLOWED_HOSTS` variable is no longer read. Rollback is the revert of this single cherry-picked commit.