### PR TITLE
bug fix

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -7,6 +7,11 @@ Service-bot domain — bot publication facade, BAAS service binding, sub-resourc
 ```yaml
 purpose: "Service-bot domain — bot publication facade, BAAS service binding, sub-resource management."
 provides:
+  - "BotProcess"
+  - "PersonalBotProcess"
+  - "ServiceBotProcess"
+  - "EmptyBotProcess"
+  - "BotProcessRegistry"
   - "BotPublishService"
   - "BaasService"
   - "ServiceBot SQLAlchemy models"

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_process.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_process.py
@@ -16,8 +16,8 @@ class BotProcess(Protocol):
         ...
 
 
-class PersonalBotProcess:
-    """Read the explicit runtime engine type from a personal bot template."""
+class TemplateConfigBotProcess:
+    """Read the explicit runtime engine type from a bot template."""
 
     def __init__(self, template_service: TemplateService) -> None:
         self._template_service = template_service
@@ -31,6 +31,14 @@ class PersonalBotProcess:
         if not isinstance(runtime_engine_type, str):
             return ""
         return runtime_engine_type.strip()
+
+
+class PersonalBotProcess(TemplateConfigBotProcess):
+    """Read the explicit runtime engine type from a personal bot template."""
+
+
+class ServiceBotProcess(TemplateConfigBotProcess):
+    """Read the explicit runtime engine type from a service bot template."""
 
 
 class EmptyBotProcess:
@@ -47,11 +55,15 @@ class BotProcessRegistry:
         self,
         personal_bot_process: BotProcess,
         default_bot_process: BotProcess,
+        service_bot_process: BotProcess | None = None,
     ) -> None:
         self._personal_bot_process = personal_bot_process
+        self._service_bot_process = service_bot_process or personal_bot_process
         self._default_bot_process = default_bot_process
 
     def get(self, bot_type: str) -> BotProcess:
         if bot_type == "personal":
             return self._personal_bot_process
+        if bot_type == "service":
+            return self._service_bot_process
         return self._default_bot_process

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -74,6 +74,7 @@ from agentclaw.community.core.service_bot.services.bot_process import (
     BotProcessRegistry,
     EmptyBotProcess,
     PersonalBotProcess,
+    ServiceBotProcess,
 )
 from agentclaw.community.core.service_bot.services.bot_publish_service import BotPublishService
 from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
@@ -272,6 +273,7 @@ class ServiceBotModule(Module):
         """Construct bot-type-specific binding response processors."""
         return BotProcessRegistry(
             personal_bot_process=PersonalBotProcess(template_service),
+            service_bot_process=ServiceBotProcess(template_service),
             default_bot_process=EmptyBotProcess(),
         )
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_process.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_process.py
@@ -7,6 +7,7 @@ from agentclaw.community.core.service_bot.services.bot_process import (
     BotProcessRegistry,
     EmptyBotProcess,
     PersonalBotProcess,
+    ServiceBotProcess,
 )
 
 
@@ -35,16 +36,28 @@ def test_personal_bot_process_reads_only_explicit_runtime_engine(
     template_service.get_template_config.assert_called_once_with("bot_001")
 
 
+def test_service_bot_process_reads_template_config():
+    template_service = Mock()
+    template_service.get_template_config.return_value = {
+        "active_runtime_engine_type": "  aicoding  ",
+    }
+    process = ServiceBotProcess(template_service)
+
+    assert process.get_active_runtime_engine_type("bot_001") == "aicoding"
+    template_service.get_template_config.assert_called_once_with("bot_001")
+
+
 def test_empty_bot_process_returns_empty_runtime_engine():
     assert EmptyBotProcess().get_active_runtime_engine_type("bot_001") == ""
 
 
-def test_registry_selects_personal_process_and_defaults_other_types():
+def test_registry_selects_template_process_for_personal_and_service():
     personal = Mock()
+    service = Mock()
     default = Mock()
-    registry = BotProcessRegistry(personal, default)
+    registry = BotProcessRegistry(personal, default, service)
 
     assert registry.get("personal") is personal
-    assert registry.get("service") is default
+    assert registry.get("service") is service
     assert registry.get("desktop") is default
     assert registry.get("") is default


### PR DESCRIPTION
## Problem
Personal Bot 和 Service Bot 的 binding 响应需要支持从模板配置读取显式 Runtime Engine；其它 Bot 类型不应查询模板配置。

## Solution
- 新增模板配置读取处理基类，读取 `active_runtime_engine_type` 并清洗字符串值。
- Personal Bot 和 Service Bot 分别通过模板配置处理器读取 Runtime Engine。
- 其它 Bot 类型继续通过 `EmptyBotProcess` 返回空字符串。
- 更新依赖注入、Context Boundary 声明和单元测试。

## Validation
- `python -m py_compile` 通过。
- `git diff --check` 通过。
- pytest 未能执行：当前环境缺少 `injector` 依赖，导入阶段报 `ModuleNotFoundError: No module named 'injector'`。\n\n## Compatibility and risk\n- Binding 响应字段保持稳定。\n- 非 Personal/Service Bot 不读取模板配置，继续返回空字符串。\n- 未跟踪的本地 `.codefuse/` 和方案文档未纳入本次 PR。