### PR TITLE
fix(expert-chat): keep empty session titles stable

### DIFF
--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_service.py
@@ -42,6 +42,7 @@ from agentclaw.community.core.expert_chat.services.expert_chat_instance_service 
     ExpertChatInstanceService,
 )
 from agentclaw.community.core.expert_chat.services.expert_chat_session_runtime import (
+    DEFAULT_EXPERT_CHAT_SESSION_TITLE,
     ExpertChatSessionRuntimeMixin,
 )
 from agentclaw.community.log import get_logger
@@ -860,7 +861,7 @@ class ExpertChatService(ExpertChatSessionRuntimeMixin):
         """Build the complete list shape for an empty or unavailable session."""
         return {
             "id": row["session_key"],
-            "title": "新会话",
+            "title": DEFAULT_EXPERT_CHAT_SESSION_TITLE,
             "user_id": row["user_id"],
             "agent_id": row["bot_id"],
             "model": None,

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
@@ -25,6 +25,8 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 
 logger = get_logger()
 
+DEFAULT_EXPERT_CHAT_SESSION_TITLE = "新会话"
+
 
 class ExpertChatSessionRuntimeMixin:
     """Connection authorization and Adapter session lifecycle operations."""
@@ -247,7 +249,8 @@ class ExpertChatSessionRuntimeMixin:
     ) -> str:
         """Create a session through the active Adapter and return its full ID."""
         payload = {
-            "title": f"Chat with {bot.get('bot_name', bot['bot_id'])}",
+            # Keep empty sessions consistent with the list placeholder across refreshes.
+            "title": DEFAULT_EXPERT_CHAT_SESSION_TITLE,
             "user_id": user_id,
             "agent_id": bot["bot_id"],
             "engine": conn.get("engine_type", "openclaw"),

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_service.py
@@ -1938,7 +1938,7 @@ class TestCreateOpenclawSession:
             "POST",
             "/api/sessions",
             body={
-                "title": "Chat with Bot",
+                "title": "新会话",
                 "user_id": "user1",
                 "agent_id": "bot1",
                 "engine": "openclaw",


### PR DESCRIPTION
## Summary

- Use one shared default title for newly created expert-chat sessions and Backend placeholders.
- Create empty Adapter sessions with `新会话` so refreshing the session list does not change the title to `Chat with <Bot>`.
- Keep the existing Adapter label suffix contract and frontend suffix stripping unchanged.

## Root Cause

The create path persisted `Chat with <Bot>` while the immediate frontend state and Backend fallback used `新会话`. Once Adapter metadata became available after a refresh, the two title sources produced a visible title change.

## Impact

- Newly created sessions with no messages remain `新会话` before and after refresh.
- Existing session titles are not rewritten.
- No database, API shape, Adapter, or non-expert-chat behavior changes.

## Validation

- `uv run pytest tests/community/core/expert_chat/services/test_expert_chat_service.py -q` (`100 passed`)
- Ruff checks passed for all changed files.
- Changed-line coverage: `100.00% (1/1)`.