### PR TITLE
docs(backend): document every field, enum and parameter of the public bots API

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/router.py
@@ -126,7 +126,15 @@ PrincipalDep = Annotated[Principal, Depends(require_principal)]
 
 #: Shared by both bot-scoped path declarations so the constraint cannot drift
 #: between them.
-BotIdPath = Annotated[str, Path(min_length=1, max_length=256)]
+BotIdPath = Annotated[
+    str,
+    Path(
+        min_length=1,
+        max_length=256,
+        description="The bot the authorization covers — its `bot_id` as "
+        "returned by the bots listing.",
+    ),
+]
 
 #: Whose bot the request addresses, defaulting to the caller's own.
 #:
@@ -217,9 +225,9 @@ async def grant_authorized_app(
     resolved owner is recorded alongside them, and is someone else whenever the
     bot is shared.
 
-    ``owner_id`` names whose bot this is and defaults to the caller's own, so
+    `owner_id` names whose bot this is and defaults to the caller's own, so
     omitting it behaves exactly as this operation always has. Name it to
-    delegate on a bot shared with you: ``bot_id`` alone does not identify a bot,
+    delegate on a bot shared with you: `bot_id` alone does not identify a bot,
     and two owners may hold the same one.
 
     Idempotent: granting an authorization that is already in force returns it
@@ -268,7 +276,7 @@ async def list_authorized_apps(
     colleagues' delegations, so theirs is narrowed — the same reason their
     withdrawal is.
 
-    ``owner_id`` says whose bot to read and defaults to the caller's own. It
+    `owner_id` says whose bot to read and defaults to the caller's own. It
     addresses the bot; it does not widen the answer — a collaborator naming the
     owner still sees only what they themselves delegated.
     """
@@ -294,7 +302,11 @@ async def revoke_authorized_app(
     user_id: UserIdDep,
     principal: PrincipalDep,
     owner_id: OwnerIdQuery = None,
-    app_id: int = Path(ge=1),
+    app_id: int = Path(
+        ge=1,
+        description="The application whose authorization to revoke — its "
+        "`app_id` as listed on the bot's authorized apps.",
+    ),
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     collaborators: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
     grants: BotAppGrantServiceProtocol = Injected(BotAppGrantServiceProtocol),
@@ -305,10 +317,10 @@ async def revoke_authorized_app(
     because a withdrawal must not require the application's cooperation — that
     is precisely the situation it exists for: a credential lost, rotated, or a
     relationship ended. Withdrawing an authorization that does not exist answers
-    404, distinctly from a successful withdrawal (``GrantNotFoundError``).
+    404, distinctly from a successful withdrawal.
 
     **How much this withdraws depends on who asks**, and it has to: since a
-    delegation is keyed on the user who made it, ``{app_id}`` alone no longer
+    delegation is keyed on the user who made it, `app_id` alone no longer
     names one row.
 
     - The **owner** withdraws *every* delegation of this application on their
@@ -319,20 +331,19 @@ async def revoke_authorized_app(
     - A **collaborator** withdraws only their own. Theirs is the loan they made;
       a colleague's is not theirs to call in.
 
-    TODO(#951 follow-up): the owner's withdrawal is all-or-nothing, and it
-    should not be. An owner who wants to cut off *one* colleague's delegation of
-    an application — the colleague who left the team, say — currently has to
-    withdraw every delegation of that application on the bot, including their
-    own and other colleagues'. The record supports the narrower operation
-    already (``revoke`` is keyed on the delegating user), so what is missing is
-    a way to *name* whose delegation to withdraw: another path segment, or a
-    parameter. Deliberately not added here — it is a new operation on the public
-    surface, not a fix.
-
-    ``owner_id`` names whose bot is being withdrawn from and defaults to the
+    `owner_id` names whose bot is being withdrawn from and defaults to the
     caller's own. Which delegations go still follows from who is asking, not
     from this parameter.
     """
+    # TODO(#951 follow-up): the owner's withdrawal is all-or-nothing, and it
+    # should not be. An owner who wants to cut off one colleague's delegation
+    # of an application — the colleague who left the team, say — currently has
+    # to withdraw every delegation of that application on the bot, including
+    # their own and other colleagues'. The record supports the narrower
+    # operation already (revoke is keyed on the delegating user), so what is
+    # missing is a way to name whose delegation to withdraw: another path
+    # segment, or a parameter. Deliberately not added here — it is a new
+    # operation on the public surface, not a fix.
     del principal
     resolved_owner, _ = resolve_delegable_bot(
         bot_service, collaborators, bot_id=bot_id, caller_id=user_id,
@@ -362,7 +373,7 @@ async def list_authorized_bots(
     Names no bot and so performs no bot-existence check, unlike the three above:
     there is nothing to mask. The result is one user's own delegations to the
     calling application, and an empty page discloses nothing — which is why
-    holding none answers ``200`` with no items rather than ``404``.
+    holding none answers 200 with no items rather than 404.
 
     This is also the **only** complete view of what the application may reach.
     A delegated bot the user does not own appears in no listing of that user's

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
@@ -35,12 +35,23 @@ PrincipalDep = Annotated[Principal, Depends(require_user_and_app_principal)]
 async def list_session_traces(
     request: Request,
     principal: PrincipalDep,
-    session_key: str = Path(min_length=1, max_length=512),
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=100, ge=1, le=100),
+    session_key: str = Path(
+        min_length=1,
+        max_length=512,
+        description="The engine session key, exactly as a trace reports it "
+        "in session_key (exact match, no prefix search).",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    limit: int = Query(
+        default=100, ge=1, le=100, description="Traces per page (max 100)."
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[SessionListResponse]:
-    """List traces for one exact Session key."""
+    """List the recorded chat turns (traces) of one session, newest first.
+
+    The session key is matched exactly, as reported in a trace's
+    session_key.
+    """
     del principal
     result = await service.list_open_sessions(
         session_key=session_key,
@@ -58,13 +69,29 @@ async def list_session_traces(
 async def list_task_traces(
     request: Request,
     principal: PrincipalDep,
-    biz_scene: str = Path(min_length=1, max_length=128),
-    biz_task_id: str = Path(min_length=1, max_length=256),
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=100, ge=1, le=100),
+    biz_scene: str = Path(
+        min_length=1,
+        max_length=128,
+        description="The integrating system's business scene the task "
+        "belongs to (exact match).",
+    ),
+    biz_task_id: str = Path(
+        min_length=1,
+        max_length=256,
+        description="The integrating system's own task id within the scene "
+        "(exact match).",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    limit: int = Query(
+        default=100, ge=1, le=100, description="Traces per page (max 100)."
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[SessionListResponse]:
-    """List traces for one exact business Task."""
+    """List the traces labelled with one business scene/task pair, newest first.
+
+    Matches labels attached at recording time and labels registered as
+    relations afterwards — each item's match_sources says which.
+    """
     del principal
     result = await service.list_open_sessions(
         biz_scene=biz_scene,
@@ -83,12 +110,18 @@ async def list_task_traces(
 async def list_group_traces(
     request: Request,
     principal: PrincipalDep,
-    group_id: str = Path(min_length=1, max_length=256),
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=100, ge=1, le=100),
+    group_id: str = Path(
+        min_length=1,
+        max_length=256,
+        description="The collaboration group whose sessions' traces to list.",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    limit: int = Query(
+        default=100, ge=1, le=100, description="Traces per page (max 100)."
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[SessionListResponse]:
-    """List traces for one exact BCS Group."""
+    """List the traces of every session in one collaboration group, newest first."""
     del principal
     result = await service.list_open_sessions(
         group_id=group_id,
@@ -103,13 +136,28 @@ async def list_group_traces(
 async def list_user_bot_traces(
     request: Request,
     principal: PrincipalDep,
-    user_id: str = Query(min_length=1, max_length=256),
-    bot_id: str = Query(min_length=1, max_length=256),
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=100, ge=1, le=100),
+    user_id: str = Query(
+        min_length=1,
+        max_length=256,
+        description="Whose traces to read — a filter, not the caller's "
+        "identity; naming another user is allowed here.",
+    ),
+    bot_id: str = Query(
+        min_length=1,
+        max_length=256,
+        description="The bot whose traces to read, paired with user_id.",
+    ),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    limit: int = Query(
+        default=100, ge=1, le=100, description="Traces per page (max 100)."
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[SessionListResponse]:
-    """List recent traces for one explicit user-and-Bot pair."""
+    """List one user-and-bot pair's recent traces, newest first.
+
+    Covers the last 72 hours only; use the session, task or group listings
+    for older history.
+    """
     del principal
     result = await service.list_open_user_bot_traces(
         user_id=user_id,
@@ -125,10 +173,18 @@ async def list_user_bot_traces(
 async def get_trace(
     request: Request,
     principal: PrincipalDep,
-    trace_id: str = Path(min_length=1, max_length=256),
+    trace_id: str = Path(
+        min_length=1,
+        max_length=256,
+        description="The trace's id, as returned in a listing entry's id.",
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[ConversationDetail]:
-    """Return one Trace with its observation tree."""
+    """Return one recorded chat turn (trace) in full.
+
+    Includes the complete input and output plus the observation tree — the
+    model generations and tool calls that made up the turn.
+    """
     del principal
     result = await service.get_open_session(trace_id)
     return envelope(result, request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    EXAMPLE_TRACE_ID,
     STARTUP_SCRIPT_WRITE_RESPONSES,
     USER_SCOPED_403,
     BotIdPath,
@@ -247,7 +248,24 @@ def _sync_passport_identity(
         202: {
             "model": Envelope[BotAuthPending],
             "description": "Needs user authorization",
-        }
+            "content": {
+                "application/json": {
+                    "example": {
+                        "code": 202000,
+                        "message": "Accepted",
+                        "data": {
+                            "bot_id": "20260813_a7k2m9p1",
+                            "iframe_url": (
+                                "https://auth.example.com/passport/consent"
+                                "?flow=f-123"
+                            ),
+                            "redirect_url": "",
+                        },
+                        "request_id": EXAMPLE_TRACE_ID,
+                    }
+                }
+            },
+        },
     },
 )
 @envelope_errors
@@ -608,6 +626,20 @@ async def restart_bot(
             "model": Envelope[BotAuthStatus],
             "description": "Authorization did not complete; `data.status` "
             "carries the terminal state (e.g. REJECTED, EXPIRED)",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "code": 400000,
+                        "message": "Authorization did not complete",
+                        "data": {
+                            "status": "REJECTED",
+                            "message": None,
+                            "bot": None,
+                        },
+                        "request_id": EXAMPLE_TRACE_ID,
+                    }
+                }
+            },
         },
     },
     dependencies=_GRANT_CHECKED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -13,14 +13,15 @@ internal router does.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     STARTUP_SCRIPT_WRITE_RESPONSES,
     USER_SCOPED_403,
+    BotIdPath,
     Deleted,
     Envelope,
     NameCheck,
@@ -262,12 +263,17 @@ async def create_bot(
         SkillSetServiceFactoryProtocol
     ),
 ):
-    """Create a bot (201), or return 202 + a Passport iframe when authorization is needed.
+    """Create a bot (201), or 202 with authorization URLs when consent is needed.
 
-    Engine-specific inputs belong in ``BotCreateSpec.extra_properties``, but
-    nothing downstream reads that bag yet, so the request model does not expose
-    an ``engine_options`` field for it — see :class:`BotCreate`.
+    On a 202, have the user complete authorization at one of the returned
+    URLs, then poll the auth-status endpoint — the bot is only created there,
+    on ISSUED. Engine-specific options are not accepted here; engine
+    configuration is managed through the engine-config endpoints after
+    creation.
     """
+    # Engine-specific inputs belong in BotCreateSpec.extra_properties, but
+    # nothing downstream reads that bag yet, so the request model does not
+    # expose an `engine_options` field for it — see BotCreate.
     # Validate the engine against the configured registry FIRST: the cluster rule
     # below treats every non-teclaw value as ACRA, so an unknown engine would
     # otherwise sail through, allocate an id, apply for a Passport, and only fail
@@ -318,9 +324,21 @@ async def list_bots(
     page_params: PageParamsDep,
     owner_id: UserIdDep,
     caller: ActingCallerDep,
-    keyword: str | None = None,
-    engine: str | None = None,
-    status: str | None = None,
+    keyword: Annotated[
+        str | None,
+        Query(description="Filter: bots whose name contains this text."),
+    ] = None,
+    engine: Annotated[
+        str | None,
+        Query(description="Filter: only bots on this engine, matched exactly."),
+    ] = None,
+    status: Annotated[
+        str | None,
+        Query(
+            description="Filter: only bots in this lifecycle status, matched "
+            "exactly (e.g. 'ACTIVE'; see the Bot schema for the vocabulary)."
+        ),
+    ] = None,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Page[Bot]]:
     """List the user's bots (filter + paginate), narrowed to what may be reached.
@@ -340,7 +358,7 @@ async def list_bots(
     Note this listing can never show a bot the user does not own, for an
     application any more than for the user — it is owner-scoped underneath. The
     complete view of what an application may reach, including bots delegated by
-    a collaborator, is ``GET /openapi/v1/bots/authorized``.
+    a collaborator, is the authorized-bots listing.
     """
     # ``owned_by_delegator``: this query is owner-scoped, and ``bot_id`` is not
     # unique across owners — filtering it by a set holding someone else's
@@ -376,21 +394,28 @@ async def list_bots(
 )
 @envelope_errors
 async def check_bot_name(
-    name: str,
+    name: Annotated[
+        str,
+        Query(
+            description="The bot name to check. Validated with the same rules "
+            "create applies (non-blank, no '@'), so an invalid name is a 400 "
+            "here rather than a false 'available'."
+        ),
+    ],
     request: Request,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[NameCheck]:
     """Check whether a bot name is available (within the caller's tenant).
 
-    Applies the same rule create and update do, because "available" has to mean
-    "you could create this". ``check_bot_name_exists`` only does a repository
-    lookup — it answers ``False`` for a blank or ``@``-bearing name, which would
-    report a name as free that the very next request would reject (400).
-    Rejecting here instead keeps one answer across the three endpoints.
-
-    The echoed ``name`` is the trimmed form actually checked, so a caller that
-    sends ``" Foo "`` sees which string the availability applies to.
+    Applies the same validation create and update do, so "available" always
+    means "you could create this". The echoed name is the trimmed form
+    actually checked — a caller that sends " Foo " sees which string the
+    availability answer applies to.
     """
+    # The same rule as create/update on purpose: the repository lookup alone
+    # answers False for a blank or @-bearing name, which would report a name
+    # as free that the very next request rejects (400). Rejecting here keeps
+    # one answer across the three endpoints.
     # No ``user_id``: this operation has no user dimension to scope by. Name
     # uniqueness is checked across the whole tenant — ``check_bot_name_exists``
     # takes only the name.
@@ -413,21 +438,24 @@ async def get_bots_ceiling(
 ) -> Envelope[Ceiling]:
     """Get the named user's bot-creation quota ceiling.
 
-    Names no bot, so there is no grant to check against one — but the answer is
-    still *about a person's account*, and a stranger application must not be
-    able to read it by naming a user id. So it is gated on the application
-    holding **at least one** live delegation from that user: proof of a
-    relationship, which is the closest thing this operation has to a scope.
-
-    An application with no delegation from them is answered as if the user were
-    not there. It learns nothing it did not already know.
-
-    Resolved through the same method creation enforces, not
-    ``PolicyService.get_bots_ceiling`` directly: that one falls back to its own
-    hardcoded default of 5, while creation falls back to the configured
-    ``max_devices_per_entity``. Reading it directly would advertise 5 to a caller
-    whose deployment allows (or rejects at) a different number.
+    The number creation actually enforces: creating a bot while the user owns
+    this many live bots is refused (409). A ceiling of 0 or less means the
+    limit is disabled. For an application caller, reading it requires holding
+    at least one live delegation from the named user; without one the user is
+    answered as if they did not exist.
     """
+    # Names no bot, so there is no grant to check against one — but the answer
+    # is still about a person's account, and a stranger application must not be
+    # able to read it by naming a user id. So it is gated on the application
+    # holding at least one live delegation from that user: proof of a
+    # relationship, the closest thing this operation has to a scope. An
+    # application with no delegation learns nothing it did not already know.
+    #
+    # Resolved through the same method creation enforces, not
+    # PolicyService.get_bots_ceiling directly: that one falls back to its own
+    # hardcoded default of 5, while creation falls back to the configured
+    # max_devices_per_entity. Reading it directly would advertise 5 to a caller
+    # whose deployment allows (or rejects at) a different number.
     granted = caller.granted_bot_ids()
     if granted is not None and not granted:
         # The named user goes to the log bounded and escaped, never into the
@@ -452,7 +480,7 @@ async def get_bots_ceiling(
 )
 @envelope_errors
 async def get_bot(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -470,7 +498,7 @@ async def get_bot(
 )
 @envelope_errors
 async def update_bot(
-    bot_id: str,
+    bot_id: BotIdPath,
     body: BotUpdate,
     request: Request,
     owner_id: UserIdDep,
@@ -479,9 +507,9 @@ async def update_bot(
 ) -> Envelope[Bot]:
     """Update a bot's name/description (engine is fixed at creation).
 
-    ``cluster_name`` is engine-derived and the engine is immutable, so it is not
-    updatable here; ``engine_options`` is managed via the engine-config
-    endpoints. Neither is accepted — see :class:`BotUpdate`.
+    The cluster is engine-derived and the engine is immutable, so neither is
+    updatable here; engine options are managed via the engine-config
+    endpoints. Sending either fails validation with the field named.
     """
     # Same name rule as create and the internal update route — otherwise this
     # surface could persist names the rest of the lifecycle rejects.
@@ -526,12 +554,17 @@ async def update_bot(
 )
 @envelope_errors
 async def delete_bot(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Deleted]:
-    """Delete a bot. See :func:`_reject_unowned_lifecycle` for what is refused."""
+    """Delete a bot.
+
+    Refused (409) for bots whose lifecycle lives elsewhere: desktop bots are
+    managed by the desktop service, and service bots are deleted through
+    their publish lifecycle.
+    """
     _reject_unowned_lifecycle(bot_service.get_bot(bot_id, owner_id), deleting=True)
     bot_service.delete_bot(bot_id, owner_id)
     return deleted_envelope(request)
@@ -545,12 +578,17 @@ async def delete_bot(
 )
 @envelope_errors
 async def restart_bot(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> Envelope[Bot]:
-    """Restart a bot. Desktop bots are rejected — see :func:`_reject_unowned_lifecycle`."""
+    """Restart a bot's container.
+
+    Also what applies a changed startup script. Refused (409) for desktop
+    bots, whose lifecycle is managed by the desktop service, and for bots in
+    a lifecycle state a restart cannot leave.
+    """
     _reject_unowned_lifecycle(bot_service.get_bot(bot_id, owner_id))
     bot = bot_service.restart_bot(bot_id, owner_id)
     return envelope(_to_bot(bot), request)
@@ -576,36 +614,59 @@ async def restart_bot(
 )
 @envelope_errors
 async def get_bot_auth_status(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
-    engine: str | None = None,
+    engine: Annotated[
+        str | None,
+        Query(
+            description="Echo of the engine the bot was requested with. "
+            "Required in practice on the 202 flow: creation completes here, "
+            "and an omitted value falls back to the deployment default."
+        ),
+    ] = None,
     # Enum, not a bare str: validate_engine_cluster accepts only ACRA/ANDC,
     # so a plain string would let a generated client compile
     # ``cluster_name=foo`` that the server always rejects — the same
     # contract/behaviour gap as F29/F35/F41. Create already models it this way.
-    cluster_name: ClusterName | None = None,
-    bot_name: str | None = None,
-    bot_desc: str | None = None,
-    bot_type: BotType | None = None,
+    cluster_name: Annotated[
+        ClusterName | None,
+        Query(
+            description="Echo of the cluster the bot was requested with; "
+            "validated against the engine exactly as on create."
+        ),
+    ] = None,
+    bot_name: Annotated[
+        str | None,
+        Query(description="Echo of the name the bot was requested with."),
+    ] = None,
+    bot_desc: Annotated[
+        str | None,
+        Query(description="Echo of the description the bot was requested with."),
+    ] = None,
+    bot_type: Annotated[
+        BotType | None,
+        Query(
+            description="Echo of the bot type the bot was requested with; "
+            "defaults to 'personal' when omitted."
+        ),
+    ] = None,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     passport_plugin: PassportPlugin = Injected(PassportPlugin),
     auth_rel_plugin: AuthRelationshipPlugin = Injected(AuthRelationshipPlugin),
 ) -> Envelope[BotAuthStatus]:
-    """Poll Passport authorization; complete creation when ISSUED.
+    """Poll authorization for a pending creation; the bot is created on ISSUED.
 
-    On the async-create flow the bot is only actually created here (on ISSUED),
-    so the caller must re-supply the attributes it created with — passed as
-    optional query params and forwarded to completion. Without them the bot
-    would be created with defaults (e.g. engine ``openclaw``) that contradict the
-    Passport applied for at ``POST`` time, so callers on the 202 flow should
-    always echo back ``engine``/``cluster_name``/``bot_name``/… here.
+    On the 202 create flow the bot is only actually created here, so the
+    caller must re-supply the attributes it created with — the optional query
+    parameters mirror the create body and are forwarded to completion. Omit
+    them and the bot is created with defaults that contradict what was
+    requested, so always echo back engine, cluster_name, bot_name, bot_desc
+    and bot_type when polling.
 
-    Because this is where the record is actually inserted, every restriction
-    ``POST`` enforces is re-applied to the echoed-back values: the same engine
-    registry check, the same engine/cluster bijection, and the same
-    personal|service restriction on ``bot_type``. Otherwise the completion path
-    would be a way to create exactly the bots ``POST`` rejects.
+    Every restriction create enforces is re-applied to the echoed values:
+    the same engine registry check, the same engine/cluster pairing, and the
+    same personal/service restriction on bot_type.
     """
     # Validate against the engine completion will actually use, not against the
     # query param: omitting ``engine`` does not mean "no engine", it means the
@@ -658,7 +719,7 @@ async def get_bot_auth_status(
 )
 @envelope_errors
 async def get_bot_status(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -686,7 +747,7 @@ async def get_bot_status(
 )
 @envelope_errors
 async def get_bot_passport(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -725,7 +786,7 @@ def _engine_config_target(bot: dict[str, Any]) -> tuple[str, str, str]:
 )
 @envelope_errors
 async def get_bot_engine_config(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -751,7 +812,7 @@ async def get_bot_engine_config(
 )
 @envelope_errors
 async def update_bot_engine_config(
-    bot_id: str,
+    bot_id: BotIdPath,
     body: dict[str, Any],
     request: Request,
     owner_id: UserIdDep,
@@ -794,7 +855,7 @@ def _audit_actor(caller: ActingCaller, owner_id: str) -> str:
 )
 @envelope_errors
 async def get_bot_startup_script(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
@@ -805,8 +866,8 @@ async def get_bot_startup_script(
     """Read a bot's startup script.
 
     A bot that has never had one reads as an empty script, not an error. An
-    unsupported bot still answers here — with ``supported: false`` and a reason —
-    so a caller can discover *why* before trying to write.
+    unsupported bot still answers here — with supported false and a reason —
+    so a caller can discover why before trying to write.
     """
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
     entity_id, state, reason = _startup_script_target(bot, startup_script_service)
@@ -822,7 +883,7 @@ async def get_bot_startup_script(
 )
 @envelope_errors
 async def update_bot_startup_script(
-    bot_id: str,
+    bot_id: BotIdPath,
     body: StartupScriptWrite,
     request: Request,
     owner_id: UserIdDep,
@@ -834,11 +895,11 @@ async def update_bot_startup_script(
 ) -> Envelope[StartupScript]:
     """Set or replace a bot's startup script.
 
-    Takes effect the next time the platform **composes** a start command. A
-    restart or republish of the bot does that; a targeted device restart
-    (``POST /api/v1/devices/{binding_id}/restart``) and a scale-out do not —
-    they reuse the deploy config stored at the last compose, so a replica or a
-    restarted instance can still run the previously published script.
+    Takes effect the next time the platform composes a start command — a
+    restart or republish of the bot does that. Lower-level restarts and
+    scale-outs reuse the previously composed configuration, so an instance
+    started that way can still run the previously stored script until the bot
+    is next restarted or republished.
 
     Refused for a bot whose container cannot run one: storing it would be a
     silent no-op the caller could not distinguish from success.
@@ -873,7 +934,7 @@ async def update_bot_startup_script(
 )
 @envelope_errors
 async def delete_bot_startup_script(
-    bot_id: str,
+    bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -49,16 +49,17 @@ _ENGINE_DESC = (
 
 # The status vocabulary is a pass-through of the stored lifecycle state, and the
 # listing can also surface bots whose lifecycle is driven elsewhere (desktop
-# bots, dormancy reclaim), so the set is open: the three main states are
-# documented as primary and the rest as possible, rather than publishing a
-# closed enum that a legitimately-listed bot would violate.
+# bots, dormancy reclaim), so the set is open: every value those lifecycles
+# emit today is listed with its meaning, but it is not published as a schema
+# `enum` — a closed set would make a legitimately-listed bot invalid the day a
+# lifecycle adds a state.
 _BOT_STATUS_DESC = (
-    "Lifecycle status. Primary states: 'PENDING' — created, its device is "
-    "still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device "
-    "provisioning failed (delete and recreate, or restart). Bots managed by "
-    "other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', "
-    "'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as "
-    "not ready for work."
+    "Lifecycle status. Values: 'PENDING' — created, its device is still "
+    "being provisioned; 'ACTIVE' — running and reachable; 'FAILED' — device "
+    "provisioning failed (restart, or delete and recreate); 'OFFLINE', "
+    "'RELEASING', 'RELEASED' — desktop-bot lifecycle states; 'RECYCLED', "
+    "'REACTIVATING' — dormant-bot reclaim states. New lifecycles can add "
+    "values, so treat any value other than 'ACTIVE' as not ready for work."
 )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -240,10 +240,14 @@ class BotAuthStatus(BaseModel):
         "(e.g. 'REJECTED', 'EXPIRED') is terminal and is answered as a 400 "
         "with the state kept in data.status."
     )
+    # Reserved, not wired: the completion flow's result carries only the
+    # status and the bot, so nothing populates this yet. Documented as always
+    # null rather than promising a note the server never sends; wiring the
+    # provider's message through is a behavior change for a separate PR.
     message: str | None = Field(
         default=None,
-        description="Optional human-readable note from the authorization "
-        "service; null when there is nothing to add.",
+        description="Reserved for a human-readable note from the "
+        "authorization service; currently always null.",
     )
     bot: Bot | None = Field(
         default=None,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -1,4 +1,9 @@
-"""Request/response models for the bots group."""
+"""Request/response models for the bots group.
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
@@ -24,36 +29,106 @@ _STRICT = ConfigDict(extra="forbid")
 # authorization-completion query params — and those must not drift apart.
 BotType = Literal["personal", "service"]
 
+_BOT_TYPE_DESC = (
+    "Kind of bot to create: 'personal' — a bot for the named user's own use, "
+    "with a single draft runtime; 'service' — a bot built to be published, "
+    "gaining verify/online runtimes through its publish lifecycle."
+)
+
 _CLUSTER_DESC = (
     "Deployment cluster, in strict 1:1 correspondence with the engine: "
     "'ANDC' for engine 'teclaw', 'ACRA' for every other engine. On create the "
     "engine/cluster pair is validated against this rule (400 on mismatch)."
 )
 
+_ENGINE_DESC = (
+    "Engine that powers the bot, fixed at creation. The valid set is "
+    "deployment-configured — read it from the engine group's available-engines "
+    "endpoint; an unlisted engine is refused (400)."
+)
+
+# The status vocabulary is a pass-through of the stored lifecycle state, and the
+# listing can also surface bots whose lifecycle is driven elsewhere (desktop
+# bots, dormancy reclaim), so the set is open: the three main states are
+# documented as primary and the rest as possible, rather than publishing a
+# closed enum that a legitimately-listed bot would violate.
+_BOT_STATUS_DESC = (
+    "Lifecycle status. Primary states: 'PENDING' — created, its device is "
+    "still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device "
+    "provisioning failed (delete and recreate, or restart). Bots managed by "
+    "other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', "
+    "'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as "
+    "not ready for work."
+)
+
 
 class Bot(BaseModel):
     """An agent (bot) record."""
 
-    bot_id: str
-    bot_name: str
-    bot_desc: str
-    engine: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "bot_name": "research-assistant",
+                "bot_desc": "Summarizes weekly industry news.",
+                "engine": "openclaw",
+                "cluster_name": "ACRA",
+                "bot_type": "personal",
+                "status": "ACTIVE",
+                "owner_entity_id": "u_165137",
+            }
+        }
+    )
+
+    bot_id: str = Field(
+        description="Unique identifier of the bot, e.g. '20260813_a7k2m9p1'. "
+        "Use it verbatim wherever an operation takes a bot_id."
+    )
+    bot_name: str = Field(description="Display name; unique within the tenant.")
+    bot_desc: str = Field(
+        description="Free-form description of what the bot is for; may be empty."
+    )
+    engine: str = Field(description=_ENGINE_DESC)
     cluster_name: ClusterName = Field(description=_CLUSTER_DESC)
-    bot_type: str
-    status: str = Field(description="Lifecycle status: PENDING | ACTIVE | FAILED.")
-    owner_entity_id: str
+    # Typed `str`, not BotType: the listing also returns bots this surface does
+    # not create (desktop), so a closed request-side set would fail on read.
+    bot_type: str = Field(
+        description="Kind of bot: 'personal', 'service', or 'desktop'. Desktop "
+        "bots run on the user's own machine; they appear in listings but their "
+        "lifecycle is not managed through this API."
+    )
+    status: str = Field(description=_BOT_STATUS_DESC)
+    owner_entity_id: str = Field(
+        description="The user who owns the bot — echoes the user_id the "
+        "request named."
+    )
 
 
 class BotCreate(BaseModel):
     """Create-a-bot request body."""
 
-    model_config = _STRICT
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {
+                "bot_name": "research-assistant",
+                "bot_desc": "Summarizes weekly industry news.",
+                "engine": "openclaw",
+                "cluster_name": "ACRA",
+                "bot_type": "personal",
+            }
+        },
+    )
 
-    bot_name: str
-    bot_desc: str
-    engine: str
+    bot_name: str = Field(
+        description="Display name. Must be non-blank, must not contain '@', "
+        "and must be unused within the tenant (409 on a duplicate); leading "
+        "and trailing whitespace is trimmed."
+    )
+    bot_desc: str = Field(description="Description of what the bot is for.")
+    engine: str = Field(description=_ENGINE_DESC)
     cluster_name: ClusterName = Field(description=_CLUSTER_DESC)
-    bot_type: BotType
+    bot_type: BotType = Field(description=_BOT_TYPE_DESC)
     # ``engine_options`` is deliberately absent. Nothing downstream consumes
     # ``BotCreateSpec.extra_properties`` yet, so declaring the field would
     # publish a contract slot the server rejects on every non-empty value —
@@ -64,18 +139,19 @@ class BotCreate(BaseModel):
 
 
 class BotUpdate(BaseModel):
-    """Partial update — only the fields this operation can actually apply.
+    """Rename a bot and/or replace its description.
 
-    ``engine``, ``cluster_name`` and ``engine_options`` are all deliberately
-    absent *and* rejected by ``extra="forbid"``. Declaring them for symmetry
-    would mean answering 200 to a request that changed nothing: the engine is
-    fixed at creation, ``cluster_name`` is derived from it, and engine options
-    are managed through the engine-config endpoints. A caller that sends one now
-    gets a validation error naming the field instead of a success they have to
-    verify by re-reading the bot.
+    Only these two fields are updatable: the engine is fixed at creation, the
+    cluster is derived from the engine, and engine options are managed through
+    the engine-config endpoints. Sending any other field fails validation with
+    the field named in the error. Omit a field to leave it unchanged; explicit
+    null is rejected.
     """
 
-    model_config = _STRICT
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={"example": {"bot_name": "research-assistant-v2"}},
+    )
 
     # Declared ``str`` with a ``None`` default on purpose. Omitting a field means
     # "leave it alone" — that is what the default encodes, and defaults are not
@@ -89,62 +165,171 @@ class BotUpdate(BaseModel):
     # Neither does the internal route — ``update_bot`` has no representation for
     # it — so that is a product gap to close deliberately, not something to fake
     # here by treating "" as null.
-    bot_name: str = Field(default=None, description="New name; omit to keep.")
+    bot_name: str = Field(
+        default=None,
+        description="New name; omit to keep. Same rules as on create: "
+        "non-blank, no '@', unique within the tenant.",
+    )
     bot_desc: str = Field(default=None, description="New description; omit to keep.")
 
 
 class BotAuthPending(BaseModel):
-    """Returned (202) when bot creation needs user authorization (Passport).
+    """Returned (202) when bot creation needs user authorization first.
 
-    Passport may hand back either handle, so both are surfaced: a caller that
-    only receives ``redirect_url`` would otherwise have no way to complete
-    authorization. Each is empty when Passport did not supply it.
+    Open whichever URL is populated to let the user complete authorization,
+    then poll the bot's auth-status endpoint. Each URL is empty when the
+    authorization service did not supply it — at least one is populated.
     """
 
-    bot_id: str
-    iframe_url: str = ""
-    redirect_url: str = ""
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "iframe_url": "https://auth.example.com/passport/consent?flow=f-123",
+                "redirect_url": "",
+            }
+        }
+    )
+
+    bot_id: str = Field(
+        description="Identifier reserved for the bot being created. Pass it to "
+        "the auth-status endpoint to poll and complete creation."
+    )
+    iframe_url: str = Field(
+        default="",
+        description="URL suitable for embedding in an iframe for the user to "
+        "authorize in-page; empty when not offered.",
+    )
+    redirect_url: str = Field(
+        default="",
+        description="URL to redirect the user to for authorization; empty "
+        "when not offered.",
+    )
 
 
 class BotAuthStatus(BaseModel):
-    """Passport authorization status; ``bot`` is present once ISSUED."""
+    """Authorization status of a pending bot creation."""
 
-    status: str
-    message: str | None = None
-    bot: Bot | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "ISSUED",
+                "message": None,
+                "bot": {
+                    "bot_id": "20260813_a7k2m9p1",
+                    "bot_name": "research-assistant",
+                    "bot_desc": "Summarizes weekly industry news.",
+                    "engine": "openclaw",
+                    "cluster_name": "ACRA",
+                    "bot_type": "personal",
+                    "status": "PENDING",
+                    "owner_entity_id": "u_165137",
+                },
+            }
+        }
+    )
+
+    # Typed `str`, not an enum: the state originates in the external
+    # authorization service, which may add terminal states — an unknown value
+    # must survive the round trip rather than 500.
+    status: str = Field(
+        description="Authorization state: 'PENDING' — the user has not "
+        "finished authorizing, keep polling; 'ISSUED' — authorization granted "
+        "and the bot is now created ('bot' is populated). Any other value "
+        "(e.g. 'REJECTED', 'EXPIRED') is terminal and is answered as a 400 "
+        "with the state kept in data.status."
+    )
+    message: str | None = Field(
+        default=None,
+        description="Optional human-readable note from the authorization "
+        "service; null when there is nothing to add.",
+    )
+    bot: Bot | None = Field(
+        default=None,
+        description="The created bot; present once status is 'ISSUED', "
+        "null before that.",
+    )
 
 
 class BotStatus(BaseModel):
     """Runtime / device readiness of a bot."""
 
-    status: str
-    is_ready: bool
-    device_id: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "status": "ACTIVE",
+                "is_ready": True,
+                "device_id": "device-8f2c91",
+            }
+        }
+    )
+
+    status: str = Field(description=_BOT_STATUS_DESC)
+    is_ready: bool = Field(
+        description="True once the bot can actually take work. Stricter than "
+        "status == 'ACTIVE': an application-coding bot is not ready until its "
+        "initial repository checkout has also succeeded."
+    )
+    device_id: str | None = Field(
+        default=None,
+        description="Identifier of the device (container) backing the bot; "
+        "null while none is bound.",
+    )
 
 
 class Ceiling(BaseModel):
-    """Per-caller bot creation quota ceiling."""
+    """Per-user bot creation quota."""
 
-    ceiling: int
+    model_config = ConfigDict(json_schema_extra={"example": {"ceiling": 5}})
+
+    ceiling: int = Field(
+        description="Maximum number of live bots the named user may own in "
+        "this deployment; creation is refused (409) at the limit. Desktop "
+        "bots do not count toward it. A value of 0 or less means the limit "
+        "is disabled."
+    )
 
 
 class Passport(BaseModel):
     """Agent Passport (identity credential) summary."""
 
-    bot_id: str
-    passport_id: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "passport_id": "20260813_a7k2m9p1",
+            }
+        }
+    )
+
+    bot_id: str = Field(description="The bot this Passport belongs to.")
+    passport_id: str = Field(
+        description="Identifier of the bot's Passport — the platform-issued "
+        "identity credential downstream services authenticate the bot "
+        "against. An opaque string whose shape is deployment-defined; it may "
+        "equal the bot_id."
+    )
 
 
 class StartupScriptWrite(BaseModel):
-    """PUT body for a bot's startup script — the only client-supplied field.
+    """PUT body for a bot's startup script — the script is the only field.
 
-    Audit fields are deliberately absent: ``updated_by`` comes from the request
-    principal and ``updated_at`` from the row's own timestamp, so neither can be
-    asserted by a caller, and ``extra="forbid"`` means an attempt to send one
-    fails validation rather than being silently dropped with a 200.
+    The audit fields on the stored script are server-derived and cannot be
+    supplied here; sending one fails validation rather than being silently
+    dropped.
     """
 
-    model_config = _STRICT
+    # Audit fields are deliberately absent: updated_by comes from the request
+    # principal and updated_at from the row's own timestamp, so neither can be
+    # asserted by a caller, and extra="forbid" means an attempt to send one
+    # fails validation rather than being silently dropped with a 200.
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {"script": "#!/bin/sh\npip install -q requests\n"}
+        },
+    )
 
     script: str = Field(
         description=(
@@ -159,9 +344,25 @@ class StartupScriptWrite(BaseModel):
 class StartupScript(BaseModel):
     """A bot's stored startup script. Every field is server-derived."""
 
-    bot_id: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "script": "#!/bin/sh\npip install -q requests\n",
+                "size_bytes": 34,
+                "updated_by": "u_165137",
+                "updated_at": "2026-08-01T09:12:04+00:00",
+                "supported": True,
+                "unsupported_reason": "",
+            }
+        }
+    )
+
+    bot_id: str = Field(description="The bot this script belongs to.")
     script: str = Field(description="Empty when the bot has no stored script.")
-    size_bytes: int
+    size_bytes: int = Field(
+        description="Size of the stored script in bytes; 0 when none is stored."
+    )
     updated_by: str = Field(description="Empty when the bot has no stored script.")
     updated_at: datetime | None = Field(
         default=None,
@@ -176,5 +377,3 @@ class StartupScript(BaseModel):
     unsupported_reason: str = Field(
         description="Empty when supported; otherwise names the cause.",
     )
-
-

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
@@ -7,10 +7,10 @@ generation; handlers are stubs (a later pass wires them to services).
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import Depends, Query
-from pydantic import BaseModel, Field
+from fastapi import Depends, Path, Query
+from pydantic import BaseModel, ConfigDict, Field
 
 # The published startup-script size limit, imported rather than retyped so the
 # example in STARTUP_SCRIPT_WRITE_RESPONSES cannot drift from the enforced value.
@@ -24,8 +24,32 @@ CODE_ACCEPTED = 202000
 CODE_NO_CONTENT = 204000
 
 
+# Injected into every parametrisation's schema (Envelope[Bot], Page[Skill], …):
+# a parametrised generic does not inherit the generic's docstring, so without
+# this the concrete wrapper components in the published document carry no
+# description at all. `setdefault` so a named subclass that states its own
+# docstring keeps it.
+def _describe_envelope(schema: dict[str, Any]) -> None:
+    schema.setdefault(
+        "description",
+        "Uniform response wrapper for every endpoint: `code`/`message` say how "
+        "the call went, `data` carries the payload named in the wrapper's "
+        "title, and `request_id` identifies the request for support.",
+    )
+
+
+def _describe_page(schema: dict[str, Any]) -> None:
+    schema.setdefault(
+        "description",
+        "One page of a list result: `total` counts every match, `items` holds "
+        "the current page.",
+    )
+
+
 class Envelope[T](BaseModel):
     """Uniform response wrapper for every public endpoint."""
+
+    model_config = ConfigDict(json_schema_extra=_describe_envelope)
 
     code: int = Field(
         description="6-digit code: HTTP status (3) + business subcode (3)."
@@ -42,12 +66,12 @@ class Envelope[T](BaseModel):
 
 
 class ErrorEnvelope(BaseModel):
-    """The envelope returned on every documented failure.
+    """The envelope returned on every documented failure — the same shape as
+    the success envelope, with `data` pinned to null."""
 
-    Shape-identical to :class:`Envelope` with ``data`` pinned to null, which is
-    what the error paths actually emit. Declared as its own model so generated
-    clients get a named error type instead of a synthesized ``Envelope[None]``.
-    """
+    # Shape-identical to Envelope with data pinned to null, which is what the
+    # error paths actually emit. Declared as its own model so generated clients
+    # get a named error type instead of a synthesized Envelope[None].
 
     code: int = Field(
         description="6-digit code: HTTP status (3) + business subcode (3), "
@@ -157,6 +181,8 @@ ENGINE_RUNTIME_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
 class Page[T](BaseModel):
     """A page of items returned by list endpoints."""
 
+    model_config = ConfigDict(json_schema_extra=_describe_page)
+
     total: int = Field(description="Total number of items matching the query.")
     items: list[T] = Field(
         description="Items on the current page (present, possibly empty)."
@@ -166,14 +192,45 @@ class Page[T](BaseModel):
 class Deleted(BaseModel):
     """Payload returned by delete operations."""
 
-    deleted: bool = True
+    model_config = ConfigDict(json_schema_extra={"example": {"deleted": True}})
+
+    deleted: bool = Field(
+        default=True,
+        description="Always true: the resource is gone. A failed delete "
+        "answers an error envelope instead, never `deleted: false`.",
+    )
 
 
 class NameCheck(BaseModel):
     """Payload returned by name-availability checks."""
 
-    name: str
-    exists: bool
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"name": "quarterly-report", "exists": False}}
+    )
+
+    name: str = Field(
+        description="The name in the form the server actually checked — "
+        "normalized (e.g. trimmed) from what was sent, so this is the exact "
+        "string the availability answer applies to."
+    )
+    exists: bool = Field(
+        description="True when the name is already taken; false when it is "
+        "available to use."
+    )
+
+
+#: The path parameter naming the bot an operation addresses, documented once so
+#: every group publishes the same wording. The example is the issued format
+#: (date + 8 random characters); legacy deployments may hold other shapes, so
+#: the format is illustrative, not a contract.
+BotIdPath = Annotated[
+    str,
+    Path(
+        description="The bot this operation addresses — its `bot_id` as "
+        "issued at creation and returned by the bots listing, "
+        "e.g. `20260813_a7k2m9p1`."
+    ),
+]
 
 
 class PageParams:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
@@ -23,12 +23,22 @@ CODE_CREATED = 201000
 CODE_ACCEPTED = 202000
 CODE_NO_CONTENT = 204000
 
+#: Illustrative trace id used by every example, so rendered samples show a
+#: realistic value instead of the literal placeholder "string".
+EXAMPLE_TRACE_ID = "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+
 
 # Injected into every parametrisation's schema (Envelope[Bot], Page[Skill], …):
 # a parametrised generic does not inherit the generic's docstring, so without
 # this the concrete wrapper components in the published document carry no
 # description at all. `setdefault` so a named subclass that states its own
 # docstring keeps it.
+#
+# The per-property examples exist because doc UIs synthesize a response sample
+# from the schema: without them every envelope rendered `"code": 0` and
+# `"message": "string"` around a fully-worked payload example. Property-level
+# (never a whole-schema example): a top-level example would replace the
+# synthesized `data`, losing the payload model's own example.
 def _describe_envelope(schema: dict[str, Any]) -> None:
     schema.setdefault(
         "description",
@@ -36,6 +46,15 @@ def _describe_envelope(schema: dict[str, Any]) -> None:
         "the call went, `data` carries the payload named in the wrapper's "
         "title, and `request_id` identifies the request for support.",
     )
+    properties = schema.get("properties") or {}
+    for name, value in (
+        ("code", CODE_OK),
+        ("message", "OK"),
+        ("request_id", EXAMPLE_TRACE_ID),
+    ):
+        prop = properties.get(name)
+        if isinstance(prop, dict):
+            prop.setdefault("example", value)
 
 
 def _describe_page(schema: dict[str, Any]) -> None:
@@ -44,6 +63,10 @@ def _describe_page(schema: dict[str, Any]) -> None:
         "One page of a list result: `total` counts every match, `items` holds "
         "the current page.",
     )
+    # Matches the synthesized `items` sample, which holds one element.
+    total = (schema.get("properties") or {}).get("total")
+    if isinstance(total, dict):
+        total.setdefault("example", 1)
 
 
 class Envelope[T](BaseModel):
@@ -72,16 +95,46 @@ class ErrorEnvelope(BaseModel):
     # Shape-identical to Envelope with data pinned to null, which is what the
     # error paths actually emit. Declared as its own model so generated clients
     # get a named error type instead of a synthesized Envelope[None].
+    #
+    # Field examples are the schema-view fallback; each documented status also
+    # carries its own response example (see error_example below) with that
+    # status's real code and message, which is what response samples render.
 
     code: int = Field(
         description="6-digit code: HTTP status (3) + business subcode (3), "
-        "e.g. 404000 for a not-found failure."
+        "e.g. 404000 for a not-found failure.",
+        json_schema_extra={"example": 404000},
     )
-    message: str = Field(description="Human-readable failure reason; always English.")
+    message: str = Field(
+        description="Human-readable failure reason; always English.",
+        json_schema_extra={"example": "Not found"},
+    )
     data: None = Field(default=None, description="Always null on an error response.")
     request_id: str = Field(
-        description="Trace id; mirrors the X-Trace-Id response header."
+        description="Trace id; mirrors the X-Trace-Id response header.",
+        json_schema_extra={"example": EXAMPLE_TRACE_ID},
     )
+
+
+def error_example(status: int, message: str) -> dict[str, object]:
+    """A worked response sample for one documented failure status.
+
+    The code follows the status*1000 rule and the message is one the server
+    really emits for that status, so rendered samples show actual values
+    instead of type placeholders.
+    """
+    return {
+        "content": {
+            "application/json": {
+                "example": {
+                    "code": status * 1000,
+                    "message": message,
+                    "data": None,
+                    "request_id": EXAMPLE_TRACE_ID,
+                }
+            }
+        }
+    }
 
 
 # Documented failure responses shared by every public route. Applied at router
@@ -96,18 +149,48 @@ class ErrorEnvelope(BaseModel):
 # Declared surface-wide, not per route: the envelope is uniform by design, the
 # app-level backstop can produce 500 on any route, and a per-route list would
 # drift out of sync with the mappings in ``responses.ENVELOPE_ERRORS``.
+#
+# Example messages: where a status has one fixed public message on this surface
+# (401/403/404/422) the example carries it verbatim; where messages vary by
+# cause (400/409/500/502) it carries the reason-phrase fallback the unmapped
+# path emits, since any specific domain message would be wrong on most routes.
 ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
-    400: {"model": ErrorEnvelope, "description": "Invalid request"},
-    401: {"model": ErrorEnvelope, "description": "Missing or invalid credentials"},
+    400: {
+        "model": ErrorEnvelope,
+        "description": "Invalid request",
+        **error_example(400, "Bad Request"),
+    },
+    401: {
+        "model": ErrorEnvelope,
+        "description": "Missing or invalid credentials",
+        **error_example(401, "Unauthorized"),
+    },
     404: {
         "model": ErrorEnvelope,
         "description": "Not found — also returned when the resource exists but "
         "does not belong to the caller",
+        **error_example(404, "Not found"),
     },
-    409: {"model": ErrorEnvelope, "description": "Conflicts with current state"},
-    422: {"model": ErrorEnvelope, "description": "Request failed validation"},
-    500: {"model": ErrorEnvelope, "description": "Internal error"},
-    502: {"model": ErrorEnvelope, "description": "Upstream service error"},
+    409: {
+        "model": ErrorEnvelope,
+        "description": "Conflicts with current state",
+        **error_example(409, "Conflict"),
+    },
+    422: {
+        "model": ErrorEnvelope,
+        "description": "Request failed validation",
+        **error_example(422, "Invalid request"),
+    },
+    500: {
+        "model": ErrorEnvelope,
+        "description": "Internal error",
+        **error_example(500, "Internal Server Error"),
+    },
+    502: {
+        "model": ErrorEnvelope,
+        "description": "Upstream service error",
+        **error_example(502, "Bad Gateway"),
+    },
 }
 
 # The extra failure a **user-scoped** route can produce: its ``user_id`` named
@@ -120,6 +203,7 @@ USER_SCOPED_403: dict[int | str, dict[str, object]] = {
         "model": ErrorEnvelope,
         "description": "The user_id names a user the authenticated caller may "
         "not act for",
+        **error_example(403, "Forbidden"),
     },
 }
 
@@ -136,18 +220,9 @@ STARTUP_SCRIPT_WRITE_RESPONSES: dict[int | str, dict[str, object]] = {
     413: {
         "model": ErrorEnvelope,
         "description": "Script body exceeds the size limit.",
-        "content": {
-            "application/json": {
-                "example": {
-                    "code": 413000,
-                    "message": (
-                        f"Startup script exceeds the {MAX_SCRIPT_BYTES}-byte limit"
-                    ),
-                    "data": None,
-                    "request_id": "",
-                }
-            }
-        },
+        **error_example(
+            413, f"Startup script exceeds the {MAX_SCRIPT_BYTES}-byte limit"
+        ),
     },
 }
 
@@ -173,8 +248,17 @@ ENGINE_RUNTIME_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
         "description": "Not supported for this bot — either its engine does not "
         "declare the capability (see the engine-capabilities endpoint) or the "
         "operation is not offered for this bot type",
+        **error_example(
+            501,
+            "Not supported by this bot's engine; see the engine capabilities "
+            "endpoint",
+        ),
     },
-    504: {"model": ErrorEnvelope, "description": "Upstream service timed out"},
+    504: {
+        "model": ErrorEnvelope,
+        "description": "Upstream service timed out",
+        **error_example(504, "Engine request timed out"),
+    },
 }
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/approvals/router.py
@@ -12,7 +12,10 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Query, Request
 
-from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Envelope,
+)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.approvals.schemas import (
     ApprovalModeInfo,
     ApprovalModeSet,
@@ -88,7 +91,7 @@ def _reject_refused_set(raw: Any) -> None:
 @router.get("/{bot_id}/mode", response_model=Envelope[ApprovalState])
 @envelope_errors
 async def get_approval_mode(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,
@@ -121,7 +124,7 @@ async def get_approval_mode(
 @router.put("/{bot_id}/mode", response_model=Envelope[ApprovalState])
 @envelope_errors
 async def set_approval_mode(
-    bot_id: str,
+    bot_id: BotIdPath,
     body: ApprovalModeSet,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -157,7 +160,7 @@ async def set_approval_mode(
 @router.get("/{bot_id}/modes", response_model=Envelope[list[ApprovalModeInfo]])
 @envelope_errors
 async def list_approval_modes(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/connection/router.py
@@ -11,7 +11,10 @@ import asyncio
 
 from fastapi import APIRouter, Request
 
-from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Envelope,
+)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.connection.schemas import (
     Connection,
     Socket,
@@ -39,7 +42,7 @@ router = APIRouter(prefix="/openapi/v1/bots/connection", tags=["connection"])
 @router.get("/{bot_id}", response_model=Envelope[Connection])
 @envelope_errors
 async def get_connection(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/engine/router.py
@@ -17,7 +17,10 @@ from typing import Any
 
 from fastapi import APIRouter, Request
 
-from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Envelope,
+)
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.engine.schemas import (
     EngineCapabilities,
     EngineInfo,
@@ -63,7 +66,7 @@ def _names(raw: Any) -> list[str]:
 @router.get("/{bot_id}/status", response_model=Envelope[EngineStatus])
 @envelope_errors
 async def get_engine_status(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,
@@ -103,7 +106,7 @@ async def get_engine_status(
 @router.get("/{bot_id}/capabilities", response_model=Envelope[EngineCapabilities])
 @envelope_errors
 async def get_engine_capabilities(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,
@@ -146,7 +149,7 @@ async def get_engine_capabilities(
 @router.get("/{bot_id}/available", response_model=Envelope[list[EngineInfo]])
 @envelope_errors
 async def list_available_engines(
-    bot_id: str,
+    bot_id: BotIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/enums.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/enums.py
@@ -25,38 +25,10 @@ Deliberately **not** enums, each checked against its source:
 
 from __future__ import annotations
 
-from enum import Enum
-from typing import Any
-
-
-class _DocumentedEnum(str, Enum):
-    """Base for published enums; not itself part of the API."""
-
-    # member value -> caller-facing meaning. Every member must be covered; the
-    # schema-documentation gate fails the build otherwise.
-    __descriptions__: dict[str, str] = {}
-
-    @classmethod
-    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> Any:
-        schema = handler(core_schema)
-        if not cls.__descriptions__:
-            return schema
-        # OpenAPI has no native slot for per-member documentation, and the two
-        # dominant generators disagree on the extension:
-        #   openapi-generator reads x-enum-descriptions / x-enum-varnames as
-        #     ARRAYS positionally parallel to `enum`
-        #   NSwag reads x-enumNames
-        # Emit all three so a generated client actually carries the docs. Member
-        # order is declaration order in Pydantic, which is what makes the
-        # parallel-array form well-defined.
-        values = list(schema.get("enum", []))
-        schema["x-enum-descriptions"] = [
-            cls.__descriptions__.get(v, "") for v in values
-        ]
-        names = {m.value: m.name for m in cls}
-        schema["x-enum-varnames"] = [names.get(v, str(v)) for v in values]
-        schema["x-enumNames"] = list(schema["x-enum-varnames"])
-        return schema
+# The base lives one package up so the non-engine-runtime groups can publish
+# documented enums too; re-exported here because this module's subclasses and
+# the schema-documentation gate both name it from here.
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
 
 class RuntimeStage(_DocumentedEnum):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/models/router.py
@@ -8,11 +8,12 @@ draft by default), and device-wide — see ``engine_runtime/gating.py`` and
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Path, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
     Envelope,
     Page,
     PageParamsDep,
@@ -42,6 +43,15 @@ from agentclaw.community.di import Injected
 
 router = APIRouter(prefix="/openapi/v1/bots/models", tags=["models"])
 
+#: The path parameter naming the model an operation addresses.
+ModelIdPath = Annotated[
+    str,
+    Path(
+        description="The model's id, exactly as returned by the model "
+        "listing for this bot."
+    ),
+]
+
 
 def _map_model(data: dict[str, Any]) -> Model:
     return Model(
@@ -54,7 +64,7 @@ def _map_model(data: dict[str, Any]) -> Model:
 @router.get("/{bot_id}", response_model=Envelope[Page[Model]])
 @envelope_errors
 async def list_models(
-    bot_id: str,
+    bot_id: BotIdPath,
     page: PageParamsDep,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -92,8 +102,8 @@ async def list_models(
 @router.get("/{bot_id}/{model_id:path}", response_model=Envelope[Model])
 @envelope_errors
 async def get_model(
-    bot_id: str,
-    model_id: str,
+    bot_id: BotIdPath,
+    model_id: ModelIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Path, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
     Deleted,
     Envelope,
     PageParamsDep,
@@ -54,6 +55,15 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 router = APIRouter(prefix="/openapi/v1/bots/sessions", tags=["sessions"])
+
+#: The path parameter naming the session an operation addresses.
+SessionIdPath = Annotated[
+    str,
+    Path(
+        description="The session's id, exactly as returned in a session "
+        "listing's session_id — use it verbatim, do not re-encode it."
+    ),
+]
 
 
 #: One extra item is requested beyond the page, purely to learn whether more
@@ -289,7 +299,7 @@ def _history_page(
 @router.get("/{bot_id}", response_model=Envelope[SessionPage])
 @envelope_errors
 async def list_sessions(
-    bot_id: str,
+    bot_id: BotIdPath,
     page: PageParamsDep,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -338,7 +348,7 @@ async def list_sessions(
 @router.post("/{bot_id}", status_code=201, response_model=Envelope[Session])
 @envelope_errors
 async def create_session(
-    bot_id: str,
+    bot_id: BotIdPath,
     body: SessionCreate,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -374,8 +384,8 @@ async def create_session(
 @router.get("/{bot_id}/{session_id}", response_model=Envelope[Session])
 @envelope_errors
 async def get_session(
-    bot_id: str,
-    session_id: str,
+    bot_id: BotIdPath,
+    session_id: SessionIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,
@@ -410,8 +420,8 @@ async def get_session(
 @router.patch("/{bot_id}/{session_id}", response_model=Envelope[Session])
 @envelope_errors
 async def update_session(
-    bot_id: str,
-    session_id: str,
+    bot_id: BotIdPath,
+    session_id: SessionIdPath,
     body: SessionUpdate,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -449,8 +459,8 @@ async def update_session(
 @router.delete("/{bot_id}/{session_id}", response_model=Envelope[Deleted])
 @envelope_errors
 async def delete_session(
-    bot_id: str,
-    session_id: str,
+    bot_id: BotIdPath,
+    session_id: SessionIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,
@@ -477,8 +487,8 @@ async def delete_session(
 @router.get("/{bot_id}/{session_id}/messages", response_model=Envelope[MessagePage])
 @envelope_errors
 async def list_session_messages(
-    bot_id: str,
-    session_id: str,
+    bot_id: BotIdPath,
+    session_id: SessionIdPath,
     page: PageParamsDep,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
@@ -523,8 +533,8 @@ async def list_session_messages(
 @router.delete("/{bot_id}/{session_id}/messages", response_model=Envelope[Deleted])
 @envelope_errors
 async def clear_session_messages(
-    bot_id: str,
-    session_id: str,
+    bot_id: BotIdPath,
+    session_id: SessionIdPath,
     user_id: UserIdDep,
     owner_id: OwnerIdDep,
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/enums.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/enums.py
@@ -1,0 +1,53 @@
+"""The base for published enums on the ``/openapi/v1/bots`` surface.
+
+IMPORTANT — everything a class or field docstring says in this package is
+published verbatim into the OpenAPI document that external tenants read.
+Docstrings are therefore caller-facing prose only. Rationale, upstream defects,
+internal component and route names, and deployment-tier details belong in ``#``
+comments like these, which are not published.
+
+Only value sets that are **genuinely closed at the source** may subclass this.
+An open set — one an upstream service or deployment configuration can extend —
+stays a plain ``str`` field whose description lists the known values, because
+validating a response against a set the source does not enforce turns a
+backward-compatible upstream change into a public 500. The engine-runtime
+enums module records the per-set rulings for its groups.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class _DocumentedEnum(str, Enum):
+    """Base for published enums; not itself part of the API."""
+
+    # member value -> caller-facing meaning. Every member must be covered; the
+    # schema-documentation gate fails the build otherwise.
+    __descriptions__: dict[str, str] = {}
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> Any:
+        schema = handler(core_schema)
+        if not cls.__descriptions__:
+            return schema
+        # OpenAPI has no native slot for per-member documentation, and the two
+        # dominant generators disagree on the extension:
+        #   openapi-generator reads x-enum-descriptions / x-enum-varnames as
+        #     ARRAYS positionally parallel to `enum`
+        #   NSwag reads x-enumNames
+        # Emit all three so a generated client actually carries the docs. Member
+        # order is declaration order in Pydantic, which is what makes the
+        # parallel-array form well-defined.
+        values = list(schema.get("enum", []))
+        schema["x-enum-descriptions"] = [
+            cls.__descriptions__.get(v, "") for v in values
+        ]
+        names = {m.value: m.name for m in cls}
+        schema["x-enum-varnames"] = [names.get(v, str(v)) for v in values]
+        schema["x-enumNames"] = list(schema["x-enum-varnames"])
+        return schema
+
+
+__all__ = ["_DocumentedEnum"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
@@ -12,11 +12,12 @@ openapi_v1 and not reachable through this API.
 
 from __future__ import annotations
 
+from typing import Annotated
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Path, Request
 
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
-from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.contracts import BotIdPath, Envelope
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -41,20 +42,32 @@ from .schemas import (
 
 router = APIRouter(prefix="/openapi/v1/bots/identity", tags=["identity"])
 
+#: The path parameter naming which identity file an operation addresses.
+FileTypePath = Annotated[
+    IdentityFileType,
+    Path(
+        description="Which identity file to address — one of the whitelisted "
+        "types (see the enum's per-value documentation for what each file is "
+        "for)."
+    ),
+]
+
 
 @router.get("/{bot_id}", response_model=Envelope[IdentityFileList])
 @envelope_errors
 async def list_bot_identity_files(
-    bot_id: str,
+    bot_id: BotIdPath,
     owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileList]:
-    """List a bot's identity files and whether each exists.
+    """List every identity file type a bot can carry and whether each exists.
 
-    I2: entity_type/entity_id/operator_id come from the authenticated
-    request's ``user_id`` parameter (personal bot owner = the named user).
+    A file reports exists false both when it is absent and when it exists
+    with empty content. Entry order is not guaranteed — key off type.
     """
+    # I2: entity_type/entity_id/operator_id come from the authenticated
+    # request's user_id parameter (personal bot owner = the named user).
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     presence = await identity_service.list_bot_files(
@@ -80,21 +93,23 @@ async def list_bot_identity_files(
 )
 @envelope_errors
 async def get_bot_identity_file(
-    bot_id: str,
-    file_type: IdentityFileType,
+    bot_id: BotIdPath,
+    file_type: FileTypePath,
     owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFile]:
     """Read one identity file of a bot.
 
-    I2: entity params come from the authenticated principal via
-    ``UserIdDep`` (personal bot owner = the named user). I3: ``publish_id`` is
-    not exposed — only draft-device reads (``get_bot_file`` default branch).
-    The service's ``validate_file_type`` requires the physical ``<type>.md``
-    form (``VALID_IDENTITY_FILES`` carries the suffix), so the enum value is
-    re-suffixed before forwarding.
+    A file that has never been written reads as an empty content string, not
+    an error. Reads address the bot's draft runtime.
     """
+    # I2: entity params come from the authenticated principal via UserIdDep
+    # (personal bot owner = the named user). I3: publish_id is not exposed —
+    # only draft-device reads (get_bot_file default branch). The service's
+    # validate_file_type requires the physical <type>.md form
+    # (VALID_IDENTITY_FILES carries the suffix), so the enum value is
+    # re-suffixed before forwarding.
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     file_type_md = f"{file_type.value}.md"
@@ -124,19 +139,20 @@ async def get_bot_identity_file(
 )
 @envelope_errors
 async def update_bot_identity_file(
-    bot_id: str,
-    file_type: IdentityFileType,
+    bot_id: BotIdPath,
+    file_type: FileTypePath,
     body: IdentityFileWrite,
     owner_id: UserIdDep,
     request: Request,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileRef]:
-    """Overwrite one identity file of a bot.
+    """Create or overwrite one identity file of a bot.
 
-    I2: entity params come from the authenticated principal via
-    ``UserIdDep`` as above; ``validate_file_type`` requires the
-    ``<type>.md`` form. Returns an ``IdentityFileRef`` (no content echoed).
+    A full replacement — the body's content becomes the whole file. The
+    response is a reference only; the content is not echoed back.
     """
+    # I2: entity params come from the authenticated principal via UserIdDep
+    # as above; validate_file_type requires the <type>.md form.
     entity_type = "staff"  # personal bot owner is a staff entity
     entity_id = owner_id
     file_type_md = f"{file_type.value}.md"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/schemas.py
@@ -1,14 +1,25 @@
-"""Request/response models for the identity (bot identity files) group."""
+"""Request/response models for the identity (bot identity files) group.
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
-from enum import StrEnum
+from pydantic import BaseModel, ConfigDict, Field
 
-from pydantic import BaseModel
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
 
-class IdentityFileType(StrEnum):
-    """Whitelisted identity-file types (physical file is ``<type>.md``)."""
+class IdentityFileType(_DocumentedEnum):
+    """The identity files a bot can carry (each stored as `<TYPE>.md`)."""
+
+    # A closed whitelist at the source: the identity service accepts exactly
+    # these file names and nothing else, so a documented enum is safe on both
+    # request and response. The per-member texts describe how the platform and
+    # the engines actually use each file; GREETING and README are accepted and
+    # stored but read only by engines/clients, not by the platform itself.
 
     RULES = "RULES"
     OKR = "OKR"
@@ -27,40 +38,156 @@ class IdentityFileType(StrEnum):
     GREETING = "GREETING"
     README = "README"
 
+    __descriptions__ = {
+        "RULES": "The bot's hard operating rules — constraints it must always "
+        "follow and lines it must never cross.",
+        "OKR": "The bot's objectives and key results — the goals it works "
+        "toward and is measured against.",
+        "SAFETY": "Safety boundaries and conduct rules — data the bot may not "
+        "touch and harms it must warn about.",
+        "SOUL": "The bot's persona — temperament, tone, communication style "
+        "and behavioural principles.",
+        "OUTPUT": "The required shape of the bot's answers — its output "
+        "format contract.",
+        "MEMORY": "Durable facts the bot carries between sessions; typically "
+        "written by the bot itself rather than authored by hand.",
+        "IDENTITY": "The bot's identity card — structured name, display name, "
+        "emoji and role, which other services parse to recognise the bot.",
+        "AGENTS": "The main instruction file the bot's engine boots from; on "
+        "some engines the platform maintains a reference section in it that "
+        "points at the other identity files.",
+        "USER": "Who the bot serves and how to talk to them — its default "
+        "audience and interaction posture.",
+        "TOOLS": "The capabilities the bot may use and the boundaries on "
+        "them.",
+        "HEARTBEAT": "The bot's periodic self-check — what to re-verify each "
+        "cycle and what to do when something is off.",
+        "BOOTSTRAP": "The bot's startup sequence — which identity files to "
+        "read in what order, and the first action after boot.",
+        "KNOWLEDGE": "The bot's domain knowledge and its source-priority "
+        "rules — which inputs win over which.",
+        "CLAUDE": "The instruction file consumed by bots on the Claude Code "
+        "engine.",
+        "GREETING": "The bot's opening greeting text; read by engines and "
+        "clients, not by the platform.",
+        "README": "Free-form human documentation about the bot.",
+    }
+
+
+# What `file_path` means, stated once: it is informational — the file is
+# addressed by its type, never by this path.
+_FILE_PATH_DESC = (
+    "Where the file lives inside the bot's identity namespace, e.g. "
+    "'identity/RULES.md'. Informational — address the file by its type, not "
+    "by this path."
+)
+
 
 class IdentityFileInfo(BaseModel):
     """One identity file's presence within a bot."""
 
-    type: IdentityFileType
-    exists: bool
-    file_path: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "type": "RULES",
+                "exists": True,
+                "file_path": "identity/RULES.md",
+            }
+        }
+    )
+
+    type: IdentityFileType = Field(description="Which identity file this is.")
+    # Derived from content presence, so empty-but-existing is reported False —
+    # stated in the description because a client cannot tell the two apart.
+    exists: bool = Field(
+        description="True when the file has content. A file that exists but "
+        "is empty reports false — empty and absent are indistinguishable."
+    )
+    file_path: str = Field(description=_FILE_PATH_DESC)
 
 
 class IdentityFileList(BaseModel):
     """All possible identity files for a bot and whether each exists."""
 
-    bot_id: str
-    files: list[IdentityFileInfo]
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "files": [
+                    {
+                        "type": "RULES",
+                        "exists": True,
+                        "file_path": "identity/RULES.md",
+                    },
+                    {
+                        "type": "SOUL",
+                        "exists": False,
+                        "file_path": "identity/SOUL.md",
+                    },
+                ],
+            }
+        }
+    )
+
+    bot_id: str = Field(description="The bot the listing describes.")
+    files: list[IdentityFileInfo] = Field(
+        description="One entry per known file type. Order is not guaranteed — "
+        "key off each entry's type."
+    )
 
 
 class IdentityFile(BaseModel):
     """A single identity file's content."""
 
-    type: IdentityFileType
-    bot_id: str
-    content: str
-    file_path: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "type": "RULES",
+                "bot_id": "20260813_a7k2m9p1",
+                "content": "# Rules\n- Never contact customers directly.\n",
+                "file_path": "identity/RULES.md",
+            }
+        }
+    )
+
+    type: IdentityFileType = Field(description="Which identity file this is.")
+    bot_id: str = Field(description="The bot the file belongs to.")
+    content: str = Field(
+        description="Full markdown content. Empty string when the file has "
+        "never been written — reading a missing file is not an error."
+    )
+    file_path: str = Field(description=_FILE_PATH_DESC)
 
 
 class IdentityFileRef(BaseModel):
     """Reference to an identity file (returned after a write)."""
 
-    type: IdentityFileType
-    bot_id: str
-    file_path: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "type": "RULES",
+                "bot_id": "20260813_a7k2m9p1",
+                "file_path": "identity/RULES.md",
+            }
+        }
+    )
+
+    type: IdentityFileType = Field(description="Which identity file was written.")
+    bot_id: str = Field(description="The bot the file belongs to.")
+    file_path: str = Field(description=_FILE_PATH_DESC)
 
 
 class IdentityFileWrite(BaseModel):
     """Write-an-identity-file request body."""
 
-    content: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"content": "# Rules\n- Never contact customers directly.\n"}
+        }
+    )
+
+    content: str = Field(
+        description="Full replacement content (markdown). The write creates "
+        "the file when absent and overwrites it entirely otherwise; send an "
+        "empty string to clear the file."
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
@@ -64,7 +64,7 @@ _AUTH = [Depends(require_principal)]
 @router.get("/hello", response_model=Envelope[HelloWorld], dependencies=_AUTH)
 @envelope_errors
 async def hello_world(request: Request) -> Envelope[HelloWorld]:
-    """Answer the constant ``hello world``.
+    """Answer the constant "hello world".
 
     Reads nothing and calls nothing, so the response time is the path's, not the
     handler's.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -20,9 +20,9 @@ bots slice took).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Path, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     USER_SCOPED_403,
@@ -69,6 +69,16 @@ from .schemas import (
 )
 
 router = APIRouter(prefix="/openapi/v1/bots/mcp", tags=["mcp"])
+
+#: The path parameter naming the MCP server an operation addresses.
+ServerCodePath = Annotated[
+    str,
+    Path(
+        description="The MCP server's code, exactly as returned by the server "
+        "listing — an opaque, case-sensitive identifier, e.g. "
+        "'mcp.example.weather'."
+    ),
+]
 
 
 # The caller's own identity is used as both entity id and (staff) entity type
@@ -157,10 +167,16 @@ def _to_config(cfg: Any) -> McpConfig:
 async def list_mcp_servers(
     request: Request,
     page_params: PageParamsDep,
-    keyword: str | None = None,
+    keyword: Annotated[
+        str | None,
+        Query(
+            description="Filter: case-insensitive fuzzy match against the "
+            "server's name and code."
+        ),
+    ] = None,
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[Page[McpServer]]:
-    """List marketplace MCP servers (filter by ``keyword``, paginate)."""
+    """List marketplace MCP servers (filter by keyword, paginate)."""
     # No ``user_id``: this operation has no user dimension to scope by. The
     # marketplace catalogue is identical for every caller in the tenant.
     # An authenticated caller is still required — ``_PUBLIC_AUTH`` in
@@ -209,7 +225,7 @@ async def list_mcp_tenants(
 )
 @envelope_errors
 async def get_mcp_server(
-    server_code: str,
+    server_code: ServerCodePath,
     request: Request,
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[McpServerDetail]:
@@ -233,27 +249,27 @@ async def get_mcp_server(
 )
 @envelope_errors
 async def check_mcp_permission(
-    server_code: str,
+    server_code: ServerCodePath,
     request: Request,
     owner_id: UserIdDep,
     auth_service: MCPAuthServiceProtocol = Injected(MCPAuthServiceProtocol),
 ) -> Envelope[McpPermission]:
     """Report the caller's own permission for an MCP server.
 
-    Always the caller's own permission. The identity is the request's required
-    ``user_id``, and it is refused unless it names the verified caller — so this
-    still cannot be pointed at someone else to probe their grants, which is the
-    property the internal route's free-form ``user_id`` query param does not
-    have. The parameter states whose permission is being asked about; it does
-    not widen whose it may be.
+    Always the caller's own permission: the required user_id must name the
+    verified caller, so this cannot be pointed at someone else to probe their
+    grants.
 
-    **Fail-open, by decision (spec Open Question 1).** When the marketplace
-    lookup errors, ``check_mcp_permission_detail`` reports the caller *as
-    permitted*. This surface preserves that rather than failing closed: the
-    endpoint is advisory — the MCP server itself is the enforcement point — so a
-    wrong "yes" during an upstream outage costs one failed call, whereas failing
-    closed would make a marketplace outage look like a permission revocation.
+    Advisory, and fail-open by design: when the marketplace lookup errors,
+    the answer reports the caller as permitted — the MCP server itself is the
+    enforcement point, so a wrong "yes" during an outage costs one failed
+    call, whereas failing closed would make an outage look like a permission
+    revocation.
     """
+    # The fail-open ruling is recorded in the MCP track's spec (Open Question
+    # 1); the identity property is what the internal route's free-form user_id
+    # query param does not have — the parameter states whose permission is
+    # being asked about, it does not widen whose it may be.
     result = auth_service.check_mcp_permission_detail(owner_id, server_code)
     return envelope(
         McpPermission(
@@ -275,15 +291,15 @@ async def check_mcp_permission(
 )
 @envelope_errors
 async def get_mcp_config(
-    server_code: str,
+    server_code: ServerCodePath,
     request: Request,
     owner_id: UserIdDep,
     config_service: MCPConfigServiceProtocol = Injected(MCPConfigServiceProtocol),
 ) -> Envelope[McpConfig]:
-    """Read the caller's unified config for an MCP server (``api_key`` masked).
+    """Read the caller's unified config for an MCP server (api_key masked).
 
     A server the caller has never configured is not an error — it returns
-    ``has_config: false`` with defaults.
+    has_config false with defaults.
     """
     cfg = read_unified_config(
         user_id=owner_id, server_code=server_code, config_service=config_service
@@ -298,7 +314,7 @@ async def get_mcp_config(
 )
 @envelope_errors
 async def update_mcp_config(
-    server_code: str,
+    server_code: ServerCodePath,
     body: McpConfigWrite,
     request: Request,
     owner_id: UserIdDep,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
@@ -1,4 +1,9 @@
-"""Request/response models for the MCP group."""
+"""Request/response models for the MCP group.
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
@@ -16,29 +21,132 @@ from pydantic import BaseModel, ConfigDict, Field
 # they are not guarded.
 _STRICT = ConfigDict(extra="forbid")
 
+_SERVER_CODE_DESC = (
+    "The server's unique identifier in the marketplace catalogue — an opaque, "
+    "case-sensitive string, e.g. 'mcp.example.weather'. Obtain it from the "
+    "server listing; do not parse it."
+)
+
+# The catalogue reads are pass-throughs of an upstream marketplace, so most
+# enum-looking strings here are upstream-defined open sets: the descriptions
+# name the known values without publishing a closed enum that a
+# backward-compatible catalogue change would violate. Only the two request
+# fields on McpConfigWrite are closed sets enforced by this API.
+_TRANSPORT_RESPONSE_DESC = (
+    "The MCP transport, as the catalogue publishes it — typically 'SSE' "
+    "(HTTP + Server-Sent Events), 'STREAMABLE_HTTP' (streamable HTTP), or "
+    "'STDIO' for a server the deployment runs locally. Echoed as published, "
+    "so casing can vary; null when the catalogue declares none."
+)
+
 
 class McpServer(BaseModel):
     """An MCP server in the marketplace."""
 
-    server_code: str
-    name: str
-    description: str | None = None
-    network_types: list[str] = Field(default_factory=list)
-    transport_protocol: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "server_code": "mcp.example.weather",
+                "name": "Weather",
+                "description": "Forecasts and current conditions.",
+                "network_types": ["INTERNET"],
+                "transport_protocol": "STREAMABLE_HTTP",
+            }
+        }
+    )
+
+    server_code: str = Field(description=_SERVER_CODE_DESC)
+    name: str = Field(description="The server's display name.")
+    description: str | None = Field(
+        default=None,
+        description="What the server offers; null when the catalogue has none.",
+    )
+    network_types: list[str] = Field(
+        default_factory=list,
+        description="Networks the server is reachable on, as the catalogue "
+        "declares them: 'INTERNET' — the public internet; 'OFFICE' — the "
+        "corporate network. Only servers reachable on at least one of those "
+        "two (or declaring none) are visible on this API. Empty when the "
+        "catalogue declares none.",
+    )
+    transport_protocol: str | None = Field(
+        default=None, description=_TRANSPORT_RESPONSE_DESC
+    )
 
 
 class McpServerDetail(McpServer):
     """An MCP server's detail, including its tools."""
 
-    tools: list[dict[str, Any]] = Field(default_factory=list)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "server_code": "mcp.example.weather",
+                "name": "Weather",
+                "description": "Forecasts and current conditions.",
+                "network_types": ["INTERNET"],
+                "transport_protocol": "STREAMABLE_HTTP",
+                "tools": [
+                    {
+                        "name": "getForecast",
+                        "description": "Forecast for a city and date range",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": "string"},
+                                "days": {"type": "integer"},
+                            },
+                            "required": ["city"],
+                        },
+                    }
+                ],
+            }
+        }
+    )
+
+    tools: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="The server's tools as the catalogue publishes them. Each "
+        "entry is one MCP tool declaration — typically 'name' (the callable "
+        "name), 'description', and 'inputSchema' (a JSON Schema for the "
+        "tool's arguments); any further catalogue keys pass through "
+        "unchanged.",
+    )
 
 
 class McpPermission(BaseModel):
     """The caller's permission for an MCP server."""
 
-    has_access: bool
-    access_level: str | None = None
-    tool_permissions: dict[str, Any] = Field(default_factory=dict)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "has_access": True,
+                "access_level": "PUBLIC",
+                "tool_permissions": {
+                    "getForecast": {"code": "AUTHORIZED", "name": "Authorized"},
+                    "setAlert": {"code": "UNAUTHORIZED", "name": "Unauthorized"},
+                },
+            }
+        }
+    )
+
+    has_access: bool = Field(
+        description="Whether the caller may use this server at all."
+    )
+    access_level: str | None = Field(
+        default=None,
+        description="The marketplace's access label for the server: 'PUBLIC' "
+        "or 'PRIVATE' for marketplace servers, 'LOCAL' for a server the "
+        "deployment serves itself, 'COMMUNITY' on community deployments. "
+        "Empty when the marketplace could not classify the server. Not a "
+        "closed set — treat unknown values as informational.",
+    )
+    tool_permissions: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Per-tool authorization, keyed by tool name. Each value "
+        "carries 'code' — the state, e.g. 'AUTHORIZED' or 'UNAUTHORIZED' — "
+        "and 'name', a display label whose language is deployment-defined. "
+        "Empty when the server is local, unknown, or declares no tools.",
+    )
 
 
 class McpTenant(BaseModel):
@@ -49,25 +157,72 @@ class McpTenant(BaseModel):
     catalog — every Avernet tenant sees the same MCP tenants.
     """
 
-    code: str
-    name: str
-    categories: list[str] = Field(default_factory=list)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "code": "default",
+                "name": "Community",
+                "categories": ["Productivity", "Developer Tools"],
+            }
+        }
+    )
+
+    code: str = Field(
+        description="The tenant's identifier in the marketplace catalogue, "
+        "e.g. 'default'."
+    )
+    name: str = Field(description="The tenant's display name.")
+    categories: list[str] = Field(
+        default_factory=list,
+        description="Category labels from the marketplace taxonomy — display "
+        "strings for grouping, not stable machine codes.",
+    )
+
+
+_ENDPOINT_ENV_DESC = (
+    "Which of the server's published endpoints the caller's bots connect to: "
+    "'PROD' — the production endpoint (the default); 'PRE' — the "
+    "pre-production endpoint, for testing against a server's staging "
+    "deployment."
+)
 
 
 class McpConfig(BaseModel):
     """The caller's unified config for an MCP server.
 
-    ``api_key`` is always returned masked (first/last four for a long key, fully
-    masked otherwise), never in full.
+    The api_key is always returned masked (first/last four characters for a
+    long key, fully masked otherwise), never in full.
     """
 
-    server_code: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "server_code": "mcp.example.weather",
+                "api_key": "auth****mnop",
+                "endpoint_env": "PROD",
+                "transport_protocol": "STREAMABLE_HTTP",
+                "headers": {"x-region": "eu-1"},
+                "has_config": True,
+            }
+        }
+    )
+
+    server_code: str = Field(description=_SERVER_CODE_DESC)
     api_key: str | None = Field(
         default=None, description="Masked API key; null when none is stored."
     )
-    endpoint_env: str
-    transport_protocol: str | None = None
-    headers: dict[str, str] = Field(default_factory=dict)
+    endpoint_env: str = Field(description=_ENDPOINT_ENV_DESC)
+    transport_protocol: str | None = Field(
+        default=None,
+        description="The caller's stored transport preference — 'SSE' or "
+        "'STREAMABLE_HTTP'; null when never set, in which case the server's "
+        "own published transport applies.",
+    )
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra HTTP headers sent to the server on every call; "
+        "empty when none are stored.",
+    )
     has_config: bool = Field(
         description="True when a stored config row exists for this server; "
         "false only when the caller has never configured it."
@@ -75,17 +230,45 @@ class McpConfig(BaseModel):
 
 
 class McpConfigWrite(BaseModel):
-    """Write the unified config. A null (omitted) field means "leave unchanged".
+    """Write the unified config. An omitted (null) field means "leave unchanged".
 
-    ``extra="forbid"``: an unknown field is a 422, not a silent no-op. In
-    particular the old ``sync_mode`` field is gone — the only push path is to
-    every device under the caller, so a per-device mode would advertise
-    something the server ignores.
+    The write is pushed to every device under the caller before it is
+    reported successful; a failed push rolls the change back and answers an
+    upstream error.
     """
 
-    model_config = _STRICT
+    # extra="forbid": an unknown field is a 422, not a silent no-op. In
+    # particular the old sync_mode field is gone — the only push path is to
+    # every device under the caller, so a per-device mode would advertise
+    # something the server ignores.
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "example": {
+                "api_key": "authorization=sk-abcdefghijklmnop",
+                "endpoint_env": "PROD",
+                "transport_protocol": "STREAMABLE_HTTP",
+            }
+        },
+    )
 
-    api_key: str | None = None
-    endpoint_env: Literal["PROD", "PRE"] | None = None
-    transport_protocol: Literal["SSE", "STREAMABLE_HTTP"] | None = None
-    headers: dict[str, str] | None = None
+    api_key: str | None = Field(
+        default=None,
+        description="New credential to store, or omit to leave unchanged. "
+        "Never send back the masked value from a read — it would be stored "
+        "literally and replace the real credential.",
+    )
+    endpoint_env: Literal["PROD", "PRE"] | None = Field(
+        default=None, description=_ENDPOINT_ENV_DESC
+    )
+    transport_protocol: Literal["SSE", "STREAMABLE_HTTP"] | None = Field(
+        default=None,
+        description="Transport preference to store: 'SSE' — HTTP + "
+        "Server-Sent Events; 'STREAMABLE_HTTP' — streamable HTTP. Omit to "
+        "leave unchanged.",
+    )
+    headers: dict[str, str] | None = Field(
+        default=None,
+        description="Replacement header map sent to the server on every "
+        "call; omit to leave unchanged.",
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -40,6 +40,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     NameCheck,
     Page,
     PageParamsDep,
+    error_example,
 )
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
@@ -146,6 +147,7 @@ _TOO_LARGE_RESPONSE: dict[int | str, dict[str, object]] = {
         "model": ErrorEnvelope,
         "description": "File exceeds the size the provider will serve, or the "
         "1 MB preview cap.",
+        **error_example(413, "File too large for preview"),
     },
 }
 # The group is already user-scoped, so it carries ``USER_SCOPED_403`` from
@@ -159,6 +161,7 @@ _READ_ONLY_RESPONSE: dict[int | str, dict[str, object]] = {
         "description": "The path is read-only — a dotfile, or a workspace-root "
         "identity file — or the user_id names a user the authenticated caller "
         "may not act for.",
+        **error_example(403, "Forbidden"),
     },
 }
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from typing import Annotated
 
 import httpx
-from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Body, HTTPException, Path, Query, Request, Response
 
 from agentclaw.community.api.resource_service import ResourceServiceFactoryProtocol
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
@@ -235,6 +235,28 @@ def _file_coords(
 
 router = APIRouter(prefix="/openapi/v1/bots/resources", tags=["resources"])
 
+#: The query parameter addressing a file or folder, documented once. Kept as an
+#: Annotated default so handlers stay directly callable in tests.
+FilePathQuery = Annotated[
+    str,
+    Query(
+        description="Workspace-relative path of the file or folder, e.g. "
+        "'docs/spec/a.txt' — exactly as returned in a listing entry's "
+        "`path`. A leading slash is tolerated; '..' segments are refused "
+        "(400)."
+    ),
+]
+
+#: The path parameter naming a link resource, documented once.
+ResourceIdPath = Annotated[
+    str,
+    Path(
+        description="The link resource's id, as returned by the listing or "
+        "create response (decimal digits, e.g. '42'). Files and folders "
+        "have no id — address them by `path` on the path-based endpoints."
+    ),
+]
+
 
 @router.get("", response_model=Envelope[Page[Resource]])
 @envelope_errors
@@ -246,7 +268,14 @@ async def list_resources(
     path: str = Query(
         "", description="Directory to list, relative to the workspace root."
     ),
-    type: ResourceType | None = None,
+    type: Annotated[
+        ResourceType | None,
+        Query(
+            description="Filter: 'file' or 'folder' lists only workspace "
+            "entries of that kind; 'link' returns only the bot's links "
+            "(path is then ignored). Omit for everything."
+        ),
+    ] = None,
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
@@ -263,8 +292,9 @@ async def list_resources(
     presence on any device, so the record *is* the resource. They are read from
     the repo and appended.
 
-    ``path`` selects the directory (empty = workspace root). Listing is
-    non-recursive, which bounds the device round trip this endpoint now makes.
+    The path parameter selects the directory (empty = workspace root).
+    Listing is non-recursive, which bounds the device round trip this
+    endpoint makes.
     """
     safe = _safe_path(path)
     entries: list[Resource] = []
@@ -339,12 +369,32 @@ async def list_resources(
 async def check_resource_name(
     owner_id: UserIdDep,
     request: Request,
-    # Plain defaults rather than ``Query(...)``: FastAPI still treats them as
-    # query parameters, and the handler stays directly callable in tests without
-    # a ``Query`` sentinel standing in for a string.
-    name: str = "",
-    path: str = "",
-    type: ResourceType | None = None,
+    # Annotated defaults rather than ``Query(...)`` defaults: FastAPI treats
+    # them as query parameters either way, and the plain default keeps the
+    # handler directly callable in tests without a ``Query`` sentinel standing
+    # in for a string.
+    name: Annotated[
+        str,
+        Query(
+            description="Link name to check against the bot's link records "
+            "(exact, case-sensitive match). Supply this or path."
+        ),
+    ] = "",
+    path: Annotated[
+        str,
+        Query(
+            description="Workspace-relative path to check for a file or "
+            "folder, e.g. 'docs/spec.md'. When given, the file check runs "
+            "and name is ignored."
+        ),
+    ] = "",
+    type: Annotated[
+        ResourceType | None,
+        Query(
+            description="Addressing hint: 'file' or 'folder' forces the "
+            "workspace check; otherwise a supplied path decides."
+        ),
+    ] = None,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
@@ -353,15 +403,15 @@ async def check_resource_name(
     """Whether a resource already exists.
 
     Two parameters because there are two kinds of resource, addressed
-    differently. A **file** is checked against the workspace by ``path`` — the
-    same question the upload asks before writing, answered by the same authority,
-    so the two can never disagree. A **link** is checked by ``name`` against the
-    records, because a link has no file.
-
-    A caller supplying ``path`` gets the file check; otherwise it is the link
-    check. Splitting the two surfaces entirely would be cleaner than one endpoint
-    with two addressing modes, but that is a larger contract change than this one.
+    differently. A file or folder is checked against the workspace by path —
+    the same question the upload asks before writing, answered by the same
+    authority, so the two can never disagree. A link is checked by name
+    against the records, because a link has no file. Supplying path gets the
+    file check; otherwise it is the link check.
     """
+    # Splitting the two surfaces entirely would be cleaner than one endpoint
+    # with two addressing modes, but that is a larger contract change than
+    # this one.
     # Neither addressing mode supplied. Both parameters carry plain defaults so
     # that one may be omitted, which costs FastAPI's required-parameter check —
     # so the "at least one" rule is enforced here instead. Without it the link
@@ -451,7 +501,7 @@ async def create_resource(
 @envelope_errors
 async def upload_resource(
     owner_id: UserIdDep,
-    path: str,
+    path: FilePathQuery,
     content: Annotated[bytes, Body(media_type="application/octet-stream")],
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
@@ -461,16 +511,17 @@ async def upload_resource(
 ) -> Envelope[Resource]:
     """Upload a file's raw bytes into the bot's workspace.
 
-    ``path`` is workspace-relative and carries its own directories
-    (``docs/spec/a.txt``); intermediate ones are created by the engine. There is
-    no separate name or parent-directory parameter — the directory is part of the
-    path, and ``path`` is the same spelling every other file endpoint uses.
-
-    The write goes through ``ResourceFileService``, the same service the console
-    uses, so both surfaces compose the workspace address identically and cannot
-    drift. ``owner_id`` comes from the request's ``user_id`` (``UserIdDep``),
-    fail-closed — mirroring the bots router.
+    The body is the file's raw bytes (content type application/octet-stream),
+    not a multipart form. The path is workspace-relative and carries its own
+    directories ('docs/spec/a.txt'); intermediate ones are created as needed
+    — there is no separate name or parent-directory parameter. An occupied
+    path answers 409; the size limit is 500 MB, and only common document,
+    code, image and archive extensions are accepted (400 otherwise).
     """
+    # The write goes through ResourceFileService, the same service the console
+    # uses, so both surfaces compose the workspace address identically and
+    # cannot drift. owner_id comes from the request's user_id (UserIdDep),
+    # fail-closed — mirroring the bots router.
     safe = _safe_path(path)
     if not safe:
         raise InvalidResourcePathError("path is required")
@@ -662,7 +713,7 @@ async def _read_file_or_404(
 @envelope_errors
 async def download_file(
     owner_id: UserIdDep,
-    path: str,
+    path: FilePathQuery,
     # Required by ``@envelope_errors`` to locate the request: without it the
     # decorator cannot build an error envelope and re-raises instead, so a
     # rejected path would surface as a 500 rather than a 400. The success path
@@ -674,10 +725,11 @@ async def download_file(
 ) -> Response:
     """Stream a file's bytes from the bot's workspace, addressed by path.
 
-    Raw bytes, not an envelope — the body is the file. Replaces the former
-    ``/{resource_id}/download``: a record id cannot address a file the bot
-    created itself, and the record is no longer what decides existence.
+    Raw bytes, not an envelope — the body is the file.
     """
+    # Replaces the former /{resource_id}/download: a record id cannot address
+    # a file the bot created itself, and the record is no longer what decides
+    # existence.
     content = await _read_file_or_404(
         file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=path
     )
@@ -692,7 +744,7 @@ async def download_file(
 @envelope_errors
 async def preview_file(
     owner_id: UserIdDep,
-    path: str,
+    path: FilePathQuery,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     bot_repo: BotRepository = Injected(BotRepository),
@@ -730,7 +782,7 @@ async def preview_file(
 @envelope_errors
 async def delete_file(
     owner_id: UserIdDep,
-    path: str,
+    path: FilePathQuery,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
@@ -796,19 +848,21 @@ async def delete_file(
 @envelope_errors
 async def create_directory(
     owner_id: UserIdDep,
-    path: str,
+    path: FilePathQuery,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
 ) -> Envelope[Resource]:
-    """Create a directory in the bot's workspace.
+    """Create a directory in the bot's workspace, addressed by path.
 
-    Physical only — no FOLDER record is written, and ``POST ""`` with
-    ``type=FOLDER`` still returns 501. Directories exist on the filesystem and
-    are reported by listing it; giving them records would reintroduce exactly
-    the record-vs-filesystem divergence this change removes.
+    Intermediate directories are created as needed. Directories exist on the
+    workspace filesystem only and are reported by listing it — they have no
+    record and no resource id.
     """
+    # No FOLDER record is written, and the create endpoint's type=folder still
+    # returns 501: giving directories records would reintroduce exactly the
+    # record-vs-filesystem divergence this change removed.
     safe = _safe_path(path)
     if not safe:
         raise InvalidResourcePathError("path is required")
@@ -835,20 +889,20 @@ async def create_directory(
 @router.get("/{resource_id}", response_model=Envelope[Resource])
 @envelope_errors
 async def get_resource(
-    resource_id: str,
+    resource_id: ResourceIdPath,
     user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
 ) -> Envelope[Resource]:
-    """Get a **link** resource by record id.
+    """Get a link resource by id.
 
-    A file id 404s here, mirroring ``DELETE /{resource_id}``: serving a file
-    from its record would report size and name from a row that nothing keeps in
-    step with the workspace, which is the divergence this change removes. A
-    file's address is its path — ``GET ""?path=`` lists it, ``GET /download``
-    and ``GET /preview`` serve it.
+    Only links are served by id — a file's id answers 404 here. A file's
+    address is its path: the listing shows it, and download/preview serve it.
     """
+    # Serving a file from its record would report size and name from a row
+    # nothing keeps in step with the workspace, which is the divergence this
+    # change removed.
     del user_id  # not-yet-enforced ownership — see list_resources
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
@@ -863,25 +917,23 @@ async def get_resource(
 @router.put("/{resource_id}", response_model=Envelope[Resource])
 @envelope_errors
 async def update_resource(
-    resource_id: str,
+    resource_id: ResourceIdPath,
     body: ResourceUpdate,
     user_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
 ) -> Envelope[Resource]:
-    """Update a **link** resource by record id (rename / url change).
+    """Rename a link resource and/or change its URL, by id.
 
-    ``link_type`` is intentionally not exposed on the openapi contract.
-    ValueError from the service (not found / url clash) → 409 Conflict, per
-    legacy + create parity.
-
-    A file id 404s, completing what ``GET`` and ``DELETE /{resource_id}``
-    already do. ``update_link_resource`` checks no type, so a stale file id
-    would otherwise rename a FILE row that nothing reads — the response would
-    even show the new name, while the workspace, which is what every file
-    response is actually built from, is untouched.
+    Only links are updatable by id — a file's id answers 404. A name or URL
+    clash with an existing link answers 409.
     """
+    # link_type is intentionally not exposed on the openapi contract.
+    # ValueError from the service (not found / url clash) → 409 Conflict, per
+    # legacy + create parity. A file id 404s, completing what GET and DELETE
+    # /{resource_id} already do: update_link_resource checks no type, so a
+    # stale file id would otherwise rename a FILE row that nothing reads.
     del user_id  # not-yet-enforced ownership — see list_resources
     effective_bot_id = bot_id
     service = factory.create(bot_id=effective_bot_id)
@@ -901,25 +953,24 @@ async def update_resource(
 @router.delete("/{resource_id}", response_model=Envelope[Deleted])
 @envelope_errors
 async def delete_resource(
-    resource_id: str,
+    resource_id: ResourceIdPath,
     owner_id: UserIdDep,
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
 ) -> Envelope[Deleted]:
-    """Delete a **link** resource by record id.
+    """Delete a link resource by id.
 
-    Files are no longer addressed this way — they live in the workspace and are
-    deleted through ``DELETE ""?path=``. A link has no file, so the record is
-    the resource and the record id is the only address it can have. A file id
-    sent here resolves to nothing and 404s, which is also the right answer for
-    a stale id from before the change.
-
-    No device is touched, so this must not require a bound one: the former
-    unconditional ``resolve_for_bot`` raised DeviceNotBoundError (409) on an
-    unbound bot even for a link, which is the follow-up that removing the file
-    branch resolves.
+    Only links are deleted by id — files and folders are deleted through the
+    path-addressed delete. A file's id answers 404. Works whether or not the
+    bot currently has a live device.
     """
+    # A link has no file, so the record is the resource and the record id is
+    # the only address it can have; a stale file id from before the change
+    # resolves to nothing and 404s, which is the right answer for it too. No
+    # device is touched, so this must not require a bound one: the former
+    # unconditional resolve_for_bot raised DeviceNotBoundError (409) on an
+    # unbound bot even for a link.
     service = factory.create(bot_id=bot_id)
     # Refuse a FILE row explicitly. ``delete_resource`` would otherwise accept
     # one, skip the device because ``device_fs`` is None, soft-delete the row and

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/schemas.py
@@ -1,70 +1,192 @@
-"""Request/response models for the resources group (unified files + links)."""
+"""Request/response models for the resources group (unified files + links).
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
-from enum import StrEnum
+from pydantic import BaseModel, ConfigDict, Field
 
-from pydantic import BaseModel
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
 
-class ResourceType(StrEnum):
+class ResourceType(_DocumentedEnum):
     """A resource is a file, an external link, or a folder."""
 
     FILE = "file"
     LINK = "link"
     FOLDER = "folder"
 
+    __descriptions__ = {
+        "file": "A file in the bot's workspace, addressed by its "
+        "workspace-relative path.",
+        "link": "An external URL saved for the bot, addressed by its "
+        "resource id.",
+        "folder": "A directory in the bot's workspace, addressed by its "
+        "workspace-relative path.",
+    }
+
 
 class Resource(BaseModel):
     """A resource: a file or folder in the bot's workspace, or an external link.
 
-    The container's own storage layout is never exposed — ``path`` is relative to
-    the workspace root, not the engine-view absolute path the device returns.
+    The container's own storage layout is never exposed — `path` is relative to
+    the workspace root, not to any real filesystem the bot runs on.
     """
 
-    resource_id: str
-    name: str
-    type: ResourceType
-    source: str | None = None  # e.g. "yuque" for a link resource
-    url: str | None = None  # link URL for LINK resources
-    size: int | None = None
-    #: Workspace-relative path of a file or folder, e.g. ``docs/spec/a.txt``.
-    #: This is the addressing key: it is what ``?path=`` takes on download,
-    #: preview and delete, so a client can pass a listing entry straight back.
-    #: It is the *whole* path, not the directory — ``name`` is its last segment,
-    #: kept because a LINK has a name and no path. ``None`` for links.
-    path: str | None = None
-    #: ``None`` for a file the bot created itself. The device's directory listing
-    #: carries no timestamps (``FileEntry`` is name/path/relative_path/is_dir/size),
-    #: so these come from the resource record — which exists for an uploaded file
-    #: and for a link, but not for a file that was never uploaded through this API.
-    #: Names kept DB-flavoured on purpose: they are the prevailing openapi_v1
-    #: convention (sessions, routines), and renaming only this group would deepen
-    #: the split with ``skills``, which uses ``created_at``/``updated_at``.
-    gmt_create: str | None = None
-    gmt_modified: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "resource_id": "",
+                "name": "spec.md",
+                "type": "file",
+                "source": None,
+                "url": None,
+                "size": 2048,
+                "path": "docs/spec.md",
+                "gmt_create": None,
+                "gmt_modified": None,
+            }
+        }
+    )
+
+    resource_id: str = Field(
+        description="Identifier of the resource's stored record — decimal "
+        "digits for a link, e.g. '42'. Empty for files and folders, which "
+        "have no record: address those by `path` instead."
+    )
+    name: str = Field(
+        description="Display name. For a file or folder this is the last "
+        "segment of `path`; a link has only a name."
+    )
+    type: ResourceType = Field(description="What kind of resource this is.")
+    # Pass-through of the record's provenance column; only links surface a
+    # record on this API, so files/folders read null here.
+    source: str | None = Field(
+        default=None,
+        description="How the resource record came to exist — e.g. 'manual' "
+        "for a link created through this API, 'upload' for an uploaded "
+        "file's record. Null for files and folders read straight from the "
+        "workspace, which have no record.",
+    )
+    url: str | None = Field(
+        default=None,
+        description="The link's URL; null for files and folders.",
+    )
+    size: int | None = Field(
+        default=None,
+        description="Size in bytes; null when not reported (links, and "
+        "entries whose listing carries no size).",
+    )
+    path: str | None = Field(
+        default=None,
+        description="Workspace-relative path of a file or folder, e.g. "
+        "'docs/spec/a.txt' — the whole path, not the directory; `name` is "
+        "its last segment. This is the addressing key: pass it as `path` on "
+        "download, preview, upload and delete exactly as listed. Null for "
+        "links.",
+    )
+    gmt_create: str | None = Field(
+        default=None,
+        description="When the record was created (ISO 8601, no timezone "
+        "designator). Null for files and folders read straight from the "
+        "workspace — their listing carries no timestamps.",
+    )
+    gmt_modified: str | None = Field(
+        default=None,
+        description="When the record last changed (ISO 8601, no timezone "
+        "designator); null for files and folders read straight from the "
+        "workspace.",
+    )
+    # Timestamp field names kept DB-flavoured on purpose: they are the
+    # prevailing openapi_v1 convention (sessions, routines), and renaming only
+    # this group would deepen the split with `skills`, which uses
+    # created_at/updated_at.
 
 
 class ResourceCreate(BaseModel):
-    """Create a resource. ``url`` is required for a link, ``parent_id`` optional."""
+    """Create a link resource.
 
-    name: str
-    type: ResourceType
-    url: str | None = None
-    parent_id: str | None = None
+    Only links are created here: files are created through the upload
+    endpoint (a file request answers 400 pointing there), and folders through
+    the mkdir endpoint (a folder request answers 501).
+    """
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "name": "Team wiki",
+                "type": "link",
+                "url": "https://wiki.example.com/team",
+            }
+        }
+    )
+
+    name: str = Field(
+        description="Display name for the link; a duplicate of an existing "
+        "link answers 409."
+    )
+    type: ResourceType = Field(
+        description="What to create. Only 'link' is accepted here — see the "
+        "model description for where files and folders are created."
+    )
+    url: str | None = Field(
+        default=None,
+        description="The URL the link points to. Required when type is "
+        "'link' (400 when missing).",
+    )
+    parent_id: str | None = Field(
+        default=None,
+        description="Accepted for compatibility and currently ignored — "
+        "links are not placed in folders.",
+    )
 
 
 class ResourceUpdate(BaseModel):
-    """Partial update of a resource."""
+    """Partial update of a link resource. Omitted fields are left unchanged."""
 
-    name: str | None = None
-    url: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"name": "Team wiki (new)"}}
+    )
+
+    name: str | None = Field(
+        default=None, description="New display name; omit to keep."
+    )
+    url: str | None = Field(default=None, description="New URL; omit to keep.")
 
 
 class Preview(BaseModel):
-    """A resource preview."""
+    """A file's preview content."""
 
-    resource_id: str
-    content_type: str
-    preview_url: str | None = None
-    content: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "resource_id": "",
+                "content_type": "application/octet-stream",
+                "preview_url": None,
+                "content": "# Spec\nThe gateway forwards…",
+            }
+        }
+    )
+
+    resource_id: str = Field(
+        description="Always empty — previews address files by their `path`."
+    )
+    content_type: str = Field(
+        description="MIME label of the returned content; currently always "
+        "'application/octet-stream' — the server does not classify further."
+    )
+    preview_url: str | None = Field(
+        default=None,
+        description="Reserved for a URL-based preview; currently always null "
+        "— the content is returned inline instead.",
+    )
+    content: str | None = Field(
+        default=None,
+        description="The file's content decoded as UTF-8, with undecodable "
+        "bytes replaced. Files over the preview size limit (1 MB) are "
+        "refused with 413 rather than truncated; an empty file previews as "
+        "an empty string.",
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
@@ -8,9 +8,9 @@ requires an authenticated user principal.
 from __future__ import annotations
 
 from datetime import datetime, timezone as _tz
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Path, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     ActingCallerDep,
@@ -38,6 +38,26 @@ from agentclaw.community.di import Injected
 from .schemas import Routine, RoutineCreate, RoutineRun, RoutineUpdate, ScheduleTrigger
 
 router = APIRouter(prefix="/openapi/v1/bots/routines", tags=["routines"])
+
+#: The path parameter naming the routine an operation addresses.
+RoutineIdPath = Annotated[
+    str,
+    Path(
+        description="The routine's id, exactly as returned on create or in "
+        "the listing — an opaque string; treat it as a token."
+    ),
+]
+
+#: Routines are addressed (routine_id, bot_id) together: the id alone does not
+#: say which bot's engine holds it, so every per-routine operation requires the
+#: bot in the query string.
+RoutineBotIdQuery = Annotated[
+    str,
+    Query(
+        description="The bot the routine belongs to — required, because a "
+        "routine id alone does not identify the bot that holds it."
+    ),
+]
 
 
 def _ms_to_iso(ms: Any) -> str:
@@ -102,19 +122,25 @@ def _map_run(data: dict, routine_id: str) -> RoutineRun:
 async def list_routines(
     page: PageParamsDep,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: Annotated[
+        str, Query(description="The bot whose routines to list.")
+    ],
     request: Request,
-    status: str | None = None,
+    status: Annotated[
+        str | None,
+        Query(
+            description="Reserved; currently ignored — the full set is "
+            "returned. Filter client-side on `enabled`."
+        ),
+    ] = None,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Page[Routine]]:
-    """List routines (filter + paginate).
-
-    ``status`` is an openapi query hint with no direct field on ``Routine``
-    (which only carries ``enabled``). It is currently a no-op: the adapter
-    does not expose a status filter at the list seam, so we return the full
-    set and let the client filter on ``enabled``. Wire a server-side filter
-    here only if/when the engine surfaces a status dimension.
-    """
+    """List a bot's routines (paginated)."""
+    # `status` is an openapi query hint with no direct field on `Routine`
+    # (which only carries `enabled`). It is currently a no-op: the adapter
+    # does not expose a status filter at the list seam, so we return the full
+    # set and let the client filter on `enabled`. Wire a server-side filter
+    # here only if/when the engine surfaces a status dimension.
     user_id = owner_id
     nick_name = owner_id
     # Draft only, like every other route in this group: the public surface
@@ -147,21 +173,23 @@ async def create_routine(
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Routine]:
-    """Create a routine.
+    """Create a routine on a bot.
 
-    The only operation in this group whose bot is in the **body**, so the grant
-    check cannot run as a dependency — the body is not parsed yet when those
-    resolve. It runs here instead, immediately after parsing and **before any
-    service call**, which is the same guarantee in a different place. The
-    shared dependency defers for exactly this operation (it is named in
-    ``admission.py``), so nothing checks it twice and nothing skips it.
-
-    Translates the openapi ``RoutineCreate`` body into the engine adapter
-    cron body shape: ``schedule`` is the raw cron expression STRING (not
-    the nested ``{kind,expr,tz}`` dict — the adapter wraps it on read in
-    ``device_adapter_transport._build_item``), and ``timezone`` defaults
-    to ``Asia/Shanghai`` to match legacy ``cron/router.py``'s create path.
+    The schedule fires in the routine's timezone, which defaults to
+    Asia/Shanghai when omitted. Each firing starts a fresh session and hands
+    the bot the command as its user message.
     """
+    # The only operation in this group whose bot is in the body, so the grant
+    # check cannot run as a dependency — the body is not parsed yet when those
+    # resolve. It runs here instead, immediately after parsing and before any
+    # service call, which is the same guarantee in a different place. The
+    # shared dependency defers for exactly this operation (it is named in
+    # admission.py), so nothing checks it twice and nothing skips it.
+    #
+    # Translation to the engine adapter cron body shape: schedule is the raw
+    # cron expression STRING (not the nested {kind,expr,tz} dict — the adapter
+    # wraps it on read in device_adapter_transport._build_item), and timezone
+    # defaults to Asia/Shanghai to match legacy cron/router.py's create path.
     bot_id = body.bot_id
     # Before anything else touches the bot.
     caller.require_bot(bot_id, owner_id=owner_id)
@@ -190,19 +218,22 @@ async def create_routine(
 @router.get("/{routine_id}", response_model=Envelope[Routine])
 @envelope_errors
 async def get_routine(
-    routine_id: str,
+    routine_id: RoutineIdPath,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: RoutineBotIdQuery,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Routine]:
     """Get a routine.
 
-    C3: the path carries only ``routine_id`` (no routine table to
-    reverse-map to a bot), so ``bot_id`` is a required query. Owner
-    identity comes from the authenticated principal via
-    ``UserIdDep``. Missing/non-dict ``data`` collapses to 404.
+    The bot_id query parameter is required — a routine id alone does not
+    identify the bot that holds it. Note the returned bot_id may be empty on
+    this read; keep the one you queried with.
     """
+    # C3: the path carries only routine_id (no routine table to reverse-map
+    # to a bot), so bot_id is a required query. Owner identity comes from the
+    # authenticated principal via UserIdDep. Missing/non-dict data collapses
+    # to 404.
     user_id = owner_id
     nick_name = owner_id
     result = await factory.get_cron_detail(
@@ -217,21 +248,22 @@ async def get_routine(
 @router.patch("/{routine_id}", response_model=Envelope[Routine])
 @envelope_errors
 async def update_routine(
-    routine_id: str,
+    routine_id: RoutineIdPath,
     body: RoutineUpdate,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: RoutineBotIdQuery,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Routine]:
-    """Update a routine (partial).
+    """Update a routine. Omitted fields are left unchanged.
 
-    C3: ``bot_id`` is a required query (see ``get_routine``). Partial
-    update: only set fields flow to the adapter. ``trigger.cron`` becomes
-    a raw ``schedule`` STRING (not a ``{kind,expr,tz}`` dict — the adapter
-    wraps it on read; Task 3 contract). Missing/non-dict ``data`` on the
-    response collapses to 404.
+    When sending a new trigger, send the timezone with it — a trigger update
+    without one resets the schedule's zone to the default.
     """
+    # C3: bot_id is a required query (see get_routine). Partial update: only
+    # set fields flow to the adapter. trigger.cron becomes a raw schedule
+    # STRING (not a {kind,expr,tz} dict — the adapter wraps it on read; Task 3
+    # contract). Missing/non-dict data on the response collapses to 404.
     user_id = owner_id
     nick_name = owner_id
     update_body: dict = {}
@@ -261,23 +293,23 @@ async def update_routine(
 @router.delete("/{routine_id}", response_model=Envelope[Deleted])
 @envelope_errors
 async def delete_routine(
-    routine_id: str,
+    routine_id: RoutineIdPath,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: RoutineBotIdQuery,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Deleted]:
     """Delete a routine.
 
-    C3: ``bot_id`` is a required query (path carries only ``routine_id``).
-    ``delete_cron`` only operates on the draft stage; a published-stage delete
-    raises ``CronRelayError`` (error_code 403), mapped here (the code is dynamic
-    per-raise, so not in the static ``ENVELOPE_ERRORS`` map). A failed draft
-    delete is NOT surfaced as ``200 {deleted: false}`` — a missing routine_id
-    maps to 404 and a relay timeout to 502. The engine result distinguishes the
-    two only via its ``error`` text today; a structured engine ``error_code``
-    would make timeout-vs-missing precise (follow-up).
+    A failure is never reported as a successful delete: an unknown routine
+    answers 404 and a timeout answers 502.
     """
+    # C3: bot_id is a required query (path carries only routine_id).
+    # delete_cron only operates on the draft stage; a published-stage delete
+    # raises CronRelayError (error_code 403), mapped here (the code is dynamic
+    # per-raise, so not in the static ENVELOPE_ERRORS map). The engine result
+    # distinguishes timeout-vs-missing only via its error text today; a
+    # structured engine error_code would make that precise (follow-up).
     user_id = owner_id
     nick_name = owner_id
     try:
@@ -304,23 +336,24 @@ async def delete_routine(
 @router.post("/{routine_id}/run", response_model=Envelope[RoutineRun])
 @envelope_errors
 async def run_routine(
-    routine_id: str,
+    routine_id: RoutineIdPath,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: RoutineBotIdQuery,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[RoutineRun]:
-    """Run a routine now.
+    """Trigger a routine now.
 
-    C3: ``bot_id`` is a required query. ``run_cron`` returns
-    ``{"success":..,"data":{"ok":..,"ran":..,"reason":..}}`` — no run_id, no
-    timestamps. We synthesize ``run_id`` from ``routine_id`` + the handler's
-    UTC trigger timestamp (uniqueness is good enough for an immediate-trigger
-    echo; the engine has no run_id to return). ``status`` is derived from
-    ``ran``/``reason``: completed | failed | unknown. ``started_at`` /
-    ``finished_at`` are None because the adapter doesn't surface them on the
-    run-trigger seam (use ``GET /{routine_id}/runs`` for actual timestamps).
+    The response describes the trigger attempt, not a finished run: status is
+    'completed' (the engine acknowledged the trigger), 'failed' (it declined,
+    with a reason) or 'unknown', and both timestamps are null. Read the runs
+    listing for actual execution results and timings.
     """
+    # bot_id is a required query (C3). run_cron returns
+    # {"success":..,"data":{"ok":..,"ran":..,"reason":..}} — no run_id, no
+    # timestamps. run_id is synthesized from routine_id + the handler's UTC
+    # trigger timestamp (uniqueness good enough for an immediate-trigger echo;
+    # the engine has no run_id to return).
     user_id = owner_id
     nick_name = owner_id
     result = await factory.run_cron(
@@ -354,22 +387,24 @@ async def run_routine(
 )
 @envelope_errors
 async def list_routine_runs(
-    routine_id: str,
+    routine_id: RoutineIdPath,
     page: PageParamsDep,
     owner_id: UserIdDep,
-    bot_id: str,
+    bot_id: RoutineBotIdQuery,
     request: Request,
     factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
 ) -> Envelope[Page[RoutineRun]]:
-    """List a routine's execution history.
+    """List a routine's execution history, most recent first.
 
-    C3: ``bot_id`` is a required query. ``get_cron_runs`` returns
-    ``{"success":..,"data":{"runs":[{job_id, started_at_ms, finished_at_ms,
-    status, ...}]}}`` in draft mode (``_forward_single_stage_request``
-    passthrough; ``_decorate_single_result`` only adds bot_metadata fields to
-    ``data``, leaving ``runs`` intact). We map each entry via ``_map_run``
-    and paginate client-side.
+    The engine keeps a bounded history per routine, so deep pages come back
+    empty by construction.
     """
+    # bot_id is a required query (C3). get_cron_runs returns
+    # {"success":..,"data":{"runs":[{job_id, started_at_ms, finished_at_ms,
+    # status, ...}]}} in draft mode (_forward_single_stage_request
+    # passthrough; _decorate_single_result only adds bot_metadata fields to
+    # data, leaving runs intact). Each entry maps via _map_run; pagination is
+    # client-side over the fetched set.
     user_id = owner_id
     nick_name = owner_id
     result = await factory.get_cron_runs(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py
@@ -1,60 +1,194 @@
-"""Request/response models for the routines group (was cron)."""
+"""Request/response models for the routines group (was cron).
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+# `command` is a natural-language instruction handed to the bot as the user
+# message of a fresh session at fire time — the name is legacy, it was never a
+# shell command. Stated once here and reused so create/read cannot drift.
+_COMMAND_DESC = (
+    "The instruction the bot receives when the routine fires — free-form "
+    "natural language, delivered as the user message of a fresh session per "
+    "run. Not a shell command."
+)
+
+_TIMEZONE_DESC = (
+    "IANA time-zone name the schedule is evaluated in, e.g. 'Asia/Shanghai' "
+    "(the default when omitted on create). When updating the trigger, send "
+    "the timezone alongside it — a trigger update without one resets the "
+    "schedule to its default zone."
+)
 
 
 class ScheduleTrigger(BaseModel):
     """A schedule trigger. Modeled as a typed nested object so other trigger
     kinds (event, webhook) can be added later without a breaking change."""
 
-    type: Literal["schedule"] = "schedule"
-    cron: str  # cron expression, e.g. "0 9 * * *"
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"type": "schedule", "cron": "0 9 * * 1-5"}}
+    )
+
+    type: Literal["schedule"] = Field(
+        default="schedule",
+        description="Trigger kind; 'schedule' (a cron schedule) is the only "
+        "kind today.",
+    )
+    cron: str = Field(
+        description="Standard 5-field cron expression — minute, hour, "
+        "day-of-month, month, day-of-week — e.g. '0 9 * * 1-5' for 09:00 on "
+        "weekdays. Minute granularity; seconds are not supported. Evaluated "
+        "in the routine's timezone."
+    )
 
 
 class Routine(BaseModel):
-    """A scheduled/triggered task run by an agent."""
+    """A scheduled task run by a bot."""
 
-    routine_id: str
-    bot_id: str
-    name: str
-    trigger: ScheduleTrigger
-    command: str
-    enabled: bool
-    timezone: str | None = None
-    gmt_create: str
-    gmt_modified: str
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "routine_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+                "bot_id": "20260813_a7k2m9p1",
+                "name": "morning-brief",
+                "trigger": {"type": "schedule", "cron": "0 9 * * 1-5"},
+                "command": "Summarize yesterday's tickets and post the brief.",
+                "enabled": True,
+                "timezone": "Asia/Shanghai",
+                "gmt_create": "2026-08-01T02:00:00+00:00",
+                "gmt_modified": "2026-08-10T02:00:00+00:00",
+            }
+        }
+    )
+
+    routine_id: str = Field(
+        description="Identifier of the routine — an opaque string assigned by "
+        "the bot's engine; treat it as a token."
+    )
+    bot_id: str = Field(
+        description="The bot the routine belongs to; may be empty on the "
+        "detail read — keep the bot_id you queried with."
+    )
+    name: str = Field(description="Human-readable routine name.")
+    trigger: ScheduleTrigger = Field(description="When the routine fires.")
+    command: str = Field(description=_COMMAND_DESC)
+    enabled: bool = Field(
+        description="Whether the schedule is armed; a disabled routine keeps "
+        "its definition but never fires."
+    )
+    timezone: str | None = Field(default=None, description=_TIMEZONE_DESC)
+    gmt_create: str = Field(
+        description="When the routine was created (ISO 8601 UTC); empty when "
+        "the engine reports none."
+    )
+    gmt_modified: str = Field(
+        description="When the routine last changed (ISO 8601 UTC); empty "
+        "when the engine reports none."
+    )
 
 
 class RoutineCreate(BaseModel):
     """Create-a-routine request body."""
 
-    bot_id: str
-    name: str
-    trigger: ScheduleTrigger
-    command: str
-    timezone: str | None = None
-    enabled: bool = True
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "bot_id": "20260813_a7k2m9p1",
+                "name": "morning-brief",
+                "trigger": {"type": "schedule", "cron": "0 9 * * 1-5"},
+                "command": "Summarize yesterday's tickets and post the brief.",
+                "timezone": "Asia/Shanghai",
+                "enabled": True,
+            }
+        }
+    )
+
+    bot_id: str = Field(description="The bot that will run the routine.")
+    name: str = Field(description="Human-readable routine name.")
+    trigger: ScheduleTrigger = Field(description="When the routine fires.")
+    command: str = Field(description=_COMMAND_DESC)
+    timezone: str | None = Field(default=None, description=_TIMEZONE_DESC)
+    enabled: bool = Field(
+        default=True,
+        description="Whether the schedule starts armed; defaults to true.",
+    )
 
 
 class RoutineUpdate(BaseModel):
-    """Partial update of a routine."""
+    """Partial update of a routine. Omitted fields are left unchanged."""
 
-    name: str | None = None
-    trigger: ScheduleTrigger | None = None
-    command: str | None = None
-    timezone: str | None = None
-    enabled: bool | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "trigger": {"type": "schedule", "cron": "30 8 * * 1-5"},
+                "timezone": "Asia/Shanghai",
+            }
+        }
+    )
+
+    name: str | None = Field(default=None, description="New name; omit to keep.")
+    trigger: ScheduleTrigger | None = Field(
+        default=None,
+        description="New trigger; omit to keep. Send timezone alongside it — "
+        "see that field's description.",
+    )
+    command: str | None = Field(
+        default=None, description="New instruction; omit to keep."
+    )
+    timezone: str | None = Field(default=None, description=_TIMEZONE_DESC)
+    enabled: bool | None = Field(
+        default=None,
+        description="Arm (true) or disarm (false) the schedule; omit to keep.",
+    )
 
 
 class RoutineRun(BaseModel):
     """One execution of a routine."""
 
-    run_id: str
-    routine_id: str
-    status: str
-    started_at: str | None = None
-    finished_at: str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "run_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+                "routine_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+                "status": "ok",
+                "started_at": "2026-08-13T01:00:00+00:00",
+                "finished_at": "2026-08-13T01:04:12+00:00",
+            }
+        }
+    )
+
+    run_id: str = Field(
+        description="Identifier of the run entry. Not guaranteed unique "
+        "across a routine's history — treat the list positionally."
+    )
+    routine_id: str = Field(description="The routine that ran.")
+    # Two producers, two vocabularies — the run-now endpoint synthesizes its
+    # own three values, the history read passes the engine's through — so this
+    # is documented as open rather than published as an enum either endpoint
+    # would violate.
+    status: str = Field(
+        description="Outcome of the run. In the run history this is the "
+        "engine's own label — today 'ok' (the run completed), 'error' (it "
+        "failed or timed out) or 'skipped' (fired but not runnable), and "
+        "empty when the engine reported none. The run-now endpoint instead "
+        "answers 'completed', 'failed' or 'unknown' for the trigger attempt "
+        "it just made. Treat unknown values as informational."
+    )
+    started_at: str | None = Field(
+        default=None,
+        description="When the run started (ISO 8601 UTC); null when not "
+        "reported — including on the run-now response, which reports no "
+        "timestamps.",
+    )
+    finished_at: str | None = Field(
+        default=None,
+        description="When the run finished (ISO 8601 UTC); null while the "
+        "run is still in flight or when not reported.",
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Body, Path, Query, Request, Response
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    EXAMPLE_TRACE_ID,
     Deleted,
     Envelope,
     ErrorEnvelope,
@@ -218,7 +219,7 @@ async def get_skill(
                         "code": 413101,
                         "message": "Skill package is too large",
                         "data": None,
-                        "request_id": "",
+                        "request_id": EXAMPLE_TRACE_ID,
                     }
                 }
             },

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -8,9 +8,9 @@ non-public surfaces.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Query, Request, Response
+from fastapi import APIRouter, Body, Path, Query, Request, Response
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
@@ -47,6 +47,17 @@ from agentclaw.community.di import Injected
 from .schemas import Skill, SkillState, SkillUpload
 
 router = APIRouter(prefix="/openapi/v1/bots/skills", tags=["skills"])
+
+#: The path parameter naming the skill an operation addresses. The id alone
+#: resolves the bot and owner, so the per-skill operations take no bot_id.
+SkillIdPath = Annotated[
+    str,
+    Path(
+        description="The skill's id, as returned by the listing or upload "
+        "(decimal digits, e.g. '42'). The id alone identifies the skill and "
+        "its bot."
+    ),
+]
 
 
 def _tags(value: Any) -> list[str]:
@@ -126,23 +137,35 @@ async def list_skills(
     request: Request,
     bot_id: str = Query(..., description="Bot ID whose Local Skills are listed."),
     owner_entity_id: str | None = Query(
-        default=None, description="Verified Bot owner locator."
+        default=None,
+        description="Owner of the bot; defaults to the caller. Name it only "
+        "to list skills of a bot shared with you.",
     ),
-    active: bool | None = Query(default=None),
-    keyword: str | None = Query(default=None),
+    active: bool | None = Query(
+        default=None,
+        description="Filter: true for only active skills, false for only "
+        "inactive ones; omit for both.",
+    ),
+    keyword: str | None = Query(
+        default=None,
+        description="Filter: case-insensitive substring match against the "
+        "skill's name and description.",
+    ),
     query_service: LocalSkillQueryServiceProtocol = Injected(
         LocalSkillQueryServiceProtocol
     ),
 ) -> Envelope[Page[Skill]]:
-    """List exact Bot-owned Local Skills from database desired state.
+    """List a bot's skills from stored desired state (paginated).
 
-    Grant-checked **here** rather than by the shared dependency, because only
-    this handler knows whose bot it is about to read: ``owner_entity_id`` names
-    an owner and defaults to the caller. Checking against the caller instead
-    would be wrong in both directions — it would let a grant on the caller's own
-    same-named bot authorize a read of someone else's, and refuse a legitimate
-    grant on a bot shared with them.
+    Answers even while the bot is offline: active reflects the desired
+    state, not the live runtime.
     """
+    # Grant-checked here rather than by the shared dependency, because only
+    # this handler knows whose bot it is about to read: owner_entity_id names
+    # an owner and defaults to the caller. Checking against the caller instead
+    # would be wrong in both directions — it would let a grant on the caller's
+    # own same-named bot authorize a read of someone else's, and refuse a
+    # legitimate grant on a bot shared with them.
     caller.require_bot(bot_id, owner_id=owner_entity_id or actor_id)
     total, records = query_service.list_local_skills(
         bot_id=bot_id,
@@ -159,7 +182,7 @@ async def list_skills(
 @router.get("/{skill_id}", response_model=Envelope[Skill])
 @envelope_errors
 async def get_skill(
-    skill_id: str,
+    skill_id: SkillIdPath,
     actor_id: UserIdDep,
     caller: ActingCallerDep,
     request: Request,
@@ -217,13 +240,19 @@ async def upload_skill(
         LocalSkillUploadServiceProtocol
     ),
 ) -> Envelope[SkillUpload]:
-    """Create one inactive Local Skill from a complete raw ZIP package.
+    """Upload a skill package (raw ZIP) to create or replace a bot's skill.
 
-    Grant-checked here for the same reason as the listing above: the owner this
-    writes under is ``owner_entity_id or actor_id``, which only the handler
-    knows. A write makes the mis-binding worse — it would create a skill on a
-    bot the application was never granted.
+    The body is the ZIP's raw bytes with content type application/zip — not a
+    multipart form. The archive must contain exactly one SKILL.md manifest,
+    whose front matter names the skill. When the bot already has a skill of
+    that name, its package is replaced in place (200, operation 'updated');
+    otherwise a new, inactive skill is created (201, operation 'created').
+    Limits: 10 MB compressed, 50 MB uncompressed, 500 files (413 beyond).
     """
+    # Grant-checked here for the same reason as the listing above: the owner
+    # this writes under is `owner_entity_id or actor_id`, which only the
+    # handler knows. A write makes the mis-binding worse — it would create a
+    # skill on a bot the application was never granted.
     caller.require_bot(bot_id, owner_id=owner_entity_id or actor_id)
     if (
         request.headers.get("content-type", "").split(";", 1)[0].lower()
@@ -253,7 +282,7 @@ async def upload_skill(
 )
 @envelope_errors
 async def activate_skill(
-    skill_id: str,
+    skill_id: SkillIdPath,
     actor_id: UserIdDep,
     caller: ActingCallerDep,
     request: Request,
@@ -264,7 +293,11 @@ async def activate_skill(
         LocalSkillStateServiceProtocol
     ),
 ) -> Envelope[SkillState]:
-    """Activate one Bot-owned Local Skill and synchronously reconcile runtime."""
+    """Activate a skill so its bot can use it.
+
+    Idempotent — activating an already-active skill succeeds with changed
+    false. The bot's runtime is reconciled synchronously either way.
+    """
     _authorize_skills_bot(
         caller, query_service, skill_id=skill_id, actor_id=actor_id
     )
@@ -283,7 +316,7 @@ async def activate_skill(
 )
 @envelope_errors
 async def deactivate_skill(
-    skill_id: str,
+    skill_id: SkillIdPath,
     actor_id: UserIdDep,
     caller: ActingCallerDep,
     request: Request,
@@ -294,7 +327,11 @@ async def deactivate_skill(
         LocalSkillStateServiceProtocol
     ),
 ) -> Envelope[SkillState]:
-    """Deactivate one Bot-owned Local Skill and synchronously reconcile runtime."""
+    """Deactivate a skill so its bot stops using it.
+
+    Idempotent — deactivating an already-inactive skill succeeds with changed
+    false. The bot's runtime is reconciled synchronously either way.
+    """
     _authorize_skills_bot(
         caller, query_service, skill_id=skill_id, actor_id=actor_id
     )
@@ -310,7 +347,7 @@ async def deactivate_skill(
 @router.delete("/{skill_id}", response_model=Envelope[Deleted])
 @envelope_errors
 async def delete_skill(
-    skill_id: str,
+    skill_id: SkillIdPath,
     actor_id: UserIdDep,
     caller: ActingCallerDep,
     request: Request,
@@ -321,7 +358,11 @@ async def delete_skill(
         LocalSkillQueryServiceProtocol
     ),
 ) -> Envelope[Deleted]:
-    """Delete one inactive Bot-owned Local Skill by deployment-wide ID."""
+    """Delete a skill by id.
+
+    Only an inactive skill can be deleted — deactivate it first; deleting an
+    active one answers 409.
+    """
     _authorize_skills_bot(
         caller, query_service, skill_id=skill_id, actor_id=actor_id
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
@@ -1,35 +1,135 @@
-"""Request/response models for the skills group."""
+"""Request/response models for the skills group.
+
+Docstrings and field descriptions here are published verbatim into the OpenAPI
+document external tenants read — keep them caller-facing prose. Rationale and
+internal names belong in ``#`` comments.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Skill(BaseModel):
     """Public metadata for one Bot-owned Skill."""
 
-    skill_id: str
-    name: str
-    description: str | None = None
-    category: str | None = None
-    tags: list[str] = Field(default_factory=list)
-    active: bool
-    created_at: datetime | str | None = None
-    updated_at: datetime | str | None = None
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "skill_id": "42",
+                "name": "weekly-report",
+                "description": "Builds the weekly status report.",
+                "category": "general",
+                "tags": [],
+                "active": True,
+                "created_at": "2026-08-04T10:00:00",
+                "updated_at": "2026-08-10T08:30:00",
+            }
+        }
+    )
+
+    skill_id: str = Field(
+        description="Identifier of the skill — decimal digits, e.g. '42'. "
+        "Stable across package replacement. Address skills by this id, "
+        "never by name."
+    )
+    name: str = Field(
+        description="The skill's name, taken from its package manifest — "
+        "ASCII letters, digits and hyphens only. Unique per bot, not "
+        "globally; renaming means uploading under a new name."
+    )
+    description: str | None = Field(
+        default=None,
+        description="What the skill does, from its package manifest.",
+    )
+    # Pass-through of a free-form column; the public upload always writes
+    # "general", other values come from legacy or internal writers.
+    category: str | None = Field(
+        default=None,
+        description="Free-form grouping label. Currently always 'general' "
+        "for skills uploaded through this API; other values can appear on "
+        "records created elsewhere. Null on some legacy records.",
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Labels attached to the skill. Currently always empty "
+        "for skills uploaded through this API; records created elsewhere "
+        "may carry manifest-declared tags.",
+    )
+    active: bool = Field(
+        description="Whether the skill is enabled for the bot. This is the "
+        "desired state — it answers even while the bot is offline."
+    )
+    created_at: datetime | str | None = Field(
+        default=None,
+        description="When the skill was created (ISO 8601, no timezone "
+        "designator); null when unrecorded.",
+    )
+    updated_at: datetime | str | None = Field(
+        default=None,
+        description="When the skill last changed (ISO 8601, no timezone "
+        "designator); null when unrecorded. Right after a package "
+        "replacement this can still show the pre-replacement time — re-read "
+        "the skill for the fresh value.",
+    )
 
 
 class SkillUpload(BaseModel):
     """Response for a Skill create or same-name package replacement."""
 
-    operation: Literal["created", "updated"]
-    skill: Skill
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "operation": "created",
+                "skill": {
+                    "skill_id": "42",
+                    "name": "weekly-report",
+                    "description": "Builds the weekly status report.",
+                    "category": "general",
+                    "tags": [],
+                    "active": False,
+                    "created_at": "2026-08-04T10:00:00",
+                    "updated_at": "2026-08-04T10:00:00",
+                },
+            }
+        }
+    )
+
+    operation: Literal["created", "updated"] = Field(
+        description="'created' — no skill of that name existed for the bot; "
+        "a new one was created, inactive, and answers 201. 'updated' — a "
+        "same-name skill existed and its package was replaced in place, "
+        "keeping its id and active state; answers 200."
+    )
+    skill: Skill = Field(description="The skill as stored after the upload.")
 
 
 class SkillState(BaseModel):
     """Result of an idempotent Skill desired-state command."""
 
-    skill: Skill
-    changed: bool
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "skill": {
+                    "skill_id": "42",
+                    "name": "weekly-report",
+                    "description": "Builds the weekly status report.",
+                    "category": "general",
+                    "tags": [],
+                    "active": True,
+                    "created_at": "2026-08-04T10:00:00",
+                    "updated_at": "2026-08-10T08:30:00",
+                },
+                "changed": True,
+            }
+        }
+    )
+
+    skill: Skill = Field(description="The skill in its resulting state.")
+    changed: bool = Field(
+        description="False when the skill was already in the requested state "
+        "— the call is idempotent and succeeded either way."
+    )

--- a/src/backend/src/agentclaw/community/core/bot_chat/schemas.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/schemas.py
@@ -1,32 +1,105 @@
 from typing import Any, Generic, TypeVar
 
-from pydantic import BaseModel, Field
-
+from pydantic import BaseModel, ConfigDict, Field
 
 # --- Response Data Models ---
+#
+# These models are served on the public /openapi/v1/bots/logs surface as well
+# as internally, so docstrings and field descriptions are caller-facing prose;
+# rationale and internal component names belong in # comments.
+
+# One trace = one recorded chat turn. Shared field texts, stated once so the
+# list and detail models cannot drift apart.
+_TRACE_ID_DESC = (
+    "Trace id of the recorded chat turn — globally unique; pass it to the "
+    "trace-detail endpoint."
+)
+_BIZ_SCENE_DESC = (
+    "Business label supplied by the integrating system, naming the calling "
+    "business domain. Null unless a label was attached to the trace or "
+    "registered as a relation afterwards."
+)
+_BIZ_TASK_ID_DESC = (
+    "The integrating system's own task id within its business scene; always "
+    "paired with biz_scene. Null unless labelled."
+)
+_SESSION_ID_DESC = (
+    "The engine's canonical session id; may equal session_key when the "
+    "engine reported only one of the two."
+)
+_SESSION_KEY_DESC = (
+    "The engine session key grouping this conversation's traces — the "
+    "exact-match key the session-traces endpoint takes."
+)
+_BOT_NAME_DESC = (
+    "The bot's current display name; null when the bot no longer resolves — "
+    "fall back to bot_id."
+)
+_GROUP_ID_DESC = (
+    "The collaboration group the session belongs to; null for non-group "
+    "sessions."
+)
+_SESSION_KIND_DESC = (
+    "Kind of group session: 'chat' — an ordinary group conversation; "
+    "'service_invocation' — a request/response style invocation of the "
+    "group. Null for non-group sessions."
+)
+# Hardcoded SUCCESS on this read path today; per-span failure is recorded but
+# not surfaced, so the honest public wording is "reserved".
+_STATUS_DESC = (
+    "Reserved: 'SUCCESS' or 'FAILED'. Records returned today always report "
+    "'SUCCESS' — do not use this field to detect a failed turn."
+)
+_TIMESTAMP_DESC = (
+    "When the turn started (ISO 8601 UTC); empty when the source reported "
+    "no time."
+)
+_USER_ID_DESC = "The user the turn belongs to."
+_TOTAL_COST_DESC = "Model cost of the turn in USD; 0 when not reported."
+_LATENCY_DESC = "Duration in milliseconds; 0 when not reported."
+_TOTAL_TOKENS_DESC = "Total model tokens; 0 when not reported."
+_NAME_DESC = "Trace name reported by the engine."
 
 
 class SessionMetadata(BaseModel):
-    """Metadata from Langfuse trace, including identity attributes."""
+    """Metadata recorded with a trace."""
 
-    attributes: dict[str, Any] = Field(default_factory=dict, description="Trace metadata attributes (e.g. identity.bot_id, identity.owner_id, session_id)")
+    attributes: dict[str, Any] = Field(
+        default_factory=dict,
+        description="The trace's attribute bag as recorded at ingest — e.g. "
+        "identity.owner_id, identity.bot_id, gen_ai.request.model, "
+        "gen_ai.usage.* token counts, and derived usage_details / "
+        "cost_details breakdowns. A superset of what the emitter sent.",
+    )
 
 
 class ConversationSession(BaseModel):
-    """A single conversation session (mapped from a Langfuse trace)."""
+    """One recorded chat turn (trace), as a list item.
 
-    id: str = Field(..., description="Trace ID")
-    biz_task_id: str | None = Field(default=None, description="Business task ID")
-    biz_scene: str | None = Field(default=None, description="Business scene")
-    session_id: str | None = Field(default=None, description="Canonical session ID")
-    session_key: str | None = Field(default=None, description="Engine session key")
-    bot_id: str | None = Field(default=None, description="Bot ID")
-    bot_name: str | None = Field(default=None, description="Bot display name")
-    group_id: str | None = Field(default=None, description="BCS group ID")
-    session_kind: str | None = Field(default=None, description="Optional group-session label")
-    name: str = Field(default="", description="Session / trace name")
-    input: str | None = Field(default=None, description="Last user message extracted from trace input")
-    output_preview: str | None = Field(default=None, description="Short trace output preview")
+    List items carry a preview only — read the trace detail for the full
+    input, output and observation tree.
+    """
+
+    id: str = Field(..., description=_TRACE_ID_DESC)
+    biz_task_id: str | None = Field(default=None, description=_BIZ_TASK_ID_DESC)
+    biz_scene: str | None = Field(default=None, description=_BIZ_SCENE_DESC)
+    session_id: str | None = Field(default=None, description=_SESSION_ID_DESC)
+    session_key: str | None = Field(default=None, description=_SESSION_KEY_DESC)
+    bot_id: str | None = Field(
+        default=None, description="The bot that handled the turn."
+    )
+    bot_name: str | None = Field(default=None, description=_BOT_NAME_DESC)
+    group_id: str | None = Field(default=None, description=_GROUP_ID_DESC)
+    session_kind: str | None = Field(default=None, description=_SESSION_KIND_DESC)
+    name: str = Field(default="", description=_NAME_DESC)
+    input: str | None = Field(
+        default=None,
+        description="The last user message extracted from the turn's input.",
+    )
+    output_preview: str | None = Field(
+        default=None,
+        description="The turn's output, truncated to its first 500 characters.",
+    )
     search_output: str | None = Field(
         default=None,
         exclude=True,
@@ -35,69 +108,155 @@ class ConversationSession(BaseModel):
     )
     match_sources: list[str] = Field(
         default_factory=list,
-        description="Sources that matched the business task, such as direct or biz_ref",
+        description="How a task query matched this trace: 'direct' — the "
+        "business labels are on the trace itself; 'biz_ref' — matched "
+        "through a registered relation. Empty outside task queries.",
     )
-    status: str = Field(default="SUCCESS", description="SUCCESS or FAILED")
-    timestamp: str = Field(..., description="ISO 8601 timestamp")
-    user_id: str | None = Field(default=None, description="Langfuse userId (owner_id)")
-    metadata: SessionMetadata | None = Field(default=None, description="Trace metadata with attributes")
-    total_cost: float = Field(default=0.0, description="Total cost in USD")
-    latency_ms: float = Field(default=0.0, description="Total latency in milliseconds")
-    total_tokens: int = Field(default=0, description="Total tokens used")
+    status: str = Field(default="SUCCESS", description=_STATUS_DESC)
+    timestamp: str = Field(..., description=_TIMESTAMP_DESC)
+    user_id: str | None = Field(default=None, description=_USER_ID_DESC)
+    metadata: SessionMetadata | None = Field(
+        default=None, description="The trace's recorded attributes."
+    )
+    total_cost: float = Field(default=0.0, description=_TOTAL_COST_DESC)
+    latency_ms: float = Field(default=0.0, description=_LATENCY_DESC)
+    total_tokens: int = Field(default=0, description=_TOTAL_TOKENS_DESC)
 
 
 class ConversationObservation(BaseModel):
-    """A single observation within a trace (span or generation)."""
+    """One span of a trace — the turn itself, a model generation, or a tool
+    call — with its child spans nested."""
 
-    id: str
-    biz_task_id: str | None = Field(default=None)
-    biz_scene: str | None = Field(default=None)
-    name: str = Field(default="")
-    type: str = Field(..., description="GENERATION or SPAN")
-    latency_ms: float = Field(default=0.0)
-    total_cost: float = Field(default=0.0)
-    total_tokens: int = Field(default=0)
-    input: Any = Field(default=None)
-    output: Any = Field(default=None)
-    metadata: dict[str, Any] | None = Field(default=None, description="Raw observation metadata")
-    model_name: str | None = Field(default=None, description="Model name from metadata.attributes['gen_ai.request.model']")
-    parent_observation_id: str | None = Field(default=None)
-    children: list["ConversationObservation"] = Field(default_factory=list)
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "a3f81c2b90d4e5f6",
+                "biz_task_id": None,
+                "biz_scene": None,
+                "name": "write",
+                "type": "TOOL",
+                "latency_ms": 240.0,
+                "total_cost": 0.0,
+                "total_tokens": 0,
+                "input": {"path": "reports/q3.md"},
+                "output": {"ok": True},
+                "metadata": {"attributes": {"gen_ai.span.kind": "TOOL"}},
+                "model_name": None,
+                "parent_observation_id": "9b7c1d2e3f405162",
+                "children": [],
+            }
+        }
+    )
+
+    id: str = Field(
+        description="Span id — unique per observation. Distinct from the "
+        "trace id, even for the turn's root span."
+    )
+    biz_task_id: str | None = Field(default=None, description=_BIZ_TASK_ID_DESC)
+    biz_scene: str | None = Field(default=None, description=_BIZ_SCENE_DESC)
+    name: str = Field(
+        default="",
+        description="The span's name — for a tool span, the tool's name.",
+    )
+    type: str = Field(
+        ...,
+        description="Span kind: 'CHAT' — the chat-turn root; 'LLM' — a model "
+        "generation; 'TOOL' — a tool call; 'SPAN' — anything else. Migrated "
+        "records may carry other labels (e.g. 'GENERATION'); treat unknown "
+        "values as 'SPAN'.",
+    )
+    latency_ms: float = Field(default=0.0, description=_LATENCY_DESC)
+    total_cost: float = Field(default=0.0, description=_TOTAL_COST_DESC)
+    total_tokens: int = Field(default=0, description=_TOTAL_TOKENS_DESC)
+    input: Any = Field(
+        default=None,
+        description="What went into the span — for a model span the "
+        "messages, for a tool span the call arguments. JSON when the "
+        "recorded value parses as JSON, otherwise the raw string.",
+    )
+    output: Any = Field(
+        default=None,
+        description="What the span produced — a model span's reply, a tool "
+        "span's result. JSON when it parses, otherwise the raw string.",
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description="The span's raw recorded metadata — its attribute bag "
+        "nested under an 'attributes' key.",
+    )
+    model_name: str | None = Field(
+        default=None,
+        description="Model that served a generation span; null for "
+        "non-model spans.",
+    )
+    parent_observation_id: str | None = Field(
+        default=None,
+        description="Span id of the parent observation; null for a root.",
+    )
+    children: list["ConversationObservation"] = Field(
+        default_factory=list,
+        description="Child observations, in start order.",
+    )
 
 
 class ConversationDetail(BaseModel):
-    """Full conversation session detail including observation tree."""
+    """One recorded chat turn (trace) in full, including its observation tree."""
 
-    id: str
-    biz_task_id: str | None = Field(default=None)
-    biz_scene: str | None = Field(default=None)
-    session_id: str | None = Field(default=None)
-    session_key: str | None = Field(default=None)
-    bot_id: str | None = Field(default=None)
-    bot_name: str | None = Field(default=None)
-    group_id: str | None = Field(default=None)
-    session_kind: str | None = Field(default=None)
-    name: str = Field(default="")
-    input: Any = Field(default=None)
-    output: Any = Field(default=None)
-    status: str = Field(default="SUCCESS")
-    timestamp: str = Field(..., description="ISO 8601 timestamp")
-    user_id: str | None = Field(default=None)
-    metadata: SessionMetadata | None = Field(default=None)
-    total_cost: float = Field(default=0.0)
-    latency_ms: float = Field(default=0.0)
-    total_tokens: int = Field(default=0)
-    observations: list[ConversationObservation] = Field(default_factory=list, description="Root-level observations with nested children")
+    id: str = Field(..., description=_TRACE_ID_DESC)
+    biz_task_id: str | None = Field(default=None, description=_BIZ_TASK_ID_DESC)
+    biz_scene: str | None = Field(default=None, description=_BIZ_SCENE_DESC)
+    session_id: str | None = Field(default=None, description=_SESSION_ID_DESC)
+    session_key: str | None = Field(default=None, description=_SESSION_KEY_DESC)
+    bot_id: str | None = Field(
+        default=None, description="The bot that handled the turn."
+    )
+    bot_name: str | None = Field(default=None, description=_BOT_NAME_DESC)
+    group_id: str | None = Field(default=None, description=_GROUP_ID_DESC)
+    session_kind: str | None = Field(default=None, description=_SESSION_KIND_DESC)
+    name: str = Field(default="", description=_NAME_DESC)
+    input: Any = Field(
+        default=None,
+        description="The turn's full input — typically the chat messages "
+        "sent to the bot, e.g. a list of role/content objects. JSON when "
+        "the recorded value parses as JSON, otherwise the raw string.",
+    )
+    output: Any = Field(
+        default=None,
+        description="The turn's full output — typically the assistant's "
+        "reply message. JSON when it parses, otherwise the raw string.",
+    )
+    status: str = Field(default="SUCCESS", description=_STATUS_DESC)
+    timestamp: str = Field(..., description=_TIMESTAMP_DESC)
+    user_id: str | None = Field(default=None, description=_USER_ID_DESC)
+    metadata: SessionMetadata | None = Field(
+        default=None, description="The trace's recorded attributes."
+    )
+    total_cost: float = Field(default=0.0, description=_TOTAL_COST_DESC)
+    latency_ms: float = Field(default=0.0, description=_LATENCY_DESC)
+    total_tokens: int = Field(default=0, description=_TOTAL_TOKENS_DESC)
+    observations: list[ConversationObservation] = Field(
+        default_factory=list,
+        description="Root observations with children nested — typically one "
+        "root (the chat turn) whose children are the model and tool spans.",
+    )
 
 
 class SessionListResponse(BaseModel):
-    """Paginated list of conversation sessions."""
+    """Paginated list of recorded chat turns (traces), newest first."""
 
-    sessions: list[ConversationSession] = Field(default_factory=list)
+    sessions: list[ConversationSession] = Field(
+        default_factory=list,
+        description="The current page of traces. Items carry previews only — "
+        "read the trace detail for full input/output and observations.",
+    )
     total: int = Field(default=0, description="Total number of matching sessions")
-    page: int = Field(default=1)
-    limit: int = Field(default=20)
-    has_more: bool = Field(default=False)
+    page: int = Field(
+        default=1, description="The effective 1-based page number answered."
+    )
+    limit: int = Field(default=20, description="The effective page size answered.")
+    has_more: bool = Field(
+        default=False, description="Whether more pages exist beyond this one."
+    )
 
 
 class HealthCheckData(BaseModel):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -1056,7 +1056,11 @@ def test_the_write_contract_does_not_promise_starts_that_never_recompose(
 
     put_doc = ops["put"]["description"]
     assert "composes" in put_doc
-    assert "scale-out" in put_doc and "devices/{binding_id}/restart" in put_doc
+    # The caveat is stated in caller terms; the engine's private restart route
+    # must NOT be named — published text carries no internal paths (see
+    # test_schema_docs.py).
+    assert "scale-out" in put_doc
+    assert "/api/" not in put_doc
     assert "next start." not in put_doc
 
     delete_doc = ops["delete"]["description"]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
@@ -1,0 +1,145 @@
+"""Schema-documentation gate for the whole public surface.
+
+The engine-runtime groups carry their own gate
+(``engine_runtime/test_schema_docs.py``); this one holds the same bar for the
+**generated document of every group**, because that document — parameters,
+schema descriptions, enum member docs — is what client generators and external
+tenants actually consume. "Every field is documented" has to be enforced rather
+than left to reviewer diligence; the convention decays on the first hurried PR
+otherwise.
+
+Asserted against the real generated document rather than the source models, so
+a model published through any group (including ones defined outside the
+``openapi_v1`` package, like the Bot Logs models) is covered exactly as it is
+published.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+
+_METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
+
+
+def _document() -> dict:
+    app = FastAPI()
+    app.include_router(build_public_router())
+    return app.openapi()
+
+
+def _operations(document: dict):
+    for path, methods in document["paths"].items():
+        for method, operation in methods.items():
+            if method in _METHODS:
+                yield path, method, operation
+
+
+def _schemas(document: dict) -> dict:
+    return document.get("components", {}).get("schemas", {})
+
+
+def test_document_generation_found_something():
+    """Guard the guard: an assembly bug must not silently disable the checks."""
+    document = _document()
+    assert len(list(_operations(document))) > 50
+    assert len(_schemas(document)) > 50
+
+
+def test_every_parameter_is_described():
+    """A generated client's parameter docs are only as good as these."""
+    problems: list[str] = []
+    for path, method, operation in _operations(_document()):
+        for param in operation.get("parameters", []):
+            if not (param.get("description") or "").strip():
+                where = f"{method.upper()} {path}"
+                problems.append(f"{where}: {param['in']}:{param['name']}")
+    assert not problems, "undocumented parameters:\n  " + "\n  ".join(problems)
+
+
+def test_every_schema_and_field_is_described():
+    """Every published component and every property carries a description.
+
+    Parametrised generics (the Envelope/Page concretisations) are covered too:
+    the wrappers inject a description into each concretisation's schema, so no
+    exemption list is needed here — and none should ever be added.
+    """
+    problems: list[str] = []
+    for name, schema in _schemas(_document()).items():
+        if not (schema.get("description") or "").strip():
+            problems.append(f"{name}: no schema description")
+        for prop, spec in (schema.get("properties") or {}).items():
+            if not (spec.get("description") or "").strip():
+                problems.append(f"{name}.{prop}: no description")
+    assert not problems, "undocumented schema members:\n  " + "\n  ".join(problems)
+
+
+def test_every_published_enum_documents_its_members():
+    """Component-level enums must carry the parallel x-enum-descriptions.
+
+    Inline (Literal-typed) enums are exempt: they have no component to attach
+    the extension to, so their member meanings belong in the field or
+    parameter description — which the description gates above require.
+    """
+    problems: list[str] = []
+    for name, schema in _schemas(_document()).items():
+        values = schema.get("enum")
+        if not values:
+            continue
+        docs = schema.get("x-enum-descriptions")
+        if not isinstance(docs, list) or len(docs) != len(values):
+            problems.append(f"{name}: missing/short x-enum-descriptions")
+            continue
+        for value, doc in zip(values, docs):
+            if not (doc or "").strip():
+                problems.append(f"{name}[{value}]: empty member description")
+    assert not problems, "undocumented enums:\n  " + "\n  ".join(problems)
+
+
+# ── nothing internal reaches the published document ──────────────────────────
+#
+# Docstrings and Field descriptions are promoted verbatim into the OpenAPI
+# document external tenants read. Rationale therefore belongs in `#` comments.
+# The base list mirrors the engine-runtime gate; the additions are markers that
+# leaked from the other groups before this gate existed.
+_FORBIDDEN_IN_PUBLISHED_TEXT = (
+    "src/engine",          # internal source paths
+    "singlebox",           # deployment tiers
+    "OCB",                 # internal component names
+    "teamclaw",
+    "mcporter",
+    "stub",                # test/deployment scaffolding
+    "on_miss",             # unpublished alias spellings
+    "/api/",               # private route paths
+    "EngineManager",       # internal class names
+    "``",                  # RST markup — Swagger/Redoc render markdown, not RST
+    ":class:",
+    ":func:",
+    "langfuse",            # retired internal observability vendor naming
+    "TODO(",               # roadmap notes are not caller documentation
+)
+
+
+def _published_strings(node, path: str = ""):
+    """Every description/title/summary string in the document, with its path."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in ("description", "title", "summary") and isinstance(value, str):
+                yield f"{path}.{key}", value
+            else:
+                yield from _published_strings(value, f"{path}.{key}")
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            yield from _published_strings(value, f"{path}[{i}]")
+
+
+def test_the_published_document_contains_nothing_internal():
+    problems: list[str] = []
+    for where, text in _published_strings(_document()):
+        for marker in _FORBIDDEN_IN_PUBLISHED_TEXT:
+            if marker.lower() in text.lower():
+                problems.append(f"{where}: contains {marker!r}")
+    assert not problems, "internal detail in the published document:\n  " + "\n  ".join(
+        problems
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -18,6 +18,7 @@ from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
 from tests.community.adapters.http.openapi_v1.conftest import (
     user_scoped_client,
 )
+from agentclaw.community.adapters.http.openapi_v1.contracts import EXAMPLE_TRACE_ID
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     require_principal,
@@ -366,10 +367,12 @@ def test_openapi_declares_exactly_the_six_ratified_skills_operations():
     assert {"200", "201", "413"} <= set(upload["responses"])
     assert set(upload["requestBody"]["content"]) == {"application/zip"}
     error_example = upload["responses"]["413"]["content"]["application/json"]["example"]
+    # request_id carries the surface-wide illustrative trace id, so rendered
+    # samples show a realistic value instead of an empty placeholder.
     assert {**error_example, "data": error_example.get("data")} == {
         "code": 413101,
         "message": "Skill package is too large",
-        "request_id": "",
+        "request_id": EXAMPLE_TRACE_ID,
         "data": None,
     }
     error_schema = upload["responses"]["413"]["content"]["application/json"]["schema"]

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -309,7 +309,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional human-readable note from the authorization service; null when there is nothing to add.",
+            "description": "Reserved for a human-readable note from the authorization service; currently always null.",
             "title": "Message"
           },
           "status": {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -172,20 +172,34 @@
       },
       "Bot": {
         "description": "An agent (bot) record.",
+        "example": {
+          "bot_desc": "Summarizes weekly industry news.",
+          "bot_id": "20260813_a7k2m9p1",
+          "bot_name": "research-assistant",
+          "bot_type": "personal",
+          "cluster_name": "ACRA",
+          "engine": "openclaw",
+          "owner_entity_id": "u_165137",
+          "status": "ACTIVE"
+        },
         "properties": {
           "bot_desc": {
+            "description": "Free-form description of what the bot is for; may be empty.",
             "title": "Bot Desc",
             "type": "string"
           },
           "bot_id": {
+            "description": "Unique identifier of the bot, e.g. '20260813_a7k2m9p1'. Use it verbatim wherever an operation takes a bot_id.",
             "title": "Bot Id",
             "type": "string"
           },
           "bot_name": {
+            "description": "Display name; unique within the tenant.",
             "title": "Bot Name",
             "type": "string"
           },
           "bot_type": {
+            "description": "Kind of bot: 'personal', 'service', or 'desktop'. Desktop bots run on the user's own machine; they appear in listings but their lifecycle is not managed through this API.",
             "title": "Bot Type",
             "type": "string"
           },
@@ -199,15 +213,17 @@
             "type": "string"
           },
           "engine": {
+            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400).",
             "title": "Engine",
             "type": "string"
           },
           "owner_entity_id": {
+            "description": "The user who owns the bot — echoes the user_id the request named.",
             "title": "Owner Entity Id",
             "type": "string"
           },
           "status": {
-            "description": "Lifecycle status: PENDING | ACTIVE | FAILED.",
+            "description": "Lifecycle status. Primary states: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device provisioning failed (delete and recreate, or restart). Bots managed by other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', 'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as not ready for work.",
             "title": "Status",
             "type": "string"
           }
@@ -226,19 +242,27 @@
         "type": "object"
       },
       "BotAuthPending": {
-        "description": "Returned (202) when bot creation needs user authorization (Passport).\n\nPassport may hand back either handle, so both are surfaced: a caller that\nonly receives ``redirect_url`` would otherwise have no way to complete\nauthorization. Each is empty when Passport did not supply it.",
+        "description": "Returned (202) when bot creation needs user authorization first.\n\nOpen whichever URL is populated to let the user complete authorization,\nthen poll the bot's auth-status endpoint. Each URL is empty when the\nauthorization service did not supply it — at least one is populated.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "iframe_url": "https://auth.example.com/passport/consent?flow=f-123",
+          "redirect_url": ""
+        },
         "properties": {
           "bot_id": {
+            "description": "Identifier reserved for the bot being created. Pass it to the auth-status endpoint to poll and complete creation.",
             "title": "Bot Id",
             "type": "string"
           },
           "iframe_url": {
             "default": "",
+            "description": "URL suitable for embedding in an iframe for the user to authorize in-page; empty when not offered.",
             "title": "Iframe Url",
             "type": "string"
           },
           "redirect_url": {
             "default": "",
+            "description": "URL to redirect the user to for authorization; empty when not offered.",
             "title": "Redirect Url",
             "type": "string"
           }
@@ -250,7 +274,20 @@
         "type": "object"
       },
       "BotAuthStatus": {
-        "description": "Passport authorization status; ``bot`` is present once ISSUED.",
+        "description": "Authorization status of a pending bot creation.",
+        "example": {
+          "bot": {
+            "bot_desc": "Summarizes weekly industry news.",
+            "bot_id": "20260813_a7k2m9p1",
+            "bot_name": "research-assistant",
+            "bot_type": "personal",
+            "cluster_name": "ACRA",
+            "engine": "openclaw",
+            "owner_entity_id": "u_165137",
+            "status": "PENDING"
+          },
+          "status": "ISSUED"
+        },
         "properties": {
           "bot": {
             "anyOf": [
@@ -260,7 +297,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The created bot; present once status is 'ISSUED', null before that."
           },
           "message": {
             "anyOf": [
@@ -271,9 +309,11 @@
                 "type": "null"
               }
             ],
+            "description": "Optional human-readable note from the authorization service; null when there is nothing to add.",
             "title": "Message"
           },
           "status": {
+            "description": "Authorization state: 'PENDING' — the user has not finished authorizing, keep polling; 'ISSUED' — authorization granted and the bot is now created ('bot' is populated). Any other value (e.g. 'REJECTED', 'EXPIRED') is terminal and is answered as a 400 with the state kept in data.status.",
             "title": "Status",
             "type": "string"
           }
@@ -287,16 +327,26 @@
       "BotCreate": {
         "additionalProperties": false,
         "description": "Create-a-bot request body.",
+        "example": {
+          "bot_desc": "Summarizes weekly industry news.",
+          "bot_name": "research-assistant",
+          "bot_type": "personal",
+          "cluster_name": "ACRA",
+          "engine": "openclaw"
+        },
         "properties": {
           "bot_desc": {
+            "description": "Description of what the bot is for.",
             "title": "Bot Desc",
             "type": "string"
           },
           "bot_name": {
+            "description": "Display name. Must be non-blank, must not contain '@', and must be unused within the tenant (409 on a duplicate); leading and trailing whitespace is trimmed.",
             "title": "Bot Name",
             "type": "string"
           },
           "bot_type": {
+            "description": "Kind of bot to create: 'personal' — a bot for the named user's own use, with a single draft runtime; 'service' — a bot built to be published, gaining verify/online runtimes through its publish lifecycle.",
             "enum": [
               "personal",
               "service"
@@ -314,6 +364,7 @@
             "type": "string"
           },
           "engine": {
+            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400).",
             "title": "Engine",
             "type": "string"
           }
@@ -330,6 +381,11 @@
       },
       "BotStatus": {
         "description": "Runtime / device readiness of a bot.",
+        "example": {
+          "device_id": "device-8f2c91",
+          "is_ready": true,
+          "status": "ACTIVE"
+        },
         "properties": {
           "device_id": {
             "anyOf": [
@@ -340,13 +396,16 @@
                 "type": "null"
               }
             ],
+            "description": "Identifier of the device (container) backing the bot; null while none is bound.",
             "title": "Device Id"
           },
           "is_ready": {
+            "description": "True once the bot can actually take work. Stricter than status == 'ACTIVE': an application-coding bot is not ready until its initial repository checkout has also succeeded.",
             "title": "Is Ready",
             "type": "boolean"
           },
           "status": {
+            "description": "Lifecycle status. Primary states: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device provisioning failed (delete and recreate, or restart). Bots managed by other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', 'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as not ready for work.",
             "title": "Status",
             "type": "string"
           }
@@ -360,7 +419,10 @@
       },
       "BotUpdate": {
         "additionalProperties": false,
-        "description": "Partial update — only the fields this operation can actually apply.\n\n``engine``, ``cluster_name`` and ``engine_options`` are all deliberately\nabsent *and* rejected by ``extra=\"forbid\"``. Declaring them for symmetry\nwould mean answering 200 to a request that changed nothing: the engine is\nfixed at creation, ``cluster_name`` is derived from it, and engine options\nare managed through the engine-config endpoints. A caller that sends one now\ngets a validation error naming the field instead of a success they have to\nverify by re-reading the bot.",
+        "description": "Rename a bot and/or replace its description.\n\nOnly these two fields are updatable: the engine is fixed at creation, the\ncluster is derived from the engine, and engine options are managed through\nthe engine-config endpoints. Sending any other field fails validation with\nthe field named in the error. Omit a field to leave it unchanged; explicit\nnull is rejected.",
+        "example": {
+          "bot_name": "research-assistant-v2"
+        },
         "properties": {
           "bot_desc": {
             "description": "New description; omit to keep.",
@@ -368,7 +430,7 @@
             "type": "string"
           },
           "bot_name": {
-            "description": "New name; omit to keep.",
+            "description": "New name; omit to keep. Same rules as on create: non-blank, no '@', unique within the tenant.",
             "title": "Bot Name",
             "type": "string"
           }
@@ -377,9 +439,13 @@
         "type": "object"
       },
       "Ceiling": {
-        "description": "Per-caller bot creation quota ceiling.",
+        "description": "Per-user bot creation quota.",
+        "example": {
+          "ceiling": 5
+        },
         "properties": {
           "ceiling": {
+            "description": "Maximum number of live bots the named user may own in this deployment; creation is refused (409) at the limit. Desktop bots do not count toward it. A value of 0 or less means the limit is disabled.",
             "title": "Ceiling",
             "type": "integer"
           }
@@ -431,7 +497,7 @@
         "type": "object"
       },
       "ConversationDetail": {
-        "description": "Full conversation session detail including observation tree.",
+        "description": "One recorded chat turn (trace) in full, including its observation tree.",
         "properties": {
           "biz_scene": {
             "anyOf": [
@@ -442,6 +508,7 @@
                 "type": "null"
               }
             ],
+            "description": "Business label supplied by the integrating system, naming the calling business domain. Null unless a label was attached to the trace or registered as a relation afterwards.",
             "title": "Biz Scene"
           },
           "biz_task_id": {
@@ -453,6 +520,7 @@
                 "type": "null"
               }
             ],
+            "description": "The integrating system's own task id within its business scene; always paired with biz_scene. Null unless labelled.",
             "title": "Biz Task Id"
           },
           "bot_id": {
@@ -464,6 +532,7 @@
                 "type": "null"
               }
             ],
+            "description": "The bot that handled the turn.",
             "title": "Bot Id"
           },
           "bot_name": {
@@ -475,6 +544,7 @@
                 "type": "null"
               }
             ],
+            "description": "The bot's current display name; null when the bot no longer resolves — fall back to bot_id.",
             "title": "Bot Name"
           },
           "group_id": {
@@ -486,17 +556,21 @@
                 "type": "null"
               }
             ],
+            "description": "The collaboration group the session belongs to; null for non-group sessions.",
             "title": "Group Id"
           },
           "id": {
+            "description": "Trace id of the recorded chat turn — globally unique; pass it to the trace-detail endpoint.",
             "title": "Id",
             "type": "string"
           },
           "input": {
+            "description": "The turn's full input — typically the chat messages sent to the bot, e.g. a list of role/content objects. JSON when the recorded value parses as JSON, otherwise the raw string.",
             "title": "Input"
           },
           "latency_ms": {
             "default": 0.0,
+            "description": "Duration in milliseconds; 0 when not reported.",
             "title": "Latency Ms",
             "type": "number"
           },
@@ -508,15 +582,17 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The trace's recorded attributes."
           },
           "name": {
             "default": "",
+            "description": "Trace name reported by the engine.",
             "title": "Name",
             "type": "string"
           },
           "observations": {
-            "description": "Root-level observations with nested children",
+            "description": "Root observations with children nested — typically one root (the chat turn) whose children are the model and tool spans.",
             "items": {
               "$ref": "#/components/schemas/ConversationObservation"
             },
@@ -524,6 +600,7 @@
             "type": "array"
           },
           "output": {
+            "description": "The turn's full output — typically the assistant's reply message. JSON when it parses, otherwise the raw string.",
             "title": "Output"
           },
           "session_id": {
@@ -535,6 +612,7 @@
                 "type": "null"
               }
             ],
+            "description": "The engine's canonical session id; may equal session_key when the engine reported only one of the two.",
             "title": "Session Id"
           },
           "session_key": {
@@ -546,6 +624,7 @@
                 "type": "null"
               }
             ],
+            "description": "The engine session key grouping this conversation's traces — the exact-match key the session-traces endpoint takes.",
             "title": "Session Key"
           },
           "session_kind": {
@@ -557,25 +636,29 @@
                 "type": "null"
               }
             ],
+            "description": "Kind of group session: 'chat' — an ordinary group conversation; 'service_invocation' — a request/response style invocation of the group. Null for non-group sessions.",
             "title": "Session Kind"
           },
           "status": {
             "default": "SUCCESS",
+            "description": "Reserved: 'SUCCESS' or 'FAILED'. Records returned today always report 'SUCCESS' — do not use this field to detect a failed turn.",
             "title": "Status",
             "type": "string"
           },
           "timestamp": {
-            "description": "ISO 8601 timestamp",
+            "description": "When the turn started (ISO 8601 UTC); empty when the source reported no time.",
             "title": "Timestamp",
             "type": "string"
           },
           "total_cost": {
             "default": 0.0,
+            "description": "Model cost of the turn in USD; 0 when not reported.",
             "title": "Total Cost",
             "type": "number"
           },
           "total_tokens": {
             "default": 0,
+            "description": "Total model tokens; 0 when not reported.",
             "title": "Total Tokens",
             "type": "integer"
           },
@@ -588,6 +671,7 @@
                 "type": "null"
               }
             ],
+            "description": "The user the turn belongs to.",
             "title": "User Id"
           }
         },
@@ -599,7 +683,28 @@
         "type": "object"
       },
       "ConversationObservation": {
-        "description": "A single observation within a trace (span or generation).",
+        "description": "One span of a trace — the turn itself, a model generation, or a tool\ncall — with its child spans nested.",
+        "example": {
+          "children": [],
+          "id": "a3f81c2b90d4e5f6",
+          "input": {
+            "path": "reports/q3.md"
+          },
+          "latency_ms": 240.0,
+          "metadata": {
+            "attributes": {
+              "gen_ai.span.kind": "TOOL"
+            }
+          },
+          "name": "write",
+          "output": {
+            "ok": true
+          },
+          "parent_observation_id": "9b7c1d2e3f405162",
+          "total_cost": 0.0,
+          "total_tokens": 0,
+          "type": "TOOL"
+        },
         "properties": {
           "biz_scene": {
             "anyOf": [
@@ -610,6 +715,7 @@
                 "type": "null"
               }
             ],
+            "description": "Business label supplied by the integrating system, naming the calling business domain. Null unless a label was attached to the trace or registered as a relation afterwards.",
             "title": "Biz Scene"
           },
           "biz_task_id": {
@@ -621,9 +727,11 @@
                 "type": "null"
               }
             ],
+            "description": "The integrating system's own task id within its business scene; always paired with biz_scene. Null unless labelled.",
             "title": "Biz Task Id"
           },
           "children": {
+            "description": "Child observations, in start order.",
             "items": {
               "$ref": "#/components/schemas/ConversationObservation"
             },
@@ -631,14 +739,17 @@
             "type": "array"
           },
           "id": {
+            "description": "Span id — unique per observation. Distinct from the trace id, even for the turn's root span.",
             "title": "Id",
             "type": "string"
           },
           "input": {
+            "description": "What went into the span — for a model span the messages, for a tool span the call arguments. JSON when the recorded value parses as JSON, otherwise the raw string.",
             "title": "Input"
           },
           "latency_ms": {
             "default": 0.0,
+            "description": "Duration in milliseconds; 0 when not reported.",
             "title": "Latency Ms",
             "type": "number"
           },
@@ -652,7 +763,7 @@
                 "type": "null"
               }
             ],
-            "description": "Raw observation metadata",
+            "description": "The span's raw recorded metadata — its attribute bag nested under an 'attributes' key.",
             "title": "Metadata"
           },
           "model_name": {
@@ -664,15 +775,17 @@
                 "type": "null"
               }
             ],
-            "description": "Model name from metadata.attributes['gen_ai.request.model']",
+            "description": "Model that served a generation span; null for non-model spans.",
             "title": "Model Name"
           },
           "name": {
             "default": "",
+            "description": "The span's name — for a tool span, the tool's name.",
             "title": "Name",
             "type": "string"
           },
           "output": {
+            "description": "What the span produced — a model span's reply, a tool span's result. JSON when it parses, otherwise the raw string.",
             "title": "Output"
           },
           "parent_observation_id": {
@@ -684,20 +797,23 @@
                 "type": "null"
               }
             ],
+            "description": "Span id of the parent observation; null for a root.",
             "title": "Parent Observation Id"
           },
           "total_cost": {
             "default": 0.0,
+            "description": "Model cost of the turn in USD; 0 when not reported.",
             "title": "Total Cost",
             "type": "number"
           },
           "total_tokens": {
             "default": 0,
+            "description": "Total model tokens; 0 when not reported.",
             "title": "Total Tokens",
             "type": "integer"
           },
           "type": {
-            "description": "GENERATION or SPAN",
+            "description": "Span kind: 'CHAT' — the chat-turn root; 'LLM' — a model generation; 'TOOL' — a tool call; 'SPAN' — anything else. Migrated records may carry other labels (e.g. 'GENERATION'); treat unknown values as 'SPAN'.",
             "title": "Type",
             "type": "string"
           }
@@ -710,7 +826,7 @@
         "type": "object"
       },
       "ConversationSession": {
-        "description": "A single conversation session (mapped from a Langfuse trace).",
+        "description": "One recorded chat turn (trace), as a list item.\n\nList items carry a preview only — read the trace detail for the full\ninput, output and observation tree.",
         "properties": {
           "biz_scene": {
             "anyOf": [
@@ -721,7 +837,7 @@
                 "type": "null"
               }
             ],
-            "description": "Business scene",
+            "description": "Business label supplied by the integrating system, naming the calling business domain. Null unless a label was attached to the trace or registered as a relation afterwards.",
             "title": "Biz Scene"
           },
           "biz_task_id": {
@@ -733,7 +849,7 @@
                 "type": "null"
               }
             ],
-            "description": "Business task ID",
+            "description": "The integrating system's own task id within its business scene; always paired with biz_scene. Null unless labelled.",
             "title": "Biz Task Id"
           },
           "bot_id": {
@@ -745,7 +861,7 @@
                 "type": "null"
               }
             ],
-            "description": "Bot ID",
+            "description": "The bot that handled the turn.",
             "title": "Bot Id"
           },
           "bot_name": {
@@ -757,7 +873,7 @@
                 "type": "null"
               }
             ],
-            "description": "Bot display name",
+            "description": "The bot's current display name; null when the bot no longer resolves — fall back to bot_id.",
             "title": "Bot Name"
           },
           "group_id": {
@@ -769,11 +885,11 @@
                 "type": "null"
               }
             ],
-            "description": "BCS group ID",
+            "description": "The collaboration group the session belongs to; null for non-group sessions.",
             "title": "Group Id"
           },
           "id": {
-            "description": "Trace ID",
+            "description": "Trace id of the recorded chat turn — globally unique; pass it to the trace-detail endpoint.",
             "title": "Id",
             "type": "string"
           },
@@ -786,17 +902,17 @@
                 "type": "null"
               }
             ],
-            "description": "Last user message extracted from trace input",
+            "description": "The last user message extracted from the turn's input.",
             "title": "Input"
           },
           "latency_ms": {
             "default": 0.0,
-            "description": "Total latency in milliseconds",
+            "description": "Duration in milliseconds; 0 when not reported.",
             "title": "Latency Ms",
             "type": "number"
           },
           "match_sources": {
-            "description": "Sources that matched the business task, such as direct or biz_ref",
+            "description": "How a task query matched this trace: 'direct' — the business labels are on the trace itself; 'biz_ref' — matched through a registered relation. Empty outside task queries.",
             "items": {
               "type": "string"
             },
@@ -812,11 +928,11 @@
                 "type": "null"
               }
             ],
-            "description": "Trace metadata with attributes"
+            "description": "The trace's recorded attributes."
           },
           "name": {
             "default": "",
-            "description": "Session / trace name",
+            "description": "Trace name reported by the engine.",
             "title": "Name",
             "type": "string"
           },
@@ -829,7 +945,7 @@
                 "type": "null"
               }
             ],
-            "description": "Short trace output preview",
+            "description": "The turn's output, truncated to its first 500 characters.",
             "title": "Output Preview"
           },
           "session_id": {
@@ -841,7 +957,7 @@
                 "type": "null"
               }
             ],
-            "description": "Canonical session ID",
+            "description": "The engine's canonical session id; may equal session_key when the engine reported only one of the two.",
             "title": "Session Id"
           },
           "session_key": {
@@ -853,7 +969,7 @@
                 "type": "null"
               }
             ],
-            "description": "Engine session key",
+            "description": "The engine session key grouping this conversation's traces — the exact-match key the session-traces endpoint takes.",
             "title": "Session Key"
           },
           "session_kind": {
@@ -865,29 +981,29 @@
                 "type": "null"
               }
             ],
-            "description": "Optional group-session label",
+            "description": "Kind of group session: 'chat' — an ordinary group conversation; 'service_invocation' — a request/response style invocation of the group. Null for non-group sessions.",
             "title": "Session Kind"
           },
           "status": {
             "default": "SUCCESS",
-            "description": "SUCCESS or FAILED",
+            "description": "Reserved: 'SUCCESS' or 'FAILED'. Records returned today always report 'SUCCESS' — do not use this field to detect a failed turn.",
             "title": "Status",
             "type": "string"
           },
           "timestamp": {
-            "description": "ISO 8601 timestamp",
+            "description": "When the turn started (ISO 8601 UTC); empty when the source reported no time.",
             "title": "Timestamp",
             "type": "string"
           },
           "total_cost": {
             "default": 0.0,
-            "description": "Total cost in USD",
+            "description": "Model cost of the turn in USD; 0 when not reported.",
             "title": "Total Cost",
             "type": "number"
           },
           "total_tokens": {
             "default": 0,
-            "description": "Total tokens used",
+            "description": "Total model tokens; 0 when not reported.",
             "title": "Total Tokens",
             "type": "integer"
           },
@@ -900,7 +1016,7 @@
                 "type": "null"
               }
             ],
-            "description": "Langfuse userId (owner_id)",
+            "description": "The user the turn belongs to.",
             "title": "User Id"
           }
         },
@@ -913,9 +1029,13 @@
       },
       "Deleted": {
         "description": "Payload returned by delete operations.",
+        "example": {
+          "deleted": true
+        },
         "properties": {
           "deleted": {
             "default": true,
+            "description": "Always true: the resource is gone. A failed delete answers an error envelope instead, never `deleted: false`.",
             "title": "Deleted",
             "type": "boolean"
           }
@@ -1037,6 +1157,7 @@
         "type": "object"
       },
       "Envelope_ApprovalState_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1075,6 +1196,7 @@
         "type": "object"
       },
       "Envelope_AuthorizedApp_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1113,6 +1235,7 @@
         "type": "object"
       },
       "Envelope_BotAuthPending_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1151,6 +1274,7 @@
         "type": "object"
       },
       "Envelope_BotAuthStatus_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1189,6 +1313,7 @@
         "type": "object"
       },
       "Envelope_BotStatus_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1227,6 +1352,7 @@
         "type": "object"
       },
       "Envelope_Bot_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1265,6 +1391,7 @@
         "type": "object"
       },
       "Envelope_Ceiling_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1303,6 +1430,7 @@
         "type": "object"
       },
       "Envelope_Connection_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1341,6 +1469,7 @@
         "type": "object"
       },
       "Envelope_ConversationDetail_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1379,6 +1508,7 @@
         "type": "object"
       },
       "Envelope_Deleted_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1417,6 +1547,7 @@
         "type": "object"
       },
       "Envelope_EngineCapabilities_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1455,6 +1586,7 @@
         "type": "object"
       },
       "Envelope_EngineStatus_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1493,6 +1625,7 @@
         "type": "object"
       },
       "Envelope_HelloWorld_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1531,6 +1664,7 @@
         "type": "object"
       },
       "Envelope_IdentityFileList_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1569,6 +1703,7 @@
         "type": "object"
       },
       "Envelope_IdentityFileRef_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1607,6 +1742,7 @@
         "type": "object"
       },
       "Envelope_IdentityFile_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1645,6 +1781,7 @@
         "type": "object"
       },
       "Envelope_McpConfig_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1683,6 +1820,7 @@
         "type": "object"
       },
       "Envelope_McpPermission_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1721,6 +1859,7 @@
         "type": "object"
       },
       "Envelope_McpServerDetail_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1759,6 +1898,7 @@
         "type": "object"
       },
       "Envelope_MessagePage_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1797,6 +1937,7 @@
         "type": "object"
       },
       "Envelope_Model_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1835,6 +1976,7 @@
         "type": "object"
       },
       "Envelope_NameCheck_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1873,6 +2015,7 @@
         "type": "object"
       },
       "Envelope_Page_AuthorizedApp__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1911,6 +2054,7 @@
         "type": "object"
       },
       "Envelope_Page_AuthorizedBot__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1949,6 +2093,7 @@
         "type": "object"
       },
       "Envelope_Page_Bot__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -1987,6 +2132,7 @@
         "type": "object"
       },
       "Envelope_Page_McpServer__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2025,6 +2171,7 @@
         "type": "object"
       },
       "Envelope_Page_Model__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2063,6 +2210,7 @@
         "type": "object"
       },
       "Envelope_Page_Resource__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2101,6 +2249,7 @@
         "type": "object"
       },
       "Envelope_Page_RoutineRun__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2139,6 +2288,7 @@
         "type": "object"
       },
       "Envelope_Page_Routine__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2177,6 +2327,7 @@
         "type": "object"
       },
       "Envelope_Page_Skill__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2215,6 +2366,7 @@
         "type": "object"
       },
       "Envelope_Passport_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2253,6 +2405,7 @@
         "type": "object"
       },
       "Envelope_Preview_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2291,6 +2444,7 @@
         "type": "object"
       },
       "Envelope_Resource_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2329,6 +2483,7 @@
         "type": "object"
       },
       "Envelope_RoutineRun_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2367,6 +2522,7 @@
         "type": "object"
       },
       "Envelope_Routine_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2405,6 +2561,7 @@
         "type": "object"
       },
       "Envelope_SessionListResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2443,6 +2600,7 @@
         "type": "object"
       },
       "Envelope_SessionPage_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2481,6 +2639,7 @@
         "type": "object"
       },
       "Envelope_Session_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2519,6 +2678,7 @@
         "type": "object"
       },
       "Envelope_SkillState_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2557,6 +2717,7 @@
         "type": "object"
       },
       "Envelope_SkillUpload_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2595,6 +2756,7 @@
         "type": "object"
       },
       "Envelope_Skill_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2633,6 +2795,7 @@
         "type": "object"
       },
       "Envelope_StartupScript_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2671,6 +2834,7 @@
         "type": "object"
       },
       "Envelope_dict_str__Any__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2711,6 +2875,7 @@
         "type": "object"
       },
       "Envelope_list_ApprovalModeInfo__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2753,6 +2918,7 @@
         "type": "object"
       },
       "Envelope_list_EngineInfo__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2795,6 +2961,7 @@
         "type": "object"
       },
       "Envelope_list_McpTenant__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
@@ -2837,7 +3004,7 @@
         "type": "object"
       },
       "ErrorEnvelope": {
-        "description": "The envelope returned on every documented failure.\n\nShape-identical to :class:`Envelope` with ``data`` pinned to null, which is\nwhat the error paths actually emit. Declared as its own model so generated\nclients get a named error type instead of a synthesized ``Envelope[None]``.",
+        "description": "The envelope returned on every documented failure — the same shape as\nthe success envelope, with `data` pinned to null.",
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3), e.g. 404000 for a not-found failure.",
@@ -2885,21 +3052,31 @@
       },
       "IdentityFile": {
         "description": "A single identity file's content.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "content": "# Rules\n- Never contact customers directly.\n",
+          "file_path": "identity/RULES.md",
+          "type": "RULES"
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot the file belongs to.",
             "title": "Bot Id",
             "type": "string"
           },
           "content": {
+            "description": "Full markdown content. Empty string when the file has never been written — reading a missing file is not an error.",
             "title": "Content",
             "type": "string"
           },
           "file_path": {
+            "description": "Where the file lives inside the bot's identity namespace, e.g. 'identity/RULES.md'. Informational — address the file by its type, not by this path.",
             "title": "File Path",
             "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/IdentityFileType"
+            "$ref": "#/components/schemas/IdentityFileType",
+            "description": "Which identity file this is."
           }
         },
         "required": [
@@ -2913,17 +3090,25 @@
       },
       "IdentityFileInfo": {
         "description": "One identity file's presence within a bot.",
+        "example": {
+          "exists": true,
+          "file_path": "identity/RULES.md",
+          "type": "RULES"
+        },
         "properties": {
           "exists": {
+            "description": "True when the file has content. A file that exists but is empty reports false — empty and absent are indistinguishable.",
             "title": "Exists",
             "type": "boolean"
           },
           "file_path": {
+            "description": "Where the file lives inside the bot's identity namespace, e.g. 'identity/RULES.md'. Informational — address the file by its type, not by this path.",
             "title": "File Path",
             "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/IdentityFileType"
+            "$ref": "#/components/schemas/IdentityFileType",
+            "description": "Which identity file this is."
           }
         },
         "required": [
@@ -2936,12 +3121,29 @@
       },
       "IdentityFileList": {
         "description": "All possible identity files for a bot and whether each exists.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "files": [
+            {
+              "exists": true,
+              "file_path": "identity/RULES.md",
+              "type": "RULES"
+            },
+            {
+              "exists": false,
+              "file_path": "identity/SOUL.md",
+              "type": "SOUL"
+            }
+          ]
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot the listing describes.",
             "title": "Bot Id",
             "type": "string"
           },
           "files": {
+            "description": "One entry per known file type. Order is not guaranteed — key off each entry's type.",
             "items": {
               "$ref": "#/components/schemas/IdentityFileInfo"
             },
@@ -2958,17 +3160,25 @@
       },
       "IdentityFileRef": {
         "description": "Reference to an identity file (returned after a write).",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "file_path": "identity/RULES.md",
+          "type": "RULES"
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot the file belongs to.",
             "title": "Bot Id",
             "type": "string"
           },
           "file_path": {
+            "description": "Where the file lives inside the bot's identity namespace, e.g. 'identity/RULES.md'. Informational — address the file by its type, not by this path.",
             "title": "File Path",
             "type": "string"
           },
           "type": {
-            "$ref": "#/components/schemas/IdentityFileType"
+            "$ref": "#/components/schemas/IdentityFileType",
+            "description": "Which identity file was written."
           }
         },
         "required": [
@@ -2980,7 +3190,7 @@
         "type": "object"
       },
       "IdentityFileType": {
-        "description": "Whitelisted identity-file types (physical file is ``<type>.md``).",
+        "description": "The identity files a bot can carry (each stored as `<TYPE>.md`).",
         "enum": [
           "RULES",
           "OKR",
@@ -3000,12 +3210,70 @@
           "README"
         ],
         "title": "IdentityFileType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "The bot's hard operating rules — constraints it must always follow and lines it must never cross.",
+          "The bot's objectives and key results — the goals it works toward and is measured against.",
+          "Safety boundaries and conduct rules — data the bot may not touch and harms it must warn about.",
+          "The bot's persona — temperament, tone, communication style and behavioural principles.",
+          "The required shape of the bot's answers — its output format contract.",
+          "Durable facts the bot carries between sessions; typically written by the bot itself rather than authored by hand.",
+          "The bot's identity card — structured name, display name, emoji and role, which other services parse to recognise the bot.",
+          "The main instruction file the bot's engine boots from; on some engines the platform maintains a reference section in it that points at the other identity files.",
+          "Who the bot serves and how to talk to them — its default audience and interaction posture.",
+          "The capabilities the bot may use and the boundaries on them.",
+          "The bot's periodic self-check — what to re-verify each cycle and what to do when something is off.",
+          "The bot's startup sequence — which identity files to read in what order, and the first action after boot.",
+          "The bot's domain knowledge and its source-priority rules — which inputs win over which.",
+          "The instruction file consumed by bots on the Claude Code engine.",
+          "The bot's opening greeting text; read by engines and clients, not by the platform.",
+          "Free-form human documentation about the bot."
+        ],
+        "x-enum-varnames": [
+          "RULES",
+          "OKR",
+          "SAFETY",
+          "SOUL",
+          "OUTPUT",
+          "MEMORY",
+          "IDENTITY",
+          "AGENTS",
+          "USER",
+          "TOOLS",
+          "HEARTBEAT",
+          "BOOTSTRAP",
+          "KNOWLEDGE",
+          "CLAUDE",
+          "GREETING",
+          "README"
+        ],
+        "x-enumNames": [
+          "RULES",
+          "OKR",
+          "SAFETY",
+          "SOUL",
+          "OUTPUT",
+          "MEMORY",
+          "IDENTITY",
+          "AGENTS",
+          "USER",
+          "TOOLS",
+          "HEARTBEAT",
+          "BOOTSTRAP",
+          "KNOWLEDGE",
+          "CLAUDE",
+          "GREETING",
+          "README"
+        ]
       },
       "IdentityFileWrite": {
         "description": "Write-an-identity-file request body.",
+        "example": {
+          "content": "# Rules\n- Never contact customers directly.\n"
+        },
         "properties": {
           "content": {
+            "description": "Full replacement content (markdown). The write creates the file when absent and overwrites it entirely otherwise; send an empty string to clear the file.",
             "title": "Content",
             "type": "string"
           }
@@ -3017,7 +3285,17 @@
         "type": "object"
       },
       "McpConfig": {
-        "description": "The caller's unified config for an MCP server.\n\n``api_key`` is always returned masked (first/last four for a long key, fully\nmasked otherwise), never in full.",
+        "description": "The caller's unified config for an MCP server.\n\nThe api_key is always returned masked (first/last four characters for a\nlong key, fully masked otherwise), never in full.",
+        "example": {
+          "api_key": "auth****mnop",
+          "endpoint_env": "PROD",
+          "has_config": true,
+          "headers": {
+            "x-region": "eu-1"
+          },
+          "server_code": "mcp.example.weather",
+          "transport_protocol": "STREAMABLE_HTTP"
+        },
         "properties": {
           "api_key": {
             "anyOf": [
@@ -3032,6 +3310,7 @@
             "title": "Api Key"
           },
           "endpoint_env": {
+            "description": "Which of the server's published endpoints the caller's bots connect to: 'PROD' — the production endpoint (the default); 'PRE' — the pre-production endpoint, for testing against a server's staging deployment.",
             "title": "Endpoint Env",
             "type": "string"
           },
@@ -3044,10 +3323,12 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Extra HTTP headers sent to the server on every call; empty when none are stored.",
             "title": "Headers",
             "type": "object"
           },
           "server_code": {
+            "description": "The server's unique identifier in the marketplace catalogue — an opaque, case-sensitive string, e.g. 'mcp.example.weather'. Obtain it from the server listing; do not parse it.",
             "title": "Server Code",
             "type": "string"
           },
@@ -3060,6 +3341,7 @@
                 "type": "null"
               }
             ],
+            "description": "The caller's stored transport preference — 'SSE' or 'STREAMABLE_HTTP'; null when never set, in which case the server's own published transport applies.",
             "title": "Transport Protocol"
           }
         },
@@ -3073,7 +3355,12 @@
       },
       "McpConfigWrite": {
         "additionalProperties": false,
-        "description": "Write the unified config. A null (omitted) field means \"leave unchanged\".\n\n``extra=\"forbid\"``: an unknown field is a 422, not a silent no-op. In\nparticular the old ``sync_mode`` field is gone — the only push path is to\nevery device under the caller, so a per-device mode would advertise\nsomething the server ignores.",
+        "description": "Write the unified config. An omitted (null) field means \"leave unchanged\".\n\nThe write is pushed to every device under the caller before it is\nreported successful; a failed push rolls the change back and answers an\nupstream error.",
+        "example": {
+          "api_key": "authorization=sk-abcdefghijklmnop",
+          "endpoint_env": "PROD",
+          "transport_protocol": "STREAMABLE_HTTP"
+        },
         "properties": {
           "api_key": {
             "anyOf": [
@@ -3084,6 +3371,7 @@
                 "type": "null"
               }
             ],
+            "description": "New credential to store, or omit to leave unchanged. Never send back the masked value from a read — it would be stored literally and replace the real credential.",
             "title": "Api Key"
           },
           "endpoint_env": {
@@ -3099,6 +3387,7 @@
                 "type": "null"
               }
             ],
+            "description": "Which of the server's published endpoints the caller's bots connect to: 'PROD' — the production endpoint (the default); 'PRE' — the pre-production endpoint, for testing against a server's staging deployment.",
             "title": "Endpoint Env"
           },
           "headers": {
@@ -3113,6 +3402,7 @@
                 "type": "null"
               }
             ],
+            "description": "Replacement header map sent to the server on every call; omit to leave unchanged.",
             "title": "Headers"
           },
           "transport_protocol": {
@@ -3128,6 +3418,7 @@
                 "type": "null"
               }
             ],
+            "description": "Transport preference to store: 'SSE' — HTTP + Server-Sent Events; 'STREAMABLE_HTTP' — streamable HTTP. Omit to leave unchanged.",
             "title": "Transport Protocol"
           }
         },
@@ -3136,6 +3427,20 @@
       },
       "McpPermission": {
         "description": "The caller's permission for an MCP server.",
+        "example": {
+          "access_level": "PUBLIC",
+          "has_access": true,
+          "tool_permissions": {
+            "getForecast": {
+              "code": "AUTHORIZED",
+              "name": "Authorized"
+            },
+            "setAlert": {
+              "code": "UNAUTHORIZED",
+              "name": "Unauthorized"
+            }
+          }
+        },
         "properties": {
           "access_level": {
             "anyOf": [
@@ -3146,14 +3451,17 @@
                 "type": "null"
               }
             ],
+            "description": "The marketplace's access label for the server: 'PUBLIC' or 'PRIVATE' for marketplace servers, 'LOCAL' for a server the deployment serves itself, 'COMMUNITY' on community deployments. Empty when the marketplace could not classify the server. Not a closed set — treat unknown values as informational.",
             "title": "Access Level"
           },
           "has_access": {
+            "description": "Whether the caller may use this server at all.",
             "title": "Has Access",
             "type": "boolean"
           },
           "tool_permissions": {
             "additionalProperties": true,
+            "description": "Per-tool authorization, keyed by tool name. Each value carries 'code' — the state, e.g. 'AUTHORIZED' or 'UNAUTHORIZED' — and 'name', a display label whose language is deployment-defined. Empty when the server is local, unknown, or declares no tools.",
             "title": "Tool Permissions",
             "type": "object"
           }
@@ -3166,6 +3474,15 @@
       },
       "McpServer": {
         "description": "An MCP server in the marketplace.",
+        "example": {
+          "description": "Forecasts and current conditions.",
+          "name": "Weather",
+          "network_types": [
+            "INTERNET"
+          ],
+          "server_code": "mcp.example.weather",
+          "transport_protocol": "STREAMABLE_HTTP"
+        },
         "properties": {
           "description": {
             "anyOf": [
@@ -3176,13 +3493,16 @@
                 "type": "null"
               }
             ],
+            "description": "What the server offers; null when the catalogue has none.",
             "title": "Description"
           },
           "name": {
+            "description": "The server's display name.",
             "title": "Name",
             "type": "string"
           },
           "network_types": {
+            "description": "Networks the server is reachable on, as the catalogue declares them: 'INTERNET' — the public internet; 'OFFICE' — the corporate network. Only servers reachable on at least one of those two (or declaring none) are visible on this API. Empty when the catalogue declares none.",
             "items": {
               "type": "string"
             },
@@ -3190,6 +3510,7 @@
             "type": "array"
           },
           "server_code": {
+            "description": "The server's unique identifier in the marketplace catalogue — an opaque, case-sensitive string, e.g. 'mcp.example.weather'. Obtain it from the server listing; do not parse it.",
             "title": "Server Code",
             "type": "string"
           },
@@ -3202,6 +3523,7 @@
                 "type": "null"
               }
             ],
+            "description": "The MCP transport, as the catalogue publishes it — typically 'SSE' (HTTP + Server-Sent Events), 'STREAMABLE_HTTP' (streamable HTTP), or 'STDIO' for a server the deployment runs locally. Echoed as published, so casing can vary; null when the catalogue declares none.",
             "title": "Transport Protocol"
           }
         },
@@ -3214,6 +3536,35 @@
       },
       "McpServerDetail": {
         "description": "An MCP server's detail, including its tools.",
+        "example": {
+          "description": "Forecasts and current conditions.",
+          "name": "Weather",
+          "network_types": [
+            "INTERNET"
+          ],
+          "server_code": "mcp.example.weather",
+          "tools": [
+            {
+              "description": "Forecast for a city and date range",
+              "inputSchema": {
+                "properties": {
+                  "city": {
+                    "type": "string"
+                  },
+                  "days": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "city"
+                ],
+                "type": "object"
+              },
+              "name": "getForecast"
+            }
+          ],
+          "transport_protocol": "STREAMABLE_HTTP"
+        },
         "properties": {
           "description": {
             "anyOf": [
@@ -3224,13 +3575,16 @@
                 "type": "null"
               }
             ],
+            "description": "What the server offers; null when the catalogue has none.",
             "title": "Description"
           },
           "name": {
+            "description": "The server's display name.",
             "title": "Name",
             "type": "string"
           },
           "network_types": {
+            "description": "Networks the server is reachable on, as the catalogue declares them: 'INTERNET' — the public internet; 'OFFICE' — the corporate network. Only servers reachable on at least one of those two (or declaring none) are visible on this API. Empty when the catalogue declares none.",
             "items": {
               "type": "string"
             },
@@ -3238,10 +3592,12 @@
             "type": "array"
           },
           "server_code": {
+            "description": "The server's unique identifier in the marketplace catalogue — an opaque, case-sensitive string, e.g. 'mcp.example.weather'. Obtain it from the server listing; do not parse it.",
             "title": "Server Code",
             "type": "string"
           },
           "tools": {
+            "description": "The server's tools as the catalogue publishes them. Each entry is one MCP tool declaration — typically 'name' (the callable name), 'description', and 'inputSchema' (a JSON Schema for the tool's arguments); any further catalogue keys pass through unchanged.",
             "items": {
               "additionalProperties": true,
               "type": "object"
@@ -3258,6 +3614,7 @@
                 "type": "null"
               }
             ],
+            "description": "The MCP transport, as the catalogue publishes it — typically 'SSE' (HTTP + Server-Sent Events), 'STREAMABLE_HTTP' (streamable HTTP), or 'STDIO' for a server the deployment runs locally. Echoed as published, so casing can vary; null when the catalogue declares none.",
             "title": "Transport Protocol"
           }
         },
@@ -3270,8 +3627,17 @@
       },
       "McpTenant": {
         "description": "An MCP tenant.\n\nNote: an \"MCP tenant\" is a marketplace concept from the upstream MCP Center,\nunrelated to the Avernet data-isolation tenant. The marketplace is a shared\ncatalog — every Avernet tenant sees the same MCP tenants.",
+        "example": {
+          "categories": [
+            "Productivity",
+            "Developer Tools"
+          ],
+          "code": "default",
+          "name": "Community"
+        },
         "properties": {
           "categories": {
+            "description": "Category labels from the marketplace taxonomy — display strings for grouping, not stable machine codes.",
             "items": {
               "type": "string"
             },
@@ -3279,10 +3645,12 @@
             "type": "array"
           },
           "code": {
+            "description": "The tenant's identifier in the marketplace catalogue, e.g. 'default'.",
             "title": "Code",
             "type": "string"
           },
           "name": {
+            "description": "The tenant's display name.",
             "title": "Name",
             "type": "string"
           }
@@ -3430,12 +3798,18 @@
       },
       "NameCheck": {
         "description": "Payload returned by name-availability checks.",
+        "example": {
+          "exists": false,
+          "name": "quarterly-report"
+        },
         "properties": {
           "exists": {
+            "description": "True when the name is already taken; false when it is available to use.",
             "title": "Exists",
             "type": "boolean"
           },
           "name": {
+            "description": "The name in the form the server actually checked — normalized (e.g. trimmed) from what was sent, so this is the exact string the availability answer applies to.",
             "title": "Name",
             "type": "string"
           }
@@ -3448,6 +3822,7 @@
         "type": "object"
       },
       "Page_AuthorizedApp_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3471,6 +3846,7 @@
         "type": "object"
       },
       "Page_AuthorizedBot_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3494,6 +3870,7 @@
         "type": "object"
       },
       "Page_Bot_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3517,6 +3894,7 @@
         "type": "object"
       },
       "Page_McpServer_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3540,6 +3918,7 @@
         "type": "object"
       },
       "Page_Model_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3563,6 +3942,7 @@
         "type": "object"
       },
       "Page_Resource_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3586,6 +3966,7 @@
         "type": "object"
       },
       "Page_RoutineRun_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3609,6 +3990,7 @@
         "type": "object"
       },
       "Page_Routine_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3632,6 +4014,7 @@
         "type": "object"
       },
       "Page_Skill_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
           "items": {
             "description": "Items on the current page (present, possibly empty).",
@@ -3656,12 +4039,18 @@
       },
       "Passport": {
         "description": "Agent Passport (identity credential) summary.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "passport_id": "20260813_a7k2m9p1"
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot this Passport belongs to.",
             "title": "Bot Id",
             "type": "string"
           },
           "passport_id": {
+            "description": "Identifier of the bot's Passport — the platform-issued identity credential downstream services authenticate the bot against. An opaque string whose shape is deployment-defined; it may equal the bot_id.",
             "title": "Passport Id",
             "type": "string"
           }
@@ -3674,7 +4063,12 @@
         "type": "object"
       },
       "Preview": {
-        "description": "A resource preview.",
+        "description": "A file's preview content.",
+        "example": {
+          "content": "# Spec\nThe gateway forwards…",
+          "content_type": "application/octet-stream",
+          "resource_id": ""
+        },
         "properties": {
           "content": {
             "anyOf": [
@@ -3685,9 +4079,11 @@
                 "type": "null"
               }
             ],
+            "description": "The file's content decoded as UTF-8, with undecodable bytes replaced. Files over the preview size limit (1 MB) are refused with 413 rather than truncated; an empty file previews as an empty string.",
             "title": "Content"
           },
           "content_type": {
+            "description": "MIME label of the returned content; currently always 'application/octet-stream' — the server does not classify further.",
             "title": "Content Type",
             "type": "string"
           },
@@ -3700,9 +4096,11 @@
                 "type": "null"
               }
             ],
+            "description": "Reserved for a URL-based preview; currently always null — the content is returned inline instead.",
             "title": "Preview Url"
           },
           "resource_id": {
+            "description": "Always empty — previews address files by their `path`.",
             "title": "Resource Id",
             "type": "string"
           }
@@ -3715,7 +4113,14 @@
         "type": "object"
       },
       "Resource": {
-        "description": "A resource: a file or folder in the bot's workspace, or an external link.\n\nThe container's own storage layout is never exposed — ``path`` is relative to\nthe workspace root, not the engine-view absolute path the device returns.",
+        "description": "A resource: a file or folder in the bot's workspace, or an external link.\n\nThe container's own storage layout is never exposed — `path` is relative to\nthe workspace root, not to any real filesystem the bot runs on.",
+        "example": {
+          "name": "spec.md",
+          "path": "docs/spec.md",
+          "resource_id": "",
+          "size": 2048,
+          "type": "file"
+        },
         "properties": {
           "gmt_create": {
             "anyOf": [
@@ -3726,6 +4131,7 @@
                 "type": "null"
               }
             ],
+            "description": "When the record was created (ISO 8601, no timezone designator). Null for files and folders read straight from the workspace — their listing carries no timestamps.",
             "title": "Gmt Create"
           },
           "gmt_modified": {
@@ -3737,9 +4143,11 @@
                 "type": "null"
               }
             ],
+            "description": "When the record last changed (ISO 8601, no timezone designator); null for files and folders read straight from the workspace.",
             "title": "Gmt Modified"
           },
           "name": {
+            "description": "Display name. For a file or folder this is the last segment of `path`; a link has only a name.",
             "title": "Name",
             "type": "string"
           },
@@ -3752,9 +4160,11 @@
                 "type": "null"
               }
             ],
+            "description": "Workspace-relative path of a file or folder, e.g. 'docs/spec/a.txt' — the whole path, not the directory; `name` is its last segment. This is the addressing key: pass it as `path` on download, preview, upload and delete exactly as listed. Null for links.",
             "title": "Path"
           },
           "resource_id": {
+            "description": "Identifier of the resource's stored record — decimal digits for a link, e.g. '42'. Empty for files and folders, which have no record: address those by `path` instead.",
             "title": "Resource Id",
             "type": "string"
           },
@@ -3767,6 +4177,7 @@
                 "type": "null"
               }
             ],
+            "description": "Size in bytes; null when not reported (links, and entries whose listing carries no size).",
             "title": "Size"
           },
           "source": {
@@ -3778,10 +4189,12 @@
                 "type": "null"
               }
             ],
+            "description": "How the resource record came to exist — e.g. 'manual' for a link created through this API, 'upload' for an uploaded file's record. Null for files and folders read straight from the workspace, which have no record.",
             "title": "Source"
           },
           "type": {
-            "$ref": "#/components/schemas/ResourceType"
+            "$ref": "#/components/schemas/ResourceType",
+            "description": "What kind of resource this is."
           },
           "url": {
             "anyOf": [
@@ -3792,6 +4205,7 @@
                 "type": "null"
               }
             ],
+            "description": "The link's URL; null for files and folders.",
             "title": "Url"
           }
         },
@@ -3804,9 +4218,15 @@
         "type": "object"
       },
       "ResourceCreate": {
-        "description": "Create a resource. ``url`` is required for a link, ``parent_id`` optional.",
+        "description": "Create a link resource.\n\nOnly links are created here: files are created through the upload\nendpoint (a file request answers 400 pointing there), and folders through\nthe mkdir endpoint (a folder request answers 501).",
+        "example": {
+          "name": "Team wiki",
+          "type": "link",
+          "url": "https://wiki.example.com/team"
+        },
         "properties": {
           "name": {
+            "description": "Display name for the link; a duplicate of an existing link answers 409.",
             "title": "Name",
             "type": "string"
           },
@@ -3819,10 +4239,12 @@
                 "type": "null"
               }
             ],
+            "description": "Accepted for compatibility and currently ignored — links are not placed in folders.",
             "title": "Parent Id"
           },
           "type": {
-            "$ref": "#/components/schemas/ResourceType"
+            "$ref": "#/components/schemas/ResourceType",
+            "description": "What to create. Only 'link' is accepted here — see the model description for where files and folders are created."
           },
           "url": {
             "anyOf": [
@@ -3833,6 +4255,7 @@
                 "type": "null"
               }
             ],
+            "description": "The URL the link points to. Required when type is 'link' (400 when missing).",
             "title": "Url"
           }
         },
@@ -3851,10 +4274,28 @@
           "folder"
         ],
         "title": "ResourceType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "A file in the bot's workspace, addressed by its workspace-relative path.",
+          "An external URL saved for the bot, addressed by its resource id.",
+          "A directory in the bot's workspace, addressed by its workspace-relative path."
+        ],
+        "x-enum-varnames": [
+          "FILE",
+          "LINK",
+          "FOLDER"
+        ],
+        "x-enumNames": [
+          "FILE",
+          "LINK",
+          "FOLDER"
+        ]
       },
       "ResourceUpdate": {
-        "description": "Partial update of a resource.",
+        "description": "Partial update of a link resource. Omitted fields are left unchanged.",
+        "example": {
+          "name": "Team wiki (new)"
+        },
         "properties": {
           "name": {
             "anyOf": [
@@ -3865,6 +4306,7 @@
                 "type": "null"
               }
             ],
+            "description": "New display name; omit to keep.",
             "title": "Name"
           },
           "url": {
@@ -3876,6 +4318,7 @@
                 "type": "null"
               }
             ],
+            "description": "New URL; omit to keep.",
             "title": "Url"
           }
         },
@@ -3883,33 +4326,54 @@
         "type": "object"
       },
       "Routine": {
-        "description": "A scheduled/triggered task run by an agent.",
+        "description": "A scheduled task run by a bot.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "command": "Summarize yesterday's tickets and post the brief.",
+          "enabled": true,
+          "gmt_create": "2026-08-01T02:00:00+00:00",
+          "gmt_modified": "2026-08-10T02:00:00+00:00",
+          "name": "morning-brief",
+          "routine_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+          "timezone": "Asia/Shanghai",
+          "trigger": {
+            "cron": "0 9 * * 1-5",
+            "type": "schedule"
+          }
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot the routine belongs to; may be empty on the detail read — keep the bot_id you queried with.",
             "title": "Bot Id",
             "type": "string"
           },
           "command": {
+            "description": "The instruction the bot receives when the routine fires — free-form natural language, delivered as the user message of a fresh session per run. Not a shell command.",
             "title": "Command",
             "type": "string"
           },
           "enabled": {
+            "description": "Whether the schedule is armed; a disabled routine keeps its definition but never fires.",
             "title": "Enabled",
             "type": "boolean"
           },
           "gmt_create": {
+            "description": "When the routine was created (ISO 8601 UTC); empty when the engine reports none.",
             "title": "Gmt Create",
             "type": "string"
           },
           "gmt_modified": {
+            "description": "When the routine last changed (ISO 8601 UTC); empty when the engine reports none.",
             "title": "Gmt Modified",
             "type": "string"
           },
           "name": {
+            "description": "Human-readable routine name.",
             "title": "Name",
             "type": "string"
           },
           "routine_id": {
+            "description": "Identifier of the routine — an opaque string assigned by the bot's engine; treat it as a token.",
             "title": "Routine Id",
             "type": "string"
           },
@@ -3922,10 +4386,12 @@
                 "type": "null"
               }
             ],
+            "description": "IANA time-zone name the schedule is evaluated in, e.g. 'Asia/Shanghai' (the default when omitted on create). When updating the trigger, send the timezone alongside it — a trigger update without one resets the schedule to its default zone.",
             "title": "Timezone"
           },
           "trigger": {
-            "$ref": "#/components/schemas/ScheduleTrigger"
+            "$ref": "#/components/schemas/ScheduleTrigger",
+            "description": "When the routine fires."
           }
         },
         "required": [
@@ -3943,21 +4409,36 @@
       },
       "RoutineCreate": {
         "description": "Create-a-routine request body.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "command": "Summarize yesterday's tickets and post the brief.",
+          "enabled": true,
+          "name": "morning-brief",
+          "timezone": "Asia/Shanghai",
+          "trigger": {
+            "cron": "0 9 * * 1-5",
+            "type": "schedule"
+          }
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot that will run the routine.",
             "title": "Bot Id",
             "type": "string"
           },
           "command": {
+            "description": "The instruction the bot receives when the routine fires — free-form natural language, delivered as the user message of a fresh session per run. Not a shell command.",
             "title": "Command",
             "type": "string"
           },
           "enabled": {
             "default": true,
+            "description": "Whether the schedule starts armed; defaults to true.",
             "title": "Enabled",
             "type": "boolean"
           },
           "name": {
+            "description": "Human-readable routine name.",
             "title": "Name",
             "type": "string"
           },
@@ -3970,10 +4451,12 @@
                 "type": "null"
               }
             ],
+            "description": "IANA time-zone name the schedule is evaluated in, e.g. 'Asia/Shanghai' (the default when omitted on create). When updating the trigger, send the timezone alongside it — a trigger update without one resets the schedule to its default zone.",
             "title": "Timezone"
           },
           "trigger": {
-            "$ref": "#/components/schemas/ScheduleTrigger"
+            "$ref": "#/components/schemas/ScheduleTrigger",
+            "description": "When the routine fires."
           }
         },
         "required": [
@@ -3987,6 +4470,13 @@
       },
       "RoutineRun": {
         "description": "One execution of a routine.",
+        "example": {
+          "finished_at": "2026-08-13T01:04:12+00:00",
+          "routine_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+          "run_id": "5f0f2c9a-b1c3-4f6e-9a0d-2e7c8b1d4a55",
+          "started_at": "2026-08-13T01:00:00+00:00",
+          "status": "ok"
+        },
         "properties": {
           "finished_at": {
             "anyOf": [
@@ -3997,13 +4487,16 @@
                 "type": "null"
               }
             ],
+            "description": "When the run finished (ISO 8601 UTC); null while the run is still in flight or when not reported.",
             "title": "Finished At"
           },
           "routine_id": {
+            "description": "The routine that ran.",
             "title": "Routine Id",
             "type": "string"
           },
           "run_id": {
+            "description": "Identifier of the run entry. Not guaranteed unique across a routine's history — treat the list positionally.",
             "title": "Run Id",
             "type": "string"
           },
@@ -4016,9 +4509,11 @@
                 "type": "null"
               }
             ],
+            "description": "When the run started (ISO 8601 UTC); null when not reported — including on the run-now response, which reports no timestamps.",
             "title": "Started At"
           },
           "status": {
+            "description": "Outcome of the run. In the run history this is the engine's own label — today 'ok' (the run completed), 'error' (it failed or timed out) or 'skipped' (fired but not runnable), and empty when the engine reported none. The run-now endpoint instead answers 'completed', 'failed' or 'unknown' for the trigger attempt it just made. Treat unknown values as informational.",
             "title": "Status",
             "type": "string"
           }
@@ -4032,7 +4527,14 @@
         "type": "object"
       },
       "RoutineUpdate": {
-        "description": "Partial update of a routine.",
+        "description": "Partial update of a routine. Omitted fields are left unchanged.",
+        "example": {
+          "timezone": "Asia/Shanghai",
+          "trigger": {
+            "cron": "30 8 * * 1-5",
+            "type": "schedule"
+          }
+        },
         "properties": {
           "command": {
             "anyOf": [
@@ -4043,6 +4545,7 @@
                 "type": "null"
               }
             ],
+            "description": "New instruction; omit to keep.",
             "title": "Command"
           },
           "enabled": {
@@ -4054,6 +4557,7 @@
                 "type": "null"
               }
             ],
+            "description": "Arm (true) or disarm (false) the schedule; omit to keep.",
             "title": "Enabled"
           },
           "name": {
@@ -4065,6 +4569,7 @@
                 "type": "null"
               }
             ],
+            "description": "New name; omit to keep.",
             "title": "Name"
           },
           "timezone": {
@@ -4076,6 +4581,7 @@
                 "type": "null"
               }
             ],
+            "description": "IANA time-zone name the schedule is evaluated in, e.g. 'Asia/Shanghai' (the default when omitted on create). When updating the trigger, send the timezone alongside it — a trigger update without one resets the schedule to its default zone.",
             "title": "Timezone"
           },
           "trigger": {
@@ -4086,7 +4592,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "New trigger; omit to keep. Send timezone alongside it — see that field's description."
           }
         },
         "title": "RoutineUpdate",
@@ -4119,14 +4626,20 @@
       },
       "ScheduleTrigger": {
         "description": "A schedule trigger. Modeled as a typed nested object so other trigger\nkinds (event, webhook) can be added later without a breaking change.",
+        "example": {
+          "cron": "0 9 * * 1-5",
+          "type": "schedule"
+        },
         "properties": {
           "cron": {
+            "description": "Standard 5-field cron expression — minute, hour, day-of-month, month, day-of-week — e.g. '0 9 * * 1-5' for 09:00 on weekdays. Minute granularity; seconds are not supported. Evaluated in the routine's timezone.",
             "title": "Cron",
             "type": "string"
           },
           "type": {
             "const": "schedule",
             "default": "schedule",
+            "description": "Trigger kind; 'schedule' (a cron schedule) is the only kind today.",
             "title": "Type",
             "type": "string"
           }
@@ -4251,24 +4764,28 @@
         "type": "object"
       },
       "SessionListResponse": {
-        "description": "Paginated list of conversation sessions.",
+        "description": "Paginated list of recorded chat turns (traces), newest first.",
         "properties": {
           "has_more": {
             "default": false,
+            "description": "Whether more pages exist beyond this one.",
             "title": "Has More",
             "type": "boolean"
           },
           "limit": {
             "default": 20,
+            "description": "The effective page size answered.",
             "title": "Limit",
             "type": "integer"
           },
           "page": {
             "default": 1,
+            "description": "The effective 1-based page number answered.",
             "title": "Page",
             "type": "integer"
           },
           "sessions": {
+            "description": "The current page of traces. Items carry previews only — read the trace detail for full input/output and observations.",
             "items": {
               "$ref": "#/components/schemas/ConversationSession"
             },
@@ -4286,11 +4803,11 @@
         "type": "object"
       },
       "SessionMetadata": {
-        "description": "Metadata from Langfuse trace, including identity attributes.",
+        "description": "Metadata recorded with a trace.",
         "properties": {
           "attributes": {
             "additionalProperties": true,
-            "description": "Trace metadata attributes (e.g. identity.bot_id, identity.owner_id, session_id)",
+            "description": "The trace's attribute bag as recorded at ingest — e.g. identity.owner_id, identity.bot_id, gen_ai.request.model, gen_ai.usage.* token counts, and derived usage_details / cost_details breakdowns. A superset of what the emitter sent.",
             "title": "Attributes",
             "type": "object"
           }
@@ -4356,8 +4873,19 @@
       },
       "Skill": {
         "description": "Public metadata for one Bot-owned Skill.",
+        "example": {
+          "active": true,
+          "category": "general",
+          "created_at": "2026-08-04T10:00:00",
+          "description": "Builds the weekly status report.",
+          "name": "weekly-report",
+          "skill_id": "42",
+          "tags": [],
+          "updated_at": "2026-08-10T08:30:00"
+        },
         "properties": {
           "active": {
+            "description": "Whether the skill is enabled for the bot. This is the desired state — it answers even while the bot is offline.",
             "title": "Active",
             "type": "boolean"
           },
@@ -4370,6 +4898,7 @@
                 "type": "null"
               }
             ],
+            "description": "Free-form grouping label. Currently always 'general' for skills uploaded through this API; other values can appear on records created elsewhere. Null on some legacy records.",
             "title": "Category"
           },
           "created_at": {
@@ -4385,6 +4914,7 @@
                 "type": "null"
               }
             ],
+            "description": "When the skill was created (ISO 8601, no timezone designator); null when unrecorded.",
             "title": "Created At"
           },
           "description": {
@@ -4396,17 +4926,21 @@
                 "type": "null"
               }
             ],
+            "description": "What the skill does, from its package manifest.",
             "title": "Description"
           },
           "name": {
+            "description": "The skill's name, taken from its package manifest — ASCII letters, digits and hyphens only. Unique per bot, not globally; renaming means uploading under a new name.",
             "title": "Name",
             "type": "string"
           },
           "skill_id": {
+            "description": "Identifier of the skill — decimal digits, e.g. '42'. Stable across package replacement. Address skills by this id, never by name.",
             "title": "Skill Id",
             "type": "string"
           },
           "tags": {
+            "description": "Labels attached to the skill. Currently always empty for skills uploaded through this API; records created elsewhere may carry manifest-declared tags.",
             "items": {
               "type": "string"
             },
@@ -4426,6 +4960,7 @@
                 "type": "null"
               }
             ],
+            "description": "When the skill last changed (ISO 8601, no timezone designator); null when unrecorded. Right after a package replacement this can still show the pre-replacement time — re-read the skill for the fresh value.",
             "title": "Updated At"
           }
         },
@@ -4439,13 +4974,28 @@
       },
       "SkillState": {
         "description": "Result of an idempotent Skill desired-state command.",
+        "example": {
+          "changed": true,
+          "skill": {
+            "active": true,
+            "category": "general",
+            "created_at": "2026-08-04T10:00:00",
+            "description": "Builds the weekly status report.",
+            "name": "weekly-report",
+            "skill_id": "42",
+            "tags": [],
+            "updated_at": "2026-08-10T08:30:00"
+          }
+        },
         "properties": {
           "changed": {
+            "description": "False when the skill was already in the requested state — the call is idempotent and succeeded either way.",
             "title": "Changed",
             "type": "boolean"
           },
           "skill": {
-            "$ref": "#/components/schemas/Skill"
+            "$ref": "#/components/schemas/Skill",
+            "description": "The skill in its resulting state."
           }
         },
         "required": [
@@ -4457,8 +5007,22 @@
       },
       "SkillUpload": {
         "description": "Response for a Skill create or same-name package replacement.",
+        "example": {
+          "operation": "created",
+          "skill": {
+            "active": false,
+            "category": "general",
+            "created_at": "2026-08-04T10:00:00",
+            "description": "Builds the weekly status report.",
+            "name": "weekly-report",
+            "skill_id": "42",
+            "tags": [],
+            "updated_at": "2026-08-04T10:00:00"
+          }
+        },
         "properties": {
           "operation": {
+            "description": "'created' — no skill of that name existed for the bot; a new one was created, inactive, and answers 201. 'updated' — a same-name skill existed and its package was replaced in place, keeping its id and active state; answers 200.",
             "enum": [
               "created",
               "updated"
@@ -4467,7 +5031,8 @@
             "type": "string"
           },
           "skill": {
-            "$ref": "#/components/schemas/Skill"
+            "$ref": "#/components/schemas/Skill",
+            "description": "The skill as stored after the upload."
           }
         },
         "required": [
@@ -4520,8 +5085,18 @@
       },
       "StartupScript": {
         "description": "A bot's stored startup script. Every field is server-derived.",
+        "example": {
+          "bot_id": "20260813_a7k2m9p1",
+          "script": "#!/bin/sh\npip install -q requests\n",
+          "size_bytes": 34,
+          "supported": true,
+          "unsupported_reason": "",
+          "updated_at": "2026-08-01T09:12:04+00:00",
+          "updated_by": "u_165137"
+        },
         "properties": {
           "bot_id": {
+            "description": "The bot this script belongs to.",
             "title": "Bot Id",
             "type": "string"
           },
@@ -4531,6 +5106,7 @@
             "type": "string"
           },
           "size_bytes": {
+            "description": "Size of the stored script in bytes; 0 when none is stored.",
             "title": "Size Bytes",
             "type": "integer"
           },
@@ -4576,7 +5152,10 @@
       },
       "StartupScriptWrite": {
         "additionalProperties": false,
-        "description": "PUT body for a bot's startup script — the only client-supplied field.\n\nAudit fields are deliberately absent: ``updated_by`` comes from the request\nprincipal and ``updated_at`` from the row's own timestamp, so neither can be\nasserted by a caller, and ``extra=\"forbid\"`` means an attempt to send one\nfails validation rather than being silently dropped with a 200.",
+        "description": "PUT body for a bot's startup script — the script is the only field.\n\nThe audit fields on the stored script are server-derived and cannot be\nsupplied here; sending one fails validation rather than being silently\ndropped.",
+        "example": {
+          "script": "#!/bin/sh\npip install -q requests\n"
+        },
         "properties": {
           "script": {
             "description": "Shell script run inside the bot's container on every container start, after the platform's own boot steps. Must be idempotent — it runs again on every start and the platform does not dedupe. Do not put secrets in the body.",
@@ -4600,10 +5179,11 @@
   "paths": {
     "/openapi/v1/bots": {
       "get": {
-        "description": "List the user's bots (filter + paginate), narrowed to what may be reached.\n\nFor a human caller this is their own bots, unfiltered — unchanged.\n\nFor an **application** the result is narrowed to the bots that user granted\nit. Filtering here rather than in the service keeps the narrowing beside the\nthing it protects, and it is applied **before** paginating: filtering a page\nafter the fact would return short pages and, worse, let a caller infer how\nmany bots it was *not* granted from the gaps. The count reports the narrowed\nset for the same reason.\n\nAn application granted nothing gets an empty page, not an error: naming no\nbot, this operation has nothing to mask.\n\nNote this listing can never show a bot the user does not own, for an\napplication any more than for the user — it is owner-scoped underneath. The\ncomplete view of what an application may reach, including bots delegated by\na collaborator, is ``GET /openapi/v1/bots/authorized``.",
+        "description": "List the user's bots (filter + paginate), narrowed to what may be reached.\n\nFor a human caller this is their own bots, unfiltered — unchanged.\n\nFor an **application** the result is narrowed to the bots that user granted\nit. Filtering here rather than in the service keeps the narrowing beside the\nthing it protects, and it is applied **before** paginating: filtering a page\nafter the fact would return short pages and, worse, let a caller infer how\nmany bots it was *not* granted from the gaps. The count reports the narrowed\nset for the same reason.\n\nAn application granted nothing gets an empty page, not an error: naming no\nbot, this operation has nothing to mask.\n\nNote this listing can never show a bot the user does not own, for an\napplication any more than for the user — it is owner-scoped underneath. The\ncomplete view of what an application may reach, including bots delegated by\na collaborator, is the authorized-bots listing.",
         "operationId": "list_bots_openapi_v1_bots_get",
         "parameters": [
           {
+            "description": "Filter: bots whose name contains this text.",
             "in": "query",
             "name": "keyword",
             "required": false,
@@ -4616,10 +5196,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: bots whose name contains this text.",
               "title": "Keyword"
             }
           },
           {
+            "description": "Filter: only bots on this engine, matched exactly.",
             "in": "query",
             "name": "engine",
             "required": false,
@@ -4632,10 +5214,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: only bots on this engine, matched exactly.",
               "title": "Engine"
             }
           },
           {
+            "description": "Filter: only bots in this lifecycle status, matched exactly (e.g. 'ACTIVE'; see the Bot schema for the vocabulary).",
             "in": "query",
             "name": "status",
             "required": false,
@@ -4648,6 +5232,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: only bots in this lifecycle status, matched exactly (e.g. 'ACTIVE'; see the Bot schema for the vocabulary).",
               "title": "Status"
             }
           },
@@ -4789,7 +5374,7 @@
         ]
       },
       "post": {
-        "description": "Create a bot (201), or return 202 + a Passport iframe when authorization is needed.\n\nEngine-specific inputs belong in ``BotCreateSpec.extra_properties``, but\nnothing downstream reads that bag yet, so the request model does not expose\nan ``engine_options`` field for it — see :class:`BotCreate`.",
+        "description": "Create a bot (201), or 202 with authorization URLs when consent is needed.\n\nOn a 202, have the user complete authorization at one of the returned\nURLs, then poll the auth-status endpoint — the bot is only created there,\non ISSUED. Engine-specific options are not accepted here; engine\nconfiguration is managed through the engine-config endpoints after\ncreation.",
         "operationId": "create_bot_openapi_v1_bots_post",
         "parameters": [
           {
@@ -4929,10 +5514,12 @@
         "operationId": "get_approval_mode_openapi_v1_bots_approvals__bot_id__mode_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -5113,10 +5700,12 @@
         "operationId": "set_approval_mode_openapi_v1_bots_approvals__bot_id__mode_put",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -5298,10 +5887,12 @@
         "operationId": "list_approval_modes_openapi_v1_bots_approvals__bot_id__modes_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -5469,7 +6060,7 @@
     },
     "/openapi/v1/bots/authorized": {
       "get": {
-        "description": "The application's view — which bots may it reach as this user.\n\nNames no bot and so performs no bot-existence check, unlike the three above:\nthere is nothing to mask. The result is one user's own delegations to the\ncalling application, and an empty page discloses nothing — which is why\nholding none answers ``200`` with no items rather than ``404``.\n\nThis is also the **only** complete view of what the application may reach.\nA delegated bot the user does not own appears in no listing of that user's\nbots, so without this it would be undiscoverable.",
+        "description": "The application's view — which bots may it reach as this user.\n\nNames no bot and so performs no bot-existence check, unlike the three above:\nthere is nothing to mask. The result is one user's own delegations to the\ncalling application, and an empty page discloses nothing — which is why\nholding none answers 200 with no items rather than 404.\n\nThis is also the **only** complete view of what the application may reach.\nA delegated bot the user does not own appears in no listing of that user's\nbots, so without this it would be undiscoverable.",
         "operationId": "list_authorized_bots_openapi_v1_bots_authorized_get",
         "parameters": [
           {
@@ -5585,7 +6176,7 @@
     },
     "/openapi/v1/bots/ceiling": {
       "get": {
-        "description": "Get the named user's bot-creation quota ceiling.\n\nNames no bot, so there is no grant to check against one — but the answer is\nstill *about a person's account*, and a stranger application must not be\nable to read it by naming a user id. So it is gated on the application\nholding **at least one** live delegation from that user: proof of a\nrelationship, which is the closest thing this operation has to a scope.\n\nAn application with no delegation from them is answered as if the user were\nnot there. It learns nothing it did not already know.\n\nResolved through the same method creation enforces, not\n``PolicyService.get_bots_ceiling`` directly: that one falls back to its own\nhardcoded default of 5, while creation falls back to the configured\n``max_devices_per_entity``. Reading it directly would advertise 5 to a caller\nwhose deployment allows (or rejects at) a different number.",
+        "description": "Get the named user's bot-creation quota ceiling.\n\nThe number creation actually enforces: creating a bot while the user owns\nthis many live bots is refused (409). A ceiling of 0 or less means the\nlimit is disabled. For an application caller, reading it requires holding\nat least one live delegation from the named user; without one the user is\nanswered as if they did not exist.",
         "operationId": "get_bots_ceiling_openapi_v1_bots_ceiling_get",
         "parameters": [
           {
@@ -5701,14 +6292,16 @@
     },
     "/openapi/v1/bots/check-name": {
       "get": {
-        "description": "Check whether a bot name is available (within the caller's tenant).\n\nApplies the same rule create and update do, because \"available\" has to mean\n\"you could create this\". ``check_bot_name_exists`` only does a repository\nlookup — it answers ``False`` for a blank or ``@``-bearing name, which would\nreport a name as free that the very next request would reject (400).\nRejecting here instead keeps one answer across the three endpoints.\n\nThe echoed ``name`` is the trimmed form actually checked, so a caller that\nsends ``\" Foo \"`` sees which string the availability applies to.",
+        "description": "Check whether a bot name is available (within the caller's tenant).\n\nApplies the same validation create and update do, so \"available\" always\nmeans \"you could create this\". The echoed name is the trimmed form\nactually checked — a caller that sends \" Foo \" sees which string the\navailability answer applies to.",
         "operationId": "check_bot_name_openapi_v1_bots_check_name_get",
         "parameters": [
           {
+            "description": "The bot name to check. Validated with the same rules create applies (non-blank, no '@'), so an invalid name is a 400 here rather than a false 'available'.",
             "in": "query",
             "name": "name",
             "required": true,
             "schema": {
+              "description": "The bot name to check. Validated with the same rules create applies (non-blank, no '@'), so an invalid name is a 400 here rather than a false 'available'.",
               "title": "Name",
               "type": "string"
             }
@@ -5808,10 +6401,12 @@
         "operationId": "get_connection_openapi_v1_bots_connection__bot_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -5983,10 +6578,12 @@
         "operationId": "list_available_engines_openapi_v1_bots_engine__bot_id__available_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -6158,10 +6755,12 @@
         "operationId": "get_engine_capabilities_openapi_v1_bots_engine__bot_id__capabilities_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -6333,10 +6932,12 @@
         "operationId": "get_engine_status_openapi_v1_bots_engine__bot_id__status_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -6504,14 +7105,16 @@
     },
     "/openapi/v1/bots/identity/{bot_id}": {
       "get": {
-        "description": "List a bot's identity files and whether each exists.\n\nI2: entity_type/entity_id/operator_id come from the authenticated\nrequest's ``user_id`` parameter (personal bot owner = the named user).",
+        "description": "List every identity file type a bot can carry and whether each exists.\n\nA file reports exists false both when it is absent and when it exists\nwith empty content. Entry order is not guaranteed — key off type.",
         "operationId": "list_bot_identity_files_openapi_v1_bots_identity__bot_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -6629,24 +7232,28 @@
     },
     "/openapi/v1/bots/identity/{bot_id}/{file_type}": {
       "get": {
-        "description": "Read one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``UserIdDep`` (personal bot owner = the named user). I3: ``publish_id`` is\nnot exposed — only draft-device reads (``get_bot_file`` default branch).\nThe service's ``validate_file_type`` requires the physical ``<type>.md``\nform (``VALID_IDENTITY_FILES`` carries the suffix), so the enum value is\nre-suffixed before forwarding.",
+        "description": "Read one identity file of a bot.\n\nA file that has never been written reads as an empty content string, not\nan error. Reads address the bot's draft runtime.",
         "operationId": "get_bot_identity_file_openapi_v1_bots_identity__bot_id___file_type__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "Which identity file to address — one of the whitelisted types (see the enum's per-value documentation for what each file is for).",
             "in": "path",
             "name": "file_type",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IdentityFileType"
+              "$ref": "#/components/schemas/IdentityFileType",
+              "description": "Which identity file to address — one of the whitelisted types (see the enum's per-value documentation for what each file is for)."
             }
           },
           {
@@ -6760,24 +7367,28 @@
         ]
       },
       "put": {
-        "description": "Overwrite one identity file of a bot.\n\nI2: entity params come from the authenticated principal via\n``UserIdDep`` as above; ``validate_file_type`` requires the\n``<type>.md`` form. Returns an ``IdentityFileRef`` (no content echoed).",
+        "description": "Create or overwrite one identity file of a bot.\n\nA full replacement — the body's content becomes the whole file. The\nresponse is a reference only; the content is not echoed back.",
         "operationId": "update_bot_identity_file_openapi_v1_bots_identity__bot_id___file_type__put",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "Which identity file to address — one of the whitelisted types (see the enum's per-value documentation for what each file is for).",
             "in": "path",
             "name": "file_type",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IdentityFileType"
+              "$ref": "#/components/schemas/IdentityFileType",
+              "description": "Which identity file to address — one of the whitelisted types (see the enum's per-value documentation for what each file is for)."
             }
           },
           {
@@ -6903,7 +7514,7 @@
     },
     "/openapi/v1/bots/loadtest/hello": {
       "get": {
-        "description": "Answer the constant ``hello world``.\n\nReads nothing and calls nothing, so the response time is the path's, not the\nhandler's.",
+        "description": "Answer the constant \"hello world\".\n\nReads nothing and calls nothing, so the response time is the path's, not the\nhandler's.",
         "operationId": "hello_world_openapi_v1_bots_loadtest_hello_get",
         "responses": {
           "200": {
@@ -6995,14 +7606,16 @@
     },
     "/openapi/v1/bots/logs/groups/{group_id}/traces": {
       "get": {
-        "description": "List traces for one exact BCS Group.",
+        "description": "List the traces of every session in one collaboration group, newest first.",
         "operationId": "list_group_traces_openapi_v1_bots_logs_groups__group_id__traces_get",
         "parameters": [
           {
+            "description": "The collaboration group whose sessions' traces to list.",
             "in": "path",
             "name": "group_id",
             "required": true,
             "schema": {
+              "description": "The collaboration group whose sessions' traces to list.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Group Id",
@@ -7010,22 +7623,26 @@
             }
           },
           {
+            "description": "1-based page number.",
             "in": "query",
             "name": "page",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "1-based page number.",
               "minimum": 1,
               "title": "Page",
               "type": "integer"
             }
           },
           {
+            "description": "Traces per page (max 100).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 100,
+              "description": "Traces per page (max 100).",
               "maximum": 100,
               "minimum": 1,
               "title": "Limit",
@@ -7123,14 +7740,16 @@
     },
     "/openapi/v1/bots/logs/sessions/{session_key}/traces": {
       "get": {
-        "description": "List traces for one exact Session key.",
+        "description": "List the recorded chat turns (traces) of one session, newest first.\n\nThe session key is matched exactly, as reported in a trace's\nsession_key.",
         "operationId": "list_session_traces_openapi_v1_bots_logs_sessions__session_key__traces_get",
         "parameters": [
           {
+            "description": "The engine session key, exactly as a trace reports it in session_key (exact match, no prefix search).",
             "in": "path",
             "name": "session_key",
             "required": true,
             "schema": {
+              "description": "The engine session key, exactly as a trace reports it in session_key (exact match, no prefix search).",
               "maxLength": 512,
               "minLength": 1,
               "title": "Session Key",
@@ -7138,22 +7757,26 @@
             }
           },
           {
+            "description": "1-based page number.",
             "in": "query",
             "name": "page",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "1-based page number.",
               "minimum": 1,
               "title": "Page",
               "type": "integer"
             }
           },
           {
+            "description": "Traces per page (max 100).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 100,
+              "description": "Traces per page (max 100).",
               "maximum": 100,
               "minimum": 1,
               "title": "Limit",
@@ -7251,14 +7874,16 @@
     },
     "/openapi/v1/bots/logs/tasks/{biz_scene}/{biz_task_id}/traces": {
       "get": {
-        "description": "List traces for one exact business Task.",
+        "description": "List the traces labelled with one business scene/task pair, newest first.\n\nMatches labels attached at recording time and labels registered as\nrelations afterwards — each item's match_sources says which.",
         "operationId": "list_task_traces_openapi_v1_bots_logs_tasks__biz_scene___biz_task_id__traces_get",
         "parameters": [
           {
+            "description": "The integrating system's business scene the task belongs to (exact match).",
             "in": "path",
             "name": "biz_scene",
             "required": true,
             "schema": {
+              "description": "The integrating system's business scene the task belongs to (exact match).",
               "maxLength": 128,
               "minLength": 1,
               "title": "Biz Scene",
@@ -7266,10 +7891,12 @@
             }
           },
           {
+            "description": "The integrating system's own task id within the scene (exact match).",
             "in": "path",
             "name": "biz_task_id",
             "required": true,
             "schema": {
+              "description": "The integrating system's own task id within the scene (exact match).",
               "maxLength": 256,
               "minLength": 1,
               "title": "Biz Task Id",
@@ -7277,22 +7904,26 @@
             }
           },
           {
+            "description": "1-based page number.",
             "in": "query",
             "name": "page",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "1-based page number.",
               "minimum": 1,
               "title": "Page",
               "type": "integer"
             }
           },
           {
+            "description": "Traces per page (max 100).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 100,
+              "description": "Traces per page (max 100).",
               "maximum": 100,
               "minimum": 1,
               "title": "Limit",
@@ -7390,14 +8021,16 @@
     },
     "/openapi/v1/bots/logs/traces": {
       "get": {
-        "description": "List recent traces for one explicit user-and-Bot pair.",
+        "description": "List one user-and-bot pair's recent traces, newest first.\n\nCovers the last 72 hours only; use the session, task or group listings\nfor older history.",
         "operationId": "list_user_bot_traces_openapi_v1_bots_logs_traces_get",
         "parameters": [
           {
+            "description": "Whose traces to read — a filter, not the caller's identity; naming another user is allowed here.",
             "in": "query",
             "name": "user_id",
             "required": true,
             "schema": {
+              "description": "Whose traces to read — a filter, not the caller's identity; naming another user is allowed here.",
               "maxLength": 256,
               "minLength": 1,
               "title": "User Id",
@@ -7405,10 +8038,12 @@
             }
           },
           {
+            "description": "The bot whose traces to read, paired with user_id.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot whose traces to read, paired with user_id.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Bot Id",
@@ -7416,22 +8051,26 @@
             }
           },
           {
+            "description": "1-based page number.",
             "in": "query",
             "name": "page",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "1-based page number.",
               "minimum": 1,
               "title": "Page",
               "type": "integer"
             }
           },
           {
+            "description": "Traces per page (max 100).",
             "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
               "default": 100,
+              "description": "Traces per page (max 100).",
               "maximum": 100,
               "minimum": 1,
               "title": "Limit",
@@ -7529,14 +8168,16 @@
     },
     "/openapi/v1/bots/logs/traces/{trace_id}": {
       "get": {
-        "description": "Return one Trace with its observation tree.",
+        "description": "Return one recorded chat turn (trace) in full.\n\nIncludes the complete input and output plus the observation tree — the\nmodel generations and tool calls that made up the turn.",
         "operationId": "get_trace_openapi_v1_bots_logs_traces__trace_id__get",
         "parameters": [
           {
+            "description": "The trace's id, as returned in a listing entry's id.",
             "in": "path",
             "name": "trace_id",
             "required": true,
             "schema": {
+              "description": "The trace's id, as returned in a listing entry's id.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Trace Id",
@@ -7634,10 +8275,11 @@
     },
     "/openapi/v1/bots/mcp/servers": {
       "get": {
-        "description": "List marketplace MCP servers (filter by ``keyword``, paginate).",
+        "description": "List marketplace MCP servers (filter by keyword, paginate).",
         "operationId": "list_mcp_servers_openapi_v1_bots_mcp_servers_get",
         "parameters": [
           {
+            "description": "Filter: case-insensitive fuzzy match against the server's name and code.",
             "in": "query",
             "name": "keyword",
             "required": false,
@@ -7650,6 +8292,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: case-insensitive fuzzy match against the server's name and code.",
               "title": "Keyword"
             }
           },
@@ -7775,10 +8418,12 @@
         "operationId": "get_mcp_server_openapi_v1_bots_mcp_servers__server_code__get",
         "parameters": [
           {
+            "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
             "in": "path",
             "name": "server_code",
             "required": true,
             "schema": {
+              "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
               "title": "Server Code",
               "type": "string"
             }
@@ -7874,14 +8519,16 @@
     },
     "/openapi/v1/bots/mcp/servers/{server_code}/config": {
       "get": {
-        "description": "Read the caller's unified config for an MCP server (``api_key`` masked).\n\nA server the caller has never configured is not an error — it returns\n``has_config: false`` with defaults.",
+        "description": "Read the caller's unified config for an MCP server (api_key masked).\n\nA server the caller has never configured is not an error — it returns\nhas_config false with defaults.",
         "operationId": "get_mcp_config_openapi_v1_bots_mcp_servers__server_code__config_get",
         "parameters": [
           {
+            "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
             "in": "path",
             "name": "server_code",
             "required": true,
             "schema": {
+              "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
               "title": "Server Code",
               "type": "string"
             }
@@ -8001,10 +8648,12 @@
         "operationId": "update_mcp_config_openapi_v1_bots_mcp_servers__server_code__config_put",
         "parameters": [
           {
+            "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
             "in": "path",
             "name": "server_code",
             "required": true,
             "schema": {
+              "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
               "title": "Server Code",
               "type": "string"
             }
@@ -8132,14 +8781,16 @@
     },
     "/openapi/v1/bots/mcp/servers/{server_code}/permissions": {
       "get": {
-        "description": "Report the caller's own permission for an MCP server.\n\nAlways the caller's own permission. The identity is the request's required\n``user_id``, and it is refused unless it names the verified caller — so this\nstill cannot be pointed at someone else to probe their grants, which is the\nproperty the internal route's free-form ``user_id`` query param does not\nhave. The parameter states whose permission is being asked about; it does\nnot widen whose it may be.\n\n**Fail-open, by decision (spec Open Question 1).** When the marketplace\nlookup errors, ``check_mcp_permission_detail`` reports the caller *as\npermitted*. This surface preserves that rather than failing closed: the\nendpoint is advisory — the MCP server itself is the enforcement point — so a\nwrong \"yes\" during an upstream outage costs one failed call, whereas failing\nclosed would make a marketplace outage look like a permission revocation.",
+        "description": "Report the caller's own permission for an MCP server.\n\nAlways the caller's own permission: the required user_id must name the\nverified caller, so this cannot be pointed at someone else to probe their\ngrants.\n\nAdvisory, and fail-open by design: when the marketplace lookup errors,\nthe answer reports the caller as permitted — the MCP server itself is the\nenforcement point, so a wrong \"yes\" during an outage costs one failed\ncall, whereas failing closed would make an outage look like a permission\nrevocation.",
         "operationId": "check_mcp_permission_openapi_v1_bots_mcp_servers__server_code__permissions_get",
         "parameters": [
           {
+            "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
             "in": "path",
             "name": "server_code",
             "required": true,
             "schema": {
+              "description": "The MCP server's code, exactly as returned by the server listing — an opaque, case-sensitive identifier, e.g. 'mcp.example.weather'.",
               "title": "Server Code",
               "type": "string"
             }
@@ -8353,10 +9004,12 @@
         "operationId": "list_models_openapi_v1_bots_models__bot_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -8555,19 +9208,23 @@
         "operationId": "get_model_openapi_v1_bots_models__bot_id___model_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The model's id, exactly as returned by the model listing for this bot.",
             "in": "path",
             "name": "model_id",
             "required": true,
             "schema": {
+              "description": "The model's id, exactly as returned by the model listing for this bot.",
               "title": "Model Id",
               "type": "string"
             }
@@ -8739,10 +9396,12 @@
         "operationId": "delete_file_openapi_v1_bots_resources_delete",
         "parameters": [
           {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
             "in": "query",
             "name": "path",
             "required": true,
             "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
               "title": "Path",
               "type": "string"
             }
@@ -8869,7 +9528,7 @@
         ]
       },
       "get": {
-        "description": "List a directory of the bot's workspace, plus the bot's link resources.\n\nFiles and folders come from the **workspace**, never from records. That is\nwhat makes a file the bot produced itself a first-class resource: it has no\nrecord and never will, and a record-backed listing simply could not see it.\nIt also removes the divergence the other direction — a record whose bytes are\nnot where it claims can no longer be reported as a file that exists.\n\nLinks are the exception, and not an inconsistency: a link has no file and no\npresence on any device, so the record *is* the resource. They are read from\nthe repo and appended.\n\n``path`` selects the directory (empty = workspace root). Listing is\nnon-recursive, which bounds the device round trip this endpoint now makes.",
+        "description": "List a directory of the bot's workspace, plus the bot's link resources.\n\nFiles and folders come from the **workspace**, never from records. That is\nwhat makes a file the bot produced itself a first-class resource: it has no\nrecord and never will, and a record-backed listing simply could not see it.\nIt also removes the divergence the other direction — a record whose bytes are\nnot where it claims can no longer be reported as a file that exists.\n\nLinks are the exception, and not an inconsistency: a link has no file and no\npresence on any device, so the record *is* the resource. They are read from\nthe repo and appended.\n\nThe path parameter selects the directory (empty = workspace root).\nListing is non-recursive, which bounds the device round trip this\nendpoint makes.",
         "operationId": "list_resources_openapi_v1_bots_resources_get",
         "parameters": [
           {
@@ -8896,6 +9555,7 @@
             }
           },
           {
+            "description": "Filter: 'file' or 'folder' lists only workspace entries of that kind; 'link' returns only the bot's links (path is then ignored). Omit for everything.",
             "in": "query",
             "name": "type",
             "required": false,
@@ -8908,6 +9568,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: 'file' or 'folder' lists only workspace entries of that kind; 'link' returns only the bot's links (path is then ignored). Omit for everything.",
               "title": "Type"
             }
           },
@@ -9186,30 +9847,35 @@
     },
     "/openapi/v1/bots/resources/check-name": {
       "get": {
-        "description": "Whether a resource already exists.\n\nTwo parameters because there are two kinds of resource, addressed\ndifferently. A **file** is checked against the workspace by ``path`` — the\nsame question the upload asks before writing, answered by the same authority,\nso the two can never disagree. A **link** is checked by ``name`` against the\nrecords, because a link has no file.\n\nA caller supplying ``path`` gets the file check; otherwise it is the link\ncheck. Splitting the two surfaces entirely would be cleaner than one endpoint\nwith two addressing modes, but that is a larger contract change than this one.",
+        "description": "Whether a resource already exists.\n\nTwo parameters because there are two kinds of resource, addressed\ndifferently. A file or folder is checked against the workspace by path —\nthe same question the upload asks before writing, answered by the same\nauthority, so the two can never disagree. A link is checked by name\nagainst the records, because a link has no file. Supplying path gets the\nfile check; otherwise it is the link check.",
         "operationId": "check_resource_name_openapi_v1_bots_resources_check_name_get",
         "parameters": [
           {
+            "description": "Link name to check against the bot's link records (exact, case-sensitive match). Supply this or path.",
             "in": "query",
             "name": "name",
             "required": false,
             "schema": {
               "default": "",
+              "description": "Link name to check against the bot's link records (exact, case-sensitive match). Supply this or path.",
               "title": "Name",
               "type": "string"
             }
           },
           {
+            "description": "Workspace-relative path to check for a file or folder, e.g. 'docs/spec.md'. When given, the file check runs and name is ignored.",
             "in": "query",
             "name": "path",
             "required": false,
             "schema": {
               "default": "",
+              "description": "Workspace-relative path to check for a file or folder, e.g. 'docs/spec.md'. When given, the file check runs and name is ignored.",
               "title": "Path",
               "type": "string"
             }
           },
           {
+            "description": "Addressing hint: 'file' or 'folder' forces the workspace check; otherwise a supplied path decides.",
             "in": "query",
             "name": "type",
             "required": false,
@@ -9222,6 +9888,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Addressing hint: 'file' or 'folder' forces the workspace check; otherwise a supplied path decides.",
               "title": "Type"
             }
           },
@@ -9349,14 +10016,16 @@
     },
     "/openapi/v1/bots/resources/download": {
       "get": {
-        "description": "Stream a file's bytes from the bot's workspace, addressed by path.\n\nRaw bytes, not an envelope — the body is the file. Replaces the former\n``/{resource_id}/download``: a record id cannot address a file the bot\ncreated itself, and the record is no longer what decides existence.",
+        "description": "Stream a file's bytes from the bot's workspace, addressed by path.\n\nRaw bytes, not an envelope — the body is the file.",
         "operationId": "download_file_openapi_v1_bots_resources_download_get",
         "parameters": [
           {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
             "in": "query",
             "name": "path",
             "required": true,
             "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
               "title": "Path",
               "type": "string"
             }
@@ -9494,14 +10163,16 @@
     },
     "/openapi/v1/bots/resources/mkdir": {
       "post": {
-        "description": "Create a directory in the bot's workspace.\n\nPhysical only — no FOLDER record is written, and ``POST \"\"`` with\n``type=FOLDER`` still returns 501. Directories exist on the filesystem and\nare reported by listing it; giving them records would reintroduce exactly\nthe record-vs-filesystem divergence this change removes.",
+        "description": "Create a directory in the bot's workspace, addressed by path.\n\nIntermediate directories are created as needed. Directories exist on the\nworkspace filesystem only and are reported by listing it — they have no\nrecord and no resource id.",
         "operationId": "create_directory_openapi_v1_bots_resources_mkdir_post",
         "parameters": [
           {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
             "in": "query",
             "name": "path",
             "required": true,
             "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
               "title": "Path",
               "type": "string"
             }
@@ -9634,10 +10305,12 @@
         "operationId": "preview_file_openapi_v1_bots_resources_preview_get",
         "parameters": [
           {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
             "in": "query",
             "name": "path",
             "required": true,
             "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
               "title": "Path",
               "type": "string"
             }
@@ -9776,14 +10449,16 @@
     },
     "/openapi/v1/bots/resources/upload": {
       "post": {
-        "description": "Upload a file's raw bytes into the bot's workspace.\n\n``path`` is workspace-relative and carries its own directories\n(``docs/spec/a.txt``); intermediate ones are created by the engine. There is\nno separate name or parent-directory parameter — the directory is part of the\npath, and ``path`` is the same spelling every other file endpoint uses.\n\nThe write goes through ``ResourceFileService``, the same service the console\nuses, so both surfaces compose the workspace address identically and cannot\ndrift. ``owner_id`` comes from the request's ``user_id`` (``UserIdDep``),\nfail-closed — mirroring the bots router.",
+        "description": "Upload a file's raw bytes into the bot's workspace.\n\nThe body is the file's raw bytes (content type application/octet-stream),\nnot a multipart form. The path is workspace-relative and carries its own\ndirectories ('docs/spec/a.txt'); intermediate ones are created as needed\n— there is no separate name or parent-directory parameter. An occupied\npath answers 409; the size limit is 500 MB, and only common document,\ncode, image and archive extensions are accepted (400 otherwise).",
         "operationId": "upload_resource_openapi_v1_bots_resources_upload_post",
         "parameters": [
           {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
             "in": "query",
             "name": "path",
             "required": true,
             "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
               "title": "Path",
               "type": "string"
             }
@@ -9924,14 +10599,16 @@
     },
     "/openapi/v1/bots/resources/{resource_id}": {
       "delete": {
-        "description": "Delete a **link** resource by record id.\n\nFiles are no longer addressed this way — they live in the workspace and are\ndeleted through ``DELETE \"\"?path=``. A link has no file, so the record is\nthe resource and the record id is the only address it can have. A file id\nsent here resolves to nothing and 404s, which is also the right answer for\na stale id from before the change.\n\nNo device is touched, so this must not require a bound one: the former\nunconditional ``resolve_for_bot`` raised DeviceNotBoundError (409) on an\nunbound bot even for a link, which is the follow-up that removing the file\nbranch resolves.",
+        "description": "Delete a link resource by id.\n\nOnly links are deleted by id — files and folders are deleted through the\npath-addressed delete. A file's id answers 404. Works whether or not the\nbot currently has a live device.",
         "operationId": "delete_resource_openapi_v1_bots_resources__resource_id__delete",
         "parameters": [
           {
+            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
             "in": "path",
             "name": "resource_id",
             "required": true,
             "schema": {
+              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
               "title": "Resource Id",
               "type": "string"
             }
@@ -10058,14 +10735,16 @@
         ]
       },
       "get": {
-        "description": "Get a **link** resource by record id.\n\nA file id 404s here, mirroring ``DELETE /{resource_id}``: serving a file\nfrom its record would report size and name from a row that nothing keeps in\nstep with the workspace, which is the divergence this change removes. A\nfile's address is its path — ``GET \"\"?path=`` lists it, ``GET /download``\nand ``GET /preview`` serve it.",
+        "description": "Get a link resource by id.\n\nOnly links are served by id — a file's id answers 404 here. A file's\naddress is its path: the listing shows it, and download/preview serve it.",
         "operationId": "get_resource_openapi_v1_bots_resources__resource_id__get",
         "parameters": [
           {
+            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
             "in": "path",
             "name": "resource_id",
             "required": true,
             "schema": {
+              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
               "title": "Resource Id",
               "type": "string"
             }
@@ -10192,14 +10871,16 @@
         ]
       },
       "put": {
-        "description": "Update a **link** resource by record id (rename / url change).\n\n``link_type`` is intentionally not exposed on the openapi contract.\nValueError from the service (not found / url clash) → 409 Conflict, per\nlegacy + create parity.\n\nA file id 404s, completing what ``GET`` and ``DELETE /{resource_id}``\nalready do. ``update_link_resource`` checks no type, so a stale file id\nwould otherwise rename a FILE row that nothing reads — the response would\neven show the new name, while the workspace, which is what every file\nresponse is actually built from, is untouched.",
+        "description": "Rename a link resource and/or change its URL, by id.\n\nOnly links are updatable by id — a file's id answers 404. A name or URL\nclash with an existing link answers 409.",
         "operationId": "update_resource_openapi_v1_bots_resources__resource_id__put",
         "parameters": [
           {
+            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
             "in": "path",
             "name": "resource_id",
             "required": true,
             "schema": {
+              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
               "title": "Resource Id",
               "type": "string"
             }
@@ -10338,19 +11019,22 @@
     },
     "/openapi/v1/bots/routines": {
       "get": {
-        "description": "List routines (filter + paginate).\n\n``status`` is an openapi query hint with no direct field on ``Routine``\n(which only carries ``enabled``). It is currently a no-op: the adapter\ndoes not expose a status filter at the list seam, so we return the full\nset and let the client filter on ``enabled``. Wire a server-side filter\nhere only if/when the engine surfaces a status dimension.",
+        "description": "List a bot's routines (paginated).",
         "operationId": "list_routines_openapi_v1_bots_routines_get",
         "parameters": [
           {
+            "description": "The bot whose routines to list.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot whose routines to list.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "Reserved; currently ignored — the full set is returned. Filter client-side on `enabled`.",
             "in": "query",
             "name": "status",
             "required": false,
@@ -10363,6 +11047,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Reserved; currently ignored — the full set is returned. Filter client-side on `enabled`.",
               "title": "Status"
             }
           },
@@ -10504,7 +11189,7 @@
         ]
       },
       "post": {
-        "description": "Create a routine.\n\nThe only operation in this group whose bot is in the **body**, so the grant\ncheck cannot run as a dependency — the body is not parsed yet when those\nresolve. It runs here instead, immediately after parsing and **before any\nservice call**, which is the same guarantee in a different place. The\nshared dependency defers for exactly this operation (it is named in\n``admission.py``), so nothing checks it twice and nothing skips it.\n\nTranslates the openapi ``RoutineCreate`` body into the engine adapter\ncron body shape: ``schedule`` is the raw cron expression STRING (not\nthe nested ``{kind,expr,tz}`` dict — the adapter wraps it on read in\n``device_adapter_transport._build_item``), and ``timezone`` defaults\nto ``Asia/Shanghai`` to match legacy ``cron/router.py``'s create path.",
+        "description": "Create a routine on a bot.\n\nThe schedule fires in the routine's timezone, which defaults to\nAsia/Shanghai when omitted. Each firing starts a fresh session and hands\nthe bot the command as its user message.",
         "operationId": "create_routine_openapi_v1_bots_routines_post",
         "parameters": [
           {
@@ -10630,23 +11315,27 @@
     },
     "/openapi/v1/bots/routines/{routine_id}": {
       "delete": {
-        "description": "Delete a routine.\n\nC3: ``bot_id`` is a required query (path carries only ``routine_id``).\n``delete_cron`` only operates on the draft stage; a published-stage delete\nraises ``CronRelayError`` (error_code 403), mapped here (the code is dynamic\nper-raise, so not in the static ``ENVELOPE_ERRORS`` map). A failed draft\ndelete is NOT surfaced as ``200 {deleted: false}`` — a missing routine_id\nmaps to 404 and a relay timeout to 502. The engine result distinguishes the\ntwo only via its ``error`` text today; a structured engine ``error_code``\nwould make timeout-vs-missing precise (follow-up).",
+        "description": "Delete a routine.\n\nA failure is never reported as a successful delete: an unknown routine\nanswers 404 and a timeout answers 502.",
         "operationId": "delete_routine_openapi_v1_bots_routines__routine_id__delete",
         "parameters": [
           {
+            "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
             "in": "path",
             "name": "routine_id",
             "required": true,
             "schema": {
+              "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
               "title": "Routine Id",
               "type": "string"
             }
           },
           {
+            "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -10762,23 +11451,27 @@
         ]
       },
       "get": {
-        "description": "Get a routine.\n\nC3: the path carries only ``routine_id`` (no routine table to\nreverse-map to a bot), so ``bot_id`` is a required query. Owner\nidentity comes from the authenticated principal via\n``UserIdDep``. Missing/non-dict ``data`` collapses to 404.",
+        "description": "Get a routine.\n\nThe bot_id query parameter is required — a routine id alone does not\nidentify the bot that holds it. Note the returned bot_id may be empty on\nthis read; keep the one you queried with.",
         "operationId": "get_routine_openapi_v1_bots_routines__routine_id__get",
         "parameters": [
           {
+            "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
             "in": "path",
             "name": "routine_id",
             "required": true,
             "schema": {
+              "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
               "title": "Routine Id",
               "type": "string"
             }
           },
           {
+            "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -10894,23 +11587,27 @@
         ]
       },
       "patch": {
-        "description": "Update a routine (partial).\n\nC3: ``bot_id`` is a required query (see ``get_routine``). Partial\nupdate: only set fields flow to the adapter. ``trigger.cron`` becomes\na raw ``schedule`` STRING (not a ``{kind,expr,tz}`` dict — the adapter\nwraps it on read; Task 3 contract). Missing/non-dict ``data`` on the\nresponse collapses to 404.",
+        "description": "Update a routine. Omitted fields are left unchanged.\n\nWhen sending a new trigger, send the timezone with it — a trigger update\nwithout one resets the schedule's zone to the default.",
         "operationId": "update_routine_openapi_v1_bots_routines__routine_id__patch",
         "parameters": [
           {
+            "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
             "in": "path",
             "name": "routine_id",
             "required": true,
             "schema": {
+              "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
               "title": "Routine Id",
               "type": "string"
             }
           },
           {
+            "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -11038,23 +11735,27 @@
     },
     "/openapi/v1/bots/routines/{routine_id}/run": {
       "post": {
-        "description": "Run a routine now.\n\nC3: ``bot_id`` is a required query. ``run_cron`` returns\n``{\"success\":..,\"data\":{\"ok\":..,\"ran\":..,\"reason\":..}}`` — no run_id, no\ntimestamps. We synthesize ``run_id`` from ``routine_id`` + the handler's\nUTC trigger timestamp (uniqueness is good enough for an immediate-trigger\necho; the engine has no run_id to return). ``status`` is derived from\n``ran``/``reason``: completed | failed | unknown. ``started_at`` /\n``finished_at`` are None because the adapter doesn't surface them on the\nrun-trigger seam (use ``GET /{routine_id}/runs`` for actual timestamps).",
+        "description": "Trigger a routine now.\n\nThe response describes the trigger attempt, not a finished run: status is\n'completed' (the engine acknowledged the trigger), 'failed' (it declined,\nwith a reason) or 'unknown', and both timestamps are null. Read the runs\nlisting for actual execution results and timings.",
         "operationId": "run_routine_openapi_v1_bots_routines__routine_id__run_post",
         "parameters": [
           {
+            "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
             "in": "path",
             "name": "routine_id",
             "required": true,
             "schema": {
+              "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
               "title": "Routine Id",
               "type": "string"
             }
           },
           {
+            "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -11172,23 +11873,27 @@
     },
     "/openapi/v1/bots/routines/{routine_id}/runs": {
       "get": {
-        "description": "List a routine's execution history.\n\nC3: ``bot_id`` is a required query. ``get_cron_runs`` returns\n``{\"success\":..,\"data\":{\"runs\":[{job_id, started_at_ms, finished_at_ms,\nstatus, ...}]}}`` in draft mode (``_forward_single_stage_request``\npassthrough; ``_decorate_single_result`` only adds bot_metadata fields to\n``data``, leaving ``runs`` intact). We map each entry via ``_map_run``\nand paginate client-side.",
+        "description": "List a routine's execution history, most recent first.\n\nThe engine keeps a bounded history per routine, so deep pages come back\nempty by construction.",
         "operationId": "list_routine_runs_openapi_v1_bots_routines__routine_id__runs_get",
         "parameters": [
           {
+            "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
             "in": "path",
             "name": "routine_id",
             "required": true,
             "schema": {
+              "description": "The routine's id, exactly as returned on create or in the listing — an opaque string; treat it as a token.",
               "title": "Routine Id",
               "type": "string"
             }
           },
           {
+            "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
             "in": "query",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the routine belongs to — required, because a routine id alone does not identify the bot that holds it.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -11337,10 +12042,12 @@
         "operationId": "list_sessions_openapi_v1_bots_sessions__bot_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -11573,10 +12280,12 @@
         "operationId": "create_session_openapi_v1_bots_sessions__bot_id__post",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -11758,19 +12467,23 @@
         "operationId": "delete_session_openapi_v1_bots_sessions__bot_id___session_id__delete",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
             "in": "path",
             "name": "session_id",
             "required": true,
             "schema": {
+              "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
               "title": "Session Id",
               "type": "string"
             }
@@ -11940,19 +12653,23 @@
         "operationId": "get_session_openapi_v1_bots_sessions__bot_id___session_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
             "in": "path",
             "name": "session_id",
             "required": true,
             "schema": {
+              "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
               "title": "Session Id",
               "type": "string"
             }
@@ -12122,19 +12839,23 @@
         "operationId": "update_session_openapi_v1_bots_sessions__bot_id___session_id__patch",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
             "in": "path",
             "name": "session_id",
             "required": true,
             "schema": {
+              "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
               "title": "Session Id",
               "type": "string"
             }
@@ -12316,19 +13037,23 @@
         "operationId": "clear_session_messages_openapi_v1_bots_sessions__bot_id___session_id__messages_delete",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
             "in": "path",
             "name": "session_id",
             "required": true,
             "schema": {
+              "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
               "title": "Session Id",
               "type": "string"
             }
@@ -12498,19 +13223,23 @@
         "operationId": "list_session_messages_openapi_v1_bots_sessions__bot_id___session_id__messages_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
             "in": "path",
             "name": "session_id",
             "required": true,
             "schema": {
+              "description": "The session's id, exactly as returned in a session listing's session_id — use it verbatim, do not re-encode it.",
               "title": "Session Id",
               "type": "string"
             }
@@ -12705,7 +13434,7 @@
     },
     "/openapi/v1/bots/skills": {
       "get": {
-        "description": "List exact Bot-owned Local Skills from database desired state.\n\nGrant-checked **here** rather than by the shared dependency, because only\nthis handler knows whose bot it is about to read: ``owner_entity_id`` names\nan owner and defaults to the caller. Checking against the caller instead\nwould be wrong in both directions — it would let a grant on the caller's own\nsame-named bot authorize a read of someone else's, and refuse a legitimate\ngrant on a bot shared with them.",
+        "description": "List a bot's skills from stored desired state (paginated).\n\nAnswers even while the bot is offline: active reflects the desired\nstate, not the live runtime.",
         "operationId": "list_skills_openapi_v1_bots_skills_get",
         "parameters": [
           {
@@ -12720,7 +13449,7 @@
             }
           },
           {
-            "description": "Verified Bot owner locator.",
+            "description": "Owner of the bot; defaults to the caller. Name it only to list skills of a bot shared with you.",
             "in": "query",
             "name": "owner_entity_id",
             "required": false,
@@ -12733,11 +13462,12 @@
                   "type": "null"
                 }
               ],
-              "description": "Verified Bot owner locator.",
+              "description": "Owner of the bot; defaults to the caller. Name it only to list skills of a bot shared with you.",
               "title": "Owner Entity Id"
             }
           },
           {
+            "description": "Filter: true for only active skills, false for only inactive ones; omit for both.",
             "in": "query",
             "name": "active",
             "required": false,
@@ -12750,10 +13480,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: true for only active skills, false for only inactive ones; omit for both.",
               "title": "Active"
             }
           },
           {
+            "description": "Filter: case-insensitive substring match against the skill's name and description.",
             "in": "query",
             "name": "keyword",
             "required": false,
@@ -12766,6 +13498,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Filter: case-insensitive substring match against the skill's name and description.",
               "title": "Keyword"
             }
           },
@@ -12909,7 +13642,7 @@
     },
     "/openapi/v1/bots/skills/upload": {
       "post": {
-        "description": "Create one inactive Local Skill from a complete raw ZIP package.\n\nGrant-checked here for the same reason as the listing above: the owner this\nwrites under is ``owner_entity_id or actor_id``, which only the handler\nknows. A write makes the mis-binding worse — it would create a skill on a\nbot the application was never granted.",
+        "description": "Upload a skill package (raw ZIP) to create or replace a bot's skill.\n\nThe body is the ZIP's raw bytes with content type application/zip — not a\nmultipart form. The archive must contain exactly one SKILL.md manifest,\nwhose front matter names the skill. When the bot already has a skill of\nthat name, its package is replaced in place (200, operation 'updated');\notherwise a new, inactive skill is created (201, operation 'created').\nLimits: 10 MB compressed, 50 MB uncompressed, 500 files (413 beyond).",
         "operationId": "upload_skill_openapi_v1_bots_skills_upload_post",
         "parameters": [
           {
@@ -13091,14 +13824,16 @@
     },
     "/openapi/v1/bots/skills/{skill_id}": {
       "delete": {
-        "description": "Delete one inactive Bot-owned Local Skill by deployment-wide ID.",
+        "description": "Delete a skill by id.\n\nOnly an inactive skill can be deleted — deactivate it first; deleting an\nactive one answers 409.",
         "operationId": "delete_skill_openapi_v1_bots_skills__skill_id__delete",
         "parameters": [
           {
+            "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
             "in": "path",
             "name": "skill_id",
             "required": true,
             "schema": {
+              "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
               "title": "Skill Id",
               "type": "string"
             }
@@ -13218,10 +13953,12 @@
         "operationId": "get_skill_openapi_v1_bots_skills__skill_id__get",
         "parameters": [
           {
+            "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
             "in": "path",
             "name": "skill_id",
             "required": true,
             "schema": {
+              "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
               "title": "Skill Id",
               "type": "string"
             }
@@ -13339,14 +14076,16 @@
     },
     "/openapi/v1/bots/skills/{skill_id}/activate": {
       "post": {
-        "description": "Activate one Bot-owned Local Skill and synchronously reconcile runtime.",
+        "description": "Activate a skill so its bot can use it.\n\nIdempotent — activating an already-active skill succeeds with changed\nfalse. The bot's runtime is reconciled synchronously either way.",
         "operationId": "activate_skill_openapi_v1_bots_skills__skill_id__activate_post",
         "parameters": [
           {
+            "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
             "in": "path",
             "name": "skill_id",
             "required": true,
             "schema": {
+              "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
               "title": "Skill Id",
               "type": "string"
             }
@@ -13464,14 +14203,16 @@
     },
     "/openapi/v1/bots/skills/{skill_id}/deactivate": {
       "post": {
-        "description": "Deactivate one Bot-owned Local Skill and synchronously reconcile runtime.",
+        "description": "Deactivate a skill so its bot stops using it.\n\nIdempotent — deactivating an already-inactive skill succeeds with changed\nfalse. The bot's runtime is reconciled synchronously either way.",
         "operationId": "deactivate_skill_openapi_v1_bots_skills__skill_id__deactivate_post",
         "parameters": [
           {
+            "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
             "in": "path",
             "name": "skill_id",
             "required": true,
             "schema": {
+              "description": "The skill's id, as returned by the listing or upload (decimal digits, e.g. '42'). The id alone identifies the skill and its bot.",
               "title": "Skill Id",
               "type": "string"
             }
@@ -13589,14 +14330,16 @@
     },
     "/openapi/v1/bots/{bot_id}": {
       "delete": {
-        "description": "Delete a bot. See :func:`_reject_unowned_lifecycle` for what is refused.",
+        "description": "Delete a bot.\n\nRefused (409) for bots whose lifecycle lives elsewhere: desktop bots are\nmanaged by the desktop service, and service bots are deleted through\ntheir publish lifecycle.",
         "operationId": "delete_bot_openapi_v1_bots__bot_id__delete",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -13716,10 +14459,12 @@
         "operationId": "get_bot_openapi_v1_bots__bot_id__get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -13835,14 +14580,16 @@
         ]
       },
       "put": {
-        "description": "Update a bot's name/description (engine is fixed at creation).\n\n``cluster_name`` is engine-derived and the engine is immutable, so it is not\nupdatable here; ``engine_options`` is managed via the engine-config\nendpoints. Neither is accepted — see :class:`BotUpdate`.",
+        "description": "Update a bot's name/description (engine is fixed at creation).\n\nThe cluster is engine-derived and the engine is immutable, so neither is\nupdatable here; engine options are managed via the engine-config\nendpoints. Sending either fails validation with the field named.",
         "operationId": "update_bot_openapi_v1_bots__bot_id__put",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -13970,19 +14717,22 @@
     },
     "/openapi/v1/bots/{bot_id}/auth-status": {
       "get": {
-        "description": "Poll Passport authorization; complete creation when ISSUED.\n\nOn the async-create flow the bot is only actually created here (on ISSUED),\nso the caller must re-supply the attributes it created with — passed as\noptional query params and forwarded to completion. Without them the bot\nwould be created with defaults (e.g. engine ``openclaw``) that contradict the\nPassport applied for at ``POST`` time, so callers on the 202 flow should\nalways echo back ``engine``/``cluster_name``/``bot_name``/… here.\n\nBecause this is where the record is actually inserted, every restriction\n``POST`` enforces is re-applied to the echoed-back values: the same engine\nregistry check, the same engine/cluster bijection, and the same\npersonal|service restriction on ``bot_type``. Otherwise the completion path\nwould be a way to create exactly the bots ``POST`` rejects.",
+        "description": "Poll authorization for a pending creation; the bot is created on ISSUED.\n\nOn the 202 create flow the bot is only actually created here, so the\ncaller must re-supply the attributes it created with — the optional query\nparameters mirror the create body and are forwarded to completion. Omit\nthem and the bot is created with defaults that contradict what was\nrequested, so always echo back engine, cluster_name, bot_name, bot_desc\nand bot_type when polling.\n\nEvery restriction create enforces is re-applied to the echoed values:\nthe same engine registry check, the same engine/cluster pairing, and the\nsame personal/service restriction on bot_type.",
         "operationId": "get_bot_auth_status_openapi_v1_bots__bot_id__auth_status_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
           },
           {
+            "description": "Echo of the engine the bot was requested with. Required in practice on the 202 flow: creation completes here, and an omitted value falls back to the deployment default.",
             "in": "query",
             "name": "engine",
             "required": false,
@@ -13995,10 +14745,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Echo of the engine the bot was requested with. Required in practice on the 202 flow: creation completes here, and an omitted value falls back to the deployment default.",
               "title": "Engine"
             }
           },
           {
+            "description": "Echo of the cluster the bot was requested with; validated against the engine exactly as on create.",
             "in": "query",
             "name": "cluster_name",
             "required": false,
@@ -14015,10 +14767,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Echo of the cluster the bot was requested with; validated against the engine exactly as on create.",
               "title": "Cluster Name"
             }
           },
           {
+            "description": "Echo of the name the bot was requested with.",
             "in": "query",
             "name": "bot_name",
             "required": false,
@@ -14031,10 +14785,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Echo of the name the bot was requested with.",
               "title": "Bot Name"
             }
           },
           {
+            "description": "Echo of the description the bot was requested with.",
             "in": "query",
             "name": "bot_desc",
             "required": false,
@@ -14047,10 +14803,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Echo of the description the bot was requested with.",
               "title": "Bot Desc"
             }
           },
           {
+            "description": "Echo of the bot type the bot was requested with; defaults to 'personal' when omitted.",
             "in": "query",
             "name": "bot_type",
             "required": false,
@@ -14067,6 +14825,7 @@
                   "type": "null"
                 }
               ],
+              "description": "Echo of the bot type the bot was requested with; defaults to 'personal' when omitted.",
               "title": "Bot Type"
             }
           },
@@ -14183,14 +14942,16 @@
     },
     "/openapi/v1/bots/{bot_id}/authorized-apps": {
       "get": {
-        "description": "Which applications can reach this bot, and who let each one in.\n\n**The owner sees everything; a collaborator sees only their own.** An owner\nwho could not see a grant a colleague made would have machine access to\ntheir own bot that was invisible to them, which is the failure this whole\nrecord exists to prevent. A collaborator has no equivalent claim on their\ncolleagues' delegations, so theirs is narrowed — the same reason their\nwithdrawal is.\n\n``owner_id`` says whose bot to read and defaults to the caller's own. It\naddresses the bot; it does not widen the answer — a collaborator naming the\nowner still sees only what they themselves delegated.",
+        "description": "Which applications can reach this bot, and who let each one in.\n\n**The owner sees everything; a collaborator sees only their own.** An owner\nwho could not see a grant a colleague made would have machine access to\ntheir own bot that was invisible to them, which is the failure this whole\nrecord exists to prevent. A collaborator has no equivalent claim on their\ncolleagues' delegations, so theirs is narrowed — the same reason their\nwithdrawal is.\n\n`owner_id` says whose bot to read and defaults to the caller's own. It\naddresses the bot; it does not widen the answer — a collaborator naming the\nowner still sees only what they themselves delegated.",
         "operationId": "list_authorized_apps_openapi_v1_bots__bot_id__authorized_apps_get",
         "parameters": [
           {
+            "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Bot Id",
@@ -14327,14 +15088,16 @@
         ]
       },
       "post": {
-        "description": "Lend this bot's access to the calling application.\n\nThe caller delegates **their own** access, so they must be able to operate\nthe bot — its owner, or a collaborator at member level or above. The\nresolved owner is recorded alongside them, and is someone else whenever the\nbot is shared.\n\n``owner_id`` names whose bot this is and defaults to the caller's own, so\nomitting it behaves exactly as this operation always has. Name it to\ndelegate on a bot shared with you: ``bot_id`` alone does not identify a bot,\nand two owners may hold the same one.\n\nIdempotent: granting an authorization that is already in force returns it\nunchanged rather than failing, so a partner retrying a timed-out request is\nnot punished for one that actually succeeded. Two *different* users\ndelegating the same application on the same bot are two separate grants, not\na repeat — they are lending two different authorities.",
+        "description": "Lend this bot's access to the calling application.\n\nThe caller delegates **their own** access, so they must be able to operate\nthe bot — its owner, or a collaborator at member level or above. The\nresolved owner is recorded alongside them, and is someone else whenever the\nbot is shared.\n\n`owner_id` names whose bot this is and defaults to the caller's own, so\nomitting it behaves exactly as this operation always has. Name it to\ndelegate on a bot shared with you: `bot_id` alone does not identify a bot,\nand two owners may hold the same one.\n\nIdempotent: granting an authorization that is already in force returns it\nunchanged rather than failing, so a partner retrying a timed-out request is\nnot punished for one that actually succeeded. Two *different* users\ndelegating the same application on the same bot are two separate grants, not\na repeat — they are lending two different authorities.",
         "operationId": "grant_authorized_app_openapi_v1_bots__bot_id__authorized_apps_post",
         "parameters": [
           {
+            "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Bot Id",
@@ -14473,14 +15236,16 @@
     },
     "/openapi/v1/bots/{bot_id}/authorized-apps/{app_id}": {
       "delete": {
-        "description": "Withdraw an application's authorization for this bot.\n\nThe application is named in the path rather than read off a principal,\nbecause a withdrawal must not require the application's cooperation — that\nis precisely the situation it exists for: a credential lost, rotated, or a\nrelationship ended. Withdrawing an authorization that does not exist answers\n404, distinctly from a successful withdrawal (``GrantNotFoundError``).\n\n**How much this withdraws depends on who asks**, and it has to: since a\ndelegation is keyed on the user who made it, ``{app_id}`` alone no longer\nnames one row.\n\n- The **owner** withdraws *every* delegation of this application on their\n  bot. That is what an owner means by revoking an app's access to their own\n  bot — a withdrawal that left it reaching them through a colleague's grant\n  would not be a withdrawal — and it is why the path needs no extra segment\n  naming whose grant to remove.\n- A **collaborator** withdraws only their own. Theirs is the loan they made;\n  a colleague's is not theirs to call in.\n\nTODO(#951 follow-up): the owner's withdrawal is all-or-nothing, and it\nshould not be. An owner who wants to cut off *one* colleague's delegation of\nan application — the colleague who left the team, say — currently has to\nwithdraw every delegation of that application on the bot, including their\nown and other colleagues'. The record supports the narrower operation\nalready (``revoke`` is keyed on the delegating user), so what is missing is\na way to *name* whose delegation to withdraw: another path segment, or a\nparameter. Deliberately not added here — it is a new operation on the public\nsurface, not a fix.\n\n``owner_id`` names whose bot is being withdrawn from and defaults to the\ncaller's own. Which delegations go still follows from who is asking, not\nfrom this parameter.",
+        "description": "Withdraw an application's authorization for this bot.\n\nThe application is named in the path rather than read off a principal,\nbecause a withdrawal must not require the application's cooperation — that\nis precisely the situation it exists for: a credential lost, rotated, or a\nrelationship ended. Withdrawing an authorization that does not exist answers\n404, distinctly from a successful withdrawal.\n\n**How much this withdraws depends on who asks**, and it has to: since a\ndelegation is keyed on the user who made it, `app_id` alone no longer\nnames one row.\n\n- The **owner** withdraws *every* delegation of this application on their\n  bot. That is what an owner means by revoking an app's access to their own\n  bot — a withdrawal that left it reaching them through a colleague's grant\n  would not be a withdrawal — and it is why the path needs no extra segment\n  naming whose grant to remove.\n- A **collaborator** withdraws only their own. Theirs is the loan they made;\n  a colleague's is not theirs to call in.\n\n`owner_id` names whose bot is being withdrawn from and defaults to the\ncaller's own. Which delegations go still follows from who is asking, not\nfrom this parameter.",
         "operationId": "revoke_authorized_app_openapi_v1_bots__bot_id__authorized_apps__app_id__delete",
         "parameters": [
           {
+            "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot the authorization covers — its `bot_id` as returned by the bots listing.",
               "maxLength": 256,
               "minLength": 1,
               "title": "Bot Id",
@@ -14488,10 +15253,12 @@
             }
           },
           {
+            "description": "The application whose authorization to revoke — its `app_id` as listed on the bot's authorized apps.",
             "in": "path",
             "name": "app_id",
             "required": true,
             "schema": {
+              "description": "The application whose authorization to revoke — its `app_id` as listed on the bot's authorized apps.",
               "minimum": 1,
               "title": "App Id",
               "type": "integer"
@@ -14633,10 +15400,12 @@
         "operationId": "get_bot_engine_config_openapi_v1_bots__bot_id__engine_config_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -14756,10 +15525,12 @@
         "operationId": "update_bot_engine_config_openapi_v1_bots__bot_id__engine_config_put",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -14893,10 +15664,12 @@
         "operationId": "get_bot_passport_openapi_v1_bots__bot_id__passport_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -15014,14 +15787,16 @@
     },
     "/openapi/v1/bots/{bot_id}/restart": {
       "post": {
-        "description": "Restart a bot. Desktop bots are rejected — see :func:`_reject_unowned_lifecycle`.",
+        "description": "Restart a bot's container.\n\nAlso what applies a changed startup script. Refused (409) for desktop\nbots, whose lifecycle is managed by the desktop service, and for bots in\na lifecycle state a restart cannot leave.",
         "operationId": "restart_bot_openapi_v1_bots__bot_id__restart_post",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -15143,10 +15918,12 @@
         "operationId": "delete_bot_startup_script_openapi_v1_bots__bot_id__startup_script_delete",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -15262,14 +16039,16 @@
         ]
       },
       "get": {
-        "description": "Read a bot's startup script.\n\nA bot that has never had one reads as an empty script, not an error. An\nunsupported bot still answers here — with ``supported: false`` and a reason —\nso a caller can discover *why* before trying to write.",
+        "description": "Read a bot's startup script.\n\nA bot that has never had one reads as an empty script, not an error. An\nunsupported bot still answers here — with supported false and a reason —\nso a caller can discover why before trying to write.",
         "operationId": "get_bot_startup_script_openapi_v1_bots__bot_id__startup_script_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -15385,14 +16164,16 @@
         ]
       },
       "put": {
-        "description": "Set or replace a bot's startup script.\n\nTakes effect the next time the platform **composes** a start command. A\nrestart or republish of the bot does that; a targeted device restart\n(``POST /api/v1/devices/{binding_id}/restart``) and a scale-out do not —\nthey reuse the deploy config stored at the last compose, so a replica or a\nrestarted instance can still run the previously published script.\n\nRefused for a bot whose container cannot run one: storing it would be a\nsilent no-op the caller could not distinguish from success.",
+        "description": "Set or replace a bot's startup script.\n\nTakes effect the next time the platform composes a start command — a\nrestart or republish of the bot does that. Lower-level restarts and\nscale-outs reuse the previously composed configuration, so an instance\nstarted that way can still run the previously stored script until the bot\nis next restarted or republished.\n\nRefused for a bot whose container cannot run one: storing it would be a\nsilent no-op the caller could not distinguish from success.",
         "operationId": "update_bot_startup_script_openapi_v1_bots__bot_id__startup_script_put",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }
@@ -15539,10 +16320,12 @@
         "operationId": "get_bot_status_openapi_v1_bots__bot_id__status_get",
         "parameters": [
           {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
             "in": "path",
             "name": "bot_id",
             "required": true,
             "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
               "title": "Bot Id",
               "type": "string"
             }

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -223,7 +223,7 @@
             "type": "string"
           },
           "status": {
-            "description": "Lifecycle status. Primary states: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device provisioning failed (delete and recreate, or restart). Bots managed by other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', 'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as not ready for work.",
+            "description": "Lifecycle status. Values: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — running and reachable; 'FAILED' — device provisioning failed (restart, or delete and recreate); 'OFFLINE', 'RELEASING', 'RELEASED' — desktop-bot lifecycle states; 'RECYCLED', 'REACTIVATING' — dormant-bot reclaim states. New lifecycles can add values, so treat any value other than 'ACTIVE' as not ready for work.",
             "title": "Status",
             "type": "string"
           }
@@ -405,7 +405,7 @@
             "type": "boolean"
           },
           "status": {
-            "description": "Lifecycle status. Primary states: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — the device is up; 'FAILED' — device provisioning failed (delete and recreate, or restart). Bots managed by other lifecycles can also report 'OFFLINE', 'RELEASING', 'RELEASED', 'RECYCLED' or 'REACTIVATING'; treat any value other than 'ACTIVE' as not ready for work.",
+            "description": "Lifecycle status. Values: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — running and reachable; 'FAILED' — device provisioning failed (restart, or delete and recreate); 'OFFLINE', 'RELEASING', 'RELEASED' — desktop-bot lifecycle states; 'RECYCLED', 'REACTIVATING' — dormant-bot reclaim states. New lifecycles can add values, so treat any value other than 'ACTIVE' as not ready for work.",
             "title": "Status",
             "type": "string"
           }
@@ -1161,6 +1161,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1177,11 +1178,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1200,6 +1203,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1216,11 +1220,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1239,6 +1245,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1255,11 +1262,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1278,6 +1287,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1294,11 +1304,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1317,6 +1329,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1333,11 +1346,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1356,6 +1371,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1372,11 +1388,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1395,6 +1413,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1411,11 +1430,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1434,6 +1455,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1450,11 +1472,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1473,6 +1497,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1489,11 +1514,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1512,6 +1539,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1528,11 +1556,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1551,6 +1581,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1567,11 +1598,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1590,6 +1623,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1606,11 +1640,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1629,6 +1665,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1645,11 +1682,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1668,6 +1707,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1684,11 +1724,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1707,6 +1749,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1723,11 +1766,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1746,6 +1791,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1762,11 +1808,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1785,6 +1833,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1801,11 +1850,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1824,6 +1875,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1840,11 +1892,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1863,6 +1917,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1879,11 +1934,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1902,6 +1959,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1918,11 +1976,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1941,6 +2001,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1957,11 +2018,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -1980,6 +2043,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -1996,11 +2060,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2019,6 +2085,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2035,11 +2102,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2058,6 +2127,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2074,11 +2144,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2097,6 +2169,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2113,11 +2186,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2136,6 +2211,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2152,11 +2228,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2175,6 +2253,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2191,11 +2270,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2214,6 +2295,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2230,11 +2312,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2253,6 +2337,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2269,11 +2354,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2292,6 +2379,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2308,11 +2396,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2331,6 +2421,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2347,11 +2438,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2370,6 +2463,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2386,11 +2480,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2409,6 +2505,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2425,11 +2522,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2448,6 +2547,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2464,11 +2564,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2487,6 +2589,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2503,11 +2606,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2526,6 +2631,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2542,11 +2648,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2565,6 +2673,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2581,11 +2690,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2604,6 +2715,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2620,11 +2732,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2643,6 +2757,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2659,11 +2774,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2682,6 +2799,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2698,11 +2816,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2721,6 +2841,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2737,11 +2858,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2760,6 +2883,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2776,11 +2900,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2799,6 +2925,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2815,11 +2942,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2838,6 +2967,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2856,11 +2986,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2879,6 +3011,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2899,11 +3032,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2922,6 +3057,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2942,11 +3078,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -2965,6 +3103,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
             "title": "Code",
             "type": "integer"
           },
@@ -2985,11 +3124,13 @@
           },
           "message": {
             "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -3008,6 +3149,7 @@
         "properties": {
           "code": {
             "description": "6-digit code: HTTP status (3) + business subcode (3), e.g. 404000 for a not-found failure.",
+            "example": 404000,
             "title": "Code",
             "type": "integer"
           },
@@ -3018,11 +3160,13 @@
           },
           "message": {
             "description": "Human-readable failure reason; always English.",
+            "example": "Not found",
             "title": "Message",
             "type": "string"
           },
           "request_id": {
             "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
             "title": "Request Id",
             "type": "string"
           }
@@ -3720,6 +3864,7 @@
           },
           "total": {
             "description": "Lower bound on the number of items matching the query — at least this many exist. Becomes the exact count once you reach the last page (identifiable by a page shorter than `page_size`). Paginate until a short page rather than computing a page count from this value.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3834,6 +3979,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3858,6 +4004,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3882,6 +4029,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3906,6 +4054,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3930,6 +4079,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3954,6 +4104,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -3978,6 +4129,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -4002,6 +4154,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -4026,6 +4179,7 @@
           },
           "total": {
             "description": "Total number of items matching the query.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -4828,6 +4982,7 @@
           },
           "total": {
             "description": "Lower bound on the number of items matching the query — at least this many exist. Becomes the exact count once you reach the last page (identifiable by a page shorter than `page_size`). Paginate until a short page rather than computing a page count from this value.",
+            "example": 1,
             "title": "Total",
             "type": "integer"
           }
@@ -5290,6 +5445,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5300,6 +5460,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5310,6 +5475,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5320,6 +5490,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5330,6 +5505,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5340,6 +5520,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5350,6 +5535,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5360,6 +5550,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5414,6 +5609,16 @@
           "202": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 202000,
+                  "data": {
+                    "bot_id": "20260813_a7k2m9p1",
+                    "iframe_url": "https://auth.example.com/passport/consent?flow=f-123",
+                    "redirect_url": ""
+                  },
+                  "message": "Accepted",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/Envelope_BotAuthPending_"
                 }
@@ -5424,6 +5629,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5434,6 +5644,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5444,6 +5659,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5454,6 +5674,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5464,6 +5689,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5474,6 +5704,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5484,6 +5719,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5494,6 +5734,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5592,6 +5837,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5602,6 +5852,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5612,6 +5867,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5622,6 +5882,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5632,6 +5897,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5642,6 +5912,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5652,6 +5927,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5662,6 +5942,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5672,6 +5957,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5682,6 +5972,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5777,6 +6072,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5787,6 +6087,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5797,6 +6102,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5807,6 +6117,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5817,6 +6132,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5827,6 +6147,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5837,6 +6162,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5847,6 +6177,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5857,6 +6192,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5867,6 +6207,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5954,6 +6299,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5964,6 +6314,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5974,6 +6329,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5984,6 +6344,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -5994,6 +6359,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6004,6 +6374,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6014,6 +6389,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6024,6 +6404,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6034,6 +6419,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6044,6 +6434,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6090,6 +6485,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6100,6 +6500,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6110,6 +6515,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6120,6 +6530,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6130,6 +6545,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6140,6 +6560,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6150,6 +6575,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6160,6 +6590,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6206,6 +6641,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6216,6 +6656,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6226,6 +6671,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6236,6 +6686,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6246,6 +6701,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6256,6 +6716,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6266,6 +6731,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6276,6 +6746,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6321,6 +6796,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6331,6 +6811,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6341,6 +6826,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6351,6 +6841,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6361,6 +6856,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6371,6 +6871,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6381,6 +6886,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6468,6 +6978,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6478,6 +6993,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6488,6 +7008,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6498,6 +7023,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6508,6 +7038,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6518,6 +7053,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6528,6 +7068,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6538,6 +7083,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6548,6 +7098,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6558,6 +7113,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6645,6 +7205,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6655,6 +7220,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6665,6 +7235,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6675,6 +7250,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6685,6 +7265,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6695,6 +7280,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6705,6 +7295,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6715,6 +7310,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6725,6 +7325,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6735,6 +7340,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6822,6 +7432,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6832,6 +7447,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6842,6 +7462,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6852,6 +7477,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6862,6 +7492,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6872,6 +7507,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6882,6 +7522,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6892,6 +7537,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6902,6 +7552,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6912,6 +7567,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -6999,6 +7659,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7009,6 +7674,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7019,6 +7689,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7029,6 +7704,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7039,6 +7719,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7049,6 +7734,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7059,6 +7749,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7069,6 +7764,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7079,6 +7779,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7089,6 +7794,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7146,6 +7856,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7156,6 +7871,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7166,6 +7886,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7176,6 +7901,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7186,6 +7916,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7196,6 +7931,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7206,6 +7946,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7216,6 +7961,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7283,6 +8033,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7293,6 +8048,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7303,6 +8063,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7313,6 +8078,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7323,6 +8093,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7333,6 +8108,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7343,6 +8123,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7353,6 +8138,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7428,6 +8218,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7438,6 +8233,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7448,6 +8248,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7458,6 +8263,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7468,6 +8278,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7478,6 +8293,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7488,6 +8308,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7498,6 +8323,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7530,6 +8360,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7540,6 +8375,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7550,6 +8390,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7560,6 +8405,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7570,6 +8420,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7580,6 +8435,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7590,6 +8450,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7664,6 +8529,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7674,6 +8544,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7684,6 +8559,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7694,6 +8574,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7704,6 +8589,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7714,6 +8604,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7724,6 +8619,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7798,6 +8698,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7808,6 +8713,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7818,6 +8728,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7828,6 +8743,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7838,6 +8758,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7848,6 +8773,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7858,6 +8788,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7945,6 +8880,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7955,6 +8895,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7965,6 +8910,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7975,6 +8925,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7985,6 +8940,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -7995,6 +8955,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8005,6 +8970,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8092,6 +9062,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8102,6 +9077,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8112,6 +9092,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8122,6 +9107,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8132,6 +9122,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8142,6 +9137,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8152,6 +9152,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8199,6 +9204,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8209,6 +9219,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8219,6 +9234,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8229,6 +9249,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8239,6 +9264,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8249,6 +9279,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8259,6 +9294,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8338,6 +9378,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8348,6 +9393,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8358,6 +9408,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8368,6 +9423,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8378,6 +9438,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8388,6 +9453,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8398,6 +9468,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8443,6 +9518,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8453,6 +9533,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8463,6 +9548,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8473,6 +9563,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8483,6 +9578,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8493,6 +9593,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8503,6 +9608,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8560,6 +9670,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8570,6 +9685,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8580,6 +9700,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8590,6 +9715,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8600,6 +9730,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8610,6 +9745,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8620,6 +9760,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8630,6 +9775,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8695,6 +9845,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8705,6 +9860,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8715,6 +9875,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8725,6 +9890,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8735,6 +9905,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8745,6 +9920,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8755,6 +9935,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8765,6 +9950,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8822,6 +10012,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8832,6 +10027,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8842,6 +10042,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8852,6 +10057,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8862,6 +10072,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8872,6 +10087,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8882,6 +10102,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8892,6 +10117,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8924,6 +10154,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8934,6 +10169,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8944,6 +10184,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8954,6 +10199,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8964,6 +10214,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8974,6 +10229,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -8984,6 +10244,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9098,6 +10363,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9108,6 +10378,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9118,6 +10393,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9128,6 +10408,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9138,6 +10423,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9148,6 +10438,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9158,6 +10453,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9168,6 +10468,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9178,6 +10483,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9188,6 +10498,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9286,6 +10601,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9296,6 +10616,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9306,6 +10631,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9316,6 +10646,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9326,6 +10661,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9336,6 +10676,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9346,6 +10691,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9356,6 +10706,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9366,6 +10721,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9376,6 +10736,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9444,6 +10809,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9454,6 +10824,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9464,6 +10839,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9474,6 +10854,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9484,6 +10869,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9494,6 +10884,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9504,6 +10899,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9514,6 +10914,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9626,6 +11031,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9636,6 +11046,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9646,6 +11061,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9656,6 +11076,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9666,6 +11091,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9676,6 +11106,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9686,6 +11121,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9696,6 +11136,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9761,6 +11206,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9771,6 +11221,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9781,6 +11236,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9791,6 +11251,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9801,6 +11266,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9811,6 +11281,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9821,6 +11296,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9831,6 +11311,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9930,6 +11415,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9940,6 +11430,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9950,6 +11445,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9960,6 +11460,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9970,6 +11475,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9980,6 +11490,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -9990,6 +11505,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10000,6 +11520,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10067,6 +11592,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10077,6 +11607,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10087,6 +11622,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10097,6 +11637,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10107,6 +11652,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10117,6 +11667,11 @@
           "413": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 413000,
+                  "message": "File too large for preview",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10127,6 +11682,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10137,6 +11697,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10147,6 +11712,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10215,6 +11785,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10225,6 +11800,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10235,6 +11815,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10245,6 +11830,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10255,6 +11845,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10265,6 +11860,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10275,6 +11875,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10285,6 +11890,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10353,6 +11963,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10363,6 +11978,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10373,6 +11993,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10383,6 +12008,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10393,6 +12023,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10403,6 +12038,11 @@
           "413": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 413000,
+                  "message": "File too large for preview",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10413,6 +12053,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10423,6 +12068,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10433,6 +12083,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10513,6 +12168,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10523,6 +12183,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10533,6 +12198,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10543,6 +12213,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10553,6 +12228,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10563,6 +12243,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10573,6 +12258,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10583,6 +12273,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10651,6 +12346,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10661,6 +12361,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10671,6 +12376,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10681,6 +12391,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10691,6 +12406,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10701,6 +12421,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10711,6 +12436,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10721,6 +12451,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10787,6 +12522,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10797,6 +12537,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10807,6 +12552,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10817,6 +12567,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10827,6 +12582,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10837,6 +12597,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10847,6 +12612,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10857,6 +12627,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10933,6 +12708,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10943,6 +12723,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10953,6 +12738,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10963,6 +12753,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10973,6 +12768,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10983,6 +12783,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -10993,6 +12798,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11003,6 +12813,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11105,6 +12920,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11115,6 +12935,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11125,6 +12950,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11135,6 +12965,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11145,6 +12980,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11155,6 +12995,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11165,6 +13010,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11175,6 +13025,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11229,6 +13084,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11239,6 +13099,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11249,6 +13114,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11259,6 +13129,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11269,6 +13144,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11279,6 +13159,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11289,6 +13174,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11299,6 +13189,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11367,6 +13262,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11377,6 +13277,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11387,6 +13292,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11397,6 +13307,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11407,6 +13322,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11417,6 +13337,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11427,6 +13352,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11437,6 +13367,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11503,6 +13438,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11513,6 +13453,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11523,6 +13468,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11533,6 +13483,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11543,6 +13498,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11553,6 +13513,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11563,6 +13528,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11573,6 +13543,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11649,6 +13624,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11659,6 +13639,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11669,6 +13654,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11679,6 +13669,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11689,6 +13684,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11699,6 +13699,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11709,6 +13714,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11719,6 +13729,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11787,6 +13802,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11797,6 +13817,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11807,6 +13832,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11817,6 +13847,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11827,6 +13862,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11837,6 +13877,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11847,6 +13892,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11857,6 +13907,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11952,6 +14007,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11962,6 +14022,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11972,6 +14037,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11982,6 +14052,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -11992,6 +14067,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12002,6 +14082,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12012,6 +14097,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12022,6 +14112,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12172,6 +14267,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12182,6 +14282,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12192,6 +14297,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12202,6 +14312,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12212,6 +14327,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12222,6 +14342,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12232,6 +14357,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12242,6 +14372,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12252,6 +14387,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12262,6 +14402,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12357,6 +14502,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12367,6 +14517,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12377,6 +14532,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12387,6 +14547,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12397,6 +14562,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12407,6 +14577,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12417,6 +14592,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12427,6 +14607,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12437,6 +14622,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12447,6 +14637,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12545,6 +14740,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12555,6 +14755,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12565,6 +14770,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12575,6 +14785,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12585,6 +14800,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12595,6 +14815,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12605,6 +14830,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12615,6 +14845,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12625,6 +14860,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12635,6 +14875,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12731,6 +14976,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12741,6 +14991,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12751,6 +15006,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12761,6 +15021,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12771,6 +15036,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12781,6 +15051,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12791,6 +15066,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12801,6 +15081,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12811,6 +15096,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12821,6 +15111,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12927,6 +15222,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12937,6 +15237,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12947,6 +15252,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12957,6 +15267,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12967,6 +15282,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12977,6 +15297,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12987,6 +15312,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -12997,6 +15327,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13007,6 +15342,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13017,6 +15357,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13115,6 +15460,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13125,6 +15475,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13135,6 +15490,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13145,6 +15505,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13155,6 +15520,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13165,6 +15535,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13175,6 +15550,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13185,6 +15565,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13195,6 +15580,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13205,6 +15595,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13328,6 +15723,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13338,6 +15738,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13348,6 +15753,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13358,6 +15768,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13368,6 +15783,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13378,6 +15798,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13388,6 +15813,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13398,6 +15828,11 @@
           "501": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13408,6 +15843,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13418,6 +15858,11 @@
           "504": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13556,6 +16001,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13566,6 +16016,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13576,6 +16031,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13586,6 +16046,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13596,6 +16061,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13606,6 +16076,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13616,6 +16091,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13626,6 +16106,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13723,6 +16208,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13733,6 +16223,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13743,6 +16238,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13753,6 +16253,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13763,6 +16268,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13776,7 +16286,7 @@
                 "example": {
                   "code": 413101,
                   "message": "Skill package is too large",
-                  "request_id": ""
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
                 },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
@@ -13788,6 +16298,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13798,6 +16313,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13808,6 +16328,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13865,6 +16390,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13875,6 +16405,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13885,6 +16420,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13895,6 +16435,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13905,6 +16450,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13915,6 +16465,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13925,6 +16480,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13935,6 +16495,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -13990,6 +16555,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14000,6 +16570,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14010,6 +16585,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14020,6 +16600,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14030,6 +16615,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14040,6 +16630,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14050,6 +16645,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14060,6 +16660,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14117,6 +16722,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14127,6 +16737,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14137,6 +16752,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14147,6 +16767,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14157,6 +16782,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14167,6 +16797,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14177,6 +16812,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14187,6 +16827,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14244,6 +16889,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14254,6 +16904,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14264,6 +16919,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14274,6 +16934,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14284,6 +16949,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14294,6 +16964,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14304,6 +16979,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14314,6 +16994,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14371,6 +17056,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14381,6 +17071,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14391,6 +17086,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14401,6 +17101,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14411,6 +17116,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14421,6 +17131,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14431,6 +17146,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14441,6 +17161,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14496,6 +17221,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14506,6 +17236,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14516,6 +17251,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14526,6 +17266,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14536,6 +17281,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14546,6 +17296,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14556,6 +17311,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14566,6 +17326,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14631,6 +17396,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14641,6 +17411,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14651,6 +17426,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14661,6 +17441,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14671,6 +17456,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14681,6 +17471,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14691,6 +17486,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14701,6 +17501,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14856,6 +17661,14 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "data": {
+                    "status": "REJECTED"
+                  },
+                  "message": "Authorization did not complete",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/Envelope_BotAuthStatus_"
                 }
@@ -14866,6 +17679,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14876,6 +17694,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14886,6 +17709,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14896,6 +17724,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14906,6 +17739,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14916,6 +17754,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -14926,6 +17769,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15004,6 +17852,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15014,6 +17867,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15024,6 +17882,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15034,6 +17897,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15044,6 +17912,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15054,6 +17927,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15064,6 +17942,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15074,6 +17957,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15150,6 +18038,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15160,6 +18053,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15170,6 +18068,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15180,6 +18083,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15190,6 +18098,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15200,6 +18113,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15210,6 +18128,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15220,6 +18143,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15310,6 +18238,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15320,6 +18253,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15330,6 +18268,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15340,6 +18283,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15350,6 +18298,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15360,6 +18313,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15370,6 +18328,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15380,6 +18343,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15437,6 +18405,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15447,6 +18420,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15457,6 +18435,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15467,6 +18450,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15477,6 +18465,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15487,6 +18480,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15497,6 +18495,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15507,6 +18510,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15574,6 +18582,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15584,6 +18597,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15594,6 +18612,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15604,6 +18627,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15614,6 +18642,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15624,6 +18657,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15634,6 +18672,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15644,6 +18687,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15701,6 +18749,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15711,6 +18764,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15721,6 +18779,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15731,6 +18794,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15741,6 +18809,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15751,6 +18824,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15761,6 +18839,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15771,6 +18854,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15828,6 +18916,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15838,6 +18931,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15848,6 +18946,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15858,6 +18961,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15868,6 +18976,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15878,6 +18991,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15888,6 +19006,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15898,6 +19021,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15955,6 +19083,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15965,6 +19098,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15975,6 +19113,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15985,6 +19128,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -15995,6 +19143,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16005,6 +19158,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16015,6 +19173,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16025,6 +19188,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16080,6 +19248,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16090,6 +19263,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16100,6 +19278,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16110,6 +19293,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16120,6 +19308,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16130,6 +19323,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16140,6 +19338,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16150,6 +19353,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16215,6 +19423,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16225,6 +19438,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16235,6 +19453,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16245,6 +19468,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16255,6 +19483,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16268,7 +19501,7 @@
                 "example": {
                   "code": 413000,
                   "message": "Startup script exceeds the 24576-byte limit",
-                  "request_id": ""
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
                 },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
@@ -16280,6 +19513,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16290,6 +19528,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16300,6 +19543,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16357,6 +19605,11 @@
           "400": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16367,6 +19620,11 @@
           "401": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16377,6 +19635,11 @@
           "403": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16387,6 +19650,11 @@
           "404": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16397,6 +19665,11 @@
           "409": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16407,6 +19680,11 @@
           "422": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16417,6 +19695,11 @@
           "500": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }
@@ -16427,6 +19710,11 @@
           "502": {
             "content": {
               "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
                 "schema": {
                   "$ref": "#/components/schemas/ErrorEnvelope"
                 }


### PR DESCRIPTION
## Problem

The published `src/gateway/configs/schemas/bots.openapi.json` was close to unusable as caller documentation. Concretely, across its 53 operations:

- 56 component schemas and 156 fields carried no description at all — a caller reading the doc saw only types.
- 102 path/query parameters were undocumented (every `bot_id` path segment, the resource `path` addressing parameter, the routines `bot_id` query, the logs filters, …).
- String fields that are de-facto enums named no valid values: bot lifecycle `status`, Passport auth `status`, routine run `status`, MCP `access_level` / `network_types` / transports, trace `status` / span `type`, identity file types, resource `source`.
- There were no request/response examples anywhere at field level — schemas showed `"type": "string"` and nothing else.
- Several operation descriptions leaked internal detail into the published document: RST markup that Swagger/Redoc render as garbage, internal class and route names, spec references, and a TODO.

The file is a build output of the backend's `/openapi/v1` surface, so the fix had to land in the backend source, not the JSON.

## Solution

Documented the source models and routers, then regenerated the artifact through the existing dump + compatibility-gate pipeline.

- **Descriptions everywhere.** Every published schema, field, and parameter now carries a caller-facing description. Repeated parameters (`bot_id`, resource `path`, `routine_id`+`bot_id`, `skill_id`, `server_code`, `session_id`, `model_id`) are documented once via shared `Annotated` aliases so groups cannot drift.
- **Enum vocabularies stated, with the closed/open distinction the engine-runtime groups already ruled on.** Value sets that are closed at the source became documented enums with `x-enum-descriptions` / `x-enum-varnames` (`IdentityFileType` — with a one-line meaning per identity file — and `ResourceType`). Sets an upstream or deployment can extend (bot `status`, auth `status`, routine run `status`, MCP `access_level`, trace span kinds, …) stay strings whose descriptions list today's values and say how to treat unknown ones. Two wrong claims were fixed along the way: `Bot.status` no longer advertises a three-value set its own listing can exceed, and the resources schema no longer suggests `"yuque"` as a `source` value (it never was one).
- **Examples.** Request and response models carry realistic `json_schema_extra` examples (bots, identity files, MCP config/permission, resources, routines, skills, trace observations). The `Envelope`/`Page` generics now inject a description into every concretisation via a `setdefault` callable, so the ~40 wrapper components (`Envelope_Bot_`, `Page_Skill_`, …) stop publishing bare while named subclasses keep their own docstrings.
- **No internal detail in published text.** Handler docstrings become the operation descriptions external tenants read, so the ones leaking RST markup, internal names (`BotService`, `GrantNotFoundError`, engine route paths), spec references, or TODOs were rewritten as caller prose, with the rationale moved to `#` comments per the engine-runtime convention.
- **A gate so it stays fixed.** `_DocumentedEnum` moved from `engine_runtime/enums.py` to a shared `openapi_v1/enums.py` (re-exported in place, so the existing gate and subclasses are untouched), and a new surface-wide `test_schema_docs.py` asserts the *generated document* has no undocumented parameter, schema, field, or enum member and no forbidden internal markers. Asserting on the document rather than the models is what also covers models published from outside the package (the Bot Logs group publishes `core/bot_chat` models directly).

One existing test pinned the old startup-script wording, including the engine's private restart route in the published text; it now asserts the same recompose caveat while requiring that no internal path is named.

## Validation

- Regenerated `bots.openapi.json` via `scripts/dump_openapi.py` (community profile); before the change, the dump reproduced the checked-in artifact byte-for-byte, confirming the pipeline was in sync.
- Gateway compatibility gate (`check_compatible`, the same check `gate_and_publish_openapi.py` runs): **0 breaking changes** — the diff is descriptions, examples, and `x-enum-*` extensions only.
- Post-regeneration audit of the artifact: 0 schemas, 0 fields, 0 parameters without descriptions (from 56 / 156 / 102); 46 schemas with examples (from 10); 6/6 enum components documented; 0 internal-marker hits in any published string.
- Backend: `tests/community/adapters/http/openapi_v1` — 773 passed (includes the new surface-wide gate and the existing engine-runtime gate); `tests/community/adapters/http/bot_chat`, `tests/community/core/bot_chat`, `tests/community/endpoints/test_open_bot_chat.py` — 169 passed; `tests/community/contracts/gateway/test_public_namespace.py` + engine_runtime suite — 270 passed.
- Gateway: `test_served_openapi`, `test_combined_schema_catalogs`, `test_domain_map`, `test_schema_catalog` — 137 passed; `e2e/asgi/baseline/test_served_openapi.py` + `integration/baseline/test_startup.py` — 18 passed.
- SAST block-rule scan (`flake8` with the `python_sast_local.sh` rule set) clean on all changed files; `ruff check` clean.
- Not run: the full singlebox coverage/E2E gates (heavier than this doc-only change warrants; the pre-push default is lint-only).

## Compatibility and risk

Doc-only on the wire: no field added, removed, retyped, or re-required; the compat gate confirms zero breaking changes. The two `StrEnum` → documented-enum conversions publish identical `enum` value lists and only add `x-` extensions. Rollback is reverting the commit and re-running the dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NDt42KjVU59YiXJTztKDJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDt42KjVU59YiXJTztKDJ5)_