### PR TITLE
feat(baas): pass the engine repo URL to install_engine.sh from the secret store

### DIFF
--- a/src/backend/src/agentclaw/community/api/baas_service.py
+++ b/src/backend/src/agentclaw/community/api/baas_service.py
@@ -86,6 +86,14 @@ class BaasServiceProtocol(Protocol):
         """Open a bot's working folder on the device side."""
         ...
 
+    def get_install_engine_repo_arg(self) -> str:
+        """Repo-URL argument for ``install_engine.sh`` (``" '<url>'"`` or ``""``).
+
+        The URL is a resolved secret; the empty string means "pass no argument",
+        which leaves the script on its own default repo.
+        """
+        ...
+
     def exec_command_on_bot(
         self,
         *,

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -140,8 +140,9 @@ user_config:
     env_prefix: "AGENTCLAW_SECRET_"
 
   # Secret-registry key NAMES the app resolves via SecretResolver. Left unset:
-  # the dormant-token feature uses a local fallback and git-sync degrades to its
-  # on-disk source when no repo-URL secret name is configured.
+  # the dormant-token feature uses a local fallback, git-sync degrades to its
+  # on-disk source when no repo-URL secret name is configured, and the engine
+  # install falls back to the repo baked into install_engine.sh's properties.
   # TODO(community): if you provision these secrets, register their names here.
   # A registered name is the BARE key, with no env prefix: CommunitySecretResolver
   # uppercases it and prepends `secret.env_prefix` itself, so a name already
@@ -151,10 +152,17 @@ user_config:
   #   secret_names:
   #     dormant_internal_token: "dormant_internal_token"   # gates /api/internal/dormant/*
   #     aiworkbench_repo_url: "aiworkbench_repo_url"       # skills source repo URL
+  #     engine_repo_url: "engine_repo_url"                 # engine source repo URL
   #
   # ...each read from "{env_prefix}{NAME}_VALUE", so with the prefix above:
   #     AGENTCLAW_SECRET_DORMANT_INTERNAL_TOKEN_VALUE
   #     AGENTCLAW_SECRET_AIWORKBENCH_REPO_URL_VALUE
+  #     AGENTCLAW_SECRET_ENGINE_REPO_URL_VALUE
+  #
+  # engine_repo_url is the repository install_engine.sh clones inside a sandbox.
+  # It is a secret because the URL carries an access token. Unset (the default),
+  # backend passes no repo argument and the script installs from the repo baked
+  # into its own properties file.
   #
   # The gateway principal signing key needs NO entry here — its name already
   # defaults in SecretNamesConfig, so a community deployment only exports the

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -4,6 +4,7 @@ All knowledge about coding template types, relay default envs and CodeFuse token
 provisioning lives here instead of being duplicated in bot/device/template
 services.
 """
+
 from __future__ import annotations
 
 import json
@@ -157,7 +158,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             template_config.get("template_key") and template_config.get("template_uid")
         )
         normalized_engine = cls.normalize_engine_type(active_engine, default="")
-        return normalized_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES and has_template_identity
+        return (
+            normalized_engine in TEMPLATE_CONFIG_CONSUMING_ENGINES
+            and has_template_identity
+        )
 
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         template_type = ctx.template_type
@@ -174,9 +178,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         # template-factory templates expose their template_type verbatim so new
         # template types do not require backend enum/map changes.
         if template_type:
-            envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(
-                template_type, template_type
-            )
+            envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(template_type, template_type)
 
         devflow_workflow = template_config.get("devflow_workflow", "")
         if isinstance(devflow_workflow, dict):
@@ -199,7 +201,11 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             if not isinstance(repos, list):
                 continue
             for repo in repos:
-                if isinstance(repo, str) and repo_key not in legacy_repo_keys and repo.strip():
+                if (
+                    isinstance(repo, str)
+                    and repo_key not in legacy_repo_keys
+                    and repo.strip()
+                ):
                     repo_list.append(repo.strip())
                 elif isinstance(repo, dict):
                     for url_key in ("repo_url", "url", "git_url", "ssh_url"):
@@ -252,30 +258,99 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             ctx.active_engine not in TEMPLATE_CONFIG_CONSUMING_ENGINES
             and ctx.template_type not in CODING_TEMPLATE_TYPES
         ):
+            logger.info(
+                "[AicodingProvisioningStrategy.build_extra_properties] skipped: "
+                "bot_id=%s, active_engine=%s, template_type=%s, "
+                "reason=unsupported_engine_or_template",
+                ctx.bot_id,
+                ctx.active_engine,
+                ctx.template_type,
+            )
             return None
 
         stored = self._get_template_value(ctx.template_config, _THETA_KEY_PATH)
-        if (
-            secret_resolver is None
-            or not theta_master_key_secret
-            or not isinstance(stored, str)
-            or not stored.startswith(_ENCRYPTED_VALUE_PREFIX)
-        ):
+        has_theta_key = isinstance(stored, str) and bool(stored)
+        has_encrypted_theta_key = isinstance(stored, str) and stored.startswith(
+            _ENCRYPTED_VALUE_PREFIX
+        )
+        logger.info(
+            "[AicodingProvisioningStrategy.build_extra_properties] input: "
+            "bot_id=%s, active_engine=%s, template_type=%s, "
+            "has_template_config=%s, has_theta_key=%s, "
+            "has_encrypted_theta_key=%s, has_secret_resolver=%s, "
+            "has_theta_master_key_secret=%s",
+            ctx.bot_id,
+            ctx.active_engine,
+            ctx.template_type,
+            isinstance(ctx.template_config, dict),
+            has_theta_key,
+            has_encrypted_theta_key,
+            secret_resolver is not None,
+            bool(theta_master_key_secret),
+        )
+        if secret_resolver is None:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=secret_resolver_missing",
+                ctx.bot_id,
+            )
             return None
-        ciphertext = stored[len(_ENCRYPTED_VALUE_PREFIX):]
+        if not theta_master_key_secret:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_master_key_secret_name_missing",
+                ctx.bot_id,
+            )
+            return None
+        if not has_encrypted_theta_key:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=encrypted_theta_key_missing_or_invalid",
+                ctx.bot_id,
+            )
+            return None
+
+        ciphertext = stored[len(_ENCRYPTED_VALUE_PREFIX) :]
         if not ciphertext:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_ciphertext_empty",
+                ctx.bot_id,
+            )
             return None
 
         try:
             secret = secret_resolver.get_secret(theta_master_key_secret)
             master_key = getattr(secret, "secret_value", secret) if secret else None
             if not master_key:
+                logger.warning(
+                    "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                    "bot_id=%s, reason=theta_master_secret_empty",
+                    ctx.bot_id,
+                )
                 return None
             api_key = secret_utils.symmetric_decrypt(ciphertext, str(master_key))
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=theta_key_decrypt_failed, error_type=%s",
+                ctx.bot_id,
+                type(exc).__name__,
+            )
             return None
         if not isinstance(api_key, str) or not api_key:
+            logger.warning(
+                "[AicodingProvisioningStrategy.build_extra_properties] fallback: "
+                "bot_id=%s, reason=decrypted_theta_key_empty",
+                ctx.bot_id,
+            )
             return None
+
+        logger.info(
+            "[AicodingProvisioningStrategy.build_extra_properties] resolved: "
+            "bot_id=%s, custom_outbound_key_resolved=True",
+            ctx.bot_id,
+        )
         return {"outbound_api_key": api_key}
 
     def should_encrypt_template_token(self, ctx: BotProvisioningContext) -> bool:
@@ -361,7 +436,9 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         logger.info(
             "[aicoding.restart] persisted newer template snapshot: "
             "bot_id=%s old_version=%s new_version=%s",
-            ctx.bot_id, stored_version, incoming_version,
+            ctx.bot_id,
+            stored_version,
+            incoming_version,
         )
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -1,4 +1,5 @@
 """Composition root for engine provisioning strategies."""
+
 from __future__ import annotations
 
 from typing import Any, Protocol, TYPE_CHECKING
@@ -68,8 +69,6 @@ class BaasEngineBucketResolverRegistry:
         return normalized_engine
 
 
-
-
 class DefaultCapabilitiesEngineBucketResolver(Protocol):
     """Resolver that may map an engine context to a default-capabilities bucket."""
 
@@ -127,11 +126,14 @@ class McpDefaultsResolverRegistry:
 
     def register(self, engine_bucket: str, resolver: McpDefaultsResolver) -> None:
         if engine_bucket in self._resolvers:
-            raise ValueError(f"MCP defaults resolver already registered: {engine_bucket}")
+            raise ValueError(
+                f"MCP defaults resolver already registered: {engine_bucket}"
+            )
         self._resolvers[engine_bucket] = resolver
 
     def resolve(self, engine_bucket: str) -> McpDefaultsResolver | None:
         return self._resolvers.get(engine_bucket)
+
 
 class EngineProvisioningRegistry:
     def __init__(self) -> None:
@@ -205,7 +207,9 @@ def get_engine_provisioning_registry() -> EngineProvisioningRegistry:
     return _REGISTRY
 
 
-def _build_default_baas_engine_bucket_resolver_registry() -> BaasEngineBucketResolverRegistry:
+def _build_default_baas_engine_bucket_resolver_registry() -> (
+    BaasEngineBucketResolverRegistry
+):
     """Assemble the process-wide BaaS bucket resolver registry."""
     registry = BaasEngineBucketResolverRegistry()
     registry.register(AicodingBaasEngineBucketResolver())
@@ -244,7 +248,9 @@ def resolve_baas_engine_bucket(
     )
 
 
-def _build_default_capabilities_engine_bucket_resolver_registry() -> DefaultCapabilitiesEngineBucketResolverRegistry:
+def _build_default_capabilities_engine_bucket_resolver_registry() -> (
+    DefaultCapabilitiesEngineBucketResolverRegistry
+):
     """Assemble the process-wide default MCP/CLI bucket resolver registry."""
     registry = DefaultCapabilitiesEngineBucketResolverRegistry()
     registry.register(AicodingBaasEngineBucketResolver())
@@ -256,7 +262,9 @@ _DEFAULT_CAPABILITIES_ENGINE_BUCKET_RESOLVER_REGISTRY = (
 )
 
 
-def get_default_capabilities_engine_bucket_resolver_registry() -> DefaultCapabilitiesEngineBucketResolverRegistry:
+def get_default_capabilities_engine_bucket_resolver_registry() -> (
+    DefaultCapabilitiesEngineBucketResolverRegistry
+):
     """Return the process-wide default-capabilities bucket resolver registry."""
     return _DEFAULT_CAPABILITIES_ENGINE_BUCKET_RESOLVER_REGISTRY
 
@@ -347,39 +355,111 @@ def resolve_outbound_rule_envelope(
     typed as ``Any`` so the neutral composition root does not reverse-import
     ``core/devices`` (see architecture review).
     """
+    logger.info(
+        "[engines.resolve_outbound_rule_envelope] start: "
+        "bot_id=%s, owner_id=%s, has_template_service=%s, "
+        "has_secret_resolver=%s, has_theta_master_key_secret=%s",
+        bot_id,
+        owner_id,
+        template_service is not None,
+        secret_resolver is not None,
+        bool(theta_master_key_secret),
+    )
     if template_service is None:
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] fallback: "
+            "bot_id=%s, owner_id=%s, reason=template_service_missing",
+            bot_id,
+            owner_id,
+        )
         return None
+
     bot = bot_query.get_by_id_and_owner(bot_id, owner_id)
     if not bot:
+        logger.warning(
+            "[engines.resolve_outbound_rule_envelope] fallback: "
+            "bot_id=%s, owner_id=%s, reason=bot_not_found",
+            bot_id,
+            owner_id,
+        )
         return None
+
+    active_engine = bot.get("active_engine")
+    template_type = bot.get("template_type")
     try:
         template_config = template_service.get_template_config(bot_id)
     except Exception as e:
         logger.warning(
             "[engines.resolve_outbound_rule_envelope] get_template_config "
-            "failed: bot_id=%s, error=%s", bot_id, e)
+            "failed: bot_id=%s, owner_id=%s, error=%s",
+            bot_id,
+            owner_id,
+            e,
+        )
         return None
+
+    logger.info(
+        "[engines.resolve_outbound_rule_envelope] context: "
+        "bot_id=%s, owner_id=%s, active_engine=%s, template_type=%s, "
+        "has_template_config=%s",
+        bot_id,
+        owner_id,
+        active_engine,
+        template_type,
+        isinstance(template_config, dict),
+    )
+
     try:
         ctx, strategy = resolve_provisioning(
             bot_id=bot_id,
             owner_id=owner_id,
             bot_type=bot.get("bot_type", ""),
-            active_engine=bot.get("active_engine"),
-            template_type=bot.get("template_type"),
+            active_engine=active_engine,
+            template_type=template_type,
             template_config=template_config,
         )
-        return strategy.build_extra_properties(
+        extra_properties = strategy.build_extra_properties(
             ctx,
             secret_resolver=secret_resolver,
             theta_master_key_secret=theta_master_key_secret,
         )
+        custom_outbound_key_resolved = bool(
+            isinstance(extra_properties, dict)
+            and extra_properties.get("outbound_api_key")
+        )
+        logger.info(
+            "[engines.resolve_outbound_rule_envelope] result: "
+            "bot_id=%s, owner_id=%s, strategy=%s, "
+            "custom_outbound_key_resolved=%s",
+            bot_id,
+            owner_id,
+            type(strategy).__name__,
+            custom_outbound_key_resolved,
+        )
+        if not custom_outbound_key_resolved:
+            logger.warning(
+                "[engines.resolve_outbound_rule_envelope] fallback: "
+                "bot_id=%s, owner_id=%s, active_engine=%s, "
+                "template_type=%s, reason=strategy_returned_no_custom_key, "
+                "has_secret_resolver=%s, has_theta_master_key_secret=%s",
+                bot_id,
+                owner_id,
+                active_engine,
+                template_type,
+                secret_resolver is not None,
+                bool(theta_master_key_secret),
+            )
+        return extra_properties
     except Exception as e:  # pragma: no cover - defensive: resolve_provisioning
         # and each registered strategy's build_extra_properties never raise for
         # any real bot (they fail-open internally); this only fires on a future
         # broken engine/strategy or registry corruption. Fail-safe to None.
         logger.warning(
             "[engines.resolve_outbound_rule_envelope] resolve failed: "
-            "bot_id=%s, error=%s", bot_id, e)
+            "bot_id=%s, error=%s",
+            bot_id,
+            e,
+        )
         return None
 
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
@@ -72,9 +72,17 @@ class BaasContainerInitializer:
         logger.info("[_run_baas_bootstrap] done: bot_uuid=%s", bot_uuid)
 
     def _run_baas_install_engine(self, bot_uuid: str) -> None:
+        # The engine repo URL is the script's first positional argument and is
+        # a resolved secret; ``BaasService`` owns both the lookup and the
+        # quoting, and yields "" when no such secret is configured — the script
+        # then falls back to the repo URL baked into its own properties file.
+        repo_arg = self._baas_service.get_install_engine_repo_arg()
         self._baas_service.exec_command_on_bot(
             bot_uuid=bot_uuid,
-            cmd="nohup bash /home/admin/bin/install_engine.sh >> /home/admin/logs/install_engine.log 2>&1 &",
+            cmd=(
+                f"nohup bash /home/admin/bin/install_engine.sh{repo_arg} "
+                ">> /home/admin/logs/install_engine.log 2>&1 &"
+            ),
             timeout_seconds=30,
         )
         logger.info("[_run_baas_install_engine] dispatched: bot_uuid=%s", bot_uuid)

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_header_updater.py
@@ -13,7 +13,9 @@ from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.protocols import BotQueryProtocol
-    from agentclaw.community.core.devices.services.baas_device_service import TemplateConfigReader
+    from agentclaw.community.core.devices.services.baas_device_service import (
+        TemplateConfigReader,
+    )
     from agentclaw.community.core.service_bot.services.baas_service import BaasService
     from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
@@ -70,8 +72,10 @@ class BaasDeviceHeaderUpdater:
 
         try:
             if device.device_provider == TECLAW_DEVICE_PROVIDER:
-                outbound_rule = self._baas_service._build_teclaw_outbound_operation_rule(
-                    agent_pass_token=agent_pass_token,
+                outbound_rule = (
+                    self._baas_service._build_teclaw_outbound_operation_rule(
+                        agent_pass_token=agent_pass_token,
+                    )
                 )
             else:
                 # 引擎解耦：复用创建链路同一套 provisioning 协议解析自定义 egress-key
@@ -79,6 +83,7 @@ class BaasDeviceHeaderUpdater:
                 from agentclaw.community.core.bot_management.engines import (
                     resolve_outbound_rule_envelope,
                 )
+
                 extra_properties = resolve_outbound_rule_envelope(
                     bot_id=bolt_id,
                     owner_id=owner_id,
@@ -86,6 +91,18 @@ class BaasDeviceHeaderUpdater:
                     template_service=self._template_service,
                     secret_resolver=self._secret_resolver,
                     theta_master_key_secret=self._theta_master_key_secret,
+                )
+                logger.info(
+                    "[BaasDeviceHeaderUpdater.update] outbound envelope: "
+                    "device_id=%s, bolt_id=%s, owner_id=%s, "
+                    "custom_outbound_key_resolved=%s",
+                    device.device_id,
+                    bolt_id,
+                    owner_id,
+                    bool(
+                        isinstance(extra_properties, dict)
+                        and extra_properties.get("outbound_api_key")
+                    ),
                 )
                 outbound_rule = self._baas_service._build_outbound_operation_rule(
                     bot_id=bolt_id,
@@ -162,10 +179,12 @@ class BaasDeviceHeaderUpdater:
             f"device_id={device.device_id}, device_uuid={device_uuid}, "
             f"paas_device_id={paas_device_id}"
         )
-        return [{
-            "baas_device_uuid": device_uuid,
-            "paas_device_id": paas_device_id,
-        }]
+        return [
+            {
+                "baas_device_uuid": device_uuid,
+                "paas_device_id": paas_device_id,
+            }
+        ]
 
     def _update_bot_devices(
         self,
@@ -200,10 +219,12 @@ class BaasDeviceHeaderUpdater:
                 paas_device_id,
                 outbound_rule,
             )
-            updated_devices.append({
-                "device_uuid": device_uuid,
-                "paas_device_id": paas_device_id,
-            })
+            updated_devices.append(
+                {
+                    "device_uuid": device_uuid,
+                    "paas_device_id": paas_device_id,
+                }
+            )
             logger.info(
                 f"[BaasDeviceHeaderUpdater.update] Device updated: "
                 f"device_id={device.device_id}, device_uuid={device_uuid}, "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -154,19 +154,38 @@ def _elide_encoded_body(match: "re.Match[str]") -> str:
     return f"echo <startup script elided, {decoded_len} bytes> | base64 -d"
 
 
+#: The repo-URL argument handed to ``install_engine.sh``. It is a resolved
+#: secret (the URL carries an access token), and the command strings it sits in
+#: are logged at INFO on every create, release, restart and container init — so
+#: every log site that can carry it runs the string through
+#: :func:`_redact_install_engine_repo_arg` first. The pattern is exact because
+#: :meth:`BaasService.get_install_engine_repo_arg` always emits the argument as
+#: one single-quoted token and refuses a URL containing a quote or whitespace.
+_INSTALL_ENGINE_REPO_ARG_RE = re.compile(r"(install_engine\.sh) '[^']*'")
+
+
+def _redact_install_engine_repo_arg(cmd: str) -> str:
+    """Elide the repo-URL argument in a command string bound for the log."""
+    return _INSTALL_ENGINE_REPO_ARG_RE.sub(r"\1 <repo url elided>", cmd)
+
+
 def _redact_payload_for_log(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Shallow copy of a create payload with the *script body* elided.
+    """Shallow copy of a create payload with the *secrets* in the hook elided.
 
     ``after_create_cmd_hook`` is mostly the platform's own boot chain, which is
     exactly what someone reads these logs to debug — so everything the platform
     authored stays verbatim, including the ``if``/``fi``/``exit`` scaffolding
-    around the user stage. Only the caller's encoded body is replaced: the
-    published contract's "no secrets in a script body" is advice, not an
-    enforcement mechanism, and these payloads are logged at INFO on every
-    create, release and restart.
+    around the user stage. Two spans are replaced:
 
-    A hook with no encoded body is returned unchanged, so this is a no-op for
-    every bot without a script.
+    - the caller's encoded startup-script body: the published contract's "no
+      secrets in a script body" is advice, not an enforcement mechanism, and
+      these payloads are logged at INFO on every create, release and restart;
+    - the ``install_engine.sh`` repo-URL argument, which *is* a resolved secret
+      the platform itself put there (see
+      :meth:`BaasService.get_install_engine_repo_arg`).
+
+    A hook carrying neither is returned unchanged, so this is a no-op for every
+    bot without a script on a deployment with no repo-URL secret configured.
 
     **This covers this log only.** The same hook travels on to the device
     service, which logs ``rendered_hook[:1024]`` at INFO
@@ -187,8 +206,9 @@ def _redact_payload_for_log(payload: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(hook, str):
         return payload
 
-    elided, count = _ENCODED_BODY_RE.subn(_elide_encoded_body, hook)
-    if not count:
+    elided, _ = _ENCODED_BODY_RE.subn(_elide_encoded_body, hook)
+    elided = _redact_install_engine_repo_arg(elided)
+    if elided == hook:
         return payload
 
     redacted = dict(payload)
@@ -466,6 +486,7 @@ class BaasService:  # pragma: no cover
         startup_script_reader: "StartupScriptReaderProtocol",
         personal_bot_template_uuid: Optional[str] = None,
         theta_master_key_secret: str = "",
+        engine_repo_url_secret: str = "",
     ):
         """初始化 BaasService。
 
@@ -496,6 +517,12 @@ class BaasService:  # pragma: no cover
         layotto/Mist); singlebox / pytest → LocalSecretResolver (返 None
         → token 退化为空字符串,BaaS LocalPaasService 无视 outbound rule)。
         None (仅旧测试构造时省略) → 走 layotto 老路径,仅 prod 可用。
+
+        ``engine_repo_url_secret``: the secret-registry *name* holding the
+        engine source repo URL passed to ``install_engine.sh`` (see
+        :meth:`get_install_engine_repo_arg`). Empty — the neutral default and
+        what every deployment that has not registered the secret gets — means
+        the argument is omitted and the script uses its own baked-in default.
         """
         self._baas_api_base = baas_api_base
         self._http = http_client
@@ -514,6 +541,7 @@ class BaasService:  # pragma: no cover
         self._common_whitelist_service = common_whitelist_service
         self._outbound_rule_provider = outbound_rule_provider
         self._theta_master_key_secret = theta_master_key_secret
+        self._engine_repo_url_secret = engine_repo_url_secret
         # Per-bot startup script (issue #926). Resolved here rather than passed
         # down by each caller: _build_create_bot_payload is reached from create,
         # from service-bot release, and from upgrade_bot (restart), and a script
@@ -1618,9 +1646,13 @@ class BaasService:  # pragma: no cover
         Raises:
             BaasServiceError: on HTTP or API-level error.
         """
+        # The install_engine command carries a resolved secret as its first
+        # argument, so the logged copy goes through the redactor. Truncation
+        # alone is no defense: the argument sits right after the script path,
+        # well inside the first 120 characters.
         logger.info(
             "[BaasService.exec_command_on_bot] bot_uuid=%s cmd=%.120s timeout=%s",
-            bot_uuid, cmd, timeout_seconds,
+            bot_uuid, _redact_install_engine_repo_arg(cmd), timeout_seconds,
         )
 
         payload: dict[str, Any] = {
@@ -2517,6 +2549,74 @@ class BaasService:  # pragma: no cover
         logger.info(f"[_get_setup_sync_service_cmd] Executing cmd: {setup_cmd}")
         return setup_cmd
 
+    def get_install_engine_repo_arg(self) -> str:
+        """The repo-URL argument for ``install_engine.sh``, ready to append.
+
+        Returns either ``" '<url>'"`` — a leading space plus one single-quoted
+        token, so a caller appends it straight after the script path — or ``""``
+        when there is no URL to pass. Omitting it is a supported state, not a
+        failure: the script then clones the repo named in its own properties
+        file, which is what every deployment did before the argument existed.
+
+        The URL is a secret (it carries an access token), so it is resolved
+        through ``SecretResolver`` rather than read from config, and never
+        logged. Every degradation — no secret name registered, no such secret,
+        a resolver error — yields ``""`` and keeps the boot going on the
+        script's own default; a broken secret store must not stop bots from
+        starting.
+
+        A URL containing whitespace or a single quote is refused rather than
+        quoted. No git remote URL contains either, so such a value is a
+        misconfiguration, and refusing it keeps the emitted token exactly one
+        unambiguous ``'…'`` span — which is what lets
+        :func:`_redact_install_engine_repo_arg` elide it from the logs whole.
+        """
+        url = self._resolve_engine_repo_url()
+        if not url:
+            return ""
+        return f" '{url}'"
+
+    def _resolve_engine_repo_url(self) -> str:
+        """Resolve the engine repo URL secret, or ``""`` when unavailable."""
+        if not self._engine_repo_url_secret:
+            return ""
+
+        try:
+            secret = self._secret_resolver.get_secret(self._engine_repo_url_secret)
+        except Exception as e:
+            logger.warning(
+                "[_resolve_engine_repo_url] secret lookup failed, falling back to "
+                "the install script default: secret_name=%s, error_type=%s",
+                self._engine_repo_url_secret,
+                type(e).__name__,
+            )
+            return ""
+
+        value = getattr(secret, "secret_value", "") if secret else ""
+        url = value.strip() if isinstance(value, str) else ""
+        if not url:
+            logger.warning(
+                "[_resolve_engine_repo_url] secret empty or absent, falling back to "
+                "the install script default: secret_name=%s",
+                self._engine_repo_url_secret,
+            )
+            return ""
+
+        if "'" in url or any(c.isspace() for c in url):
+            logger.error(
+                "[_resolve_engine_repo_url] secret value is not a usable repo URL "
+                "(contains whitespace or a quote); falling back to the install "
+                "script default: secret_name=%s",
+                self._engine_repo_url_secret,
+            )
+            return ""
+
+        logger.info(
+            "[_resolve_engine_repo_url] resolved: secret_name=%s",
+            self._engine_repo_url_secret,
+        )
+        return url
+
     def _get_install_engine_cmd(self):
         """执行 install_engine.sh 脚本。
 
@@ -2525,15 +2625,22 @@ class BaasService:  # pragma: no cover
         会等待该 marker 才继续。BaaS 路径通过 && 串联各步，install_engine
         同步执行即可，无需 nohup；存在性保护用于 backend 先发版而 daas-script
         旧镜像尚无该脚本的窗口。
+
+        脚本的第一个位置参数是引擎仓库地址（secret，见
+        :meth:`get_install_engine_repo_arg`）；未配置时不传，脚本回落到自带默认值。
         """
         script_path = "/home/admin/bin/install_engine.sh"
         log_path = "/home/admin/logs/install_engine.log"
+        repo_arg = self.get_install_engine_repo_arg()
         install_cmd = (
             f"if [ -f {script_path} ]; then "
-            f"bash {script_path} >> {log_path} 2>&1; "
+            f"bash {script_path}{repo_arg} >> {log_path} 2>&1; "
             f"else echo '[install_engine] {script_path} not found, skip'; fi"
         )
-        logger.info(f"[_get_install_engine_cmd] Executing cmd: {install_cmd}")
+        logger.info(
+            "[_get_install_engine_cmd] Executing cmd: %s",
+            _redact_install_engine_repo_arg(install_cmd),
+        )
         return install_cmd
 
     def _get_start_sandbox_service_cmd(

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -174,12 +174,20 @@ class SecretNamesConfig:
     and the name were two config entries for one secret. Defaulting it means a
     deployment configures only the value, wherever its resolver reads that
     from; corp env overlays still override the name with the real Mist key.
+
+    ``engine_repo_url`` names the secret holding the engine source repository
+    URL that ``install_engine.sh`` clones from inside the sandbox. It is a
+    secret rather than plain config because the URL carries an access token.
+    Empty (the neutral default) means the argument is not passed at all and the
+    install script falls back to the repo URL baked into its own properties
+    file — the behavior every deployment had before the argument existed.
     """
 
     dormant_internal_token: str = ""
     aiworkbench_repo_url: str = ""
     gateway_principal_signing_key: str = "gateway_principal_signing_key"
     aicoding_theta_master_key: str = ""
+    engine_repo_url: str = ""
 
 
 def _default_cors_origins() -> list[str]:

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -195,6 +195,9 @@ class ConfigModule(Module):
                 "aicoding_theta_master_key",
                 defaults.aicoding_theta_master_key,
             ),
+            engine_repo_url=block.get(
+                "engine_repo_url", defaults.engine_repo_url
+            ),
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -219,6 +219,7 @@ class ServiceBotModule(Module):
             common_whitelist_service=common_whitelist_service,
             outbound_rule_provider=outbound_rule_provider,
             theta_master_key_secret=secret_names.aicoding_theta_master_key,
+            engine_repo_url_secret=secret_names.engine_repo_url,
             startup_script_reader=startup_script_service,
         )
         logger.info(

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -217,6 +217,7 @@
       "aicoding_theta_master_key": "",
       "aiworkbench_repo_url": "",
       "dormant_internal_token": "",
+      "engine_repo_url": "",
       "gateway_principal_signing_key": "gateway_principal_signing_key"
     },
     "skill_scan": {

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -320,6 +320,7 @@
       "aicoding_theta_master_key": "",
       "aiworkbench_repo_url": "other_manual_agentclaw_aiworkbench_repo_url",
       "dormant_internal_token": "",
+      "engine_repo_url": "",
       "gateway_principal_signing_key": "gateway_principal_signing_key"
     },
     "skill_scan": {

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -187,6 +187,7 @@
       "aicoding_theta_master_key": "",
       "aiworkbench_repo_url": "",
       "dormant_internal_token": "",
+      "engine_repo_url": "",
       "gateway_principal_signing_key": "gateway_principal_signing_key"
     },
     "skill_scan": {

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -1266,14 +1266,50 @@ class TestStartService:
 class TestStartServiceInitSteps:
     """Tests for the 6-step container init that runs after publish SUCCESS."""
 
-    def _make_success_svc(self):
+    def _make_success_svc(self, install_engine_repo_arg: str = ""):
         baas = MagicMock()
         baas._baas_api_base = "http://baas.local"
         baas.get_publish_progress.return_value = {"status": "SUCCESS"}
         baas.exec_command_on_bot.return_value = {"exit_code": 0, "stdout": "", "stderr": ""}
+        # Default empty: the deployment has registered no engine repo-URL
+        # secret, so install_engine.sh is invoked bare as it always was.
+        baas.get_install_engine_repo_arg.return_value = install_engine_repo_arg
         svc = _make_service(baas_service=baas)
         svc.report_device_alive = MagicMock()
         return svc, baas
+
+    def _init_cmds(self, svc, baas, engine: str = "aicoding") -> list[str]:
+        with patch(
+            "agentclaw.community.core.devices.services.baas_device_service.time.sleep",
+            return_value=None,
+        ):
+            ok, _ = svc._start_service(device=_device_with_publish(), engine=engine)
+        assert ok is True
+        return [c.kwargs["cmd"] for c in baas.exec_command_on_bot.call_args_list]
+
+    def test_install_engine_takes_the_repo_url_as_its_first_argument(self):
+        """The URL is a secret BaasService resolves; the init step just passes it."""
+        svc, baas = self._make_success_svc(
+            install_engine_repo_arg=" 'https://tok@example.invalid/engine.git'"
+        )
+
+        cmds = self._init_cmds(svc, baas)
+
+        assert (
+            "bash /home/admin/bin/install_engine.sh "
+            "'https://tok@example.invalid/engine.git' "
+            ">> /home/admin/logs/install_engine.log" in cmds[1]
+        )
+
+    def test_install_engine_runs_bare_when_no_repo_url_is_configured(self):
+        svc, baas = self._make_success_svc()
+
+        cmds = self._init_cmds(svc, baas)
+
+        assert (
+            "bash /home/admin/bin/install_engine.sh "
+            ">> /home/admin/logs/install_engine.log" in cmds[1]
+        )
 
     def test_init_commands_called_in_order(self):
         svc, baas = self._make_success_svc()

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
@@ -4,6 +4,8 @@ Covers the install_engine step that was added so the BaaS path mirrors the
 arca path (script split out of start_service.sh, marker file coordinates with
 setup_supervisor_sync_service.sh).
 """
+import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,9 +14,19 @@ from agentclaw.community.core.service_bot.services.baas_service import BaasServi
 from agentclaw.community.plugins.local.http_client import LocalHttpClient
 
 
-def _make_service() -> BaasService:
-    """Build a ``BaasService`` with mocks — all deps are required now."""
+def _make_service(
+    *,
+    secret_resolver: object | None = None,
+    engine_repo_url_secret: str = "",
+) -> BaasService:
+    """Build a ``BaasService`` with mocks — all deps are required now.
+
+    ``engine_repo_url_secret`` defaults to empty, the state of every deployment
+    that has registered no repo-URL secret, so the existing cases keep asserting
+    the command they always asserted.
+    """
     return BaasService(
+        engine_repo_url_secret=engine_repo_url_secret,
         startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
         baas_api_base="http://test",
         tenant="test",
@@ -28,7 +40,7 @@ def _make_service() -> BaasService:
         sandbox_registry=MagicMock(),
         http_client=LocalHttpClient(),
         general_http_client=LocalHttpClient(base_url=""),
-        secret_resolver=MagicMock(),
+        secret_resolver=secret_resolver if secret_resolver is not None else MagicMock(),
         common_whitelist_service=MagicMock(),
         outbound_rule_provider=MagicMock(),
     )
@@ -506,6 +518,118 @@ class TestStartupScriptPrivilege:
         assert "rm -rf" not in inner  # the body survives only as base64
 
 
+class TestGetInstallEngineRepoArg:
+    """The repo URL install_engine.sh clones from is a resolved secret."""
+
+    def _resolver(self, value):
+        return MagicMock(**{"get_secret.return_value": SimpleNamespace(secret_value=value)})
+
+    def test_no_secret_name_configured_passes_no_argument(self):
+        assert _make_service().get_install_engine_repo_arg() == ""
+
+    def test_resolved_url_is_a_single_quoted_argument(self):
+        svc = _make_service(
+            secret_resolver=self._resolver("https://tok@example.invalid/engine.git"),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        assert svc.get_install_engine_repo_arg() == (
+            " 'https://tok@example.invalid/engine.git'"
+        )
+
+    def test_secret_is_looked_up_under_the_configured_name(self):
+        resolver = self._resolver("https://example.invalid/engine.git")
+        _make_service(
+            secret_resolver=resolver, engine_repo_url_secret="a_registry_key"
+        ).get_install_engine_repo_arg()
+        assert resolver.get_secret.call_args[0][0] == "a_registry_key"
+
+    def test_absent_secret_falls_back_to_the_script_default(self):
+        svc = _make_service(
+            secret_resolver=MagicMock(**{"get_secret.return_value": None}),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        assert svc.get_install_engine_repo_arg() == ""
+
+    def test_empty_secret_value_falls_back_to_the_script_default(self):
+        svc = _make_service(
+            secret_resolver=self._resolver("   "),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        assert svc.get_install_engine_repo_arg() == ""
+
+    def test_resolver_error_does_not_break_the_boot(self):
+        """A broken secret store must not stop bots from starting."""
+        svc = _make_service(
+            secret_resolver=MagicMock(**{"get_secret.side_effect": RuntimeError("mist down")}),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        assert svc.get_install_engine_repo_arg() == ""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://example.invalid/e.git'; rm -rf /; '",
+            "https://example.invalid/e.git && rm -rf /",
+            "https://example.invalid/e.git\nrm -rf /",
+        ],
+    )
+    def test_url_that_could_break_out_of_the_quoting_is_refused(self, value):
+        svc = _make_service(
+            secret_resolver=self._resolver(value),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        assert svc.get_install_engine_repo_arg() == ""
+
+
+class TestInstallEngineCmdCarriesTheRepoArg:
+    def _svc(self, url: str = "https://tok@example.invalid/engine.git") -> BaasService:
+        return _make_service(
+            secret_resolver=MagicMock(
+                **{"get_secret.return_value": SimpleNamespace(secret_value=url)}
+            ),
+            engine_repo_url_secret="engine_repo_url",
+        )
+
+    def test_repo_url_is_the_first_positional_argument(self):
+        cmd = self._svc()._get_install_engine_cmd()
+        assert (
+            "bash /home/admin/bin/install_engine.sh "
+            "'https://tok@example.invalid/engine.git' "
+            ">> /home/admin/logs/install_engine.log" in cmd
+        )
+
+    def test_existence_guard_still_tests_the_bare_script_path(self):
+        cmd = self._svc()._get_install_engine_cmd()
+        assert "if [ -f /home/admin/bin/install_engine.sh ]" in cmd
+
+    def test_url_reaches_the_boot_chain(self):
+        cmd = self._svc()._get_start_cmd(
+            bot_id="bot-1", owner_id="owner-1", entity_id="entity-1",
+            entity_type="user", migration_pat="/tmp/src", bot_type="agent",
+            engine="openclaw", stage="online", version="1",
+        )
+        assert "'https://tok@example.invalid/engine.git'" in cmd
+
+    def test_url_is_kept_out_of_the_command_log(self, caplog):
+        with caplog.at_level(logging.INFO):
+            self._svc()._get_install_engine_cmd()
+        assert "tok@example.invalid" not in caplog.text
+
+    def test_url_is_kept_out_of_the_exec_command_log(self, caplog):
+        svc = self._svc()
+        svc._http = MagicMock(
+            **{"post.return_value": MagicMock(**{"json.return_value": {"code": 0, "data": {}}})}
+        )
+        with caplog.at_level(logging.INFO):
+            svc.exec_command_on_bot(
+                bot_uuid="bot-uuid",
+                cmd=f"nohup bash /home/admin/bin/install_engine.sh"
+                    f"{svc.get_install_engine_repo_arg()} >> /dev/null 2>&1 &",
+            )
+        assert "tok@example.invalid" not in caplog.text
+        assert "<repo url elided>" in caplog.text
+
+
 class TestPayloadLogRedaction:
     """Create payloads are logged at INFO and carry the user's script."""
 
@@ -563,6 +687,36 @@ class TestPayloadLogRedaction:
 
         payload = self._payload("bootstrap && start_service.sh")
         assert _redact_payload_for_log(payload) == payload
+
+    def test_the_engine_repo_url_is_elided(self):
+        """The platform put a resolved secret in the hook; it must not log."""
+        from agentclaw.community.core.service_bot.services.baas_service import (
+            _redact_payload_for_log,
+        )
+
+        svc = _make_service(
+            secret_resolver=MagicMock(
+                **{
+                    "get_secret.return_value": SimpleNamespace(
+                        secret_value="https://tok@example.invalid/engine.git"
+                    )
+                }
+            ),
+            engine_repo_url_secret="engine_repo_url",
+        )
+        hook = svc._get_start_cmd(
+            bot_id="bot-1", owner_id="owner-1", entity_id="entity-1",
+            entity_type="user", migration_pat="/tmp/src", bot_type="agent",
+            engine="openclaw", stage="online", version="1",
+        )
+        redacted = _redact_payload_for_log(self._payload(hook))
+        logged = redacted["config"]["deploy_config"]["after_create_cmd_hook"]
+
+        assert "tok@example.invalid" not in str(redacted)
+        assert "install_engine.sh <repo url elided>" in logged
+        # The rest of the boot chain still reads like a boot chain.
+        assert "bootstrap_minimal.sh" in logged
+        assert "start_service.sh" in logged
 
     def test_payload_without_a_deploy_config_passes_through(self):
         from agentclaw.community.core.service_bot.services.baas_service import (


### PR DESCRIPTION
## Problem

`install_engine.sh` takes the engine source repository as its first positional
argument, and falls back to the URL baked into its own `openClawEnterprise.properties`
when the argument is absent. Backend never passed it — neither on the BaaS boot
chain nor on the post-publish container init — so every sandbox installed from
that baked-in default and the repository could not vary per deployment.

The URL is not ordinary config: it carries an access token, so it has to be
resolved through `SecretResolver` (like `aiworkbench_repo_url` already is for
git-sync) rather than read from a yaml block.

## Solution

- `SecretNamesConfig.engine_repo_url` — a new secret-registry *key name*,
  neutral default empty, read by `ConfigModule.secret_names` and wired into
  `BaasService` as `engine_repo_url_secret`.
- `BaasService.get_install_engine_repo_arg()` resolves the secret and returns
  either `" '<url>'"` or `""`. Both paths that run the script append it:
  `_get_install_engine_cmd()` (the `after_create_cmd_hook` boot chain used by
  create / release / restart / desktop) and `BaasContainerInitializer._run_baas_install_engine`
  (the post-publish exec path).
- Every degradation yields no argument rather than a failed boot: no secret name
  registered (the neutral default, and what every deployment gets today), no such
  secret, an empty value, or a resolver error all leave the script on its own
  default. A broken secret store must not stop bots from starting.
- A value containing whitespace or a single quote is refused instead of quoted.
  No git remote URL contains either, so such a value is a misconfiguration; refusing
  it also keeps the emitted argument exactly one unambiguous `'…'` span.
- Redaction: the argument is a resolved secret living in command strings logged at
  INFO on every create, release, restart and container init. `_redact_install_engine_repo_arg`
  elides it at the three sites that can carry it — `_get_install_engine_cmd`,
  `exec_command_on_bot` (whose `%.120s` truncation is no defense, since the argument
  sits right after the script path) and `_redact_payload_for_log`.

Rejected alternative: passing the URL as a plain `user_config` value. It would have
put a credential-bearing URL in a config file and in every log line that prints the
boot chain, which is exactly what the existing `SecretResolver` seam avoids for the
skills repo URL.

`BaasServiceProtocol` gains `get_install_engine_repo_arg` because the devices module
consumes it across the module boundary, alongside `exec_command_on_bot`.

## Validation

Run from `src/backend` with `DEPLOY_PROFILE=test`:

- `pytest tests` — 11681 passed, 3 skipped. Two failures in
  `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs`
  are pre-existing: they fail identically on the base commit with this branch's
  changes stashed, and are deselected in the run above.
- New tests: secret resolution (name unset / absent / empty / resolver error /
  unsafe value), the argument's position in both the boot chain and the container
  init command, and that the URL appears in none of the three log paths.
- `flake8 --select E999,E902,E117,F405,E712,E701,E702,F821,F822,F823,F831` over
  every changed file — clean.
- Golden effective-config snapshots regenerated via
  `python -m tests.community.config.regen_golden`; the only delta is the new
  `engine_repo_url: ""` key in all three profiles.

Not run: singlebox coverage / E2E — no sandbox available in this environment to
start the stack.

## Compatibility and risk

Behavior is unchanged for every existing deployment: with no `secret_names.engine_repo_url`
registered, no argument is passed and `install_engine.sh` installs from its properties
default exactly as before. Enabling the feature is one config line plus the secret in
the deployment's resolver; rollback is removing that config line.

One thing to weigh before registering the secret: the boot chain the argument rides in
is also serialised into `baas_bot.extra_config` / `baas_publish.extra_config` on the
corp path, so the resolved URL would be persisted there. Redaction in this PR covers
the log sites, not that storage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ8RTcahsL6FCcrYCo7YwW)_