### PR TITLE
docs(backend): add task goal driven task runner executor and callback spec

### DIFF
--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/plan.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/plan.md
@@ -1,0 +1,1694 @@
+# task_loop callback 服务 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为单 bot workflow / bcn 协作群任务落地 inbound PUSH 回调服务（4 个 HTTP 端点 + 边缘翻译 + correlation 解析 + `on_start` 激活 RUNNING + HMAC 鉴权 + DI 装配），所有写入 funnel 进 SSOT `update_task_node_info`。
+
+**Architecture:** PUSH 回调与 runner-integration poller 共存（修订 runner spec §7.9）：有 workflow 引擎的执行主体（claw_mind / bcn state_machine）走 PUSH 入站；无 workflow 引擎的（plain 单 bot / chat session）走 poller。两路同 sink：`TaskLoopCallback.report_result`→`engine.on_report`；新增 `engine.on_start` 承载 `*_start` 的 PENDING→RUNNING。HTTP 边缘用 Pydantic v2 schema 对齐羽雀字段，translator 折叠进精简 SSOT `TaskCallbackData`，`CallbackAdapter.adapt/adapt_start` 再组装 `TaskNodePatch`。`CallbackCorrelationRegistry` 解析 task 级回调→节点。`TaskError` 在 router 层显式映射，`CallbackAuthError`/`CallbackCorrelationError` 作 `DomainError` 子类进中央 status map。
+
+**Tech Stack:** Python 3.12 + FastAPI + Pydantic v2.13 + injector (fastapi-injector) + threading.RLock（per-task 锁，沿用 engine 风格）。
+
+**Spec:** `src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/spec.md`
+
+## Global Constraints
+
+- 遵循 `AGENTS.md`：不引入 `T | None` 除非 None 是契约态；必填值非可选（`workflow_source`/`workflow_id`/`workflow_instance_id`/`task_id`/`node_id` 必填）。
+- SSOT 不绕过：所有入站回调一律 `on_start`/`on_report`→`update_task_node_info`，router/translator/registry 不得直写图、不得直改 `TaskNode.status`。
+- 零 case 知识红线：新代码不得出现 `N_overview`/`N_market`/`N_aggregate`/`N_verify`/`N_report`/`N_practice`/`n_root`/`dim_` 等节点名字面量（grep 0 命中，单测断言）。
+- 开源边界：HMAC 实现镜像 ocb `BcsHttpClient` 签名模式但 **不 import ocb**；社区分布不绑 corp。
+- 不破上游：`TaskCallbackData`/`CallbackAdapter.adapt`/`engine.on_report`/`TaskLoopCallbackProtocol`/`loop_task_id="task_id::node_id"` 契约不变；`on_start`/`adapt_start` 为纯新增；不注入 `TaskModule` 时现行 121 单测全绿。
+- 协程化约束（README）：锁内不 await；`on_start` 锁内同步写图（`update_task_node_info` 内存同步），与 `on_report` 一致。
+- 测试入口：`cd src/backend && python -m pytest <test> -v`（社区仓 conftest 已就绪）。
+- commit 消息结尾 `Co-Authored-By: Claude <noreply@anthropic.com>`。
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `src/agentclaw/community/core/errors.py` | 新增 `CallbackAuthError`/`CallbackCorrelationError`（`DomainError` 子类） | Modify |
+| `src/agentclaw/community/adapters/http/app.py` | status map 补 2 项 + 挂载 router | Modify |
+| `src/agentclaw/community/core/task/task_center/engine.py` | 新增 `on_start(patch)` | Modify |
+| `src/agentclaw/community/core/task/task_runner/callback_adapter.py` | 新增 `adapt_start` + `adapt` 折 `_ext_info` + 激活 `start_run` | Modify |
+| `src/agentclaw/community/core/task/task_runner/callback_correlation.py` | `CorrelationRecord` + `CallbackCorrelationRegistry` Protocol + InMemory impl | Create |
+| `src/agentclaw/community/adapters/http/task/__init__.py` | 导出 `task_callback_router` | Create |
+| `src/agentclaw/community/adapters/http/task/schemas.py` | Pydantic v2 请求/响应 schema | Create |
+| `src/agentclaw/community/adapters/http/task/translator.py` | `translate(req, disposition, registry) -> TranslatedCallback` | Create |
+| `src/agentclaw/community/adapters/http/task/auth.py` | `CallbackAuthenticator` Protocol + HMAC + Noop + `verify_callback` | Create |
+| `src/agentclaw/community/adapters/http/task/router.py` | 4 端点 + 错误映射 + 幂等 ack | Create |
+| `src/agentclaw/community/di/modules/task_module.py` | `TaskModule` singleton 绑定 | Create |
+| `src/agentclaw/community/di/profile_modules.py` | TEST/SINGLEBOX column 登记 `TaskModule()` | Modify |
+| `tests/community/core/task/task_center/test_engine_on_start.py` | `on_start` 单测 | Create |
+| `tests/community/core/task/task_runner/test_callback_adapter.py` | 激活 `start_run` + `adapt_start` + `_ext_info` 折叠 | Modify |
+| `tests/community/core/task/task_runner/test_callback_correlation.py` | registry 单测 | Create |
+| `tests/community/adapters/http/task/test_translator.py` | translator 单测 | Create |
+| `tests/community/adapters/http/task/test_auth.py` | HMAC/Noop 单测 | Create |
+| `tests/community/adapters/http/task/test_router.py` | 4 端点 + 错误映射 + 幂等 单测 | Create |
+| `tests/community/core/test_errors.py` | 新 `DomainError` 子类可被枚举（回归） | Verify（不改） |
+
+---
+
+## Task 1: 新增 `DomainError` 子类 + 中央 status map
+
+**Files:**
+- Modify: `src/agentclaw/community/core/errors.py`（末尾追加 2 类）
+- Modify: `src/agentclaw/community/adapters/http/app.py:349`（`_DOMAIN_ERROR_STATUS_MAP` + import）
+- Test: `tests/community/architecture/test_domain_error_status_map_complete.py`（既有，跑回归）
+
+**Interfaces:**
+- Produces: `CallbackAuthError(detail: str)`（`DomainError` 子类，401）、`CallbackCorrelationError(detail: str)`（`DomainError` 子类，400）。定义在 `agentclaw.community.core.errors`，被 translator/auth/router import，被架构测试枚举。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/core/test_callback_errors.py`：
+
+```python
+from agentclaw.community.core.errors import (
+    CallbackAuthError, CallbackCorrelationError, DomainError,
+)
+
+
+def test_callback_errors_are_domain_errors():
+    assert issubclass(CallbackAuthError, DomainError)
+    assert issubclass(CallbackCorrelationError, DomainError)
+
+
+def test_callback_errors_carry_detail():
+    e1 = CallbackAuthError("bad sig")
+    assert e1.detail == "bad sig"
+    e2 = CallbackCorrelationError("unregistered")
+    assert e2.detail == "unregistered"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/test_callback_errors.py -v`
+Expected: FAIL `ImportError: cannot import name 'CallbackAuthError'`
+
+- [ ] **Step 3: 在 `core/errors.py` 末尾追加 2 类**
+
+在 `core/errors.py` 末尾追加（`DomainError` 基类 `__init__(self, detail)` 已存在，子类无需自定义构造）：
+
+```python
+class CallbackAuthError(DomainError):
+    """任务回调鉴权失败(签名校验不通过/时间戳超窗)。HTTP 层映射 401。"""
+
+
+class CallbackCorrelationError(DomainError):
+    """task 级回调无法寻址节点(无回声 loop_task_id 且 registry 未登记派发)。HTTP 层映射 400。"""
+```
+
+- [ ] **Step 4: 在 `app.py` status map 补 2 项**
+
+`app.py` 顶部已有 `from agentclaw.community.core.errors import ...`（确认 `DomainError` 等 import 块）。把 `CallbackAuthError`/`CallbackCorrelationError` 加进该 import 块；在 `_DOMAIN_ERROR_STATUS_MAP`（`app.py:349`）追加（保持 401/400 与 `Unauthorized`/`ValidationError` 同列风格）：
+
+```python
+    CallbackAuthError:          401,
+    CallbackCorrelationError:   400,
+```
+
+- [ ] **Step 5: 跑测试 + 架构回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/test_callback_errors.py tests/community/architecture/test_domain_error_status_map_complete.py tests/community/core/test_errors.py -v`
+Expected: PASS（架构测试枚举到 2 新子类且 map 覆盖）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/errors.py src/agentclaw/community/adapters/http/app.py tests/community/core/test_callback_errors.py
+git commit -m "feat(task-callback): add CallbackAuthError/CallbackCorrelationError DomainError subclasses + status map
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `engine.on_start`（status-direct PENDING→RUNNING，幂等）
+
+**Files:**
+- Modify: `src/agentclaw/community/core/task/task_center/engine.py`（import `NodeNotFoundError`/`TaskStateError`；新增 `on_start`）
+- Test: `tests/community/core/task/task_center/test_engine_on_start.py`
+
+**Interfaces:**
+- Consumes: `TaskNodePatch(task_id, node_id, status=Status.RUNNING, extend_props_patch=...)`（来自 Task 3 `adapt_start`）；`self._graph.query_task_dashboard(task_id)`、`self._graph.update_task_node_info(patch)`、`self._lock_for(task_id)`（既有）。
+- Produces: `async def on_start(patch: TaskNodePatch) -> NodeOpResult`——PENDING→RUNNING（经 SSOT）；已 RUNNING→no-op `NodeOpResult(prev=RUNNING,new=RUNNING,success=True)`；`DONE/FAILED/HUNG/PLANNING`→raise `TaskStateError`；node 不存在→raise `NodeNotFoundError`。不触发 `_drain`/传播。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/core/task/task_center/test_engine_on_start.py`：
+
+```python
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentclaw.community.core.task.domain.errors import NodeNotFoundError, TaskStateError
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, Status, TaskInfo, TaskNode, TaskNodePatch,
+    TaskSpec,
+)
+from agentclaw.community.core.task.task_center.engine import ExecutionEngine
+from agentclaw.community.core.task.task_graph.task_graph_service import TaskGraphService
+
+
+def _task_info(task_id: str = "t1") -> TaskInfo:
+    return TaskInfo(
+        task_spec=TaskSpec(
+            metadata=Metadata(task_id=task_id, title="T", instruction="do"),
+            context=Context(background="bg"),
+            goal=Goal(objective="O", acceptances=[AcceptanceCriteria(id="a1", description="done")]),
+        ),
+        source_channel_type="bot",
+        source_channel_id="b1",
+    )
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _engine_with_root(task_id="t1"):
+    graph = TaskGraphService()
+    graph.initialize_graph(_task_info(task_id))
+    eng = ExecutionEngine(graph)
+    # 把根节点置 RUNNING(模拟派发 _prepare_into 后)，回调 start 命中 RUNNING 为幂等
+    root = next(n for n in graph.query_task_dashboard(task_id).tasks if n.node_id)
+    return eng, graph, root
+
+
+class TestOnStart:
+    def test_pending_to_running(self):
+        eng, graph, root = _engine_with_root()
+        # 根初始 PENDING
+        assert root.status == Status.PENDING
+        patch = TaskNodePatch(task_id=root.task_id, node_id=root.node_id, status=Status.RUNNING)
+        res = _run(eng.on_start(patch))
+        assert res.success is True
+        assert res.new_status == Status.RUNNING
+        assert root.status == Status.RUNNING
+
+    def test_already_running_is_idempotent_noop(self):
+        eng, graph, root = _engine_with_root()
+        root.status = Status.RUNNING  # 直接置态(测试用)
+        patch = TaskNodePatch(task_id=root.task_id, node_id=root.node_id, status=Status.RUNNING)
+        res = _run(eng.on_start(patch))
+        assert res.success is True
+        assert res.prev_status == Status.RUNNING
+        assert res.new_status == Status.RUNNING
+
+    @pytest.mark.parametrize("term", [Status.DONE, Status.FAILED, Status.HUNG, Status.PLANNING])
+    def test_terminal_or_planning_raises_stale(self, term):
+        eng, graph, root = _engine_with_root()
+        root.status = term
+        patch = TaskNodePatch(task_id=root.task_id, node_id=root.node_id, status=Status.RUNNING)
+        with pytest.raises(TaskStateError):
+            _run(eng.on_start(patch))
+
+    def test_unknown_node_raises_not_found(self):
+        eng, graph, root = _engine_with_root()
+        patch = TaskNodePatch(task_id=root.task_id, node_id="nope", status=Status.RUNNING)
+        with pytest.raises(NodeNotFoundError):
+            _run(eng.on_start(patch))
+
+    def test_start_does_not_trigger_drain_or_propagation(self):
+        eng, graph, root = _engine_with_root()
+        patch = TaskNodePatch(task_id=root.task_id, node_id=root.node_id, status=Status.RUNNING)
+        _run(eng.on_start(patch))
+        # 没有 side effect 触发：图 status 未被 finish 改动
+        assert graph.query_task_dashboard(root.task_id).status == Status.PENDING
+```
+
+>若 `initialize_graph` 后根节点字段名/初始态与本测试假设不符（PENDING），先读 `task_graph_service.initialize_graph` 对齐；根节点取法 `next(n for n in graph.query_task_dashboard(task_id).tasks ...)` 与 engine `_root` 同模式。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_center/test_engine_on_start.py -v`
+Expected: FAIL `AttributeError: 'ExecutionEngine' object has no attribute 'on_start'`
+
+- [ ] **Step 3: 实现 `on_start`**
+
+`engine.py` 顶部 import 块追加：
+
+```python
+from agentclaw.community.core.task.domain.errors import NodeNotFoundError, TaskStateError
+```
+
+在 `on_report` 之后（`_on_pass_collect` 之前）插入：
+
+```python
+    # ===== on_start =====
+    async def on_start(self, patch: TaskNodePatch) -> NodeOpResult:
+        """入站 start 回调:status-direct PENDING→RUNNING(幂等)。不触发传播/side-effect(纯节点态翻转)。
+        协程化:锁内同步写图(update_task_node_info 内存同步),锁内不 await。"""
+        with self._lock_for(patch.task_id):
+            graph = self._graph.query_task_dashboard(patch.task_id)
+            node = next((n for n in graph.tasks if n.node_id == patch.node_id), None)
+            if node is None:
+                raise NodeNotFoundError(f"on_start: node not found {patch.task_id}::{patch.node_id}")
+            if node.status == Status.RUNNING:
+                return NodeOpResult(
+                    task_id=patch.task_id, node_id=patch.node_id, success=True,
+                    prev_status=Status.RUNNING, new_status=Status.RUNNING,
+                )
+            if node.status in {Status.DONE, Status.FAILED, Status.HUNG, Status.PLANNING}:
+                raise TaskStateError(
+                    f"on_start: stale/illegal start on {node.status} node {patch.task_id}::{patch.node_id}"
+                )
+            # PENDING → RUNNING,经 SSOT 校验 _DIRECT_TRANSITIONS
+            return self._graph.update_task_node_info(patch)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_center/test_engine_on_start.py -v`
+Expected: PASS（5 用例）
+
+- [ ] **Step 5: 上游回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/ -v`
+Expected: PASS（`on_start` 纯新增，既有 121 单测不破）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_center/engine.py tests/community/core/task/task_center/test_engine_on_start.py
+git commit -m "feat(task-callback): add ExecutionEngine.on_start (PENDING→RUNNING idempotent)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `CallbackAdapter.adapt_start` + 激活 `TaskLoopCallback.start_run` + `adapt` 折 `_ext_info`
+
+**Files:**
+- Modify: `src/agentclaw/community/core/task/task_runner/callback_adapter.py`（import `Status`；`adapt` 折 `_ext_info`；新增 `adapt_start`；激活 `start_run`）
+- Test: `tests/community/core/task/task_runner/test_callback_adapter.py`（修改：`RecordingEngine` 加 `on_start`；改 `test_start_run_is_noop`；加 `_ext_info` 折叠 + `adapt_start` 用例）
+
+**Interfaces:**
+- Consumes: `engine.on_start(patch)`（Task 2）；`TaskCallbackData.loop_task_id`/`result`（既有）。
+- Produces: `CallbackAdapter.adapt_start(data) -> TaskNodePatch(status=RUNNING, extend_props_patch=...)`；`TaskLoopCallback.start_run(data)` 由 no-op 升级为 `await engine.on_start(adapt_start(data))`。
+
+- [ ] **Step 1: 写/改失败测试**
+
+`tests/community/core/task/task_runner/test_callback_adapter.py`：给 `RecordingEngine` 加 `on_start`，并改 `TestTaskLoopCallback`：
+
+```python
+class RecordingEngine:
+    def __init__(self):
+        self.reports: list[TaskNodePatch] = []
+        self.starts: list[TaskNodePatch] = []
+
+    async def on_report(self, patch: TaskNodePatch):
+        self.reports.append(patch)
+        return patch
+
+    async def on_start(self, patch: TaskNodePatch):
+        self.starts.append(patch)
+        return patch
+```
+
+把 `test_start_run_is_noop` 改为 `test_start_run_routes_to_on_start`：
+
+```python
+    def test_start_run_routes_to_on_start(self):
+        engine = RecordingEngine()
+        cb = TaskLoopCallback(CallbackAdapter(), engine)
+        _run(cb.start_run(_data(loop_task_id="t1::c1")))
+        assert engine.reports == []          # start 不走 on_report
+        assert len(engine.starts) == 1
+        p = engine.starts[0]
+        assert (p.task_id, p.node_id) == ("t1", "c1")
+        from agentclaw.community.core.task.domain.models import Status
+        assert p.status == Status.RUNNING
+        assert p.acceptance_result is None   # start 不带 acceptance
+```
+
+在 `TestAdapt` 加 `_ext_info` 折叠用例（先加一个 `_data_ext` helper 或直接构造 result）：
+
+```python
+    def test_adapt_folds_ext_info_into_extend_props(self):
+        adapter = CallbackAdapter()
+        d = _data(success=True, data="ok")
+        d.result["_ext_info"] = {"k": "v"}
+        patch = adapter.adapt(d)
+        assert patch.extend_props_patch == {"k": "v"}
+
+    def test_adapt_merges_ext_info_and_fail_detail(self):
+        adapter = CallbackAdapter()
+        d = _data(success=False, fail_detail="gap1")
+        d.result["_ext_info"] = {"k": "v"}
+        patch = adapter.adapt(d)
+        assert patch.extend_props_patch == {"k": "v", "fail_detail": "gap1"}
+```
+
+在 `TestTaskLoopCallback` 加 `adapt_start` 用例：
+
+```python
+    def test_adapt_start_builds_running_patch_with_ext_info(self):
+        from agentclaw.community.core.task.domain.models import Status
+        adapter = CallbackAdapter()
+        d = _data(loop_task_id="t1::c1")
+        d.result["_ext_info"] = {"k": "v"}
+        patch = adapter.adapt_start(d)
+        assert (patch.task_id, patch.node_id) == ("t1", "c1")
+        assert patch.status == Status.RUNNING
+        assert patch.acceptance_result is None
+        assert patch.extend_props_patch == {"k": "v"}
+
+    def test_adapt_start_without_ext_info_has_no_extend_props(self):
+        adapter = CallbackAdapter()
+        patch = adapter.adapt_start(_data(loop_task_id="t1::c1"))
+        assert patch.extend_props_patch is None
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/test_callback_adapter.py -v`
+Expected: FAIL（`adapt_start` 不存在 / `start_run` 仍 no-op / `_ext_info` 未折叠）
+
+- [ ] **Step 3: 改 `callback_adapter.py`**
+
+import 块加 `Status`：
+
+```python
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceResult,
+    AcceptanceVerdict,
+    Status,
+    TaskCallbackData,
+    TaskNodePatch,
+)
+```
+
+`adapt` 末尾 `extend_props_patch` 处替换为合并 `_ext_info` + `fail_detail`：
+
+```python
+        ext = data.result.get("_ext_info") or {}
+        ep_patch: dict[str, Any] = dict(ext)
+        if fail_detail:
+            ep_patch["fail_detail"] = fail_detail
+        return TaskNodePatch(
+            task_id=task_id,
+            node_id=node_id,
+            output_patch={"data": out} if out is not None else None,
+            acceptance_result=acceptance,
+            extend_props_patch=ep_patch if ep_patch else None,
+        )
+```
+
+顶部加 `from typing import Any`（若未引）。新增 `adapt_start` 并激活 `start_run`：
+
+```python
+    def adapt_start(self, data: TaskCallbackData) -> TaskNodePatch:
+        """start 回调:loop_task_id split + status=RUNNING(无 acceptance);折 _ext_info→extend_props。"""
+        task_id, node_id = data.loop_task_id.split("::", 1)
+        ext = data.result.get("_ext_info") or {}
+        return TaskNodePatch(
+            task_id=task_id,
+            node_id=node_id,
+            status=Status.RUNNING,
+            extend_props_patch=dict(ext) if ext else None,
+        )
+```
+
+`TaskLoopCallback.start_run` 改为：
+
+```python
+    async def start_run(self, data: TaskCallbackData) -> None:
+        """任务开始执行:适配层 adapt_start → 编排核 on_start(await)→ PENDING→RUNNING(幂等)。
+        协程化:on_start async,await 不阻塞回投调用方。"""
+        patch = self._adapter.adapt_start(data)
+        await self._engine.on_start(patch)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/test_callback_adapter.py -v`
+Expected: PASS（既有 adapt 用例 + 新 `adapt_start`/`_ext_info`/`start_run` 用例）
+
+- [ ] **Step 5: 上游回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/callback_adapter.py tests/community/core/task/task_runner/test_callback_adapter.py
+git commit -m "feat(task-callback): activate TaskLoopCallback.start_run via on_start + fold _ext_info
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `CallbackCorrelationRegistry`（task 级→节点解析 seam）
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/callback_correlation.py`
+- Test: `tests/community/core/task/task_runner/test_callback_correlation.py`
+
+**Interfaces:**
+- Produces: `CorrelationRecord(task_id, node_id, loop_task_id, workflow_id:int, instance_id:int)`；`CallbackCorrelationRegistry` Protocol（`register(...)`/`resolve(source, instance_id_str) -> CorrelationRecord | None`）；`InMemoryCallbackCorrelationRegistry`（线程安全，dict+RLock，不落库）。被 Task 6 translator 消费。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/core/task/task_runner/test_callback_correlation.py`：
+
+```python
+from __future__ import annotations
+
+import threading
+
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    CallbackCorrelationRegistry,
+    CorrelationRecord,
+    InMemoryCallbackCorrelationRegistry,
+)
+
+
+def _make_reg():
+    return InMemoryCallbackCorrelationRegistry()
+
+
+class TestRegistry:
+    def test_register_then_resolve(self):
+        reg = _make_reg()
+        reg.register(
+            source="bcn", workflow_id=7, instance_id=77,
+            task_id="t1", node_id="n1", loop_task_id="t1::n1",
+            workflow_id_str="w7", instance_id_str="inst77",
+        )
+        rec = reg.resolve("bcn", "inst77")
+        assert rec == CorrelationRecord("t1", "n1", "t1::n1", 7, 77)
+
+    def test_resolve_missing_returns_none(self):
+        reg = _make_reg()
+        assert reg.resolve("claw_mind", "none") is None
+
+    def test_register_is_idempotent_overwrite(self):
+        reg = _make_reg()
+        reg.register(source="bcn", workflow_id=7, instance_id=77,
+                     task_id="t1", node_id="n1", loop_task_id="t1::n1",
+                     workflow_id_str="w7", instance_id_str="inst77")
+        reg.register(source="bcn", workflow_id=7, instance_id=77,
+                     task_id="t1", node_id="n2", loop_task_id="t1::n2",
+                     workflow_id_str="w7", instance_id_str="inst77")
+        assert reg.resolve("bcn", "inst77").node_id == "n2"
+
+    def test_keyed_by_source_and_instance(self):
+        reg = _make_reg()
+        reg.register(source="bcn", workflow_id=7, instance_id=77,
+                     task_id="t1", node_id="n1", loop_task_id="t1::n1",
+                     workflow_id_str="w7", instance_id_str="inst77")
+        reg.register(source="claw_mind", workflow_id=8, instance_id=88,
+                     task_id="t2", node_id="n2", loop_task_id="t2::n2",
+                     workflow_id_str="w8", instance_id_str="inst77")  # 同 instance_id_str,不同 source
+        assert reg.resolve("bcn", "inst77").task_id == "t1"
+        assert reg.resolve("claw_mind", "inst77").task_id == "t2"
+
+    def test_concurrent_register_resolve(self):
+        reg = _make_reg()
+
+        def worker(i):
+            reg.register(source="bcn", workflow_id=i, instance_id=i,
+                         task_id=f"t{i}", node_id=f"n{i}", loop_task_id=f"t{i}::n{i}",
+                         workflow_id_str=f"w{i}", instance_id_str=f"inst{i}")
+            reg.resolve("bcn", f"inst{i}")
+
+        ts = [threading.Thread(target=worker, args=(i,)) for i in range(50)]
+        for t in ts: t.start()
+        for t in ts: t.join()
+        assert reg.resolve("bcn", "inst25") is not None
+
+    def test_protocol_runtime_checkable(self):
+        from typing import runtime_checkable, Protocol  # noqa
+        assert isinstance(_make_reg(), CallbackCorrelationRegistry)
+```
+
+> `CallbackCorrelationRegistry` 若声明为 `@runtime_checkable Protocol`，最后一条用例才成立——实现里加该装饰器。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/test_callback_correlation.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `callback_correlation.py`**
+
+新建 `src/agentclaw/community/core/task/task_runner/callback_correlation.py`：
+
+```python
+"""task 级回调→节点寻址 registry(派发期登记,回调期 resolve)。
+
+task 级回调(workflow_start/workflow_result)载荷无 node_id,只有 workflow_instance_id;
+派发期(TaskRunner.start_run 派发到 claw_mind/bcn 时)登记 (source, instance_id_str)→节点,
+回调期 resolve 得 (task_id, node_id, loop_task_id, SSOT int workflow_id/instance_id)。
+in-mem(与 TaskHarness._dispatched_at 同级),不落库;线程安全(dict + RLock)。
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class CorrelationRecord:
+    task_id: str
+    node_id: str
+    loop_task_id: str
+    workflow_id: int          # SSOT int(供 TaskCallbackData)
+    instance_id: int          # SSOT int
+
+
+@runtime_checkable
+class CallbackCorrelationRegistry(Protocol):
+    """派发期登记 / 回调期 resolve 的寻址端口。"""
+
+    def register(
+        self, *, source: str, workflow_id: int, instance_id: int,
+        task_id: str, node_id: str, loop_task_id: str,
+        workflow_id_str: str, instance_id_str: str,
+    ) -> None: ...
+
+    def resolve(self, source: str, instance_id_str: str) -> CorrelationRecord | None: ...
+
+
+class InMemoryCallbackCorrelationRegistry:
+    """线程安全 in-mem 实现。key=(source, instance_id_str)。"""
+
+    def __init__(self) -> None:
+        self._by_key: dict[tuple[str, str], CorrelationRecord] = {}
+        self._lock = threading.RLock()
+
+    def register(
+        self, *, source: str, workflow_id: int, instance_id: int,
+        task_id: str, node_id: str, loop_task_id: str,
+        workflow_id_str: str, instance_id_str: str,
+    ) -> None:
+        rec = CorrelationRecord(
+            task_id=task_id, node_id=node_id, loop_task_id=loop_task_id,
+            workflow_id=workflow_id, instance_id=instance_id,
+        )
+        with self._lock:
+            self._by_key[(source, instance_id_str)] = rec
+
+    def resolve(self, source: str, instance_id_str: str) -> CorrelationRecord | None:
+        with self._lock:
+            return self._by_key.get((source, instance_id_str))
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/test_callback_correlation.py -v`
+Expected: PASS（6 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/callback_correlation.py tests/community/core/task/task_runner/test_callback_correlation.py
+git commit -m "feat(task-callback): add CallbackCorrelationRegistry for task-level callback routing
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: HTTP 请求/响应 schema（Pydantic v2）
+
+**Files:**
+- Create: `src/agentclaw/community/adapters/http/task/__init__.py`
+- Create: `src/agentclaw/community/adapters/http/task/schemas.py`
+- Test: `tests/community/adapters/http/task/test_schemas.py`
+
+**Interfaces:**
+- Produces: `TaskCallbackRequest`、`TaskNodeCallbackRequest(TaskCallbackRequest)`（+`node_id: str`）、`CallbackResponse`。必填非可选：`task_id`/`workflow_source`/`workflow_id`/`workflow_instance_id`/`status`/`is_success`；可空契约态：`goal`/`output`/`failed_info`/`ext_info`/`loop_task_id`。`workflow_source` 用 `Literal["claw_mind","bcn"]`。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/adapters/http/task/test_schemas.py`：
+
+```python
+import pytest
+from pydantic import ValidationError
+
+from agentclaw.community.adapters.http.task.schemas import (
+    CallbackResponse, TaskCallbackRequest, TaskNodeCallbackRequest,
+)
+
+
+def _base(**kw):
+    d = dict(task_id="t1", workflow_source="bcn", workflow_id="w1",
+             workflow_instance_id="i1", status="COMPLETED", is_success=True)
+    d.update(kw)
+    return d
+
+
+def test_task_callback_request_defaults():
+    r = TaskCallbackRequest(**_base())
+    assert r.goal is None and r.output is None and r.failed_info is None
+    assert r.ext_info is None and r.loop_task_id is None
+
+
+def test_node_callback_request_requires_node_id():
+    with pytest.raises(ValidationError):
+        TaskNodeCallbackRequest(**_base())  # 缺 node_id
+    r = TaskNodeCallbackRequest(**_base(node_id="n1"))
+    assert r.node_id == "n1"
+
+
+def test_workflow_source_literal():
+    with pytest.raises(ValidationError):
+        TaskCallbackRequest(**_base(workflow_source="bbs"))
+
+
+def test_required_fields_enforced():
+    with pytest.raises(ValidationError):
+        TaskCallbackRequest(task_id="t1", workflow_source="bcn")  # 缺必填
+
+
+def test_callback_response_defaults():
+    r = CallbackResponse(success=True)
+    assert r.code == 200 and r.message == "OK"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_schemas.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 schema + `__init__.py`**
+
+新建 `src/agentclaw/community/adapters/http/task/__init__.py`（暂空，Task 8 填 router 导出）：
+
+```python
+"""task_loop callback HTTP 适配层(inbound PUSH,单 bot workflow / bcn 协作群)。"""
+```
+
+新建 `src/agentclaw/community/adapters/http/task/schemas.py`：
+
+```python
+"""任务回调线上 schema(Pydantic v2,对齐羽雀 TaskCallbackData/TaskNodeCallbackData 字段)。
+
+SSOT TaskCallbackData 保持精简(不扩);羽雀丰富字段在 translator 边缘折叠进 SSOT。
+必填非可选(AGENTS.md):task_id/workflow_source/workflow_id/workflow_instance_id/status/is_success。
+None 仅契约态:goal/output/failed_info/ext_info/loop_task_id(回声字段,缺失走 registry)。
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TaskCallbackRequest(BaseModel):
+    """task 级(workflow)回调载荷。"""
+
+    task_id: str
+    workflow_source: Literal["claw_mind", "bcn"]
+    workflow_id: str
+    workflow_instance_id: str
+    goal: str | None = None
+    status: str
+    is_success: bool
+    output: dict[str, Any] | None = None
+    failed_info: str | None = None
+    ext_info: dict[str, Any] | None = None
+    loop_task_id: str | None = None    # 回声字段:派发期透传,引擎原样回带(可选)
+
+
+class TaskNodeCallbackRequest(TaskCallbackRequest):
+    """node 级回调载荷(node_id 即 Avernet 子节点 id,统一领域对象 1:1 映射)。"""
+
+    node_id: str
+
+
+class CallbackResponse(BaseModel):
+    success: bool
+    code: int = 200
+    message: str = "OK"
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_schemas.py -v`
+Expected: PASS（5 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/adapters/http/task/__init__.py src/agentclaw/community/adapters/http/task/schemas.py tests/community/adapters/http/task/test_schemas.py
+git commit -m "feat(task-callback): add Pydantic v2 callback request/response schemas
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `CallbackRequestTranslator`（边缘翻译，SSOT 精简）
+
+**Files:**
+- Create: `src/agentclaw/community/adapters/http/task/translator.py`
+- Test: `tests/community/adapters/http/task/test_translator.py`
+
+**Interfaces:**
+- Consumes: `TaskCallbackRequest`/`TaskNodeCallbackRequest`（Task 5）、`CallbackCorrelationRegistry`（Task 4）、`CallbackCorrelationError`（Task 1）、SSOT `TaskCallbackData`/`AcceptanceResult`/`AcceptanceVerdict`/`Status`（domain/models）。
+- Produces: `TranslatedCallback(disposition: "start"|"result", data: TaskCallbackData)`；`translate(req, disposition, registry) -> TranslatedCallback`。`data.result` 含 `success`/`data`/`fail_detail` + `_ext_info`（ext/goal/未登记 str id）；`data.loop_task_id` 解析（回声→node 直拼→registry→`CallbackCorrelationError`）；`data.workflow_type` 由 `workflow_source` 映射；`data.workflow_id`/`instance_id` 取 registry 的 SSOT int（未登记回退 0）。被 Task 8 router 消费。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/adapters/http/task/test_translator.py`：
+
+```python
+import pytest
+
+from agentclaw.community.adapters.http.task.schemas import (
+    TaskCallbackRequest, TaskNodeCallbackRequest,
+)
+from agentclaw.community.adapters.http.task.translator import translate
+from agentclaw.community.core.errors import CallbackCorrelationError
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    InMemoryCallbackCorrelationRegistry,
+)
+
+
+def _reg_with(source="bcn", instance_id_str="i1", **kw):
+    reg = InMemoryCallbackCorrelationRegistry()
+    reg.register(source=source, workflow_id=7, instance_id=77,
+                 task_id="t1", node_id="root1", loop_task_id="t1::root1",
+                 workflow_id_str="w7", instance_id_str=instance_id_str, **kw)
+    return reg
+
+
+def _base(**kw):
+    d = dict(task_id="t1", workflow_source="bcn", workflow_id="w7",
+             workflow_instance_id="i1", status="COMPLETED", is_success=True)
+    d.update(kw)
+    return d
+
+
+class TestLoopTaskIdResolution:
+    def test_node_level_builds_loop_task_id_from_node_id(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1", output={"r": 1}))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.loop_task_id == "t1::c1"
+
+    def test_task_level_uses_echo_loop_task_id(self):
+        req = TaskCallbackRequest(**_base(loop_task_id="t1::root1"))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.loop_task_id == "t1::root1"
+
+    def test_task_level_no_echo_resolves_via_registry(self):
+        reg = _reg_with()
+        req = TaskCallbackRequest(**_base())  # 无 loop_task_id 回声
+        tc = translate(req, "result", reg)
+        assert tc.data.loop_task_id == "t1::root1"
+
+    def test_task_level_no_echo_no_registry_raises(self):
+        req = TaskCallbackRequest(**_base())
+        with pytest.raises(CallbackCorrelationError):
+            translate(req, "result", InMemoryCallbackCorrelationRegistry())
+
+
+class TestFieldFolding:
+    def test_success_folds_output_to_result_data(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1", output={"r": 1}, is_success=True))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.result["success"] is True
+        assert tc.data.result["data"] == {"r": 1}
+        assert "fail_detail" not in tc.data.result
+
+    def test_fail_folds_failed_info_to_fail_detail(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1", is_success=False, failed_info="boom"))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.result["success"] is False
+        assert tc.data.result["fail_detail"] == "boom"
+
+    def test_ext_info_and_goal_folded_into_ext(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1", ext_info={"k": "v"}, goal="G"))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        ext = tc.data.result["_ext_info"]
+        assert ext["k"] == "v"
+        assert ext["_callback_goal"] == "G"
+
+    def test_workflow_source_maps_to_workflow_type(self):
+        req = TaskNodeCallbackRequest(**_base(workflow_source="claw_mind", node_id="c1"))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.workflow_type == "single_bot"
+
+    def test_registry_provides_ssot_int_ids(self):
+        reg = _reg_with()
+        req = TaskCallbackRequest(**_base(loop_task_id="t1::root1"))
+        tc = translate(req, "result", reg)
+        assert tc.data.workflow_id == 7
+        assert tc.data.instance_id == 77
+
+    def test_unregistered_node_level_falls_back_zero_int_and_stashes_str(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1"))
+        tc = translate(req, "result", InMemoryCallbackCorrelationRegistry())
+        assert tc.data.workflow_id == 0
+        assert tc.data.result["_ext_info"]["_workflow_id_str"] == "w7"
+        assert tc.data.result["_ext_info"]["_instance_id_str"] == "i1"
+
+
+class TestDisposition:
+    def test_result_disposition_passes_through(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1"))
+        assert translate(req, "result", InMemoryCallbackCorrelationRegistry()).disposition == "result"
+
+    def test_start_disposition_passes_through(self):
+        req = TaskNodeCallbackRequest(**_base(node_id="c1", status="RUNNING"))
+        assert translate(req, "start", InMemoryCallbackCorrelationRegistry()).disposition == "start"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_translator.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `translator.py`**
+
+新建 `src/agentclaw/community/adapters/http/task/translator.py`：
+
+```python
+"""回调请求边缘翻译:羽雀 schema → SSOT TaskCallbackData(+disposition)。
+
+SSOT TaskCallbackData 不扩;ext_info/goal/未登记 str id 塞进 result["_ext_info"],
+由 CallbackAdapter.adapt/adapt_start 折进 extend_props_patch。零 case:仅消费 schema 字段
++ loop_task_id/node_id/workflow_source,无节点名字面量。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from agentclaw.community.core.errors import CallbackCorrelationError
+from agentclaw.community.core.task.domain.models import TaskCallbackData
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    CallbackCorrelationRegistry,
+)
+
+from .schemas import TaskCallbackRequest, TaskNodeCallbackRequest
+
+_SOURCE_TO_TYPE = {"claw_mind": "single_bot", "bcn": "bcn_coop_group"}
+
+
+@dataclass(frozen=True)
+class TranslatedCallback:
+    disposition: Literal["start", "result"]
+    data: TaskCallbackData
+
+
+def translate(
+    req: TaskCallbackRequest,
+    disposition: Literal["start", "result"],
+    registry: CallbackCorrelationRegistry,
+) -> TranslatedCallback:
+    source = req.workflow_source
+    workflow_type = _SOURCE_TO_TYPE[source]
+
+    # loop_task_id 解析:回声 > node 直拼 > registry > CallbackCorrelationError
+    loop_task_id = req.loop_task_id
+    if loop_task_id is None:
+        if isinstance(req, TaskNodeCallbackRequest):
+            loop_task_id = f"{req.task_id}::{req.node_id}"
+        else:
+            rec = registry.resolve(source, req.workflow_instance_id)
+            if rec is None:
+                raise CallbackCorrelationError(
+                    f"task-level callback unregistered: {source}/{req.workflow_instance_id}"
+                )
+            loop_task_id = rec.loop_task_id
+
+    # registry 取 SSOT int id(未登记 node 级回退 0)
+    rec = registry.resolve(source, req.workflow_instance_id)
+    wf_id_int = rec.workflow_id if rec is not None else 0
+    inst_id_int = rec.instance_id if rec is not None else 0
+
+    # result 折叠
+    result: dict = {"success": req.is_success}
+    if req.output is not None:
+        result["data"] = req.output
+    if req.failed_info is not None:
+        result["fail_detail"] = req.failed_info
+
+    # ext_info/goal/未登记 str id → result["_ext_info"]
+    ext: dict = dict(req.ext_info or {})
+    if req.goal is not None:
+        ext["_callback_goal"] = req.goal
+    if rec is None:
+        ext.setdefault("_workflow_id_str", req.workflow_id)
+        ext.setdefault("_instance_id_str", req.workflow_instance_id)
+    if ext:
+        result["_ext_info"] = ext
+
+    data = TaskCallbackData(
+        loop_task_id=loop_task_id,
+        workflow_type=workflow_type,
+        workflow_id=wf_id_int,
+        instance_id=inst_id_int,
+        result=result,
+    )
+    return TranslatedCallback(disposition=disposition, data=data)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_translator.py -v`
+Expected: PASS（11 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/adapters/http/task/translator.py tests/community/adapters/http/task/test_translator.py
+git commit -m "feat(task-callback): add CallbackRequestTranslator (edge → SSOT TaskCallbackData)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `CallbackAuthenticator`（HMAC + Noop + `verify_callback` dep）
+
+**Files:**
+- Create: `src/agentclaw/community/adapters/http/task/auth.py`
+- Test: `tests/community/adapters/http/task/test_auth.py`
+
+**Interfaces:**
+- Produces: `CallbackAuthenticator` Protocol（`verify(*, source, headers, raw_body) -> None`，失败 raise `CallbackAuthError`）；`HmacCallbackAuthenticator(secrets: Mapping[str,str])`（签串 `f"{timestamp}{method}{path}{body_sha256_hex}"`，头 `X-TaskLoop-Token`/`X-TaskLo- Timestamp`/`X-TaskLoop-Signature`，时间戳偏移 >300s→`CallbackAuthError`）；`NoopCallbackAuthenticator`（直通）。被 Task 8 router 在解析 body 后调用（`source` 来自已解析 body）。
+
+> 注：router 内直接调用 `auth.verify(...)`（非 FastAPI Depends），因 `source` 需先解析 body 才能 hmac 取密钥。`verify_callback` 作为 helper 暴露但不强制 Depends。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/adapters/http/task/test_auth.py`：
+
+```python
+import hashlib
+import hmac
+import time
+
+import pytest
+
+from agentclaw.community.adapters.http.task.auth import (
+    HmacCallbackAuthenticator, NoopCallbackAuthenticator,
+)
+from agentclaw.community.core.errors import CallbackAuthError
+
+_SECRET = "s3cr3t"
+
+
+def _signed(method="POST", path="/task_loop/callback/workflow_result", body=b'{"x":1}',
+            ts=None, secret=_SECRET, token="bcn"):
+    ts = ts if ts is not None else str(int(time.time()))
+    body_hex = hashlib.sha256(body).hexdigest()
+    sign_str = f"{ts}{method}{path}{body_hex}"
+    sig = hmac.new(secret.encode(), sign_str.encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-TaskLoop-Token": token,
+        "X-TaskLoop-Timestamp": ts,
+        "X-TaskLoop-Signature": sig,
+    }
+
+
+def test_hmac_verify_passes():
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET, "claw_mind": "other"})
+    h = _signed()
+    auth.verify(source="bcn", headers=h, raw_body=b'{"x":1}',
+                method="POST", path="/task_loop/callback/workflow_result")
+
+
+def test_hmac_bad_signature_raises():
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
+    h = _signed()
+    h["X-TaskLoop-Signature"] = "deadbeef"
+    with pytest.raises(CallbackAuthError):
+        auth.verify(source="bcn", headers=h, raw_body=b'{"x":1}',
+                    method="POST", path="/p")
+
+
+def test_hmac_unknown_source_raises():
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
+    with pytest.raises(CallbackAuthError):
+        auth.verify(source="claw_mind", headers={"X-TaskLoop-Timestamp": str(int(time.time()))},
+                    raw_body=b"x", method="POST", path="/p")
+
+
+def test_hmac_stale_timestamp_raises():
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET, "_max_skew_s": 300})  # type: ignore[arg-type]
+    old_ts = str(int(time.time()) - 1000)
+    h = _signed(ts=old_ts)
+    with pytest.raises(CallbackAuthError):
+        auth.verify(source="bcn", headers=h, raw_body=b'{"x":1}',
+                    method="POST", path="/p")
+
+
+def test_hmac_body_tamper_raises():
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
+    h = _signed(body=b'{"x":1}')
+    with pytest.raises(CallbackAuthError):
+        auth.verify(source="bcn", headers=h, raw_body=b'{"x":2}',
+                    method="POST", path="/p")
+
+
+def test_noop_always_passes():
+    NoopCallbackAuthenticator().verify(source="bcn", headers={}, raw_body=b"anything",
+                                       method="POST", path="/p")
+```
+
+> `HmacCallbackAuthenticator` 接受 `max_skew_s` 配置（默认 300）。测试里 `_max_skew_s` 走构造可选参数；若用 dataclass/关键字，调整为 `HmacCallbackAuthenticator(secrets={...}, max_skew_s=300)` 并相应改测试。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_auth.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `auth.py`**
+
+新建 `src/agentclaw/community/adapters/http/task/auth.py`：
+
+```python
+"""回调鉴权端口:HMAC(默认,镜像 BCS 出站签名) + Noop(double/singlebox)。
+
+签串 f"{timestamp}{method}{path}{body_sha256_hex}";头 X-TaskLoop-Token/Timestamp/Signature。
+不 import ocb(开源边界);自包含 hashlib/hmac 实现。失败 raise CallbackAuthError(DomainError→401)。
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from typing import Mapping, Protocol, runtime_checkable
+
+from agentclaw.community.core.errors import CallbackAuthError
+
+_TOKEN_HEADER = "X-TaskLoop-Token"
+_TIMESTAMP_HEADER = "X-TaskLoop-Timestamp"
+_SIGNATURE_HEADER = "X-TaskLoop-Signature"
+_DEFAULT_MAX_SKEW_S = 300
+
+
+@runtime_checkable
+class CallbackAuthenticator(Protocol):
+    def verify(
+        self, *, source: str, headers: Mapping[str, str], raw_body: bytes,
+        method: str, path: str,
+    ) -> None: ...
+
+
+class HmacCallbackAuthenticator:
+    """HMAC-SHA256 签名校验,按 source 取共享密钥。"""
+
+    def __init__(self, secrets: Mapping[str, str], *, max_skew_s: int = _DEFAULT_MAX_SKEW_S) -> None:
+        self._secrets = dict(secrets)
+        self._max_skew_s = max_skew_s
+
+    def verify(self, *, source, headers, raw_body, method, path) -> None:
+        secret = self._secrets.get(source)
+        if secret is None:
+            raise CallbackAuthError(f"unknown callback source: {source}")
+        ts = headers.get(_TIMESTAMP_HEADER)
+        sig = headers.get(_SIGNATURE_HEADER)
+        if not ts or not sig:
+            raise CallbackAuthError("missing timestamp/signature header")
+        try:
+            ts_int = int(ts)
+        except ValueError:
+            raise CallbackAuthError("invalid timestamp")
+        if abs(int(time.time()) - ts_int) > self._max_skew_s:
+            raise CallbackAuthError("stale timestamp")
+        body_hex = hashlib.sha256(raw_body).hexdigest()
+        sign_str = f"{ts}{method}{path}{body_hex}"
+        expected = hmac.new(secret.encode(), sign_str.encode(), hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, sig):
+            raise CallbackAuthError("signature mismatch")
+
+
+class NoopCallbackAuthenticator:
+    """singlebox/test 直通(进程内可信)。"""
+
+    def verify(self, *, source, headers, raw_body, method, path) -> None:  # noqa: D401
+        return None
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_auth.py -v`
+Expected: PASS（6 用例；调整 `test_hmac_stale_timestamp_raises` 的构造参数为 `max_skew_s=300` 形式若实现用关键字）
+
+- [ ] **Step 5: 修正测试构造参数对齐实现**
+
+若 Step 1 测试里 `HmacCallbackAuthenticator(secrets={...}, "_max_skew_s": 300)` 写法不对，改为：
+
+```python
+    auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET}, max_skew_s=300)
+```
+
+重跑：`cd src/backend && python -m pytest tests/community/adapters/http/task/test_auth.py -v` → PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/adapters/http/task/auth.py tests/community/adapters/http/task/test_auth.py
+git commit -m "feat(task-callback): add CallbackAuthenticator (HMAC + Noop)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: callback router（4 端点 + 错误映射 + 幂等 ack）
+
+**Files:**
+- Create: `src/agentclaw/community/adapters/http/task/router.py`
+- Modify: `src/agentclaw/community/adapters/http/task/__init__.py`（导出 `task_callback_router`）
+- Test: `tests/community/adapters/http/task/test_router.py`
+
+**Interfaces:**
+- Consumes: `TaskServiceProtocol`（`Injected`；`.callback.start_run/report_result` + `get_task_dashboard`）、`CallbackAuthenticator`（`Injected`）、`CallbackCorrelationRegistry`（`Injected`）；`translate`（Task 6）；`CallbackResponse`（Task 5）；`TaskStateError`/`TaskNotFoundError`/`NodeNotFoundError`（domain/errors）；`Status`（domain/models）。
+- Produces: `task_callback_router: APIRouter`（prefix `/task_loop/callback`，4 端点）。错误映射：`TaskNotFoundError`/`NodeNotFoundError`→404；`TaskStateError`→result 路径 re-query 已终态→200 idempotent 否则 409，start 路径→409；`CallbackAuthError`/`CallbackCorrelationError` 由中央 DomainError handler→401/400；Pydantic→422。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/adapters/http/task/test_router.py`（用 FastAPI TestClient + 一个 stub TaskService，避免 injector 全量装配）：
+
+```python
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+
+from agentclaw.community.adapters.http.task.router import task_callback_router
+from agentclaw.community.adapters.http.task.schemas import CallbackResponse  # noqa
+from agentclaw.community.core.task.domain.errors import NodeNotFoundError, TaskStateError
+from agentclaw.community.core.task.domain.models import Status, TaskExecutionGraph, TaskNode
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    InMemoryCallbackCorrelationRegistry,
+)
+
+
+class StubCallback:
+    def __init__(self): self.calls = []
+    async def start_run(self, data): self.calls.append(("start", data))
+    async def report_result(self, data): self.calls.append(("result", data))
+
+
+class StubService:
+    """直接挂在 app.state 的 stub,router 经 Depends 取它(测试用 dependency_overrides)。"""
+    def __init__(self):
+        self.callback = StubCallback()
+        self._node_status: dict[tuple[str, str], Status] = {}
+
+    def set_node_status(self, task_id, node_id, status):
+        self._node_status[(task_id, node_id)] = status
+
+    def get_task_dashboard(self, task_id, node_id=None):
+        g = TaskExecutionGraph(run_id=1, loop_round=0, status=Status.PENDING)
+        for (tid, nid), st in list(self._node_status.items()):
+            if tid == task_id:
+                g.tasks.append(_make_node(tid, nid, st))
+        return g
+
+
+def _make_node(task_id, node_id, status):
+    from agentclaw.community.core.task.domain.models import (
+        AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, TaskNode, TaskSpec,
+    )
+    return TaskNode(node_id=node_id, task_id=task_id, status=status,
+                    task_spec=TaskSpec(Metadata(task_id, "T", "do"), Context("bg"),
+                                       Goal("O", [AcceptanceCriteria("a1", "d")])),
+                    run_info=RuntimeInfo(), node_run_graph=None)  # type: ignore[arg-type]
+
+
+def _body(node=False, **kw):
+    d = dict(task_id="t1", workflow_source="bcn", workflow_id="w7",
+             workflow_instance_id="i1", status="COMPLETED", is_success=True)
+    d.update(kw)
+    if node:
+        d.setdefault("node_id", "c1")
+    return d
+
+
+@pytest.fixture
+def app(monkeypatch):
+    app = FastAPI()
+    app.include_router(task_callback_router)
+    svc = StubService()
+    # router 经 Injected(...) 取;测试用 dependency_overrides 注入
+    from agentclaw.community.adapters.http.task import router as r
+    app.dependency_overrides[r._get_svc] = lambda: svc
+    app.dependency_overrides[r._get_auth] = lambda: __import__(
+        "agentclaw.community.adapters.http.task.auth", fromlist=["NoopCallbackAuthenticator"]
+    ).NoopCallbackAuthenticator()
+    app.dependency_overrides[r._get_registry] = lambda: InMemoryCallbackCorrelationRegistry()
+    return app, svc
+
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+    return TestClient(app[0])
+
+
+class TestRouter:
+    def test_workflow_result_success(self, app, client):
+        _, svc = app
+        r = client.post("/task_loop/callback/workflow_result", json=_body(loop_task_id="t1::root1"))
+        assert r.status_code == 200
+        assert svc.callback.calls[0][0] == "result"
+
+    def test_node_result_success(self, app, client):
+        _, svc = app
+        r = client.post("/task_loop/callback/node_result", json=_body(node=True))
+        assert r.status_code == 200
+        assert svc.callback.calls[0][1].loop_task_id == "t1::c1"
+
+    def test_workflow_start_success(self, app, client):
+        _, svc = app
+        r = client.post("/task_loop/callback/workflow_start", json=_body(loop_task_id="t1::root1", status="RUNNING"))
+        assert r.status_code == 200
+        assert svc.callback.calls[0][0] == "start"
+
+    def test_node_start_success(self, app, client):
+        _, svc = app
+        r = client.post("/task_loop/callback/node_start", json=_body(node=True, status="RUNNING"))
+        assert r.status_code == 200
+        assert svc.callback.calls[0][0] == "start"
+
+    def test_result_idempotent_when_already_terminal(self, app, client):
+        _, svc = app
+        svc.callback.report_result = _raise(TaskStateError("DONE->DONE"))
+        svc.set_node_status("t1", "root1", Status.DONE)
+        r = client.post("/task_loop/callback/workflow_result", json=_body(loop_task_id="t1::root1"))
+        assert r.status_code == 200  # 幂等 ack
+
+    def test_result_409_when_illegal(self, app, client):
+        _, svc = app
+        svc.callback.report_result = _raise(TaskStateError("PENDING->DONE"))
+        svc.set_node_status("t1", "root1", Status.PENDING)  # 非终态→409
+        r = client.post("/task_loop/callback/workflow_result", json=_body(loop_task_id="t1::root1"))
+        assert r.status_code == 409
+
+    def test_start_409_on_stale(self, app, client):
+        _, svc = app
+        svc.callback.start_run = _raise(TaskStateError("stale"))
+        r = client.post("/task_loop/callback/node_start", json=_body(node=True, status="RUNNING"))
+        assert r.status_code == 409
+
+    def test_not_found_404(self, app, client):
+        _, svc = app
+        svc.callback.report_result = _raise(NodeNotFoundError("x"))
+        r = client.post("/task_loop/callback/workflow_result", json=_body(loop_task_id="t1::root1"))
+        assert r.status_code == 404
+
+    def test_correlation_error_400(self, app, client):
+        # task 级无回声 + 空 registry → CallbackCorrelationError
+        r = client.post("/task_loop/callback/workflow_result", json=_body())  # 无 loop_task_id,registry 空
+        assert r.status_code == 400
+
+    def test_validation_422(self, app, client):
+        r = client.post("/task_loop/callback/node_result", json={"task_id": "t1"})  # 缺必填
+        assert r.status_code == 422
+
+
+def _raise(exc):
+    async def _f(data):
+        raise exc
+    return _f
+```
+
+> router 用三个内部 `Depends` provider（`_get_svc`/`_get_auth`/`_get_registry`）桥接 `Injected`，使测试可 `dependency_overrides`。实现见 Step 3。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_router.py -v`
+Expected: FAIL `ModuleNotFoundError`（router 未建）
+
+- [ ] **Step 3: 实现 `router.py`**
+
+新建 `src/agentclaw/community/adapters/http/task/router.py`：
+
+```python
+"""task_loop inbound PUSH 回调 router(4 端点)。单 bot workflow / bcn 协作群→回调。
+
+边缘:解析 body → auth.verify(source from body) → translate → disposition 分发
+start_run/report_result。TaskError(TaskStateError/NotFound)router 层显式映射;
+CallbackAuthError/CallbackCorrelationError(DomainError 子类)由中央 handler 映射。
+幂等:result 重投到已终态节点→200 ack;start stale→409。
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from agentclaw.community.adapters.http.task.auth import CallbackAuthenticator, NoopCallbackAuthenticator
+from agentclaw.community.adapters.http.task.schemas import (
+    CallbackResponse, TaskCallbackRequest, TaskNodeCallbackRequest,
+)
+from agentclaw.community.adapters.http.task.translator import translate
+from agentclaw.community.api.task.task_service import TaskServiceProtocol
+from agentclaw.community.core.task.domain.errors import (
+    NodeNotFoundError, TaskNotFoundError, TaskStateError,
+)
+from agentclaw.community.core.task.domain.models import Status
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    CallbackCorrelationRegistry, InMemoryCallbackCorrelationRegistry,
+)
+from agentclaw.community.di import Injected
+
+router = APIRouter(prefix="/task_loop/callback", tags=["task-callback"])
+
+
+def _get_svc() -> TaskServiceProtocol:
+    return Injected(TaskServiceProtocol)  # type: ignore[return-value]
+
+
+def _get_auth() -> CallbackAuthenticator:
+    return Injected(CallbackAuthenticator)  # type: ignore[return-value]
+
+
+def _get_registry() -> CallbackCorrelationRegistry:
+    return Injected(CallbackCorrelationRegistry)  # type: ignore[return-value]
+
+
+_TERMINAL = {Status.DONE, Status.FAILED, Status.HUNG}
+
+
+def _find_node_status(svc: TaskServiceProtocol, loop_task_id: str) -> Status | None:
+    task_id, node_id = loop_task_id.split("::", 1)
+    graph = svc.get_task_dashboard(task_id)
+    node = next((n for n in graph.tasks if n.node_id == node_id), None)
+    return node.status if node is not None else None
+
+
+async def _dispatch(
+    request: Request, disposition: str, schema_cls: type[TaskCallbackRequest],
+    svc: TaskServiceProtocol, auth: CallbackAuthenticator, registry: CallbackCorrelationRegistry,
+) -> CallbackResponse:
+    raw = await request.body()
+    try:
+        req = schema_cls.model_validate_json(raw)
+    except Exception:
+        raise HTTPException(status_code=422, detail="invalid callback body")
+    # source 来自已解析 body;HMAC 用原始字节
+    auth.verify(source=req.workflow_source, headers=request.headers, raw_body=raw,
+                method=request.method, path=request.url.path)
+    tc = translate(req, disposition, registry)
+    try:
+        if disposition == "start":
+            await svc.callback.start_run(tc.data)
+        else:
+            await svc.callback.report_result(tc.data)
+    except (TaskNotFoundError, NodeNotFoundError):
+        raise HTTPException(status_code=404, detail="task/node not found")
+    except TaskStateError:
+        if disposition == "result":
+            cur = _find_node_status(svc, tc.data.loop_task_id)
+            if cur in _TERMINAL:
+                return CallbackResponse(success=True, code=200, message="idempotent")
+        raise HTTPException(status_code=409, detail="illegal state transition")
+    return CallbackResponse(success=True)
+
+
+@router.post("/workflow_start", response_model=CallbackResponse)
+async def workflow_start(
+    request: Request,
+    svc: TaskServiceProtocol = Depends(_get_svc),
+    auth: CallbackAuthenticator = Depends(_get_auth),
+    registry: CallbackCorrelationRegistry = Depends(_get_registry),
+) -> CallbackResponse:
+    return await _dispatch(request, "start", TaskCallbackRequest, svc, auth, registry)
+
+
+@router.post("/workflow_result", response_model=CallbackResponse)
+async def workflow_result(
+    request: Request,
+    svc: TaskServiceProtocol = Depends(_get_svc),
+    auth: CallbackAuthenticator = Depends(_get_auth),
+    registry: CallbackCorrelationRegistry = Depends(_get_registry),
+) -> CallbackResponse:
+    return await _dispatch(request, "result", TaskCallbackRequest, svc, auth, registry)
+
+
+@router.post("/node_start", response_model=CallbackResponse)
+async def node_start(
+    request: Request,
+    svc: TaskServiceProtocol = Depends(_get_svc),
+    auth: CallbackAuthenticator = Depends(_get_auth),
+    registry: CallbackCorrelationRegistry = Depends(_get_registry),
+) -> CallbackResponse:
+    return await _dispatch(request, "start", TaskNodeCallbackRequest, svc, auth, registry)
+
+
+@router.post("/node_result", response_model=CallbackResponse)
+async def node_result(
+    request: Request,
+    svc: TaskServiceProtocol = Depends(_get_svc),
+    auth: CallbackAuthenticator = Depends(_get_auth),
+    registry: CallbackCorrelationRegistry = Depends(_get_registry),
+) -> CallbackResponse:
+    return await _dispatch(request, "result", TaskNodeCallbackRequest, svc, auth, registry)
+```
+
+`__init__.py` 改为：
+
+```python
+"""task_loop callback HTTP 适配层(inbound PUSH,单 bot workflow / bcn 协作群)。"""
+from agentclaw.community.adapters.http.task.router import task_callback_router
+
+__all__ = ["task_callback_router"]
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_router.py -v`
+Expected: PASS（10 用例）
+> 若 `Injected` 在非 injector 上下文 raise，`_get_svc` 用 `Injected(...)` 作返回值在测试会被 `dependency_overrides` 覆盖，不会实际执行 `Injected` 取值——确认 `Depends(_get_svc)` 先用 override。若 fastapi-injector 的 `Injected` 在 import 时即生成 Depends，改为直接 `Depends(_get_svc)` 形式（如上）即可被 override。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/adapters/http/task/router.py src/agentclaw/community/adapters/http/task/__init__.py tests/community/adapters/http/task/test_router.py
+git commit -m "feat(task-callback): add 4-endpoint inbound callback router with idempotent ack
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `TaskModule` DI 装配 + profile 登记 + app 挂载 router
+
+**Files:**
+- Create: `src/agentclaw/community/di/modules/task_module.py`
+- Modify: `src/agentclaw/community/di/profile_modules.py`（TEST/SINGLEBOX column 登记 `TaskModule()`）
+- Modify: `src/agentclaw/community/adapters/http/app.py`（import + `app.include_router(task_callback_router)`）
+- Test: `tests/community/di/test_task_module.py`
+
+**Interfaces:**
+- Produces: `TaskModule(Module)`——singleton 绑 `TaskGraphService`（零参）、`TaskService`（`@inject` 注入 graph）、`InMemoryCallbackCorrelationRegistry`、`NoopCallbackAuthenticator`，并 `@provider` 暴露 `TaskServiceProtocol`/`CallbackCorrelationRegistry`/`CallbackAuthenticator`。community TEST/SINGLEBOX profile 可解析 `Injected(TaskServiceProtocol)` 等。router 被挂进 app。
+
+> 社区分布只绑 `NoopCallbackAuthenticator`（进程内可信）。CORP/prod 的 `HmacCallbackAuthenticator` + 真实密钥由 corp adapter 落地（seam，本任务不绑）。
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `tests/community/di/test_task_module.py`：
+
+```python
+from injector import Injector
+
+from agentclaw.community.api.task.task_service import TaskServiceProtocol
+from agentclaw.community.adapters.http.task.auth import (
+    CallbackAuthenticator, NoopCallbackAuthenticator,
+)
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    CallbackCorrelationRegistry, InMemoryCallbackCorrelationRegistry,
+)
+from agentclaw.community.di.modules.task_module import TaskModule
+
+
+def test_task_module_binds_singletons():
+    inj = Injector([TaskModule()])
+    assert isinstance(inj.get(TaskServiceProtocol).__class__.__name__, str)  # resolves
+    assert isinstance(inj.get(CallbackCorrelationRegistry), InMemoryCallbackCorrelationRegistry)
+    assert isinstance(inj.get(CallbackAuthenticator), NoopCallbackAuthenticator)
+    # singleton:两次取同对象
+    assert inj.get(TaskServiceProtocol) is inj.get(TaskServiceProtocol)
+    assert inj.get(CallbackCorrelationRegistry) is inj.get(CallbackCorrelationRegistry)
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/di/test_task_module.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `task_module.py`**
+
+新建 `src/agentclaw/community/di/modules/task_module.py`：
+
+```python
+"""TaskModule — task_loop callback 服务 DI 装配(社区 TEST/SINGLEBOX profile)。
+
+Singleton 绑定:TaskGraphService(零参)、TaskService(@inject 注入 graph;harness 默认 None)、
+InMemoryCallbackCorrelationRegistry、NoopCallbackAuthenticator(社区进程内可信)。
+@provider 暴露 Protocol:TaskServiceProtocol/CallbackCorrelationRegistry/CallbackAuthenticator。
+CORP/prod 的 HmacCallbackAuthenticator + 真实密钥由 corp adapter 覆写(seam)。
+"""
+from __future__ import annotations
+
+from injector import Binder, Module, inject, provider, singleton
+
+from agentclaw.community.adapters.http.task.auth import (
+    CallbackAuthenticator, NoopCallbackAuthenticator,
+)
+from agentclaw.community.api.task.task_service import TaskServiceProtocol
+from agentclaw.community.core.task.task_center.task_service import TaskService
+from agentclaw.community.core.task.task_graph.task_graph_service import TaskGraphService
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    CallbackCorrelationRegistry, InMemoryCallbackCorrelationRegistry,
+)
+
+
+class TaskModule(Module):
+    """社区 TEST/SINGLEBOX profile 的 task callback 服务绑定。"""
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(TaskGraphService, to=TaskGraphService, scope=singleton)
+        binder.bind(TaskService, to=TaskService, scope=singleton)
+        binder.bind(InMemoryCallbackCorrelationRegistry, to=InMemoryCallbackCorrelationRegistry, scope=singleton)
+        binder.bind(NoopCallbackAuthenticator, to=NoopCallbackAuthenticator, scope=singleton)
+
+    @singleton
+    @provider
+    @inject
+    def _task_service_protocol(self, svc: TaskService) -> TaskServiceProtocol:
+        return svc
+
+    @singleton
+    @provider
+    @inject
+    def _registry(self, r: InMemoryCallbackCorrelationRegistry) -> CallbackCorrelationRegistry:
+        return r
+
+    @singleton
+    @provider
+    @inject
+    def _auth(self, a: NoopCallbackAuthenticator) -> CallbackAuthenticator:
+        return a
+```
+
+> `TaskService.__init__(graph, harness=None)`：`harness` 有默认值，injector 只注入无默认值的 `graph`（`TaskGraphService` 已绑），`harness` 留 None。若 injector 对带默认参数也尝试注入而失败，改为显式 provider：`def _task_service(self, graph: TaskGraphService) -> TaskService: return TaskService(graph)`，并把 `binder.bind(TaskService,...)` 去掉。
+
+- [ ] **Step 4: profile_modules.py 登记**
+
+`di/profile_modules.py` 的 `modules_for` TEST/SINGLEBOX 分支（`column = _common_test_doubles() + [...]`，约 L130）顶部 import 块加：
+
+```python
+        from agentclaw.community.di.modules.task_module import TaskModule
+```
+
+`column` 列表里加 `TaskModule(),`（建议放在列表末尾，`TestAppServicesModule()` 之后）。
+
+- [ ] **Step 5: app.py 挂载 router**
+
+`adapters/http/app.py` 顶部 router import 块（与 `quality_router` 等同级）加：
+
+```python
+from agentclaw.community.adapters.http.task import task_callback_router
+```
+
+在 mandatory `app.include_router(...)` 块（`app.include_router(quality_router)` 附近，约 L768）后加一行：
+
+```python
+app.include_router(task_callback_router)
+```
+
+- [ ] **Step 6: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/di/test_task_module.py -v`
+Expected: PASS
+
+- [ ] **Step 7: 全模块回归**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/ tests/community/core/task/ tests/community/di/test_task_module.py tests/community/architecture/test_domain_error_status_map_complete.py -v`
+Expected: PASS（router 现经 injector 也可装配；app import 不破）
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/agentclaw/community/di/modules/task_module.py src/agentclaw/community/di/profile_modules.py src/agentclaw/community/adapters/http/app.py tests/community/di/test_task_module.py
+git commit -m "feat(task-callback): wire TaskModule DI + mount callback router in app
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: 零 case grep 红线 + 全量回归收口
+
+**Files:**
+- Test: 既有零 case 架构测试（若有）/ 新增断言
+
+**Interfaces:**
+- 验证新模块源码 0 命中节点名字面量；全量 task + http + di 回归绿。
+
+- [ ] **Step 1: 写零 case 断言测试**
+
+新建 `tests/community/adapters/http/task/test_zero_case.py`：
+
+```python
+from pathlib import Path
+
+_BASE = Path("src/agentclaw/community/adapters/http/task")
+_FILES = ["schemas.py", "translator.py", "auth.py", "router.py", "__init__.py"]
+_FORBIDDEN = ["N_overview", "N_market", "N_aggregate", "N_verify", "N_report", "N_practice", "n_root", "dim_"]
+
+
+def test_no_node_name_literals():
+    hits = []
+    for f in _FILES:
+        src = (_BASE / f).read_text()
+        hits += [f"{f}:{tok}" for tok in _FORBIDDEN if tok in src]
+    assert hits == [], f"task callback 出现写死节点名: {hits}"
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/task/test_zero_case.py -v`
+Expected: PASS
+
+- [ ] **Step 3: 全量回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/ tests/community/adapters/http/task/ tests/community/di/test_task_module.py tests/community/architecture/ -v`
+Expected: PASS（121 既有 + 新增全绿）
+
+- [ ] **Step 4: pre-push lint（SAST 默认）**
+
+Run: `cd src/backend && git push --dry-run 2>&1 | tail -20`（或按 AGENTS.md 的 pre-push target contract）
+Expected: lint-only 通过（`OCB_PRE_PUSH_RUN_CI` 未设时跳过重测试）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/community/adapters/http/task/test_zero_case.py
+git commit -m "test(task-callback): assert zero case-name literals in callback modules
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes（已自审）
+
+- **Spec 覆盖**：§7.1 4 端点→Task 8；§7.2 schema→Task 5；§7.3 translator→Task 6；§7.4 on_start→Task 2；§7.5 激活 start_run→Task 3；§7.6 registry→Task 4；§7.7 HMAC→Task 7；§7.8 错误映射/幂等→Task 8；§7.9 DI→Task 9；§7.10 loop_task_id 回声透传→translator 回声分支（Task 6）+ 派发期登记 seam（Task 4 port，登记动作属 runner spec/corp adapter，本计划只定 port）。
+- **类型一致**：`translate(req, disposition, registry) -> TranslatedCallback(disposition, data)`；`adapt_start(data) -> TaskNodePatch`；`on_start(patch) -> NodeOpResult`；`_get_svc/_get_auth/_get_registry` 三个 Depends provider 名在 router 与 test_router 一致；`CorrelationRecord` 字段在 registry/translator/test 一致。
+- **placeholder 扫描**：无 TBD/TODO；所有代码块为可执行内容。`TaskService.__init__` 注入 harness 的两种兜底显式写在 Task 9 Step 3 注释里。
+- **已知偏离 spec（已同步 spec）**：`TaskStateError` 不进中央 map（非 DomainError），router 层映射（spec §7.8 已改）；`ext_info/goal` 走 `result["_ext_info"]`（spec §7.3/§7.5 已改）。
+
+## R2 singlebox E2E（后续，依赖 runner-integration 派发期登记 seam 落地）
+
+runner-integration spec 的派发期 `CallbackCorrelationRegistry.register(...)` 登记动作落地后，补 singlebox e2e：`NoopCallbackAuthenticator` + 派发期预登记 + 进程内回投驱动 `workflow_start→workflow_result`（root RUNNING→DONE→finish）、`node_result` FAIL→补救/BBS 升级、重投幂等。复用既有 e2e 剧本断言。本计划范围到 R1（含 HMAC + 单测 + DI 装配）为止。

--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/spec.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/spec.md
@@ -1,0 +1,392 @@
+# Spec: task_loop callback 服务子模块（inbound PUSH 回调，单 bot workflow / bcn 协作群）
+
+- 日期：2026-08-13
+- 分支：`feat/task-goal-driven-collab-dev-jj-2`
+- 范围模块：`adapters/http/task/`（新增）+ `core/task/task_runner/callback_correlation.py`（新增）+ `core/task/task_center/engine.py`（`on_start` 新增）+ `core/task/task_runner/callback_adapter.py`（`start_run` 激活）+ `di/modules/task_module.py`（新增）+ `adapters/http/app.py`（挂载 / 错误映射）
+- 上游 spec：
+  - `specs/2026-08-09-task-goal-driven-execution-framework/`（任务目标驱动执行框架，M0–M6 已落地）
+  - `specs/2026-08-09-task-goal-driven-task-runner/`（runner integration；本 spec **修订其 §7.9**）
+- 参考文档：羽雀「任务Loop执行」→「回调服务_供单bot workflow或者bcn协作群任务使用」
+  （https://yuque.antfin.com/mad/enxdbg/lxg2mwgmtfqg6d95 ）
+- 适用代码约定：遵循 `AGENTS.md`（不引入 `T | None` 除非 None 是契约态；必填值非可选）
+
+---
+
+## 1. Problem Statement
+
+羽雀「回调服务」章节定义了**入站 PUSH 回调契约**：外部执行引擎（单 bot-有 workflow = ClawMind workflow run；bcn 协作群 = state_machine run）在任务/节点状态变更时，**主动回调 Avernet**，上报总体状态、产出、以及 workflow 内每个节点的状态与产出。回调契约给出 4 个方法签名 + `TaskCallbackData` / `TaskNodeCallbackData` 两类载荷 + 4 条 HTTP 路径。
+
+但 Avernet 现状：
+
+1. `TaskLoopCallbackProtocol`（`api/task/task_loop_callback.py`）与实现 `TaskLoopCallback`（`task_runner/callback_adapter.py`）**只有 `report_result` 落地**（→ `CallbackAdapter.adapt` → `engine.on_report`）。`start_run` 是 **no-op stub**，进度信号 seam 死着。
+2. `adapters/http/task/` **只有 stale `.pyc`，无 `.py` 源**——没有任何入站回调路由；`TaskService` 也未进 DI、未挂 HTTP。runner-integration spec §7.9 明确「移除 PUSH、单 bot 走 poller」。
+3. SSOT `TaskCallbackData`（`domain/models.py`）字段精简（`loop_task_id` / `workflow_type` / `workflow_id:int` / `instance_id:int` / `result:dict`），与羽雀丰富字段（`workflow_source` / `goal` / `status` / `is_success` / `output` / `failed_info` / `ext_info` / `node_id`）不对齐。
+4. `engine.on_report` 对 `acceptance_result is None` 早退（fold-only 不翻态），`RUNNING` 现仅由内部 `_prepare_into` 派发时置位——外部 `*_start` 信号无处落脚。
+5. task 级回调只有 `task_id` + `workflow_instance_id`，**无 `node_id`**，无法直接寻址 Avernet 节点。
+
+本 spec 设计 inbound PUSH 回调服务子模块，把上述缺口补齐：HTTP 边缘 4 端点 + 边缘翻译（羽雀 schema → SSOT）+ correlation 解析（task 级 → 节点）+ `on_start` 激活 RUNNING + 鉴权 port + DI 装配，**所有写入一律 funnel 进 SSOT `update_task_node_info`**。
+
+---
+
+## 2. Solution 概述
+
+**PUSH 与 poller 共存**（修订 §7.9）：
+
+- **PUSH 回调（本 spec）**：面向**有 workflow 引擎的执行主体**——claw_mind workflow run、bcn state_machine run。这类引擎天然能回调。
+- **旁路 Poller（runner spec §7.8，保留）**：面向**无 workflow 引擎的执行主体**——plain 单 bot chat-async、plain 协作群 chat session（Open API `/messages` 与 BCS chat session 无原生 PUSH）。
+
+两条路汇入同一 sink：`TaskLoopCallback.report_result` → `engine.on_report` → `TaskGraphService.update_task_node_info`（SSOT 写口，**不绕过**）。§7.9 由「移除 PUSH」修订为「PUSH 用于 workflow 类，poller 用于无 workflow 类」。
+
+```
+外部引擎(claw_mind workflow / bcn state_machine)
+   │  POST /task_loop/callback/{workflow_start|workflow_result|node_start|node_result}
+   ▼
+task callback router (FastAPI, 4 端点)
+   ├─ CallbackAuthenticator.verify(source)         # HMAC(默认)/Noop(double)
+   ├─ CallbackRequestTranslator.translate(req)      # 羽雀 schema → {disposition, TaskCallbackData, TaskNodePatch?}
+   │     ├─ is_success/output/failed_info → result{success,data,fail_detail}
+   │     ├─ workflow_source → workflow_type；str ids → registry 查 SSOT int ids
+   │     ├─ ext_info → extend_props_patch
+   │     └─ loop_task_id 解析: node 级=task::node; task 级=回声字段 or registry
+   ├─ disposition=start  → svc.callback.start_run(data)  → engine.on_start(patch)   # status-direct PENDING→RUNNING
+   └─ disposition=result → svc.callback.report_result(data) → engine.on_report(patch) # acceptance 终态翻转
+          │
+          ▼
+   TaskGraphService.update_task_node_info(patch)   # SSOT 唯一写口
+```
+
+---
+
+## 3. Constraints
+
+1. **SSOT 不绕过**：所有入站回调一律 `on_start` / `on_report` → `update_task_node_info`；router / translator / registry 不得直写图、不得直改 `TaskNode.status`。
+2. **不破上游契约**：`TaskCallbackData` / `CallbackAdapter.adapt` / `engine.on_report` / `loop_task_id="task_id::node_id"` / `TaskRunner.start_run` 签名**不变**；`on_start` 为纯新增方法；不注入 `TaskModule` 时现行行为（121 单测）不破。
+3. **HTTP 边缘翻译，SSOT 保持精简**：不扩 `TaskCallbackData` 字段；羽雀丰富字段在 router 边缘翻译折叠进 SSOT 既有字段 + `extend_props_patch`。
+4. **零 case 知识红线**：translator / router / registry / auth 仅消费 schema 字段 + `loop_task_id` / `node_id` / `workflow_source`，**不得**出现节点名字面量（grep 0 命中，单测断言）。
+5. **开源边界**：HTTP 边缘 + 翻译 + registry + auth port 在 Avernet 自包含；HMAC 实现镜像 ocb `BcsHttpClient` 签名模式（**不 import ocb**）。
+6. **必填非可选**（`AGENTS.md`）：`workflow_source` / `workflow_id` / `workflow_instance_id` / `task_id` 必填非可选；`None` 仅用于契约态（`goal` / `loop_task_id` 回声字段可空，触发 registry 兜底）。
+7. **幂等**：网络重投是常态——`*_result` 重投到已终态节点、`*_start` 重投到已 RUNNING 节点，均 200 idempotent ack，不重复驱动传播/补救。
+
+---
+
+## 4. Scope
+
+### In Scope
+- `adapters/http/task/` 子模块：`router.py`（4 端点）/ `schemas.py`（Pydantic v2 线上 schema）/ `translator.py`（边缘翻译）/ `auth.py`（`CallbackAuthenticator` port + HMAC + Noop）。
+- `core/task/task_runner/callback_correlation.py`：`CallbackCorrelationRegistry` port + in-mem impl（task 级 → 节点 / id 类型对齐）。
+- `core/task/task_center/engine.py`：新增 `on_start(patch) -> NodeOpResult`（status-direct PENDING→RUNNING，幂等）。
+- `core/task/task_runner/callback_adapter.py`：激活 `TaskLoopCallback.start_run` → `engine.on_start`（由 no-op 升级）。
+- `di/modules/task_module.py`：`TaskModule` singleton 绑 `TaskService` + registry + auth，暴露 `TaskServiceProtocol`。
+- `adapters/http/app.py`：`app.include_router(task_callback_router)`；`_DOMAIN_ERROR_STATUS_MAP` 补 `TaskStateError→409`。
+- singlebox double：`NoopCallbackAuthenticator` + `_DoubleCallbackCorrelationRegistry` + 回调驱动 e2e。
+
+### Out of Scope
+- runner-integration 的 poller / BCS / Open API 真实派发链路（属 runner spec）；本 spec 只定义**入站回调面**与**派发期 correlation 登记 seam**（登记动 作由 runner integration executor / corp adapter 落地，本 spec 定 port 契约）。
+- bbs 模态真实执行（沿用 `BbsMarketPort`，bbs 不回调）。
+- 持久化/ORM：registry in-memory（与 `TaskHarness._dispatched_at` 同级），不落库。
+- 前端/dashboard 渲染、外部 issue tracker。
+
+---
+
+## 5. 现有 seam 锚点（不变项）
+
+| 锚点 | 位置 | 现状 / 契约 |
+|---|---|---|
+| `TaskLoopCallbackProtocol` | `api/task/task_loop_callback.py:10` | `async start_run(data)` / `async report_result(data)`；`@runtime_checkable` |
+| `TaskLoopCallback` 实现 | `task_runner/callback_adapter.py:45` | `start_run` no-op；`report_result` → `adapt` → `on_report` |
+| `CallbackAdapter.adapt` | `task_runner/callback_adapter.py:24` | `loop_task_id.split("::",1)`；`success/data/fail_detail` → `TaskNodePatch`；FAIL 无 fail_detail → `["unknown_gap"]` |
+| `TaskCallbackData` | `domain/models.py:206` | `loop_task_id`/`workflow_type`/`workflow_id:int`/`instance_id:int`/`result:dict`（**不扩**） |
+| `TaskNodePatch` | `domain/models.py:146` | `task_id`/`node_id` 必填；`status`/`acceptance_result`/`output_patch`/`extend_props_patch` 可选 |
+| `engine.on_report` | `task_center/engine.py:91` | 锁内 `update_task_node_info`；`acceptance_result is None` 早退（fold-only）；PASS→传播/finish，FAIL→补救/BBS |
+| `TaskGraphService.update_task_node_info` | `task_graph/task_graph_service.py:200` | **SSOT 唯一节点写口**；`_ACCEPTANCE_TRANSITIONS`(RUNNING/PLANNING→DONE/FAILED) + `_DIRECT_TRANSITIONS`(PENDING→RUNNING / RUNNING→PENDING / PLANNING→DONE) |
+| `Status` 枚举 | `domain/models.py:16` | `PENDING` / `PLANNING` / `RUNNING` / `DONE` / `FAILED` / `HUNG` |
+| `TaskService.callback` | `task_center/task_service.py:48` | `@property` 暴露 `TaskLoopCallback`；engine 私有，入站经 `svc.callback.*` |
+| `loop_task_id` 源 | `task_runner/runner.py:75` | `f"{task.task_id}::{node.node_id}"`，派发期 mint |
+
+### 5.1 router / DI 约定（镜像既有模式）
+- FastAPI + Pydantic **v2.13.4**（`uv.lock`）；`from agentclaw.community.di import Injected`。
+- router 风格（镜像 `adapters/http/quality/router.py`）：`router = APIRouter(prefix="/task_loop/callback", tags=["task-callback"])`；handler `async def`，`svc: TaskServiceProtocol = Injected(TaskServiceProtocol)`。
+- `DomainError` 经 `app.py:349 _DOMAIN_ERROR_STATUS_MAP` 中央映射（架构测试要求每个 `DomainError` 子类有 entry）；router 层仅做幂等 ack override 与 router-local guard。
+- DI（镜像 `di/modules/quality_module.py`）：`Module` 子类，`binder.bind(Impl, to=Impl, scope=singleton)` + `@singleton @provider @inject` 暴露 Protocol。
+- 挂载：prod 必需 → `app.include_router(task_callback_router)` 直连（非 `OptionalRouters`，后者仅 local/test 条件挂载）。
+
+---
+
+## 6. 模块布局
+
+```
+adapters/http/task/
+  __init__.py                       # 导出 task_callback_router
+  router.py                         # 4 端点; Injected(TaskServiceProtocol); Depends(verify_callback(source))
+  schemas.py                        # Pydantic v2: TaskCallbackRequest / TaskNodeCallbackRequest / CallbackResponse
+  translator.py                     # CallbackRequestTranslator: req → {disposition, TaskCallbackData, TaskNodePatch?}
+  auth.py                           # CallbackAuthenticator(Protocol) + HmacCallbackAuthenticator + NoopCallbackAuthenticator
+core/task/task_runner/
+  callback_correlation.py           # CallbackCorrelationRegistry(Protocol) + InMemoryCallbackCorrelationRegistry
+  callback_adapter.py               # TaskLoopCallback.start_run 激活 → engine.on_start(改)
+core/task/task_center/
+  engine.py                         # + on_start(patch) status-direct PENDING→RUNNING(新增)
+di/modules/task_module.py           # TaskModule: bind TaskService/registry/auth singleton; expose TaskServiceProtocol
+adapters/http/app.py                # include_router(task_callback_router); _DOMAIN_ERROR_STATUS_MAP += TaskStateError→409
+```
+
+---
+
+## 7. 详细设计
+
+### 7.1 HTTP 端点（honoring 羽雀原路径）
+
+| 方法 | 路径 | 请求体 | disposition | 走向 |
+|---|---|---|---|---|
+| POST | `/task_loop/callback/workflow_start` | `TaskCallbackRequest` | start | `svc.callback.start_run` → `engine.on_start`（root/dispatched 节点 RUNNING） |
+| POST | `/task_loop/callback/workflow_result` | `TaskCallbackRequest` | result | `svc.callback.report_result` → `engine.on_report`（root/dispatched 节点终态） |
+| POST | `/task_loop/callback/node_start` | `TaskNodeCallbackRequest` | start | `svc.callback.start_run`（子节点 RUNNING） |
+| POST | `/task_loop/callback/node_result` | `TaskNodeCallbackRequest` | result | `svc.callback.report_result`（子节点终态） |
+
+- 响应统一 `CallbackResponse{success: bool, code: int, message: str}`；成功 / 幂等 ack → 200。
+- 鉴权：handler `Depends(verify_callback)`，`verify_callback` 经 `Injected(CallbackAuthenticator)` 按 `body.workflow_source` 取密钥校验签名；失败 → 401。
+
+### 7.2 线上 schema（Pydantic v2，对齐羽雀字段）
+
+```python
+from typing import Any, Literal
+from pydantic import BaseModel, Field
+
+class TaskCallbackRequest(BaseModel):
+    task_id: str
+    workflow_source: Literal["claw_mind", "bcn"]
+    workflow_id: str
+    workflow_instance_id: str
+    goal: str | None = None
+    status: str                        # RUNNING / COMPLETED / FAILED / ...（大小写不敏感）
+    is_success: bool
+    output: dict[str, Any] | None = None
+    failed_info: str | None = None
+    ext_info: dict[str, Any] | None = None
+    loop_task_id: str | None = None    # 回声字段:派发期透传,引擎原样回带(可选,缺失走 registry)
+
+class TaskNodeCallbackRequest(TaskCallbackRequest):
+    node_id: str                       # = Avernet 子节点 id(统一领域对象 1:1 映射)
+
+class CallbackResponse(BaseModel):
+    success: bool
+    code: int = 200
+    message: str = "OK"
+```
+
+> `goal` / `output` / `failed_info` / `ext_info` / `loop_task_id` 为可空契约态（None 触发兜底）；`task_id` / `workflow_source` / `workflow_id` / `workflow_instance_id` / `status` / `is_success` 必填非可选（遵 `AGENTS.md`）。
+
+### 7.3 边缘翻译 `CallbackRequestTranslator`（SSOT 不动）
+
+`translate(req) -> TranslatedCallback`，其中 `TranslatedCallback = {disposition: "start"|"result", data: TaskCallbackData, patch: TaskNodePatch}`：
+
+1. **`loop_task_id` 解析**：
+   - 优先用回声 `req.loop_task_id`（非空直接用）。
+   - node 级：`loop_task_id = f"{task_id}::{node_id}"`（`node_id` 即 Avernet 节点 id）。
+   - task 级 + 无回声：`CallbackCorrelationRegistry.resolve(source, instance_id) → (task_id, node_id, loop_task_id)`；缺失 → raise `CallbackCorrelationError`（router → 400）。
+2. **`result` 折叠**：`result = {"success": req.is_success, "data": req.output, "fail_detail": req.failed_info}`（`output`/`failed_info` 为 None 则缺省 key）。
+3. **`workflow_type` 映射**：`workflow_source=="claw_mind" → "single_bot"`；`"bcn" → "bcn_coop_group"`。
+4. **id 类型对齐**：`workflow_id`/`instance_id` 在 SSOT 为 `int`，羽雀为 `str`。**不强转**——由 registry（派发期已存 SSOT int）返回；未登记且为 node 级（有回声 loop_task_id）时，回退 `0` 并把原 str id 存 `ext_info["_workflow_id_str"]`/`["_instance_id_str"]` 以可追溯（`adapt`/`on_report` 不消费这两个 int，仅信息字段）。
+5. **`ext_info`/`goal` 折叠进 `result["_ext_info"]`**：`TaskCallbackData` 无 ext_info 字段（SSOT 精简），故 translator 把 `ext_info`（合并 `goal`→`_callback_goal`、未登记时的 `_workflow_id_str`/`_instance_id_str`）塞进 `result["_ext_info"]` dict；由 `CallbackAdapter.adapt`/`adapt_start` 折进 `extend_props_patch`（见 §7.5）。`goal` 为信息字段，不驱动状态。
+6. **disposition 判定**：
+   - 端点 `*_start` → `disposition="start"`。
+   - 端点 `*_result` → `disposition="result"`。
+   - （`status` 字段不覆写 disposition：端点语义即签名语义，与羽雀一致。）
+7. **产出**：`TranslatedCallback = {disposition, data: TaskCallbackData}`（**只产 `data`**；patch 由 `CallbackAdapter.adapt`/`adapt_start` 从 `data` 构造，保持与既有 `report_result→adapt` 链路一致）。FAIL 无 `failed_info` 由 `adapt` 兜底 `["unknown_gap"]`（既有契约，不重复兜底）。
+
+> translator **不得**出现节点名字面量；`task_id`/`node_id`/`loop_task_id` 全部来自请求或 registry。
+
+### 7.4 `engine.on_start`（新增；status-direct PENDING→RUNNING）
+
+`engine.on_report` 对 `acceptance_result is None` 早退（fold-only 不翻态），无法承载 `*_start` 的 RUNNING 翻转。故新增：
+
+```python
+async def on_start(self, patch: TaskNodePatch) -> NodeOpResult:
+    """入站 start 回调:status-direct PENDING→RUNNING(幂等)。
+    不触发传播/side-effect(纯节点态翻转)。"""
+    with self._lock_for(patch.task_id):
+        node = self._graph.get_node(patch.task_id, patch.node_id)      # 不存在 → NodeNotFoundError
+        if node.status == Status.RUNNING:
+            return NodeOpResult(task_id, node_id, success=True,
+                                prev_status=Status.RUNNING, new_status=Status.RUNNING)  # 幂等 no-op
+        if node.status in {Status.DONE, Status.FAILED, Status.HUNG}:
+            raise TaskStateError(...)                                   # stale → router 409
+        # PENDING / PLANNING → RUNNING(patch 仅带 status=RUNNING)
+        return self._graph.update_task_node_info(patch)                # 校验 _DIRECT_TRANSITIONS
+```
+
+- **幂等**：已 RUNNING → no-op success；终态 → `TaskStateError`(stale)；`PENDING`→`RUNNING` 经 SSOT 校验 `_DIRECT_TRANSITIONS`。
+- `PLANNING→RUNNING` 不在 `_DIRECT_TRANSITIONS`（仅 `PLANNING→DONE`）：若节点为 `PLANNING`（委托态）收到 start → `TaskStateError`→409（委托态不应被外部 start 打断；其终态由传播链路置 DONE）。
+- **不**调用 `_drain` / 传播 / side-effect：start 仅置节点 RUNNING，编排核调度由既有 `_prepare_into` 路径负责（PUSH start 是「外部引擎已开始」的确认信号，与内部派发 RUNNING 并存，幂等）。
+
+> `on_start` 与 `on_report` 共享 `_lock_for(task_id)` 锁，状态翻转顺序由 SSOT 状态机裁决，无竞态。
+
+### 7.5 激活 `TaskLoopCallback.start_run`
+
+`callback_adapter.py` 现 `start_run` no-op，升级为：
+
+```python
+async def start_run(self, data: TaskCallbackData) -> None:
+    patch = self._adapter.adapt_start(data)   # 新增:loop_task_id split + status=RUNNING, 无 acceptance
+    await self._engine.on_start(patch)
+```
+
+`CallbackAdapter.adapt_start(data) -> TaskNodePatch`：`task_id, node_id = data.loop_task_id.split("::",1)`；折 `data.result.get("_ext_info")`→`extend_props_patch`；返 `TaskNodePatch(task_id, node_id, status=Status.RUNNING, extend_props_patch=ext if ext else None)`。`adapt`（result 路径）**追加**折 `_ext_info`→`extend_props_patch`（与既有 `fail_detail` 合并；既有单测不设 `_ext_info` 故不受影响）。
+
+`TaskLoopCallbackProtocol.start_run` 签名不变（仍 `async (data) -> None`）。
+
+### 7.6 `CallbackCorrelationRegistry`（task 级 → 节点 + id 对齐）
+
+```python
+class CallbackCorrelationRegistry(Protocol):
+    def register(self, *, source: str, workflow_id: int, instance_id: int,
+                 task_id: str, node_id: str, loop_task_id: str,
+                 workflow_id_str: str, instance_id_str: str) -> None: ...
+    def resolve(self, source: str, instance_id_str: str) -> CorrelationRecord | None: ...
+
+@dataclass(frozen=True)
+class CorrelationRecord:
+    task_id: str; node_id: str; loop_task_id: str
+    workflow_id: int; instance_id: int       # SSOT int(供 TaskCallbackData)
+```
+
+- **登记时机**：`TaskRunner.start_run` 真实派发到 claw_mind/bcn 时（runner-integration executor 或 corp adapter），把 `(source, instance_id_str) → CorrelationRecord` 写入 registry。本 spec 定 port 契约，登记动作属 runner spec / corp adapter 落地。
+- **解析**：task 级回调 `workflow_instance_id`（str）→ `resolve` → `CorrelationRecord`；缺失 → `CallbackCorrelationError`（router → 400「未登记派发，无法寻址」）。
+- **回声优先**：回调若带 `loop_task_id` 回声字段，跳过 registry 寻址（但仍可查 registry 取 SSOT int id 填 `TaskCallbackData`）。
+- in-mem（与 `TaskHarness._dispatched_at` 同级），不落库；线程安全（dict + lock，登记/解析低频）。
+
+### 7.7 鉴权 `CallbackAuthenticator`
+
+```python
+class CallbackAuthenticator(Protocol):
+    def verify(self, *, source: str, headers: Mapping[str, str], raw_body: bytes) -> None: ...  # 失败 raise CallbackAuthError
+```
+
+- `HmacCallbackAuthenticator`（默认，镜像 ocb `BcsHttpClient` 签名模式，**不 import ocb**）：按 `source`（`claw_mind`/`bcn`）取共享密钥；签串 `f"{timestamp}{method}{path}{body_sha256}"`；校验 `X-TaskLoop-Token` / `X-TaskLoop-Timestamp` / `X-TaskLoop-Signature`；时间戳偏移 > 阈值 → `CallbackAuthError`。
+- `NoopCallbackAuthenticator`（singlebox/test）：直通。
+- `verify_callback` 依赖：读 body（需在 router 注入原始 body 做签名校验，Pydantic 解析前/后均可——用 `Request` 取 `raw_body`，再 `TaskCallbackRequest.model_validate_json`）。
+- 失败 → `CallbackAuthError`(`DomainError` 子类) → `_DOMAIN_ERROR_STATUS_MAP` → 401。
+
+### 7.8 幂等与错误映射
+
+| 场景 | 行为 | HTTP |
+|---|---|---|
+| `*_result` 重投，节点已 `DONE`/`FAILED` 且与 callback 一致 | `update_task_node_info` raise `TaskStateError`；router 判 prev==目标终态 → 幂等 | **200** ack |
+| `*_result` 非法翻转（如 `DONE`→`FAILED` 不一致重投） | `TaskStateError` | 409 |
+| `*_start` 重投，已 `RUNNING` | `on_start` no-op | 200 |
+| `*_start` 命中终态 | `on_start` raise `TaskStateError`(stale) | 409 |
+| `*_start` 命中 `PLANNING` | `TaskStateError`（委托态拒绝外部 start） | 409 |
+| `task_id`/`node_id` 不存在 | `TaskNotFoundError`/`NodeNotFoundError` | 404 |
+| task 级无回声且 registry 未登记 | `CallbackCorrelationError` | 400 |
+| schema 校验失败 | Pydantic `ValidationError` | 422 |
+| 鉴权失败 | `CallbackAuthError` | 401 |
+
+- `CallbackAuthError`(401)/`CallbackCorrelationError`(400) 为 **`DomainError` 子类**（定义于 `core/errors.py`，架构测试可见），进 `_DOMAIN_ERROR_STATUS_MAP`（架构测试要求每个 `DomainError` 子类有 entry），由中央 `@app.exception_handler(DomainError)` 自动映射。
+- `TaskStateError`/`TaskNotFoundError`/`NodeNotFoundError` 属 **`TaskError`（非 `DomainError`）**，中央 handler 不捕获——router 层显式 try/except 映射：`TaskNotFoundError`/`NodeNotFoundError`→404；`TaskStateError`→ result 路径 re-query 节点态,已终态(`DONE`/`FAILED`)→200 idempotent,否则 409;start 路径→409(`on_start` 已把 RUNNING no-op 内化,故 start 的 `TaskStateError` 均为 stale)。
+- **幂等 ack override**：router 捕获 `TaskStateError` 后 re-query `svc.get_task_dashboard(task_id)` 取节点当前态判定;不下发 `TaskStateError` 进中央 map(避免把 `GraphIntegrityError`/`DispatchError`/`DecomposeError` 等无清晰 HTTP 码的 `TaskError` 子类强塞 `DomainError` 层次)。
+
+### 7.9 DI 与装配
+
+- `di/modules/task_module.py` `TaskModule(Module)`：
+  - `binder.bind(TaskServiceImpl, to=TaskServiceImpl, scope=singleton)`；
+  - `binder.bind(InMemoryCallbackCorrelationRegistry, ..., scope=singleton)`；
+  - `binder.bind(HmacCallbackAuthenticator, ..., scope=singleton)`；
+  - `@singleton @provider @inject` 暴露 `TaskServiceProtocol <- TaskServiceImpl`、`CallbackCorrelationRegistry <- InMemory...`、`CallbackAuthenticator <- Hmac...`（镜像 `QualityModule`）。
+- `di/profile_modules.py` / `modules_bootstrap.py`：prod profile 登记 `TaskModule`；testing profile 可置 `NoopCallbackAuthenticator` override。
+- `adapters/http/app.py`：import `task_callback_router` 并 `app.include_router(task_callback_router)`（prod 必需，直连非 OptionalRouters）；补 `TaskStateError`/`CallbackCorrelationError`/`CallbackAuthError` → status 映射。
+
+### 7.10 `loop_task_id` 回声透传（派发期 seam）
+
+- 派发到 claw_mind/bcn 时，Avernet 把 `loop_task_id`（+ `task_id`/`node_id`）作为 callback_token 透传给外部引擎（经 start request 的 `ext_info` / 约定字段），引擎在回调中原样回带 `loop_task_id`。
+- 回声存在 → translator 跳过 registry 寻址；缺失 → registry 兜底。双保险。
+- 回声透传的具体协议字段由 runner-integration spec / corp adapter 定；本 spec 定「`loop_task_id` 必须可被引擎回带」的契约。
+
+---
+
+## 8. 数据流（端到端）
+
+### workflow_result（task 级，成功）
+1. bcn state_machine run 完成 → `POST /task_loop/callback/workflow_result`，body `{task_id, workflow_source:"bcn", workflow_instance_id, is_success:true, output:{...}}`。
+2. router：`verify_callback`（HMAC）→ `translator.translate`：
+   - 回声 `loop_task_id` 或 registry `resolve("bcn", instance_id)` → `(task_id, root_node_id, loop_task_id)`。
+   - `result={"success":true,"data":output}`；`acceptance=PASS`；`patch=TaskNodePatch(task_id, root_node_id, output_patch, acceptance_result=PASS)`。
+3. `svc.callback.report_result(data)` → `engine.on_report(patch)` → 锁内 `update_task_node_info`（`RUNNING→DONE` via `_ACCEPTANCE_TRANSITIONS`）→ `_on_pass_collect`（传播 / `_maybe_finish_graph`）→ `_drain`。
+4. 响应 200。
+
+### node_result（node 级，失败）
+1. claw_mind workflow 内某节点失败 → `POST /task_loop/callback/node_result`，`{task_id, node_id, workflow_source:"claw_mind", is_success:false, failed_info:"..."}`。
+2. translator：`loop_task_id=f"{task_id}::{node_id}"`；`acceptance=FAIL(gaps=[failed_info])`。
+3. `report_result` → `on_report` → `update_task_node_info`（`RUNNING→FAILED`）→ `_on_fail_collect`（`<MAX_DEPTH`→规划补救子节点；`≥MAX_DEPTH`→`_escalate_bbs` / `HUNG`）→ `_drain`。
+4. 200。
+
+### workflow_start（task 级）/ node_start
+1. 外部引擎开始执行 → `POST .../workflow_start` 或 `/node_start`。
+2. translator：disposition=start；`patch=TaskNodePatch(task_id, node_id, status=RUNNING)`。
+3. `svc.callback.start_run` → `engine.on_start`：已 `RUNNING`→no-op 200；`PENDING`→`RUNNING`（SSOT 校验）→ 200；终态/`PLANNING`→409。
+
+### 重投幂等
+- 同一 `workflow_result` 网络重投到已 `DONE` 节点 → `update_task_node_info` raise `TaskStateError`（`DONE→DONE` 非法）→ router 判 prev=`DONE`==目标 → 200 idempotent ack，不重复传播/finish。
+
+---
+
+## 9. 零 case 知识红线
+
+- `CallbackRequestTranslator` / router / registry / auth 仅消费 schema 字段 + `loop_task_id`/`node_id`/`workflow_source`，**不得**出现 `N_market`/`N_overview` 等节点名字面量。
+- `workflow_source`→`workflow_type` 映射表仅含 `claw_mind`/`bcn`（执行主体类型，非节点名）。
+- singlebox double 的 canned 回调用泛化 `node_id`（如 `worker_a`），不绑定具体 case 节点名；e2e 断言 `grep` 框架源码 0 命中 `N_market`/`N_overview` 等。
+
+---
+
+## 10. 测试策略
+
+### 10.1 单测（`tests/community/adapters/http/task/` + `core/task/`）
+- `test_translator.py`：4 端点×字段折叠（`is_success/output/failed_info`→`result`）、`workflow_source`→`workflow_type`、`ext_info`→`extend_props_patch`、disposition 判定、`loop_task_id` 解析（node 级直拼 / task 级回声 / task 级 registry 兜底 / registry 缺失→`CallbackCorrelationError`）、FAIL 无 `failed_info` 由 adapt 兜底。
+- `test_callback_correlation.py`：`register`/`resolve` 往返、缺失返 None、并发安全。
+- `test_engine_on_start.py`：`PENDING→RUNNING`、已 `RUNNING` no-op、`DONE/FAILED/HUNG`→`TaskStateError`(stale)、`PLANNING`→`TaskStateError`、不触发 `_drain`/传播。
+- `test_callback_adapter.py`：`TaskLoopCallback.start_run` 激活（→ `on_start`，非 no-op）；`report_result` 不变（回归）。
+- `test_router.py`：4 端点 happy→200；HMAC 失败→401；幂等 ack（result 重投→200, start 重投→200）；`TaskStateError` 非法→409；`NodeNotFoundError`→404；`CallbackCorrelationError`→400；schema 错→422。
+- `test_auth.py`：HMAC 签名/时间戳校验、Noop 直通。
+
+### 10.2 singlebox E2E
+- `NoopCallbackAuthenticator` + `_DoubleCallbackCorrelationRegistry`（派发期预登记）+ 进程内回投。
+- 模拟 claw_mind/bcn 回调驱动三态闭环：`workflow_start→workflow_result`（root 节点 RUNNING→DONE→finish）；`node_result` FAIL→补救/BBS 升级；`node_start/node_result` 子节点链路；重投幂等（result 重投不二次传播）。
+- 复用既有 e2e 闭环断言（DONE / FAIL 补救 / MISS 升 BBS / dashboard 终态）。
+
+### 10.3 上游回归
+- 无 `TaskModule` 时现行 121 单测全绿（`on_start` 纯新增、`start_run` 激活不破既有 `test_start_run_is_noop`——该测试更新为断言激活后走向 `on_start`）。
+- `TaskCallbackData`/`adapt`/`on_report` 契约不变 → execution-framework 回归不破。
+
+---
+
+## 11. 里程碑（实现计划由 writing-plans 展开）
+
+- **R0 schema + translator + registry 骨架**：`schemas.py`/`translator.py`/`callback_correlation.py`；`engine.on_start` + 激活 `TaskLoopCallback.start_run` + `adapt_start`；`TaskModule` 装配；router 4 端点（Noop auth）；单测。
+- **R1 HMAC 鉴权 + 回声透传 + 错误映射**：`HmacCallbackAuthenticator`；`loop_task_id` 回声契约；`_DOMAIN_ERROR_STATUS_MAP` 补项；幂等 ack override；单测。
+- **R2 singlebox E2E 收口**：double 回调驱动三态闭环 + 重投幂等；零 case grep 红线 0 命中；上游回归全绿。
+
+---
+
+## 12. Risks / 已知缺口
+
+| 项 | 说明 | 处置 |
+|---|---|---|
+| 与 runner spec §7.9 表面冲突 | §7.9「移除 PUSH」 | 本 spec 修订为「PUSH(workflow 类) + poller(无 workflow 类) 共存」；两路同 sink |
+| `workflow_id/instance_id` SSOT int vs 羽雀 str | 类型不一致 | registry 存 SSOT int；未登记 node 级回退 0 + str 存 ext_info；`adapt`/`on_report` 不消费 |
+| task 级无 `node_id` | 羽雀 task 级载荷无 node_id | 回声 `loop_task_id` 优先；registry `(source,instance_id)→node` 兜底；缺失→400 |
+| `on_report` 早退 fold-only | `acceptance_result is None` 不翻态 | 新增 `on_start`（status-direct）承载 `*_start`；`on_report` 不动 |
+| `PLANNING` 态收 start | 委托态不应被外部 start 打断 | `on_start` 对 `PLANNING`→`TaskStateError`→409 |
+| 外部引擎鉴权 | claw_mind/bcn 回调可信度 | HMAC port（默认）；singlebox Noop；密钥按 source 配置 |
+| `loop_task_id` 回声依赖外部引擎 | 引擎未必回带 | 回声优先 + registry 兜底双保险；回声契约写进 runner spec / corp adapter |
+| `TaskService` 未进 DI | 现仅测试驱动 | `TaskModule` singleton 绑定 + profile 登记 |
+| 持久化 | registry in-mem | 与 `TaskHarness` 同级；ORM 适配后续 |
+| 重投幂等 vs 非法翻转 | `TaskStateError` 既覆盖二者 | router 按 `prev_status` 区分：一致→200, 不一致→409 |
+
+---
+
+## 13. 与上游 spec 的一致性
+
+- `TaskLoopCallbackProtocol`（`start_run`/`report_result`）、`TaskCallbackData`、`CallbackAdapter.adapt`、`engine.on_report`、`loop_task_id="task_id::node_id"`、`TaskRunner.start_run` 签名**不变**。
+- `on_start` 为纯新增；`TaskLoopCallback.start_run` 由 no-op 升级为真实（`test_start_run_is_noop` 同步更新为断言激活走向）。
+- runner-integration spec §7.9 由「移除 PUSH」修订为「PUSH（workflow 类）+ poller（无 workflow 类）共存」，两路统一经 `on_report`/`on_start` → `update_task_node_info`（SSOT），不绕过图级/节点级写口。
+- 羽雀「回调服务」4 端点 + `TaskCallbackData`/`TaskNodeCallbackData` 契约由 HTTP 边缘 schema + translator 承接，SSOT 模型保持精简不扩。
+- 零 case 知识红线、开源边界（seam + double + HMAC 自包含）延续。

--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/tasks.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/tasks.md
@@ -1,0 +1,81 @@
+# Tasks — task_loop callback 服务子模块(inbound PUSH,单 bot workflow / bcn 协作群)
+
+> 参考羽雀「任务Loop执行」→「回调服务_供单bot workflow或者bcn协作群任务使用」(`lxg2mwgmtfqg6d95`)。
+> 落点:`src/backend`(core `on_start`/`adapt_start`/registry + `adapters/http/task` 边缘 + `di/modules/task_module` 装配);PUSH 与 runner-integration poller 共存(修订 runner spec §7.9)。
+> 权威 spec:`specs/2026-08-09-task-goal-driven-task-runner-callback/spec.md`;实现计划:`plan.md`。
+
+## 实现原则(对齐 AGENTS.md)
+- **SSOT 不绕过**:所有入站回调一律 `on_start`/`on_report`→`update_task_node_info`;router/translator/registry 不得直写图、不得直改 `TaskNode.status`。
+- **不破上游契约**:`TaskCallbackData`/`CallbackAdapter.adapt`/`engine.on_report`/`TaskLoopCallbackProtocol`/`loop_task_id="task_id::node_id"` 不变;`on_start`/`adapt_start` 为纯新增;不注入 `TaskModule` 时现行 121 单测全绿。
+- **HTTP 边缘翻译,SSOT 精简**:不扩 `TaskCallbackData`;羽雀丰富字段(`goal`/`status`/`is_success`/`output`/`failed_info`/`ext_info`/`node_id`)在 translator 边缘折叠进 SSOT 既有字段 + `result["_ext_info"]`(由 `adapt`/`adapt_start` 折 `extend_props_patch`)。
+- **协程化(对齐 README)**:`on_start` per-task `threading.RLock` 锁内同步写图(`update_task_node_info` 内存同步),**锁内不 await**;与 `on_report` 一致;router handler `async def`。
+- **必填非可选**:`workflow_source`/`workflow_id`/`workflow_instance_id`/`task_id`/`node_id` 必填;`T|None` 仅契约态(`goal`/`output`/`failed_info`/`ext_info`/`loop_task_id` 可空,None 触发兜底)。
+- **错误分层**:`CallbackAuthError`(401)/`CallbackCorrelationError`(400) 为 `DomainError` 子类进中央 `_DOMAIN_ERROR_STATUS_MAP`;`TaskStateError`/`TaskNotFoundError`/`NodeNotFoundError` 属 `TaskError`(非 `DomainError`),router 层显式 try/except 映射。
+- **零 case 知识红线**:callback 模块源码 `grep -rE 'N_overview|N_market|N_aggregate|N_verify|N_report|N_practice|n_root|dim_'` 必须 0 命中(节点名仅存 case 策略 stub/测试)。
+- **开源边界**:HMAC 镜像 ocb `BcsHttpClient` 签名模式但**不 import ocb**;社区分布只绑 `NoopCallbackAuthenticator`,CORP/prod 的 `HmacCallbackAuthenticator`+密钥由 corp adapter 覆写。
+- **TDD / 主 seam 优先**:R2 singlebox E2E 最高 seam(依赖 runner-integration 派发期登记 seam 落地);R0–R1 契约单测覆盖 4 端点×分支。
+
+## 依赖与落地序(R0 边缘+核心骨架 → R1 鉴权+契约 → R2 e2e+收口)
+
+```
+R0  DomainError 子类+status map
+ → engine.on_start(status-direct PENDING→RUNNING 幂等)
+ → CallbackAdapter.adapt_start + 激活 start_run + adapt 折 _ext_info
+ → CallbackCorrelationRegistry(task 级→节点寻址 seam)
+ → Pydantic v2 schema + CallbackRequestTranslator(边缘→SSOT)
+ → callback router 4 端点(Noop auth + 错误映射 + 幂等 ack)
+ → TaskModule DI 装配 + profile 登记 + app 挂载 router
+R1  HMAC CallbackAuthenticator + loop_task_id 回声透传契约 + 幂等/错误映射收口
+R2  singlebox E2E(double 回调驱动三态闭环 + 重投幂等) + 零 case grep + 全量回归
+```
+R2 依赖 runner-integration 委托期 `CallbackCorrelationRegistry.register(...)` 登记动作落地;R0–R1 可独立交付(进程内 wired 回投)。
+
+---
+
+## R0 — 边缘 + 核心骨架(可独立测试)
+- **T0.1** `core/errors.py` 新增 `CallbackAuthError`/`CallbackCorrelationError`(`DomainError` 子类);`adapters/http/app.py:_DOMAIN_ERROR_STATUS_MAP` 补 `CallbackAuthError→401`/`CallbackCorrelationError→400`(架构测试 `test_domain_error_status_map_complete` 枚举到 2 新子类且 map 覆盖)。
+- **T0.2** `ExecutionEngine.on_start(patch: TaskNodePatch) -> NodeOpResult`(新增,`task_center/engine.py`):锁内 `query_task_dashboard` 取节点;`PENDING→RUNNING` 经 `update_task_node_info`(`_DIRECT_TRANSITIONS`);已 `RUNNING`→no-op `NodeOpResult(prev=new=RUNNING,success=True)`;`DONE/FAILED/HUNG/PLANNING`→raise `TaskStateError`(stale);node 不存在→raise `NodeNotFoundError`;**不**触发 `_drain`/传播/side-effect。
+- **T0.3** `CallbackAdapter.adapt_start(data) -> TaskNodePatch`(`callback_adapter.py`):`loop_task_id.split("::",1)` + `status=Status.RUNNING` + 折 `result["_ext_info"]`→`extend_props_patch`;`adapt`(result) 追加折 `_ext_info`(与既有 `fail_detail` 合并,既有单测不设 `_ext_info` 故不受影响)。
+- **T0.4** 激活 `TaskLoopCallback.start_run`(`callback_adapter.py`):由 no-op 升级为 `await engine.on_start(adapt_start(data))`;`report_result` 不变;`TaskLoopCallbackProtocol` 签名不变。
+- **T0.5** `core/task/task_runner/callback_correlation.py`:`CorrelationRecord(task_id/node_id/loop_task_id/workflow_id:int/instance_id:int)` + `CallbackCorrelationRegistry` Protocol(`register(...)`/`resolve(source,instance_id_str)->CorrelationRecord|None`,`@runtime_checkable`) + `InMemoryCallbackCorrelationRegistry`(dict+RLock,key=`(source,instance_id_str)`,in-mem 不落库)。
+- **T0.6** `adapters/http/task/schemas.py`(Pydantic v2):`TaskCallbackRequest`(task_id/workflow_source:Literal["claw_mind","bcn"]/workflow_id/workflow_instance_id/status/is_success 必填;goal/output/failed_info/ext_info/loop_task_id 可空)、`TaskNodeCallbackRequest(+node_id 必填)`、`CallbackResponse(success/code=200/message="OK")`。
+- **T0.7** `adapters/http/task/translator.py`:`translate(req,disposition,registry)->TranslatedCallback(disposition,data:TaskCallbackData)`;`loop_task_id` 解析(回声 > node 直拼 `task::node` > registry > `CallbackCorrelationError`);`workflow_source`→`workflow_type`(`claw_mind`→`single_bot`/`bcn`→`bcn_coop_group`);registry 取 SSOT int id(未登记 node 级回退 0 + str 存 `_ext_info`);`is_success/output/failed_info`→`result{success,data,fail_detail}`;`ext_info/goal`→`result["_ext_info"]`。
+- **T0.8** `adapters/http/task/router.py`:`APIRouter(prefix="/task_loop/callback",tags=["task-callback"])` 4 端点(`workflow_start`/`workflow_result`/`node_start`/`node_result`);handler `async def`,经 `_get_svc/_get_auth/_get_registry` 三个 `Depends` provider 取 `Injected(TaskServiceProtocol/CallbackAuthenticator/CallbackCorrelationRegistry)`;`_dispatch`:读 raw body→`model_validate_json`→`auth.verify(source=req.workflow_source,headers,raw_body,method,path)`→`translate`→`start_run`/`report_result`;错误映射:`TaskNotFoundError`/`NodeNotFoundError`→404,`TaskStateError`→result 路径 re-query 已终态→200 idempotent 否则 409,start 路径→409;Pydantic→422。
+- **T0.9** `di/modules/task_module.py`:`TaskModule(Module)` singleton 绑 `TaskGraphService`(零参)/`TaskService`(`@inject` 注入 graph,harness 默认 None)/`InMemoryCallbackCorrelationRegistry`/`NoopCallbackAuthenticator`;`@provider` 暴露 `TaskServiceProtocol`/`CallbackCorrelationRegistry`/`CallbackAuthenticator`(镜像 `QualityModule`)。
+- **T0.10** `di/profile_modules.py`:`modules_for` TEST/SINGLEBOX column 登记 `TaskModule()`;`adapters/http/app.py` import + `app.include_router(task_callback_router)`(mandatory 块,非 `OptionalRouters`)。
+- ✅ 验收:T0.1 架构测试通过;T0.2 `on_start` 5 用例(PENDING→RUNNING/已RUNNING no-op/终态+PLANNING stale/unknown node 404/不触发 drain)绿;T0.3-T0.4 既有 `test_callback_adapter` 更新 `test_start_run_is_noop`→`test_start_run_routes_to_on_start` + `adapt_start`/`_ext_info` 用例绿;T0.5 registry 6 用例(register/resolve/幂等覆盖/source 区分/并发/runtime_checkable)绿;T0.6 schema 5 用例必填校验绿;T0.7 translator 11 用例(loop_task_id 解析 4/字段折叠 5/disposition 2)绿;T0.8 router 10 用例(4 端点 happy + 幂等/409/404/400/422)绿;T0.9 `test_task_module` singleton 解析绿;T0.10 app import 不破、121 既有单测全绿。
+
+## R1 — HMAC 鉴权 + 回声契约 + 错误映射收口
+- **T1.1** `adapters/http/task/auth.py`:`CallbackAuthenticator` Protocol(`verify(*,source,headers,raw_body,method,path)->None`,失败 raise `CallbackAuthError`);`HmacCallbackAuthenticator(secrets:Mapping[str,str],max_skew_s=300)`——签串 `f"{timestamp}{method}{path}{body_sha256_hex}"`,头 `X-TaskLoop-Token`/`X-TaskLoop-Timestamp`/`X-TaskLoop-Signature`(`hmac.compare_digest`,不 import ocb);`NoopCallbackAuthenticator`(直通)。
+- **T1.2** `loop_task_id` 回声透传契约:派发到 claw_mind/bcn 时(TaskRunner.start_run 真实派发,runner-integration executor/corp adapter)把 `loop_task_id` 作 callback_token 透传给外部引擎;translator 回声优先(回声存在跳过 registry 寻址),缺失 registry 兜底——双保险。**登记动作属 runner spec/corp adapter**,本任务只定「`loop_task_id` 必须可被引擎回带」契约 + registry port(T0.5)。
+- **T1.3** 幂等/错误映射收口:router `_dispatch` 的 `TaskStateError` 分支 re-query `svc.get_task_dashboard(task_id)` 取节点当前态,result 路径已终态(`DONE/FAILED/HUNG`)→200 idempotent `CallbackResponse(success=True,message="idempotent")`,否则 409;start 路径 `TaskStateError`→409(`on_start` 已内化 RUNNING no-op);`CallbackAuthError`/`CallbackCorrelationError` 由中央 `@app.exception_handler(DomainError)`→401/400。
+- ✅ 验收:`test_auth` 6 用例(verify 通过/坏签名/未知 source/超窗时间戳/body 篡改/Noop 直通)绿;router 幂等/409/401(中央)/400 用例绿;HMAC 实现自包含无 ocb import。
+
+## R2 — singlebox E2E + 零 case + 回归收口(依赖 runner-integration 派发期登记 seam)
+- **T2.1** singlebox e2e:`NoopCallbackAuthenticator` + 派发期预登记 `InMemoryCallbackCorrelationRegistry` + 进程内回投;模拟 claw_mind/bcn 回调驱动三态闭环:`workflow_start→workflow_result`(root 节点 RUNNING→DONE→finish)、`node_result` FAIL→补救/BBS 升级、`node_start/node_result` 子节点链路;重投幂等(result 重投不二次传播/finish)。
+- **T2.2** 零 case grep 红线:`tests/community/adapters/http/task/test_zero_case.py` 断言 `schemas/translator/auth/router/__init__.py` 0 命中 `N_overview/N_market/N_aggregate/N_verify/N_report/N_practice/n_root/dim_`。
+- **T2.3** 全量回归 + pre-push:`tests/community/core/task/` + `tests/community/adapters/http/task/` + `tests/community/di/test_task_module.py` + `tests/community/architecture/` 全绿;pre-push Backend SAST gate 通过(默认 lint-only)。
+- ✅ 验收:singlebox e2e 复用既有闭环断言(DONE/FAIL 补救/MISS 升 BBS/dashboard 终态)+ 重投幂等断言;零 case 0 命中;121 既有 + 新增全绿。
+
+## Cross-cutting
+- 架构宪法(`docs/arch/arch.rules.md` Rule 7:core transport-free——`CallbackAuthError`/`CallbackCorrelationError` 语义错误落 `core/errors.py`,HTTP 状态仅 `app.py` 映射)。
+- CI gates(`docs/arch/ci.enforce.md`)、依赖边界(core 不 import transport;translator/router 可 import core + di)。
+- `loop_task_id` mint 在 `TaskRunner.start_run`(runner.py:75 `f"{task.task_id}::{node.node_id}"`);回声透传 + registry 双保险。
+- 事件日志/审计位点:`loop_task_id`、`workflow_source`、`workflow_instance_id`、`prev/new_status`(幂等 ack 判定)。
+
+## Risks / 待实现期定的项
+- CORP/prod 的 `HmacCallbackAuthenticator`+密钥 wiring(社区只发 Noop;corp adapter 覆写 `CallbackAuthenticator` 绑定 + 真实 `loop_task_id` 回声透传)。
+- 派发期 `CallbackCorrelationRegistry.register(...)` 登记动作(runner-integration executor/corp adapter 落地;R2 e2e 依赖)。
+- `workflow_id/instance_id` SSOT int vs 羽雀 str:registry 存 SSOT int;未登记 node 级回退 0 + str 存 `ext_info`;`adapt`/`on_report` 不消费(仅信息字段)。
+- task 级无 `node_id`:回声 `loop_task_id` 优先;registry `(source,instance_id)→node` 兜底;缺失→400。
+- `on_report` 早退 fold-only(`acceptance_result is None`):新增 `on_start`(status-direct)承载 `*_start`;`on_report` 不动。
+- `PLANNING` 态收 start:委托态拒绝外部 start→`TaskStateError`→409。
+- 持久化:registry in-mem(与 `TaskHarness._dispatched_at` 同级);ORM 适配后续。
+- 重投幂等 vs 非法翻转:`TaskStateError` 既覆盖二者,router 按 re-query 节点态区分(已终态→200,非终态→409)。
+
+## 里程碑(R0–R1 本计划交付;R2 依赖 runner-integration)
+- ⬜ **R0** 边缘 + 核心骨架(`on_start`/`adapt_start`/registry/schema/translator/router/TaskModule 装配),4 端点 Noop auth 可跑通进程内回投。
+- ⬜ **R1** HMAC 鉴权 + `loop_task_id` 回声契约 + 幂等/错误映射收口。
+- ⬜ **R2** singlebox E2E(三态闭环 + 重投幂等) + 零 case grep + 全量回归。
+
+> 实现逐任务 TDD 细节见 `plan.md`(每任务含失败测试→实现→通过→commit 可执行步骤);契约依据见 `spec.md`。

--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner/plan.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner/plan.md
@@ -1,0 +1,2302 @@
+# task_runner integration 子模块 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `TaskRunner.start_run` / `form_coop_group` 的 stub 替换为真实执行接入——单 bot 走 BaaS Open API（静态 App Key + `allowed-bots` grant + `POST /openapi/v1/messages` 取 `run_id`）、协作群走自包含 BCS HTTP client（三态 chat/manager_worker/state_machine）、bbs 仅记日志；结果统一经旁路 `TaskExecutorResultPoller` 回收 → `TaskLoopCallback.report_result` → `on_report`。
+
+**Architecture:** 方案 A——所有模态「派发 await 取 `run_id`/`session_id` 即返回（不等待结果）+ 旁路 Poller 回收终态」。`TaskExecutor.dispatch` 为 async（在上游 `start_run` 的 caller loop 上 `gather`+`Semaphore` 限流），**await 到拿到 `run_id` 为止**，失败（grant 403 等）→ 该 node 返 `False`；`TaskExecutorResultPoller` 是独立 daemon 线程 sidecar（同 `TaskHarness` 风格：`register`/`run_poll_loop(stop_event)`/可注入 clock+sleep/`_poll_once` async 可单测），三模态回收。开源边界：httpx async 自包含，不 import ocb `ecb` / 不 import in-repo `secbaas`；HMAC 镜像 ocb `BcsHttpClient` 模式。singlebox 经注入 double 跑真实集成形态。
+
+**Tech Stack:** Python 3.12 + httpx 0.28 async（`httpx.MockTransport` 单测）+ asyncio（`gather`+`Semaphore(8)`）+ threading（poller daemon 线程，per-handle `threading.RLock`）。
+
+**Spec:** `src/backend/specs/2026-08-09-task-goal-driven-task-runner-2/spec.md`
+
+## Global Constraints
+
+- 遵循 `AGENTS.md`：不引入 `T | None` 除非 None 是契约态（`session_id is None`→`create_session`、`bot_id` 不在 `allowed_bots`→`ensure_grant`、`run_id is None`→session 模）；必填值非可选。
+- 不破上游契约：`TaskRunner.start_run(toDoTaskList) -> list[bool]` async 签名不变；`TaskLoopCallback`/`CallbackAdapter`/`TaskCallbackData`/`loop_task_id="task_id::node_id"` 不变；不注入 `execution_backend` 时现行 stub 行为 + 121 单测全绿。
+- SSOT 不绕过：结果回流一律 `ResultSink.report_result(TaskCallbackData)` → `TaskLoopCallback.report_result` → `engine.on_report` → `update_task_node_info`；integration 不直写图。
+- 零 case 知识红线：`PromptFormatter`/adapter/registry 仅消费 `_build_context` dict 字段 + `TaskNode.task_spec` + `run_info.assignee`/`run_mode`，不得出现 `N_market`/`N_overview` 等节点名字面量（grep 0 命中，单测断言）。
+- 开源边界：integration 不 `import` corp ocb `ecb`；单 bot 走 BaaS HTTP Open API（httpx async，**不 import in-repo `secbaas` BotRunner**）；BCS client 自包含重写（httpx async + HMAC）。
+- 协程化约束（README）：`engine._drain` 锁外 `await runner.start_run`；`start_run` 内 `gather`+`Semaphore` 并发投递；poller `_poll_once` 为 `async def`（端口是 async httpx），daemon 线程持自有 loop 跑 `run_poll_loop`；锁内不 await。
+- httpx 单测一律 `httpx.MockTransport(handler)`，不经网络。
+- 测试入口：`cd src/backend && python -m pytest <test> -v`；单测 async 经 `asyncio.new_event_loop().run_until_complete`（不用 `@pytest.mark.asyncio`）。
+- commit 消息结尾 `Co-Authored-By: Claude <noreply@anthropic.com>`。
+
+## 与 spec §7.7 的细化（plan 锁定，非 spec 违背）
+
+spec §7.7 称 `dispatch` 为「同步入口」+ executor「自有后台事件循环线程跑所有 async I/O」。但上游 `start_run` 是 `async` 且需 `await` 到捕获 `run_id` 才能返 `list[bool]`（grant 403→False 的判定依赖 await）。故 plan 细化：**`TaskExecutor.dispatch` 为 `async`，在上游 caller loop 上 `gather`+`Semaphore` 直接 `await` 端口 IO**（已锁外，不阻塞编排核）；**executor 的 daemon 线程专属 `TaskExecutorResultPoller.run_poll_loop`**（同 `TaskHarness` 风格），不再为 dispatch 单开 bg loop。这保持「派发取 `run_id` 即返回、不等待结果」语义（结果回收归 poller）。
+
+---
+
+## File Structure
+
+| 文件 | 职责 | 动作 |
+|---|---|---|
+| `core/task/task_runner/integration/__init__.py` | `build_integration(real|double)` 组合根 | Create |
+| `core/task/task_runner/integration/ports.py` | Port: `OpenApiBotPort`/`BcsClientPort`/`ApiKeyProvider`/`TaskContextBuilder`/`PromptFormatter`/`ResultSink` + handle dataclass | Create |
+| `core/task/task_runner/integration/translators.py` | `SingleBotRunTranslator`/`BcsSessionTranslator`/`BcsStateMachineRunTranslator` | Create |
+| `core/task/task_runner/integration/open_api_bot_adapter.py` | `OpenApiBotAdapter` + exceptions + `parse_bot_id`(httpx async) | Create |
+| `core/task/task_runner/integration/bcs_http_adapter.py` | `BcsCreateGroupRequest`/`Result` + `BcsHttpAdapter`(httpx async + HMAC) + BCS exceptions | Create |
+| `core/task/task_runner/integration/bcs_token_provider.py` | `BcsTokenProvider`(driver bot 签名取数 real/double) | Create |
+| `core/task/task_runner/integration/prompt_formatter.py` | 默认 `PromptFormatter` + `_RunnerContextBuilder`(包 `runner._build_context`) | Create |
+| `core/task/task_runner/integration/task_executor.py` | `TaskExecutor`:`dispatch`/`form_coop_group`/`_group_meta`/`aclose` | Create |
+| `core/task/task_runner/integration/task_executor_result_poller.py` | `TaskExecutorResultPoller` sidecar + `SingleBotHandle`/`BcsGroupHandle` | Create |
+| `core/task/task_runner/integration/double/__init__.py` | singlebox double | Create |
+| `core/task/task_runner/integration/double/double_open_api_bot.py` | `_DoubleOpenApiBot` | Create |
+| `core/task/task_runner/integration/double/double_bcs_client.py` | `_DoubleBcsClient` | Create |
+| `core/task/task_runner/integration/double/double_context_provider.py` | `_DoubleApiKeyProvider`/`_DoubleContextProvider`/`_DoublePollerSink` | Create |
+| `core/task/task_runner/runner.py` | `__init__(graph, execution_backend=None)` + `start_run`/`form_coop_group` 委托 | Modify |
+| `tests/community/core/task/task_runner/integration/*` | 单测 | Create |
+| `tests/community/e2e/...`(singlebox) | 复用剧本 `gwqie46v7hzr1w6h` | Modify |
+
+---
+
+## Task 1: ports.py — Port 契约 + handle dataclass
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/__init__.py`
+- Create: `src/agentclaw/community/core/task/task_runner/integration/ports.py`
+- Test: `tests/community/core/task/task_runner/integration/test_ports.py`
+
+**Interfaces:**
+- Produces: `OpenApiBotPort`/`BcsClientPort`/`ApiKeyProvider`/`TaskContextBuilder`/`PromptFormatter`/`ResultSink` Protocol；`BcsCreateGroupRequest`/`BcsCreateGroupResult` 前向声明（实现在 Task 7 的 `bcs_http_adapter.py`，ports.py 只 `TYPE_CHECKING` 引用）；`SingleBotHandle`/`BcsGroupHandle`(实现在 Task 5 poller 文件，ports.py 这里先不定义，避免环——本任务只定 5 Port + 2 Request/Result dataclass 占位放 `bcs_http_adapter.py`，Task 7 落地)。**本任务只产 5 Protocol。**
+
+- [ ] **Step 1: 写失败测试**
+
+`tests/community/core/task/task_runner/integration/test_ports.py`：
+
+```python
+from typing import Any, Protocol, runtime_checkable  # noqa: F401
+import pytest
+
+from agentclaw.community.core.task.task_runner.integration.ports import (
+    ApiKeyProvider, BcsClientPort, OpenApiBotPort, PromptFormatter,
+    ResultSink, TaskContextBuilder,
+)
+
+
+def test_protocols_are_runtime_checkable():
+    for p in (OpenApiBotPort, BcsClientPort, ApiKeyProvider, TaskContextBuilder, PromptFormatter, ResultSink):
+        assert hasattr(p, "_is_protocol")  # Protocol 子类
+
+
+def test_open_api_bot_port_methods():
+    assert "ensure_grant" in OpenApiBotPort.__dict__["_is_protocol"] or True  # 仅断言可导入
+    # 真实结构断言:方法名存在
+    assert hasattr(OpenApiBotPort, "ensure_grant")
+    assert hasattr(OpenApiBotPort, "send_message")
+    assert hasattr(OpenApiBotPort, "get_run")
+
+
+def test_bcs_client_port_methods():
+    for m in ("create_group", "create_session", "get_group", "get_session_messages",
+              "start_state_machine_run", "get_state_machine_run", "validate_definition"):
+        assert hasattr(BcsClientPort, m)
+
+
+def test_api_key_provider_properties():
+    for p in ("api_key", "api_key_prefix", "base_url", "cookie", "referer"):
+        assert hasattr(ApiKeyProvider, p)
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_ports.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `ports.py` + 空 `__init__.py`**
+
+`integration/__init__.py`：
+
+```python
+"""task_runner integration 子模块:单 bot(Open API)/协作群(BCS)/bbs 真实执行接入。
+
+组合根 ``build_integration`` 在 R4(double)落地;真实 wiring 属 corp adapter。
+"""
+```
+
+`integration/ports.py`：
+
+```python
+"""integration Port 契约(对齐 spec §7.4)。transport-agnostic Protocol;组合根选实现。"""
+from __future__ import annotations
+
+from typing import Any, Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.task.domain.models import TaskCallbackData, TaskNode
+
+
+@runtime_checkable
+class OpenApiBotPort(Protocol):
+    async def ensure_grant(self, bot_id: str) -> None: ...
+    async def send_message(self, *, bot_id: str, message: str, metadata: dict[str, Any]) -> str: ...
+    async def get_run(self, run_id: str) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class BcsClientPort(Protocol):
+    async def create_group(self, req: "BcsCreateGroupRequest") -> "BcsCreateGroupResult": ...
+    async def create_session(self, group_id: str, *, bootstrap_prompt: str | None = None,
+                             idempotency_key: str | None = None) -> str: ...
+    async def get_group(self, group_id: str) -> dict[str, Any]: ...
+    async def get_session_messages(self, session_id: str, *, limit: int = 50,
+                                   since_msg_id: str | None = None) -> list[Any]: ...
+    async def start_state_machine_run(self, group_id: str, *, definition_yaml: str | None,
+                                      definition_ref: dict[str, Any] | None, session_id: str | None,
+                                      input: dict[str, Any]) -> str: ...
+    async def get_state_machine_run(self, run_id: str) -> dict[str, Any]: ...
+    async def validate_definition(self, definition_yaml: str) -> None: ...
+
+
+@runtime_checkable
+class ApiKeyProvider(Protocol):
+    @property
+    def api_key(self) -> str: ...
+    @property
+    def api_key_prefix(self) -> str: ...
+    @property
+    def base_url(self) -> str: ...
+    @property
+    def cookie(self) -> str: ...
+    @property
+    def referer(self) -> str: ...
+
+
+@runtime_checkable
+class TaskContextBuilder(Protocol):
+    def build(self, task_id: str, node_id: str) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class PromptFormatter(Protocol):
+    def format_execute(self, context: dict[str, Any], node: "TaskNode") -> str: ...
+    def format_verify(self, context: dict[str, Any], node: "TaskNode") -> str: ...
+
+
+@runtime_checkable
+class ResultSink(Protocol):
+    async def report_result(self, data: "TaskCallbackData") -> None: ...
+
+
+# 前向声明(实现在 bcs_http_adapter.py,Task 7)
+class BcsCreateGroupRequest(Protocol): ...  # noqa: D204
+class BcsCreateGroupResult(Protocol): ...
+```
+
+> `BcsCreateGroupRequest`/`Result` 在 Task 7 改为真实 dataclass 并从 `bcs_http_adapter` re-export；此处的 Protocol 占位仅为打破环、让 Port 可引用。Task 7 会移除占位、改为 `if TYPE_CHECKING` import 真实 dataclass。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_ports.py -v`
+Expected: PASS（4 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/__init__.py src/agentclaw/community/core/task/task_runner/integration/ports.py tests/community/core/task/task_runner/integration/test_ports.py
+git commit -m "feat(task-runner-integration): add integration Port contracts
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: translators.py — 三翻译器（结果 dict → TaskCallbackData）
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/translators.py`
+- Test: `tests/community/core/task/task_runner/integration/test_translators.py`
+
+**Interfaces:**
+- Consumes: `TaskCallbackData(loop_task_id, workflow_type, workflow_id, instance_id, result)`（domain/models）。
+- Produces: `SingleBotRunTranslator.adapt(run_dict, loop_task_id) -> TaskCallbackData`、`BcsSessionTranslator.adapt(group_dict, messages, loop_task_id) -> TaskCallbackData`、`BcsStateMachineRunTranslator.adapt(run_dict, loop_task_id) -> TaskCallbackData`。被 Task 5/8/9 poller 消费。`workflow_type` 分别 `"single_bot"`/`"bcn_coop_group"`/`"bcn_coop_group"`；`workflow_id`/`instance_id` 取 0（回调 sink 不消费）。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+from agentclaw.community.core.task.task_runner.integration.translators import (
+    BcsSessionTranslator, BcsStateMachineRunTranslator, SingleBotRunTranslator,
+)
+
+
+def test_single_bot_completed():
+    d = SingleBotRunTranslator.adapt({"status": "COMPLETED", "result": {"content": "行业全貌"}}, "t1::c1")
+    assert d.loop_task_id == "t1::c1"
+    assert d.result["success"] is True
+    assert d.result["data"] == "行业全貌"
+    assert "fail_detail" not in d.result
+
+
+def test_single_bot_failed_with_error():
+    d = SingleBotRunTranslator.adapt({"status": "FAILED", "error": "boom"}, "t1::c1")
+    assert d.result["success"] is False
+    assert d.result["fail_detail"] == "boom"
+
+
+def test_single_bot_status_case_insensitive():
+    d = SingleBotRunTranslator.adapt({"status": "completed"}, "t1::c1")
+    assert d.result["success"] is True
+
+
+def test_single_bot_timeout_mapped():
+    d = SingleBotRunTranslator.adapt({"status": "FAILED", "error": "TIME_OUT"}, "t1::c1")
+    assert d.result["fail_detail"] == "timeout"
+
+
+def test_bcs_session_completed():
+    group = {"session": {"status": "completed", "output": {"r": 1}, "error_message": None}}
+    d = BcsSessionTranslator.adapt(group, [], "t1::g1")
+    assert d.result["success"] is True
+    assert d.result["data"] == {"r": 1}
+
+
+def test_bcs_session_failed():
+    group = {"session": {"status": "failed", "output": None, "error_message": "err"}}
+    d = BcsSessionTranslator.adapt(group, [], "t1::g1")
+    assert d.result["success"] is False
+    assert d.result["fail_detail"] == "err"
+
+
+def test_bcs_session_output_fallback_to_last_assistant_msg():
+    group = {"session": {"status": "completed", "output": None, "error_message": None}}
+    msgs = [{"role": "user", "content": "q"}, {"role": "assistant", "content": "ans"}]
+    d = BcsSessionTranslator.adapt(group, msgs, "t1::g1")
+    assert d.result["data"] == "ans"
+
+
+def test_state_machine_completed():
+    d = BcsStateMachineRunTranslator.adapt({"status": "completed", "output": {"x": 1}, "error": None}, "t1::g1")
+    assert d.result["success"] is True
+    assert d.result["data"] == {"x": 1}
+
+
+def test_state_machine_aborted():
+    d = BcsStateMachineRunTranslator.adapt({"status": "aborted"}, "t1::g1")
+    assert d.result["success"] is False
+    assert d.result["fail_detail"] == "aborted"
+
+
+def test_state_machine_failed_with_error():
+    d = BcsStateMachineRunTranslator.adapt({"status": "failed", "error": "boom"}, "t1::g1")
+    assert d.result["success"] is False
+    assert d.result["fail_detail"] == "boom"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_translators.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `translators.py`**
+
+```python
+"""三翻译器:执行主体终态 dict → TaskCallbackData(loop_task_id/result{success,data,fail_detail})。
+
+零 case:仅消费 dict 字段,不出现节点名。结果回流经 ResultSink → on_report。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.task.domain.models import TaskCallbackData
+
+
+def _cb(loop_task_id: str, workflow_type: str, *, success: bool, data: Any = None,
+        fail_detail: str | None = None) -> TaskCallbackData:
+    result: dict[str, Any] = {"success": success}
+    if data is not None:
+        result["data"] = data
+    if fail_detail is not None:
+        result["fail_detail"] = fail_detail
+    return TaskCallbackData(
+        loop_task_id=loop_task_id, workflow_type=workflow_type,
+        workflow_id=0, instance_id=0, result=result,
+    )
+
+
+class SingleBotRunTranslator:
+    @staticmethod
+    def adapt(run_dict: dict[str, Any], loop_task_id: str) -> TaskCallbackData:
+        status = str(run_dict.get("status") or "").lower()
+        success = status == "completed"
+        data = (run_dict.get("result") or {}).get("content")
+        err = run_dict.get("error")
+        fail_detail = "timeout" if (err and str(err).upper() == "TIME_OUT") else err
+        return _cb(loop_task_id, "single_bot", success=success, data=data, fail_detail=fail_detail)
+
+
+class BcsSessionTranslator:
+    @staticmethod
+    def adapt(group_dict: dict[str, Any], messages: list[Any], loop_task_id: str) -> TaskCallbackData:
+        sess = group_dict.get("session") or {}
+        status = str(sess.get("status") or "").lower()
+        success = status == "completed"
+        data = sess.get("output")
+        if data is None:
+            for m in reversed(messages):
+                if (m.get("role") if isinstance(m, dict) else None) == "assistant":
+                    data = m.get("content")
+                    break
+        fail_detail = sess.get("error_message")
+        return _cb(loop_task_id, "bcn_coop_group", success=success, data=data, fail_detail=fail_detail)
+
+
+class BcsStateMachineRunTranslator:
+    @staticmethod
+    def adapt(run_dict: dict[str, Any], loop_task_id: str) -> TaskCallbackData:
+        status = str(run_dict.get("status") or "").lower()
+        success = status == "completed"
+        data = run_dict.get("output")
+        err = run_dict.get("error")
+        fail_detail = "aborted" if status == "aborted" else err
+        return _cb(loop_task_id, "bcn_coop_group", success=success, data=data, fail_detail=fail_detail)
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_translators.py -v`
+Expected: PASS（10 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/translators.py tests/community/core/task/task_runner/integration/test_translators.py
+git commit -m "feat(task-runner-integration): add result translators (single_bot/session/state_machine)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: TaskExecutor 骨架 + TaskRunner 注入点（默认 stub 不破）+ bbs no-op + dispatch list[bool]
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/task_executor.py`
+- Modify: `src/agentclaw/community/core/task/task_runner/runner.py`（`__init__` + `start_run`/`form_coop_group` 委托）
+- Test: `tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py`
+
+**Interfaces:**
+- Consumes: `TaskNode.run_info.run_mode`/`assignee`（domain）；`PromptFormatter`/`TaskContextBuilder`/`OpenApiBotPort`/`BcsClientPort`/`ResultSink`/`TaskExecutorResultPoller`（后续任务产出，本任务用占位 Optional）。
+- Produces: `TaskExecutor(dispatcher_deps...)` with `async dispatch(toDoTaskList) -> list[bool]`（三模态分流；`single_bot`/`coop_group` 暂返 `True` 占位待 T5/T8 替换；`bbs` 仅记日志返 `True`）、`async form_coop_group(gf) -> str`（暂 stub 占位待 T8）、`aclose()`。`TaskRunner.__init__(graph, execution_backend=None)`；注入时 `start_run`/`form_coop_group` 委托，否则现行 stub。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+import asyncio
+import logging
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status, TaskNode, TaskSpec,
+)
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+
+
+def _node(node_id="c1", task_id="t1", run_mode="bbs", assignee="b1"):
+    return TaskNode(node_id=node_id, task_id=task_id, status=Status.PENDING,
+                    task_spec=TaskSpec(Metadata(task_id, "T", "do"), Context("bg"),
+                                       Goal("O", [AcceptanceCriteria("a1", "d")])),
+                    run_info=RuntimeInfo(run_mode=run_mode, assignee=assignee),
+                    node_run_graph=None)  # type: ignore[arg-type]
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_bbs_dispatch_is_noop_and_returns_true(caplog):
+    exe = TaskExecutor(bot=None, bcs=None, formatter=None, context=None, sink=None, poller=None)
+    with caplog.at_level(logging.INFO):
+        res = _run(exe.dispatch([_node(run_mode="bbs")]))
+    assert res == [True]
+    assert any("bbs" in r.message.lower() for r in caplog.records)
+
+
+def test_unknown_mode_returns_false():
+    exe = TaskExecutor(bot=None, bcs=None, formatter=None, context=None, sink=None, poller=None)
+    res = _run(exe.dispatch([_node(run_mode="weird")]))
+    assert res == [False]
+
+
+def test_dispatch_returns_one_bool_per_node():
+    exe = TaskExecutor(bot=None, bcs=None, formatter=None, context=None, sink=None, poller=None)
+    res = _run(exe.dispatch([_node("a", run_mode="bbs"), _node("b", run_mode="bbs")]))
+    assert res == [True, True]
+
+
+def test_runner_falls_back_to_stub_without_backend():
+    from agentclaw.community.core.task.task_graph.task_graph_service import TaskGraphService
+    from agentclaw.community.core.task.task_runner.runner import TaskRunner
+    g = TaskGraphService()
+    r = TaskRunner(g)  # 无 execution_backend
+    res = _run(r.start_run([_node()]))
+    assert res == [True]  # stub fallback
+    assert r._run_log  # 记了投递日志
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `task_executor.py` 骨架**
+
+```python
+"""TaskExecutor:三模态派发(single_bot/coop_group/bbs)+ 旁路 poller 登记入口。
+
+dispatch(async):上游 start_run caller loop 上 gather+Semaphore await 端口 IO,拿到 run_id 即返回
+(不等待结果);bbs 仅记日志。form_coop_group(async):BCS 建群壳。poller 为独立 daemon sidecar(同 TaskHarness)。
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Protocol
+
+from agentclaw.community.core.task.domain.models import TaskNode
+from agentclaw.community.core.task.task_dispatch.strategies import GroupFormation
+
+logger = logging.getLogger(__name__)
+_DISPATCH_CONCURRENCY = 8
+
+
+class TaskExecutor:
+    def __init__(self, *, bot, bcs, formatter, context, sink, poller) -> None:
+        """bot: OpenApiBotPort|None; bcs: BcsClientPort|None; formatter: PromptFormatter|None;
+        context: TaskContextBuilder|None; sink: ResultSink|None; poller: TaskExecutorResultPoller|None。
+        R0 骨架允许 None;bbs 路径不依赖任何端口。"""
+        self._bot = bot
+        self._bcs = bcs
+        self._formatter = formatter
+        self._context = context
+        self._sink = sink
+        self._poller = poller
+        self._group_meta: dict[str, dict[str, Any]] = {}  # group_id -> {collab_mode, gf, definition_ref, session_id}
+
+    async def dispatch(self, toDoTaskList: list[TaskNode]) -> list[bool]:
+        sem = asyncio.Semaphore(_DISPATCH_CONCURRENCY)
+
+        async def _one(node: TaskNode) -> bool:
+            mode = node.run_info.run_mode
+            if mode == "bbs":
+                logger.info("[task_executor] bbs node dispatched (no-op): task=%s node=%s assignee=%s",
+                            node.task_id, node.node_id, node.run_info.assignee)
+                return True
+            if mode == "single_bot":
+                return await self._dispatch_single_bot(node, sem)
+            if mode == "coop_group":
+                return await self._dispatch_coop_group(node, sem)
+            return False
+
+        return list(await asyncio.gather(*[_one(n) for n in toDoTaskList]))
+
+    async def _dispatch_single_bot(self, node: TaskNode, sem: asyncio.Semaphore) -> bool:
+        return True  # T5 替换:ensure_grant→send_message→poller.register
+
+    async def _dispatch_coop_group(self, node: TaskNode, sem: asyncio.Semaphore) -> bool:
+        return True  # T8/T9 替换:create_session/start_state_machine_run→poller.register
+
+    async def form_coop_group(self, gf: GroupFormation) -> str:
+        gid = f"grp_{uuid.uuid4().hex[:8]}"  # T8 替换:真实 BcsHttpAdapter.create_group
+        self._group_meta[gid] = {"collab_mode": gf.collab_mode, "gf": gf,
+                                 "definition_ref": None, "session_id": None}
+        return gid
+
+    async def aclose(self) -> None:
+        if self._poller is not None:
+            self._poller.stop()
+```
+
+- [ ] **Step 4: 改 `runner.py` 注入点**
+
+`runner.py` `__init__` 加 `execution_backend=None`：
+
+```python
+    def __init__(self, graph, execution_backend=None) -> None:
+        """graph: TaskGraphService;execution_backend: TaskExecutor | None(注入则真实派发;缺省 stub)。"""
+        self._graph = graph
+        self._execution_backend = execution_backend
+        self._deliveries: dict[str, DeliveryPort] = {}
+        self._groups: dict[str, GroupFormation] = {}
+        self._run_log: list[dict[str, Any]] = []
+```
+
+`start_run` `_deliver_one` 内优先委托：
+
+```python
+        async def _deliver_one(node: TaskNode) -> bool:
+            mode = node.run_info.run_mode
+            if mode not in ("single_bot", "coop_group", "bbs"):
+                return False
+            if self._execution_backend is not None:
+                # execution_backend.dispatch 自身按 run_mode 三模态分流(含 bbs no-op)
+                return await self._execution_backend.dispatch([node]) == [True]
+            async with sem:
+                port = self._deliveries.get(mode)
+                if port is not None:
+                    return bool(await port.deliver(node))
+                self._run_log.append({...})  # 既有 stub 日志(保持不变)
+                return True
+```
+
+`form_coop_group` 委托：
+
+```python
+    async def form_coop_group(self, gf: GroupFormation) -> str:
+        if self._execution_backend is not None:
+            return await self._execution_backend.form_coop_group(gf)
+        gid = f"grp_{uuid.uuid4().hex[:8]}"
+        self._groups[gid] = gf
+        return gid
+```
+
+> 把原 stub 体挪到 `else`/`if backend is None` 分支，保持 121 单测引用的 `_run_log`/`_groups` 行为不变。
+
+- [ ] **Step 5: 跑测试 + 上游回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py tests/community/core/task/ -v`
+Expected: PASS（新 4 + 既有 121 不破）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/task_executor.py src/agentclaw/community/core/task/task_runner/runner.py tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py
+git commit -m "feat(task-runner-integration): TaskExecutor skeleton + TaskRunner execution_backend injection (bbs no-op)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: OpenApiBotAdapter + exceptions + parse_bot_id（httpx async + ensure_grant）
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py`
+- Test: `tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py`
+
+**Interfaces:**
+- Consumes: `ApiKeyProvider`（api_key/api_key_prefix/base_url/cookie/referer）；httpx 0.28。
+- Produces: `OpenApiBotAdapter(ApiKeyProvider)` 实现 `OpenApiBotPort`：`async ensure_grant(bot_id)`（`GET /api/v1/api-keys/{prefix}/allowed-bots`→缺则 `POST .../grant` Cookie+Referer）、`async send_message(*, bot_id, message, metadata) -> str`（`POST /openapi/v1/messages` Bearer→`data.message_id`）、`async get_run(run_id) -> dict`（`GET /openapi/v1/messages/{run_id}`）；异常 `OpenApiAuthError`/`OpenApiBadRequestError`/`OpenApiRateLimitError`/`OpenApiServerError`/`OpenApiTimeoutError`；`parse_bot_id(bot_id) -> (real_bot_id, entity_id)`。`bot_id` 格式 `<real>:<entity>`。
+
+- [ ] **Step 1: 写失败测试（httpx MockTransport）**
+
+```python
+import httpx
+import pytest
+
+from agentclaw.community.core.task.task_runner.integration.open_api_bot_adapter import (
+    OpenApiAuthError, OpenApiBotAdapter, OpenApiServerError, parse_bot_id,
+)
+
+
+class _Key:
+    api_key = "ak1234567890"
+    api_key_prefix = "ak12345678"
+    base_url = "http://b:8890"
+    cookie = "sess=1"
+    referer = "http://b/"
+
+
+def _adapter(handler):
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://b:8890")
+    return OpenApiBotAdapter(_Key(), http_client=client)
+
+
+async def _run(coro):
+    import asyncio
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_parse_bot_id():
+    assert parse_bot_id("bot9:ent1") == ("bot9", "ent1")
+
+
+def test_ensure_grant_already_allowed():
+    allowed = {"data": {"allowed_bots": ["bot9:ent1"]}}
+    def h(req): return httpx.Response(200, json=allowed)
+    a = _adapter(h)
+    _run(a.ensure_grant("bot9:ent1"))  # 不抛
+
+
+def test_ensure_grant_grants_when_missing():
+    state = {"allowed": False}
+    def h(req):
+        if req.url.path.endswith("/allowed-bots") and req.method == "GET":
+            return httpx.Response(200, json={"data": {"allowed_bots": [] if not state["allowed"] else ["bot9:ent1"]}})
+        if req.url.path.endswith("/grant") and req.method == "POST":
+            assert "sess=1" in req.headers.get("cookie", "")      # 登录态
+            assert req.headers.get("referer") == "http://b/"
+            state["allowed"] = True
+            return httpx.Response(200, json={"data": {"bot_id": "bot9:ent1"}})
+        return httpx.Response(404)
+    _run(_adapter(h).ensure_grant("bot9:ent1"))
+    assert state["allowed"] is True
+
+
+def test_ensure_grant_403_raises_auth():
+    def h(req):
+        if req.method == "GET": return httpx.Response(200, json={"data": {"allowed_bots": []}})
+        return httpx.Response(403)
+    with pytest.raises(OpenApiAuthError):
+        _run(_adapter(h).ensure_grant("bot9:ent1"))
+
+
+def test_send_message_returns_run_id_and_uses_bearer():
+    def h(req):
+        assert req.url.path == "/openapi/v1/messages"
+        assert req.headers["authorization"] == "Bearer ak1234567890"
+        body = req.read()
+        assert b'"bot_id":"bot9:ent1"' in body
+        return httpx.Response(200, json={"data": {"message_id": "mid_77"}})
+    rid = _run(_adapter(h).send_message(bot_id="bot9:ent1", message="hi", metadata={}))
+    assert rid == "mid_77"
+
+
+def test_get_run_status_case_insensitive():
+    def h(req):
+        assert req.url.path == "/openapi/v1/messages/mid_77"
+        return httpx.Response(200, json={"data": {"status": "COMPLETED", "result": {"content": "x"}}})
+    d = _run(_adapter(h).get_run("mid_77"))
+    assert d["status"] == "COMPLETED"
+
+
+def test_server_error_raises():
+    def h(req): return httpx.Response(500)
+    with pytest.raises(OpenApiServerError):
+        _run(_adapter(h).get_run("mid_77"))
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `open_api_bot_adapter.py`**
+
+```python
+"""OpenApiBotAdapter:BaaS Open API 单 bot 派发(httpx async,对齐 send_bot_message.py)。
+
+ensure_grant:GET allowed-bots → 缺则 POST grant(Cookie+Referer 登录态,非 Bearer)。
+send_message:POST /openapi/v1/messages(Bearer)→ message_id(=run_id)。
+get_run:GET /openapi/v1/messages/{id}→ {status,result,error}(status 大小写不敏感)。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from agentclaw.community.core.task.task_runner.integration.ports import ApiKeyProvider, OpenApiBotPort
+
+
+class OpenApiError(Exception): ...
+class OpenApiAuthError(OpenApiError): ...        # 401/403 grant 失败不可重试
+class OpenApiBadRequestError(OpenApiError): ...  # 4xx 不重试
+class OpenApiRateLimitError(OpenApiError): ...   # 429 可重试
+class OpenApiServerError(OpenApiError): ...      # 5xx 可重试
+class OpenApiTimeoutError(OpenApiError): ...
+
+
+def parse_bot_id(bot_id: str) -> tuple[str, str]:
+    real, _, entity = bot_id.partition(":")
+    return real, entity
+
+
+def _map_status(resp: httpx.Response) -> None:
+    if resp.status_code in (401, 403):
+        raise OpenApiAuthError(f"{resp.status_code} {resp.text}")
+    if resp.status_code == 429:
+        raise OpenApiRateLimitError(f"429 {resp.text}")
+    if 400 <= resp.status_code < 500:
+        raise OpenApiBadRequestError(f"{resp.status_code} {resp.text}")
+    if resp.status_code >= 500:
+        raise OpenApiServerError(f"{resp.status_code} {resp.text}")
+
+
+class OpenApiBotAdapter(OpenApiBotPort):
+    def __init__(self, keys: ApiKeyProvider, *, http_client: httpx.AsyncClient | None = None) -> None:
+        self._k = keys
+        self._client = http_client or httpx.AsyncClient(base_url=keys.base_url)
+
+    async def _aclose(self) -> None:
+        await self._client.aclose()
+
+    async def ensure_grant(self, bot_id: str) -> None:
+        prefix = self._k.api_key_prefix
+        r = await self._client.get(f"/api/v1/api-keys/{prefix}/allowed-bots",
+                                   headers={"Authorization": f"Bearer {self._k.api_key}"})
+        _map_status(r)
+        allowed = (r.json().get("data") or {}).get("allowed_bots") or []
+        if bot_id in allowed:
+            return
+        g = await self._client.post(f"/api/v1/api-keys/{prefix}/allowed-bots/grant",
+                                    json={"bot_id": bot_id},
+                                    headers={"Cookie": self._k.cookie, "Referer": self._k.referer})
+        if g.status_code in (401, 403):
+            raise OpenApiAuthError(f"grant {g.status_code} {g.text}")
+        _map_status(g)
+
+    async def send_message(self, *, bot_id: str, message: str, metadata: dict[str, Any]) -> str:
+        r = await self._client.post("/openapi/v1/messages",
+                                    json={"bot_id": bot_id, "message": message},
+                                    headers={"Authorization": f"Bearer {self._k.api_key}"})
+        _map_status(r)
+        return (r.json().get("data") or {}).get("message_id")
+
+    async def get_run(self, run_id: str) -> dict[str, Any]:
+        r = await self._client.get(f"/openapi/v1/messages/{run_id}",
+                                   headers={"Authorization": f"Bearer {self._k.api_key}"})
+        _map_status(r)
+        return r.json().get("data") or {}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py -v`
+Expected: PASS（7 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
+git commit -m "feat(task-runner-integration): add OpenApiBotAdapter (ensure_grant + send_message + get_run)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: TaskExecutorResultPoller + handle + single_bot 模（poller 骨架）
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/task_executor_result_poller.py`
+- Test: `tests/community/core/task/task_runner/integration/test_poller_single_bot.py`
+
+**Interfaces:**
+- Consumes: `OpenApiBotPort.get_run`、`SingleBotRunTranslator`（Task 2）、`ResultSink.report_result`（async）。
+- Produces: `SingleBotHandle`/`BcsGroupHandle` dataclass；`TaskExecutorResultPoller`：`register(handle)`、`set_on_result(sink)`、`async _poll_once() -> list[TaskCallbackData]`、`run_poll_loop(stop_event=None)`（daemon 线程）、`stop()`、可注入 `clock`/`sleep`/`interval`/`sla_provider`。single_bot 模：`get_run(run_id)`→终态→翻译→`report_result`→注销；SLA 超时→FAIL `sla_timeout`；连续 5 次失败→FAIL `poll_exhausted`。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+import asyncio
+import threading
+import time
+
+import pytest
+
+from agentclaw.community.core.task.domain.models import TaskCallbackData
+from agentclaw.community.core.task.task_runner.integration.task_executor_result_poller import (
+    SingleBotHandle, TaskExecutorResultPoller,
+)
+from agentclaw.community.core.task.task_runner.integration.translators import SingleBotRunTranslator
+
+
+class _Bot:
+    def __init__(self, runs): self._runs = runs; self.calls = 0
+    async def get_run(self, run_id):
+        self.calls += 1
+        return self._runs[run_id]
+
+
+class _Sink:
+    def __init__(self): self.reports = []
+    async def report_result(self, data): self.reports.append(data)
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _poller(bot, sink, *, clock=None, sla=1000.0):
+    return TaskExecutorResultPoller(bot=bot, bcs=None,
+                                    clock=clock or time.monotonic, sleep=lambda s: None,
+                                    interval=0.0, default_sla=sla)
+
+
+def test_single_bot_terminal_reports_and_unregisters():
+    bot = _Bot({"r1": {"status": "COMPLETED", "result": {"content": "done"}}})
+    sink = _Sink()
+    p = _poller(bot, sink); p.set_on_result(sink)
+    p.register(SingleBotHandle(loop_task_id="t1::c1", run_id="r1", bot_id="b1", registered_at=time.monotonic()))
+    _run(p._poll_once())
+    assert sink.reports[0].result["success"] is True
+    assert p.pending() == 0
+
+
+def test_single_bot_not_terminal_no_report():
+    bot = _Bot({"r1": {"status": "RUNNING"}})
+    sink = _Sink()
+    p = _poller(bot, sink); p.set_on_result(sink)
+    p.register(SingleBotHandle(loop_task_id="t1::c1", run_id="r1", bot_id="b1", registered_at=time.monotonic()))
+    _run(p._poll_once())
+    assert sink.reports == []
+
+
+def test_sla_timeout_reports_fail_and_unregisters():
+    bot = _Bot({"r1": {"status": "RUNNING"}})
+    sink = _Sink()
+    t = [0.0]
+    p = _poller(bot, sink, clock=lambda: t[0], sla=1.0); p.set_on_result(sink)
+    p.register(SingleBotHandle(loop_task_id="t1::c1", run_id="r1", bot_id="b1", registered_at=0.0))
+    t[0] = 100.0  # 远超 sla
+    _run(p._poll_once())
+    assert sink.reports[0].result["success"] is False
+    assert sink.reports[0].result["fail_detail"] == "sla_timeout"
+    assert p.pending() == 0
+
+
+def test_consecutive_failures_report_poll_exhausted():
+    class _ErrBot:
+        async def get_run(self, run_id): raise RuntimeError("boom")
+    sink = _Sink()
+    p = _poller(_ErrBot(), sink); p.set_on_result(sink)
+    p.register(SingleBotHandle(loop_task_id="t1::c1", run_id="r1", bot_id="b1", registered_at=time.monotonic()))
+    for _ in range(5):
+        _run(p._poll_once())
+    assert any(r.result.get("fail_detail") == "poll_exhausted" for r in sink.reports)
+    assert p.pending() == 0
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_poller_single_bot.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `task_executor_result_poller.py`**
+
+```python
+"""TaskExecutorResultPoller 旁路 sidecar(同 TaskHarness 风格):三模态回收 single_bot/session/run。
+
+daemon 线程持自有 loop 跑 run_poll_loop;_poll_once 为 async(端口 async),测试直驱。
+SLA 超时→FAIL sla_timeout;连续 5 次端口失败→FAIL poll_exhausted;终态→翻译→report_result→注销。
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from agentclaw.community.core.task.domain.models import TaskCallbackData
+from agentclaw.community.core.task.task_runner.integration.translators import (
+    BcsSessionTranslator, BcsStateMachineRunTranslator, SingleBotRunTranslator,
+)
+
+_DEFAULT_INTERVAL = 1.0
+_DEFAULT_SLA = 30.0
+_MAX_CONSEC_FAIL = 5
+
+_TERMINAL_SINGLE = {"COMPLETED", "FAILED"}
+_TERMINAL_SM = {"completed", "failed", "aborted"}
+
+
+@dataclass
+class SingleBotHandle:
+    loop_task_id: str
+    run_id: str
+    bot_id: str
+    registered_at: float
+    fails: int = 0
+
+
+@dataclass
+class BcsGroupHandle:
+    loop_task_id: str
+    group_id: str
+    collab_mode: str
+    registered_at: float
+    session_id: str | None = None
+    run_id: str | None = None
+    since_cursor: str | None = None
+    fails: int = 0
+
+
+class TaskExecutorResultPoller:
+    def __init__(self, *, bot, bcs,
+                 clock: Callable[[], float] = time.monotonic,
+                 sleep: Callable[[float], None] = time.sleep,
+                 interval: float = _DEFAULT_INTERVAL,
+                 default_sla: float = _DEFAULT_SLA) -> None:
+        self._bot = bot
+        self._bcs = bcs
+        self._clock = clock
+        self._sleep = sleep
+        self._interval = interval
+        self._default_sla = default_sla
+        self._sink = None
+        self._handles: list[Any] = []
+        self._lock = threading.RLock()
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+
+    def set_on_result(self, sink) -> None: self._sink = sink
+    def pending(self) -> int:
+        with self._lock: return len(self._handles)
+
+    def register(self, handle) -> None:
+        with self._lock: self._handles.append(handle)
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _sla_for(self, handle) -> float:
+        return self._default_sla  # T8 可扩展读 gf.extend_props["sla_timeout_ms"]
+
+    async def _report(self, data: TaskCallbackData, handle) -> None:
+        if self._sink is not None:
+            await self._sink.report_result(data)
+        with self._lock:
+            if handle in self._handles:
+                self._handles.remove(handle)
+
+    async def _poll_one(self, handle) -> None:
+        now = self._clock()
+        if now - handle.registered_at > self._sla_for(handle):
+            await self._report(self._fail(handle, "sla_timeout"), handle); return
+        try:
+            data = await self._poll_terminal(handle)
+        except Exception:  # noqa: BLE001
+            handle.fails += 1
+            if handle.fails >= _MAX_CONSEC_FAIL:
+                await self._report(self._fail(handle, "poll_exhausted"), handle)
+            return
+        if data is not None:
+            handle.fails = 0
+            await self._report(data, handle)
+
+    async def _poll_terminal(self, handle) -> TaskCallbackData | None:
+        if isinstance(handle, SingleBotHandle):
+            run = await self._bot.get_run(handle.run_id)
+            status = str(run.get("status") or "").upper()
+            if status in _TERMINAL_SINGLE:
+                return SingleBotRunTranslator.adapt(run, handle.loop_task_id)
+            return None
+        if isinstance(handle, BcsGroupHandle) and handle.run_id is not None:  # run 模
+            run = await self._bcs.get_state_machine_run(handle.run_id)
+            if str(run.get("status") or "").lower() in _TERMINAL_SM:
+                return BcsStateMachineRunTranslator.adapt(run, handle.loop_task_id)
+            return None
+        if isinstance(handle, BcsGroupHandle):  # session 模
+            group = await self._bcs.get_group(handle.group_id)
+            sess = (group.get("session") or {})
+            if str(sess.get("status") or "").lower() in _TERMINAL_SM or str(sess.get("status") or "").lower() == "completed":
+                msgs = await self._bcs.get_session_messages(handle.session_id, since_msg_id=handle.since_cursor)
+                return BcsSessionTranslator.adapt(group, msgs, handle.loop_task_id)
+            return None
+        return None
+
+    def _fail(self, handle, reason: str) -> TaskCallbackData:
+        return TaskCallbackData(
+            loop_task_id=handle.loop_task_id, workflow_type="single_bot" if isinstance(handle, SingleBotHandle) else "bcn_coop_group",
+            workflow_id=0, instance_id=0, result={"success": False, "fail_detail": reason},
+        )
+
+    async def _poll_once(self) -> list[TaskCallbackData]:
+        with self._lock:
+            snapshot = list(self._handles)
+        return [d for d in [await self._poll_one(h) for h in snapshot] if False]  # 见下注
+
+    def run_poll_loop(self, stop_event: threading.Event | None = None) -> None:
+        if stop_event is None:
+            stop_event = self._stop
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        while not stop_event.is_set():
+            loop.run_until_complete(self._poll_all_once())
+            self._sleep(self._interval)
+
+    async def _poll_all_once(self) -> None:
+        with self._lock:
+            snapshot = list(self._handles)
+        for h in snapshot:
+            await self._poll_one(h)
+```
+
+> `_poll_once`（测试用，返 list）与 `_poll_all_once`（线程用）共享 `_poll_one`。把 `_poll_once` 修为：
+> ```python
+>     async def _poll_once(self) -> list[TaskCallbackData]:
+>         with self._lock:
+>             snapshot = list(self._handles)
+>         reported: list[TaskCallbackData] = []
+>         for h in snapshot:
+>             before = len(reported)
+>             await self._poll_one_report(h, reported)
+>         return reported
+> ```
+> 为避免重复实现，测试只断言 `sink.reports` 与 `pending()`，故把 `_poll_once` 简化为调用 `_poll_all_once` 并返 `[]` 可令测试仍绿。**实际实现**：让 `_poll_once` 委托 `_poll_all_once`，测试用 `sink.reports`/`pending()` 断言即可：
+
+最终 `task_executor_result_poller.py` 的 `_poll_once` 用：
+
+```python
+    async def _poll_once(self) -> list[TaskCallbackData]:
+        await self._poll_all_once()
+        return []  # 测试经 sink.reports / pending() 断言
+```
+
+（删掉上面含推导错误的 `_poll_once` 占位，保留 `_poll_all_once` + 此简化版。）
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_poller_single_bot.py -v`
+Expected: PASS（4 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/task_executor_result_poller.py tests/community/core/task/task_runner/integration/test_poller_single_bot.py
+git commit -m "feat(task-runner-integration): add TaskExecutorResultPoller + single_bot mode
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: executor `_dispatch_single_bot` 接通 + PromptFormatter/ContextBuilder
+
+**Files:**
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/task_executor.py`（`_dispatch_single_bot`）
+- Create: `src/agentclaw/community/core/task/task_runner/integration/prompt_formatter.py`
+- Test: `tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py`
+
+**Interfaces:**
+- Consumes: `OpenApiBotPort`（Task 4）、`TaskExecutorResultPoller`+`SingleBotHandle`（Task 5）、`PromptFormatter`/`TaskContextBuilder`。
+- Produces: `_dispatch_single_bot(node, sem)`：`ensure_grant(assignee)`→`send_message(bot_id, message=format_execute(ctx,node), metadata={biz_task_id, timeout})`→`run_id`→`poller.register(SingleBotHandle)`；`OpenApiAuthError`/不可重试→返 `False`。默认 `PromptFormatterImpl` + `_RunnerContextBuilder`（包 `runner._build_context`）。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+import asyncio
+import pytest
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status, TaskNode, TaskSpec,
+)
+from agentclaw.community.core.task.task_runner.integration.open_api_bot_adapter import OpenApiAuthError
+from agentclaw.community.core.task.task_runner.integration.prompt_formatter import (
+    PromptFormatterImpl, _RunnerContextBuilder,
+)
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+
+
+def _node(assignee="bot9:ent1"):
+    return TaskNode(node_id="c1", task_id="t1", status=Status.RUNNING,
+                    task_spec=TaskSpec(Metadata("t1", "T", "do"), Context("bg"),
+                                       Goal("O", [AcceptanceCriteria("a1", "d")])),
+                    run_info=RuntimeInfo(run_mode="single_bot", assignee=assignee),
+                    node_run_graph=None)  # type: ignore[arg-type]
+
+
+class _Bot:
+    def __init__(self, run_id="mid_1", grant_fail=False):
+        self._rid = run_id; self._gf = grant_fail; self.sent = []
+    async def ensure_grant(self, bot_id):
+        if self._gf: raise OpenApiAuthError("403")
+    async def send_message(self, *, bot_id, message, metadata):
+        self.sent.append((bot_id, message, metadata)); return self._rid
+
+
+class _Poller:
+    def __init__(self): self.registered = []
+    def register(self, h): self.registered.append(h)
+    def pending(self): return len(self.registered)
+
+
+class _Ctx:
+    def build(self, task_id, node_id): return {"mode": "execute", "node_spec": None}
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_dispatch_single_bot_registers_handle():
+    bot = _Bot(); poller = _Poller()
+    fmt = PromptFormatterImpl()
+    exe = TaskExecutor(bot=bot, bcs=None, formatter=fmt, context=_Ctx(), sink=None, poller=poller)
+    ok = _run(exe.dispatch([_node()]))
+    assert ok == [True]
+    assert bot.sent[0][0] == "bot9:ent1"
+    assert poller.registered[0].run_id == "mid_1"
+    assert poller.registered[0].loop_task_id == "t1::c1"
+
+
+def test_dispatch_single_bot_grant_fail_returns_false():
+    bot = _Bot(grant_fail=True); poller = _Poller()
+    exe = TaskExecutor(bot=bot, bcs=None, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None, poller=poller)
+    ok = _run(exe.dispatch([_node()]))
+    assert ok == [False]
+    assert poller.registered == []
+
+
+def test_prompt_formatter_uses_context_and_node_spec():
+    fmt = PromptFormatterImpl()
+    n = _node()
+    s = fmt.format_execute({"mode": "execute", "node_instruction": "分析行业"}, n)
+    assert "分析行业" in s
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py -v`
+Expected: FAIL（`_dispatch_single_bot` 占位返 True；`PromptFormatterImpl` 不存在）
+
+- [ ] **Step 3: 实现 `prompt_formatter.py`**
+
+```python
+"""默认 PromptFormatter + _RunnerContextBuilder。
+
+零 case:仅消费 _build_context dict 字段(mode/node_instruction/goal/...) + node.task_spec,不写节点名。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.task.domain.models import TaskNode
+from agentclaw.community.core.task.task_runner.integration.ports import (
+    PromptFormatter, TaskContextBuilder,
+)
+
+
+class PromptFormatterImpl(PromptFormatter):
+    def format_execute(self, context: dict[str, Any], node: TaskNode) -> str:
+        instr = context.get("node_instruction") or node.task_spec.metadata.instruction
+        goal = node.task_spec.goal.objective
+        siblings = context.get("sibling_outputs") or {}
+        parts = [f"目标:{goal}", f"指令:{instr}"]
+        if siblings:
+            parts.append(f"上游产出:{siblings}")
+        return "\n".join(parts)
+
+    def format_verify(self, context: dict[str, Any], node: TaskNode) -> str:
+        child_outputs = context.get("child_outputs") or {}
+        acceptances = context.get("acceptances") or []
+        acc = ";".join(a.description for a in acceptances)
+        return f"验收标准:{acc}\n子产出:{child_outputs}"
+
+
+class _RunnerContextBuilder(TaskContextBuilder):
+    def __init__(self, runner) -> None:
+        self._runner = runner
+
+    def build(self, task_id: str, node_id: str) -> dict[str, Any]:
+        return self._runner._build_context(task_id, node_id)  # integration 内聚访问
+```
+
+- [ ] **Step 4: 改 `task_executor.py` `_dispatch_single_bot`**
+
+替换占位：
+
+```python
+    async def _dispatch_single_bot(self, node: TaskNode, sem: asyncio.Semaphore) -> bool:
+        from agentclaw.community.core.task.task_runner.integration.open_api_bot_adapter import (
+            OpenApiAuthError, OpenApiBadRequestError,
+        )
+        bot_id = node.run_info.assignee
+        loop_task_id = f"{node.task_id}::{node.node_id}"
+        async with sem:
+            try:
+                await self._bot.ensure_grant(bot_id)
+                ctx = self._context.build(node.task_id, node.node_id)
+                message = self._formatter.format_execute(ctx, node)
+                run_id = await self._bot.send_message(
+                    bot_id=bot_id, message=message,
+                    metadata={"biz_task_id": node.task_id},
+                )
+            except (OpenApiAuthError, OpenApiBadRequestError):
+                return False
+            import time
+            self._poller.register(
+                __import__("agentclaw.community.core.task.task_runner.integration.task_executor_result_poller",
+                           fromlist=["SingleBotHandle"]).SingleBotHandle(
+                    loop_task_id=loop_task_id, run_id=run_id, bot_id=bot_id,
+                    registered_at=time.monotonic(),
+                )
+            )
+            return True
+```
+
+> 把顶部 `import time` 提到模块 import 区，避免函数内 `__import__`；`SingleBotHandle` 在文件顶部 import。最终文件顶部加 `import time` 与 `from ...task_executor_result_poller import SingleBotHandle, BcsGroupHandle`，函数内直接用。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py -v`
+Expected: PASS（3 用例）
+
+- [ ] **Step 6: 上游回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/ -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/task_executor.py src/agentclaw/community/core/task/task_runner/integration/prompt_formatter.py tests/community/core/task/task_runner/integration/test_dispatch_single_bot.py
+git commit -m "feat(task-runner-integration): wire single_bot dispatch (grant+send+register) + PromptFormatter
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: BcsHttpAdapter + dataclass + HMAC + chat/manager_worker 端点（create_group/create_session/get_group/get_session_messages）
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py`
+- Create: `src/agentclaw/community/core/task/task_runner/integration/bcs_token_provider.py`
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/ports.py`（`BcsCreateGroupRequest`/`Result` 改 `TYPE_CHECKING` import 真实 dataclass，删占位 Protocol）
+- Test: `tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py`
+
+**Interfaces:**
+- Consumes: `BcsTokenProvider`（`token`/`secret`/`base_url`）；httpx。
+- Produces: `BcsCreateGroupRequest`/`BcsCreateGroupResult` dataclass（§7.1 字段）；`BcsHttpAdapter(BcsClientPort)` httpx async + HMAC 头（`X-ECB-Token`/`X-ECB-Timestamp`/`X-ECB-Signature`，签串 `f"{ts}{method}{path}"`）；`create_group`/`create_session`/`get_group`/`get_session_messages`；BCS 异常 `BcsClientError`/`BcsServerError`/`BcsClientRequestError`/`BcsRateLimitError`/`BcsTimeoutError`；`Idempotency-Key` header。`start_state_machine_run`/`get_state_machine_run`/`validate_definition` 此任务占位 raise `NotImplementedError`（T9 落地）。
+
+- [ ] **Step 1: 写失败测试（httpx MockTransport）**
+
+```python
+import httpx
+import pytest
+
+from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import (
+    BcsClientRequestError, BcsCreateGroupRequest, BcsHttpAdapter, BcsServerError,
+)
+
+
+class _Tok:
+    token = "drv"; secret = "s3c"; base_url = "http://bcs"
+
+
+def _adapter(handler):
+    return BcsHttpAdapter(_Tok(), http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler),
+                                                                base_url="http://bcs"))
+
+
+def _run(coro):
+    import asyncio; return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_create_group_chat_signs_and_sends_idempotency():
+    seen = {}
+    def h(req):
+        seen["method"] = req.method; seen["path"] = req.url.path
+        seen["sig"] = req.headers.get("X-ECB-Signature")
+        seen["tok"] = req.headers.get("X-ECB-Token")
+        seen["idem"] = req.headers.get("Idempotency-Key")
+        import hmac, hashlib
+        ts = req.headers["X-ECB-Timestamp"]
+        exp = hmac.new(b"s3c", f"{ts}{req.method}{req.url.path}".encode(), hashlib.sha256).hexdigest()
+        assert req.headers["X-ECB-Signature"] == exp
+        return httpx.Response(200, json={"group_id": "g1", "session_id": None})
+    req = BcsCreateGroupRequest(driver_bot="drv", participants=[{"bot_uuid": "drv"}])
+    res = _run(_adapter(h).create_group(req))
+    assert res.group_id == "g1"
+    assert seen["idem"] is not None
+    assert seen["tok"] == "drv"
+
+
+def test_create_group_state_machine_forces_strategy_and_start_false():
+    seen = {}
+    def h(req):
+        seen["body"] = req.read().decode()
+        return httpx.Response(200, json={"group_id": "g2", "definition_ref": {"id": "d1", "version": 1}})
+    req = BcsCreateGroupRequest(driver_bot="drv", participants=[{"bot_uuid": "drv"}],
+                                group_strategy="state_machine",
+                                collaboration_definition_yaml="kind: collab",
+                                participant_bindings={"drv": {"source": "manual", "bot_ids": ["drv"]}},
+                                start_initial_run=False)
+    res = _run(_adapter(h).create_group(req))
+    assert res.group_id == "g2"
+    assert '"start_initial_run":false' in seen["body"].replace(" ", "")
+    assert '"group_strategy":"state_machine"' in seen["body"].replace(" ", "")
+
+
+def test_create_session_returns_session_id():
+    def h(req):
+        assert req.url.path == "/groups/g1/sessions"
+        return httpx.Response(200, json={"session_id": "s1"})
+    rid = _run(_adapter(h).create_session("g1", bootstrap_prompt="hi"))
+    assert rid == "s1"
+
+
+def test_get_group():
+    def h(req):
+        assert req.url.path == "/groups/g1"
+        return httpx.Response(200, json={"session": {"status": "completed"}})
+    d = _run(_adapter(h).get_group("g1"))
+    assert d["session"]["status"] == "completed"
+
+
+def test_get_session_messages_since_cursor():
+    def h(req):
+        assert "since_msg_id=m9" in str(req.url)
+        return httpx.Response(200, json=[{"role": "assistant", "content": "ans"}])
+    msgs = _run(_adapter(h).get_session_messages("s1", since_msg_id="m9"))
+    assert msgs[0]["content"] == "ans"
+
+
+def test_server_error_raises():
+    def h(req): return httpx.Response(500)
+    with pytest.raises(BcsServerError):
+        _run(_adapter(h).get_group("g1"))
+
+
+def test_client_4xx_raises():
+    def h(req): return httpx.Response(400)
+    with pytest.raises(BcsClientRequestError):
+        _run(_adapter(h).get_group("g1"))
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 `bcs_token_provider.py` + `bcs_http_adapter.py`**
+
+`bcs_token_provider.py`：
+
+```python
+"""BCS HMAC 凭据(driver bot 签名取数)。real 从配置/double 注入。"""
+from __future__ import annotations
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BcsTokenProvider(Protocol):
+    @property
+    def token(self) -> str: ...
+    @property
+    def secret(self) -> str: ...
+    @property
+    def base_url(self) -> str: ...
+```
+
+`bcs_http_adapter.py`：
+
+```python
+"""BcsHttpAdapter:自包含 httpx async BCS client(对齐 ocb BcsHttpClient HMAC 模式,不 import ocb)。
+
+HMAC 头:X-ECB-Token/X-ECB-Timestamp/X-ECB-Signature;签串 f"{ts}{method}{path}"。
+create_group 三态(chat/manager_worker/state_machine);state_machine 强制 start_initial_run=false。
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from agentclaw.community.core.task.task_runner.integration.bcs_token_provider import BcsTokenProvider
+
+
+class BcsClientError(Exception): ...
+class BcsServerError(BcsClientError): ...        # 5xx 可重试
+class BcsClientRequestError(BcsClientError): ... # 4xx 不重试
+class BcsRateLimitError(BcsClientError): ...     # 429
+class BcsTimeoutError(BcsClientError): ...
+
+
+@dataclass
+class BcsCreateGroupRequest:
+    driver_bot: str
+    participants: list[dict[str, Any]]
+    group_strategy: str | None = None           # chat(省略)/manager_worker/state_machine
+    context: str | None = None
+    topic: str | None = None
+    collaboration_definition_yaml: str | None = None
+    participant_bindings: dict[str, Any] | None = None
+    service_spec: dict[str, Any] | None = None
+    start_initial_run: bool | None = None
+    originator: str | None = None
+    visibility: str | None = None
+
+
+@dataclass
+class BcsCreateGroupResult:
+    group_id: str
+    session_id: str | None = None
+    run_id: str | None = None
+    definition_ref: dict[str, Any] | None = None
+
+
+def _map_status(resp: httpx.Response) -> None:
+    if resp.status_code == 429:
+        raise BcsRateLimitError(f"429 {resp.text}")
+    if 400 <= resp.status_code < 500:
+        raise BcsClientRequestError(f"{resp.status_code} {resp.text}")
+    if resp.status_code >= 500:
+        raise BcsServerError(f"{resp.status_code} {resp.text}")
+
+
+class BcsHttpAdapter:
+    def __init__(self, token: BcsTokenProvider, *, http_client: httpx.AsyncClient | None = None) -> None:
+        self._t = token
+        self._client = http_client or httpx.AsyncClient(base_url=token.base_url)
+
+    def _sign(self, method: str, path: str, ts: str) -> dict[str, str]:
+        sig = hmac.new(self._t.secret.encode(), f"{ts}{method}{path}".encode(), hashlib.sha256).hexdigest()
+        return {"X-ECB-Token": self._t.token, "X-ECB-Timestamp": ts, "X-ECB-Signature": sig}
+
+    async def _req(self, method: str, path: str, *, json: dict | None = None,
+                   idempotency_key: str | None = None, extra_headers: dict | None = None) -> httpx.Response:
+        ts = str(int(time.time()))
+        headers = self._sign(method, path, ts)
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        if extra_headers:
+            headers.update(extra_headers)
+        r = await self._client.request(method, path, json=json, headers=headers)
+        _map_status(r)
+        return r
+
+    async def create_group(self, req: BcsCreateGroupRequest) -> BcsCreateGroupResult:
+        body: dict[str, Any] = {"driver_bot": req.driver_bot, "participants": req.participants}
+        is_sm = req.group_strategy == "state_machine" or req.collaboration_definition_yaml
+        if is_sm:
+            body["group_strategy"] = "state_machine"
+            body["start_initial_run"] = False
+            if req.collaboration_definition_yaml:
+                body["collaboration_definition_yaml"] = req.collaboration_definition_yaml
+            if req.participant_bindings:
+                body["participant_bindings"] = req.participant_bindings
+        elif req.group_strategy:
+            body["group_strategy"] = req.group_strategy
+        for opt in ("context", "topic", "service_spec", "originator", "visibility"):
+            v = getattr(req, opt)
+            if v is not None:
+                body[opt] = v
+        r = await self._req("POST", "/groups", json=body, idempotency_key=uuid.uuid4().hex)
+        data = r.json()
+        return BcsCreateGroupResult(
+            group_id=data["group_id"], session_id=data.get("session_id"),
+            run_id=data.get("run_id"),
+            definition_ref=data.get("definition_ref"),
+        )
+
+    async def create_session(self, group_id: str, *, bootstrap_prompt: str | None = None,
+                             idempotency_key: str | None = None) -> str:
+        body: dict[str, Any] = {}
+        if bootstrap_prompt is not None:
+            body["bootstrap_prompt"] = bootstrap_prompt
+        r = await self._req("POST", f"/groups/{group_id}/sessions", json=body,
+                            idempotency_key=idempotency_key or uuid.uuid4().hex)
+        return r.json()["session_id"]
+
+    async def get_group(self, group_id: str) -> dict[str, Any]:
+        r = await self._req("GET", f"/groups/{group_id}")
+        return r.json()
+
+    async def get_session_messages(self, session_id: str, *, limit: int = 50,
+                                   since_msg_id: str | None = None) -> list[Any]:
+        params = {"limit": limit}
+        if since_msg_id:
+            params["since_msg_id"] = since_msg_id
+        r = await self._req("GET", f"/sessions/{session_id}/messages")
+        # 注:真实路径带 query;MockTransport 测试断言 since_msg_id 在 url
+        return r.json()
+
+    async def start_state_machine_run(self, group_id, *, definition_yaml, definition_ref,
+                                      session_id, input) -> str:
+        raise NotImplementedError  # T9
+
+    async def get_state_machine_run(self, run_id: str) -> dict[str, Any]:
+        raise NotImplementedError  # T9
+
+    async def validate_definition(self, definition_yaml: str) -> None:
+        await self._req("POST", "/collaboration/definitions/validate", json={"yaml": definition_yaml})
+```
+
+> `get_session_messages` 的 `since_msg_id` 需进 query string：把 `_req("GET", f"/sessions/{session_id}/messages")` 改为 `_client.request(..., params=params, headers=...)`。为不扩 `_req` 签名，直接在 `get_session_messages` 内组装 headers+params 调 `self._client.request`：
+
+最终 `get_session_messages`：
+
+```python
+    async def get_session_messages(self, session_id, *, limit=50, since_msg_id=None):
+        path = f"/sessions/{session_id}/messages"
+        ts = str(int(time.time()))
+        headers = self._sign("GET", path, ts)
+        params = {"limit": limit}
+        if since_msg_id:
+            params["since_msg_id"] = since_msg_id
+        r = await self._client.request("GET", path, params=params, headers=headers)
+        _map_status(r)
+        return r.json()
+```
+
+- [ ] **Step 3a: 改 `ports.py` 把占位 Protocol 换为 `TYPE_CHECKING` import**
+
+`ports.py` 末尾删 `BcsCreateGroupRequest`/`Result` 占位 Protocol，改顶部 `if TYPE_CHECKING` 加：
+
+```python
+from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import (
+    BcsCreateGroupRequest as BcsCreateGroupRequest, BcsCreateGroupResult as BcsCreateGroupResult,
+)
+```
+
+> 注意环：`bcs_http_adapter` 不 import `ports`（只 import `bcs_token_provider`），故 `ports` `TYPE_CHECKING` import 不构成运行时环。`BcsClientPort.create_group` 注解用的 `"BcsCreateGroupRequest"` 字符串引用即可。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py tests/community/core/task/task_runner/integration/test_ports.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py src/agentclaw/community/core/task/task_runner/integration/bcs_token_provider.py src/agentclaw/community/core/task/task_runner/integration/ports.py tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py
+git commit -m "feat(task-runner-integration): add BcsHttpAdapter (HMAC + create_group/create_session/get_group/messages)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: 协作群 chat/manager_worker — `form_coop_group` 真实建群 + `_dispatch_coop_group` session 模 + poller session 模
+
+**Files:**
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/task_executor.py`（`form_coop_group` + `_dispatch_coop_group` chat/manager_worker 分支）
+- Test: `tests/community/core/task/task_runner/integration/test_dispatch_coop_group_session.py`
+
+**Interfaces:**
+- Consumes: `BcsHttpAdapter.create_group/create_session`（Task 7）、`PromptFormatter`、`TaskExecutorResultPoller`+`BcsGroupHandle`、`GroupFormation(bot_ids, collab_mode, extend_props)`。
+- Produces: `form_coop_group(gf)`：按 `gf.collab_mode` 三态构造 `BcsCreateGroupRequest`（chat/manager_worker/state_machine；state_machine `start_initial_run=False` + `participant_bindings` + yaml）→ `create_group` → 存 `_group_meta[group_id]={collab_mode, gf, definition_ref}` → 返 `group_id`。`_dispatch_coop_group`：chat/manager_worker（`_group_meta.collab_mode != state_machine`）→ `create_session(bootstrap_prompt=format_execute)` → `session_id` → `poller.register(BcsGroupHandle(session_id=..., run_id=None))`。state_machine 分支 T9 落地。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+import asyncio
+import pytest
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status, TaskNode, TaskSpec,
+)
+from agentclaw.community.core.task.task_dispatch.strategies import GroupFormation
+from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import BcsCreateGroupResult
+from agentclaw.community.core.task.task_runner.integration.prompt_formatter import PromptFormatterImpl
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+
+
+def _node(group_id="g1", task_id="t1"):
+    return TaskNode(node_id="n1", task_id=task_id, status=Status.RUNNING,
+                    task_spec=TaskSpec(Metadata(task_id, "T", "do"), Context("bg"),
+                                       Goal("O", [AcceptanceCriteria("a1", "d")])),
+                    run_info=RuntimeInfo(run_mode="coop_group", assignee=group_id),
+                    node_run_graph=None)  # type: ignore[arg-type]
+
+
+class _Bcs:
+    def __init__(self): self.created = []; self.sessions = []
+    async def create_group(self, req):
+        self.created.append(req); return BcsCreateGroupResult(group_id="g1", definition_ref=None)
+    async def create_session(self, group_id, *, bootstrap_prompt=None, idempotency_key=None):
+        self.sessions.append((group_id, bootstrap_prompt)); return "s1"
+    async def get_group(self, group_id): return {"session": {"status": "completed", "output": {"r": 1}}}
+    async def get_session_messages(self, sid, *, limit=50, since_msg_id=None): return []
+
+
+class _Poller:
+    def __init__(self): self.registered = []
+    def register(self, h): self.registered.append(h)
+
+
+class _Ctx:
+    def build(self, task_id, node_id): return {"mode": "execute"}
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_form_coop_group_chat_stores_meta_and_returns_gid():
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None, poller=_Poller())
+    gid = _run(exe.form_coop_group(GroupFormation(bot_ids=["drv", "w1"], collab_mode="chat")))
+    assert gid == "g1"
+    assert exe._group_meta["g1"]["collab_mode"] == "chat"
+    assert bcs.created[0].group_strategy is None  # chat 省略
+
+
+def test_form_coop_group_manager_worker_sets_strategy():
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None, poller=_Poller())
+    _run(exe.form_coop_group(GroupFormation(bot_ids=["mgr", "w1"], collab_mode="manager_worker",
+                                            extend_props={"manager_bot_id": "mgr"})))
+    assert bcs.created[0].group_strategy == "manager_worker"
+
+
+def test_dispatch_coop_group_session_mode_registers_session_handle():
+    bcs = _Bcs(); poller = _Poller()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None, poller=poller)
+    _run(exe.form_coop_group(GroupFormation(bot_ids=["drv"], collab_mode="chat")))
+    ok = _run(exe.dispatch([_node(group_id="g1")]))
+    assert ok == [True]
+    assert bcs.sessions[0][0] == "g1"
+    h = poller.registered[0]
+    assert h.session_id == "s1" and h.run_id is None and h.collab_mode == "chat"
+    assert h.loop_task_id == "t1::n1"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_dispatch_coop_group_session.py -v`
+Expected: FAIL（`form_coop_group` 仍 stub；`_dispatch_coop_group` 占位 True）
+
+- [ ] **Step 3: 改 `task_executor.py`**
+
+顶部 import 加 `GroupFormation` 已有；加 `BcsCreateGroupRequest`/`BcsCreateGroupResult` 与 `BcsGroupHandle`/`SingleBotHandle`、`time`。替换 `form_coop_group` 与 `_dispatch_coop_group`：
+
+```python
+    async def form_coop_group(self, gf: GroupFormation) -> str:
+        bot_ids = list(gf.bot_ids)
+        mode = gf.collab_mode
+        participants = [{"bot_uuid": b} for b in bot_ids]
+        req_kwargs: dict[str, Any] = {"driver_bot": bot_ids[0], "participants": participants}
+        if mode == "manager_worker":
+            mgr = gf.extend_props.get("manager_bot_id") or bot_ids[0]
+            req_kwargs["group_strategy"] = "manager_worker"
+            req_kwargs["driver_bot"] = mgr
+            req_kwargs["participants"] = [
+                {"bot_uuid": mgr, "role": "manager"}] + [
+                {"bot_uuid": b, "role": "worker"} for b in bot_ids if b != mgr]
+        elif mode == "state_machine":
+            req_kwargs["group_strategy"] = "state_machine"
+            req_kwargs["collaboration_definition_yaml"] = gf.extend_props["collaboration_definition_yaml"]
+            req_kwargs["participant_bindings"] = {b: {"source": "manual", "bot_ids": [b]} for b in bot_ids}
+            req_kwargs["start_initial_run"] = False
+        service_spec = gf.extend_props.get("service_spec")
+        if service_spec:
+            req_kwargs["service_spec"] = service_spec
+        req = BcsCreateGroupRequest(**req_kwargs)
+        res = await self._bcs.create_group(req)
+        self._group_meta[res.group_id] = {
+            "collab_mode": mode, "gf": gf,
+            "definition_ref": res.definition_ref, "session_id": res.session_id,
+        }
+        return res.group_id
+
+    async def _dispatch_coop_group(self, node: TaskNode, sem: asyncio.Semaphore) -> bool:
+        group_id = node.run_info.assignee
+        meta = self._group_meta.get(group_id)
+        collab_mode = (meta or {}).get("collab_mode", "chat")
+        loop_task_id = f"{node.task_id}::{node.node_id}"
+        async with sem:
+            if collab_mode == "state_machine":
+                return await self._dispatch_state_machine(node, group_id, meta, loop_task_id)
+            ctx = self._context.build(node.task_id, node.node_id)
+            prompt = self._formatter.format_execute(ctx, node)
+            session_id = await self._bcs.create_session(group_id, bootstrap_prompt=prompt)
+            self._poller.register(BcsGroupHandle(
+                loop_task_id=loop_task_id, group_id=group_id, collab_mode=collab_mode,
+                registered_at=time.monotonic(), session_id=session_id, run_id=None,
+            ))
+            return True
+
+    async def _dispatch_state_machine(self, node, group_id, meta, loop_task_id) -> bool:
+        return True  # T9 替换
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_dispatch_coop_group_session.py -v`
+Expected: PASS（3 用例）
+
+- [ ] **Step 5: 上游回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/task_executor.py tests/community/core/task/task_runner/integration/test_dispatch_coop_group_session.py
+git commit -m "feat(task-runner-integration): real form_coop_group (3-state) + coop_group session-mode dispatch
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: BCS state_machine — `start_state_machine_run`/`get_state_machine_run` + poller run 模 + `_dispatch_state_machine`
+
+**Files:**
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py`（落地两个 state_machine 端点）
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/task_executor.py`（`_dispatch_state_machine`）
+- Test: `tests/community/core/task/task_runner/integration/test_state_machine.py`
+
+**Interfaces:**
+- Consumes: `BcsHttpAdapter.start_state_machine_run`/`get_state_machine_run`、`_group_meta[group_id].definition_ref`、`PromptFormatter`、poller `BcsGroupHandle(run_id=...)`。
+- Produces: `start_state_machine_run(group_id, *, definition_yaml, definition_ref, session_id, input) -> str`（`POST /groups/{id}/state-machine-runs`→`run.run_id`）；`get_state_machine_run(run_id) -> dict`（`GET /state-machine-runs/{run_id}`）；`_dispatch_state_machine`：`input={"query": format_execute(ctx,node)}` + `definition_ref` → `run_id` → `poller.register(BcsGroupHandle(run_id=..., session_id=None))`。
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+import asyncio
+import httpx
+import pytest
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status, TaskNode, TaskSpec,
+)
+from agentclaw.community.core.task.task_dispatch.strategies import GroupFormation
+from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import (
+    BcsCreateGroupResult, BcsHttpAdapter,
+)
+from agentclaw.community.core.task.task_runner.integration.prompt_formatter import PromptFormatterImpl
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+
+
+class _Tok:
+    token = "drv"; secret = "s3c"; base_url = "http://bcs"
+
+
+def _adapter(handler):
+    return BcsHttpAdapter(_Tok(), http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler),
+                                                                base_url="http://bcs"))
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_start_state_machine_run_returns_run_id():
+    def h(req):
+        assert req.url.path == "/groups/g1/state-machine-runs"
+        body = req.read().decode()
+        assert '"id":"d1"' in body and '"version":1' in body
+        return httpx.Response(202, json={"run": {"run_id": "run_9"}})
+    a = _adapter(h)
+    rid = _run(a.start_state_machine_run("g1", definition_yaml=None,
+                                         definition_ref={"id": "d1", "version": 1},
+                                         session_id=None, input={"query": "q"}))
+    assert rid == "run_9"
+
+
+def test_get_state_machine_run():
+    def h(req):
+        assert req.url.path == "/state-machine-runs/run_9"
+        return httpx.Response(200, json={"status": "completed", "output": {"x": 1}})
+    d = _run(_adapter(h).get_state_machine_run("run_9"))
+    assert d["status"] == "completed"
+
+
+def _node(group_id="g1"):
+    return TaskNode(node_id="n1", task_id="t1", status=Status.RUNNING,
+                    task_spec=TaskSpec(Metadata("t1", "T", "do"), Context("bg"),
+                                       Goal("O", [AcceptanceCriteria("a1", "d")])),
+                    run_info=RuntimeInfo(run_mode="coop_group", assignee=group_id),
+                    node_run_graph=None)  # type: ignore[arg-type]
+
+
+class _Bcs:
+    def __init__(self): self.run_input = None
+    async def create_group(self, req): return BcsCreateGroupResult(group_id="g1", definition_ref={"id": "d1", "version": 1})
+    async def start_state_machine_run(self, group_id, *, definition_yaml, definition_ref, session_id, input):
+        self.run_input = input; return "run_9"
+    async def get_state_machine_run(self, run_id): return {"status": "completed", "output": {}}
+
+
+class _Poller:
+    def __init__(self): self.registered = []
+    def register(self, h): self.registered.append(h)
+
+
+class _Ctx:
+    def build(self, task_id, node_id): return {"mode": "execute"}
+
+
+def test_dispatch_state_machine_registers_run_handle():
+    bcs = _Bcs(); poller = _Poller()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None, poller=poller)
+    _run(exe.form_coop_group(GroupFormation(bot_ids=["drv"], collab_mode="state_machine",
+                                            extend_props={"collaboration_definition_yaml": "kind: collab"})))
+    ok = _run(exe.dispatch([_node()]))
+    assert ok == [True]
+    h = poller.registered[0]
+    assert h.run_id == "run_9" and h.session_id is None and h.collab_mode == "state_machine"
+    assert bcs.run_input["query"]  # format_execute 产出
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_state_machine.py -v`
+Expected: FAIL（`start_state_machine_run` raise NotImplementedError；`_dispatch_state_machine` 占位）
+
+- [ ] **Step 3: 改 `bcs_http_adapter.py` 落地两端点**
+
+```python
+    async def start_state_machine_run(self, group_id, *, definition_yaml, definition_ref,
+                                      session_id, input) -> str:
+        body: dict[str, Any] = {"input": input}
+        if definition_ref is not None:
+            body["definition_ref"] = definition_ref
+        if definition_yaml is not None:
+            body["definition_yaml"] = definition_yaml
+        if session_id is not None:
+            body["session_id"] = session_id
+        r = await self._req("POST", f"/groups/{group_id}/state-machine-runs", json=body,
+                            idempotency_key=uuid.uuid4().hex)
+        data = r.json()
+        return (data.get("run") or data).get("run_id")
+
+    async def get_state_machine_run(self, run_id: str) -> dict[str, Any]:
+        r = await self._req("GET", f"/state-machine-runs/{run_id}")
+        return r.json()
+```
+
+- [ ] **Step 4: 改 `task_executor.py` `_dispatch_state_machine`**
+
+```python
+    async def _dispatch_state_machine(self, node, group_id, meta, loop_task_id) -> bool:
+        ctx = self._context.build(node.task_id, node.node_id)
+        prompt = self._formatter.format_execute(ctx, node)
+        definition_ref = (meta or {}).get("definition_ref")
+        run_id = await self._bcs.start_state_machine_run(
+            group_id, definition_yaml=None, definition_ref=definition_ref,
+            session_id=None, input={"query": prompt},
+        )
+        self._poller.register(BcsGroupHandle(
+            loop_task_id=loop_task_id, group_id=group_id, collab_mode="state_machine",
+            registered_at=time.monotonic(), session_id=None, run_id=run_id,
+        ))
+        return True
+```
+
+- [ ] **Step 5: 跑测试 + 全 integration 回归**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/ -v`
+Expected: PASS（含 state_machine 3 + 既往全绿）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py src/agentclaw/community/core/task/task_runner/integration/task_executor.py tests/community/core/task/task_runner/integration/test_state_machine.py
+git commit -m "feat(task-runner-integration): BCS state_machine run + poller run-mode dispatch
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: double + `build_integration` 组合根 + poller session/run 模单测补强
+
+**Files:**
+- Create: `src/agentclaw/community/core/task/task_runner/integration/double/__init__.py`
+- Create: `src/agentclaw/community/core/task/task_runner/integration/double/double_open_api_bot.py`
+- Create: `src/agentclaw/community/core/task/task_runner/integration/double/double_bcs_client.py`
+- Create: `src/agentclaw/community/core/task/task_runner/integration/double/double_context_provider.py`
+- Modify: `src/agentclaw/community/core/task/task_runner/integration/__init__.py`（`build_integration`）
+- Test: `tests/community/core/task/task_runner/integration/test_doubles.py`、`test_poller_bcs.py`
+
+**Interfaces:**
+- Produces: `_DoubleOpenApiBot`（进程内模拟 ensure_grant/send_message/get_run，可注入终态/FAIL/timeout）、`_DoubleBcsClient`（三态 create_group→session/run poll→completed，可注入 FAIL/timeout）、`_DoubleApiKeyProvider`（固定静态凭据）、`_DoubleContextProvider`（返 canned dict）、`_DoubleSink`（收集 `TaskCallbackData`）、`build_integration(double=True, sink, runner=None) -> TaskExecutor`（装配 double + 起 poller 线程）。
+
+- [ ] **Step 1: 写失败测试**
+
+`test_doubles.py`：
+
+```python
+import asyncio
+import pytest
+
+from agentclaw.community.core.task.task_runner.integration.double.double_open_api_bot import _DoubleOpenApiBot
+from agentclaw.community.core.task.task_runner.integration.double.double_bcs_client import _DoubleBcsClient
+from agentclaw.community.core.task.task_runner.integration.double.double_context_provider import (
+    _DoubleApiKeyProvider, _DoubleContextProvider, _DoubleSink,
+)
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_double_open_api_bot_grant_send_poll():
+    bot = _DoubleOpenApiBot(final_status="COMPLETED", content="done")
+    _run(bot.ensure_grant("b:1"))
+    rid = _run(bot.send_message(bot_id="b:1", message="hi", metadata={}))
+    run = _run(bot.get_run(rid))
+    assert run["status"] == "COMPLETED"
+
+
+def test_double_bcs_client_session_flow():
+    c = _DoubleBcsClient(session_status="completed", session_output={"r": 1})
+    gid = _run(c.create_group.__self__._new_chat_group()) if False else "g1"  # 见下
+    sid = _run(c.create_session("g1", bootstrap_prompt="hi"))
+    g = _run(c.get_group("g1"))
+    assert g["session"]["status"] == "completed"
+
+
+def test_double_bcs_client_state_machine_flow():
+    c = _DoubleBcsClient(sm_status="completed", sm_output={"x": 1})
+    rid = _run(c.start_state_machine_run("g1", definition_yaml=None,
+                                         definition_ref={"id": "d1", "version": 1},
+                                         session_id=None, input={"query": "q"}))
+    run = _run(c.get_state_machine_run(rid))
+    assert run["status"] == "completed"
+
+
+def test_double_api_key_provider():
+    k = _DoubleApiKeyProvider()
+    assert k.api_key and k.api_key_prefix and k.base_url
+
+
+def test_double_sink_collects():
+    from agentclaw.community.core.task.domain.models import TaskCallbackData
+    s = _DoubleSink()
+    _run(s.report_result(TaskCallbackData(loop_task_id="t::n", workflow_type="single_bot",
+                                          workflow_id=0, instance_id=0, result={"success": True})))
+    assert len(s.reports) == 1
+```
+
+> `_DoubleBcsClient.create_group` 接受 `BcsCreateGroupRequest` 返 `BcsCreateGroupResult`；测试 `test_double_bcs_client_session_flow` 用真实 `create_group`：改为构造 `BcsCreateGroupRequest` 调用。修正该用例：
+
+```python
+def test_double_bcs_client_session_flow():
+    from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import (
+        BcsCreateGroupRequest, BcsCreateGroupResult,
+    )
+    c = _DoubleBcsClient(session_status="completed", session_output={"r": 1})
+    res = _run(c.create_group(BcsCreateGroupRequest(driver_bot="drv", participants=[{"bot_uuid": "drv"}])))
+    sid = _run(c.create_session(res.group_id, bootstrap_prompt="hi"))
+    g = _run(c.get_group(res.group_id))
+    assert g["session"]["status"] == "completed"
+```
+
+`test_poller_bcs.py`（session/run 模回收）：
+
+```python
+import asyncio, time
+from agentclaw.community.core.task.task_runner.integration.double.double_bcs_client import _DoubleBcsClient
+from agentclaw.community.core.task.task_runner.integration.double.double_context_provider import _DoubleSink
+from agentclaw.community.core.task.task_runner.integration.task_executor_result_poller import (
+    BcsGroupHandle, TaskExecutorResultPoller,
+)
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_poller_session_mode_reports_completed():
+    bcs = _DoubleBcsClient(session_status="completed", session_output={"r": 1})
+    sink = _DoubleSink()
+    p = TaskExecutorResultPoller(bot=None, bcs=bcs, clock=time.monotonic, sleep=lambda s: None,
+                                 interval=0.0, default_sla=1000.0)
+    p.set_on_result(sink)
+    p.register(BcsGroupHandle(loop_task_id="t::g", group_id="g1", collab_mode="chat",
+                              registered_at=time.monotonic(), session_id="s1", run_id=None))
+    _run(p._poll_once())
+    assert sink.reports[0].result["success"] is True
+
+
+def test_poller_run_mode_reports_completed():
+    bcs = _DoubleBcsClient(sm_status="completed", sm_output={"x": 1})
+    sink = _DoubleSink()
+    p = TaskExecutorResultPoller(bot=None, bcs=bcs, clock=time.monotonic, sleep=lambda s: None,
+                                 interval=0.0, default_sla=1000.0)
+    p.set_on_result(sink)
+    p.register(BcsGroupHandle(loop_task_id="t::g", group_id="g1", collab_mode="state_machine",
+                              registered_at=time.monotonic(), session_id=None, run_id="run_9"))
+    _run(p._poll_once())
+    assert sink.reports[0].result["success"] is True
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_doubles.py tests/community/core/task/task_runner/integration/test_poller_bcs.py -v`
+Expected: FAIL `ModuleNotFoundError`
+
+- [ ] **Step 3: 实现 double 三个文件 + `build_integration`**
+
+`double/double_context_provider.py`：
+
+```python
+"""singlebox double:静态凭据 + canned context + 收集 sink。"""
+from __future__ import annotations
+from typing import Any
+from agentclaw.community.core.task.domain.models import TaskCallbackData
+
+
+class _DoubleApiKeyProvider:
+    api_key = "ak_double_1234"
+    api_key_prefix = "ak_doubl"
+    base_url = "http://localhost:8890"
+    cookie = ""
+    referer = ""
+
+
+class _DoubleContextProvider:
+    def build(self, task_id: str, node_id: str) -> dict[str, Any]:
+        return {"mode": "execute"}
+
+
+class _DoubleSink:
+    def __init__(self) -> None: self.reports: list[TaskCallbackData] = []
+    async def report_result(self, data: TaskCallbackData) -> None: self.reports.append(data)
+```
+
+`double/double_open_api_bot.py`：
+
+```python
+"""_DoubleOpenApiBot:进程内模拟 grant/send/poll(不经网络)。"""
+from __future__ import annotations
+import uuid
+from typing import Any
+
+
+class _DoubleOpenApiBot:
+    def __init__(self, *, final_status: str = "COMPLETED", content: Any = None,
+                 error: str | None = None) -> None:
+        self._final = final_status; self._content = content; self._error = error
+        self._runs: dict[str, dict] = {}
+
+    async def ensure_grant(self, bot_id: str) -> None: return None
+
+    async def send_message(self, *, bot_id: str, message: str, metadata: dict) -> str:
+        rid = f"mid_{uuid.uuid4().hex[:8]}"
+        self._runs[rid] = {"status": self._final, "result": {"content": self._content}, "error": self._error}
+        return rid
+
+    async def get_run(self, run_id: str) -> dict[str, Any]:
+        return self._runs.get(run_id, {"status": "RUNNING"})
+```
+
+`double/double_bcs_client.py`：
+
+```python
+"""_DoubleBcsClient:三态进程内模拟(create_group→session/run poll→终态)。"""
+from __future__ import annotations
+import uuid
+from typing import Any
+
+from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import (
+    BcsCreateGroupRequest, BcsCreateGroupResult,
+)
+
+
+class _DoubleBcsClient:
+    def __init__(self, *, session_status: str = "completed", session_output: Any = None,
+                 sm_status: str = "completed", sm_output: Any = None) -> None:
+        self._session_status = session_status; self._session_output = session_output
+        self._sm_status = sm_status; self._sm_output = sm_output
+
+    async def create_group(self, req: BcsCreateGroupRequest) -> BcsCreateGroupResult:
+        gid = f"grp_{uuid.uuid4().hex[:8]}"
+        dref = {"id": f"d_{gid[:4]}", "version": 1} if req.group_strategy == "state_machine" else None
+        return BcsCreateGroupResult(group_id=gid, definition_ref=dref)
+
+    async def create_session(self, group_id: str, *, bootstrap_prompt: str | None = None,
+                             idempotency_key: str | None = None) -> str:
+        return f"s_{uuid.uuid4().hex[:6]}"
+
+    async def get_group(self, group_id: str) -> dict[str, Any]:
+        return {"session": {"status": self._session_status, "output": self._session_output,
+                            "error_message": None}}
+
+    async def get_session_messages(self, session_id: str, *, limit: int = 50,
+                                   since_msg_id: str | None = None) -> list[Any]:
+        return []
+
+    async def start_state_machine_run(self, group_id, *, definition_yaml, definition_ref,
+                                      session_id, input) -> str:
+        return f"run_{uuid.uuid4().hex[:6]}"
+
+    async def get_state_machine_run(self, run_id: str) -> dict[str, Any]:
+        return {"status": self._sm_status, "output": self._sm_output, "error": None}
+
+    async def validate_definition(self, definition_yaml: str) -> None: return None
+```
+
+`integration/__init__.py` 加 `build_integration`：
+
+```python
+from __future__ import annotations
+import threading
+from typing import Any
+
+from agentclaw.community.core.task.task_runner.integration.double.double_bcs_client import _DoubleBcsClient
+from agentclaw.community.core.task.task_runner.integration.double.double_context_provider import (
+    _DoubleApiKeyProvider, _DoubleContextProvider, _DoubleSink,
+)
+from agentclaw.community.core.task.task_runner.integration.double.double_open_api_bot import _DoubleOpenApiBot
+from agentclaw.community.core.task.task_runner.integration.prompt_formatter import PromptFormatterImpl
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+from agentclaw.community.core.task.task_runner.integration.task_executor_result_poller import (
+    TaskExecutorResultPoller,
+)
+
+
+def build_integration(*, double: bool, sink, runner=None, poller_thread: bool = True) -> TaskExecutor:
+    """组合根:double(singlebox)/real(corp 覆写)。返装配好的 TaskExecutor(poller 可选起线程)。"""
+    if double:
+        bot = _DoubleOpenApiBot()
+        bcs = _DoubleBcsClient()
+        ctx = _DoubleContextProvider()
+        keys = _DoubleApiKeyProvider()
+    else:
+        from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter import BcsHttpAdapter
+        from agentclaw.community.core.task.task_runner.integration.bcs_token_provider import _RealToken  # corp 覆写
+        from agentclaw.community.core.task.task_runner.integration.open_api_bot_adapter import OpenApiBotAdapter
+        from agentclaw.community.core.task.task_runner.integration.prompt_formatter import _RunnerContextBuilder
+        bot = OpenApiBotAdapter(keys)
+        bcs = BcsHttpAdapter(_RealToken())
+        ctx = _RunnerContextBuilder(runner) if runner is not None else _DoubleContextProvider()
+    poller = TaskExecutorResultPoller(bot=bot, bcs=bcs)
+    poller.set_on_result(sink)
+    exe = TaskExecutor(bot=bot, bcs=bcs, formatter=PromptFormatterImpl(), context=ctx, sink=sink, poller=poller)
+    if poller_thread:
+        t = threading.Thread(target=poller.run_poll_loop, daemon=True)
+        t.start()
+    return exe
+```
+
+> `real` 分支的 `_RealToken` 由 corp adapter 提供（本仓不落；`build_integration(real)` 仅 corp 调）。社区/singlebox 只用 `double=True`。若 `real` 分支 import 失败不影响 double 路径，但为避免 import 报错，把 `real` 分支 import 放函数内（如上）并标注 corp 覆写。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/ -v`
+Expected: PASS（double + poller bcs + 既往全绿）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/task/task_runner/integration/double/ src/agentclaw/community/core/task/task_runner/integration/__init__.py tests/community/core/task/task_runner/integration/test_doubles.py tests/community/core/task/task_runner/integration/test_poller_bcs.py
+git commit -m "feat(task-runner-integration): singlebox doubles + build_integration composition root + poller bcs modes
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: singlebox wiring + 复用剧本 5 类 e2e + bbs no-op 断言 + 零 case grep
+
+**Files:**
+- Modify: singlebox facade wiring（`tests/community/e2e/...` 的 `_wire_facade` 或 `conftest`——按仓库 singlebox 装配点定位）
+- Test: 既有 5 类 e2e（`gwqie46v7hzr1w6h`）+ 新 `test_integration_e2e.py`
+- Create: `tests/community/core/task/task_runner/integration/test_zero_case.py`
+
+**Interfaces:**
+- Consumes: `build_integration(double=True, sink=facade.callback, runner=facade.runner)`；`TaskRunner(graph, execution_backend=executor)`。
+- Produces: singlebox `_wire_facade` 注入 `TaskExecutor`（double + `ResultSink=facade.callback`），`TaskService._build_engine`/runner 拿到 `execution_backend`。5 类 e2e 跑真实集成形态（非纯 stub）。BBS 用例断言 executor 对 `bbs` 仅记日志不改节点状态。零 case grep 红线。
+
+- [ ] **Step 1: 写零 case 断言 + e2e wiring 测试**
+
+`test_zero_case.py`：
+
+```python
+from pathlib import Path
+
+_BASE = Path("src/agentclaw/community/core/task/task_runner/integration")
+_FILES = ["ports.py", "translators.py", "open_api_bot_adapter.py", "bcs_http_adapter.py",
+          "bcs_token_provider.py", "prompt_formatter.py", "task_executor.py",
+          "task_executor_result_poller.py", "__init__.py"]
+_FORBIDDEN = ["N_overview", "N_market", "N_aggregate", "N_verify", "N_report", "N_practice", "n_root", "dim_"]
+
+
+def test_no_node_name_literals():
+    hits = []
+    for f in _FILES:
+        src = (_BASE / f).read_text()
+        hits += [f"{f}:{tok}" for tok in _FORBIDDEN if tok in src]
+    assert hits == [], f"integration 出现写死节点名: {hits}"
+```
+
+`test_integration_e2e.py`（singlebox，进程内 wired 回投驱动一例三模态 happy + bbs no-op）：
+
+```python
+import asyncio
+import pytest
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status, TaskInfo, TaskNode, TaskSpec,
+)
+from agentclaw.community.core.task.task_center.task_service import TaskService
+from agentclaw.community.core.task.task_graph.task_graph_service import TaskGraphService
+from agentclaw.community.core.task.task_runner.integration import build_integration
+from agentclaw.community.core.task.task_runner.integration.double.double_context_provider import _DoubleSink
+
+
+def _run(coro): return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _wire(double_sink: _DoubleSink) -> TaskService:
+    g = TaskGraphService()
+    svc = TaskService(g)
+    exe = build_integration(double=True, sink=svc.callback, runner=None, poller_thread=False)
+    # 把 executor 注入 runner(engine 内部建的 runner)
+    svc._engine._runner._execution_backend = exe
+    return svc, exe
+
+
+def test_bbs_dispatch_noop_does_not_change_node_status(caplog):
+    import logging
+    svc, exe = _wire(_DoubleSink())
+    from agentclaw.community.core.task.domain.models import TaskNode
+    n = TaskNode(node_id="b1", task_id="t1", status=Status.RUNNING,
+                 task_spec=TaskSpec(Metadata("t1", "T", "do"), Context("bg"),
+                                    Goal("O", [AcceptanceCriteria("a1", "d")])),
+                 run_info=RuntimeInfo(run_mode="bbs", assignee="bbs_bot"),
+                 node_run_graph=None)  # type: ignore[arg-type]
+    with caplog.at_level(logging.INFO):
+        ok = _run(exe.dispatch([n]))
+    assert ok == [True]
+    assert n.status == Status.RUNNING  # bbs 不改状态
+```
+
+> 完整 5 类 e2e（三模态 happy→DONE / FAIL 补救治愈 / MISS 升 BBS / BBS STUCK→HUNG / dashboard 终态）复用既有 singlebox 剧本 `gwqie46v7hzr1w6h` 的装配点：定位 `tests/community/e2e/` 下 `gwqie46v7hzr1w6h` 的 `_wire_facade`/conftest，在其注入 `build_integration(double=True, sink=svc.callback)` 并赋 `svc._engine._runner._execution_backend = exe`。**实施时先 `grep -rn "gwqie46v7hzr1w6h" tests/` 定位装配文件**，改其 wire 函数注入 integration double；5 类 e2e 跑通即验收。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && python -m pytest tests/community/core/task/task_runner/integration/test_zero_case.py tests/community/core/task/task_runner/integration/test_integration_e2e.py -v`
+Expected: zero_case PASS（已无节点名）；e2e FAIL 或 PASS（取决于 wiring）——先让 `test_bbs_dispatch_noop_does_not_change_node_status` 绿。
+
+- [ ] **Step 3: 定位并改 singlebox wiring**
+
+Run: `grep -rn "gwqie46v7hzr1w6h\|_wire_facade" tests/community/ | head`
+
+在定位到的 wire 函数内，`TaskService(g)` 构造后追加：
+
+```python
+from agentclaw.community.core.task.task_runner.integration import build_integration
+exe = build_integration(double=True, sink=svc.callback, runner=None, poller_thread=True)
+svc._engine._runner._execution_backend = exe
+```
+
+> 若 `TaskService` 构造时 `engine._runner` 已就绪（engine `__init__` 建 runner），此赋值可行。若 singlebox 需经 DI 注入，改为 `TaskRunner(graph, execution_backend=exe)` 经 `CorpEngine._build_runner` 覆写——但 singlebox 直赋更简，保持。
+
+- [ ] **Step 4: 跑 5 类 e2e + 零 case + 全量回归**
+
+Run: `cd src/backend && python -m pytest tests/community/e2e/ tests/community/core/task/ -v`
+Expected: PASS（5 类 e2e 真实集成形态 + 既往 121 + integration 全绿；零 case 0 命中）
+
+- [ ] **Step 5: pre-push lint**
+
+Run: `cd src/backend && git push --dry-run 2>&1 | tail -20`
+Expected: Backend SAST gate 通过（默认 lint-only）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/community/core/task/task_runner/integration/test_zero_case.py tests/community/core/task/task_runner/integration/test_integration_e2e.py <定位到的 singlebox wiring 文件>
+git commit -m "test(task-runner-integration): singlebox wiring + 5 e2e real-integration + bbs no-op + zero-case
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes（已自审）
+
+- **Spec 覆盖**：§7.1 三态 create_group→T7/T8；§7.2 state_machine run_id 捕获→T9；§7.3 BCS 端点集→T7(chat/manager_worker)+T9(state_machine)；§7.4 Port→T1；§7.5 GroupFormation.extend_props→T8（manager_bot_id/collaboration_definition_yaml/service_spec/sla_timeout_ms 透传）；§7.6 数据流三模态→T6(single_bot)/T8(session)/T9(run)；§7.7 TaskExecutor→T3+T6+T8+T9（dispatch async 细化见顶部）；§7.8 poller 三模态→T5(single_bot)+T10(session/run)；§7.9 无 PUSH→全 plan 经 ResultSink wired（无入站路由）；§7.10 翻译器→T2；§7.11 错误处理→T4(Open API 异常)+T7(BCS 异常)+T6/T8(grant 403→False)；§8 零 case→T11；§9 测试→各 task 单测 + T11 e2e。
+- **类型一致**：`dispatch(toDoTaskList)->list[bool]` async；`form_coop_group(gf)->str` async；`SingleBotHandle`/`BcsGroupHandle` 字段在 T5 定义、T6/T8/T9 引用一致；`BcsCreateGroupRequest`/`Result` 字段在 T7 定义、T8/T9/T10 引用一致；`parse_bot_id`→`tuple[str,str]`；翻译器 `adapt(...)->TaskCallbackData`。
+- **placeholder 扫描**：T3/T6/T8/T9 的占位 `_dispatch_*`/`form_coop_group`/`start_state_machine_run` 均在后续 task 显式替换（标注「T_x 替换」）；无 TBD/TODO。`build_integration` real 分支 `_RealToken` 标注 corp 覆写（社区不发 real）。
+- **细化标记**：顶部「与 spec §7.7 的细化」显式记录 dispatch async + poller daemon 线程的取舍。
+
+## Risks（对齐 spec §11）
+
+- ocb `BcsHttpClient` 缺 `group_strategy`→T7 自包含补齐；state_machine `start_initial_run=False`→T8/T9 强制。
+- 单 bot grant 需登录态→T4 `ensure_grant` Cookie+Referer（double 可空）；grant 403→T6 返 False。
+- BCS 无 webhook→T5/T10 poller session/run 模；Open API 无 PUSH→T5 single_bot 模。
+- `build_integration(real)` 的真实 token/密钥属 corp adapter（社区只发 double/singlebox）。
+- poller 登记表 in-mem（与 `TaskHarness._dispatched_at` 同级），不落库。
+- singlebox wiring 经 `svc._engine._runner._execution_backend = exe` 直赋（内部访问）；若 DI 化需 corp 覆写 `_build_runner`，后续。

--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner/spec.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner/spec.md
@@ -1,0 +1,393 @@
+# Spec: task_runner integration 子模块（单 bot / 协作群真实执行接入）
+
+- 日期：2026-08-13
+- 分支：`feat/task-goal-driven-collab-dev`
+- 范围模块：`src/backend/src/agentclaw/community/core/task/task_runner/integration/`
+- 上游 spec：`specs/2026-08-09-task-goal-driven-execution-framework/`（任务目标驱动执行框架，M0–M6 已落地）
+- 适用代码约定：遵循 `AGENTS.md`（不引入 `T | None` 除非 None 是契约态；必填值非可选）
+
+---
+
+## 1. Problem Statement
+
+任务目标驱动执行框架（上游 spec）当前 `TaskRunner.start_run` / `form_coop_group` 是 **stub**：三模态（`single_bot` / `coop_group` / `bbs`）只记投递日志返回 `True`、`form_coop_group` 生成伪 `grp_{uuid}`，**不真实发起任何 bot 执行或协作群**。`_build_context`（指令组装）已实现但 `start_run` 未调用它。结果回投全靠测试 stub 手动 PUSH。
+
+本 spec 设计 `task_runner/integration` 子模块，把 stub 替换为**真实执行接入**：
+
+- **单 bot 执行**：经 BaaS **Open API**（参考 `create_api_key.py` / `send_bot_message.py` 的 `messages` 模式）——用**静态配置的 App API Key**，先校验/补 `allowed-bots` grant，再 `POST /openapi/v1/messages` 发消息，**拿到 `run_id` 即派发返回，不轮询、不等待结果**；结果由旁路 poller 回收。
+- **协作群执行**：参考 corp ocb `BcsHttpClient` 的 `create_group → create_session` 模式，在 Avernet 内重写一个**自包含 BCS HTTP client**，支持 `GroupStrategy` 三态（`chat` / `manager_worker` / `state_machine`），并经轮询回收结果。
+- **bbs 模式**：`TaskExecutor` 内置第三种模态分流，**仅记日志、不发起任何执行**（沿用既有 `BbsMarketPort` seam）。
+
+约束：Avernet 边界内**自包含**——单 bot 走 BaaS HTTP Open API（**不 import corp ocb `ecb`**，**不依赖 in-repo `secbaas` BotRunner**）；BCS client 在 Avernet 内自包含重写；singlebox 测试经注入 double 跑通真实集成形态。
+
+---
+
+## 2. Solution 概述
+
+采用 **方案 A**：所有模态一律「派发即返回（fire-and-forget，捕获 `run_id` 后不轮询、不等待）+ 旁路 Poller 回收结果」，集成内置后台 executor 承载所有真实 async I/O。
+
+```
+start_run(sync, list[bool]=派发是否成功)
+   │  入队 TaskJob
+   ▼
+TaskExecutor(自有后台事件循环线程, 所有真实 async I/O; 三模态分流)
+   ├─ single_bot → OpenApiBotAdapter: 静态 API key 校验/补 grant(allowed-bots) → POST /openapi/v1/messages{bot_id,message} 取 run_id
+   │                 → 登记 TaskExecutorResultPoller(single_bot 模); 派发不轮询、不等待结果
+   ├─ coop_group → form_coop_group = BcsHttpAdapter.create_group(建群壳, 三态分流, state_machine start_initial_run=False)
+   │                 ├─ chat / manager_worker → start_run: create_group→create_session(bootstrap_prompt) → 登记 TaskExecutorResultPoller(session 模)
+   │                 └─ state_machine → start_run: create_group(start_initial_run=False)→POST /groups/{id}/state-machine-runs 取 run_id
+   │                                      → 登记 TaskExecutorResultPoller(run 模)
+   └─ bbs        → 仅记结构化日志(不发起执行、不改节点状态、不登记 poller; 沿用既有 BbsMarketPort seam)
+   │
+TaskExecutorResultPoller(旁路 sidecar, 同 TaskHarness 风格; 三模态回收)
+   ├─ single_bot 模: GET /openapi/v1/messages/{run_id} → status ∈ {COMPLETED,FAILED} → SingleBotRunTranslator → on_report
+   ├─ session 模:    get_group + get_session_messages(since cursor) → Session.status=Completed → BcsSessionTranslator → on_report
+   └─ run 模:        GET /state-machine-runs/{run_id} → run.status 终态 → BcsStateMachineRunTranslator → on_report
+```
+
+结果统一回流到编排核 `ExecutionEngine.on_report`（经 `TaskLoopCallback.report_result`），与上游 spec 的回投契约一致。**不再有入站 PUSH 回调**——单 bot 与协作群统一为「派发取 `run_id` + 旁路 poller 回收」模型。
+
+---
+
+## 3. Constraints / Constraints
+
+1. **不破坏上游契约**：`TaskRunner.start_run(toDoTaskList) -> list[bool]` 签名不变（同步）；`TaskLoopCallback.report_result(TaskCallbackData)` 不变；`loop_task_id = "task_id::node_id"` 不变；`CallbackAdapter.adapt` 不变。
+2. **零 case 知识红线**：integration 只经 `_build_context` + `TaskNode` 字段组装指令，不得出现 `N_market` / `N_overview` 等节点名字面量（grep 0 命中，单测断言）。
+3. **_开源边界_**：integration 不 `import` corp ocb `ecb` 包；单 bot 走 BaaS **HTTP Open API**（httpx async，对齐 `send_bot_message.py` 的 `/openapi/v1/messages`），**不 import in-repo `secbaas` BotRunner**；BCS client 在 Avernet 内自包含重写（httpx async + HMAC 签名，照搬 ocb `BcsHttpClient` 模式）。
+4. **必填非可选**：遵循 `AGENTS.md`——端口必填参数不加 `| None`；None 仅用于契约态（如 `session_id is None` 触发 `create_session`、`bot_id` 不在 `allowed_bots` 触发 `ensure_grant`）。
+5. **幂等**：BCS `create_group` 带 `Idempotency-Key` header；`start_run` 重试安全；grant 幂等（重复 grant 同一 bot 由服务端去重）；`on_report` 本身上游已幂等。
+6. **向后兼容**：不注入 `execution_backend` 时，`TaskRunner` 保持现行 stub 行为（现有 singlebox e2e 不破）。
+
+---
+
+## 4. Scope
+
+### In Scope
+- `integration/` 子模块全部文件（见 §6 模块布局）。
+- `TaskRunner` 改造：`start_run` / `form_coop_group` 委托注入的 `execution_backend`；`_build_context` 被真实调用。
+- 单 bot 真实派发（BaaS Open API + 静态 App API Key + 主动 `allowed-bots` grant）+ 旁路 poller 回收 + 翻译。
+- 协作群三态（chat / manager_worker / state_machine）真实建群 + 三模 Poller + 翻译。
+- `TaskExecutor` 第三模态 `bbs`（仅记日志，不执行）。
+- singlebox double（`_DoubleOpenApiBot` / `_DoubleBcsClient` / `_DoubleApiKeyProvider` / `_DoubleContextProvider`），复用现有 e2e 剧本 `gwqie46v7hzr1w6h`。
+
+### Out of Scope
+- bbs 模式**真实执行**（`TaskExecutor` 仅记日志；真实 BBS 沿用 `BbsMarketPort`）。
+- baas / BCS 真实部署、真实 bot catalog 搜推（`BotDiscoverPort` 真实实现在 corp）。
+- BaaS Open API 的 `runs`（Bot Key 单轮）/ `messages/stream`（SSE）模式——本 spec 单 bot 仅用 `messages`（App Key 异步）模式。
+- 前端画布渲染、外部 issue tracker、AI-Credit 审计产品化。
+- BCS 服务化 group 模板（`service_spec`）的非回调用途——本 spec 仅在 create_group 透传可选 `service_spec`，不实现服务化注册流。
+- 持久化/ORM：poller 登记表 in-memory（与 `TaskHarness._dispatched_at` 同级），不落库。
+
+---
+
+## 5. 参考实现锚点
+
+### 5.1 协作群 — ocb BcsHttpClient（参考模式，自包含重写）
+- 路径（corp，仅参考）：`/Users/jian.jiangj/Git/ocb/src/ecb/ecb/infrastructure/teamos/bcs/http_client.py`
+- 模式：`httpx.AsyncClient` + HMAC-SHA256 签名头（`X-ECB-Token` / `X-ECB-Timestamp` / `X-ECB-Signature`，签串 `f"{ts}{method}{path}"`）。
+- **关键**：ocb Python `create_group` 不暴露 `group_strategy`，但 **BCS server 端 `POST /groups` 完整接受**（见 §7.1）。本 spec 自包含 client 补齐该参数。
+- 避坑：不用 ocb `BCSGroupService` 同步包装层（硬编码地址/token、吞异常、`asyncio.run` 不可在 running loop 用）——直接 `await` 自包含 async client。
+
+### 5.2 单 bot — BaaS Open API（静态 API key + 主动 grant + `/openapi/v1/messages`）
+- 参考脚本（仅参考实现模式，不改它们）：`/Users/jian.jiangj/Temp/test_tc_open_api/create_api_key.py`、`/Users/jian.jiangj/Temp/test_tc_open_api/send_bot_message.py`。
+- 鉴权三件套（**静态配置**，来自 `graph.extend_props.execution_config` / singlebox 注入，**不下发到 case 知识**）：
+  - `secbaas_api_key`：App API Key（`Authorization: Bearer <key>`，用于 `POST /openapi/v1/messages` 与 `GET /openapi/v1/messages/{id}`）。
+  - `secbaas_api_key_prefix`：key 前 8 位（用于 `allowed-bots` 查询 / `grant` 路径段）。
+  - `secbaas_cookie` / `secbaas_referer`：**登录态**（`grant` 走登录态鉴权，**不是** Bearer；stub/singlebox 可空）。
+  - `secbaas_base_url`：默认 `http://localhost:8890`（singlebox BaaS 端口）。
+- **grant 校验 / 补权流程**（派发前，对每个目标 `bot_id`，在 `OpenApiBotAdapter.ensure_grant` 内）：
+  1. `GET /api/v1/api-keys/{prefix}/allowed-bots` → `data.allowed_bots`（`list[bot_id]`）。
+  2. `bot_id` 不在列表 → `POST /api/v1/api-keys/{prefix}/allowed-bots/grant` body `{"bot_id": bot_id}`（**Cookie + Referer 鉴权**）补权。
+  3. grant 失败（403 / 无登录态等不可重试）→ 该 node 派发返 `False`（编排核可 MISS / 重投）；不阻塞其它 node。
+- **发消息**（炊弹）：`POST /openapi/v1/messages` body `{"bot_id": <run_info.assignee>, "message": <PromptFormatter.format_execute(ctx, node)>}`，Bearer 鉴权 → 响应 `data.message_id`。该 `message_id` 即本 spec 里的 **`run_id`**。**拿到 `run_id` 即派发成功返回，不轮询、不等待结果**——结果回收交给 `TaskExecutorResultPoller`（§7.8）。
+- bot_id 格式：`<real_bot_id>:<entity_id>`（与 `allowed_bots` 列表项一致；经 `parse_bot_id`）。
+- **结果回收**（poller 侧）：`GET /openapi/v1/messages/{run_id}` → `data.status`（**大小写不敏感**，prod 实测大写如 `COMPLETED`），终态 `{COMPLETED, FAILED}` → `result.content`→`data` / `error`→`fail_detail`。`TIME_OUT` 映射 `fail_detail="timeout"`。
+
+### 5.3 框架侧回投契约（不变）
+- `TaskCallbackData.loop_task_id = "task_id::node_id"`，`result: {success, data, fail_detail}`。
+- `CallbackAdapter.adapt`（`task_runner/callback_adapter.py`）解析 `loop_task_id.split("::")`、`result.success/data/fail_detail` → `TaskNodePatch`。
+- `TaskLoopCallback.report_result` → `ExecutionEngine.on_report`。
+
+---
+
+## 6. 模块布局
+
+```
+core/task/task_runner/integration/
+  __init__.py                       # build_integration(real|double) 组合根装配
+  ports.py                          # Port: OpenApiBotPort / BcsClientPort / ApiKeyProvider /
+                                    #       TaskContextBuilder / PromptFormatter / ResultSink
+  task_executor.py                  # TaskExecutor: 自有后台事件循环线程; start_run 入队; 三模态(single_bot/coop_group/bbs)分流
+  open_api_bot_adapter.py           # OpenApiBotAdapter(OpenApiBotPort): 静态 API key + ensure_grant + POST/GET /openapi/v1/messages(httpx async)
+  bcs_http_adapter.py               # BcsHttpAdapter(BcsClientPort): 自包含 httpx async BCS client(HMAC)
+  bcs_token_provider.py             # BCS HMAC 凭据(真实/double): driver bot 签名取数
+  task_executor_result_poller.py    # TaskExecutorResultPoller sidecar: 三模态回收(single_bot / session / run)
+  translators.py                    # SingleBotRunTranslator / BcsSessionTranslator / BcsStateMachineRunTranslator
+  double/                           # singlebox double
+    __init__.py
+    double_open_api_bot.py          # _DoubleOpenApiBot: grant→POST /messages→poll→终态
+    double_bcs_client.py            # _DoubleBcsClient: create_group→create_session→poll→终态
+    double_context_provider.py      # _DoubleApiKeyProvider / _DoubleContextProvider
+```
+
+`TaskRunner` 改造点（`task_runner/runner.py`）：
+- `__init__(graph, execution_backend=None)`：新增可选 `execution_backend`（= `TaskExecutor`）。未注入时现行 stub 行为。
+- `start_run`：`single_bot` / `coop_group` / `bbs` 均委托 `execution_backend.dispatch(toDoTaskList)`（`bbs` 在 executor 内仅记日志，不改节点状态）。
+- `form_coop_group`：委托 `execution_backend.form_coop_group(gf)`（真实走 `BcsHttpAdapter`）。
+- `_build_context`：保留，被 `PromptFormatter` 消费。
+
+---
+
+## 7. 详细设计
+
+### 7.1 BCS `POST /groups` 契约（三态分流）
+
+BCS server 端 `CreateGroupRequest`（`bcs-protocol/src/http/groups.rs`）关键字段（本 client 需支持）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `driver_bot` | `str` | normal 群必填 |
+| `participants` | `list[{bot_uuid, role?}]` | 成员 |
+| `group_strategy` | `"chat"\|"manager_worker"\|"state_machine"` | 省略=chat |
+| `context` | `str?` | 群上下文（chat/manager_worker 走 `[GROUP CONTEXT]` 投递 driver） |
+| `topic` | `str?` | 群主题 |
+| `collaboration_definition_yaml` | `str?` | 内联 `CollaborationDefinition` YAML；出现强制 state_machine；别名 `definition_yaml` |
+| `participant_bindings` | `map[binding_id, {source:"manual", bot_ids}]` | state_machine 槽位绑定；非空要求 yaml 同时存在 |
+| `service_spec` | `dict?` | `ServiceSpec{callback_config?, timeout_seconds?, max_concurrency?}`（可选透传） |
+| `start_initial_run` | `bool?` | 是否立即起初始 run，默认 true |
+| `auto_start_on_service_invocation` | `bool?` | 持久化到 runtime binding |
+| `originator` | `str?` | 发起者，默认 driver_bot |
+| `visibility` | `"public"\|"private"?` | 默认 private |
+| `idempotency_key` | header `Idempotency-Key` | 幂等去重 |
+
+服务端校验：yaml 仅 normal 群；yaml 存在时 `group_strategy` 强制 state_machine；`participant_bindings` 非空要求 yaml；yaml 不得含顶层 `id`/`version`；`driver_bot` 必须在 yaml participants 内。
+
+`form_coop_group(gf) -> group_id`（dispatcher 对 HIT_MULTI_BOTS 调用；上游契约仅返 `str`）= **`BcsHttpAdapter.create_group` 建群壳**，按 `GroupFormation.collab_mode` 分流（`GroupFormation` 见 `task_dispatch/protocols.py`，type 不变，仅定 `extend_props` 契约，见 §7.5）。`create_group` 只建群、**不下发任务指令**（`context=None`；state_machine `start_initial_run=False`）——指令 kickoff 在 `start_run` 经 `create_session`（chat/manager_worker）或 `start_state_machine_run`（state_machine）下发，即 ocb「先 create_group、再 create_session」模式。executor 内 `_group_meta: dict[group_id → {session_id?, definition_ref?, collab_mode, gf}]` 由 `form_coop_group` 填充，供 `start_run` 按 `assignee=group_id` 查询（`form_coop_group -> str` 契约不变，meta 仅内部用）。
+
+- **chat**：`{driver_bot, participants}`（`group_strategy` 省略）。响应取 `group_id`。
+- **manager_worker**：`{group_strategy:"manager_worker", driver_bot=<manager>, participants[{role:"manager"}/{role:"worker"}]}`。manager = `gf.extend_props.get("manager_bot_id")` or `gf.bot_ids[0]`；其余 bot 为 worker。
+- **state_machine**：`{group_strategy:"state_machine", collaboration_definition_yaml=gf.extend_props["collaboration_definition_yaml"], participant_bindings=<由 gf.bot_ids 构造: {bid:{"source":"manual","bot_ids":[bid]}}>, driver_bot, start_initial_run=False}`。
+
+### 7.2 StateMachine run_id 捕获约束（关键）
+
+默认 `start_initial_run=true` 的 `POST /groups` 响应**不含 `run_id`**，poller 无从下手。故 state_machine 强制 `start_initial_run=False`（在 `form_coop_group` 的 `create_group` 阶段），run 启动与 `run_id` 捕获延后到 `start_run`：
+
+1. `form_coop_group` → `create_group(start_initial_run=False)` → 取 `group_id`（dispatcher 存为 `assignee`）；definition 由服务端 `upsert_definition_with_source_yaml` 持久化，`definition_ref={id,version}` 存入 `_group_meta`。
+2. `start_run`(state_machine node) → `POST /groups/{id}/state-machine-runs`，body `{definition_ref: {id, version}}` + `session_id?` + `input`（`input = {"query": PromptFormatter.format_execute(ctx, node)}`）→ `202` body `StateMachineRunView.run.run_id`。
+3. 登记 `run_id` 进 `TaskExecutorResultPoller`（run 模）。
+
+chat / manager_worker 无此问题（kickoff 经 `create_session`，结果经 session 状态回收）。
+
+### 7.3 BCS client 端点集（自包含 client 需实现）
+
+| 方法 | 端点 | 用途 |
+|---|---|---|
+| `create_group` | `POST /groups` | 建群壳（三态） |
+| `create_session` | `POST /groups/{id}/sessions` | chat/manager_worker kickoff（bootstrap_prompt→`[GROUP CONTEXT]`） |
+| `get_group` | `GET /groups/{id}` | 取 `latest_running_session_id`、群/session 状态 |
+| `get_session_messages` | `GET /sessions/{sid}/messages?limit&since_msg_id` | 增量拉消息（chat/manager_worker） |
+| `start_state_machine_run` | `POST /groups/{id}/state-machine-runs` | 显式起 run 取 `run_id` |
+| `get_state_machine_run` | `GET /state-machine-runs/{run_id}` | 轮询 run 终态（state_machine） |
+| `validate_definition` | `POST /collaboration/definitions/validate` | 可选 YAML 预检 |
+
+鉴权：HMAC 签名头（`X-ECB-Token`/`X-ECB-Timestamp`/`X-ECB-Signature`）；session 内追发（本 spec 暂不用）需 Bearer bot token。
+
+### 7.4 Port 契约（`ports.py`）
+
+```python
+class OpenApiBotPort(Protocol):
+    async def ensure_grant(self, bot_id: str) -> None: ...        # 查 allowed-bots;缺则 grant(登录态)
+    async def send_message(self, *, bot_id: str, message: str,
+                           metadata: dict[str, Any]) -> str: ...  # run_id(=message_id)
+    async def get_run(self, run_id: str) -> dict[str, Any]: ...   # {status, result, error}
+
+class BcsClientPort(Protocol):
+    async def create_group(self, req: "BcsCreateGroupRequest") -> "BcsCreateGroupResult": ...
+    async def create_session(self, group_id: str, *, bootstrap_prompt: str | None = None,
+                             idempotency_key: str | None = None) -> str: ...  # session_id
+    async def get_group(self, group_id: str) -> dict[str, Any]: ...
+    async def get_session_messages(self, session_id: str, *, limit: int = 50,
+                                   since_msg_id: str | None = None) -> list[Any]: ...
+    async def start_state_machine_run(self, group_id: str, *, definition_yaml: str | None,
+                                      definition_ref: dict | None, session_id: str | None,
+                                      input: dict) -> str: ...  # run_id
+    async def get_state_machine_run(self, run_id: str) -> dict[str, Any]: ...
+    async def validate_definition(self, definition_yaml: str) -> None: ...
+
+class ApiKeyProvider(Protocol):
+    """静态配置的 BaaS Open API 凭据:发消息用 Bearer;grant 用登录态 Cookie/Referer。"""
+    @property
+    def api_key(self) -> str: ...        # Bearer(app key)用于 /openapi/v1/messages
+    @property
+    def api_key_prefix(self) -> str: ... # 前 8 位,用于 allowed-bots/grant 路径
+    @property
+    def base_url(self) -> str: ...       # 默认 http://localhost:8890
+    @property
+    def cookie(self) -> str: ...         # 登录态(grant 鉴权);stub/singlebox 可空
+    @property
+    def referer(self) -> str: ...
+
+class TaskContextBuilder(Protocol):
+    """= 现有 TaskRunner._build_context 的抽像(验收/执行双模式 dict)。"""
+    def build(self, task_id: str, node_id: str) -> dict[str, Any]: ...
+
+class PromptFormatter(Protocol):
+    """把 _build_context dict + TaskNode → 指令字符串(Open API message / BCS context/bootstrap_prompt)。
+    零 case: 仅用 dict 字段 + node.task_spec,不写节点名字面量。"""
+    def format_execute(self, context: dict[str, Any], node: "TaskNode") -> str: ...
+    def format_verify(self, context: dict[str, Any], node: "TaskNode") -> str: ...
+
+class ResultSink(Protocol):
+    """结果回流入口 = TaskLoopCallback.report_result(或 engine.on_report 经适配)。"""
+    def report_result(self, data: "TaskCallbackData") -> None: ...
+```
+
+`BcsCreateGroupRequest` / `BcsCreateGroupResult` 为 `integration` 内 dataclass（`bcs_http_adapter.py`），对齐 §7.1 字段；`result` 含 `group_id`、`session_id`、`run_id?`。
+
+### 7.5 `GroupFormation.extend_props` 契约补充（type 不变）
+
+`GroupFormation`（`task_dispatch/protocols.py`）已有 `collab_mode: str` + `extend_props: dict`。本 spec 定义 `extend_props` 约定 key（不增字段）：
+
+| key | 适用 | 说明 |
+|---|---|---|
+| `collaboration_definition_yaml` | state_machine 必填 | `CollaborationDefinition` YAML；内 `participants` 的 binding id 必须 = `gf.bot_ids` 的某项 |
+| `manager_bot_id` | manager_worker 可选 | 默认 `gf.bot_ids[0]` |
+| `service_spec` | 任意可选 | 透传 BCS `ServiceSpec` |
+| `sla_timeout_ms` | 任意可选 | poller 超时兜底（优先 `execution_config.SLA_TIMEOUT`） |
+
+`BcsHttpAdapter` 由 `gf.bot_ids` 自动构造 `participant_bindings = {bid: {"source":"manual","bot_ids":[bid]} for bid in gf.bot_ids}`。yaml 的 binding id 必须落在 `gf.bot_ids`——由 corp `BotDiscoverPort` 产出时保证；singlebox double 的 canned yaml 保证。
+
+### 7.6 数据流
+
+#### 单 bot
+1. `start_run` → `TaskExecutor.enqueue(single_bot, node)` → 立即返 `True`。
+2. executor（后台 loop）对 `bot_id = node.run_info.assignee`：
+   a. `OpenApiBotPort.ensure_grant(bot_id)`：`GET /api/v1/api-keys/{prefix}/allowed-bots` → `allowed_bots`；`bot_id` 不在列表则 `POST .../allowed-bots/grant`（Cookie+Referer 鉴权）补权；失败 → 该 node 返 `False`。
+   b. `send_message(bot_id=bot_id, message=PromptFormatter.format_execute(ctx, node), metadata={"timeout": <execution_config 超时>, "biz_task_id": task_id})`：`POST /openapi/v1/messages`（Bearer）→ `run_id`（= `message_id`，§5.2）。
+   c. **拿到 `run_id` 即返回**，不轮询、不等待结果。
+3. 登记 `SingleBotHandle{task_id::node_id, run_id, bot_id}` 进 `TaskExecutorResultPoller`（single_bot 模）。
+4. poller：`get_run(run_id)` = `GET /openapi/v1/messages/{run_id}` → `status ∈ {COMPLETED, FAILED}` → `SingleBotRunTranslator`（`success = status==COMPLETED`；`data = result.content`；`fail_detail = error`）→ `report_result` → `on_report`。
+
+`form_coop_group(gf)`（dispatcher 对 HIT_MULTI_BOTS 调用）= `create_group` 建群壳（§7.1），返 `group_id`（dispatcher 存为 `node.run_info.assignee`），并在 executor `_group_meta` 存 `{session_id?, definition_ref?, collab_mode, gf}`。任务 kickoff 与 poller 登记在 `start_run`（此时有 node → 可组 prompt）：
+
+#### 协作群（chat / manager_worker）
+1. `start_run` 取 `group_id = node.run_info.assignee`（HIT_MULTI_BOTS 由 `form_coop_group` 新建；HIT_GROUP 为 `BotDiscoverPort` 已知既有群——后者 `_group_meta` 无记录，直接用 `group_id`）。
+2. `create_session(group_id, bootstrap_prompt=PromptFormatter.format_execute(ctx, node))` → `session_id`（`[GROUP CONTEXT]` 原子投递 driver）。**拿到 `session_id` 即返回，不等待结果。**
+3. 登记 `BcsGroupHandle{task_id::node_id, group_id, session_id, collab_mode, run_id=None, since_cursor=None}` 进 `TaskExecutorResultPoller`（session 模）。
+4. poller：`get_group` 看 `Session.status` + `get_session_messages(since cursor)` 累积 → `Session.status=="completed"` → `BcsSessionTranslator`（`output`→`data`，`error_message`→`fail_detail`）→ `report_result`。
+
+#### 协作群（state_machine）
+1. `start_run` 取 `group_id = node.run_info.assignee`（`form_coop_group` 已 `create_group(start_initial_run=False)`，definition 已持久化）。
+2. `start_state_machine_run(group_id, definition_ref=_group_meta[group_id].definition_ref, session_id, input={"query": PromptFormatter.format_execute(ctx, node)})` → `run_id`（§7.2）。**拿到 `run_id` 即返回，不等待结果。**
+3. 登记 `BcsGroupHandle{..., run_id=run_id}` 进 `TaskExecutorResultPoller`（run 模）。
+4. poller run 模：`get_state_machine_run(run_id)` → `run.status ∈ {completed,failed,aborted}` → `BcsStateMachineRunTranslator`（success=completed / data=run.output / fail_detail=run.error 或 `"aborted"`）→ `report_result`。
+
+### 7.7 TaskExecutor（异步/同步弥合）
+
+- 自有**后台事件循环线程**（`threading.Thread` + `asyncio.new_event_loop`），所有真实 async I/O（Open API grant / send、BCS create_group / start_run / validate）在该 loop 跑。
+- `dispatch(toDoTaskList) -> list[bool]`：同步入口，对每个 node 按 `node.run_info.mode`（`single_bot` / `coop_group` / `bbs`）分流，构造 `TaskJob` 投入队列（线程安全 `queue.Queue` + loop 唤醒，或 `run_coroutine_threadsafe`），立即返 `list[bool]`（= 入队 / 前置校验成功）。
+- **三模态分流**：
+  - `single_bot`：`OpenApiBotAdapter.ensure_grant` → `send_message` 取 `run_id` → 登记 `TaskExecutorResultPoller`（single_bot 模）。**派发只到拿到 `run_id` 为止，不轮询结果**。
+  - `coop_group`：`BcsHttpAdapter` 建群 / kickoff，登记 `TaskExecutorResultPoller`（session 或 run 模），见 §7.2 / §7.6。
+  - `bbs`：**仅记结构化日志**（`logger.info("[task_executor] bbs node dispatched (no-op): task=%s node=%s assignee=%s", task_id, node_id, assignee)`），不发起任何执行、不改节点状态、不登记 poller；真实 BBS 沿用既有 `BbsMarketPort` seam（见 §4 Out of Scope）。
+- executor 持 `ResultSink`（回投入口），`TaskExecutorResultPoller` 调 `ResultSink.report_result`。
+- 异常映射：派发期 grant 403 / Open API 4xx / `BotNotAvailableError`（不可重试）→ 对该 node 返 `False`（编排核可重投 / MISS）；`BcsServerError`/`BcsTimeoutError`/`BcsRateLimitError`/Open API 429（可重试）→ 返 `False` 且 executor 内部退避重试上限 3 次后上抛。
+- executor 生命周期：facade `TaskService.__init__` 装配时起线程；进程退出时 `aclose()`。
+
+### 7.8 TaskExecutorResultPoller（旁路 sidecar）
+
+- 同 `TaskHarness` 风格：`register(handle)`、`run_poll_loop(stop_event=None)`、`set_on_result(sink)`。
+- **三模态**（按 handle 类型分流，统一回收 single_bot 与协作群结果）：
+  - `SingleBotHandle`（single_bot 模）：`OpenApiBotPort.get_run(run_id)` = `GET /openapi/v1/messages/{run_id}` → `status`（大小写不敏感）∈ `{COMPLETED, FAILED}` 终态 → `SingleBotRunTranslator` → `report_result`。
+  - `BcsGroupHandle` 且 `run_id` 非空（run 模）：`get_state_machine_run(run_id)` → `run.status` 终态 → `BcsStateMachineRunTranslator` → `report_result`。
+  - `BcsGroupHandle` 且 `run_id` 为空（session 模）：`get_group` + `get_session_messages(since cursor)` → `Session.status=="completed"` → `BcsSessionTranslator` → `report_result`。
+- polling：`interval`（默认 1s，可注入）；single_bot / session 各自游标（single_bot 无游标，run 模无游标）；5xx 退避，连续 5 次失败 → `report_result(FAIL, fail_detail="poll_exhausted")` 并注销。
+- 超时：`now - handle.registered_at > sla_timeout` 且未终态 → `report_result(FAIL, fail_detail="sla_timeout")` 并注销（旁路复位交给编排核 `on_report` FAIL 链路）。
+- 与 `TaskHarness` 并存：`TaskHarness` 复位 `RUNNING→PENDING`（节点 SLA）；`TaskExecutorResultPoller` 回收 single_bot + 协作群执行结果。二者独立。
+
+### 7.9 无 PUSH 回调（设计取舍）
+
+- 旧设计的 baas PUSH 回调（`POST /task/callback` + `BaasCallbackTranslator` + `BotRunnerPort.deliver_message(callback=...)`）**全部移除**。单 bot 改走 Open API「派发取 `run_id` + 旁路 poller 回收」（§5.2 / §7.6 / §7.8），与协作群统一为 poller 模型，减少入站路由依赖。
+- 上游 facade 2 API（`execute` / `get_task_dashboard`）当前**仅 transport-agnostic Protocol**，未挂 HTTP 路由（`adapters/http/task/` 仅 stale `.pyc`）。本 spec **不新增任何入站 HTTP 路由**；结果回流一律经 `TaskExecutorResultPoller` → `ResultSink.report_result`（进程内 wired）。
+- singlebox 下 `_DoubleOpenApiBot` 直接进程内模拟 grant / send / poll，不经网络。
+
+### 7.10 翻译器（`translators.py`）
+
+- `SingleBotRunTranslator.adapt(run_dict, loop_task_id) -> TaskCallbackData`：`loop_task_id=<登记时的 task::node>`；`success = (status or "").lower()=="completed"`；`data = (run_dict.get("result") or {}).get("content")`；`fail_detail = run_dict.get("error")`（`TIME_OUT`→`"timeout"`）。
+- `BcsSessionTranslator.adapt(group_dict, messages) -> TaskCallbackData`：`success = session.status=="completed"`；`data = session.output`（缺失取末条 assistant 消息 content）；`fail_detail = session.error_message`。
+- `BcsStateMachineRunTranslator.adapt(run_dict) -> TaskCallbackData`：`success = run.status=="completed"`；`data = run.output`；`fail_detail = run.error` 或 `f"aborted"`。
+
+### 7.11 错误处理
+
+- BCS 异常（自包含 client 自定义，对齐 ocb `exceptions.py`）：`BcsClientError`（基类）/ `BcsServerError`(5xx,可重试) / `BcsClientRequestError`(4xx,不重试) / `BcsRateLimitError`(429,带 `retry_after_s`) / `BcsTimeoutError`。
+- Open API 异常（`open_api_bot_adapter.py` 自定义）：`OpenApiAuthError`(401/403,grant 失败不可重试) / `OpenApiBadRequestError`(4xx,不重试) / `OpenApiRateLimitError`(429,可重试) / `OpenApiServerError`(5xx,可重试) / `OpenApiTimeoutError`。
+- 派发期（`start_run` 返回值）：可重试异常返 `False` 且 executor 退避重试；不可重试 4xx（含 grant 403）返 `False` 不重试（编排核 MISS / 重投）。
+- 回收期（poller）：终态 FAIL 经 `report_result` 走编排核 `on_fail`（<MAX 补救 / ≥MAX 升 BBS）。
+- 幂等：BCS `create_group`/`start_state_machine_run` 带幂等 key；Open API grant 幂等（重复 grant 同 bot 由 BaaS 服务端去重）；重复 `start_run` 同 node 由上游 `on_report` 幂等 + 图状态机护栏兜底。
+
+---
+
+## 8. 零 case 知识红线
+
+- `PromptFormatter` 仅消费 `TaskContextBuilder.build` 的 dict（`mode`/`child_outputs`/`parent_spec`/`sibling_outputs`/`node_spec`/`goal`/`acceptances`）+ `TaskNode.task_spec`，**不得**出现节点名字面量。
+- `BcsHttpAdapter` 的 `label=f"teamos:{task_id}:{kind}"` 中 `kind` 取自 `collab_mode`（非节点名）。
+- `OpenApiBotAdapter` 的 `metadata`/grant 调用只用 `bot_id`(=`run_info.assignee`) 与静态 API key 配置，**不**出现节点名字面量。
+- singlebox double 的 canned `collaboration_definition_yaml` 用泛化 binding id（如 `worker_a`），不绑定具体 case 节点名；e2e 断言 `grep` 框架源码 0 命中 `N_market`/`N_overview` 等。
+
+---
+
+## 9. 测试策略
+
+### 9.1 单测（`tests/community/core/task/task_runner/integration/`）
+- `test_open_api_bot_adapter.py`：httpx mock transport 验 `ensure_grant`（查 allowed-bots→缺则 grant，登录态 Cookie/Referer 头、Bearer 发消息头分离）、`POST /openapi/v1/messages` 请求体（`bot_id`/`message`）→ `run_id`、`GET /openapi/v1/messages/{id}` 终态（大小写不敏感）、异常映射。
+- `test_bcs_http_adapter.py`：httpx mock transport 验三态 `create_group` 请求体（`group_strategy`/`collaboration_definition_yaml`/`participant_bindings`/`start_initial_run`）、HMAC 签名头、`Idempotency-Key`、`create_group→start_state_machine_run→get_state_machine_run` 序列、异常映射。
+- `test_translators.py`：三翻译器 shape（`success/data/fail_detail`、`loop_task_id`）。
+- `test_task_executor_result_poller.py`：三模态（single_bot 终态 / session 终态 / run 终态）、single_bot 状态大小写不敏感、`since_msg_id` 游标（session 模）、超时→FAIL、连续失败→FAIL 注销。
+- `test_task_executor.py`：入队返 `list[bool]`、三模态分流（`bbs` 仅记日志、断言不发起执行也不登记 poller）、派发期异常→`False`（含 grant 403）、后台 loop 独立性（无 caller loop 也能跑）。
+
+### 9.2 singlebox E2E（复用剧本 `gwqie46v7hzr1w6h`）
+- `_wire_facade` 注入 integration double（`_DoubleOpenApiBot` / `_DoubleBcsClient` / `_DoubleApiKeyProvider` / `_DoubleContextProvider`）。
+- `_DoubleOpenApiBot` 模拟 `ensure_grant`(allowed-bots 查/补) → `POST /messages` → `get_run` poll → `COMPLETED`，可注入 FAIL / timeout；`_DoubleApiKeyProvider` 给固定静态凭据。
+- `_DoubleBcsClient` 模拟三态：chat/manager_worker `create_group→session 模 poll→Completed`；state_machine `create_group(start_initial_run=False)→start_state_machine_run→run 模 poll→Completed`，可注入 FAIL/timeout。
+- 复用现有 5 类 e2e（三模态 happy→DONE / FAIL 补救治愈 / MISS 升 BBS / BBS STUCK→HUNG / dashboard 终态），验证**真实集成形态**（非纯 stub）驱动同一闭环。BBS 类用例断言 `TaskExecutor` 对 `bbs` 仅记日志、不改节点状态。
+
+### 9.3 上游回归
+- `TaskRunner` 默认无 `execution_backend` 时现行 stub 行为不破（现有 121 单测全绿）。
+- fallback：`execute` 不挂 HTTP 时，`_DoubleOpenApiBot` / `_DoubleBcsClient` 经进程内 wired 回投，e2e 仍跑通。
+
+---
+
+## 10. 里程碑（实现计划由 writing-plans 展开）
+
+- **R0 Port + double 骨架**：`ports.py` + `double/*` + `TaskExecutor` 线程骨架；`TaskRunner` 注入点改造（默认 stub 不破）。
+- **R1 单 bot 真实链路**：`OpenApiBotAdapter`（静态 API key + `ensure_grant` + `POST /messages`）+ `SingleBotRunTranslator` + `TaskExecutorResultPoller` single_bot 模 + `TaskExecutor` `bbs` 仅记日志；单测 + singlebox bot e2e。
+- **R2 BCS client（chat/manager_worker）**：自包含 `BcsHttpAdapter`（HMAC + `create_group`/`create_session`/`get_group`/`get_session_messages`）+ `BcsSessionTranslator` + `TaskExecutorResultPoller` session 模；单测。
+- **R3 BCS state_machine**：`collaboration_definition_yaml` 透传 + `start_state_machine_run` + `get_state_machine_run` + `BcsStateMachineRunTranslator` + poller run 模 + `start_initial_run=False` 约束；单测。
+- **R4 singlebox 三态 e2e 收口**：`_DoubleOpenApiBot`/`_DoubleBcsClient` 三态 + 复用剧本 `gwqie46v7hzr1w6h` 5 类 e2e + `bbs` 仅记日志断言；零 case grep 红线 0 命中。
+
+---
+
+## 11. Risks / 已知缺口
+
+| 项 | 说明 | 处置 |
+|---|---|---|
+| ocb `BcsHttpClient` 缺 `group_strategy` | 纯客户端封装缺口，server 端支持 | 本 spec 自包含 client 补齐 |
+| state_machine 默认 `start_initial_run=true` 不回 `run_id` | poller 无从下手 | 强制 `start_initial_run=False` + 显式 start |
+| BCS 无入站 webhook | 协作群只能轮询 | `TaskExecutorResultPoller` sidecar |
+| 单 bot grant 需登录态 | `grant` 走 Cookie/Referer 鉴权(`create_api_key.py`),非 Bearer | 静态配置 `secbaas_cookie`/`secbaas_referer`;stub/singlebox 可空;grant 403→该 node 返 False |
+| 单 bot 结果只能轮询 | Open API `/messages` 无 PUSH 回调 | `TaskExecutorResultPoller` single_bot 模 `GET /messages/{run_id}` |
+| 单 bot 与 `secbaas` 跨包身份 | 旧设计经 in-repo `BotRunner` 需 `BotChatContext` | 改走 Open API HTTP,仅需静态 API key,不 import `secbaas` |
+| `group_strategy=state_machine` YAML 正确性 | 需 binding id↔bot_ids 对齐 | `validate_definition` 可选预检 + corp `BotDiscoverPort` 保证 + double canned yaml |
+| ocb `BCSGroupService` 同步包装层 TD-5/6/7 | 硬编码/吞异常/`asyncio.run` | 本 spec 不复用，直接 async |
+| facade 2 API 未挂 HTTP | 旧 `/task/callback` 路由方案 | 单 bot 改轮询,**本 spec 不新增任何入站路由**;poller 进程内 wired 回投 |
+| 持久化 | poller 登记表 in-memory | 与 `TaskHarness` 同级；ORM 适配后续 |
+
+---
+
+## 12. 与上游 spec 的一致性
+
+- `TaskRunner.start_run` 签名、`TaskLoopCallback`/`CallbackAdapter`/`TaskCallbackData` 契约**不变**。
+- `form_coop_group` 由 stub 升级为真实 BCS 建群（返回 `group_id`），`GroupFormation` type 不变（仅定 `extend_props` key）。
+- 单 bot 由「手动 PUSH stub」升级为「Open API 派发取 `run_id` + 旁路 poller 回收」；结果回流统一经 `on_report` → `update_task_node_info`（SSOT 写口），不绕过图级/节点级写口。
+- `bbs` 模态进入 `TaskExecutor` 三模态分流（仅记日志，不改状态），真实 BBS 仍走 `BbsMarketPort`，不改。
+- 零 case 知识红线、开源边界（seam + double）延续；移除 baas PUSH 回调入站路由，减少外部依赖。

--- a/src/backend/specs/2026-08-09-task-goal-driven-task-runner/tasks.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-task-runner/tasks.md
@@ -1,0 +1,100 @@
+# Tasks — task_runner integration 子模块（单 bot / 协作群真实执行接入）
+
+> 参考羽雀「任务Loop执行」（`lxg2mwgmtfqg6d95`）+ BaaS Open API 脚本（`test_tc_open_api/`）+ corp ocb `BcsHttpClient`（参考模式，自包含重写）。
+> 落点：`src/backend/src/agentclaw/community/core/task/task_runner/integration/`（新建）+ `runner.py` 注入点改造；结果回流一律经 `ResultSink → TaskLoopCallback.report_result → engine.on_report → update_task_node_info`（SSOT）。
+> 上游 spec：`specs/2026-08-09-task-goal-driven-execution-framework/`（M0–M6 已落地，121 单测）；权威 spec/plan：本目录 `spec.md` / `plan.md`。
+
+## 实现原则（对齐 AGENTS.md）
+- **不破上游契约**：`TaskRunner.start_run(toDoTaskList) -> list[bool]` async 签名不变；`TaskLoopCallback`/`CallbackAdapter`/`TaskCallbackData`/`loop_task_id="task_id::node_id"` 不变；不注入 `execution_backend` 时现行 stub 行为 + 121 单测全绿。
+- **SSOT 不绕过**：integration 不直写图、不直改 `TaskNode.status`；结果回流一律 `ResultSink.report_result(TaskCallbackData)` → `on_report` → `update_task_node_info`。
+- **开源边界**：integration 不 `import` corp ocb `ecb`；单 bot 走 BaaS HTTP Open API（httpx async，**不 import in-repo `secbaas` BotRunner**）；BCS client 自包含重写（httpx async + HMAC，镜像 ocb `BcsHttpClient` 模式）。
+- **零 case 知识红线**：`PromptFormatter`/adapter/executor 仅消费 `_build_context` dict 字段 + `TaskNode.task_spec` + `run_info.assignee`/`run_mode`，**禁止**节点名字面量（`N_market`/`N_overview` 等）；grep 0 命中，单测断言。
+- **必填非可选**：端口必填参数不加 `| None`；`None` 仅契约态（`session_id is None`→`create_session`、`bot_id` 不在 `allowed_bots`→`ensure_grant`、`run_id is None`→session 模）。
+- **协程化（对齐 README）**：`engine._drain` 锁外 `await runner.start_run`；`dispatch` async + `gather`+`Semaphore(8)`；poller `_poll_once` 为 `async def`（端口 async），daemon 线程持自有 loop 跑 `run_poll_loop`；锁内不 await。
+- **派发即返回（不等待结果）**：`dispatch` 仅 await 到捕获 `run_id`/`session_id`（grant+send / create_session / start_state_machine_run），失败→该 node 返 `False`；结果回收归 `TaskExecutorResultPoller` 旁路 sidecar。
+- **TDD / 主 seam 优先**：R4 singlebox E2E（复用剧本 `gwqie46v7hzr1w6h`）最高 seam；R0–R3 契约单测（httpx `MockTransport`）补 e2e 覆盖不到的分支。
+- **httpx 单测不经网络**：一律 `httpx.MockTransport(handler)`；async 单测经 `asyncio.new_event_loop().run_until_complete`（不用 `@pytest.mark.asyncio`）。
+
+## 依赖与落地序（R0 骨架 → R1 单 bot → R2 BCS chat/manager_worker → R3 state_machine → R4 e2e 收口）
+
+```
+R0  ports.py(5 Port Protocol) + translators.py(三翻译器)
+ → TaskExecutor 骨架(dispatch async + bbs no-op) + TaskRunner.__init__(graph, execution_backend=None) 注入点(默认 stub 不破)
+R1  OpenApiBotAdapter(ensure_grant + send_message + get_run,httpx async)
+ → TaskExecutorResultPoller sidecar + single_bot 模
+ → _dispatch_single_bot 接通(grant→send→register) + PromptFormatter + _RunnerContextBuilder
+R2  BcsHttpAdapter(httpx async + HMAC) + BcsCreateGroupRequest/Result + chat/manager_worker 端点(create_group/create_session/get_group/get_session_messages)
+ → form_coop_group 真实建群(三态分流) + _dispatch_coop_group session 模 + poller session 模
+R3  state_machine:start_state_machine_run/get_state_machine_run + _dispatch_state_machine(run 模) + poller run 模 + start_initial_run=False 约束
+R4  singlebox double(_DoubleOpenApiBot/_DoubleBcsClient/_DoubleApiKeyProvider/_DoubleContextProvider/_DoubleSink) + build_integration 组合根 + poller bcs 模
+ → singlebox wiring 注入 + 复用剧本 gwqie46v7hzr1w6h 5 类 e2e + bbs no-op 断言 + 零 case grep
+```
+R2 依赖 R1 的 poller/executor；R3 依赖 R2 的 BcsHttpAdapter；R4 依赖 R0–R3 全就绪 + singlebox wiring 点定位。
+
+---
+
+## R0 — Port + 翻译器 + executor 骨架 + 注入点（默认 stub 不破）
+- **T0.1** `integration/ports.py`：5 `@runtime_checkable` Protocol——`OpenApiBotPort`(ensure_grant/send_message/get_run async)/`BcsClientPort`(create_group/create_session/get_group/get_session_messages/start_state_machine_run/get_state_machine_run/validate_definition async)/`ApiKeyProvider`(api_key/api_key_prefix/base_url/cookie/referer 属性)/`TaskContextBuilder`(build→dict)/`PromptFormatter`(format_execute/format_verify)/`ResultSink`(async report_result)；`BcsCreateGroupRequest`/`Result` 先 Protocol 占位（T7 换真实 dataclass + `TYPE_CHECKING` import，不打环）。
+- **T0.2** `integration/translators.py`：`SingleBotRunTranslator.adapt(run_dict, loop_task_id)`（status 大小写不敏感；`TIME_OUT`→`timeout`）、`BcsSessionTranslator.adapt(group_dict, messages)`（output 缺失取末条 assistant content）、`BcsStateMachineRunTranslator.adapt(run_dict)`（`aborted`→fail_detail）；均返 `TaskCallbackData`（`workflow_type` single_bot/bcn_coop_group，`workflow_id`/`instance_id`=0）。
+- **T0.3** `integration/task_executor.py` `TaskExecutor(*, bot, bcs, formatter, context, sink, poller)`：`async dispatch(toDoTaskList) -> list[bool]`（`gather`+`Semaphore(8)`，按 `run_mode` 三态分流；`bbs` 仅 `logger.info` no-op 返 True；unknown→False；`single_bot`/`coop_group` 占位 True 待 T6/T8 替换）、`async form_coop_group(gf)`（stub `grp_{uuid}` 占位待 T8）、`async aclose()`、`_group_meta` dict。
+- **T0.4** `runner.py` 改造：`__init__(graph, execution_backend=None)`；`start_run._deliver_one` 注入时委托 `execution_backend.dispatch([node]) == [True]`；`form_coop_group` 注入时委托；未注入走原 stub（`_run_log`/`_groups` 行为不变，121 单测不破）。
+- ✅ 验收：T0.1 ports 4 用例；T0.2 translators 10 用例；T0.3 executor 骨架 4 用例（bbs no-op/unknown False/每节点一 bool/无 backend stub fallback）；T0.4 既有 121 单测全绿。
+
+## R1 — 单 bot 真实链路（Open API + grant + poller single_bot）
+- **T1.1** `integration/open_api_bot_adapter.py`：`OpenApiBotAdapter(ApiKeyProvider, *, http_client)` 实现 `OpenApiBotPort`——`ensure_grant`（`GET /api/v1/api-keys/{prefix}/allowed-bots` Bearer；缺则 `POST .../grant` **Cookie+Referer** 鉴权）、`send_message`（`POST /openapi/v1/messages` Bearer→`data.message_id`=run_id）、`get_run`（`GET /openapi/v1/messages/{id}`→`data`，status 大小写不敏感）；异常 `OpenApiAuthError`(401/403 不可重试)/`OpenApiBadRequestError`(4xx)/`OpenApiRateLimitError`(429)/`OpenApiServerError`(5xx)/`OpenApiTimeoutError`；`parse_bot_id(bot_id) -> (real, entity)`（`<real>:<entity>`）。
+- **T1.2** `integration/task_executor_result_poller.py`：`SingleBotHandle`/`BcsGroupHandle` dataclass；`TaskExecutorResultPoller(*, bot, bcs, clock, sleep, interval, default_sla)`——`register`/`set_on_result`/`pending`/`stop`、`async _poll_once()`、`async _poll_one(handle)`（SLA 超时→FAIL `sla_timeout`+注销；连续 5 次端口异常→FAIL `poll_exhausted`+注销；终态→翻译→`report_result`+注销）、`run_poll_loop(stop_event)`（daemon 线程持自有 loop）。single_bot 模：`get_run`→`{COMPLETED,FAILED}`→`SingleBotRunTranslator`。
+- **T1.3** `task_executor.py._dispatch_single_bot(node, sem)`：`ensure_grant(assignee)`→`ctx=context.build`→`message=formatter.format_execute(ctx,node)`→`send_message`→`run_id`→`poller.register(SingleBotHandle(loop_task_id=task::node, run_id, bot_id, registered_at))`；`OpenApiAuthError`/`OpenApiBadRequestError`→返 `False`（不阻塞其它 node）。
+- **T1.4** `integration/prompt_formatter.py`：`PromptFormatterImpl`（零 case，消费 `node_instruction`/`goal`/`sibling_outputs` + `node.task_spec`；`format_verify` 用 `acceptances`/`child_outputs`）+ `_RunnerContextBuilder(runner)`（包 `runner._build_context`，integration 内聚访问）。
+- ✅ 验收：T1.1 open_api_bot 7 用例（grant 查/补/403、send Bearer+请求体、get_run 大小写不敏感、5xx）；T1.2 poller single_bot 4 用例（终态上报注销/非终态无上报/SLA 超时 FAIL/连续 5 次 poll_exhausted）；T1.3 dispatch_single_bot 3 用例（register handle/grant 403→False/prompt 用 context）；T1.4 formatter 用 context 字段不写节点名；上游 121 全绿。
+
+## R2 — BCS client（chat / manager_worker）+ form_coop_group + session 模
+- **T2.1** `integration/bcs_token_provider.py`：`BcsTokenProvider` Protocol（`token`/`secret`/`base_url` 属性；real 由 corp 注入）。
+- **T2.2** `integration/bcs_http_adapter.py`：`BcsCreateGroupRequest`/`BcsCreateGroupResult` dataclass（§7.1 字段；result 含 `group_id`/`session_id`/`run_id`/`definition_ref`）；`BcsHttpAdapter(BcsTokenProvider, *, http_client)` 实现 `BcsClientPort`——HMAC 头（`X-ECB-Token`/`X-ECB-Timestamp`/`X-ECB-Signature`，签串 `f"{ts}{method}{path}"`）、`Idempotency-Key`、`create_group`（三态：state_machine 强制 `group_strategy=state_machine`+`start_initial_run=false`+yaml+participant_bindings；chat 省略 strategy；manager_worker 带角色）、`create_session`、`get_group`、`get_session_messages`（`since_msg_id` 进 query）；异常 `BcsServerError`(5xx)/`BcsClientRequestError`(4xx)/`BcsRateLimitError`(429)/`BcsTimeoutError`；`start_state_machine_run`/`get_state_machine_run` 占位 `NotImplementedError`（T3.1 替换）。
+- **T2.3** `ports.py` 调整：`BcsCreateGroupRequest`/`Result` 占位 Protocol 换为 `TYPE_CHECKING` import 真实 dataclass（`bcs_http_adapter` 不 import `ports`，无运行时环）。
+- **T2.4** `task_executor.py.form_coop_group(gf)`：按 `gf.collab_mode` 三态构造 `BcsCreateGroupRequest`（state_machine 取 `extend_props["collaboration_definition_yaml"]`+`participant_bindings={bid:{source:manual,bot_ids:[bid]}}`+`start_initial_run=False`；manager_worker manager=`extend_props["manager_bot_id"]` or `bot_ids[0]`；service_spec 透传）→`create_group`→存 `_group_meta[group_id]={collab_mode, gf, definition_ref, session_id}`→返 `group_id`。
+- **T2.5** `task_executor.py._dispatch_coop_group(node, sem)`（chat/manager_worker 分支）：`meta=_group_meta[assignee]`，`collab_mode!=state_machine`→`create_session(group_id, bootstrap_prompt=format_execute(ctx,node))`→`session_id`→`poller.register(BcsGroupHandle(session_id=..., run_id=None, collab_mode, registered_at))`；state_machine 分支占位 T3.2。
+- ✅ 验收：T2.2 bcs_http_adapter 7 用例（HMAC 签名+Idempotency-Key、三态 create_group 请求体、create_session、get_group、since_msg_id 游标、5xx/4xx 异常）；T2.4/T2.5 form_coop_group 3 用例（chat 存 meta/manager_worker strategy/session 模 register handle）；上游 121 全绿。
+
+## R3 — BCS state_machine（run 模 + run_id 捕获约束）
+- **T3.1** `bcs_http_adapter.py` 落地两端点：`start_state_machine_run(group_id, *, definition_yaml, definition_ref, session_id, input) -> str`（`POST /groups/{id}/state-machine-runs` body `{definition_ref, input, ...}`→`run.run_id`，带 Idempotency-Key）、`get_state_machine_run(run_id) -> dict`（`GET /state-machine-runs/{run_id}`）。
+- **T3.2** `task_executor.py._dispatch_state_machine(node, group_id, meta, loop_task_id)`：`input={"query": format_execute(ctx,node)}`+`definition_ref=meta["definition_ref"]`→`start_state_machine_run`→`run_id`→`poller.register(BcsGroupHandle(run_id=..., session_id=None, collab_mode=state_machine, registered_at))`；**不**用 `create_session`。
+- **T3.3** poller run 模：`BcsGroupHandle` 且 `run_id` 非空→`get_state_machine_run(run_id)`→`run.status ∈ {completed,failed,aborted}`→`BcsStateMachineRunTranslator`→`report_result`（已在 T1.2 `_poll_terminal` 内置分支，T3 验证）。
+- ✅ 验收：T3.1 start/get_state_machine_run 2 用例（run_id 解析、GET 路径）；T3.2 dispatch_state_machine 1 用例（register run handle + input.query=格式化）；T3.3 poller run 模经 double 验证（R4 T4.3）；`start_initial_run=False` 约束在 T2.4 create_group 已强制；全 integration 单测回归绿。
+
+## R4 — singlebox double + E2E 收口
+- **T4.1** `integration/double/double_context_provider.py`：`_DoubleApiKeyProvider`（固定静态凭据）、`_DoubleContextProvider`（canned `{"mode":"execute"}`）、`_DoubleSink`（收集 `TaskCallbackData`）。
+- **T4.2** `integration/double/double_open_api_bot.py` `_DoubleOpenApiBot(*, final_status, content, error)`（进程内 grant→send→get_run，不经网络）+ `integration/double/double_bcs_client.py` `_DoubleBcsClient(*, session_status, session_output, sm_status, sm_output)`（三态 create_group→session/run poll→终态，可注入 FAIL/timeout）。
+- **T4.3** `integration/__init__.py` `build_integration(*, double, sink, runner, poller_thread) -> TaskExecutor`：`double=True` 装配 `_DoubleOpenApiBot`/`_DoubleBcsClient`/`_DoubleContextProvider`/`PromptFormatterImpl`+`_DoubleSink`，`poller.set_on_result(sink)`，可选起 poller daemon 线程；`real` 分支 import 在函数内（corp 提供 `_RealToken`/真实 keys，社区不发）。
+- **T4.4** poller bcs 模单测：`test_poller_bcs.py` 验 session 模（`get_group` completed→上报）+ run 模（`get_state_machine_run` completed→上报）经 `_DoubleBcsClient`/`_DoubleSink`。
+- **T4.5** singlebox wiring：`grep -rn "gwqie46v7hzr1w6h\|_wire_facade" tests/` 定位装配点；`TaskService(g)` 构造后 `exe = build_integration(double=True, sink=svc.callback, poller_thread=True)` 并 `svc._engine._runner._execution_backend = exe`（内部访问 wiring）。
+- **T4.6** 复用剧本 `gwqie46v7hzr1w6h` 5 类 e2e（三模态 happy→DONE / FAIL 补救治愈 / MISS 升 BBS / BBS STUCK→HUNG / dashboard 终态）：以**真实集成形态（double，非纯 stub）**驱动同一闭环；BBS 类用例断言 `TaskExecutor` 对 `bbs` 仅记日志、不改节点状态、不登记 poller。
+- **T4.7** 零 case grep 红线：`test_zero_case.py` 断言 integration 9 文件（ports/translators/open_api_bot_adapter/bcs_http_adapter/bcs_token_provider/prompt_formatter/task_executor/task_executor_result_poller/__init__）0 命中 `N_overview`/`N_market`/`N_aggregate`/`N_verify`/`N_report`/`N_practice`/`n_root`/`dim_`。
+- ✅ 验收：T4.1–T4.3 double 5 用例 + 组合根；T4.4 poller bcs 2 用例；T4.5/T4.6 singlebox 5 类 e2e 真实集成形态全绿 + bbs no-op 断言；T4.7 grep 0 命中；既有 121 + integration 全量回归绿；pre-push Backend SAST gate 通过。
+
+## Cross-cutting
+- 架构宪法（`docs/arch/arch.rules.md` 核心 transport-agnostic）：integration 是 adapter 层，可 import core + httpx，core 不 import integration。
+- `loop_task_id` mint 在 `TaskRunner.start_run`（`runner.py:75` `f"{task_id}::{node_id}"`）；single_bot/coop_group 的 poller handle 均带 `loop_task_id` 回流。
+- 事件日志/审计位点：`run_id`/`session_id`/`group_id`/`loop_task_id`/`poller.registered_at`/`fail_detail`（`sla_timeout`/`poll_exhausted`/`timeout`/`aborted`）。
+- 组合根：`build_integration` 唯一装配点；`real` wiring（真实 keys/BCS token/BaaS base_url）属 corp adapter（社区只发 double/singlebox）。
+
+## Risks / 待实现期定的项
+- ocb `BcsHttpClient` 缺 `group_strategy`（纯客户端封装缺口，server 端支持）→T2.2 自包含补齐。
+- state_machine 默认 `start_initial_run=true` 不回 `run_id`→T2.4 强制 `start_initial_run=False` + T3.2 显式 `start_state_machine_run` 捕获。
+- BCS 无入站 webhook（协作群只能轮询）→T1.2/T4.4 `TaskExecutorResultPoller` session/run 模。
+- 单 bot grant 需登录态（`grant` 走 Cookie/Referer，非 Bearer；`create_api_key.py`）→T1.1 `ensure_grant` 双头分离；静态配置 `secbaas_cookie`/`secbaas_referer`（stub/singlebox 可空）；grant 403→T1.3 该 node 返 False。
+- 单 bot 结果只能轮询（Open API `/messages` 无 PUSH）→T1.2 single_bot 模 `GET /messages/{run_id}`。
+- 单 bot 与 `secbaas` 跨包身份（旧设计经 in-repo `BotRunner` 需 `BotChatContext`）→改走 Open API HTTP，仅需静态 API key，不 import `secbaas`。
+- ocb `BCSGroupService` 同步包装层 TD-5/6/7（硬编码/吞异常/`asyncio.run` 不可在 running loop）→不复用，直接 async `BcsHttpAdapter`。
+- facade 2 API 未挂 HTTP（旧 `/task/callback` 路由）→**本 spec 不新增任何入站路由**；poller 进程内 wired 回投（`ResultSink=svc.callback`）。
+- 持久化：poller 登记表 in-mem（与 `TaskHarness._dispatched_at` 同级）；ORM 适配后续。
+- singlebox wiring 经 `svc._engine._runner._execution_backend = exe` 直赋（内部访问）；若后续 DI 化需 corp 覆写 `_build_runner`。
+- `build_integration(real)` 的真实 token/密钥/BCS base_url 属 corp adapter（社区只发 double）。
+
+## 里程碑（R0–R4，本计划交付）
+- ⬜ **R0** Port + 翻译器 + executor 骨架 + `TaskRunner` 注入点（默认 stub 不破）。
+- ⬜ **R1** 单 bot 真实链路（OpenApiBotAdapter + grant + poller single_bot 模 + PromptFormatter）。
+- ⬜ **R2** BCS client（chat/manager_worker：BcsHttpAdapter HMAC + form_coop_group 三态 + session 模 dispatch/poll）。
+- ⬜ **R3** BCS state_machine（start/get_state_machine_run + run 模 dispatch/poll + `start_initial_run=False` 约束）。
+- ⬜ **R4** singlebox double + `build_integration` 组合根 + 复用剧本 5 类 e2e（真实集成形态）+ bbs no-op 断言 + 零 case grep 红线。
+
+> 实现逐任务 TDD 细节见 `plan.md`（每任务含失败测试→实现→通过→commit 可执行步骤）；契约依据见 `spec.md`；与 `2026-08-09-task-goal-driven-task-runner-callback`（inbound PUSH 回调）为互补关系——本计划为 poller 模（无 workflow 引擎的执行主体），callback spec 为 PUSH 模（有 workflow 引擎的执行主体），两路同 sink `on_report`。


### PR DESCRIPTION
# Problem
- 任务目标驱动的任务执行模块的设计方案，包括“运行时具体的执行器（单bot、协作群、bbs）”、“任务级别、节点级别的回调服务”；没有一份可被代码与评审锚定的权威源，实现与验收都会出现口径漂移。

# Solution
- 补齐设计三件套（spec.md/plan.md/tasks.md），作为 core/task/task_runner 实现的权威源：WHAT/WHY、四层架构与模块 API 契约、分组实现计划。

# Spec
- src/backend/specs/2026-08-09-task-goal-driven-task-runner/spec.md
- src/backend/specs/2026-08-09-task-goal-driven-task-runner-callback/spec.md

