### PR TITLE
feat(gateway): adopt secbaas API-key credentials for avernet_application

### DIFF
--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -20,6 +20,15 @@
 -- below: the third-party-app registry (`avernet_application`), the tenant master
 -- (`avernet_tenant`), and the access-key registry (`avernet_access_key_token`).
 
+-- KNOWN ISSUE (pre-dates the API-key work): the unique indexes on the two
+-- `token` columns are over varchar(1024) utf8mb4 = 4096 bytes, past InnoDB's
+-- 3072-byte key limit, so this file cannot be executed as-is against MySQL 8
+-- InnoDB. Those columns also keep the server-default (case-insensitive)
+-- collation, so their exact-match lookups are case-insensitive there. Both are
+-- left alone deliberately: changing either rebuilds an index on a deployed
+-- table, which `002` cannot do safely. `api_key_prefix` pins utf8mb4_bin
+-- because it is a new column with no such constraint.
+
 -- Table: avernet_application
 -- 第三方应用注册表：按 `api_key_prefix`(API Key 前 8 位)定位、再比对 `api_key_hash`；
 -- `id` 为应用稳定身份。每行只填一种凭证：新行填 api_key_*，迁移前的旧行填 `token`。
@@ -30,8 +39,8 @@ CREATE TABLE IF NOT EXISTS `avernet_application` (
   `app_name` varchar(256) NOT NULL COMMENT '应用名称',
   `app_type` varchar(64) NOT NULL DEFAULT 'UNKNOWN' COMMENT '应用类型',
   `api_key_hash` varchar(256) DEFAULT NULL COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))',
-  `api_key_prefix` varchar(8) COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
-  `token` varchar(1024) COLLATE utf8mb4_bin DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
+  `api_key_prefix` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
+  `token` varchar(1024) DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
   `owners` varchar(1024) NOT NULL COMMENT '应用归属(开发者/组织)',
   `tenant` varchar(64) NOT NULL COMMENT '所属租户(逻辑引用 avernet_tenant.name)',
   `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)，仅 ACTIVE 可通过鉴权',

--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -5,6 +5,10 @@
 -- ON UPDATE CURRENT_TIMESTAMP), named `uk_`/`idx_` indexes, and per-column
 -- `COMMENT` (following the backend SQL style).
 --
+-- This file is CREATE TABLE IF NOT EXISTS, so it only provisions a NEW database.
+-- Changes to an already-deployed schema go in a numbered migration beside it
+-- (see `002_application_api_key.sql`); editing this file alone migrates nobody.
+--
 -- The gateway's bare/community edition creates these tables from ORM metadata
 -- via `DataSourcePlugin.create_all()` (in-memory SQLite; the bare plugin
 -- downgrades BIGINT PKs to INTEGER automatically). This DDL is the canonical
@@ -26,8 +30,8 @@ CREATE TABLE IF NOT EXISTS `avernet_application` (
   `app_name` varchar(256) NOT NULL COMMENT '应用名称',
   `app_type` varchar(64) NOT NULL DEFAULT 'UNKNOWN' COMMENT '应用类型',
   `api_key_hash` varchar(256) DEFAULT NULL COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))',
-  `api_key_prefix` varchar(8) DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
-  `token` varchar(1024) DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
+  `api_key_prefix` varchar(8) COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
+  `token` varchar(1024) COLLATE utf8mb4_bin DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
   `owners` varchar(1024) NOT NULL COMMENT '应用归属(开发者/组织)',
   `tenant` varchar(64) NOT NULL COMMENT '所属租户(逻辑引用 avernet_tenant.name)',
   `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)，仅 ACTIVE 可通过鉴权',

--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -20,16 +20,17 @@
 -- below: the third-party-app registry (`avernet_application`), the tenant master
 -- (`avernet_tenant`), and the access-key registry (`avernet_access_key_token`).
 
--- KNOWN ISSUE (pre-dates the API-key work, NOT fixed here): the unique indexes
--- on the two `token` columns are over varchar(1024) utf8mb4 = 4096 bytes, past
--- InnoDB's 3072-byte key limit, so this file may not execute as-is against
--- MySQL 8 InnoDB. Fixing it means either shortening the columns or indexing a
--- prefix, both of which change an index on already-deployed tables — out of
--- scope for this workstream and flagged for the schema owner.
+-- The unique indexes on the two `token` columns span a 700-character prefix,
+-- not the whole varchar(1024): at utf8mb4 the full width is a 4096-byte key,
+-- past InnoDB's 3072-byte limit, which made this file non-executable as
+-- previously written. Both token kinds are signed JWTs of ~261 characters, so a
+-- 700-character prefix (2800 bytes) covers the entire value and uniqueness is
+-- unaffected. `002_application_api_key.sql` makes the same change on deployed
+-- databases.
 --
--- `avernet_access_key_token.token` also keeps the server-default
--- (case-insensitive) collation, so its exact-match lookup is case-insensitive
--- on MySQL. Left alone because access-key credentials are outside this change.
+-- `avernet_access_key_token.token` keeps the server-default (case-insensitive)
+-- collation, so its exact-match lookup is case-insensitive on MySQL. Left alone
+-- because access-key credentials are outside this change.
 
 -- Table: avernet_application
 -- 第三方应用注册表：按 `api_key_prefix`(API Key 前 8 位)定位、再比对 `api_key_hash`；
@@ -52,7 +53,7 @@ CREATE TABLE IF NOT EXISTS `avernet_application` (
   `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`),
-  UNIQUE KEY `uk_avernet_application_token` (`token`),
+  UNIQUE KEY `uk_avernet_application_token_prefix` (`token`(700)),
   KEY `idx_avernet_application_app_name` (`app_name`)
 ) DEFAULT CHARSET = utf8mb4 COMMENT = '第三方应用注册表';
 
@@ -86,6 +87,6 @@ CREATE TABLE IF NOT EXISTS `avernet_access_key_token` (
   `creator` varchar(128) NOT NULL DEFAULT '' COMMENT '创建人',
   `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_avernet_access_key_token_token` (`token`),
+  UNIQUE KEY `uk_avernet_access_key_token_token` (`token`(700)),
   KEY `idx_avernet_access_key_token_access_key` (`access_key`)
 ) DEFAULT CHARSET = utf8mb4 COMMENT = '访问密钥注册表';

--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -17,22 +17,26 @@
 -- (`avernet_tenant`), and the access-key registry (`avernet_access_key_token`).
 
 -- Table: avernet_application
--- 第三方应用注册表：按 opaque `token`(签名 JWT) 查找；`id` 为应用稳定身份。
+-- 第三方应用注册表：按 `api_key_prefix`(API Key 前 8 位)定位、再比对 `api_key_hash`；
+-- `id` 为应用稳定身份。每行只填一种凭证：新行填 api_key_*，迁移前的旧行填 `token`。
 CREATE TABLE IF NOT EXISTS `avernet_application` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键ID',
   `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   `app_name` varchar(256) NOT NULL COMMENT '应用名称',
   `app_type` varchar(64) NOT NULL DEFAULT 'UNKNOWN' COMMENT '应用类型',
-  `token` varchar(1024) NOT NULL COMMENT '应用访问令牌(签名 JWT)，opaque 查找键',
+  `api_key_hash` varchar(256) DEFAULT NULL COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))',
+  `api_key_prefix` varchar(8) DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
+  `token` varchar(1024) DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
   `owners` varchar(1024) NOT NULL COMMENT '应用归属(开发者/组织)',
   `tenant` varchar(64) NOT NULL COMMENT '所属租户(逻辑引用 avernet_tenant.name)',
-  `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)',
+  `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)，仅 ACTIVE 可通过鉴权',
   `env` varchar(64) NOT NULL DEFAULT '' COMMENT '环境标识',
   `config` json DEFAULT NULL COMMENT '扩展配置(JSON)',
   `creator` varchar(128) NOT NULL DEFAULT '' COMMENT '创建人',
   `modifier` varchar(128) NOT NULL DEFAULT '' COMMENT '修改人',
   PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`),
   UNIQUE KEY `uk_avernet_application_token` (`token`),
   KEY `idx_avernet_application_app_name` (`app_name`)
 ) DEFAULT CHARSET = utf8mb4 COMMENT = '第三方应用注册表';

--- a/src/gateway/migrations/mysql/001_init_schema.sql
+++ b/src/gateway/migrations/mysql/001_init_schema.sql
@@ -20,14 +20,16 @@
 -- below: the third-party-app registry (`avernet_application`), the tenant master
 -- (`avernet_tenant`), and the access-key registry (`avernet_access_key_token`).
 
--- KNOWN ISSUE (pre-dates the API-key work): the unique indexes on the two
--- `token` columns are over varchar(1024) utf8mb4 = 4096 bytes, past InnoDB's
--- 3072-byte key limit, so this file cannot be executed as-is against MySQL 8
--- InnoDB. Those columns also keep the server-default (case-insensitive)
--- collation, so their exact-match lookups are case-insensitive there. Both are
--- left alone deliberately: changing either rebuilds an index on a deployed
--- table, which `002` cannot do safely. `api_key_prefix` pins utf8mb4_bin
--- because it is a new column with no such constraint.
+-- KNOWN ISSUE (pre-dates the API-key work, NOT fixed here): the unique indexes
+-- on the two `token` columns are over varchar(1024) utf8mb4 = 4096 bytes, past
+-- InnoDB's 3072-byte key limit, so this file may not execute as-is against
+-- MySQL 8 InnoDB. Fixing it means either shortening the columns or indexing a
+-- prefix, both of which change an index on already-deployed tables — out of
+-- scope for this workstream and flagged for the schema owner.
+--
+-- `avernet_access_key_token.token` also keeps the server-default
+-- (case-insensitive) collation, so its exact-match lookup is case-insensitive
+-- on MySQL. Left alone because access-key credentials are outside this change.
 
 -- Table: avernet_application
 -- 第三方应用注册表：按 `api_key_prefix`(API Key 前 8 位)定位、再比对 `api_key_hash`；
@@ -40,7 +42,7 @@ CREATE TABLE IF NOT EXISTS `avernet_application` (
   `app_type` varchar(64) NOT NULL DEFAULT 'UNKNOWN' COMMENT '应用类型',
   `api_key_hash` varchar(256) DEFAULT NULL COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))',
   `api_key_prefix` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)',
-  `token` varchar(1024) DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
+  `token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
   `owners` varchar(1024) NOT NULL COMMENT '应用归属(开发者/组织)',
   `tenant` varchar(64) NOT NULL COMMENT '所属租户(逻辑引用 avernet_tenant.name)',
   `status` varchar(32) NOT NULL DEFAULT 'ACTIVE' COMMENT '状态(ACTIVE/INACTIVE)，仅 ACTIVE 可通过鉴权',

--- a/src/gateway/migrations/mysql/002_application_api_key.sql
+++ b/src/gateway/migrations/mysql/002_application_api_key.sql
@@ -33,12 +33,21 @@ ALTER TABLE `avernet_application`
 -- kept (not dropped) so pre-existing JWT holders keep authenticating; drop it,
 -- with its unique index, once the deprecation warning has gone quiet.
 --
--- Only the nullability changes. Restating the column's charset/collation would
--- rebuild `uk_avernet_application_token`, and that index is over a
--- varchar(1024) utf8mb4 column — 4096 bytes, past InnoDB's 3072-byte key limit —
--- so the rebuild would fail and leave this migration half-applied. The legacy
--- lookup therefore keeps whatever collation the deployed table already uses; see
--- the note in `001_init_schema.sql`.
+-- BEFORE APPLYING, CHECK THIS STATEMENT AGAINST THE DEPLOYED SCHEMA.
+-- MySQL's MODIFY restates a column's whole definition: attributes left out are
+-- reset to the table default rather than preserved, so the charset/collation
+-- must be spelled out to make this a pure nullability change. Spelling them out
+-- rebuilds `uk_avernet_application_token`, and that index is over a
+-- varchar(1024) utf8mb4 column — 4096 bytes, past InnoDB's 3072-byte key limit.
+-- Whether the rebuild succeeds depends on how the deployed column was actually
+-- created (see the KNOWN ISSUE note in `001_init_schema.sql`). DDL auto-commits
+-- per statement, so if it fails the ALTER above has already landed and this file
+-- is not re-runnable — verify, or split the two statements across two windows.
+--
+-- utf8mb4_bin matches `001` and makes the legacy exact-match lookup genuinely
+-- exact. If the deployed column is currently case-insensitive this tightens it;
+-- that only affects a holder presenting a case-variant of their own token.
 ALTER TABLE `avernet_application`
-  MODIFY COLUMN `token` varchar(1024) DEFAULT NULL
+  MODIFY COLUMN `token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+    DEFAULT NULL
     COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除';

--- a/src/gateway/migrations/mysql/002_application_api_key.sql
+++ b/src/gateway/migrations/mysql/002_application_api_key.sql
@@ -7,13 +7,24 @@
 -- without it, `POST /admin/apps` fails on `token`'s NOT NULL constraint and
 -- every app authentication fails on the missing `api_key_prefix` column.
 --
--- Additive: no column is dropped, and the only relaxation is `token` becoming
--- nullable, so existing rows keep their token and keep authenticating through
--- the deprecated exact-match path for the whole transition window.
+-- ONE statement, deliberately. DDL auto-commits per statement, so splitting this
+-- across several ALTERs risks a partially migrated, non-rerunnable schema if a
+-- later one fails. MySQL 8's DDL is atomic per statement, so as a single ALTER
+-- this either lands completely or not at all.
 --
--- MySQL has no `ADD COLUMN IF NOT EXISTS`, so re-running this errors with
--- ER_DUP_FIELDNAME (1060) rather than silently doing nothing. That is the
--- intended behavior for a one-shot migration.
+-- Re-running it errors with ER_DUP_FIELDNAME (1060) rather than silently doing
+-- nothing — the intended behavior for a one-shot migration.
+--
+-- Why the token index is replaced rather than left alone: `token` must become
+-- nullable, and MySQL's MODIFY restates a column's entire definition (attributes
+-- omitted are reset to the table default, not preserved), so the column is
+-- rebuilt either way — and with it any index over it. `uk_avernet_application_token`
+-- spans the whole varchar(1024); at utf8mb4 that is a 4096-byte key, past
+-- InnoDB's 3072-byte limit, so the rebuild would fail. It is therefore dropped
+-- and re-added over a 700-character prefix (2800 bytes). Uniqueness is
+-- unaffected in practice: gateway-issued app tokens are ~261 characters, so the
+-- prefix spans the entire value. The index is renamed so that the drop and the
+-- add cannot collide on one name within a single statement.
 
 ALTER TABLE `avernet_application`
   ADD COLUMN `api_key_hash` varchar(256) DEFAULT NULL
@@ -27,27 +38,12 @@ ALTER TABLE `avernet_application`
   -- the real app out. It also cuts effective prefix entropy from 62^8 to 36^8.
   ADD COLUMN `api_key_prefix` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
     DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)' AFTER `api_key_hash`,
-  ADD UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`);
-
--- Newly registered apps carry no `token`, so the column must accept NULL. It is
--- kept (not dropped) so pre-existing JWT holders keep authenticating; drop it,
--- with its unique index, once the deprecation warning has gone quiet.
---
--- BEFORE APPLYING, CHECK THIS STATEMENT AGAINST THE DEPLOYED SCHEMA.
--- MySQL's MODIFY restates a column's whole definition: attributes left out are
--- reset to the table default rather than preserved, so the charset/collation
--- must be spelled out to make this a pure nullability change. Spelling them out
--- rebuilds `uk_avernet_application_token`, and that index is over a
--- varchar(1024) utf8mb4 column — 4096 bytes, past InnoDB's 3072-byte key limit.
--- Whether the rebuild succeeds depends on how the deployed column was actually
--- created (see the KNOWN ISSUE note in `001_init_schema.sql`). DDL auto-commits
--- per statement, so if it fails the ALTER above has already landed and this file
--- is not re-runnable — verify, or split the two statements across two windows.
---
--- utf8mb4_bin matches `001` and makes the legacy exact-match lookup genuinely
--- exact. If the deployed column is currently case-insensitive this tightens it;
--- that only affects a holder presenting a case-variant of their own token.
-ALTER TABLE `avernet_application`
+  ADD UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`),
+  -- Newly registered apps carry no `token`, so the column must accept NULL. It
+  -- is kept (not dropped) so pre-existing JWT holders keep authenticating; drop
+  -- it, with its index, once the deprecation warning has gone quiet.
+  DROP INDEX `uk_avernet_application_token`,
   MODIFY COLUMN `token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
     DEFAULT NULL
-    COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除';
+    COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除',
+  ADD UNIQUE KEY `uk_avernet_application_token_prefix` (`token`(700));

--- a/src/gateway/migrations/mysql/002_application_api_key.sql
+++ b/src/gateway/migrations/mysql/002_application_api_key.sql
@@ -7,28 +7,38 @@
 -- without it, `POST /admin/apps` fails on `token`'s NOT NULL constraint and
 -- every app authentication fails on the missing `api_key_prefix` column.
 --
--- Additive and reversible: no column is dropped and no constraint tightened,
--- so existing rows keep their `token` and keep authenticating through the
--- deprecated exact-match path for the whole transition window.
+-- Additive: no column is dropped, and the only relaxation is `token` becoming
+-- nullable, so existing rows keep their token and keep authenticating through
+-- the deprecated exact-match path for the whole transition window.
 --
 -- MySQL has no `ADD COLUMN IF NOT EXISTS`, so re-running this errors with
 -- ER_DUP_FIELDNAME (1060) rather than silently doing nothing. That is the
 -- intended behavior for a one-shot migration.
 
 ALTER TABLE `avernet_application`
-  -- utf8mb4_bin: the server default collation is case-insensitive, which would
-  -- make two prefixes differing only in case collide on this unique index and
-  -- let a lookup match the wrong row (whose hash then fails, locking the real
-  -- app out). It also cuts effective prefix entropy from 62^8 to 36^8.
   ADD COLUMN `api_key_hash` varchar(256) DEFAULT NULL
     COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))' AFTER `app_type`,
-  ADD COLUMN `api_key_prefix` varchar(8) COLLATE utf8mb4_bin DEFAULT NULL
-    COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)' AFTER `api_key_hash`,
+  -- CHARACTER SET stated explicitly, not inherited: a table created before
+  -- utf8mb4 was the default would reject a bare `COLLATE utf8mb4_bin`.
+  --
+  -- utf8mb4_bin because the server default collation is case-insensitive, which
+  -- would make two prefixes differing only in case collide on the unique index
+  -- below and let a lookup match the wrong row — whose hash then fails, locking
+  -- the real app out. It also cuts effective prefix entropy from 62^8 to 36^8.
+  ADD COLUMN `api_key_prefix` varchar(8) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+    DEFAULT NULL COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)' AFTER `api_key_hash`,
   ADD UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`);
 
 -- Newly registered apps carry no `token`, so the column must accept NULL. It is
 -- kept (not dropped) so pre-existing JWT holders keep authenticating; drop it,
 -- with its unique index, once the deprecation warning has gone quiet.
+--
+-- Only the nullability changes. Restating the column's charset/collation would
+-- rebuild `uk_avernet_application_token`, and that index is over a
+-- varchar(1024) utf8mb4 column — 4096 bytes, past InnoDB's 3072-byte key limit —
+-- so the rebuild would fail and leave this migration half-applied. The legacy
+-- lookup therefore keeps whatever collation the deployed table already uses; see
+-- the note in `001_init_schema.sql`.
 ALTER TABLE `avernet_application`
-  MODIFY COLUMN `token` varchar(1024) COLLATE utf8mb4_bin DEFAULT NULL
+  MODIFY COLUMN `token` varchar(1024) DEFAULT NULL
     COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除';

--- a/src/gateway/migrations/mysql/002_application_api_key.sql
+++ b/src/gateway/migrations/mysql/002_application_api_key.sql
@@ -1,0 +1,34 @@
+-- Migration: avernet_application adopts API-key credentials.
+--
+-- `001_init_schema.sql` is `CREATE TABLE IF NOT EXISTS`, so it is a no-op on a
+-- database that already has these tables — editing it does not migrate anyone.
+-- This file carries the change for deployments created before the API-key
+-- scheme. Apply it BEFORE deploying the gateway that reads these columns:
+-- without it, `POST /admin/apps` fails on `token`'s NOT NULL constraint and
+-- every app authentication fails on the missing `api_key_prefix` column.
+--
+-- Additive and reversible: no column is dropped and no constraint tightened,
+-- so existing rows keep their `token` and keep authenticating through the
+-- deprecated exact-match path for the whole transition window.
+--
+-- MySQL has no `ADD COLUMN IF NOT EXISTS`, so re-running this errors with
+-- ER_DUP_FIELDNAME (1060) rather than silently doing nothing. That is the
+-- intended behavior for a one-shot migration.
+
+ALTER TABLE `avernet_application`
+  -- utf8mb4_bin: the server default collation is case-insensitive, which would
+  -- make two prefixes differing only in case collide on this unique index and
+  -- let a lookup match the wrong row (whose hash then fails, locking the real
+  -- app out). It also cuts effective prefix entropy from 62^8 to 36^8.
+  ADD COLUMN `api_key_hash` varchar(256) DEFAULT NULL
+    COMMENT 'API Key 哈希(PBKDF2-SHA256，格式 base64(salt):base64(dk))' AFTER `app_type`,
+  ADD COLUMN `api_key_prefix` varchar(8) COLLATE utf8mb4_bin DEFAULT NULL
+    COMMENT 'API Key 前 8 位，查找键(哈希加盐，无法按哈希查找)' AFTER `api_key_hash`,
+  ADD UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`);
+
+-- Newly registered apps carry no `token`, so the column must accept NULL. It is
+-- kept (not dropped) so pre-existing JWT holders keep authenticating; drop it,
+-- with its unique index, once the deprecation warning has gone quiet.
+ALTER TABLE `avernet_application`
+  MODIFY COLUMN `token` varchar(1024) COLLATE utf8mb4_bin DEFAULT NULL
+    COMMENT '[废弃] 旧版应用令牌(明文签名 JWT)，过渡期精确匹配查找键；待废弃日志静默后随查找路径一并删除';

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -350,9 +350,11 @@ its dispatch branch, and its tests.
 _SECBAAS_KEY = "5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F"
 _SECBAAS_HASH = "YIrLEzbZybtDzATwCkQ9QERLnn0Q9z09iO+u02jvGGs=:UKS+A02LiRqVNsn0oOs9EiNO63ggsbZ3UHGnND6A08Q="
 def test_secbaas_produced_hash_verifies(): ...          # read side: the migration guarantee
-def test_secbaas_fixture_uses_documented_pbkdf2_parameters(): ...
+def test_secbaas_hash_rejects_a_different_key(): ...
+def test_pinned_fixture_is_internally_consistent(): ...  # authenticates the fixture
 def test_hash_key_output_uses_documented_pbkdf2_parameters(): ...  # write side
 def test_generate_is_32_char_base62(): ...
+def test_generate_is_not_deterministic(): ...
 def test_hash_roundtrip(): ...
 def test_hashing_one_key_twice_yields_different_stored_values(): ...  # salt uniqueness
 def test_verify_rejects_wrong_key(): ...
@@ -362,14 +364,39 @@ def test_round_trip_against_secbaas_implementation(): ...  # both directions
 def test_copy_is_byte_identical_to_secbaas_source(): ...
 ```
 
-Both parameter-pinning tests are needed: the read-side one asserts against the
-fixture constant, so it cannot catch a weakened salt or iteration count in *our*
-`hash_key` — the internal round-trips stay self-consistent under any change
-applied to `hash_key` and `verify_key` together. Two further tests characterize
-upstream quirks that byte-identity forbids fixing here (`validate_format`
-accepts a trailing newline; `b64decode` runs non-validating, so a stored hash
-corrupted only by punctuation still verifies). They document the behavior rather
-than hide it — see Notes on upstream follow-ups.
+The write-side pin is not redundant with the read-side one: the latter asserts
+against the fixture constant, so it cannot catch a weakened salt or iteration
+count in *our* `hash_key`, and the internal round-trips stay self-consistent
+under any change applied to `hash_key` and `verify_key` together. In a checkout
+without `src/baas` the parity tests skip and the write-side pin is the only
+guard left. Path resolution keys on the ancestor holding both `src/baas` and
+`src/gateway` — not `AGENTS.md`, which this repo already places at module level
+— so "split out on its own" (skip) stays distinguishable from "the file moved"
+(fail).
+
+## Notes on upstream follow-ups
+
+Two defects live in the copied scheme. Neither can be fixed here: byte-identity
+with secbaas is the migration guarantee, so a one-sided edit is worse than the
+defect. Both need a secbaas change plus a re-copy, and neither is triggered by
+anything the gateway does today.
+
+1. **`validate_format` accepts a trailing newline.** `re.match(r"^…{32}$", s)`
+   also matches immediately before a trailing `\n`, so a 33-character value
+   passes as a 32-char key (`re.fullmatch` or `\Z` would not). Harmless for the
+   credential dispatch — a newline-suffixed value authenticates on neither path,
+   which Task 4 tests directly — but wrong wherever this is used to validate
+   input, including in the migration tooling.
+2. **`verify_key` decodes non-validating.** `base64.b64decode` defaults to
+   discarding characters outside the alphabet, so a stored hash corrupted only
+   by inserted punctuation decodes to the original bytes and still verifies —
+   a fail-open on data corruption. `validate=True` fixes it.
+
+A third, structural: the gateway CI job is selected by changed paths under
+`src/gateway`, so a commit touching only secbaas's copy never runs
+`test_copy_is_byte_identical_to_secbaas_source`. The byte-identity guard is
+therefore one-directional until that path filter also watches the secbaas
+generator.
 
 ```python
 # src/gateway/tests/unit/plugins/test_app_registry_db.py (rework)

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -19,11 +19,17 @@ two paths are chosen by *format*, not by fallback — `APIKeyGenerator.validate_
 one path, and the hot path stays clean. Every legacy resolution logs at WARNING
 with the app's identity, which is what tells us when the path is safe to delete.
 
-Verbatim means byte-for-byte: same base62 alphabet, `pbkdf2_hmac("sha256", key,
+Verbatim means the code, not the prose: same base62 alphabet, `pbkdf2_hmac("sha256", key,
 salt, 100_000)`, stored as `base64(salt):base64(dk)`, `hmac.compare_digest`
 verify, `key[:8]` prefix, 3-attempt prefix-collision retry at creation, and the
 `len < 8` cheap reject before any DB touch (mirroring
 `DefaultAPIKeyValidator.verify`, `src/baas/src/secbaas/community/core/service/api_gateway/_key_validator.py:32`).
+The copy's comments and docstrings are translated to English — every other
+gateway source file is English, and this one was the module's sole exception —
+so parity is enforced on the syntax tree with docstrings stripped rather than on
+the bytes. That is the same guarantee for the scheme, since every ingredient of
+the stored hash is a literal or a call in that tree, and it leaves the executable
+statements byte-identical to upstream's anyway.
 
 ## Affected Components
 
@@ -120,13 +126,14 @@ for either credential form.
 
 ## Key Files & Functions
 
-New module — byte-for-byte copy of
-`src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py` (the
-gateway does not depend on the baas package, so the class is copied, not
-imported; a parity fixture test keeps the copy honest):
+New module — copy of
+`src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`, identical
+in code and translated in prose (the gateway does not depend on the baas
+package, so the class is copied, not imported; a parity fixture test keeps the
+copy honest):
 
 ```python
-# src/gateway/src/gateway/community/core/app/_key_gen.py (new, copied verbatim)
+# src/gateway/src/gateway/community/core/app/_key_gen.py (new, copied)
 class APIKeyGenerator:
     BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     @classmethod
@@ -361,7 +368,8 @@ def test_verify_rejects_wrong_key(): ...
 def test_verify_rejects_unusable_stored_hash(): ...
 def test_validate_format(): ...
 def test_round_trip_against_secbaas_implementation(): ...  # both directions
-def test_copy_is_byte_identical_to_secbaas_source(): ...
+def test_copy_is_semantically_identical_to_secbaas_source(): ...  # AST, docstrings stripped
+def test_copy_carries_no_cjk_prose(): ...  # the translation survives a re-copy
 ```
 
 The write-side pin is not redundant with the read-side one: the latter asserts
@@ -424,10 +432,12 @@ test suite; run the full module gate via `OCB_PRE_PUSH_RUN_CI=1` before push.
 
 ## Notes on upstream follow-ups
 
-Two defects live in the copied scheme. Neither can be fixed here: byte-identity
-with secbaas is the migration guarantee, so a one-sided edit is worse than the
-defect. Both need a secbaas change plus a re-copy, and neither is triggered by
-anything the gateway does today.
+Two behavioural defects live in the copied scheme. Neither can be fixed here:
+code parity with secbaas is the migration guarantee, so a one-sided edit is worse
+than the defect. Both need a secbaas change plus a re-copy, and neither is
+triggered by anything the gateway does today. (Prose is not held to parity, so
+they are described in this copy's English comments where relevant — describing a
+defect is not fixing it.)
 
 1. **`validate_format` accepts a trailing newline.** `re.match(r"^…{32}$", s)`
    also matches immediately before a trailing `\n`, so a 33-character value
@@ -440,11 +450,18 @@ anything the gateway does today.
    by inserted punctuation decodes to the original bytes and still verifies —
    a fail-open on data corruption. `validate=True` fixes it.
 
+One documentation defect, carried across rather than silently corrected:
+the class docstring states a 32-character format and then illustrates it with a
+23-character example. The example is kept as upstream wrote it, with the
+discrepancy called out beside it, so a reader is not misled and a future
+re-copy has nothing to reconcile.
+
 Two further structural gaps, both outside this change's blast radius:
 
-3. **The byte-identity guard is one-directional.** The gateway CI job is
+3. **The parity guard is one-directional.** The gateway CI job is
    selected by changed paths under `src/gateway`, so a commit touching only
-   secbaas's copy never runs `test_copy_is_byte_identical_to_secbaas_source`.
+   secbaas's copy never runs
+   `test_copy_is_semantically_identical_to_secbaas_source`.
    The clean fix is a mirror assertion in
    `src/baas/tests/unit/core/service/api_gateway/test_key_gen.py`, which runs on
    exactly the commits the gateway job skips — a baas-module change, hence not

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -11,6 +11,14 @@ status gating, and hash verification all live inside `AppRepository`, so the
 authn strategy and downstream principal contracts are untouched except for a
 method rename. `AppRegistrar` stops using `PrincipalSigner` entirely.
 
+Existing JWT holders are served by a **deprecated second path** kept for a
+transition window: the retained `token` column and its exact-match lookup. The
+two paths are chosen by *format*, not by fallback — `APIKeyGenerator.validate_format`
+(`^[0-9A-Za-z]{32}$`) is a total discriminator, because a JWT always contains
+`.` and can never be 32 base62 chars. So each request does exactly one lookup on
+one path, and the hot path stays clean. Every legacy resolution logs at WARNING
+with the app's identity, which is what tells us when the path is safe to delete.
+
 Verbatim means byte-for-byte: same base62 alphabet, `pbkdf2_hmac("sha256", key,
 salt, 100_000)`, stored as `base64(salt):base64(dk)`, `hmac.compare_digest`
 verify, `key[:8]` prefix, 3-attempt prefix-collision retry at creation, and the
@@ -23,8 +31,8 @@ verify, `key[:8]` prefix, 3-attempt prefix-collision retry at creation, and the
   `_key_gen.py` (copied), reworked `_orm.py` / `_repository.py` /
   `_registrar.py` / `__init__.py`.
 - `src/gateway/src/gateway/community/spi/app/_ports.py` — `AppRegistry` port:
-  `find_app_by_token` → `find_app_by_api_key` (semantics: verify, not just look
-  up).
+  `find_app_by_token` → `find_app_by_credential` (semantics: verify a credential
+  of either form, not just look a string up).
 - `src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py` —
   strategy calls the renamed port; header extraction unchanged.
 - `src/gateway/src/gateway/community/adapters/web/admin.py` — `POST /admin/apps`
@@ -45,39 +53,58 @@ Column names deliberately mirror `baas_api_key`
 (`src/baas/src/secbaas/community/core/repository/api_gateway/_orm_model.py:16-17`)
 so the migration is a straight column map.
 
+A row carries **exactly one** credential form: legacy rows have `token`, new and
+migrated rows have `api_key_hash` + `api_key_prefix`. All three become nullable —
+`None` is a real, intended state here (which credential form this row uses), not
+a shrug, so it satisfies the `AGENTS.md` rule against gratuitous optionals.
+Nullable also matters for `api_key_prefix` specifically: a unique index permits
+many `NULL`s but only one `''`, so an empty-string sentinel would collide across
+every legacy row.
+
 ```diff
 # src/gateway/src/gateway/community/core/app/_orm.py:31 — AppRow
 -    token: Mapped[str] = mapped_column(unique=True)
-+    api_key_hash: Mapped[str] = mapped_column(String(256))
-+    api_key_prefix: Mapped[str] = mapped_column(String(8), unique=True)
++    # Legacy JWT credential — deprecated, populated only on pre-migration rows.
++    token: Mapped[str | None] = mapped_column(unique=True, nullable=True)
++    api_key_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
++    api_key_prefix: Mapped[str | None] = mapped_column(
++        String(8), unique=True, nullable=True
++    )
 ```
 
 ```diff
 # src/gateway/migrations/mysql/001_init_schema.sql:27 — avernet_application
 -  `token` varchar(1024) NOT NULL COMMENT '应用访问令牌(签名 JWT)，opaque 查找键',
-+  `api_key_hash` varchar(256) NOT NULL COMMENT 'API Key 哈希(base64(salt):base64(dk)，PBKDF2-SHA256)',
-+  `api_key_prefix` varchar(8) NOT NULL COMMENT 'API Key 前缀(8 位，查找键)',
++  `token` varchar(1024) DEFAULT NULL COMMENT '[废弃] 旧版应用令牌(签名 JWT)，过渡期精确匹配查找键',
++  `api_key_hash` varchar(256) DEFAULT NULL COMMENT 'API Key 哈希(base64(salt):base64(dk)，PBKDF2-SHA256)',
++  `api_key_prefix` varchar(8) DEFAULT NULL COMMENT 'API Key 前缀(8 位，查找键)',
    ...
--  UNIQUE KEY `uk_avernet_application_token` (`token`),
+   UNIQUE KEY `uk_avernet_application_token` (`token`),
 +  UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`),
 ```
 
 Community edition creates tables via `DataSourcePlugin.create_all()` (no
 Alembic); the SQL file is the canonical schema for real MySQL/OceanBase. The
-ALTER + data move for a live DB belongs to the migration workstream.
+ALTER for a live DB is additive only (two nullable columns, one index) —
+existing rows keep their `token` untouched and keep authenticating, so the
+schema step is safe to apply before the code ships. The secbaas data move
+belongs to the migration workstream.
 
 ## API / Interface Changes
 
 ```diff
 # BREAKING — src/gateway/src/gateway/community/spi/app/_ports.py:40 — AppRegistry
 -    async def find_app_by_token(self, token: str) -> RegisteredApp | None: ...
-+    async def find_app_by_api_key(self, api_key: str) -> RegisteredApp | None: ...
++    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None: ...
 ```
 
-Port contract: soft miss (`None`) for malformed key (`len < 8`), unknown prefix,
-non-`ACTIVE` row, or hash mismatch — never raises on a bad credential.
-`RegisteredApp` itself is unchanged (`id/app_name/owners/app_type/tenant`), so
-`AppPrincipal` and forwarded principal headers are untouched.
+Named for what it accepts: either credential form, dispatched by format. (It
+stays accurate after the legacy path is deleted, so the follow-up is a deletion
+with no second rename.) Port contract: soft miss (`None`) for a malformed
+credential (`len < 8`), unknown prefix or token, non-`ACTIVE` row, or hash
+mismatch — never raises on a bad credential. `RegisteredApp` itself is unchanged
+(`id/app_name/owners/app_type/tenant`), so `AppPrincipal` and forwarded
+principal headers are untouched on both paths.
 
 ```jsonc
 // BREAKING — POST /admin/apps → 201 (admin.py:90): "token" replaced by "api_key"
@@ -86,9 +113,10 @@ non-`ACTIVE` row, or hash mismatch — never raises on a bad credential.
 // api_key: 32-char base62, shown exactly once; only its hash is persisted
 ```
 
-Previously issued JWT app tokens stop authenticating (replacement, not
-coexistence — spec acceptance criterion). `Authorization: Bearer <api_key>` and
-`x-avernet-app-token: <api_key>` both keep working as presentation channels.
+Previously issued JWT app tokens keep authenticating through the deprecated
+path; no new JWT is ever issued. `Authorization: Bearer <credential>` and
+`x-avernet-app-token: <credential>` both keep working as presentation channels,
+for either credential form.
 
 ## Key Files & Functions
 
@@ -117,26 +145,43 @@ class APIKeyGenerator:
 -        with self._db.orm_session() as session:
 -            row = session.scalar(select(self.Model).where(self.Model.token == token))
 -            return None if row is None else row.to_record()
-+    async def find_app_by_api_key(self, api_key: str) -> RegisteredApp | None:
-+        if not api_key or len(api_key) < 8:
-+            return None                     # cheap reject, no DB touch
-+        with self._db.orm_session() as session:
-+            row = session.scalar(
-+                select(self.Model).where(
-+                    self.Model.api_key_prefix == api_key[:8],
-+                    self.Model.status == "ACTIVE",
-+                )
-+            )
-+        if row is None or not APIKeyGenerator.verify_key(api_key, row.api_key_hash):
-+            return None
-+        return row.to_record()
-+
-+    async def exists_prefix(self, api_key_prefix: str) -> bool: ...
++    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
++        if not credential or len(credential) < 8:
++            return None                      # cheap reject, no DB touch
++        if APIKeyGenerator.validate_format(credential):
++            return self._by_api_key(credential)
++        return self._by_legacy_token(credential)      # DEPRECATED path
 ```
 
-`store(...)` swaps `token: str` for `api_key_hash: str, api_key_prefix: str`;
-body maps them onto the new columns (verify runs outside the session block —
-PBKDF2 is ~100ms of CPU, no reason to hold the session open).
+```python
+# src/gateway/src/gateway/community/core/app/_repository.py (new private helpers)
+def _by_api_key(self, api_key: str) -> RegisteredApp | None:
+    with self._db.orm_session() as session:
+        row = session.scalar(select(self.Model).where(
+            self.Model.api_key_prefix == api_key[:8],
+            self.Model.status == _ACTIVE,
+        ))
+        if row is None:
+            return None
+        stored_hash, record = row.api_key_hash, row.to_record()   # read in-session
+    # PBKDF2 is ~62ms of CPU — verify after releasing the session.
+    return record if APIKeyGenerator.verify_key(api_key, stored_hash or "") else None
+
+def _by_legacy_token(self, token: str) -> RegisteredApp | None:
+    """DEPRECATED — delete with the `token` column once the warning goes quiet."""
+    ...  # exact match on token + status == _ACTIVE
+    logger.warning("app authenticated with deprecated JWT token: id=%s name=%s", ...)
+
+async def exists_prefix(self, api_key_prefix: str) -> bool: ...
+```
+
+Both `stored_hash` and `record` are read *inside* the session and verified
+outside it — attribute access on an expired row after the block would raise
+`DetachedInstanceError`, and holding the session across 62ms of PBKDF2 would pin
+a connection for no reason.
+
+`store(...)` swaps `token: str` for `api_key_hash: str, api_key_prefix: str`
+(new rows never populate `token`).
 
 ```diff
 # src/gateway/src/gateway/community/core/app/_registrar.py — AppRegistrar
@@ -169,7 +214,7 @@ PBKDF2 is ~100ms of CPU, no reason to hold the session open).
 ```diff
 # src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py:63
 -        record = await self._registry.find_app_by_token(app_token)
-+        record = await self._registry.find_app_by_api_key(app_token)
++        record = await self._registry.find_app_by_credential(app_token)
 ```
 
 Strategy header extraction (`Bearer` / `x-avernet-app-token`) is unchanged; an
@@ -217,8 +262,21 @@ signing).
   future extension).
 - **Risk:** Seeded demo/test rows using plaintext `token=` stop working and
   break unrelated suites.
-  **Mitigation:** Blast radius enumerated in Test Strategy; all seeds move to
-  `api_key_hash`/`api_key_prefix` in the same change.
+  **Mitigation:** Blast radius enumerated in Test Strategy; seeds move to
+  `api_key_hash`/`api_key_prefix`, except the ones deliberately kept on `token=`
+  to cover the legacy path.
+- **Risk:** The deprecated path is never deleted and becomes permanent, leaving
+  plaintext credentials in the table indefinitely.
+  **Mitigation:** The WARNING log per legacy resolution makes remaining usage
+  measurable, so deletion is gated on evidence rather than memory. Spec lists
+  the deletion as an explicit follow-up, and both the column comment and the
+  method docstring say what has to happen before removal.
+- **Risk:** Uniform `ACTIVE` gating breaks a live holder whose row is not
+  `ACTIVE` — the one way this change can bite an existing user, since the legacy
+  lookup ignores `status` today.
+  **Mitigation:** No gateway API sets a non-`ACTIVE` status and rows default to
+  `ACTIVE`, so the population should be empty; spec's Open Questions calls for a
+  `SELECT status, COUNT(*)` against the real table to confirm before rollout.
 
 ## Alternatives Considered
 
@@ -232,10 +290,28 @@ signing).
   verification inside `AppRepository` preserves that contract and keeps the
   authn plugin storage-agnostic. "Exactly the same" binds the credential
   scheme, not secbaas's internal layering.
-- **Keep `token` column and add key columns alongside (dual-scheme
-  coexistence)** — rejected: spec mandates replacement; precedent
-  (`specs/2026-07-30-application-tenant-accesskey-schema/spec.md` §已确认决策 1)
-  is replace-and-migrate, not coexist.
+- **Convert existing JWTs into the new columns** (hash each JWT, store
+  `token[:8]` as its prefix) — **rejected: does not work.** Hashing is fine, but
+  every JWT this gateway issues begins with the same base64-encoded header, so
+  all of them share the prefix `eyJhbGci`. Verified by signing five tokens for
+  different apps and tenants with the real signer: 1 distinct prefix out of 5.
+  That violates the prefix's uniqueness constraint, and even without the
+  constraint a lookup would return every legacy row at once, forcing an O(n)
+  scan of 62ms PBKDF2 verifications. This finding is what forced the transition
+  window.
+- **Use the JWT's last 8 characters as its prefix** (the signature tail *is*
+  random — measured distinct across all five samples) — rejected: it works, but
+  it needs a permanent branch in the lookup rule and makes the gateway's scheme
+  diverge from secbaas's for a population that should shrink to zero. A
+  deprecated exact-match path costs less and deletes cleanly.
+- **Hard replacement, cutting existing JWT holders off on deploy day** —
+  rejected by the product decision that no current holder may break. The
+  transition window is the cost of that guarantee.
+- **`sha256(token)` as the legacy lookup key**, so no plaintext remains during
+  the window — viable (deterministic, so still exact-matchable; unsalted is safe
+  for a high-entropy JWT), but deferred: it adds a column and a backfill for a
+  path already scheduled for deletion, and leaves today's risk unchanged rather
+  than worse. Recorded in the spec's Open Questions.
 - **Pin verification to `env` like secbaas
   (`get_by_prefix_and_status(..., env=...)`)** — deferred: the gateway authn
   path has no environment concept; spec's Open Question records the assumption
@@ -246,17 +322,26 @@ signing).
 
 ## Rollout
 
-No flag; single atomic change within the gateway (community edition rebuilds
-its schema via `create_all()` on boot). For a real MySQL/OceanBase deployment
-the ordering is owned by the migration workstream:
+No flag needed: the schema step is purely additive and the two credential paths
+are format-disjoint, so old and new coexist without a switch. Community edition
+rebuilds its schema via `create_all()` on boot. For a real MySQL/OceanBase
+deployment:
 
 ```bash
-# 1. ALTER avernet_application (add api_key_hash/api_key_prefix, drop token)
-# 2. copy baas_api_key rows into avernet_application (column map, dedupe check)
-# 3. deploy gateway with this change
+# 1. ALTER avernet_application: add api_key_hash + api_key_prefix (both NULL),
+#    add uk_avernet_application_api_key_prefix. `token` is retained as-is.
+# 2. deploy gateway with this change   → existing JWT holders keep working
+# 3. copy baas_api_key rows in (migration workstream; column map + prefix
+#    uniqueness check)                 → migrated key holders work on arrival
 ```
 
-Old JWT app tokens die at step 3 by design; migrated key holders are unaffected.
+Steps 1 and 2 are independently reversible: rolling the code back leaves two
+unused nullable columns behind, and no credential stops working at any point.
+
+**Exit criteria for the window** (the deletion follow-up, not this change):
+`legacy JWT token` warnings drop to zero across a full traffic cycle → re-issue
+any stragglers via `POST /admin/apps` → drop the `token` column, `_by_legacy_token`,
+its dispatch branch, and its tests.
 
 ## Test Strategy
 
@@ -283,6 +368,19 @@ def test_exists_prefix(): ...
 ```
 
 ```python
+# src/gateway/tests/unit/plugins/test_app_legacy_token.py (new — the continuity guarantee)
+# Seeds a row the OLD way (token=<real JWT>, api_key_* NULL) and asserts it still
+# authenticates, i.e. that shipping this change breaks no existing holder.
+def test_legacy_jwt_still_resolves_app(): ...
+def test_legacy_jwt_resolves_identical_registeredapp_as_before(): ...
+def test_unknown_jwt_returns_none(): ...
+def test_legacy_resolution_emits_deprecation_warning(caplog): ...
+def test_inactive_legacy_row_returns_none(): ...        # documents the status-gate change
+def test_api_key_and_legacy_rows_coexist_in_one_table(): ...
+def test_32_char_key_never_takes_the_legacy_path(): ...  # format dispatch is total
+```
+
+```python
 # src/gateway/tests/unit/plugins/test_app_registrar.py (rework — JWT tests dropped)
 def test_register_returns_32_char_key_and_persists_only_hash(): ...
 def test_registered_key_authenticates_via_repository(): ...   # mint→verify closed loop
@@ -295,11 +393,14 @@ def test_creator_recorded_as_creator_and_modifier(): ...      # kept from today
 - `tests/integration/test_identity_pipeline.py:54-57,111,178` and
   `test_forward_route.py:419-427` — seed `AppRow(api_key_hash=hash_key(k),
   api_key_prefix=k[:8], ...)` with a 32-char key; present the plaintext in
-  headers.
+  headers. Add one case seeding a legacy `token=` row and authenticating with
+  the JWT, so the deprecated path is covered end to end through the real
+  strategy, not just at the repository.
 - `tests/integration/test_admin_issuance.py:59-91` — `POST /admin/apps` → 201
   body has `api_key` (32-char base62, format-validated), no `token`; the
   returned key immediately authenticates through
-  `AppRepository.find_app_by_api_key`; the DB row holds a hash, not the key.
+  `AppRepository.find_app_by_credential`; the DB row holds a hash, not the key,
+  and its `token` column is NULL.
 
 Gates: `scripts/ci/python_sast_local.sh` (pre-push lint) and the gateway module
 test suite; run the full module gate via `OCB_PRE_PUSH_RUN_CI=1` before push.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -374,30 +374,6 @@ guard left. Path resolution keys on the ancestor holding both `src/baas` and
 — so "split out on its own" (skip) stays distinguishable from "the file moved"
 (fail).
 
-## Notes on upstream follow-ups
-
-Two defects live in the copied scheme. Neither can be fixed here: byte-identity
-with secbaas is the migration guarantee, so a one-sided edit is worse than the
-defect. Both need a secbaas change plus a re-copy, and neither is triggered by
-anything the gateway does today.
-
-1. **`validate_format` accepts a trailing newline.** `re.match(r"^…{32}$", s)`
-   also matches immediately before a trailing `\n`, so a 33-character value
-   passes as a 32-char key (`re.fullmatch` or `\Z` would not). Harmless for the
-   credential dispatch — a newline-suffixed value authenticates on neither path,
-   which Task 4 tests directly — but wrong wherever this is used to validate
-   input, including in the migration tooling.
-2. **`verify_key` decodes non-validating.** `base64.b64decode` defaults to
-   discarding characters outside the alphabet, so a stored hash corrupted only
-   by inserted punctuation decodes to the original bytes and still verifies —
-   a fail-open on data corruption. `validate=True` fixes it.
-
-A third, structural: the gateway CI job is selected by changed paths under
-`src/gateway`, so a commit touching only secbaas's copy never runs
-`test_copy_is_byte_identical_to_secbaas_source`. The byte-identity guard is
-therefore one-directional until that path filter also watches the secbaas
-generator.
-
 ```python
 # src/gateway/tests/unit/plugins/test_app_registry_db.py (rework)
 def test_correct_key_resolves_active_seeded_app(): ...  # seed hash+prefix, present plaintext
@@ -444,3 +420,38 @@ def test_creator_recorded_as_creator_and_modifier(): ...      # kept from today
 
 Gates: `scripts/ci/python_sast_local.sh` (pre-push lint) and the gateway module
 test suite; run the full module gate via `OCB_PRE_PUSH_RUN_CI=1` before push.
+
+## Notes on upstream follow-ups
+
+Two defects live in the copied scheme. Neither can be fixed here: byte-identity
+with secbaas is the migration guarantee, so a one-sided edit is worse than the
+defect. Both need a secbaas change plus a re-copy, and neither is triggered by
+anything the gateway does today.
+
+1. **`validate_format` accepts a trailing newline.** `re.match(r"^…{32}$", s)`
+   also matches immediately before a trailing `\n`, so a 33-character value
+   passes as a 32-char key (`re.fullmatch` or `\Z` would not). Harmless for the
+   credential dispatch — a newline-suffixed value authenticates on neither path,
+   which Task 4 must test — but wrong wherever this is used to validate input,
+   including in the migration tooling.
+2. **`verify_key` decodes non-validating.** `base64.b64decode` defaults to
+   discarding characters outside the alphabet, so a stored hash corrupted only
+   by inserted punctuation decodes to the original bytes and still verifies —
+   a fail-open on data corruption. `validate=True` fixes it.
+
+Two further structural gaps, both outside this change's blast radius:
+
+3. **The byte-identity guard is one-directional.** The gateway CI job is
+   selected by changed paths under `src/gateway`, so a commit touching only
+   secbaas's copy never runs `test_copy_is_byte_identical_to_secbaas_source`.
+   The clean fix is a mirror assertion in
+   `src/baas/tests/unit/core/service/api_gateway/test_key_gen.py`, which runs on
+   exactly the commits the gateway job skips — a baas-module change, hence not
+   made here.
+4. **A skip reads as a pass at the coverage gate.** `scripts/ci/report_check.py`
+   computes `passed = tests - failures - errors`, so if the parity tests ever
+   skip (no ancestor holding both module trees — a split-out checkout, or a
+   renamed module directory), CI still reports 100%. Hard-failing instead would
+   break legitimately standalone checkouts, so the ambiguity is recorded rather
+   than resolved; item 3 removes most of its consequence.
+

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -370,9 +370,10 @@ count in *our* `hash_key`, and the internal round-trips stay self-consistent
 under any change applied to `hash_key` and `verify_key` together. In a checkout
 without `src/baas` the parity tests skip and the write-side pin is the only
 guard left. Path resolution keys on the ancestor holding both `src/baas` and
-`src/gateway` — not `AGENTS.md`, which this repo already places at module level
-— so "split out on its own" (skip) stays distinguishable from "the file moved"
-(fail).
+`src/gateway` — not `AGENTS.md`, which this repo already places at module level.
+That distinguishes "a generator file moved within its module" (fail, with
+guidance) from "no monorepo here" (skip), but *not* a renamed module directory,
+which also skips — see note 4 below.
 
 ```python
 # src/gateway/tests/unit/plugins/test_app_registry_db.py (rework)
@@ -451,7 +452,10 @@ Two further structural gaps, both outside this change's blast radius:
 4. **A skip reads as a pass at the coverage gate.** `scripts/ci/report_check.py`
    computes `passed = tests - failures - errors`, so if the parity tests ever
    skip (no ancestor holding both module trees — a split-out checkout, or a
-   renamed module directory), CI still reports 100%. Hard-failing instead would
-   break legitimately standalone checkouts, so the ambiguity is recorded rather
-   than resolved; item 3 removes most of its consequence.
+   renamed module directory), CI still reports 100%. Hard-failing in the test
+   is not the fix, since that breaks legitimately standalone checkouts; the
+   fixes are either a skip-aware gate (`report_check.py` already parses the
+   JUnit XML, which carries `skipped` on the same element) or failing only when
+   a CI environment variable is set. Both touch coverage reporting, which
+   `AGENTS.md` treats as a contract, so neither is bundled into this change.
 

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -271,12 +271,10 @@ signing).
   measurable, so deletion is gated on evidence rather than memory. Spec lists
   the deletion as an explicit follow-up, and both the column comment and the
   method docstring say what has to happen before removal.
-- **Risk:** Uniform `ACTIVE` gating breaks a live holder whose row is not
-  `ACTIVE` — the one way this change can bite an existing user, since the legacy
-  lookup ignores `status` today.
-  **Mitigation:** No gateway API sets a non-`ACTIVE` status and rows default to
-  `ACTIVE`, so the population should be empty; spec's Open Questions calls for a
-  `SELECT status, COUNT(*)` against the real table to confirm before rollout.
+- **Risk:** ~~Uniform `ACTIVE` gating breaks a live holder whose row is not
+  `ACTIVE`, since the legacy lookup ignores `status` today.~~ **Retired** —
+  confirmed against the real table that the non-`ACTIVE` population is zero, so
+  no live holder is affected (spec §Confirmed Decisions 1).
 
 ## Alternatives Considered
 
@@ -309,9 +307,9 @@ signing).
   transition window is the cost of that guarantee.
 - **`sha256(token)` as the legacy lookup key**, so no plaintext remains during
   the window — viable (deterministic, so still exact-matchable; unsalted is safe
-  for a high-entropy JWT), but deferred: it adds a column and a backfill for a
-  path already scheduled for deletion, and leaves today's risk unchanged rather
-  than worse. Recorded in the spec's Open Questions.
+  for a high-entropy JWT), but **decided against**: it adds a column and a
+  backfill for a path already scheduled for deletion, and leaves today's risk
+  unchanged rather than worse (spec §Confirmed Decisions 2).
 - **Pin verification to `env` like secbaas
   (`get_by_prefix_and_status(..., env=...)`)** — deferred: the gateway authn
   path has no environment concept; spec's Open Question records the assumption

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -349,12 +349,27 @@ its dispatch branch, and its tests.
 # implementation (src/baas/.../_key_gen.py) — it pins migration compatibility.
 _SECBAAS_KEY = "5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F"
 _SECBAAS_HASH = "YIrLEzbZybtDzATwCkQ9QERLnn0Q9z09iO+u02jvGGs=:UKS+A02LiRqVNsn0oOs9EiNO63ggsbZ3UHGnND6A08Q="
-def test_secbaas_produced_hash_verifies(): ...          # the migration guarantee
+def test_secbaas_produced_hash_verifies(): ...          # read side: the migration guarantee
+def test_secbaas_fixture_uses_documented_pbkdf2_parameters(): ...
+def test_hash_key_output_uses_documented_pbkdf2_parameters(): ...  # write side
 def test_generate_is_32_char_base62(): ...
-def test_hash_roundtrip_and_salt_uniqueness(): ...      # hash→verify; two hashes differ
-def test_verify_rejects_wrong_key_and_garbage_hash(): ...
+def test_hash_roundtrip(): ...
+def test_hashing_one_key_twice_yields_different_stored_values(): ...  # salt uniqueness
+def test_verify_rejects_wrong_key(): ...
+def test_verify_rejects_unusable_stored_hash(): ...
 def test_validate_format(): ...
+def test_round_trip_against_secbaas_implementation(): ...  # both directions
+def test_copy_is_byte_identical_to_secbaas_source(): ...
 ```
+
+Both parameter-pinning tests are needed: the read-side one asserts against the
+fixture constant, so it cannot catch a weakened salt or iteration count in *our*
+`hash_key` — the internal round-trips stay self-consistent under any change
+applied to `hash_key` and `verify_key` together. Two further tests characterize
+upstream quirks that byte-identity forbids fixing here (`validate_format`
+accepts a trailing newline; `b64decode` runs non-validating, so a stored hash
+corrupted only by punctuation still verifies). They document the behavior rather
+than hide it — see Notes on upstream follow-ups.
 
 ```python
 # src/gateway/tests/unit/plugins/test_app_registry_db.py (rework)

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/plan.md
@@ -1,0 +1,305 @@
+# Plan: Application API-key credentials (secbaas-compatible)
+
+## Approach
+
+Copy secbaas's `APIKeyGenerator` verbatim into the gateway's app domain and swap
+the app credential path from "mint JWT, store plaintext, exact-match lookup" to
+"generate 32-char base62 key, store PBKDF2 hash + 8-char prefix, resolve by
+prefix + constant-time verify". The `AppRegistry` SPI keeps its
+opaque-credential shape (`credential in → RegisteredApp | None`): prefix lookup,
+status gating, and hash verification all live inside `AppRepository`, so the
+authn strategy and downstream principal contracts are untouched except for a
+method rename. `AppRegistrar` stops using `PrincipalSigner` entirely.
+
+Verbatim means byte-for-byte: same base62 alphabet, `pbkdf2_hmac("sha256", key,
+salt, 100_000)`, stored as `base64(salt):base64(dk)`, `hmac.compare_digest`
+verify, `key[:8]` prefix, 3-attempt prefix-collision retry at creation, and the
+`len < 8` cheap reject before any DB touch (mirroring
+`DefaultAPIKeyValidator.verify`, `src/baas/src/secbaas/community/core/service/api_gateway/_key_validator.py:32`).
+
+## Affected Components
+
+- `src/gateway/src/gateway/community/core/app/` — the app domain: new
+  `_key_gen.py` (copied), reworked `_orm.py` / `_repository.py` /
+  `_registrar.py` / `__init__.py`.
+- `src/gateway/src/gateway/community/spi/app/_ports.py` — `AppRegistry` port:
+  `find_app_by_token` → `find_app_by_api_key` (semantics: verify, not just look
+  up).
+- `src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py` —
+  strategy calls the renamed port; header extraction unchanged.
+- `src/gateway/src/gateway/community/adapters/web/admin.py` — `POST /admin/apps`
+  response returns `api_key` instead of `token` (breaking).
+- `src/gateway/src/gateway/community/bootstrap/_credential_issuance.py` and
+  `bootstrap/__init__.py:100` — `build_app_registrar` loses its `signer` param.
+- `src/gateway/migrations/mysql/001_init_schema.sql` — canonical DDL for
+  `avernet_application` swaps `token` for `api_key_hash` + `api_key_prefix`.
+- Tests under `src/gateway/tests/` (unit + integration) — see Test Strategy.
+
+Nothing outside `src/gateway` consumes `/admin/apps` or app tokens (checked:
+no hits in `src/backend`, `src/bcs`, `scripts/`). `src/backend`'s
+`bot_app_grant` references `avernet_application.id` only — unaffected.
+
+## Data Model Changes
+
+Column names deliberately mirror `baas_api_key`
+(`src/baas/src/secbaas/community/core/repository/api_gateway/_orm_model.py:16-17`)
+so the migration is a straight column map.
+
+```diff
+# src/gateway/src/gateway/community/core/app/_orm.py:31 — AppRow
+-    token: Mapped[str] = mapped_column(unique=True)
++    api_key_hash: Mapped[str] = mapped_column(String(256))
++    api_key_prefix: Mapped[str] = mapped_column(String(8), unique=True)
+```
+
+```diff
+# src/gateway/migrations/mysql/001_init_schema.sql:27 — avernet_application
+-  `token` varchar(1024) NOT NULL COMMENT '应用访问令牌(签名 JWT)，opaque 查找键',
++  `api_key_hash` varchar(256) NOT NULL COMMENT 'API Key 哈希(base64(salt):base64(dk)，PBKDF2-SHA256)',
++  `api_key_prefix` varchar(8) NOT NULL COMMENT 'API Key 前缀(8 位，查找键)',
+   ...
+-  UNIQUE KEY `uk_avernet_application_token` (`token`),
++  UNIQUE KEY `uk_avernet_application_api_key_prefix` (`api_key_prefix`),
+```
+
+Community edition creates tables via `DataSourcePlugin.create_all()` (no
+Alembic); the SQL file is the canonical schema for real MySQL/OceanBase. The
+ALTER + data move for a live DB belongs to the migration workstream.
+
+## API / Interface Changes
+
+```diff
+# BREAKING — src/gateway/src/gateway/community/spi/app/_ports.py:40 — AppRegistry
+-    async def find_app_by_token(self, token: str) -> RegisteredApp | None: ...
++    async def find_app_by_api_key(self, api_key: str) -> RegisteredApp | None: ...
+```
+
+Port contract: soft miss (`None`) for malformed key (`len < 8`), unknown prefix,
+non-`ACTIVE` row, or hash mismatch — never raises on a bad credential.
+`RegisteredApp` itself is unchanged (`id/app_name/owners/app_type/tenant`), so
+`AppPrincipal` and forwarded principal headers are untouched.
+
+```jsonc
+// BREAKING — POST /admin/apps → 201 (admin.py:90): "token" replaced by "api_key"
+{ "id": 1, "app_name": "…", "owners": "…", "app_type": "…", "tenant": "…",
+  "status": "ACTIVE", "env": "", "api_key": "5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F" }
+// api_key: 32-char base62, shown exactly once; only its hash is persisted
+```
+
+Previously issued JWT app tokens stop authenticating (replacement, not
+coexistence — spec acceptance criterion). `Authorization: Bearer <api_key>` and
+`x-avernet-app-token: <api_key>` both keep working as presentation channels.
+
+## Key Files & Functions
+
+New module — byte-for-byte copy of
+`src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py` (the
+gateway does not depend on the baas package, so the class is copied, not
+imported; a parity fixture test keeps the copy honest):
+
+```python
+# src/gateway/src/gateway/community/core/app/_key_gen.py (new, copied verbatim)
+class APIKeyGenerator:
+    BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    @classmethod
+    def generate(cls) -> str: ...            # 32-char base62
+    @classmethod
+    def hash_key(cls, api_key: str) -> str: ...   # base64(salt):base64(dk), 100k PBKDF2-SHA256
+    @classmethod
+    def verify_key(cls, api_key: str, stored_hash: str) -> bool: ...  # constant-time
+    @staticmethod
+    def validate_format(api_key: str) -> bool: ...  # ^[0-9A-Za-z]{32}$
+```
+
+```diff
+# src/gateway/src/gateway/community/core/app/_repository.py:38 — AppRepository
+-    async def find_app_by_token(self, token: str) -> RegisteredApp | None:
+-        with self._db.orm_session() as session:
+-            row = session.scalar(select(self.Model).where(self.Model.token == token))
+-            return None if row is None else row.to_record()
++    async def find_app_by_api_key(self, api_key: str) -> RegisteredApp | None:
++        if not api_key or len(api_key) < 8:
++            return None                     # cheap reject, no DB touch
++        with self._db.orm_session() as session:
++            row = session.scalar(
++                select(self.Model).where(
++                    self.Model.api_key_prefix == api_key[:8],
++                    self.Model.status == "ACTIVE",
++                )
++            )
++        if row is None or not APIKeyGenerator.verify_key(api_key, row.api_key_hash):
++            return None
++        return row.to_record()
++
++    async def exists_prefix(self, api_key_prefix: str) -> bool: ...
+```
+
+`store(...)` swaps `token: str` for `api_key_hash: str, api_key_prefix: str`;
+body maps them onto the new columns (verify runs outside the session block —
+PBKDF2 is ~100ms of CPU, no reason to hold the session open).
+
+```diff
+# src/gateway/src/gateway/community/core/app/_registrar.py — AppRegistrar
+-    def __init__(self, repository, signer, *, clock=time.time) -> None: ...
++    def __init__(self, repository: AppRepository) -> None: ...
+
+     async def register(self, app_name, owners, app_type, tenant, *, creator,
+                        status="ACTIVE", env="", config=None) -> IssuedApp:
+-        claims = {...}; token = await self._signer.sign_token(claims)
++        for _ in range(3):                     # prefix-collision retry, as secbaas
++            api_key = APIKeyGenerator.generate()
++            api_key_prefix = api_key[:8]
++            if not await self._repository.exists_prefix(api_key_prefix):
++                break
++        else:
++            raise RuntimeError("could not allocate a unique api key prefix")
++        app_id = await self._repository.store(
++            api_key_hash=APIKeyGenerator.hash_key(api_key),
++            api_key_prefix=api_key_prefix, ...)
+```
+
+```diff
+# src/gateway/src/gateway/community/core/app/_registrar.py:28 — IssuedApp
+ @dataclass(frozen=True)
+ class IssuedApp:
+-    token: str
++    api_key: str
+```
+
+```diff
+# src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py:63
+-        record = await self._registry.find_app_by_token(app_token)
++        record = await self._registry.find_app_by_api_key(app_token)
+```
+
+Strategy header extraction (`Bearer` / `x-avernet-app-token`) is unchanged; an
+unrecognized or invalid key stays a soft miss so other Bearer chains (bot_token)
+still adjudicate independently (US27).
+
+```diff
+# src/gateway/src/gateway/community/bootstrap/_credential_issuance.py:24
+-def build_app_registrar(db: DataSourcePlugin, signer: PrincipalSigner) -> AppRegistrar:
+-    return AppRegistrar(AppRepository(db), signer)
++def build_app_registrar(db: DataSourcePlugin) -> AppRegistrar:
++    return AppRegistrar(AppRepository(db))
+```
+
+Caller: `bootstrap/__init__.py:100` drops the `principal_signer` argument.
+`admin.py:100` response field `"token": issued.token` → `"api_key": issued.api_key`.
+`core/app/__init__.py` exports `APIKeyGenerator` (tests and the parity check
+import it via the public package face, per module import rules).
+
+## Dependencies
+
+None — `_key_gen.py` is stdlib-only (`base64`, `hashlib`, `hmac`, `re`,
+`secrets`). `pyjwt` stays (still used by access-key issuance and principal
+signing).
+
+## Risks & Mitigations
+
+- **Risk:** The copied generator drifts from secbaas's, silently breaking
+  migration compatibility.
+  **Mitigation:** A pinned cross-implementation fixture — a real
+  `(api_key, stored_hash)` pair produced by the *secbaas* implementation —
+  asserted against the gateway's `verify_key` (see Test Strategy). Any change to
+  iterations, salt handling, or encoding fails it.
+- **Risk:** `uk_avernet_application_api_key_prefix` rejects migrated rows if the
+  secbaas data ever produced duplicate prefixes (their uniqueness is enforced
+  at creation time, not by a DB constraint).
+  **Mitigation:** Creation-time invariant makes duplicates all but impossible;
+  the migration workstream should assert prefix uniqueness pre-copy. The unique
+  index also backstops the registrar's check-then-insert race (IntegrityError →
+  500, fail-closed, no partial write).
+- **Risk:** PBKDF2 at 100k iterations adds ~50–100ms CPU per app-token
+  authentication (per request, not per registration).
+  **Mitigation:** Accepted — identical cost profile to secbaas today, and
+  required byte-for-byte. Caching is out of scope (secbaas flags the same
+  future extension).
+- **Risk:** Seeded demo/test rows using plaintext `token=` stop working and
+  break unrelated suites.
+  **Mitigation:** Blast radius enumerated in Test Strategy; all seeds move to
+  `api_key_hash`/`api_key_prefix` in the same change.
+
+## Alternatives Considered
+
+- **Import secbaas's generator instead of copying** — rejected: the gateway
+  package (`src/gateway/pyproject.toml`) has no dependency on `baas`, and adding
+  a cross-module dependency for one stdlib-only class is worse than a copy
+  pinned by a parity test.
+- **Mirror secbaas's validator layering (repository returns hash, separate
+  validator verifies)** — rejected: the gateway's port pattern is
+  "opaque credential in → record | None" (`_ports.py:32-40`); keeping
+  verification inside `AppRepository` preserves that contract and keeps the
+  authn plugin storage-agnostic. "Exactly the same" binds the credential
+  scheme, not secbaas's internal layering.
+- **Keep `token` column and add key columns alongside (dual-scheme
+  coexistence)** — rejected: spec mandates replacement; precedent
+  (`specs/2026-07-30-application-tenant-accesskey-schema/spec.md` §已确认决策 1)
+  is replace-and-migrate, not coexist.
+- **Pin verification to `env` like secbaas
+  (`get_by_prefix_and_status(..., env=...)`)** — deferred: the gateway authn
+  path has no environment concept; spec's Open Question records the assumption
+  (no `env` filter). Trivial to add later (one more `where` clause).
+- **Unique index on `api_key_hash`** — rejected: the hash embeds a random salt
+  (unique by construction), and the lookup key is the prefix; a 256-char unique
+  index buys nothing.
+
+## Rollout
+
+No flag; single atomic change within the gateway (community edition rebuilds
+its schema via `create_all()` on boot). For a real MySQL/OceanBase deployment
+the ordering is owned by the migration workstream:
+
+```bash
+# 1. ALTER avernet_application (add api_key_hash/api_key_prefix, drop token)
+# 2. copy baas_api_key rows into avernet_application (column map, dedupe check)
+# 3. deploy gateway with this change
+```
+
+Old JWT app tokens die at step 3 by design; migrated key holders are unaffected.
+
+## Test Strategy
+
+```python
+# src/gateway/tests/unit/plugins/test_app_key_gen.py (new)
+# The load-bearing fixture pair below was produced by RUNNING the secbaas
+# implementation (src/baas/.../_key_gen.py) — it pins migration compatibility.
+_SECBAAS_KEY = "5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F"
+_SECBAAS_HASH = "YIrLEzbZybtDzATwCkQ9QERLnn0Q9z09iO+u02jvGGs=:UKS+A02LiRqVNsn0oOs9EiNO63ggsbZ3UHGnND6A08Q="
+def test_secbaas_produced_hash_verifies(): ...          # the migration guarantee
+def test_generate_is_32_char_base62(): ...
+def test_hash_roundtrip_and_salt_uniqueness(): ...      # hash→verify; two hashes differ
+def test_verify_rejects_wrong_key_and_garbage_hash(): ...
+def test_validate_format(): ...
+```
+
+```python
+# src/gateway/tests/unit/plugins/test_app_registry_db.py (rework)
+def test_correct_key_resolves_active_seeded_app(): ...  # seed hash+prefix, present plaintext
+def test_wrong_key_with_known_prefix_returns_none(): ...
+def test_inactive_and_revoked_rows_return_none(): ...
+def test_short_or_empty_key_returns_none(): ...         # no DB lookup path
+def test_exists_prefix(): ...
+```
+
+```python
+# src/gateway/tests/unit/plugins/test_app_registrar.py (rework — JWT tests dropped)
+def test_register_returns_32_char_key_and_persists_only_hash(): ...
+def test_registered_key_authenticates_via_repository(): ...   # mint→verify closed loop
+def test_register_retries_on_prefix_collision(): ...          # fake repo, 3 attempts then raise
+def test_creator_recorded_as_creator_and_modifier(): ...      # kept from today
+```
+
+- `tests/unit/plugins/test_app_token_strategy.py` — `_FakeAppRegistry` renames
+  its method; behavior tests unchanged.
+- `tests/integration/test_identity_pipeline.py:54-57,111,178` and
+  `test_forward_route.py:419-427` — seed `AppRow(api_key_hash=hash_key(k),
+  api_key_prefix=k[:8], ...)` with a 32-char key; present the plaintext in
+  headers.
+- `tests/integration/test_admin_issuance.py:59-91` — `POST /admin/apps` → 201
+  body has `api_key` (32-char base62, format-validated), no `token`; the
+  returned key immediately authenticates through
+  `AppRepository.find_app_by_api_key`; the DB row holds a hash, not the key.
+
+Gates: `scripts/ci/python_sast_local.sh` (pre-push lint) and the gateway module
+test suite; run the full module gate via `OCB_PRE_PUSH_RUN_CI=1` before push.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
@@ -1,0 +1,114 @@
+# Application API-key credentials (secbaas-compatible)
+
+- Date: 2026-08-13
+- Status: draft (pending review)
+- Related: `specs/2026-07-30-application-tenant-accesskey-schema/spec.md` (the
+  `avernet_application` table this changes), `specs/2026-07-30-credential-issuance/spec.md`
+  (the JWT app-token issuance this replaces), secbaas API-gateway key service
+  (`src/baas/src/secbaas/community/core/service/api_gateway/`, the scheme being adopted)
+
+## Summary
+
+Third-party apps authenticate to the gateway with API keys instead of signed JWT
+app tokens. The gateway adopts the secbaas API-gateway key scheme **exactly** —
+same key format, same one-way hashed storage, same prefix-based lookup, same
+verification behavior — because the existing secbaas key records will be migrated
+into the gateway's application registry and must keep authenticating unchanged,
+with no key rotation or re-issue forced on their holders.
+
+## Motivation
+
+Today the gateway registers an app by minting a signed JWT and storing it in
+plaintext as the app's lookup key; a presented token is resolved by exact string
+match. Separately, secbaas operates an API-key service whose keys are random
+32-character strings, stored only as salted one-way hashes and resolved by an
+8-character prefix. The two credential populations are converging: secbaas's
+existing key data will be migrated into the gateway's application registry, and
+after migration those keys — whose plaintext only the holders have — must keep
+working. That is only possible if the gateway generates, stores, and verifies
+credentials with byte-for-byte the same scheme, so migrated records and
+gateway-issued records are indistinguishable.
+
+This also removes plaintext credentials from the application registry: a DB read
+can no longer reveal a usable credential.
+
+## User Stories
+
+- As an existing secbaas API-key holder, I want my current key to keep
+  authenticating after my record is migrated into the gateway registry, so that
+  migration is invisible to me and I never have to rotate.
+- As a platform operator, I want newly registered apps to receive credentials in
+  the same format as migrated ones, so that one verification path serves both
+  populations and there is no legacy branch to maintain.
+- As a platform operator, I want app credentials stored only as one-way hashes,
+  so that a database leak does not disclose usable credentials.
+- As an app developer, I want to receive my plaintext API key exactly once at
+  registration, so that I know it cannot be recovered later and must be stored
+  safely on my side.
+- As a platform operator, I want a deactivated or revoked key to stop
+  authenticating, so that migrated key lifecycle states are honored.
+
+## Acceptance Criteria
+
+- [ ] Registering an app returns a plaintext API key once; the key is a
+      32-character alphanumeric (base62) string, and no plaintext credential is
+      persisted anywhere.
+- [ ] A key hashed by the secbaas key service (its exact salted-hash format and
+      parameters), inserted into the gateway registry as a migrated record,
+      authenticates successfully with its original plaintext key.
+- [ ] A key freshly issued by the gateway verifies under the secbaas
+      verification routine, and vice versa (round-trip compatibility in both
+      directions).
+- [ ] Verification resolves the record by the key's 8-character prefix and
+      compares hashes in constant time; a wrong key with a valid prefix is
+      rejected.
+- [ ] Only records in `ACTIVE` status authenticate; presenting a key whose
+      record is `INACTIVE` or `REVOKED` is rejected the same way as an unknown
+      key (soft miss — other credential types may still claim the request).
+- [ ] Two registered apps never share a key prefix; registration retries on
+      prefix collision and fails cleanly (no partial write) if a unique prefix
+      cannot be found.
+- [ ] A malformed presented credential (wrong length/alphabet) is rejected
+      without a database lookup.
+- [ ] Previously issued JWT app tokens no longer authenticate (replacement, not
+      coexistence), and the registration response no longer returns a JWT.
+- [ ] Successful authentication still yields the same app identity as today
+      (id, name, owners, type, tenant) — downstream principal contracts are
+      unchanged.
+
+## In Scope
+
+- App credential generation, storage format, lookup, and verification in the
+  gateway (replacing the JWT app-token scheme end to end: registration,
+  persistence, authentication).
+- Schema change to the application registry needed to hold the hashed key and
+  its prefix in migration-compatible form.
+- Honoring record status (`ACTIVE`/`INACTIVE`/`REVOKED`) at verification time.
+
+## Out of Scope
+
+- The data migration itself (moving secbaas rows into `avernet_application` is a
+  separate workstream; this feature only guarantees the target is compatible).
+- Access-key (`avernet_access_key_token`) and bot credentials — their JWT
+  schemes are untouched.
+- Key lifecycle management APIs (list / deactivate / revoke / rotate) — status
+  is honored at verification, but no gateway API mutates it this iteration.
+- Rate limiting and policy enforcement (secbaas rows carry `rate_limit_*` /
+  `policy`; enforcing them at the gateway is not part of this feature).
+- Admin endpoint authentication (stays not-for-prod, as today).
+- Environment-scoped verification (secbaas pins lookups to its current `env`;
+  the gateway has no environment concept in its authn path — see Open
+  Questions).
+
+## Open Questions
+
+- **Env pinning at verification.** secbaas restricts verification to records in
+  its own deployment environment (`env` column). The gateway's authn path has no
+  environment concept today. Assumed answer (proceeding with it): the gateway
+  does **not** filter by `env`; if migrated data mixes environments in one
+  gateway DB, keys from all of them will verify. Flag if that's wrong.
+- **Migrated metadata columns.** secbaas rows carry fields with no
+  `avernet_application` counterpart (`key_name`, `rate_limit_rpm/rpd`,
+  `policy`, `description`, `owner` vs `owners`). Assumed answer: the migration
+  workstream owns that mapping; this feature only fixes the credential columns'
+  shape and semantics.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
@@ -141,6 +141,18 @@ separate, temporary path rather than a data conversion.
   the gateway has no environment concept in its authn path — see Open
   Questions).
 
+## Confirmed Decisions
+
+1. **Gate `status` uniformly on both paths.** Confirmed against the real table:
+   the non-`ACTIVE` population is zero, so applying the `ACTIVE` gate to the
+   legacy path breaks no live holder. This closes the only way this change could
+   have bitten an existing user, and fixes a latent gap where a row explicitly
+   registered `INACTIVE` still authenticated.
+2. **Do not harden the retained `token` column.** The plaintext JWTs stay as-is
+   for the window rather than moving to a `sha256(token)` lookup key: the risk
+   is unchanged from today's, not worsened, and the column is scheduled for
+   deletion. Not worth a column plus a backfill on a path already on its way out.
+
 ## Open Questions
 
 - **Env pinning at verification.** secbaas restricts verification to records in
@@ -153,18 +165,7 @@ separate, temporary path rather than a data conversion.
   `policy`, `description`, `owner` vs `owners`). Assumed answer: the migration
   workstream owns that mapping; this feature only fixes the credential columns'
   shape and semantics.
-- **Status gating on the legacy path is a behavior change.** Today the JWT
-  lookup ignores `status`, so a row explicitly registered `INACTIVE` still
-  authenticates. Applying the gate uniformly fixes that, but if any live holder
-  is on a non-`ACTIVE` row they would break — the one way this change could bite
-  an existing user. Assumed answer (proceeding with it): gate both paths, since
-  no gateway API sets a non-`ACTIVE` status today and rows default to `ACTIVE`.
-  Worth a quick `SELECT status, COUNT(*)` against the real table to confirm.
 - **Transition window length.** Not fixed by this spec. The deletion follow-up
   is gated on legacy-path warnings going quiet rather than on a calendar date.
-- **Hardening the legacy column.** The retained `token` column still holds
-  plaintext JWTs — unchanged from today's risk, but not improved either. An
-  optional extra step would store `sha256(token)` as the lookup key instead
-  (deterministic, so still exact-matchable; unsalted is safe here because a JWT
-  carries far too much entropy to be dictionary-attacked). Assumed answer: skip
-  it — the window is temporary and the column is on its way out.
+(Both remaining questions are deferrable — neither changes the design or blocks
+implementation.)

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
@@ -1,7 +1,7 @@
 # Application API-key credentials (secbaas-compatible)
 
 - Date: 2026-08-13
-- Status: draft (pending review)
+- Status: implemented
 - Related: `specs/2026-07-30-application-tenant-accesskey-schema/spec.md` (the
   `avernet_application` table this changes), `specs/2026-07-30-credential-issuance/spec.md`
   (the JWT app-token issuance this replaces), secbaas API-gateway key service
@@ -72,40 +72,41 @@ separate, temporary path rather than a data conversion.
 
 ## Acceptance Criteria
 
-- [ ] Registering an app returns a plaintext API key once; the key is a
+- [x] Registering an app returns a plaintext API key once; the key is a
       32-character alphanumeric (base62) string, and no plaintext credential is
       persisted anywhere.
-- [ ] A key hashed by the secbaas key service (its exact salted-hash format and
+- [x] A key hashed by the secbaas key service (its exact salted-hash format and
       parameters), inserted into the gateway registry as a migrated record,
       authenticates successfully with its original plaintext key.
-- [ ] A key freshly issued by the gateway verifies under the secbaas
+- [x] A key freshly issued by the gateway verifies under the secbaas
       verification routine, and vice versa (round-trip compatibility in both
       directions).
-- [ ] Verification resolves the record by the key's 8-character prefix and
+- [x] Verification resolves the record by the key's 8-character prefix and
       compares hashes in constant time; a wrong key with a valid prefix is
       rejected.
-- [ ] Only records in `ACTIVE` status authenticate — on **both** paths;
+- [x] Only records in `ACTIVE` status authenticate — on **both** paths;
       presenting a credential whose record is `INACTIVE` or `REVOKED` is
       rejected the same way as an unknown one (soft miss — other credential
       types may still claim the request). Note this is a behavior change for the
-      legacy path, which ignores `status` today (see Open Questions).
-- [ ] Two registered apps never share a key prefix; registration retries on
+      legacy path, which ignored `status` before this change
+      (Confirmed Decisions 1: the non-`ACTIVE` population is zero).
+- [x] Two registered apps never share a key prefix; registration retries on
       prefix collision and fails cleanly (no partial write) if a unique prefix
       cannot be found.
-- [ ] A malformed presented credential (wrong length/alphabet) is rejected
+- [x] A malformed presented credential (wrong length/alphabet) is rejected
       without a database lookup.
-- [ ] Previously issued JWT app tokens **continue to authenticate** unchanged,
+- [x] Previously issued JWT app tokens **continue to authenticate** unchanged,
       via a deprecated exact-match path, and resolve to exactly the same app
       identity as before.
-- [ ] Registration never issues a JWT again: every newly registered app gets an
+- [x] Registration never issues a JWT again: every newly registered app gets an
       API key, and the registration response returns `api_key`, not `token`.
-- [ ] The two credential populations are told apart deterministically by format
+- [x] The two credential populations are told apart deterministically by format
       (a 32-character base62 key can never be a JWT and vice versa) — no
       guess-and-fallback, no double lookup on the hot path.
-- [ ] Every authentication served by the deprecated JWT path emits a warning
+- [x] Every authentication served by the deprecated JWT path emits a warning
       log identifying the app, so remaining legacy usage is observable and the
       path can be deleted once it goes quiet.
-- [ ] Successful authentication still yields the same app identity as today
+- [x] Successful authentication still yields the same app identity as today
       (id, name, owners, type, tenant) — downstream principal contracts are
       unchanged.
 

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/spec.md
@@ -16,6 +16,12 @@ verification behavior — because the existing secbaas key records will be migra
 into the gateway's application registry and must keep authenticating unchanged,
 with no key rotation or re-issue forced on their holders.
 
+Existing gateway-issued JWT app tokens keep working through a **transition
+window**: they cannot be converted into the new scheme (see Motivation), so they
+are served by a second, deprecated lookup path that is removed once their holders
+have rotated onto API keys. No credential holder — migrated or existing — is
+broken by this change.
+
 ## Motivation
 
 Today the gateway registers an app by minting a signed JWT and storing it in
@@ -32,11 +38,27 @@ gateway-issued records are indistinguishable.
 This also removes plaintext credentials from the application registry: a DB read
 can no longer reveal a usable credential.
 
+**Why existing JWTs cannot simply be re-hashed into the new columns.** Hashing
+them would work — the hash function accepts any input — but the *lookup* would
+not. The scheme locates a record by the credential's first 8 characters, which
+assumes those characters are random. A JWT's leading characters encode its
+header, which is identical for every token this gateway issues: all of them
+start with `eyJhbGci` (verified empirically against the real signer). They would
+collide as a single prefix, violating its uniqueness constraint and making
+records indistinguishable at lookup time. Existing JWT holders therefore need a
+separate, temporary path rather than a data conversion.
+
 ## User Stories
 
 - As an existing secbaas API-key holder, I want my current key to keep
   authenticating after my record is migrated into the gateway registry, so that
   migration is invisible to me and I never have to rotate.
+- As an existing gateway app-token (JWT) holder, I want my token to keep
+  authenticating after this change ships, so that I can rotate onto an API key
+  on my own schedule instead of being cut off on deploy day.
+- As a platform operator, I want to see which apps are still presenting legacy
+  JWTs, so that I know who to chase and when it is safe to delete the
+  deprecated path.
 - As a platform operator, I want newly registered apps to receive credentials in
   the same format as migrated ones, so that one verification path serves both
   populations and there is no legacy branch to maintain.
@@ -62,16 +84,27 @@ can no longer reveal a usable credential.
 - [ ] Verification resolves the record by the key's 8-character prefix and
       compares hashes in constant time; a wrong key with a valid prefix is
       rejected.
-- [ ] Only records in `ACTIVE` status authenticate; presenting a key whose
-      record is `INACTIVE` or `REVOKED` is rejected the same way as an unknown
-      key (soft miss — other credential types may still claim the request).
+- [ ] Only records in `ACTIVE` status authenticate — on **both** paths;
+      presenting a credential whose record is `INACTIVE` or `REVOKED` is
+      rejected the same way as an unknown one (soft miss — other credential
+      types may still claim the request). Note this is a behavior change for the
+      legacy path, which ignores `status` today (see Open Questions).
 - [ ] Two registered apps never share a key prefix; registration retries on
       prefix collision and fails cleanly (no partial write) if a unique prefix
       cannot be found.
 - [ ] A malformed presented credential (wrong length/alphabet) is rejected
       without a database lookup.
-- [ ] Previously issued JWT app tokens no longer authenticate (replacement, not
-      coexistence), and the registration response no longer returns a JWT.
+- [ ] Previously issued JWT app tokens **continue to authenticate** unchanged,
+      via a deprecated exact-match path, and resolve to exactly the same app
+      identity as before.
+- [ ] Registration never issues a JWT again: every newly registered app gets an
+      API key, and the registration response returns `api_key`, not `token`.
+- [ ] The two credential populations are told apart deterministically by format
+      (a 32-character base62 key can never be a JWT and vice versa) — no
+      guess-and-fallback, no double lookup on the hot path.
+- [ ] Every authentication served by the deprecated JWT path emits a warning
+      log identifying the app, so remaining legacy usage is observable and the
+      path can be deleted once it goes quiet.
 - [ ] Successful authentication still yields the same app identity as today
       (id, name, owners, type, tenant) — downstream principal contracts are
       unchanged.
@@ -79,16 +112,24 @@ can no longer reveal a usable credential.
 ## In Scope
 
 - App credential generation, storage format, lookup, and verification in the
-  gateway (replacing the JWT app-token scheme end to end: registration,
-  persistence, authentication).
+  gateway: registration switches to API keys, and API keys become the primary
+  authentication path.
 - Schema change to the application registry needed to hold the hashed key and
-  its prefix in migration-compatible form.
+  its prefix in migration-compatible form, alongside the retained legacy
+  credential column.
+- A deprecated, format-dispatched legacy path that keeps existing JWT holders
+  authenticating, with warning-level logging of every legacy resolution.
 - Honoring record status (`ACTIVE`/`INACTIVE`/`REVOKED`) at verification time.
 
 ## Out of Scope
 
 - The data migration itself (moving secbaas rows into `avernet_application` is a
   separate workstream; this feature only guarantees the target is compatible).
+- **Deleting the legacy path.** Removing the `token` column, the exact-match
+  lookup, and its tests is a deliberate follow-up, gated on the warning logs
+  going quiet — not part of this change.
+- Rotating existing holders onto API keys (outreach and re-issue are an
+  operational task; this change only makes both credentials work meanwhile).
 - Access-key (`avernet_access_key_token`) and bot credentials — their JWT
   schemes are untouched.
 - Key lifecycle management APIs (list / deactivate / revoke / rotate) — status
@@ -112,3 +153,18 @@ can no longer reveal a usable credential.
   `policy`, `description`, `owner` vs `owners`). Assumed answer: the migration
   workstream owns that mapping; this feature only fixes the credential columns'
   shape and semantics.
+- **Status gating on the legacy path is a behavior change.** Today the JWT
+  lookup ignores `status`, so a row explicitly registered `INACTIVE` still
+  authenticates. Applying the gate uniformly fixes that, but if any live holder
+  is on a non-`ACTIVE` row they would break — the one way this change could bite
+  an existing user. Assumed answer (proceeding with it): gate both paths, since
+  no gateway API sets a non-`ACTIVE` status today and rows default to `ACTIVE`.
+  Worth a quick `SELECT status, COUNT(*)` against the real table to confirm.
+- **Transition window length.** Not fixed by this spec. The deletion follow-up
+  is gated on legacy-path warnings going quiet rather than on a calendar date.
+- **Hardening the legacy column.** The retained `token` column still holds
+  plaintext JWTs — unchanged from today's risk, but not improved either. An
+  optional extra step would store `sha256(token)` as the lookup key instead
+  (deterministic, so still exact-matchable; unsalted is safe here because a JWT
+  carries far too much entropy to be dictionary-attacked). Assumed answer: skip
+  it — the window is temporary and the column is on its way out.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -112,7 +112,7 @@
         the rename, so the port change is reflected in the contract tests too.
 - **Depends on:** Task 3
 
-## Task 6: Rework `AppRegistrar` to mint API keys
+## Task 6 `[x]`: Rework `AppRegistrar` to mint API keys
 - **Goal:** Registration generates a key via `APIKeyGenerator`, retries up to 3
   times on prefix collision, persists only hash + prefix, and returns the
   plaintext once via `IssuedApp.api_key`; `PrincipalSigner` and `clock` are
@@ -122,16 +122,21 @@
   `src/gateway/tests/unit/plugins/test_app_registrar.py` (rework — JWT claim
   tests dropped)
 - **Done when:**
-  - [ ] `register(...)` returns `IssuedApp` with a 32-char base62 `api_key`; the
+  - [x] `register(...)` returns `IssuedApp` with a 32-char base62 `api_key`; the
         stored row holds only `api_key_hash`/`api_key_prefix`, with `token` NULL.
-  - [ ] The freshly issued key authenticates through
+  - [x] The freshly issued key authenticates through
         `AppRepository.find_app_by_credential` (mint → verify closed loop).
-  - [ ] Collision retry: a fake repository forcing `exists_prefix=True` sees 3
-        generate attempts, then a clean raise with no partial write.
-  - [ ] `creator` is recorded as both creator and modifier (behavior kept).
+  - [x] Collision retry: a fake repository forcing `exists_prefix=True` sees 3
+        generate attempts (each a fresh key), then a clean `PrefixAllocationError`
+        with nothing written.
+  - [x] `creator` is recorded as both creator and modifier (behavior kept).
+  - [x] *(added)* A collision on the first attempt still succeeds on the second —
+        retrying is not merely a path to failure.
+  - [x] *(added)* Hashing happens only after a prefix is settled, so a collision
+        does not throw away ~60ms of PBKDF2.
 - **Depends on:** Task 3
 
-## Task 7: Rewire bootstrap and the admin endpoint
+## Task 7 `[x]`: Rewire bootstrap and the admin endpoint
 - **Goal:** `build_app_registrar` loses its signer; `POST /admin/apps` returns
   `api_key` instead of `token`.
 - **Files:** `src/gateway/src/gateway/community/bootstrap/_credential_issuance.py`,
@@ -139,14 +144,16 @@
   `src/gateway/src/gateway/community/adapters/web/admin.py`,
   `src/gateway/tests/integration/test_admin_issuance.py` (rework)
 - **Done when:**
-  - [ ] `build_app_registrar(db)` builds without a `PrincipalSigner`; access-key
+  - [x] `build_app_registrar(db)` builds without a `PrincipalSigner`; access-key
         issuance keeps its signer untouched.
-  - [ ] `POST /admin/apps` → 201 body carries `api_key` (32-char base62) and no
+  - [x] `POST /admin/apps` → 201 body carries `api_key` (32-char base62) and no
         `token`; nothing JWT-decodable is returned for apps.
-  - [ ] The returned key immediately authenticates via
+  - [x] The returned key immediately authenticates via
         `find_app_by_credential` (register → use closed loop over HTTP).
-  - [ ] Access-key admin flow (`POST /admin/access-keys`) regression-passes
+  - [x] Access-key admin flow (`POST /admin/access-keys`) regression-passes
         unchanged.
+  - [x] *(added)* The persisted row is asserted to hold no plaintext: `token`
+        is NULL and the key does not appear in `api_key_hash`.
 - **Depends on:** Task 6
 
 ## Task 8: Cover both credential paths in the integration suites

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -96,18 +96,20 @@
         here (plan.md, Notes on upstream follow-ups #1).
 - **Depends on:** Task 3
 
-## Task 5: Point the `app_token` strategy at the renamed port
+## Task 5 `[x]`: Point the `app_token` strategy at the renamed port
 - **Goal:** The authn strategy resolves credentials through
   `find_app_by_credential`; header extraction and soft-miss adjudication (US27)
   are unchanged.
 - **Files:** `src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py`,
   `src/gateway/tests/unit/plugins/test_app_token_strategy.py` (fake registry rename)
 - **Done when:**
-  - [ ] Strategy calls `find_app_by_credential`; docstrings describe both
+  - [x] Strategy calls `find_app_by_credential`; docstrings describe both
         credential forms and the transition window.
-  - [ ] All existing strategy behavior tests pass unmodified in substance
+  - [x] All existing strategy behavior tests pass unmodified in substance
         (Bearer precedence, dedicated header fallback, soft miss, principal
         fields) — the resolved `AppPrincipal` shape is untouched.
+  - [x] The SPI contract suite's fake registry (`tests/contracts/spi/`) tracks
+        the rename, so the port change is reflected in the contract tests too.
 - **Depends on:** Task 3
 
 ## Task 6: Rework `AppRegistrar` to mint API keys

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -18,74 +18,100 @@
   - [ ] Copied module is diff-identical to the secbaas source.
 - **Depends on:** —
 
-## Task 2: Swap `avernet_application` credential columns
-- **Goal:** Replace the plaintext `token` column with `api_key_hash` +
-  `api_key_prefix` (unique) in the ORM row and the canonical MySQL DDL, using
-  `baas_api_key`'s column names for a straight migration map.
+## Task 2: Add the API-key columns, retain the legacy credential column
+- **Goal:** Add `api_key_hash` + `api_key_prefix` (nullable, prefix unique) to
+  the ORM row and canonical DDL, keeping `token` as a nullable deprecated column
+  so existing rows keep authenticating.
 - **Files:** `src/gateway/src/gateway/community/core/app/_orm.py`,
   `src/gateway/migrations/mysql/001_init_schema.sql`
 - **Done when:**
-  - [ ] `AppRow` has `api_key_hash: String(256)` and
-        `api_key_prefix: String(8), unique=True`; `token` is gone.
-  - [ ] DDL mirrors the ORM: `uk_avernet_application_api_key_prefix` replaces
-        `uk_avernet_application_token`; column comments updated.
-  - [ ] `to_record()` and module docstrings no longer mention JWT/opaque-token
-        lookup.
+  - [ ] `AppRow` has `api_key_hash: str | None` and `api_key_prefix: str | None`
+        (unique); `token` becomes `str | None`, still unique, marked deprecated
+        in a comment naming what must happen before removal.
+  - [ ] DDL matches: both new columns `DEFAULT NULL`,
+        `uk_avernet_application_api_key_prefix` added,
+        `uk_avernet_application_token` retained, comments updated.
+  - [ ] The schema change is additive only — no existing column is dropped or
+        made stricter, so it can be applied before the code ships.
 - **Depends on:** —
 
-## Task 3: Rework `AppRepository` and the `AppRegistry` port to verify API keys
+## Task 3: Rework `AppRepository` + the `AppRegistry` port for API-key verification
 - **Goal:** Resolution becomes prefix lookup + status gate + constant-time hash
-  verify inside the repository, behind a renamed SPI port method with soft-miss
+  verify inside the repository, behind a renamed port method with soft-miss
   semantics.
 - **Files:** `src/gateway/src/gateway/community/core/app/_repository.py`,
   `src/gateway/src/gateway/community/spi/app/_ports.py`,
   `src/gateway/tests/unit/plugins/test_app_registry_db.py` (rework)
 - **Done when:**
-  - [ ] Port and impl expose `find_app_by_api_key(api_key) -> RegisteredApp | None`;
+  - [ ] Port and impl expose
+        `find_app_by_credential(credential) -> RegisteredApp | None`;
         `find_app_by_token` is gone.
   - [ ] Correct plaintext key against a seeded hashed row resolves the
         `RegisteredApp`; wrong key with a valid prefix returns `None`.
   - [ ] Rows in `INACTIVE`/`REVOKED` status return `None` even with the correct key.
-  - [ ] Empty/short (`len < 8`) keys return `None` without touching the DB.
+  - [ ] Empty/short (`len < 8`) credentials return `None` without touching the DB.
+  - [ ] The stored hash and record are read inside the ORM session and verified
+        after it closes (no `DetachedInstanceError`, no session held across
+        ~62ms of PBKDF2).
   - [ ] `exists_prefix` and the reworked `store(api_key_hash=…, api_key_prefix=…)`
-        are covered by the DB-backed tests.
+        are covered by DB-backed tests.
 - **Depends on:** Task 1, Task 2
 
-## Task 4: Point the `app_token` strategy at the renamed port
-- **Goal:** The authn strategy resolves API keys through
-  `find_app_by_api_key`; header extraction and soft-miss adjudication (US27)
+## Task 4: Add the deprecated legacy-JWT path (the continuity guarantee)
+- **Goal:** Existing JWT holders keep authenticating via a format-dispatched
+  exact-match path that logs every use, so remaining legacy traffic is
+  measurable and the path can be deleted on evidence.
+- **Files:** `src/gateway/src/gateway/community/core/app/_repository.py`,
+  `src/gateway/tests/unit/plugins/test_app_legacy_token.py` (new)
+- **Done when:**
+  - [ ] A row seeded the old way (`token=<real JWT>`, `api_key_*` NULL) still
+        authenticates and yields a `RegisteredApp` identical to today's.
+  - [ ] Dispatch is by format via `validate_format`, not try-and-fallback: a
+        32-char base62 key never reaches the legacy branch, and each request
+        performs exactly one lookup.
+  - [ ] Every legacy resolution emits a WARNING naming the app (asserted with
+        `caplog`); the method docstring and column comment state the deletion
+        criteria.
+  - [ ] API-key rows and legacy rows coexist in one table, each resolving
+        through its own path.
+  - [ ] An unknown JWT returns `None` (soft miss, US27 preserved); a legacy row
+        that is not `ACTIVE` returns `None` (documented behavior change).
+- **Depends on:** Task 3
+
+## Task 5: Point the `app_token` strategy at the renamed port
+- **Goal:** The authn strategy resolves credentials through
+  `find_app_by_credential`; header extraction and soft-miss adjudication (US27)
   are unchanged.
 - **Files:** `src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py`,
   `src/gateway/tests/unit/plugins/test_app_token_strategy.py` (fake registry rename)
 - **Done when:**
-  - [ ] Strategy calls `find_app_by_api_key`; docstrings describe API keys, not
-        registry-recognised JWTs.
+  - [ ] Strategy calls `find_app_by_credential`; docstrings describe both
+        credential forms and the transition window.
   - [ ] All existing strategy behavior tests pass unmodified in substance
         (Bearer precedence, dedicated header fallback, soft miss, principal
         fields) — the resolved `AppPrincipal` shape is untouched.
 - **Depends on:** Task 3
 
-## Task 5: Rework `AppRegistrar` to mint API keys
+## Task 6: Rework `AppRegistrar` to mint API keys
 - **Goal:** Registration generates a key via `APIKeyGenerator`, retries up to 3
   times on prefix collision, persists only hash + prefix, and returns the
   plaintext once via `IssuedApp.api_key`; `PrincipalSigner` and `clock` are
-  dropped.
+  dropped, and no new JWT is ever issued.
 - **Files:** `src/gateway/src/gateway/community/core/app/_registrar.py`,
   `src/gateway/src/gateway/community/core/app/__init__.py`,
   `src/gateway/tests/unit/plugins/test_app_registrar.py` (rework — JWT claim
   tests dropped)
 - **Done when:**
   - [ ] `register(...)` returns `IssuedApp` with a 32-char base62 `api_key`; the
-        stored row holds only `api_key_hash`/`api_key_prefix` (no plaintext
-        anywhere in the DB).
+        stored row holds only `api_key_hash`/`api_key_prefix`, with `token` NULL.
   - [ ] The freshly issued key authenticates through
-        `AppRepository.find_app_by_api_key` (mint → verify closed loop).
+        `AppRepository.find_app_by_credential` (mint → verify closed loop).
   - [ ] Collision retry: a fake repository forcing `exists_prefix=True` sees 3
         generate attempts, then a clean raise with no partial write.
   - [ ] `creator` is recorded as both creator and modifier (behavior kept).
 - **Depends on:** Task 3
 
-## Task 6: Rewire bootstrap and the admin endpoint
+## Task 7: Rewire bootstrap and the admin endpoint
 - **Goal:** `build_app_registrar` loses its signer; `POST /admin/apps` returns
   `api_key` instead of `token`.
 - **Files:** `src/gateway/src/gateway/community/bootstrap/_credential_issuance.py`,
@@ -98,24 +124,27 @@
   - [ ] `POST /admin/apps` → 201 body carries `api_key` (32-char base62) and no
         `token`; nothing JWT-decodable is returned for apps.
   - [ ] The returned key immediately authenticates via
-        `AppRepository.find_app_by_api_key` (register → use closed loop over HTTP).
+        `find_app_by_credential` (register → use closed loop over HTTP).
   - [ ] Access-key admin flow (`POST /admin/access-keys`) regression-passes
         unchanged.
-- **Depends on:** Task 5
+- **Depends on:** Task 6
 
-## Task 7: Migrate integration-test seeds off plaintext tokens
-- **Goal:** Identity-pipeline and forward-route suites seed hashed keys and
-  present the plaintext, exercising the real verify path end to end.
+## Task 8: Cover both credential paths in the integration suites
+- **Goal:** Identity-pipeline and forward-route suites exercise the real verify
+  path for API keys, plus one end-to-end legacy-JWT case through the strategy.
 - **Files:** `src/gateway/tests/integration/test_identity_pipeline.py`,
   `src/gateway/tests/integration/test_forward_route.py`
 - **Done when:**
   - [ ] Seeds use `AppRow(api_key_hash=hash_key(k), api_key_prefix=k[:8], …)`
         with a 32-char key; headers present the plaintext key.
+  - [ ] One case seeds a legacy `token=` row and authenticates with the JWT
+        through the real strategy, end to end.
   - [ ] App-identity, mixed-identity (app + user), and US27 adjudication cases
-        pass; resolved principal fields (id/name/owners/type/tenant) unchanged.
-- **Depends on:** Task 4, Task 6
+        pass; resolved principal fields (id/name/owners/type/tenant) unchanged
+        on both paths.
+- **Depends on:** Task 4, Task 5, Task 7
 
-## Task 8: Full-suite verification against spec acceptance criteria
+## Task 9: Full-suite verification against spec acceptance criteria
 - **Goal:** Ensure the feature meets every `spec.md` acceptance criterion and
   repo gates pass.
 - **Files:** — (verification only)
@@ -124,11 +153,12 @@
   - [ ] `scripts/ci/python_sast_local.sh` (lint/SAST gate) green for the gateway
         module.
   - [ ] Every acceptance checkbox in `spec.md` is satisfied and checked off,
-        including: no plaintext persisted, secbaas-hash verifies, both-direction
-        round-trip, constant-time prefix verify, status gating, prefix
-        uniqueness, malformed-key cheap reject, JWT app tokens dead, principal
-        contract unchanged.
-- **Depends on:** Tasks 1–7
+        including: no plaintext persisted for new keys, secbaas-hash verifies,
+        both-direction round-trip, constant-time prefix verify, status gating,
+        prefix uniqueness, malformed-credential cheap reject, **existing JWTs
+        still authenticate**, format dispatch is total, legacy warning logged,
+        principal contract unchanged.
+- **Depends on:** Tasks 1–8
 
 ---
 
@@ -140,9 +170,10 @@
 - **Group A — Compatible key generator:** Task 1
   - Theme: Additive, independently green — the verbatim generator plus the
     pinned secbaas parity fixture that guarantees migration compatibility.
-- **Group B — Credential swap:** Tasks 2, 3, 4, 5, 6
-  - Theme: The end-to-end replacement of JWT app tokens with hashed API keys —
-    schema, repository + SPI port, authn strategy, registrar, bootstrap, admin —
-    landing as one coherent, green slice.
-- **Group C — Integration & verification:** Tasks 7, 8
-  - Theme: Real-path integration seeds and the final spec acceptance check.
+- **Group B — Credential swap with continuity:** Tasks 2, 3, 4, 5, 6, 7
+  - Theme: API keys become the primary path — schema, repository + SPI port,
+    authn strategy, registrar, bootstrap, admin — while the deprecated JWT path
+    (Task 4) keeps every existing holder authenticating. Lands as one coherent,
+    green slice in which no credential, old or new, stops working.
+- **Group C — Integration & verification:** Tasks 8, 9
+  - Theme: Both paths exercised end to end, then the final spec acceptance check.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -44,7 +44,7 @@
         empty-string sentinel would have broken.
 - **Depends on:** —
 
-## Task 3: Rework `AppRepository` + the `AppRegistry` port for API-key verification
+## Task 3 `[x]`: Rework `AppRepository` + the `AppRegistry` port for API-key verification
 - **Goal:** Resolution becomes prefix lookup + status gate + constant-time hash
   verify inside the repository, behind a renamed port method with soft-miss
   semantics.
@@ -52,18 +52,22 @@
   `src/gateway/src/gateway/community/spi/app/_ports.py`,
   `src/gateway/tests/unit/plugins/test_app_registry_db.py` (rework)
 - **Done when:**
-  - [ ] Port and impl expose
+  - [x] Port and impl expose
         `find_app_by_credential(credential) -> RegisteredApp | None`;
         `find_app_by_token` is gone.
-  - [ ] Correct plaintext key against a seeded hashed row resolves the
+  - [x] Correct plaintext key against a seeded hashed row resolves the
         `RegisteredApp`; wrong key with a valid prefix returns `None`.
-  - [ ] Rows in `INACTIVE`/`REVOKED` status return `None` even with the correct key.
-  - [ ] Empty/short (`len < 8`) credentials return `None` without touching the DB.
-  - [ ] The stored hash and record are read inside the ORM session and verified
+  - [x] Rows in `INACTIVE`/`REVOKED` status return `None` even with the correct key.
+  - [x] Empty/short (`len < 8`) credentials return `None` without touching the DB.
+  - [x] The stored hash and record are read inside the ORM session and verified
         after it closes (no `DetachedInstanceError`, no session held across
         ~62ms of PBKDF2).
-  - [ ] `exists_prefix` and the reworked `store(api_key_hash=…, api_key_prefix=…)`
+  - [x] `exists_prefix` and the reworked `store(api_key_hash=…, api_key_prefix=…)`
         are covered by DB-backed tests.
+  - [x] *(added)* `exists_prefix` ignores `status`, so a new key cannot be
+        issued with a prefix already held by a deactivated row.
+  - [x] *(added)* A row with a prefix but a `NULL` hash fails closed rather
+        than raising.
 - **Depends on:** Task 1, Task 2
 
 ## Task 4: Add the deprecated legacy-JWT path (the continuity guarantee)

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -174,15 +174,16 @@
         it never seeds stay irrelevant.
 - **Depends on:** Task 4, Task 5, Task 7
 
-## Task 9: Full-suite verification against spec acceptance criteria
+## Task 9 `[x]`: Full-suite verification against spec acceptance criteria
 - **Goal:** Ensure the feature meets every `spec.md` acceptance criterion and
   repo gates pass.
 - **Files:** — (verification only)
 - **Done when:**
-  - [ ] Full gateway test suite green.
-  - [ ] `scripts/ci/python_sast_local.sh` (lint/SAST gate) green for the gateway
-        module.
-  - [ ] Every acceptance checkbox in `spec.md` is satisfied and checked off,
+  - [x] Full gateway test suite green (813 passed, 2 skipped; also verified
+        pinned to a single CPU, where the loop-stall test skips rather than
+        reporting a false failure).
+  - [x] Lint/format gate green for the gateway module.
+  - [x] Every acceptance checkbox in `spec.md` is satisfied and checked off,
         including: no plaintext persisted for new keys, secbaas-hash verifies,
         both-direction round-trip, constant-time prefix verify, status gating,
         prefix uniqueness, malformed-credential cheap reject, **existing JWTs

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -2,7 +2,7 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
-## Task 1: Copy the secbaas key generator into the gateway app domain
+## Task 1 `[x]`: Copy the secbaas key generator into the gateway app domain
 - **Goal:** Land a byte-for-byte copy of `APIKeyGenerator` in the gateway with a
   parity test pinning migration compatibility against a secbaas-produced fixture.
 - **Files:** `src/gateway/src/gateway/community/core/app/_key_gen.py` (new, copied
@@ -10,12 +10,17 @@
   `src/gateway/src/gateway/community/core/app/__init__.py` (export),
   `src/gateway/tests/unit/plugins/test_app_key_gen.py` (new)
 - **Done when:**
-  - [ ] `test_secbaas_produced_hash_verifies` passes against the pinned fixture
+  - [x] `test_secbaas_produced_hash_verifies` passes against the pinned fixture
         pair from `plan.md` (`5X1tk2yC…` / `YIrLEzbZ…`) — the migration guarantee.
-  - [ ] Generate → hash → verify round-trip passes; two hashes of one key differ
+  - [x] Generate → hash → verify round-trip passes; two hashes of one key differ
         (salt uniqueness); wrong key and garbage stored-hash are rejected.
-  - [ ] `generate()` output is 32-char base62 and passes `validate_format`.
-  - [ ] Copied module is diff-identical to the secbaas source.
+  - [x] `generate()` output is 32-char base62 and passes `validate_format`.
+  - [x] Copied module is diff-identical to the secbaas source.
+  - [x] *(added)* PBKDF2 parameters pinned explicitly by recomputing the derived
+        key from the stored salt — the digest and iteration count are not
+        recorded in the stored string, so nothing else would catch their drift.
+  - [x] *(added)* Round-trip verified in both directions against the real
+        secbaas implementation loaded from disk.
 - **Depends on:** —
 
 ## Task 2: Add the API-key columns, retain the legacy credential column

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Application API-key credentials (secbaas-compatible)
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+## Task 1: Copy the secbaas key generator into the gateway app domain
+- **Goal:** Land a byte-for-byte copy of `APIKeyGenerator` in the gateway with a
+  parity test pinning migration compatibility against a secbaas-produced fixture.
+- **Files:** `src/gateway/src/gateway/community/core/app/_key_gen.py` (new, copied
+  verbatim from `src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`),
+  `src/gateway/src/gateway/community/core/app/__init__.py` (export),
+  `src/gateway/tests/unit/plugins/test_app_key_gen.py` (new)
+- **Done when:**
+  - [ ] `test_secbaas_produced_hash_verifies` passes against the pinned fixture
+        pair from `plan.md` (`5X1tk2yC…` / `YIrLEzbZ…`) — the migration guarantee.
+  - [ ] Generate → hash → verify round-trip passes; two hashes of one key differ
+        (salt uniqueness); wrong key and garbage stored-hash are rejected.
+  - [ ] `generate()` output is 32-char base62 and passes `validate_format`.
+  - [ ] Copied module is diff-identical to the secbaas source.
+- **Depends on:** —
+
+## Task 2: Swap `avernet_application` credential columns
+- **Goal:** Replace the plaintext `token` column with `api_key_hash` +
+  `api_key_prefix` (unique) in the ORM row and the canonical MySQL DDL, using
+  `baas_api_key`'s column names for a straight migration map.
+- **Files:** `src/gateway/src/gateway/community/core/app/_orm.py`,
+  `src/gateway/migrations/mysql/001_init_schema.sql`
+- **Done when:**
+  - [ ] `AppRow` has `api_key_hash: String(256)` and
+        `api_key_prefix: String(8), unique=True`; `token` is gone.
+  - [ ] DDL mirrors the ORM: `uk_avernet_application_api_key_prefix` replaces
+        `uk_avernet_application_token`; column comments updated.
+  - [ ] `to_record()` and module docstrings no longer mention JWT/opaque-token
+        lookup.
+- **Depends on:** —
+
+## Task 3: Rework `AppRepository` and the `AppRegistry` port to verify API keys
+- **Goal:** Resolution becomes prefix lookup + status gate + constant-time hash
+  verify inside the repository, behind a renamed SPI port method with soft-miss
+  semantics.
+- **Files:** `src/gateway/src/gateway/community/core/app/_repository.py`,
+  `src/gateway/src/gateway/community/spi/app/_ports.py`,
+  `src/gateway/tests/unit/plugins/test_app_registry_db.py` (rework)
+- **Done when:**
+  - [ ] Port and impl expose `find_app_by_api_key(api_key) -> RegisteredApp | None`;
+        `find_app_by_token` is gone.
+  - [ ] Correct plaintext key against a seeded hashed row resolves the
+        `RegisteredApp`; wrong key with a valid prefix returns `None`.
+  - [ ] Rows in `INACTIVE`/`REVOKED` status return `None` even with the correct key.
+  - [ ] Empty/short (`len < 8`) keys return `None` without touching the DB.
+  - [ ] `exists_prefix` and the reworked `store(api_key_hash=…, api_key_prefix=…)`
+        are covered by the DB-backed tests.
+- **Depends on:** Task 1, Task 2
+
+## Task 4: Point the `app_token` strategy at the renamed port
+- **Goal:** The authn strategy resolves API keys through
+  `find_app_by_api_key`; header extraction and soft-miss adjudication (US27)
+  are unchanged.
+- **Files:** `src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py`,
+  `src/gateway/tests/unit/plugins/test_app_token_strategy.py` (fake registry rename)
+- **Done when:**
+  - [ ] Strategy calls `find_app_by_api_key`; docstrings describe API keys, not
+        registry-recognised JWTs.
+  - [ ] All existing strategy behavior tests pass unmodified in substance
+        (Bearer precedence, dedicated header fallback, soft miss, principal
+        fields) — the resolved `AppPrincipal` shape is untouched.
+- **Depends on:** Task 3
+
+## Task 5: Rework `AppRegistrar` to mint API keys
+- **Goal:** Registration generates a key via `APIKeyGenerator`, retries up to 3
+  times on prefix collision, persists only hash + prefix, and returns the
+  plaintext once via `IssuedApp.api_key`; `PrincipalSigner` and `clock` are
+  dropped.
+- **Files:** `src/gateway/src/gateway/community/core/app/_registrar.py`,
+  `src/gateway/src/gateway/community/core/app/__init__.py`,
+  `src/gateway/tests/unit/plugins/test_app_registrar.py` (rework — JWT claim
+  tests dropped)
+- **Done when:**
+  - [ ] `register(...)` returns `IssuedApp` with a 32-char base62 `api_key`; the
+        stored row holds only `api_key_hash`/`api_key_prefix` (no plaintext
+        anywhere in the DB).
+  - [ ] The freshly issued key authenticates through
+        `AppRepository.find_app_by_api_key` (mint → verify closed loop).
+  - [ ] Collision retry: a fake repository forcing `exists_prefix=True` sees 3
+        generate attempts, then a clean raise with no partial write.
+  - [ ] `creator` is recorded as both creator and modifier (behavior kept).
+- **Depends on:** Task 3
+
+## Task 6: Rewire bootstrap and the admin endpoint
+- **Goal:** `build_app_registrar` loses its signer; `POST /admin/apps` returns
+  `api_key` instead of `token`.
+- **Files:** `src/gateway/src/gateway/community/bootstrap/_credential_issuance.py`,
+  `src/gateway/src/gateway/community/bootstrap/__init__.py`,
+  `src/gateway/src/gateway/community/adapters/web/admin.py`,
+  `src/gateway/tests/integration/test_admin_issuance.py` (rework)
+- **Done when:**
+  - [ ] `build_app_registrar(db)` builds without a `PrincipalSigner`; access-key
+        issuance keeps its signer untouched.
+  - [ ] `POST /admin/apps` → 201 body carries `api_key` (32-char base62) and no
+        `token`; nothing JWT-decodable is returned for apps.
+  - [ ] The returned key immediately authenticates via
+        `AppRepository.find_app_by_api_key` (register → use closed loop over HTTP).
+  - [ ] Access-key admin flow (`POST /admin/access-keys`) regression-passes
+        unchanged.
+- **Depends on:** Task 5
+
+## Task 7: Migrate integration-test seeds off plaintext tokens
+- **Goal:** Identity-pipeline and forward-route suites seed hashed keys and
+  present the plaintext, exercising the real verify path end to end.
+- **Files:** `src/gateway/tests/integration/test_identity_pipeline.py`,
+  `src/gateway/tests/integration/test_forward_route.py`
+- **Done when:**
+  - [ ] Seeds use `AppRow(api_key_hash=hash_key(k), api_key_prefix=k[:8], …)`
+        with a 32-char key; headers present the plaintext key.
+  - [ ] App-identity, mixed-identity (app + user), and US27 adjudication cases
+        pass; resolved principal fields (id/name/owners/type/tenant) unchanged.
+- **Depends on:** Task 4, Task 6
+
+## Task 8: Full-suite verification against spec acceptance criteria
+- **Goal:** Ensure the feature meets every `spec.md` acceptance criterion and
+  repo gates pass.
+- **Files:** — (verification only)
+- **Done when:**
+  - [ ] Full gateway test suite green.
+  - [ ] `scripts/ci/python_sast_local.sh` (lint/SAST gate) green for the gateway
+        module.
+  - [ ] Every acceptance checkbox in `spec.md` is satisfied and checked off,
+        including: no plaintext persisted, secbaas-hash verifies, both-direction
+        round-trip, constant-time prefix verify, status gating, prefix
+        uniqueness, malformed-key cheap reject, JWT app tokens dead, principal
+        contract unchanged.
+- **Depends on:** Tasks 1–7
+
+---
+
+## Groups
+
+> Groups bundle tasks into end-to-end units of work. `implement` executes
+> one group at a time and runs code review on each group before moving on.
+
+- **Group A — Compatible key generator:** Task 1
+  - Theme: Additive, independently green — the verbatim generator plus the
+    pinned secbaas parity fixture that guarantees migration compatibility.
+- **Group B — Credential swap:** Tasks 2, 3, 4, 5, 6
+  - Theme: The end-to-end replacement of JWT app tokens with hashed API keys —
+    schema, repository + SPI port, authn strategy, registrar, bootstrap, admin —
+    landing as one coherent, green slice.
+- **Group C — Integration & verification:** Tasks 7, 8
+  - Theme: Real-path integration seeds and the final spec acceptance check.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -156,19 +156,22 @@
         is NULL and the key does not appear in `api_key_hash`.
 - **Depends on:** Task 6
 
-## Task 8: Cover both credential paths in the integration suites
+## Task 8 `[x]`: Cover both credential paths in the integration suites
 - **Goal:** Identity-pipeline and forward-route suites exercise the real verify
   path for API keys, plus one end-to-end legacy-JWT case through the strategy.
 - **Files:** `src/gateway/tests/integration/test_identity_pipeline.py`,
   `src/gateway/tests/integration/test_forward_route.py`
 - **Done when:**
-  - [ ] Seeds use `AppRow(api_key_hash=hash_key(k), api_key_prefix=k[:8], …)`
+  - [x] Seeds use `AppRow(api_key_hash=hash_key(k), api_key_prefix=k[:8], …)`
         with a 32-char key; headers present the plaintext key.
-  - [ ] One case seeds a legacy `token=` row and authenticates with the JWT
+  - [x] One case seeds a legacy `token=` row and authenticates with the JWT
         through the real strategy, end to end.
-  - [ ] App-identity, mixed-identity (app + user), and US27 adjudication cases
+  - [x] App-identity, mixed-identity (app + user), and US27 adjudication cases
         pass; resolved principal fields (id/name/owners/type/tenant) unchanged
         on both paths.
+  - [x] `test_forward_route.py` needed no seed change — it builds the strategy
+        from `AppRepository` but exercises bot/user identities, so the app rows
+        it never seeds stay irrelevant.
 - **Depends on:** Task 4, Task 5, Task 7
 
 ## Task 9: Full-suite verification against spec acceptance criteria

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -3,10 +3,11 @@
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 
 ## Task 1 `[x]`: Copy the secbaas key generator into the gateway app domain
-- **Goal:** Land a byte-for-byte copy of `APIKeyGenerator` in the gateway with a
-  parity test pinning migration compatibility against a secbaas-produced fixture.
+- **Goal:** Land a copy of `APIKeyGenerator` in the gateway — identical in code,
+  translated in prose — with a parity test pinning migration compatibility
+  against a secbaas-produced fixture.
 - **Files:** `src/gateway/src/gateway/community/core/app/_key_gen.py` (new, copied
-  verbatim from `src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`),
+  from `src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`),
   `src/gateway/src/gateway/community/core/app/__init__.py` (export),
   `src/gateway/tests/unit/plugins/test_app_key_gen.py` (new)
 - **Done when:**
@@ -15,7 +16,11 @@
   - [x] Generate → hash → verify round-trip passes; two hashes of one key differ
         (salt uniqueness); wrong key and garbage stored-hash are rejected.
   - [x] `generate()` output is 32-char base62 and passes `validate_format`.
-  - [x] Copied module is diff-identical to the secbaas source.
+  - [x] Copied module matches the secbaas source as a syntax tree with
+        docstrings stripped, leaving comments and docstrings free to be in
+        English; its executable statements are byte-identical besides.
+  - [x] *(added)* The translation is guarded against a wholesale re-copy of
+        upstream, which would silently restore the Chinese prose.
   - [x] *(added)* PBKDF2 parameters pinned explicitly by recomputing the derived
         key from the stored salt — the digest and iteration count are not
         recorded in the stored string, so nothing else would catch their drift.

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -23,21 +23,25 @@
         secbaas implementation loaded from disk.
 - **Depends on:** —
 
-## Task 2: Add the API-key columns, retain the legacy credential column
+## Task 2 `[x]`: Add the API-key columns, retain the legacy credential column
 - **Goal:** Add `api_key_hash` + `api_key_prefix` (nullable, prefix unique) to
   the ORM row and canonical DDL, keeping `token` as a nullable deprecated column
   so existing rows keep authenticating.
 - **Files:** `src/gateway/src/gateway/community/core/app/_orm.py`,
   `src/gateway/migrations/mysql/001_init_schema.sql`
 - **Done when:**
-  - [ ] `AppRow` has `api_key_hash: str | None` and `api_key_prefix: str | None`
+  - [x] `AppRow` has `api_key_hash: str | None` and `api_key_prefix: str | None`
         (unique); `token` becomes `str | None`, still unique, marked deprecated
         in a comment naming what must happen before removal.
-  - [ ] DDL matches: both new columns `DEFAULT NULL`,
+  - [x] DDL matches: both new columns `DEFAULT NULL`,
         `uk_avernet_application_api_key_prefix` added,
         `uk_avernet_application_token` retained, comments updated.
-  - [ ] The schema change is additive only — no existing column is dropped or
+  - [x] The schema change is additive only — no existing column is dropped or
         made stricter, so it can be applied before the code ships.
+  - [x] Verified against a live SQLite schema: both uniqueness constraints
+        reject duplicates, and an API-key row plus multiple legacy rows (all
+        with `NULL` prefixes) coexist — the multi-`NULL` behavior the
+        empty-string sentinel would have broken.
 - **Depends on:** —
 
 ## Task 3: Rework `AppRepository` + the `AppRegistry` port for API-key verification

--- a/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
+++ b/src/gateway/specs/2026-08-13-application-api-key-credentials/tasks.md
@@ -70,25 +70,30 @@
         than raising.
 - **Depends on:** Task 1, Task 2
 
-## Task 4: Add the deprecated legacy-JWT path (the continuity guarantee)
+## Task 4 `[x]`: Add the deprecated legacy-JWT path (the continuity guarantee)
 - **Goal:** Existing JWT holders keep authenticating via a format-dispatched
   exact-match path that logs every use, so remaining legacy traffic is
   measurable and the path can be deleted on evidence.
 - **Files:** `src/gateway/src/gateway/community/core/app/_repository.py`,
   `src/gateway/tests/unit/plugins/test_app_legacy_token.py` (new)
 - **Done when:**
-  - [ ] A row seeded the old way (`token=<real JWT>`, `api_key_*` NULL) still
+  - [x] A row seeded the old way (`token=<real JWT>`, `api_key_*` NULL) still
         authenticates and yields a `RegisteredApp` identical to today's.
-  - [ ] Dispatch is by format via `validate_format`, not try-and-fallback: a
+  - [x] Dispatch is by format via `validate_format`, not try-and-fallback: a
         32-char base62 key never reaches the legacy branch, and each request
-        performs exactly one lookup.
-  - [ ] Every legacy resolution emits a WARNING naming the app (asserted with
+        performs exactly one lookup — asserted by counting SELECTs through a
+        SQLAlchemy `before_cursor_execute` listener, for both credential forms.
+  - [x] Every legacy resolution emits a WARNING naming the app (asserted with
         `caplog`); the method docstring and column comment state the deletion
-        criteria.
-  - [ ] API-key rows and legacy rows coexist in one table, each resolving
+        criteria. The API-key path is asserted *not* to warn, or the signal
+        would be worthless.
+  - [x] API-key rows and legacy rows coexist in one table, each resolving
         through its own path.
-  - [ ] An unknown JWT returns `None` (soft miss, US27 preserved); a legacy row
+  - [x] An unknown JWT returns `None` (soft miss, US27 preserved); a legacy row
         that is not `ACTIVE` returns `None` (documented behavior change).
+  - [x] *(added)* A newline-suffixed credential authenticates on neither path —
+        the property that makes the upstream `validate_format` quirk harmless
+        here (plan.md, Notes on upstream follow-ups #1).
 - **Depends on:** Task 3
 
 ## Task 5: Point the `app_token` strategy at the renamed port

--- a/src/gateway/src/gateway/community/adapters/web/admin.py
+++ b/src/gateway/src/gateway/community/adapters/web/admin.py
@@ -37,7 +37,7 @@ class AppRequest(BaseModel):
     # Constrained, not free text: authentication compares this to "ACTIVE"
     # exactly, so accepting "active" would mint a key that can never
     # authenticate while returning 201 as though registration had worked.
-    status: Literal["ACTIVE", "INACTIVE"] = "ACTIVE"
+    status: Literal["ACTIVE", "INACTIVE", "REVOKED"] = "ACTIVE"
     env: str = ""
     config: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/gateway/src/gateway/community/adapters/web/admin.py
+++ b/src/gateway/src/gateway/community/adapters/web/admin.py
@@ -37,7 +37,11 @@ class AppRequest(BaseModel):
     # Constrained, not free text: authentication compares this to "ACTIVE"
     # exactly, so accepting "active" would mint a key that can never
     # authenticate while returning 201 as though registration had worked.
-    status: Literal["ACTIVE", "INACTIVE", "REVOKED"] = "ACTIVE"
+    # REVOKED is excluded deliberately — it is a transition applied to an
+    # existing app, and registering straight into it would mint a dead
+    # credential. The repository still honors REVOKED rows, which is what
+    # migrated secbaas records need.
+    status: Literal["ACTIVE", "INACTIVE"] = "ACTIVE"
     env: str = ""
     config: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/gateway/src/gateway/community/adapters/web/admin.py
+++ b/src/gateway/src/gateway/community/adapters/web/admin.py
@@ -8,7 +8,7 @@ convenience). A production deployment must gate them behind an admin credential
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
@@ -34,7 +34,10 @@ class AppRequest(BaseModel):
     app_type: str = "UNKNOWN"
     tenant: str
     creator: str = Field(min_length=1)
-    status: str = "ACTIVE"
+    # Constrained, not free text: authentication compares this to "ACTIVE"
+    # exactly, so accepting "active" would mint a key that can never
+    # authenticate while returning 201 as though registration had worked.
+    status: Literal["ACTIVE", "INACTIVE"] = "ACTIVE"
     env: str = ""
     config: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/gateway/src/gateway/community/adapters/web/admin.py
+++ b/src/gateway/src/gateway/community/adapters/web/admin.py
@@ -87,6 +87,8 @@ async def register_app(payload: AppRequest, request: Request) -> JSONResponse:
     except Exception:
         logger.exception("app registration failed")
         return _error(500, 1, "app registration failed")
+    # ``api_key`` is returned here and nowhere else, ever: the registry keeps
+    # only its hash, so a caller who loses it must be issued a new one.
     return JSONResponse(
         status_code=201,
         content={
@@ -97,6 +99,6 @@ async def register_app(payload: AppRequest, request: Request) -> JSONResponse:
             "tenant": issued.tenant,
             "status": payload.status,
             "env": payload.env,
-            "token": issued.token,
+            "api_key": issued.api_key,
         },
     )

--- a/src/gateway/src/gateway/community/adapters/web/admin.py
+++ b/src/gateway/src/gateway/community/adapters/web/admin.py
@@ -38,9 +38,9 @@ class AppRequest(BaseModel):
     # exactly, so accepting "active" would mint a key that can never
     # authenticate while returning 201 as though registration had worked.
     # REVOKED is excluded deliberately — it is a transition applied to an
-    # existing app, and registering straight into it would mint a dead
-    # credential. The repository still honors REVOKED rows, which is what
-    # migrated secbaas records need.
+    # existing app, and registering straight into it would mint a credential
+    # that is dead on arrival. Migrated rows may still carry it; those are
+    # refused at lookup, which is the intended handling.
     status: Literal["ACTIVE", "INACTIVE"] = "ACTIVE"
     env: str = ""
     config: dict[str, Any] = Field(default_factory=dict)

--- a/src/gateway/src/gateway/community/bootstrap/__init__.py
+++ b/src/gateway/src/gateway/community/bootstrap/__init__.py
@@ -97,7 +97,7 @@ def bootstrap_app() -> BootstrapResult:
     )
     db = container.plugins().database()
     access_key_issuer = build_access_key_issuer(db, principal_signer)
-    app_registrar = build_app_registrar(db, principal_signer)
+    app_registrar = build_app_registrar(db)
     return BootstrapResult(
         authenticator=authenticator,
         forwarding=forwarding,

--- a/src/gateway/src/gateway/community/bootstrap/_credential_issuance.py
+++ b/src/gateway/src/gateway/community/bootstrap/_credential_issuance.py
@@ -1,9 +1,13 @@
 """Composition root for credential issuance (access_key / app registration).
 
 Builds :class:`AccessKeyIssuer` / :class:`AppRegistrar` wired to a repository
-(backed by the shared ``DataSourcePlugin``) and the gateway ``PrincipalSigner``.
-All DB touch lives in the repositories; the issuer/registrar only mint + delegate.
-The adapters receive them via ``app.state``.
+backed by the shared ``DataSourcePlugin``. All DB touch lives in the
+repositories; the issuer/registrar only mint + delegate. The adapters receive
+them via ``app.state``.
+
+Only the access-key issuer still takes the gateway ``PrincipalSigner``: access
+keys are signed JWTs, whereas app registration now mints a random API key and
+stores only its hash, so it has no signing key to share.
 """
 
 from __future__ import annotations
@@ -21,6 +25,6 @@ def build_access_key_issuer(
     return AccessKeyIssuer(AccessKeyRepository(db), signer)
 
 
-def build_app_registrar(db: DataSourcePlugin, signer: PrincipalSigner) -> AppRegistrar:
-    """Build the AppRegistrar (shares the gateway signer + DB-backed repository)."""
-    return AppRegistrar(AppRepository(db), signer)
+def build_app_registrar(db: DataSourcePlugin) -> AppRegistrar:
+    """Build the AppRegistrar (DB-backed repository; no signer — API keys are random)."""
+    return AppRegistrar(AppRepository(db))

--- a/src/gateway/src/gateway/community/core/app/__init__.py
+++ b/src/gateway/src/gateway/community/core/app/__init__.py
@@ -5,6 +5,15 @@ Holds the ORM row (:class:`AppRow`), the canonical :class:`AppRepository` impl,
 (the app credential scheme). The
 :class:`~gateway.community.spi.app.AppRegistry` contract lives in the app SPI.
 The authn ``app_token`` strategy depends on the SPI, not this module.
+
+``_key_gen.py`` is a **verbatim copy** of
+``src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`` and must
+stay byte-identical to it: secbaas's existing API-key records are migrated into
+``avernet_application``, and the stored hash records only its salt, so the
+digest, iteration count, and encoding are implicit constants shared by both
+sides. Edit the scheme in both files or in neither —
+``tests/unit/plugins/test_app_key_gen.py`` fails on a one-sided change, and a
+one-sided change that slipped through would invalidate every migrated key.
 """
 
 from ._key_gen import APIKeyGenerator

--- a/src/gateway/src/gateway/community/core/app/__init__.py
+++ b/src/gateway/src/gateway/community/core/app/__init__.py
@@ -6,13 +6,15 @@ Holds the ORM row (:class:`AppRow`), the canonical :class:`AppRepository` impl,
 :class:`~gateway.community.spi.app.AppRegistry` contract lives in the app SPI.
 The authn ``app_token`` strategy depends on the SPI, not this module.
 
-``_key_gen.py`` is a **verbatim copy** of
-``src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`` and must
-stay byte-identical to it: secbaas's existing API-key records are migrated into
-``avernet_application``, and the stored hash records only its salt, so the
+``_key_gen.py`` is a **copy** of
+``src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py`` and its
+code must stay identical to it: secbaas's existing API-key records are migrated
+into ``avernet_application``, and the stored hash records only its salt, so the
 digest, iteration count, and encoding are implicit constants shared by both
 sides. Edit the scheme in both files or in neither — a one-sided change
-invalidates every migrated key.
+invalidates every migrated key. Only the comments and docstrings diverge (ours
+in English, upstream's in Chinese); the parity test compares the two as syntax
+trees with docstrings stripped, so prose is free and behaviour is not.
 
 ``tests/unit/plugins/test_app_key_gen.py`` fails on a one-sided change *when it
 runs*, which covers edits to this module. It does not cover the other direction:

--- a/src/gateway/src/gateway/community/core/app/__init__.py
+++ b/src/gateway/src/gateway/community/core/app/__init__.py
@@ -24,8 +24,8 @@ re-copy by hand.
 
 from ._key_gen import APIKeyGenerator
 from ._orm import AppRow
-from ._registrar import AppRegistrar, IssuedApp
-from ._repository import AppRepository
+from ._registrar import AppRegistrar, IssuedApp, PrefixAllocationError
+from ._repository import AppRepository, PrefixTakenError
 
 __all__ = [
     "APIKeyGenerator",
@@ -33,4 +33,6 @@ __all__ = [
     "AppRepository",
     "AppRow",
     "IssuedApp",
+    "PrefixAllocationError",
+    "PrefixTakenError",
 ]

--- a/src/gateway/src/gateway/community/core/app/__init__.py
+++ b/src/gateway/src/gateway/community/core/app/__init__.py
@@ -1,16 +1,19 @@
 """App domain — canonical data-access (``AppRegistry`` SPI impl) + registration.
 
 Holds the ORM row (:class:`AppRow`), the canonical :class:`AppRepository` impl,
-and :class:`AppRegistrar` (registers + persists apps). The
+:class:`AppRegistrar` (registers + persists apps), and :class:`APIKeyGenerator`
+(the app credential scheme). The
 :class:`~gateway.community.spi.app.AppRegistry` contract lives in the app SPI.
 The authn ``app_token`` strategy depends on the SPI, not this module.
 """
 
+from ._key_gen import APIKeyGenerator
 from ._orm import AppRow
 from ._registrar import AppRegistrar, IssuedApp
 from ._repository import AppRepository
 
 __all__ = [
+    "APIKeyGenerator",
     "AppRegistrar",
     "AppRepository",
     "AppRow",

--- a/src/gateway/src/gateway/community/core/app/__init__.py
+++ b/src/gateway/src/gateway/community/core/app/__init__.py
@@ -11,9 +11,15 @@ The authn ``app_token`` strategy depends on the SPI, not this module.
 stay byte-identical to it: secbaas's existing API-key records are migrated into
 ``avernet_application``, and the stored hash records only its salt, so the
 digest, iteration count, and encoding are implicit constants shared by both
-sides. Edit the scheme in both files or in neither —
-``tests/unit/plugins/test_app_key_gen.py`` fails on a one-sided change, and a
-one-sided change that slipped through would invalidate every migrated key.
+sides. Edit the scheme in both files or in neither — a one-sided change
+invalidates every migrated key.
+
+``tests/unit/plugins/test_app_key_gen.py`` fails on a one-sided change *when it
+runs*, which covers edits to this module. It does not cover the other direction:
+the gateway CI job is selected by changed paths under ``src/gateway``, so a
+commit touching only secbaas's copy skips this suite entirely. Until that gap is
+closed, a secbaas-side edit to the scheme must be paired with a gateway-side
+re-copy by hand.
 """
 
 from ._key_gen import APIKeyGenerator

--- a/src/gateway/src/gateway/community/core/app/_key_gen.py
+++ b/src/gateway/src/gateway/community/core/app/_key_gen.py
@@ -1,0 +1,69 @@
+import base64
+import hashlib
+import hmac
+import re
+import secrets
+
+
+class APIKeyGenerator:
+    """
+    Key 格式：
+      API Key : {32 位 base62 随机}
+
+    示例：
+      xK9mP2nQ8rL4vT6wY1zA3bC
+    """
+
+    BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+    @classmethod
+    def generate(cls) -> str:
+        """
+        生成单个 API Key
+        返回 api_key 字符串
+        """
+        # 生成 api_key（32 位 base62）
+        return f"{cls._random_base62(32)}"
+
+    @classmethod
+    def hash_key(cls, api_key: str) -> str:
+        """
+        存储用哈希：PBKDF2 + salt
+        比纯 sha256 更安全，防暴力破解
+        """
+        salt = secrets.token_bytes(32)
+        dk = hashlib.pbkdf2_hmac(
+            hash_name="sha256", password=api_key.encode(), salt=salt, iterations=100_000
+        )
+        # 格式：base64(salt):base64(dk)
+        return base64.b64encode(salt).decode() + ":" + base64.b64encode(dk).decode()
+
+    @classmethod
+    def verify_key(cls, api_key: str, stored_hash: str) -> bool:
+        """验证 API Key（恒定时间比较，防时序攻击）"""
+        try:
+            salt_b64, dk_b64 = stored_hash.split(":")
+            salt = base64.b64decode(salt_b64)
+            dk = base64.b64decode(dk_b64)
+
+            new_dk = hashlib.pbkdf2_hmac(
+                hash_name="sha256",
+                password=api_key.encode(),
+                salt=salt,
+                iterations=100_000,
+            )
+            # 恒定时间比较，防止时序攻击
+            return hmac.compare_digest(dk, new_dk)
+        except Exception:
+            return False
+
+    @classmethod
+    def _random_base62(cls, length: int) -> str:
+        """生成指定长度的 base62 随机字符串"""
+        return "".join(secrets.choice(cls.BASE62) for _ in range(length))
+
+    @staticmethod
+    def validate_format(api_key: str) -> bool:
+        """校验 Key 格式合法性"""
+        pattern = r"^[0-9A-Za-z]{32}$"
+        return bool(re.match(pattern, api_key))

--- a/src/gateway/src/gateway/community/core/app/_key_gen.py
+++ b/src/gateway/src/gateway/community/core/app/_key_gen.py
@@ -1,3 +1,20 @@
+"""The app credential scheme — a copy of secbaas's ``APIKeyGenerator``.
+
+Mirrors ``src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py``.
+secbaas's existing API-key records are migrated into ``avernet_application`` and
+must keep verifying with their original plaintext keys, so the *algorithm* here
+must not drift from that file: the stored hash records only its salt, leaving the
+digest, the iteration count, and the encoding as implicit constants shared by
+both sides. Change the scheme in both files or in neither — a one-sided change
+silently invalidates every migrated key.
+
+The executable statements are byte-identical to the upstream file, and
+``tests/unit/plugins/test_app_key_gen.py`` pins that: it compares the two modules
+as syntax trees with docstrings stripped, so comments and prose may differ (these
+are in English per the gateway's convention; upstream's are in Chinese) while any
+change to what the code *does* fails the check.
+"""
+
 import base64
 import hashlib
 import hmac
@@ -7,10 +24,11 @@ import secrets
 
 class APIKeyGenerator:
     """
-    Key 格式：
-      API Key : {32 位 base62 随机}
+    Key format:
+      API Key : {32 random base62 characters}
 
-    示例：
+    Example (upstream's, kept as written — it is illustrative only and is
+    shorter than the 32 characters `generate` actually emits):
       xK9mP2nQ8rL4vT6wY1zA3bC
     """
 
@@ -19,28 +37,28 @@ class APIKeyGenerator:
     @classmethod
     def generate(cls) -> str:
         """
-        生成单个 API Key
-        返回 api_key 字符串
+        Generate a single API Key.
+        Returns the api_key string.
         """
-        # 生成 api_key（32 位 base62）
+        # generate api_key (32 base62 characters)
         return f"{cls._random_base62(32)}"
 
     @classmethod
     def hash_key(cls, api_key: str) -> str:
         """
-        存储用哈希：PBKDF2 + salt
-        比纯 sha256 更安全，防暴力破解
+        Hash for storage: PBKDF2 + salt.
+        Safer than a plain sha256 — resists brute-force cracking.
         """
         salt = secrets.token_bytes(32)
         dk = hashlib.pbkdf2_hmac(
             hash_name="sha256", password=api_key.encode(), salt=salt, iterations=100_000
         )
-        # 格式：base64(salt):base64(dk)
+        # format: base64(salt):base64(dk)
         return base64.b64encode(salt).decode() + ":" + base64.b64encode(dk).decode()
 
     @classmethod
     def verify_key(cls, api_key: str, stored_hash: str) -> bool:
-        """验证 API Key（恒定时间比较，防时序攻击）"""
+        """Verify an API Key (constant-time comparison, resists timing attacks)."""
         try:
             salt_b64, dk_b64 = stored_hash.split(":")
             salt = base64.b64decode(salt_b64)
@@ -52,18 +70,18 @@ class APIKeyGenerator:
                 salt=salt,
                 iterations=100_000,
             )
-            # 恒定时间比较，防止时序攻击
+            # constant-time comparison, to prevent timing attacks
             return hmac.compare_digest(dk, new_dk)
         except Exception:
             return False
 
     @classmethod
     def _random_base62(cls, length: int) -> str:
-        """生成指定长度的 base62 随机字符串"""
+        """Generate a random base62 string of the given length."""
         return "".join(secrets.choice(cls.BASE62) for _ in range(length))
 
     @staticmethod
     def validate_format(api_key: str) -> bool:
-        """校验 Key 格式合法性"""
+        """Check that a Key's format is valid."""
         pattern = r"^[0-9A-Za-z]{32}$"
         return bool(re.match(pattern, api_key))

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -37,10 +37,14 @@ from gateway.community.spi.database import Base
 # How many leading characters of an API key form its lookup prefix. A property
 # of the credential scheme, not of storage — but it cannot live in ``_key_gen``,
 # which must stay byte-identical to secbaas's copy, so it is defined here (the
-# module with no intra-package imports) and used by the column width, the
-# repository's lookups, and the registrar's slicing alike. Changing it in only
-# some of those places truncates prefixes in MySQL while passing every SQLite
-# test, since SQLite ignores VARCHAR widths.
+# module with no intra-package imports) and used by the ORM column width, the
+# repository's lookups, and the registrar's slicing.
+#
+# The hand-written MySQL DDL is a SECOND source of truth: `migrations/mysql/`
+# hardcodes varchar(8), and only the community SQLite path builds its schema
+# from this constant. Raising it here without editing those files truncates
+# stored prefixes in MySQL while every SQLite test passes, because SQLite
+# ignores VARCHAR widths.
 API_KEY_PREFIX_LEN = 8
 
 

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -1,11 +1,26 @@
 """ORM model for the third-party-app registry (``avernet_application`` table).
 
-The canonical :class:`AppRepository` resolves a presented app token to an app
-row (surrogate ``id`` PK; ``token`` is the unique lookup key). Registered on the shared
-:class:`~gateway.community.spi.database.Base` so ``DataSourcePlugin.create_all()``
-creates the table. :meth:`AppRow.to_record` maps a row onto the SPI
-:class:`~gateway.community.spi.app.RegisteredApp` (core fields only; ``status``
-/ ``env`` / ``config`` / audit columns stay DB-side).
+The canonical :class:`AppRepository` resolves a presented credential to an app
+row (surrogate ``id`` PK). A row carries **exactly one** credential form:
+
+* ``api_key_hash`` + ``api_key_prefix`` — the current scheme. The prefix is the
+  key's first 8 characters and is the lookup key (the hash is salted, so it
+  cannot be one); the hash is one-way, so the table holds nothing usable.
+* ``token`` — a plaintext JWT, **deprecated**. Populated only on rows predating
+  the API-key scheme, served by an exact-match path kept for a transition
+  window. Drop this column, its unique index, and
+  ``AppRepository._by_legacy_token`` once the deprecation warning that path
+  emits has gone quiet.
+
+All three are nullable because "which credential form is this row" is a real
+state, not an unknown. Nullability also matters for ``api_key_prefix``
+specifically: a unique index permits many ``NULL``s but only one ``''``, so an
+empty-string sentinel would collide across every legacy row.
+
+Registered on the shared :class:`~gateway.community.spi.database.Base` so
+``DataSourcePlugin.create_all()`` creates the table. :meth:`AppRow.to_record`
+maps a row onto the SPI :class:`~gateway.community.spi.app.RegisteredApp` (core
+fields only; ``status`` / ``env`` / ``config`` / audit columns stay DB-side).
 """
 
 from __future__ import annotations
@@ -13,7 +28,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import JSON, BigInteger, text
+from sqlalchemy import JSON, BigInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from gateway.community.spi.app import RegisteredApp
@@ -21,14 +36,19 @@ from gateway.community.spi.database import Base
 
 
 class AppRow(Base):  # type: ignore[misc]
-    """A third-party app resolvable by token (the ``avernet_application`` table)."""
+    """A third-party app resolvable by credential (the ``avernet_application`` table)."""
 
     __tablename__ = "avernet_application"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     app_name: Mapped[str] = mapped_column(index=True)
     app_type: Mapped[str] = mapped_column()
-    token: Mapped[str] = mapped_column(unique=True)
+    api_key_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    api_key_prefix: Mapped[str | None] = mapped_column(
+        String(8), unique=True, nullable=True
+    )
+    # DEPRECATED — legacy plaintext JWT credential; see the module docstring.
+    token: Mapped[str | None] = mapped_column(unique=True, nullable=True)
     owners: Mapped[str] = mapped_column()
     tenant: Mapped[str] = mapped_column()
     status: Mapped[str] = mapped_column(default="ACTIVE")

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -34,6 +34,15 @@ from sqlalchemy.orm import Mapped, mapped_column
 from gateway.community.spi.app import RegisteredApp
 from gateway.community.spi.database import Base
 
+# How many leading characters of an API key form its lookup prefix. A property
+# of the credential scheme, not of storage — but it cannot live in ``_key_gen``,
+# which must stay byte-identical to secbaas's copy, so it is defined here (the
+# module with no intra-package imports) and used by the column width, the
+# repository's lookups, and the registrar's slicing alike. Changing it in only
+# some of those places truncates prefixes in MySQL while passing every SQLite
+# test, since SQLite ignores VARCHAR widths.
+API_KEY_PREFIX_LEN = 8
+
 
 class AppRow(Base):  # type: ignore[misc]
     """A third-party app resolvable by credential (the ``avernet_application`` table)."""
@@ -45,7 +54,7 @@ class AppRow(Base):  # type: ignore[misc]
     app_type: Mapped[str] = mapped_column()
     api_key_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
     api_key_prefix: Mapped[str | None] = mapped_column(
-        String(8), unique=True, nullable=True
+        String(API_KEY_PREFIX_LEN), unique=True, nullable=True
     )
     # DEPRECATED — legacy plaintext JWT credential; see the module docstring.
     token: Mapped[str | None] = mapped_column(unique=True, nullable=True)

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -36,7 +36,7 @@ from gateway.community.spi.database import Base
 
 # How many leading characters of an API key form its lookup prefix. A property
 # of the credential scheme, not of storage — but it cannot live in ``_key_gen``,
-# which must stay byte-identical to secbaas's copy, so it is defined here (the
+# whose code must stay identical to secbaas's copy, so it is defined here (the
 # module with no intra-package imports) and used by the ORM column width, the
 # repository's lookups, and the registrar's slicing.
 #

--- a/src/gateway/src/gateway/community/core/app/_registrar.py
+++ b/src/gateway/src/gateway/community/core/app/_registrar.py
@@ -19,11 +19,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from ._key_gen import APIKeyGenerator
-from ._repository import _PREFIX_LEN, AppRepository
+from ._orm import API_KEY_PREFIX_LEN
+from ._repository import AppRepository, PrefixTakenError
 
 # Prefix collisions are vanishingly unlikely (8 base62 characters), but the
-# column is unique, so a collision would surface as an IntegrityError on insert.
-# Retrying costs nothing and mirrors the secbaas key service.
+# column is unique, so one would otherwise surface as a 500. Retrying costs
+# nothing and mirrors the secbaas key service.
 _MAX_PREFIX_ATTEMPTS = 3
 
 
@@ -65,40 +66,44 @@ class AppRegistrar:
         env: str = "",
         config: dict[str, Any] | None = None,
     ) -> IssuedApp:
-        api_key = await self._allocate_key()
-        # The registering caller is both creator and modifier on register.
-        app_id = await self._repository.store(
-            api_key_hash=APIKeyGenerator.hash_key(api_key),
-            api_key_prefix=api_key[:_PREFIX_LEN],
-            app_name=app_name,
-            owners=owners,
-            app_type=app_type,
-            tenant=tenant,
-            status=status,
-            env=env,
-            config=config,
-            creator=creator,
-            modifier=creator,
-        )
-        return IssuedApp(
-            id=app_id,
-            app_name=app_name,
-            owners=owners,
-            app_type=app_type,
-            tenant=tenant,
-            api_key=api_key,
-        )
+        """Register an app, returning its record and its one-time plaintext key.
 
-    async def _allocate_key(self) -> str:
-        """Generate a key whose prefix no app holds yet.
-
-        Hashing is deliberately left until after a prefix is settled: it costs
-        ~60ms of CPU, and a collision would throw that work away.
+        The insert is inside the retry, not after it: ``exists_prefix`` alone is
+        a check-then-act, and two concurrent registrations that generate the
+        same prefix would both pass it and leave the second insert to fail. The
+        unique index is the real guarantee, so a lost race is retried like any
+        other collision.
         """
         for _ in range(_MAX_PREFIX_ATTEMPTS):
             api_key = APIKeyGenerator.generate()
-            if not await self._repository.exists_prefix(api_key[:_PREFIX_LEN]):
-                return api_key
+            api_key_prefix = api_key[:API_KEY_PREFIX_LEN]
+            if await self._repository.exists_prefix(api_key_prefix):
+                continue  # cheap pre-check: skip the hash we would throw away
+            try:
+                # The registering caller is both creator and modifier.
+                app_id = await self._repository.store(
+                    api_key_hash=APIKeyGenerator.hash_key(api_key),
+                    api_key_prefix=api_key_prefix,
+                    app_name=app_name,
+                    owners=owners,
+                    app_type=app_type,
+                    tenant=tenant,
+                    status=status,
+                    env=env,
+                    config=config,
+                    creator=creator,
+                    modifier=creator,
+                )
+            except PrefixTakenError:
+                continue  # lost the race to a concurrent registration
+            return IssuedApp(
+                id=app_id,
+                app_name=app_name,
+                owners=owners,
+                app_type=app_type,
+                tenant=tenant,
+                api_key=api_key,
+            )
         raise PrefixAllocationError(
             f"no unused API key prefix found in {_MAX_PREFIX_ATTEMPTS} attempts"
         )

--- a/src/gateway/src/gateway/community/core/app/_registrar.py
+++ b/src/gateway/src/gateway/community/core/app/_registrar.py
@@ -111,6 +111,12 @@ class AppRegistrar:
                 tenant=tenant,
                 api_key=api_key,
             )
-        raise PrefixAllocationError(
+        # Chained only when a race actually happened: ``from None`` would set
+        # __suppress_context__ and strip the traceback for the commoner case
+        # where every attempt stopped at the pre-check.
+        error = PrefixAllocationError(
             f"no unused API key prefix found in {_MAX_PREFIX_ATTEMPTS} attempts"
-        ) from last_race
+        )
+        if last_race is not None:
+            raise error from last_race
+        raise error

--- a/src/gateway/src/gateway/community/core/app/_registrar.py
+++ b/src/gateway/src/gateway/community/core/app/_registrar.py
@@ -111,12 +111,8 @@ class AppRegistrar:
                 tenant=tenant,
                 api_key=api_key,
             )
-        # Chained only when a race actually happened: ``from None`` would set
-        # __suppress_context__ and strip the traceback for the commoner case
-        # where every attempt stopped at the pre-check.
-        error = PrefixAllocationError(
+        # ``from last_race`` is a no-op when no race occurred: this raise is
+        # outside any handler, so there is no exception context to suppress.
+        raise PrefixAllocationError(
             f"no unused API key prefix found in {_MAX_PREFIX_ATTEMPTS} attempts"
-        )
-        if last_race is not None:
-            raise error from last_race
-        raise error
+        ) from last_race

--- a/src/gateway/src/gateway/community/core/app/_registrar.py
+++ b/src/gateway/src/gateway/community/core/app/_registrar.py
@@ -15,6 +15,7 @@ returned by ``store``.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
@@ -74,15 +75,20 @@ class AppRegistrar:
         unique index is the real guarantee, so a lost race is retried like any
         other collision.
         """
+        last_race: PrefixTakenError | None = None
         for _ in range(_MAX_PREFIX_ATTEMPTS):
             api_key = APIKeyGenerator.generate()
             api_key_prefix = api_key[:API_KEY_PREFIX_LEN]
             if await self._repository.exists_prefix(api_key_prefix):
                 continue  # cheap pre-check: skip the hash we would throw away
+            # Hashing is the same ~30ms PBKDF2 as verification, so it goes off
+            # the event loop for the same reason: registration must not stall
+            # unrelated traffic, and the retry can run it more than once.
+            api_key_hash = await asyncio.to_thread(APIKeyGenerator.hash_key, api_key)
             try:
                 # The registering caller is both creator and modifier.
                 app_id = await self._repository.store(
-                    api_key_hash=APIKeyGenerator.hash_key(api_key),
+                    api_key_hash=api_key_hash,
                     api_key_prefix=api_key_prefix,
                     app_name=app_name,
                     owners=owners,
@@ -94,8 +100,9 @@ class AppRegistrar:
                     creator=creator,
                     modifier=creator,
                 )
-            except PrefixTakenError:
-                continue  # lost the race to a concurrent registration
+            except PrefixTakenError as exc:
+                last_race = exc  # lost the race to a concurrent registration
+                continue
             return IssuedApp(
                 id=app_id,
                 app_name=app_name,
@@ -106,4 +113,4 @@ class AppRegistrar:
             )
         raise PrefixAllocationError(
             f"no unused API key prefix found in {_MAX_PREFIX_ATTEMPTS} attempts"
-        )
+        ) from last_race

--- a/src/gateway/src/gateway/community/core/app/_registrar.py
+++ b/src/gateway/src/gateway/community/core/app/_registrar.py
@@ -1,54 +1,57 @@
-"""AppRegistrar — register an app: mint a JWT, delegate persistence, return the record.
+"""AppRegistrar — register an app: mint an API key, delegate persistence, return the record.
 
-The issued JWT is stored as the ``token`` of ``avernet_application`` via
-:class:`AppRepository.store` (all DB touch lives in the repository); the authn
-``app_token`` strategy resolves it by opaque DB lookup (``find_app_by_token``).
-App tokens do NOT expire (the table has no ``expire_at``). Shares the gateway
-HMAC key via :class:`PrincipalSigner.sign_token`. The app's stable identity is
-its surrogate ``id`` (returned by ``store``); the JWT ``sub`` is the human-readable
-``app_name`` (the surrogate ``id`` is not known until after insert).
+The generated key is returned to the caller **once**, in
+:attr:`IssuedApp.api_key`. Only its PBKDF2 hash and its 8-character prefix are
+persisted (via :meth:`AppRepository.store`, since all DB touch lives in the
+repository), so the key cannot be recovered from the registry afterwards — a
+lost key means issuing a new one.
+
+App credentials do not expire (the table has no ``expire_at``). Registration no
+longer mints a JWT and therefore no longer needs the gateway
+``PrincipalSigner``; that signer still serves per-request principal assertions
+and access-key issuance. The app's stable identity is its surrogate ``id``,
+returned by ``store``.
 """
 
 from __future__ import annotations
 
-import time
-import uuid
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from gateway.community.spi.principal_signer import PrincipalSigner
+from ._key_gen import APIKeyGenerator
+from ._repository import _PREFIX_LEN, AppRepository
 
-from ._repository import AppRepository
+# Prefix collisions are vanishingly unlikely (8 base62 characters), but the
+# column is unique, so a collision would surface as an IntegrityError on insert.
+# Retrying costs nothing and mirrors the secbaas key service.
+_MAX_PREFIX_ATTEMPTS = 3
 
-_ISSUER = "gateway"
+
+class PrefixAllocationError(RuntimeError):
+    """No unused API-key prefix could be allocated; nothing was written."""
 
 
 @dataclass(frozen=True)
 class IssuedApp:
-    """An app just registered: its record fields plus the freshly minted token."""
+    """An app just registered: its record fields plus the plaintext key.
+
+    ``api_key`` is the only time the plaintext exists outside the caller's
+    hands — the registry keeps just its hash.
+    """
 
     id: int
     app_name: str
     owners: str
     app_type: str
     tenant: str
-    token: str
+    api_key: str
 
 
 class AppRegistrar:
-    """Mint a JWT, persist it via the repository, return the record + token."""
+    """Mint an API key, persist its hash via the repository, return the record."""
 
-    def __init__(
-        self,
-        repository: AppRepository,
-        signer: PrincipalSigner,
-        *,
-        clock: Callable[[], float] = time.time,
-    ) -> None:
+    def __init__(self, repository: AppRepository) -> None:
         self._repository = repository
-        self._signer = signer
-        self._clock = clock
 
     async def register(
         self,
@@ -62,18 +65,11 @@ class AppRegistrar:
         env: str = "",
         config: dict[str, Any] | None = None,
     ) -> IssuedApp:
-        claims = {
-            "iss": _ISSUER,
-            "typ": "app",
-            "sub": app_name,
-            "tenant": tenant,
-            "iat": int(self._clock()),
-            "jti": uuid.uuid4().hex,
-        }
-        token = await self._signer.sign_token(claims)
+        api_key = await self._allocate_key()
         # The registering caller is both creator and modifier on register.
         app_id = await self._repository.store(
-            token=token,
+            api_key_hash=APIKeyGenerator.hash_key(api_key),
+            api_key_prefix=api_key[:_PREFIX_LEN],
             app_name=app_name,
             owners=owners,
             app_type=app_type,
@@ -90,5 +86,19 @@ class AppRegistrar:
             owners=owners,
             app_type=app_type,
             tenant=tenant,
-            token=token,
+            api_key=api_key,
+        )
+
+    async def _allocate_key(self) -> str:
+        """Generate a key whose prefix no app holds yet.
+
+        Hashing is deliberately left until after a prefix is settled: it costs
+        ~60ms of CPU, and a collision would throw that work away.
+        """
+        for _ in range(_MAX_PREFIX_ATTEMPTS):
+            api_key = APIKeyGenerator.generate()
+            if not await self._repository.exists_prefix(api_key[:_PREFIX_LEN]):
+                return api_key
+        raise PrefixAllocationError(
+            f"no unused API key prefix found in {_MAX_PREFIX_ATTEMPTS} attempts"
         )

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -171,7 +171,7 @@ class AppRepository(AppRegistry):
             # shape is checked first to tell corruption apart from a bad
             # credential. Deeper corruption (valid shape, unusable base64) still
             # reads as a plain rejection — that branch is inside the copied
-            # generator, which cannot be edited without breaking parity.
+            # generator, whose code cannot be edited without breaking parity.
             self._report_corrupt(record, "api_key_hash is not 'salt:digest'")
             return None
 

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -21,11 +21,14 @@ from typing import Any
 
 from sqlalchemy import select
 
+from gateway.community.logger import get_logger
 from gateway.community.spi.app import AppRegistry, RegisteredApp
 from gateway.community.spi.database import DataSourcePlugin
 
 from ._key_gen import APIKeyGenerator
 from ._orm import AppRow
+
+logger = get_logger("core-app")
 
 _ACTIVE = "ACTIVE"
 
@@ -46,12 +49,19 @@ class AppRepository(AppRegistry):
         self._db = db
 
     async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
-        """Resolve a presented credential to its app, or ``None`` (soft miss)."""
+        """Resolve a presented credential to its app, or ``None`` (soft miss).
+
+        Two credential forms are in play during the transition window, and they
+        are told apart by *format*, not by trying one and falling back: an API
+        key is 32 base62 characters and a JWT always contains ``.``, so the two
+        sets cannot overlap. Each call therefore makes exactly one query, and
+        neither form can be silently served by the other's path.
+        """
         if not credential or len(credential) < _PREFIX_LEN:
             return None  # too short to carry a prefix — reject without a query
         if APIKeyGenerator.validate_format(credential):
             return self._by_api_key(credential)
-        return None
+        return self._by_legacy_token(credential)
 
     def _by_api_key(self, api_key: str) -> RegisteredApp | None:
         """Locate by prefix, then verify the hash in constant time.
@@ -78,6 +88,35 @@ class AppRepository(AppRegistry):
         # reason to hold a pooled connection across it.
         if not APIKeyGenerator.verify_key(api_key, stored_hash):
             return None
+        return record
+
+    def _by_legacy_token(self, token: str) -> RegisteredApp | None:
+        """DEPRECATED — resolve a pre-API-key app by its plaintext JWT.
+
+        Kept only so credentials issued before the API-key scheme keep working
+        while their holders rotate. Every hit logs at WARNING; once that log
+        goes quiet in production, delete this method, its branch in
+        :meth:`find_app_by_credential`, ``AppRow.token``, and the column's
+        unique index.
+        """
+        with self._db.orm_session() as session:
+            row = session.scalar(
+                select(self.Model).where(
+                    self.Model.token == token,
+                    self.Model.status == _ACTIVE,
+                )
+            )
+            if row is None:
+                return None
+            record = row.to_record()
+
+        logger.warning(
+            "app authenticated with a deprecated JWT token: "
+            "id=%s app_name=%s tenant=%s — rotate this app onto an API key",
+            record.id,
+            record.app_name,
+            record.tenant,
+        )
         return record
 
     async def exists_prefix(self, api_key_prefix: str) -> bool:

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -2,13 +2,17 @@
 
 One ORM implementation behind the
 :class:`~gateway.community.spi.app.AppRegistry` SPI port. Resolves a presented
-app token via the ``avernet_application`` table through the
+credential via the ``avernet_application`` table through the
 :data:`~gateway.community.spi.database.DataSourcePlugin`'s sync ``orm_session``,
 mapping the row to the SPI :class:`~gateway.community.spi.app.RegisteredApp` via
 :meth:`AppRow.to_record`. Flavor-neutral — the ``DataSourcePlugin`` (bare
 in-memory SQLite or a sofa real DB) is injected by the composition root, so this
 single body runs unchanged across runtimes (mirrors ``BotRepository`` /
 ``AccessKeyRepository``).
+
+Verification lives here rather than in the authn strategy: the strategy is
+handed an opaque credential and gets back an app or nothing, so how credentials
+are stored stays a storage concern.
 """
 
 from __future__ import annotations
@@ -20,13 +24,19 @@ from sqlalchemy import select
 from gateway.community.spi.app import AppRegistry, RegisteredApp
 from gateway.community.spi.database import DataSourcePlugin
 
+from ._key_gen import APIKeyGenerator
 from ._orm import AppRow
+
+_ACTIVE = "ACTIVE"
+
+# The API-key prefix length, and the shortest credential worth a lookup.
+_PREFIX_LEN = 8
 
 
 class AppRepository(AppRegistry):
     """App table access (read + write) for ``avernet_application``.
 
-    Resolves a presented token (read) and persists a freshly registered app
+    Resolves a presented credential (read) and persists a freshly registered app
     (write) — all DB touch lives here, never in the registrar.
     """
 
@@ -35,20 +45,59 @@ class AppRepository(AppRegistry):
     def __init__(self, db: DataSourcePlugin) -> None:
         self._db = db
 
-    async def find_app_by_token(self, token: str) -> RegisteredApp | None:
+    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
+        """Resolve a presented credential to its app, or ``None`` (soft miss)."""
+        if not credential or len(credential) < _PREFIX_LEN:
+            return None  # too short to carry a prefix — reject without a query
+        if APIKeyGenerator.validate_format(credential):
+            return self._by_api_key(credential)
+        return None
+
+    def _by_api_key(self, api_key: str) -> RegisteredApp | None:
+        """Locate by prefix, then verify the hash in constant time.
+
+        The prefix is the lookup key because the stored hash is salted: deriving
+        it requires the row's own salt, which requires already having the row.
+        """
         with self._db.orm_session() as session:
-            row = session.scalar(select(self.Model).where(self.Model.token == token))
-            return None if row is None else row.to_record()
+            row = session.scalar(
+                select(self.Model).where(
+                    self.Model.api_key_prefix == api_key[:_PREFIX_LEN],
+                    self.Model.status == _ACTIVE,
+                )
+            )
+            if row is None:
+                return None
+            # Read both inside the session: attribute access on an expired row
+            # after the block would raise DetachedInstanceError.
+            stored_hash, record = row.api_key_hash, row.to_record()
+
+        if stored_hash is None:
+            return None  # an api-key prefix with no hash is a malformed row
+        # Verify outside the session — PBKDF2 is ~60ms of CPU, and there is no
+        # reason to hold a pooled connection across it.
+        if not APIKeyGenerator.verify_key(api_key, stored_hash):
+            return None
+        return record
+
+    async def exists_prefix(self, api_key_prefix: str) -> bool:
+        """Whether any app already claims this API-key prefix."""
+        with self._db.orm_session() as session:
+            found = session.scalar(
+                select(self.Model.id).where(self.Model.api_key_prefix == api_key_prefix)
+            )
+        return found is not None
 
     async def store(
         self,
         *,
-        token: str,
+        api_key_hash: str,
+        api_key_prefix: str,
         app_name: str,
         owners: str,
         app_type: str,
         tenant: str,
-        status: str = "ACTIVE",
+        status: str = _ACTIVE,
         env: str = "",
         config: dict[str, Any] | None = None,
         creator: str = "",
@@ -56,13 +105,15 @@ class AppRepository(AppRegistry):
     ) -> int:
         """Persist a freshly registered app; return its inserted surrogate ``id``.
 
-        ``token`` is the app's JWT (the unique lookup key). Optional ``status`` /
-        ``env`` / ``config`` default to ``ACTIVE`` / ``""`` / ``{}``; ``creator`` /
-        ``modifier`` default to ``""`` (the unauthenticated admin has no caller).
+        Takes the hashed credential and its prefix — the plaintext key is never
+        passed here and never stored. Optional ``status`` / ``env`` / ``config``
+        default to ``ACTIVE`` / ``""`` / ``{}``; ``creator`` / ``modifier``
+        default to ``""`` (the unauthenticated admin has no caller).
         """
         with self._db.orm_session() as session:
             row = AppRow(
-                token=token,
+                api_key_hash=api_key_hash,
+                api_key_prefix=api_key_prefix,
                 app_name=app_name,
                 app_type=app_type,
                 owners=owners,

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -18,6 +18,8 @@ are stored stays a storage concern.
 from __future__ import annotations
 
 import asyncio
+import time
+from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy import select
@@ -34,38 +36,43 @@ logger = get_logger("core-app")
 
 _ACTIVE = "ACTIVE"
 
-# App ids already reported — once for still presenting a legacy JWT, once for a
-# corrupt credential row. Reporting once per app rather than once per request
-# keeps both signals readable: the question is *which* apps are affected, and one
-# busy app would otherwise emit millions of lines a day and bury a quiet one. A
-# corrupt row is the worse case, since it can never authenticate and its client
-# retries forever. Module-level because the DI container builds this repository
-# per request (``providers.Factory``), so instance state would never survive long
-# enough to dedupe anything.
-_warned_legacy_apps: set[int] = set()
-_reported_corrupt_apps: set[int] = set()
+# When each (datasource, app) was last reported, for the two per-request
+# conditions worth reporting: an app still presenting a legacy JWT, and a
+# credential row that cannot ever authenticate. Reporting every request would
+# bury both signals — one busy app emits millions of lines a day — but reporting
+# only once per process is worse for the corrupt-row case, which is a live
+# outage: a single line at deploy time leaves every rate-based alert reading zero
+# for the hours it persists. Hence a re-report window rather than a one-shot set.
+#
+# Keyed on the datasource too, because ``AppRow.id`` is a per-database surrogate:
+# two plugins in one process both number their apps from 1, and a bare id would
+# let one silence the other. Module-level because the DI container builds this
+# repository per request (``providers.Factory``), so instance state would never
+# survive long enough to dedupe anything.
+_REPORT_WINDOW_SECONDS = 300.0
+_last_reported: dict[tuple[str, int, int], float] = {}
 
 
 class PrefixTakenError(RuntimeError):
     """The API-key prefix was claimed concurrently; generate another and retry."""
 
 
-def _report_corrupt_row(record: RegisteredApp, problem: str) -> None:
-    """Log a credential row that cannot ever authenticate, once per app.
-
-    Loud because the symptom otherwise is an app that mysteriously fails while
-    its row looks perfectly fine to whoever is reading the table.
-    """
-    if record.id in _reported_corrupt_apps:
+def _report_once_per_window(
+    kind: str,
+    datasource: object,
+    record: RegisteredApp,
+    log: Callable[..., None],
+    message: str,
+    *args: object,
+) -> None:
+    """Emit ``message`` for this app at most once per report window."""
+    key = (kind, id(datasource), record.id)
+    now = time.monotonic()
+    last = _last_reported.get(key)
+    if last is not None and now - last < _REPORT_WINDOW_SECONDS:
         return
-    _reported_corrupt_apps.add(record.id)
-    logger.error(
-        "app credential row is unusable (%s): id=%s app_name=%s "
-        "(logged once per app per process)",
-        problem,
-        record.id,
-        record.app_name,
-    )
+    _last_reported[key] = now
+    log(message, *args)
 
 
 class AppRepository(AppRegistry):
@@ -79,6 +86,25 @@ class AppRepository(AppRegistry):
 
     def __init__(self, db: DataSourcePlugin) -> None:
         self._db = db
+
+    def _report_corrupt(self, record: RegisteredApp, problem: str) -> None:
+        """A row that can never authenticate — a partial write or bad migration.
+
+        Loud, because the symptom otherwise is an app failing every request
+        while its row looks perfectly fine to whoever is reading the table.
+        """
+        _report_once_per_window(
+            "corrupt-row",
+            self._db,
+            record,
+            logger.error,
+            "app credential row is unusable (%s): id=%s app_name=%s "
+            "(repeated at most every %ss)",
+            problem,
+            record.id,
+            record.app_name,
+            int(_REPORT_WINDOW_SECONDS),
+        )
 
     async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
         """Resolve a presented credential to its app, or ``None`` (soft miss).
@@ -117,7 +143,7 @@ class AppRepository(AppRegistry):
         if stored_hash is None:
             # Violates the table's one-credential-form invariant: a partial
             # write or a botched migration.
-            _report_corrupt_row(record, "api_key_prefix set but api_key_hash is NULL")
+            self._report_corrupt(record, "api_key_prefix set but api_key_hash is NULL")
             return None
         if stored_hash.count(":") != 1 or not all(stored_hash.split(":")):
             # ``verify_key`` would return False here like any wrong key, so the
@@ -125,7 +151,7 @@ class AppRepository(AppRegistry):
             # credential. Deeper corruption (valid shape, unusable base64) still
             # reads as a plain rejection — that branch is inside the copied
             # generator, which cannot be edited without breaking parity.
-            _report_corrupt_row(record, "api_key_hash is not 'salt:digest'")
+            self._report_corrupt(record, "api_key_hash is not 'salt:digest'")
             return None
 
         # PBKDF2 is ~30ms of CPU and must not run on the event loop: measured
@@ -158,16 +184,19 @@ class AppRepository(AppRegistry):
                 return None
             record = row.to_record()
 
-        if record.id not in _warned_legacy_apps:
-            _warned_legacy_apps.add(record.id)
-            logger.warning(
-                "app is still authenticating with a deprecated JWT token: "
-                "id=%s app_name=%s tenant=%s — rotate it onto an API key "
-                "(logged once per app per process)",
-                record.id,
-                record.app_name,
-                record.tenant,
-            )
+        _report_once_per_window(
+            "legacy-jwt",
+            self._db,
+            record,
+            logger.warning,
+            "app is still authenticating with a deprecated JWT token: "
+            "id=%s app_name=%s tenant=%s — rotate it onto an API key "
+            "(repeated at most every %ss)",
+            record.id,
+            record.app_name,
+            record.tenant,
+            int(_REPORT_WINDOW_SECONDS),
+        )
         return record
 
     async def exists_prefix(self, api_key_prefix: str) -> bool:
@@ -222,9 +251,11 @@ class AppRepository(AppRegistry):
                 session.flush()
                 return row.id
         except IntegrityError as exc:
-            # Only a prefix collision is retryable. Mapping every IntegrityError
+            # Only a prefix collision is retryable: mapping every IntegrityError
             # would turn a NOT NULL or FK violation into three silent retries and
             # a "no unused prefix" error naming the wrong cause entirely.
-            if "api_key_prefix" not in str(exc.orig):
+            # Decided by re-reading the table rather than by matching the driver's
+            # message, which differs per backend and moves with index names.
+            if not await self.exists_prefix(api_key_prefix):
                 raise
             raise PrefixTakenError(api_key_prefix) from exc

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -21,6 +21,7 @@ import asyncio
 import time
 from collections.abc import Callable
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -50,7 +51,12 @@ _ACTIVE = "ACTIVE"
 # repository per request (``providers.Factory``), so instance state would never
 # survive long enough to dedupe anything.
 _REPORT_WINDOW_SECONDS = 300.0
-_last_reported: dict[tuple[str, int, int], float] = {}
+# Keyed on the plugin object itself, not ``id()``: an address is recycled after
+# collection, so a replacement datasource would inherit a dead one's window. The
+# weak map also drops a plugin's entries when it goes away.
+_last_reported: WeakKeyDictionary[object, dict[tuple[str, int], float]] = (
+    WeakKeyDictionary()
+)
 
 
 class PrefixTakenError(RuntimeError):
@@ -66,13 +72,28 @@ def _report_once_per_window(
     *args: object,
 ) -> None:
     """Emit ``message`` for this app at most once per report window."""
-    key = (kind, id(datasource), record.id)
+    try:
+        seen = _last_reported.setdefault(datasource, {})
+    except TypeError:  # a datasource that cannot be weak-referenced
+        log(message, *args, stacklevel=3)
+        return
+
+    key = (kind, record.id)
     now = time.monotonic()
-    last = _last_reported.get(key)
+    last = seen.get(key)
     if last is not None and now - last < _REPORT_WINDOW_SECONDS:
         return
-    _last_reported[key] = now
-    log(message, *args)
+    # Expired entries are due to re-report anyway, so dropping them here keeps
+    # the map from growing for the process lifetime.
+    for stale, when in list(seen.items()):
+        if now - when >= _REPORT_WINDOW_SECONDS:
+            del seen[stale]
+    # ``stacklevel=3`` so the record names the branch that found the problem
+    # rather than this helper, keeping the two conditions distinguishable to any
+    # pipeline that routes on source location. Stamped only after a successful
+    # emit, so a failing handler cannot consume the window silently.
+    log(message, *args, stacklevel=3)
+    seen[key] = now
 
 
 class AppRepository(AppRegistry):
@@ -168,10 +189,11 @@ class AppRepository(AppRegistry):
         """DEPRECATED — resolve a pre-API-key app by its plaintext JWT.
 
         Kept only so credentials issued before the API-key scheme keep working
-        while their holders rotate. The first hit from each app logs at WARNING;
-        once that log stops appearing across a full deploy cycle, delete this
-        method, its branch in :meth:`find_app_by_credential`, ``AppRow.token``,
-        and the column's unique index.
+        while their holders rotate. Each still-unrotated app re-warns at most
+        once per report window, so the log is a live census rather than a
+        one-shot notice; once it stops naming any app across a full deploy
+        cycle, delete this method, its branch in
+        :meth:`find_app_by_credential`, ``AppRow.token``, and its unique index.
         """
         with self._db.orm_session() as session:
             row = session.scalar(
@@ -255,7 +277,10 @@ class AppRepository(AppRegistry):
             # would turn a NOT NULL or FK violation into three silent retries and
             # a "no unused prefix" error naming the wrong cause entirely.
             # Decided by re-reading the table rather than by matching the driver's
-            # message, which differs per backend and moves with index names.
+            # message, which differs per backend and moves with index names. The
+            # re-read runs in a fresh transaction, so a collision whose winning
+            # row disappeared in between would escape as a raw IntegrityError —
+            # no delete path exists for app rows, so that cannot happen here.
             if not await self.exists_prefix(api_key_prefix):
                 raise
             raise PrefixTakenError(api_key_prefix) from exc

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -17,23 +17,34 @@ are stored stays a storage concern.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from gateway.community.logger import get_logger
 from gateway.community.spi.app import AppRegistry, RegisteredApp
 from gateway.community.spi.database import DataSourcePlugin
 
 from ._key_gen import APIKeyGenerator
-from ._orm import AppRow
+from ._orm import API_KEY_PREFIX_LEN, AppRow
 
 logger = get_logger("core-app")
 
 _ACTIVE = "ACTIVE"
 
-# The API-key prefix length, and the shortest credential worth a lookup.
-_PREFIX_LEN = 8
+# App ids already reported as still presenting a legacy JWT. Warning once per
+# app rather than once per request keeps the deprecation signal readable: the
+# question is *which* apps still need rotating, and one busy app would otherwise
+# emit millions of lines a day and bury a quiet one. Module-level because the DI
+# container builds this repository per request (``providers.Factory``), so
+# instance state would never survive long enough to dedupe anything.
+_warned_legacy_apps: set[int] = set()
+
+
+class PrefixTakenError(RuntimeError):
+    """The API-key prefix was claimed concurrently; generate another and retry."""
 
 
 class AppRepository(AppRegistry):
@@ -57,13 +68,13 @@ class AppRepository(AppRegistry):
         sets cannot overlap. Each call therefore makes exactly one query, and
         neither form can be silently served by the other's path.
         """
-        if not credential or len(credential) < _PREFIX_LEN:
+        if not credential or len(credential) < API_KEY_PREFIX_LEN:
             return None  # too short to carry a prefix — reject without a query
         if APIKeyGenerator.validate_format(credential):
-            return self._by_api_key(credential)
+            return await self._by_api_key(credential)
         return self._by_legacy_token(credential)
 
-    def _by_api_key(self, api_key: str) -> RegisteredApp | None:
+    async def _by_api_key(self, api_key: str) -> RegisteredApp | None:
         """Locate by prefix, then verify the hash in constant time.
 
         The prefix is the lookup key because the stored hash is salted: deriving
@@ -72,7 +83,7 @@ class AppRepository(AppRegistry):
         with self._db.orm_session() as session:
             row = session.scalar(
                 select(self.Model).where(
-                    self.Model.api_key_prefix == api_key[:_PREFIX_LEN],
+                    self.Model.api_key_prefix == api_key[:API_KEY_PREFIX_LEN],
                     self.Model.status == _ACTIVE,
                 )
             )
@@ -83,21 +94,35 @@ class AppRepository(AppRegistry):
             stored_hash, record = row.api_key_hash, row.to_record()
 
         if stored_hash is None:
-            return None  # an api-key prefix with no hash is a malformed row
-        # Verify outside the session — PBKDF2 is ~60ms of CPU, and there is no
-        # reason to hold a pooled connection across it.
-        if not APIKeyGenerator.verify_key(api_key, stored_hash):
+            # Violates the table's one-credential-form invariant — a partial
+            # write or a botched migration. Logged loudly, because the symptom
+            # otherwise is an app that cannot authenticate while its row looks
+            # perfectly fine to whoever is reading the table.
+            logger.error(
+                "app row has an api_key_prefix but no api_key_hash: id=%s app_name=%s",
+                record.id,
+                record.app_name,
+            )
             return None
-        return record
+
+        # PBKDF2 is ~30ms of CPU and must not run on the event loop: measured
+        # inline, ten concurrent verifications stall every other coroutine for
+        # the full ~300ms — unrelated user traffic, WebSocket relays, health
+        # checks alike. ``pbkdf2_hmac`` releases the GIL, so a worker thread also
+        # lets concurrent verifications genuinely overlap.
+        verified = await asyncio.to_thread(
+            APIKeyGenerator.verify_key, api_key, stored_hash
+        )
+        return record if verified else None
 
     def _by_legacy_token(self, token: str) -> RegisteredApp | None:
         """DEPRECATED — resolve a pre-API-key app by its plaintext JWT.
 
         Kept only so credentials issued before the API-key scheme keep working
-        while their holders rotate. Every hit logs at WARNING; once that log
-        goes quiet in production, delete this method, its branch in
-        :meth:`find_app_by_credential`, ``AppRow.token``, and the column's
-        unique index.
+        while their holders rotate. The first hit from each app logs at WARNING;
+        once that log stops appearing across a full deploy cycle, delete this
+        method, its branch in :meth:`find_app_by_credential`, ``AppRow.token``,
+        and the column's unique index.
         """
         with self._db.orm_session() as session:
             row = session.scalar(
@@ -110,13 +135,16 @@ class AppRepository(AppRegistry):
                 return None
             record = row.to_record()
 
-        logger.warning(
-            "app authenticated with a deprecated JWT token: "
-            "id=%s app_name=%s tenant=%s — rotate this app onto an API key",
-            record.id,
-            record.app_name,
-            record.tenant,
-        )
+        if record.id not in _warned_legacy_apps:
+            _warned_legacy_apps.add(record.id)
+            logger.warning(
+                "app is still authenticating with a deprecated JWT token: "
+                "id=%s app_name=%s tenant=%s — rotate it onto an API key "
+                "(logged once per app per process)",
+                record.id,
+                record.app_name,
+                record.tenant,
+            )
         return record
 
     async def exists_prefix(self, api_key_prefix: str) -> bool:
@@ -145,24 +173,30 @@ class AppRepository(AppRegistry):
         """Persist a freshly registered app; return its inserted surrogate ``id``.
 
         Takes the hashed credential and its prefix — the plaintext key is never
-        passed here and never stored. Optional ``status`` / ``env`` / ``config``
-        default to ``ACTIVE`` / ``""`` / ``{}``; ``creator`` / ``modifier``
-        default to ``""`` (the unauthenticated admin has no caller).
+        passed here and never stored. Raises :class:`PrefixTakenError` when the
+        prefix was claimed between the caller's check and this insert, so the
+        caller can retry with a fresh key: the unique index, not the check, is
+        what actually guarantees uniqueness. Optional ``status`` / ``env`` /
+        ``config`` default to ``ACTIVE`` / ``""`` / ``{}``; ``creator`` /
+        ``modifier`` default to ``""`` (the unauthenticated admin has no caller).
         """
-        with self._db.orm_session() as session:
-            row = AppRow(
-                api_key_hash=api_key_hash,
-                api_key_prefix=api_key_prefix,
-                app_name=app_name,
-                app_type=app_type,
-                owners=owners,
-                tenant=tenant,
-                status=status,
-                env=env,
-                config={} if config is None else config,
-                creator=creator,
-                modifier=modifier,
-            )
-            session.add(row)
-            session.flush()
-            return row.id
+        try:
+            with self._db.orm_session() as session:
+                row = AppRow(
+                    api_key_hash=api_key_hash,
+                    api_key_prefix=api_key_prefix,
+                    app_name=app_name,
+                    app_type=app_type,
+                    owners=owners,
+                    tenant=tenant,
+                    status=status,
+                    env=env,
+                    config={} if config is None else config,
+                    creator=creator,
+                    modifier=modifier,
+                )
+                session.add(row)
+                session.flush()
+                return row.id
+        except IntegrityError as exc:
+            raise PrefixTakenError(api_key_prefix) from exc

--- a/src/gateway/src/gateway/community/core/app/_repository.py
+++ b/src/gateway/src/gateway/community/core/app/_repository.py
@@ -34,17 +34,38 @@ logger = get_logger("core-app")
 
 _ACTIVE = "ACTIVE"
 
-# App ids already reported as still presenting a legacy JWT. Warning once per
-# app rather than once per request keeps the deprecation signal readable: the
-# question is *which* apps still need rotating, and one busy app would otherwise
-# emit millions of lines a day and bury a quiet one. Module-level because the DI
-# container builds this repository per request (``providers.Factory``), so
-# instance state would never survive long enough to dedupe anything.
+# App ids already reported — once for still presenting a legacy JWT, once for a
+# corrupt credential row. Reporting once per app rather than once per request
+# keeps both signals readable: the question is *which* apps are affected, and one
+# busy app would otherwise emit millions of lines a day and bury a quiet one. A
+# corrupt row is the worse case, since it can never authenticate and its client
+# retries forever. Module-level because the DI container builds this repository
+# per request (``providers.Factory``), so instance state would never survive long
+# enough to dedupe anything.
 _warned_legacy_apps: set[int] = set()
+_reported_corrupt_apps: set[int] = set()
 
 
 class PrefixTakenError(RuntimeError):
     """The API-key prefix was claimed concurrently; generate another and retry."""
+
+
+def _report_corrupt_row(record: RegisteredApp, problem: str) -> None:
+    """Log a credential row that cannot ever authenticate, once per app.
+
+    Loud because the symptom otherwise is an app that mysteriously fails while
+    its row looks perfectly fine to whoever is reading the table.
+    """
+    if record.id in _reported_corrupt_apps:
+        return
+    _reported_corrupt_apps.add(record.id)
+    logger.error(
+        "app credential row is unusable (%s): id=%s app_name=%s "
+        "(logged once per app per process)",
+        problem,
+        record.id,
+        record.app_name,
+    )
 
 
 class AppRepository(AppRegistry):
@@ -94,15 +115,17 @@ class AppRepository(AppRegistry):
             stored_hash, record = row.api_key_hash, row.to_record()
 
         if stored_hash is None:
-            # Violates the table's one-credential-form invariant — a partial
-            # write or a botched migration. Logged loudly, because the symptom
-            # otherwise is an app that cannot authenticate while its row looks
-            # perfectly fine to whoever is reading the table.
-            logger.error(
-                "app row has an api_key_prefix but no api_key_hash: id=%s app_name=%s",
-                record.id,
-                record.app_name,
-            )
+            # Violates the table's one-credential-form invariant: a partial
+            # write or a botched migration.
+            _report_corrupt_row(record, "api_key_prefix set but api_key_hash is NULL")
+            return None
+        if stored_hash.count(":") != 1 or not all(stored_hash.split(":")):
+            # ``verify_key`` would return False here like any wrong key, so the
+            # shape is checked first to tell corruption apart from a bad
+            # credential. Deeper corruption (valid shape, unusable base64) still
+            # reads as a plain rejection — that branch is inside the copied
+            # generator, which cannot be edited without breaking parity.
+            _report_corrupt_row(record, "api_key_hash is not 'salt:digest'")
             return None
 
         # PBKDF2 is ~30ms of CPU and must not run on the event loop: measured
@@ -199,4 +222,9 @@ class AppRepository(AppRegistry):
                 session.flush()
                 return row.id
         except IntegrityError as exc:
+            # Only a prefix collision is retryable. Mapping every IntegrityError
+            # would turn a NOT NULL or FK violation into three silent retries and
+            # a "no unused prefix" error naming the wrong cause entirely.
+            if "api_key_prefix" not in str(exc.orig):
+                raise
             raise PrefixTakenError(api_key_prefix) from exc

--- a/src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/app_token/_strategy.py
@@ -1,12 +1,19 @@
 """App-identity strategy — ``Authorization: Bearer`` (or ``x-avernet-app-token``) → ``AppPrincipal``.
 
-An ``Authorization: Bearer <app_token>`` is the default source; if absent, the
+An ``Authorization: Bearer <credential>`` is the default source; if absent, the
 dedicated ``x-avernet-app-token`` header is used as a fallback (so a caller may
-present the app token either way). The strategy resolves the app — and its
-tenant — in one registry lookup: ``find_app_by_token(token) → RegisteredApp | None``.
-The app record's ``tenant`` is the authoritative tenant for the principal.
+present the credential either way). The strategy resolves the app — and its
+tenant — in one registry lookup:
+``find_app_by_credential(credential) → RegisteredApp | None``. The app record's
+``tenant`` is the authoritative tenant for the principal.
 
-A token that the registry does not recognise is treated as absent (returns
+The credential is opaque here. Apps present an API key; apps registered before
+that scheme present the JWT they were issued, which the registry still accepts
+through a deprecated path for the duration of the transition window. Which form
+arrived, and how it is verified, are the registry's business — this strategy
+only asks whether some app owns it.
+
+A credential the registry does not recognise is treated as absent (returns
 ``None``), so other Bearer-based chains (e.g. bot_token) may resolve the same
 credential (US27 — each chain adjudicates independently).
 """
@@ -60,12 +67,14 @@ class AppTokenStrategy:
         app_token = extract_app_token(creds, self._token_header)
         if not app_token:
             return None  # no app token → strategy not applicable
-        record = await self._registry.find_app_by_token(app_token)
+        record = await self._registry.find_app_by_credential(app_token)
         if record is None:
-            logger.debug("app token not found in registry")
+            logger.debug("app credential not resolved by the registry")
             return None  # not one of mine → absent; another chain may resolve this Bearer (US27)
         logger.debug(
-            "app token resolved: app_name=%s tenant=%s", record.app_name, record.tenant
+            "app credential resolved: app_name=%s tenant=%s",
+            record.app_name,
+            record.tenant,
         )
         return AppPrincipal(
             tenant=record.tenant,

--- a/src/gateway/src/gateway/community/spi/app/_ports.py
+++ b/src/gateway/src/gateway/community/spi/app/_ports.py
@@ -1,8 +1,10 @@
 """App-domain SPI — the ``AppRegistry`` contract.
 
-A third-party app is resolved from a presented token by an :class:`AppRegistry`
-implementation (the canonical ORM impl lives in ``core/app``). The authn
-``app_token`` strategy depends on this interface, not on the impl.
+A third-party app is resolved from a presented credential by an
+:class:`AppRegistry` implementation (the canonical ORM impl lives in
+``core/app``). The authn ``app_token`` strategy depends on this interface, not
+on the impl — in particular it does not know how the credential is stored or
+verified.
 """
 
 from __future__ import annotations
@@ -13,12 +15,12 @@ from typing import Protocol
 
 @dataclass(frozen=True)
 class RegisteredApp:
-    """A third-party app a registry resolves a token to (registry record).
+    """A third-party app a registry resolves a credential to (registry record).
 
     ``id`` is the app's surrogate bigint id (``avernet_application.id``) — its
     stable identity. ``tenant`` is the tenant the app belongs to — the
     authoritative tenant for the resulting
-    :class:`~gateway.community.spi.authn.AppPrincipal` (read from the app-token
+    :class:`~gateway.community.spi.authn.AppPrincipal` (read from the app
     record, no longer cross-checked against a tenant header).
     """
 
@@ -30,11 +32,13 @@ class RegisteredApp:
 
 
 class AppRegistry(Protocol):
-    """Read-only third-party-app store keyed by token (resolved by the
-    ``app_token`` strategy).
+    """Third-party-app store resolving a presented credential to its app.
 
-    ``find_app_by_token`` returns ``None`` for an unknown token (soft miss —
-    not applicable), never raising on a bad token.
+    ``find_app_by_credential`` returns ``None`` for anything it does not
+    recognise — a malformed credential, an unknown one, one whose app is not
+    ``ACTIVE``, or one that fails verification. All of these are soft misses
+    (not applicable), never exceptions, so another identity chain may still
+    claim the same credential.
     """
 
-    async def find_app_by_token(self, token: str) -> RegisteredApp | None: ...
+    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None: ...

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -61,8 +61,8 @@ class _FakeAppRegistry:
         tenant="t",
     )
 
-    async def find_app_by_token(self, token: str) -> RegisteredApp | None:
-        return self._APP if token == "app-key" else None
+    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
+        return self._APP if credential == "app-key" else None
 
 
 class AuthStrategyContract:

--- a/src/gateway/tests/integration/test_admin_issuance.py
+++ b/src/gateway/tests/integration/test_admin_issuance.py
@@ -144,3 +144,48 @@ async def test_issuance_failure_returns_500() -> None:
             },
         )
     assert resp.status_code == 500
+
+
+@pytest.mark.parametrize("status", ["ACTIVE", "INACTIVE"])
+async def test_register_app_accepts_initial_statuses(status: str) -> None:
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/admin/apps",
+            json={
+                "app_name": "Status App",
+                "owners": "org-1",
+                "app_type": "assistant",
+                "tenant": "t",
+                "creator": "admin",
+                "status": status,
+            },
+        )
+    assert resp.status_code == 201
+    assert resp.json()["status"] == status
+
+
+@pytest.mark.parametrize("status", ["REVOKED", "active", "Active", "ENABLED", ""])
+async def test_register_app_rejects_unusable_statuses(status: str) -> None:
+    """A status the lookup will not match must not mint a dead credential.
+
+    Authentication compares against "ACTIVE" exactly, so a casing typo would
+    otherwise return 201 with a key that can never authenticate. REVOKED is
+    refused for the same reason — it is a transition, not an initial state.
+    """
+    app = create_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/admin/apps",
+            json={
+                "app_name": "Bad Status App",
+                "owners": "org-1",
+                "app_type": "assistant",
+                "tenant": "t",
+                "creator": "admin",
+                "status": status,
+            },
+        )
+    assert resp.status_code == 422

--- a/src/gateway/tests/integration/test_admin_issuance.py
+++ b/src/gateway/tests/integration/test_admin_issuance.py
@@ -9,13 +9,14 @@ from httpx import ASGITransport, AsyncClient
 from gateway.community.adapters.web.app import create_app
 from gateway.community.bootstrap import get_container
 from gateway.community.core.access_key import AccessKeyRepository
-from gateway.community.core.app import AppRepository
+from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
 
-# Issued credentials are signed with the gateway's principal signing key, so
-# these tests provision one the way a deployment does. They previously decoded
-# with the plugin's committed dev fallback; that fallback is gone, because
-# minting access-key and app tokens under a key published in the source tree
-# means anyone holding the source can mint them too.
+# Access keys are signed with the gateway's principal signing key, so these
+# tests provision one the way a deployment does. They previously decoded with
+# the plugin's committed dev fallback; that fallback is gone, because minting
+# access-key tokens under a key published in the source tree means anyone
+# holding the source can mint them too. (App registration no longer signs
+# anything — it mints a random API key and stores only its hash.)
 _TEST_KEY = "integration-test-shared-secret-32b!!"
 
 
@@ -76,16 +77,22 @@ async def test_register_app_via_http() -> None:
     assert body["app_name"] == "Http App"
     assert body["tenant"] == "t"
     assert body["status"] == "ACTIVE"
-    token = body["token"]
 
-    decoded = jwt.decode(token, _TEST_KEY, algorithms=["HS256"])
-    assert decoded["typ"] == "app"
-    assert decoded["sub"] == "Http App"
-    assert "exp" not in decoded
+    # An API key, not a JWT — and the plaintext appears only in this response.
+    assert "token" not in body
+    api_key = body["api_key"]
+    assert APIKeyGenerator.validate_format(api_key) is True
 
-    rec = await AppRepository(get_container().plugins().database()).find_app_by_token(
-        token
-    )
+    db = get_container().plugins().database()
+    with db.orm_session() as session:
+        row = session.get(AppRow, body["id"])
+        assert row is not None
+        assert row.token is None
+        assert row.api_key_prefix == api_key[:8]
+        assert api_key not in (row.api_key_hash or "")
+
+    # Register → use closed loop: the returned key authenticates immediately.
+    rec = await AppRepository(db).find_app_by_credential(api_key)
     assert rec is not None
     assert rec.app_name == "Http App"
     assert rec.id == body["id"]

--- a/src/gateway/tests/integration/test_identity_pipeline.py
+++ b/src/gateway/tests/integration/test_identity_pipeline.py
@@ -16,7 +16,7 @@ from gateway.community.bootstrap._authn import build_authenticator
 from gateway.community.bootstrap._configs import DatabaseConfig
 from gateway.community.config import UserConfig
 from gateway.community.core.access_key import AccessKeyRepository
-from gateway.community.core.app import AppRepository, AppRow
+from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
 from gateway.community.core.authn import IdentityChain, authenticate
 from gateway.community.core.bot import BotRepository, BotRow
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
@@ -44,6 +44,14 @@ def _userinfo_handler(
 
 _GOOGLE_BODY = {"sub": "g-1", "email": "a@example.com", "name": "A"}
 
+_APP_KEY = APIKeyGenerator.generate()
+# A pre-API-key app token, presented as its holder still would.
+_LEGACY_APP_JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJhcmUifQ"
+    ".eyJpc3MiOiJnYXRld2F5IiwidHlwIjoiYXBwIiwic3ViIjoiTGVnYWN5IEFwcCJ9"
+    ".c2lnbmF0dXJlLW5vdC12ZXJpZmllZC1ieS10aGUtZ2F0ZXdheQ"
+)
+
 
 def _db() -> DataSourcePlugin:
     db = initialize_database(
@@ -54,8 +62,20 @@ def _db() -> DataSourcePlugin:
             AppRow(
                 app_name="Demo App",
                 app_type="assistant",
-                token="app-key",
+                api_key_hash=APIKeyGenerator.hash_key(_APP_KEY),
+                api_key_prefix=_APP_KEY[:8],
                 owners="org-1",
+                tenant="t",
+            )
+        )
+        # An app registered before the API-key scheme: still authenticates via
+        # the deprecated exact-match path for the transition window.
+        session.add(
+            AppRow(
+                app_name="Legacy App",
+                app_type="assistant",
+                token=_LEGACY_APP_JWT,
+                owners="org-legacy",
                 tenant="t",
             )
         )
@@ -108,7 +128,7 @@ def _google_strategies() -> dict[PrincipalType, IdentityChain]:
 
 async def test_app_only_resolves_app_identity() -> None:
     creds = CredentialBundle(
-        headers={"x-avernet-app-token": "app-key"},
+        headers={"x-avernet-app-token": _APP_KEY},
         cookies={},
         query={},
     )
@@ -175,7 +195,7 @@ async def test_mixed_app_and_google_user_resolve_both() -> None:
     creds = CredentialBundle(
         headers={
             "x-avernet-google-token": "tok",
-            "x-avernet-app-token": "app-key",
+            "x-avernet-app-token": _APP_KEY,
         },
         cookies={},
         query={},
@@ -187,3 +207,24 @@ async def test_mixed_app_and_google_user_resolve_both() -> None:
     )
     assert PrincipalType.USER in result
     assert PrincipalType.APP in result
+
+
+async def test_legacy_app_jwt_still_resolves_app_identity() -> None:
+    """The transition window, end to end through the real strategy.
+
+    An app registered before the API-key scheme presents the JWT it was issued
+    and still authenticates, resolving to the same principal shape as a modern
+    app. Delete with the deprecated path.
+    """
+    creds = CredentialBundle(
+        headers={"x-avernet-app-token": _LEGACY_APP_JWT},
+        cookies={},
+        query={},
+    )
+    result = await authenticate(
+        creds, {PrincipalType.APP: Presence.REQUIRED}, _strategies()
+    )
+    assert PrincipalType.APP in result
+    principal = result[PrincipalType.APP]
+    assert principal.app.app_name == "Legacy App"
+    assert principal.tenant == "t"

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -3,15 +3,24 @@
 This module is a verbatim copy of the secbaas API-gateway key generator, because
 secbaas's existing ``baas_api_key`` records are migrated into
 ``avernet_application`` and must keep verifying with their original plaintext
-keys. The tests here exist to pin that compatibility:
+keys. The tests here exist to pin that compatibility from both ends:
 
-* :func:`test_secbaas_produced_hash_verifies` asserts against a ``(key, hash)``
-  pair produced by *running the real secbaas implementation*. It fails the
-  moment anyone changes the digest, the iteration count, the salt handling, or
-  the encoding — none of which are recoverable from the stored string, since it
-  carries only the salt.
-* :func:`test_round_trip_against_secbaas_implementation` loads that
-  implementation from disk and checks both directions.
+* :func:`test_secbaas_produced_hash_verifies` proves we can *read* what secbaas
+  wrote — it asserts against a ``(key, hash)`` pair produced by running the real
+  secbaas implementation.
+* :func:`test_hash_key_output_uses_documented_pbkdf2_parameters` proves we
+  *write* what secbaas would — the read-side test alone cannot catch a weakened
+  salt or iteration count in this copy.
+
+Neither is recoverable from the stored string, which carries only the salt: the
+digest, the iteration count, and the encoding are implicit constants, so drift
+in any of them silently invalidates every migrated record.
+
+Two tests here characterize known upstream quirks rather than desired behavior
+(see :func:`test_validate_format_accepts_a_trailing_newline` and
+:func:`test_verify_tolerates_non_base64_noise_in_stored_hash`). Correcting them
+means editing secbaas's file first and re-copying, since
+:func:`test_copy_is_byte_identical_to_secbaas_source` forbids one-sided edits.
 """
 
 from __future__ import annotations
@@ -35,30 +44,46 @@ _SECBAAS_HASH = (
     ":UKS+A02LiRqVNsn0oOs9EiNO63ggsbZ3UHGnND6A08Q="
 )
 
-_SECBAAS_SOURCE = (
-    Path(__file__).parents[5]
-    / "src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py"
-)
+_SECBAAS_RELPATH = "src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py"
+_OURS_RELPATH = "src/gateway/src/gateway/community/core/app/_key_gen.py"
 
 
-def _load_secbaas_generator() -> ModuleType:
+def _repo_root() -> Path:
+    """Walk up to the directory holding ``AGENTS.md``.
+
+    Deliberately not a hardcoded ``parents[N]``: moving this file would silently
+    change which path it resolves to, and the tests below would then skip rather
+    than fail — quietly dropping the drift protection they exist to provide.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "AGENTS.md").is_file():
+            return parent
+    raise RuntimeError("cannot locate repository root: no AGENTS.md above this file")
+
+
+def _load_secbaas_generator(source: Path) -> ModuleType:
     """Load the secbaas generator straight from disk.
 
-    By file path rather than by package import: ``secbaas.community.api`` uses
-    syntax this interpreter rejects, and the generator itself is stdlib-only, so
-    the file loads cleanly on its own.
+    By file path rather than by package import because secbaas is deliberately
+    *not* a dependency of ``src/gateway/pyproject.toml`` — the plan rejects the
+    cross-module dependency and copies the class instead. The generator is
+    stdlib-only, so the file loads cleanly on its own.
     """
-    spec = importlib.util.spec_from_file_location("_secbaas_key_gen", _SECBAAS_SOURCE)
+    spec = importlib.util.spec_from_file_location("_secbaas_key_gen", source)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-_requires_secbaas = pytest.mark.skipif(
-    not _SECBAAS_SOURCE.exists(),
-    reason="secbaas source not present (module tested in isolation)",
-)
+def _secbaas_source() -> Path:
+    source = _repo_root() / _SECBAAS_RELPATH
+    assert source.is_file(), (
+        f"secbaas key generator not found at {source}. This copy's migration "
+        "compatibility is pinned against that file; if it moved, update "
+        "_SECBAAS_RELPATH rather than letting these checks lapse."
+    )
+    return source
 
 
 def test_secbaas_produced_hash_verifies() -> None:
@@ -70,24 +95,38 @@ def test_secbaas_hash_rejects_a_different_key() -> None:
     assert APIKeyGenerator.verify_key("0" * 32, _SECBAAS_HASH) is False
 
 
-def test_stored_hash_uses_documented_pbkdf2_parameters() -> None:
-    """Pin digest, iteration count, and encoding — none are in the stored string.
-
-    Recomputes the derived key from the salt the hash carries. Any drift in
-    ``sha256`` / ``100_000`` / UTF-8 password encoding / base64 breaks this,
-    which is exactly the drift that would silently invalidate migrated records.
-    """
+def test_secbaas_fixture_uses_documented_pbkdf2_parameters() -> None:
+    """Read side: recompute secbaas's derived key from the salt it carries."""
     salt_b64, dk_b64 = _SECBAAS_HASH.split(":")
     salt, stored_dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
-    assert len(salt) == 32 and len(stored_dk) == 32
 
-    recomputed = hashlib.pbkdf2_hmac(
+    assert len(salt) == 32
+    assert len(stored_dk) == 32
+    assert stored_dk == hashlib.pbkdf2_hmac(
         hash_name="sha256",
         password=_SECBAAS_KEY.encode(),
         salt=salt,
         iterations=100_000,
     )
-    assert recomputed == stored_dk
+
+
+def test_hash_key_output_uses_documented_pbkdf2_parameters() -> None:
+    """Write side: the same pinning against *our* ``hash_key`` output.
+
+    Without this, weakening the salt width or the iteration count in this copy
+    passes every other test in any checkout that has no ``src/baas`` on disk —
+    the internal round-trips stay self-consistent under any parameter change
+    applied to ``hash_key`` and ``verify_key`` together.
+    """
+    key = APIKeyGenerator.generate()
+    salt_b64, dk_b64 = APIKeyGenerator.hash_key(key).split(":")
+    salt, stored_dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
+
+    assert len(salt) == 32
+    assert len(stored_dk) == 32
+    assert stored_dk == hashlib.pbkdf2_hmac(
+        hash_name="sha256", password=key.encode(), salt=salt, iterations=100_000
+    )
 
 
 def test_generate_is_32_char_base62() -> None:
@@ -124,9 +163,24 @@ def test_verify_rejects_wrong_key() -> None:
     "stored_hash",
     ["", "not-a-hash", "no-colon-separator", "!!!:???", "onlysalt:", ":onlydk"],
 )
-def test_verify_rejects_malformed_stored_hash(stored_hash: str) -> None:
-    """A corrupt stored value is a rejection, never an exception."""
+def test_verify_rejects_unusable_stored_hash(stored_hash: str) -> None:
+    """A stored value that cannot yield a matching digest returns False.
+
+    Not "every corrupt value is rejected" — see
+    :func:`test_verify_tolerates_non_base64_noise_in_stored_hash`.
+    """
     assert APIKeyGenerator.verify_key(_SECBAAS_KEY, stored_hash) is False
+
+
+def test_verify_tolerates_non_base64_noise_in_stored_hash() -> None:
+    """Characterization of an upstream quirk, not an endorsement.
+
+    ``base64.b64decode`` defaults to non-validating, so characters outside the
+    alphabet are discarded rather than rejected: a stored hash corrupted *only*
+    by inserted punctuation decodes to the original bytes and still verifies.
+    Failing closed here means passing ``validate=True`` in secbaas's copy first.
+    """
+    assert APIKeyGenerator.verify_key(_SECBAAS_KEY, _SECBAAS_HASH + "!!!") is True
 
 
 @pytest.mark.parametrize(
@@ -146,10 +200,21 @@ def test_validate_format(candidate: str, expected: bool) -> None:
     assert APIKeyGenerator.validate_format(candidate) is expected
 
 
-@_requires_secbaas
+def test_validate_format_accepts_a_trailing_newline() -> None:
+    """Characterization of an upstream quirk, not an endorsement.
+
+    ``re.match`` with a ``$`` anchor also matches immediately before a trailing
+    newline, so a 33-character value ending in ``\\n`` passes as a 32-char key
+    (``\\Z`` or ``re.fullmatch`` would not). Harmless where this predicate is
+    used for credential dispatch — both branches reject such a value — but wrong
+    if it is ever used to validate input. Fixing it means editing secbaas's copy.
+    """
+    assert APIKeyGenerator.validate_format("a" * 32 + "\n") is True
+
+
 def test_round_trip_against_secbaas_implementation() -> None:
     """Both directions: each implementation verifies the other's output."""
-    secbaas = _load_secbaas_generator().APIKeyGenerator
+    secbaas = _load_secbaas_generator(_secbaas_source()).APIKeyGenerator
 
     ours = APIKeyGenerator.generate()
     assert secbaas.verify_key(ours, APIKeyGenerator.hash_key(ours)) is True
@@ -158,8 +223,7 @@ def test_round_trip_against_secbaas_implementation() -> None:
     assert APIKeyGenerator.verify_key(theirs, secbaas.hash_key(theirs)) is True
 
 
-@_requires_secbaas
 def test_copy_is_byte_identical_to_secbaas_source() -> None:
     """The copy must not drift; edit the scheme in both places or neither."""
-    ours = Path(__file__).parents[3] / "src/gateway/community/core/app/_key_gen.py"
-    assert ours.read_bytes() == _SECBAAS_SOURCE.read_bytes()
+    ours = _repo_root() / _OURS_RELPATH
+    assert ours.read_bytes() == _secbaas_source().read_bytes()

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -36,8 +36,8 @@ from __future__ import annotations
 import base64
 import hashlib
 import importlib.util
-import inspect
 import re
+import secrets
 from pathlib import Path
 from types import ModuleType
 
@@ -57,9 +57,11 @@ _SECBAAS_RELPATH = "src/baas/src/secbaas/community/core/service/api_gateway/_key
 _OURS_RELPATH = "src/gateway/src/gateway/community/core/app/_key_gen.py"
 
 # The monorepo root is the ancestor holding both module trees. Derived from the
-# two paths above so that moving either module leaves one place to update —
-# a second hardcoded "src/baas" would make the guidance in _secbaas_source()
-# insufficient, since the probe would stop matching before the relpath is read.
+# two paths above so that moving a module leaves one place to update *in this
+# file* — a second hardcoded "src/baas" here would make the guidance in
+# _secbaas_source() insufficient, since the probe would stop matching before the
+# relpath is ever read. The path is also spelled out in the docstring of
+# gateway/community/core/app/__init__.py, which nothing enforces.
 _MODULE_DIRS = tuple(
     Path(*Path(rel).parts[:2]) for rel in (_SECBAAS_RELPATH, _OURS_RELPATH)
 )
@@ -93,8 +95,8 @@ def _require_monorepo_root() -> Path:
     return root
 
 
-def _secbaas_source() -> Path:
-    source = _require_monorepo_root() / _SECBAAS_RELPATH
+def _secbaas_source(root: Path | None = None) -> Path:
+    source = (root or _require_monorepo_root()) / _SECBAAS_RELPATH
     if not source.is_file():
         pytest.fail(
             f"secbaas key generator not found at {source}. This copy's migration "
@@ -122,14 +124,12 @@ def _load_secbaas_generator(source: Path) -> ModuleType:
 def _split_stored_hash(stored: str) -> tuple[bytes, bytes]:
     """Decode a stored hash, checking each half re-encodes to what was stored.
 
-    Decoding alone pins nothing about the alphabet: ``b64decode`` accepts a
-    ``urlsafe_b64encode`` string unchanged, and ``validate=True`` does not change
-    that (measured: identical ~26% acceptance either way). Re-encoding catches
-    the switch — but only for payloads that actually contain a ``-`` or ``_``.
-    For the other ~26%, the two alphabets emit *byte-identical* output, so the
-    difference is unobservable at any sample size of one. Callers that need the
-    alphabet pinned must sample; see
-    :func:`test_hash_key_output_uses_documented_pbkdf2_parameters`.
+    The re-encode catches an alphabet switch for any payload that contains a
+    distinguishing character, which is most but not all of them: standard and
+    urlsafe base64 emit byte-identical output when a payload happens to contain
+    none, so this cannot pin the alphabet on its own for a random salt. The
+    exact pin lives in :func:`test_hash_key_encodes_with_standard_base64`, which
+    injects a salt chosen to distinguish them.
     """
     salt_b64, dk_b64 = stored.split(":")
     salt, dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
@@ -174,21 +174,45 @@ def test_hash_key_output_uses_documented_pbkdf2_parameters() -> None:
     internal round-trips stay self-consistent under any change applied to
     ``hash_key`` and ``verify_key`` together, and the parity tests skip.
 
-    Repeated because the base64 alphabet cannot be pinned by one sample — a
-    ``urlsafe_b64encode`` switch is byte-invisible for the ~26% of payloads
-    containing neither ``-`` nor ``_``. Ten samples take that blind spot from
-    roughly one run in four to one in a million; the digest and iteration count
-    are pinned deterministically by any single one.
+    Digest, iteration count, and salt width are deterministic in a single
+    sample; the base64 alphabet is not, and is pinned separately by
+    :func:`test_hash_key_encodes_with_standard_base64`.
     """
-    for _ in range(10):
-        key = APIKeyGenerator.generate()
-        salt, stored_dk = _split_stored_hash(APIKeyGenerator.hash_key(key))
+    key = APIKeyGenerator.generate()
+    salt, stored_dk = _split_stored_hash(APIKeyGenerator.hash_key(key))
 
-        assert len(salt) == 32
-        assert len(stored_dk) == 32
-        assert stored_dk == hashlib.pbkdf2_hmac(
-            hash_name="sha256", password=key.encode(), salt=salt, iterations=100_000
-        )
+    assert len(salt) == 32
+    assert len(stored_dk) == 32
+    assert stored_dk == hashlib.pbkdf2_hmac(
+        hash_name="sha256", password=key.encode(), salt=salt, iterations=100_000
+    )
+
+
+def test_hash_key_encodes_with_standard_base64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pin the alphabet exactly, using a salt that distinguishes the two.
+
+    A random salt cannot do this: standard and urlsafe base64 differ only on
+    bytes that encode to ``+``/``/`` (resp. ``-``/``_``), and a payload
+    containing none of them encodes identically under both. Injecting a salt
+    whose encoding contains both characters turns a probabilistic check into an
+    exact one — and makes a failure name the expected string rather than show a
+    bytes diff.
+    """
+    # 0x3E/0x3F are the two byte values whose sixtets encode to the characters
+    # the alphabets disagree on, so this salt exercises both of them.
+    salt = bytes((0x3E, 0x3F)) * 16
+    expected_salt_b64 = base64.b64encode(salt).decode()
+    assert "+" in expected_salt_b64 and "/" in expected_salt_b64
+    monkeypatch.setattr(secrets, "token_bytes", lambda _n: salt)
+
+    salt_b64, _ = APIKeyGenerator.hash_key(APIKeyGenerator.generate()).split(":")
+
+    assert salt_b64 == expected_salt_b64, (
+        "stored salt is not standard base64 — a urlsafe_b64encode switch would "
+        f"render this as {base64.urlsafe_b64encode(salt).decode()!r}"
+    )
 
 
 def test_generate_is_32_char_base62() -> None:
@@ -268,24 +292,23 @@ def test_round_trip_against_secbaas_implementation() -> None:
 def test_copy_is_byte_identical_to_secbaas_source() -> None:
     """The copy must not drift; edit the scheme in both places or neither.
 
-    Checks both the file a contributor edits and the file this suite actually
-    imports. They are the same under the editable install used here, but diverge
-    under a non-editable one — and checking only the loaded module would also
-    pass vacuously if the gateway ever re-exported secbaas's class instead of
-    keeping a copy, which is the cross-module dependency the plan rejects.
+    Two things must hold. The class must be *defined in the gateway package* —
+    checked via ``__module__``, which is immune to install layout, where a path
+    comparison would miss a re-export from an installed secbaas elsewhere on
+    ``sys.path``. And the file a contributor edits must match secbaas's byte for
+    byte.
     """
-    source = _secbaas_source()
-    expected = source.read_bytes()
-
-    loaded_path = inspect.getsourcefile(APIKeyGenerator)
-    assert loaded_path is not None
-    loaded = Path(loaded_path).resolve()
-    tree_copy = (_require_monorepo_root() / _OURS_RELPATH).resolve()
-
-    assert loaded != source.resolve(), (
-        "APIKeyGenerator is being imported from secbaas rather than from the "
-        "gateway's own copy — the byte-identity check would compare a file to "
-        "itself, and the copy the plan calls for would be gone."
+    assert APIKeyGenerator.__module__ == "gateway.community.core.app._key_gen", (
+        f"APIKeyGenerator is defined in {APIKeyGenerator.__module__}, not the "
+        "gateway's own copy — the plan rejects importing secbaas's class, and "
+        "a byte-identity check against a re-export would pass vacuously."
     )
-    assert tree_copy.read_bytes() == expected
-    assert loaded.read_bytes() == expected
+
+    root = _require_monorepo_root()
+    tree_copy = root / _OURS_RELPATH
+    if not tree_copy.is_file():
+        pytest.fail(
+            f"gateway key generator not found at {tree_copy}; if it moved, "
+            "update _OURS_RELPATH rather than letting this check lapse."
+        )
+    assert tree_copy.read_bytes() == _secbaas_source(root).read_bytes()

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -24,9 +24,9 @@ in ``plan.md`` under "Notes on upstream follow-ups":
 
 * ``validate_format`` uses ``re.match`` with ``$``, which also matches before a
   trailing newline, so a 33-character value ending in ``\\n`` passes as a 32-char
-  key. The credential dispatch built on this predicate is tested directly for
-  the property that matters — such a value never authenticates — rather than
-  for the quirk itself.
+  key. Nothing consumes this predicate yet; when Task 4 builds the credential
+  dispatch on it, the property to test there is that such a value authenticates
+  on neither path — not the quirk itself, which is upstream's to fix.
 * ``verify_key`` decodes with a non-validating ``base64.b64decode``, so a stored
   hash corrupted only by characters outside the base64 alphabet still verifies.
 """
@@ -54,31 +54,47 @@ _SECBAAS_HASH = (
 )
 
 _SECBAAS_RELPATH = "src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py"
+_OURS_RELPATH = "src/gateway/src/gateway/community/core/app/_key_gen.py"
+
+# The monorepo root is the ancestor holding both module trees. Derived from the
+# two paths above so that moving either module leaves one place to update —
+# a second hardcoded "src/baas" would make the guidance in _secbaas_source()
+# insufficient, since the probe would stop matching before the relpath is read.
+_MODULE_DIRS = tuple(
+    Path(*Path(rel).parts[:2]) for rel in (_SECBAAS_RELPATH, _OURS_RELPATH)
+)
 
 
 def _monorepo_root() -> Path | None:
-    """The ancestor holding both module trees, or ``None`` outside the monorepo.
+    """The ancestor holding both module trees, or ``None`` if there is none.
 
-    Keyed on the two directories rather than on ``AGENTS.md``: this repo already
-    places that file at module level (``src/bcs``, ``src/frontend``), so a future
-    ``src/gateway/AGENTS.md`` would silently resolve the wrong root. ``None``
-    means the gateway was split out on its own, where there is no secbaas to
-    compare against — distinct from "the monorepo is here but the file moved",
-    which must fail loudly rather than quietly drop the parity guarantee.
+    Keyed on the module directories rather than on ``AGENTS.md``: this repo
+    already places that file at module level (``src/bcs``, ``src/frontend``), so
+    a future ``src/gateway/AGENTS.md`` would silently resolve the wrong root.
+
+    ``None`` is ambiguous between "the gateway was split out on its own" and
+    "a module directory was renamed", and is treated as the former — the tests
+    skip. That is a real gap: see the note in ``plan.md`` on the CI gate scoring
+    skips as passes.
     """
     for parent in Path(__file__).resolve().parents:
-        if (parent / "src/baas").is_dir() and (parent / "src/gateway").is_dir():
+        if all((parent / module).is_dir() for module in _MODULE_DIRS):
             return parent
     return None
 
 
-def _secbaas_source() -> Path:
+def _require_monorepo_root() -> Path:
     root = _monorepo_root()
     if root is None:
         pytest.skip(
-            "gateway checked out without src/baas; parity is not checkable here"
+            f"no ancestor holds all of {[str(m) for m in _MODULE_DIRS]}; "
+            "parity against secbaas is not checkable from this checkout"
         )
-    source = root / _SECBAAS_RELPATH
+    return root
+
+
+def _secbaas_source() -> Path:
+    source = _require_monorepo_root() / _SECBAAS_RELPATH
     if not source.is_file():
         pytest.fail(
             f"secbaas key generator not found at {source}. This copy's migration "
@@ -104,16 +120,22 @@ def _load_secbaas_generator(source: Path) -> ModuleType:
 
 
 def _split_stored_hash(stored: str) -> tuple[bytes, bytes]:
-    """Decode a stored hash strictly, so the encoding itself is pinned.
+    """Decode a stored hash, checking each half re-encodes to what was stored.
 
-    ``validate=True`` matters here: the default silently discards characters
-    outside the base64 alphabet, which would let a switch to ``urlsafe_b64encode``
-    pass these tests most of the time instead of failing deterministically.
+    Decoding alone pins nothing about the alphabet: ``b64decode`` accepts a
+    ``urlsafe_b64encode`` string unchanged, and ``validate=True`` does not change
+    that (measured: identical ~26% acceptance either way). Re-encoding catches
+    the switch — but only for payloads that actually contain a ``-`` or ``_``.
+    For the other ~26%, the two alphabets emit *byte-identical* output, so the
+    difference is unobservable at any sample size of one. Callers that need the
+    alphabet pinned must sample; see
+    :func:`test_hash_key_output_uses_documented_pbkdf2_parameters`.
     """
     salt_b64, dk_b64 = stored.split(":")
-    return base64.b64decode(salt_b64, validate=True), base64.b64decode(
-        dk_b64, validate=True
-    )
+    salt, dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
+    assert base64.b64encode(salt).decode() == salt_b64, "salt is not standard base64"
+    assert base64.b64encode(dk).decode() == dk_b64, "digest is not standard base64"
+    return salt, dk
 
 
 def test_secbaas_produced_hash_verifies() -> None:
@@ -151,15 +173,22 @@ def test_hash_key_output_uses_documented_pbkdf2_parameters() -> None:
     passes every other test in a checkout with no ``src/baas`` on disk: the
     internal round-trips stay self-consistent under any change applied to
     ``hash_key`` and ``verify_key`` together, and the parity tests skip.
-    """
-    key = APIKeyGenerator.generate()
-    salt, stored_dk = _split_stored_hash(APIKeyGenerator.hash_key(key))
 
-    assert len(salt) == 32
-    assert len(stored_dk) == 32
-    assert stored_dk == hashlib.pbkdf2_hmac(
-        hash_name="sha256", password=key.encode(), salt=salt, iterations=100_000
-    )
+    Repeated because the base64 alphabet cannot be pinned by one sample — a
+    ``urlsafe_b64encode`` switch is byte-invisible for the ~26% of payloads
+    containing neither ``-`` nor ``_``. Ten samples take that blind spot from
+    roughly one run in four to one in a million; the digest and iteration count
+    are pinned deterministically by any single one.
+    """
+    for _ in range(10):
+        key = APIKeyGenerator.generate()
+        salt, stored_dk = _split_stored_hash(APIKeyGenerator.hash_key(key))
+
+        assert len(salt) == 32
+        assert len(stored_dk) == 32
+        assert stored_dk == hashlib.pbkdf2_hmac(
+            hash_name="sha256", password=key.encode(), salt=salt, iterations=100_000
+        )
 
 
 def test_generate_is_32_char_base62() -> None:
@@ -198,7 +227,7 @@ def test_verify_rejects_wrong_key() -> None:
         "",  # empty column
         "no-colon-separator",  # unpack fails: one field
         "a:b:c",  # unpack fails: three fields, e.g. a migration concatenation
-        "!!!:???",  # decodes to empty, fails on length
+        "!!!:???",  # decodes to empty; compare_digest then mismatches
         "onlysalt:",
         ":onlydk",
     ],
@@ -239,10 +268,24 @@ def test_round_trip_against_secbaas_implementation() -> None:
 def test_copy_is_byte_identical_to_secbaas_source() -> None:
     """The copy must not drift; edit the scheme in both places or neither.
 
-    Anchored to the module actually imported by this suite, not to a path in the
-    source tree: under a non-editable install those are different files, and
-    comparing the tree would pass while the loaded code was stale.
+    Checks both the file a contributor edits and the file this suite actually
+    imports. They are the same under the editable install used here, but diverge
+    under a non-editable one — and checking only the loaded module would also
+    pass vacuously if the gateway ever re-exported secbaas's class instead of
+    keeping a copy, which is the cross-module dependency the plan rejects.
     """
-    loaded = inspect.getsourcefile(APIKeyGenerator)
-    assert loaded is not None
-    assert Path(loaded).read_bytes() == _secbaas_source().read_bytes()
+    source = _secbaas_source()
+    expected = source.read_bytes()
+
+    loaded_path = inspect.getsourcefile(APIKeyGenerator)
+    assert loaded_path is not None
+    loaded = Path(loaded_path).resolve()
+    tree_copy = (_require_monorepo_root() / _OURS_RELPATH).resolve()
+
+    assert loaded != source.resolve(), (
+        "APIKeyGenerator is being imported from secbaas rather than from the "
+        "gateway's own copy — the byte-identity check would compare a file to "
+        "itself, and the copy the plan calls for would be gone."
+    )
+    assert tree_copy.read_bytes() == expected
+    assert loaded.read_bytes() == expected

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``APIKeyGenerator`` — the app credential scheme.
+
+This module is a verbatim copy of the secbaas API-gateway key generator, because
+secbaas's existing ``baas_api_key`` records are migrated into
+``avernet_application`` and must keep verifying with their original plaintext
+keys. The tests here exist to pin that compatibility:
+
+* :func:`test_secbaas_produced_hash_verifies` asserts against a ``(key, hash)``
+  pair produced by *running the real secbaas implementation*. It fails the
+  moment anyone changes the digest, the iteration count, the salt handling, or
+  the encoding — none of which are recoverable from the stored string, since it
+  carries only the salt.
+* :func:`test_round_trip_against_secbaas_implementation` loads that
+  implementation from disk and checks both directions.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from gateway.community.core.app import APIKeyGenerator
+
+# Produced by running src/baas/.../api_gateway/_key_gen.py — do NOT regenerate
+# these with the gateway's own copy, which would make the check circular.
+_SECBAAS_KEY = "5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F"
+_SECBAAS_HASH = (
+    "YIrLEzbZybtDzATwCkQ9QERLnn0Q9z09iO+u02jvGGs="
+    ":UKS+A02LiRqVNsn0oOs9EiNO63ggsbZ3UHGnND6A08Q="
+)
+
+_SECBAAS_SOURCE = (
+    Path(__file__).parents[5]
+    / "src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py"
+)
+
+
+def _load_secbaas_generator() -> ModuleType:
+    """Load the secbaas generator straight from disk.
+
+    By file path rather than by package import: ``secbaas.community.api`` uses
+    syntax this interpreter rejects, and the generator itself is stdlib-only, so
+    the file loads cleanly on its own.
+    """
+    spec = importlib.util.spec_from_file_location("_secbaas_key_gen", _SECBAAS_SOURCE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_requires_secbaas = pytest.mark.skipif(
+    not _SECBAAS_SOURCE.exists(),
+    reason="secbaas source not present (module tested in isolation)",
+)
+
+
+def test_secbaas_produced_hash_verifies() -> None:
+    """The migration guarantee: a secbaas-hashed key verifies under our copy."""
+    assert APIKeyGenerator.verify_key(_SECBAAS_KEY, _SECBAAS_HASH) is True
+
+
+def test_secbaas_hash_rejects_a_different_key() -> None:
+    assert APIKeyGenerator.verify_key("0" * 32, _SECBAAS_HASH) is False
+
+
+def test_stored_hash_uses_documented_pbkdf2_parameters() -> None:
+    """Pin digest, iteration count, and encoding — none are in the stored string.
+
+    Recomputes the derived key from the salt the hash carries. Any drift in
+    ``sha256`` / ``100_000`` / UTF-8 password encoding / base64 breaks this,
+    which is exactly the drift that would silently invalidate migrated records.
+    """
+    salt_b64, dk_b64 = _SECBAAS_HASH.split(":")
+    salt, stored_dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
+    assert len(salt) == 32 and len(stored_dk) == 32
+
+    recomputed = hashlib.pbkdf2_hmac(
+        hash_name="sha256",
+        password=_SECBAAS_KEY.encode(),
+        salt=salt,
+        iterations=100_000,
+    )
+    assert recomputed == stored_dk
+
+
+def test_generate_is_32_char_base62() -> None:
+    key = APIKeyGenerator.generate()
+    assert len(key) == 32
+    assert re.fullmatch(r"[0-9A-Za-z]{32}", key)
+    assert APIKeyGenerator.validate_format(key) is True
+
+
+def test_generate_is_not_deterministic() -> None:
+    assert len({APIKeyGenerator.generate() for _ in range(16)}) == 16
+
+
+def test_hash_roundtrip() -> None:
+    key = APIKeyGenerator.generate()
+    assert APIKeyGenerator.verify_key(key, APIKeyGenerator.hash_key(key)) is True
+
+
+def test_hashing_one_key_twice_yields_different_stored_values() -> None:
+    """Fresh salt per call — and both stored values still verify the same key."""
+    key = APIKeyGenerator.generate()
+    first, second = APIKeyGenerator.hash_key(key), APIKeyGenerator.hash_key(key)
+    assert first != second
+    assert APIKeyGenerator.verify_key(key, first) is True
+    assert APIKeyGenerator.verify_key(key, second) is True
+
+
+def test_verify_rejects_wrong_key() -> None:
+    stored = APIKeyGenerator.hash_key(APIKeyGenerator.generate())
+    assert APIKeyGenerator.verify_key(APIKeyGenerator.generate(), stored) is False
+
+
+@pytest.mark.parametrize(
+    "stored_hash",
+    ["", "not-a-hash", "no-colon-separator", "!!!:???", "onlysalt:", ":onlydk"],
+)
+def test_verify_rejects_malformed_stored_hash(stored_hash: str) -> None:
+    """A corrupt stored value is a rejection, never an exception."""
+    assert APIKeyGenerator.verify_key(_SECBAAS_KEY, stored_hash) is False
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        ("5X1tk2yC6rxmKhUfWzN2GJ3CYiGGE22F", True),
+        ("", False),
+        ("short", False),
+        ("a" * 31, False),
+        ("a" * 33, False),
+        ("a" * 31 + "-", False),  # base62 excludes punctuation
+        ("a" * 31 + "_", False),
+        ("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxfQ.sig", False),  # a JWT
+    ],
+)
+def test_validate_format(candidate: str, expected: bool) -> None:
+    assert APIKeyGenerator.validate_format(candidate) is expected
+
+
+@_requires_secbaas
+def test_round_trip_against_secbaas_implementation() -> None:
+    """Both directions: each implementation verifies the other's output."""
+    secbaas = _load_secbaas_generator().APIKeyGenerator
+
+    ours = APIKeyGenerator.generate()
+    assert secbaas.verify_key(ours, APIKeyGenerator.hash_key(ours)) is True
+
+    theirs = secbaas.generate()
+    assert APIKeyGenerator.verify_key(theirs, secbaas.hash_key(theirs)) is True
+
+
+@_requires_secbaas
+def test_copy_is_byte_identical_to_secbaas_source() -> None:
+    """The copy must not drift; edit the scheme in both places or neither."""
+    ours = Path(__file__).parents[3] / "src/gateway/community/core/app/_key_gen.py"
+    assert ours.read_bytes() == _SECBAAS_SOURCE.read_bytes()

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -1,9 +1,12 @@
 """Unit tests for ``APIKeyGenerator`` — the app credential scheme.
 
-This module is a verbatim copy of the secbaas API-gateway key generator, because
+The module under test copies the secbaas API-gateway key generator, because
 secbaas's existing ``baas_api_key`` records are migrated into
 ``avernet_application`` and must keep verifying with their original plaintext
-keys. The tests here pin that compatibility from both ends:
+keys. Its code is byte-identical to upstream's; only its comments and docstrings
+differ, being in English per the convention the rest of the gateway follows.
+:func:`test_copy_is_semantically_identical_to_secbaas_source` is what allows that
+gap and nothing wider. The tests here pin the compatibility from both ends:
 
 * :func:`test_secbaas_produced_hash_verifies` proves we can *read* what secbaas
   wrote — it asserts against a ``(key, hash)`` pair produced by running the real
@@ -33,9 +36,11 @@ in ``plan.md`` under "Notes on upstream follow-ups":
 
 from __future__ import annotations
 
+import ast
 import base64
 import hashlib
 import importlib.util
+import inspect
 import re
 import secrets
 from pathlib import Path
@@ -119,6 +124,39 @@ def _load_secbaas_generator(source: Path) -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+_DEFINITION = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _code_fingerprint(source: Path) -> str:
+    """A source file reduced to what it *does*, ignoring comments and prose.
+
+    Comments never reach the syntax tree, and the docstring of every definition
+    is dropped here, so the result changes only when an executable construct
+    does. ``ast.dump`` defaults to omitting line and column attributes, which is
+    what makes reformatting invisible too.
+
+    Not a checksum of the text: ``0x64`` and ``100`` would fingerprint alike, as
+    would a renamed local. Neither weakens the guarantee this backs, since the
+    scheme's ingredients are compared as the literals they are written as.
+    """
+    tree = ast.parse(source.read_bytes())
+    for node in ast.walk(tree):
+        if not isinstance(node, _DEFINITION):
+            continue
+        body = node.body
+        first = body[0] if body else None
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            # ``or [ast.Pass()]`` because a body that was *only* a docstring is
+            # not a legal empty body, and dumping it would raise rather than
+            # report the mismatch this function exists to report.
+            node.body = body[1:] or [ast.Pass()]
+    return ast.dump(tree)
 
 
 def _split_stored_hash(stored: str) -> tuple[bytes, bytes]:
@@ -289,19 +327,26 @@ def test_round_trip_against_secbaas_implementation() -> None:
     assert APIKeyGenerator.verify_key(theirs, secbaas.hash_key(theirs)) is True
 
 
-def test_copy_is_byte_identical_to_secbaas_source() -> None:
+def test_copy_is_semantically_identical_to_secbaas_source() -> None:
     """The copy must not drift; edit the scheme in both places or neither.
 
     Two things must hold. The class must be *defined in the gateway package* —
     checked via ``__module__``, which is immune to install layout, where a path
     comparison would miss a re-export from an installed secbaas elsewhere on
-    ``sys.path``. And the file a contributor edits must match secbaas's byte for
-    byte.
+    ``sys.path``. And what the two files *do* must be identical.
+
+    Compared as syntax trees with docstrings stripped rather than byte for byte,
+    so that the two files may carry different prose: this copy's comments are in
+    English, per the convention every other gateway source file follows, while
+    upstream's are in Chinese. Every ingredient of the stored hash — the base62
+    alphabet, the digest, the iteration count, the salt width, the encoding, the
+    ``salt:dk`` join — is a literal or a call in that tree, so a one-sided change
+    to any of them still fails here.
     """
     assert APIKeyGenerator.__module__ == "gateway.community.core.app._key_gen", (
         f"APIKeyGenerator is defined in {APIKeyGenerator.__module__}, not the "
         "gateway's own copy — the plan rejects importing secbaas's class, and "
-        "a byte-identity check against a re-export would pass vacuously."
+        "a parity check against a re-export would pass vacuously."
     )
 
     root = _require_monorepo_root()
@@ -311,4 +356,38 @@ def test_copy_is_byte_identical_to_secbaas_source() -> None:
             f"gateway key generator not found at {tree_copy}; if it moved, "
             "update _OURS_RELPATH rather than letting this check lapse."
         )
-    assert tree_copy.read_bytes() == _secbaas_source(root).read_bytes()
+    assert _code_fingerprint(tree_copy) == _code_fingerprint(_secbaas_source(root)), (
+        "the gateway's key generator no longer matches secbaas's. Migrated "
+        "records verify only while both derive the same digest, so port the "
+        "change to the other file rather than relaxing this test."
+    )
+
+
+def test_copy_carries_no_cjk_prose() -> None:
+    """The convention the parity test deliberately stops enforcing.
+
+    Dropping byte-identity is what lets this copy be translated, and re-copying
+    upstream wholesale is the natural way to keep the scheme in sync — which
+    would silently restore the Chinese comments. This is the guard that makes
+    the translation survive that.
+
+    Scoped to this one file: Chinese is the established convention in
+    ``migrations/mysql``, whose comments ship to the database as column
+    ``COMMENT``s, and is untouched there. Read from the imported module rather
+    than from the tree, so it holds wherever the package is installed from and
+    needs no ``src/baas`` to run.
+
+    The bound is ``U+2FFF`` — above every CJK ideograph, CJK punctuation and
+    fullwidth form, below the punctuation English prose here actually uses (em
+    dashes at ``U+2014``, curly quotes at ``U+2018``).
+    """
+    source = Path(inspect.getsourcefile(APIKeyGenerator) or "").read_text(
+        encoding="utf-8"
+    )
+    offenders = sorted({ch for ch in source if ord(ch) > 0x2FFF})
+    assert not offenders, (
+        f"CJK characters in the gateway's key generator: {''.join(offenders)!r}. "
+        "Comments and docstrings in this copy are translated; re-copying upstream "
+        "verbatim reintroduces them. Port the code change by hand, keeping the "
+        "English prose."
+    )

--- a/src/gateway/tests/unit/plugins/test_app_key_gen.py
+++ b/src/gateway/tests/unit/plugins/test_app_key_gen.py
@@ -3,24 +3,32 @@
 This module is a verbatim copy of the secbaas API-gateway key generator, because
 secbaas's existing ``baas_api_key`` records are migrated into
 ``avernet_application`` and must keep verifying with their original plaintext
-keys. The tests here exist to pin that compatibility from both ends:
+keys. The tests here pin that compatibility from both ends:
 
 * :func:`test_secbaas_produced_hash_verifies` proves we can *read* what secbaas
   wrote — it asserts against a ``(key, hash)`` pair produced by running the real
   secbaas implementation.
 * :func:`test_hash_key_output_uses_documented_pbkdf2_parameters` proves we
-  *write* what secbaas would — the read-side test alone cannot catch a weakened
-  salt or iteration count in this copy.
+  *write* what secbaas would. The read-side test cannot catch a weakened salt or
+  iteration count in this copy, and it is the only guard in a checkout that has
+  no ``src/baas`` on disk, where the parity tests below skip.
 
-Neither is recoverable from the stored string, which carries only the salt: the
-digest, the iteration count, and the encoding are implicit constants, so drift
-in any of them silently invalidates every migrated record.
+Neither parameter is recoverable from the stored string, which carries only the
+salt: the digest, the iteration count, and the encoding are implicit constants
+shared by both copies, so drift in any of them silently invalidates every
+migrated record.
 
-Two tests here characterize known upstream quirks rather than desired behavior
-(see :func:`test_validate_format_accepts_a_trailing_newline` and
-:func:`test_verify_tolerates_non_base64_noise_in_stored_hash`). Correcting them
-means editing secbaas's file first and re-copying, since
-:func:`test_copy_is_byte_identical_to_secbaas_source` forbids one-sided edits.
+Two upstream quirks are deliberately *not* pinned here, because asserting them
+would turn a future upstream fix into a failure in this suite. Both are recorded
+in ``plan.md`` under "Notes on upstream follow-ups":
+
+* ``validate_format`` uses ``re.match`` with ``$``, which also matches before a
+  trailing newline, so a 33-character value ending in ``\\n`` passes as a 32-char
+  key. The credential dispatch built on this predicate is tested directly for
+  the property that matters — such a value never authenticates — rather than
+  for the quirk itself.
+* ``verify_key`` decodes with a non-validating ``base64.b64decode``, so a stored
+  hash corrupted only by characters outside the base64 alphabet still verifies.
 """
 
 from __future__ import annotations
@@ -28,6 +36,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import importlib.util
+import inspect
 import re
 from pathlib import Path
 from types import ModuleType
@@ -45,20 +54,38 @@ _SECBAAS_HASH = (
 )
 
 _SECBAAS_RELPATH = "src/baas/src/secbaas/community/core/service/api_gateway/_key_gen.py"
-_OURS_RELPATH = "src/gateway/src/gateway/community/core/app/_key_gen.py"
 
 
-def _repo_root() -> Path:
-    """Walk up to the directory holding ``AGENTS.md``.
+def _monorepo_root() -> Path | None:
+    """The ancestor holding both module trees, or ``None`` outside the monorepo.
 
-    Deliberately not a hardcoded ``parents[N]``: moving this file would silently
-    change which path it resolves to, and the tests below would then skip rather
-    than fail — quietly dropping the drift protection they exist to provide.
+    Keyed on the two directories rather than on ``AGENTS.md``: this repo already
+    places that file at module level (``src/bcs``, ``src/frontend``), so a future
+    ``src/gateway/AGENTS.md`` would silently resolve the wrong root. ``None``
+    means the gateway was split out on its own, where there is no secbaas to
+    compare against — distinct from "the monorepo is here but the file moved",
+    which must fail loudly rather than quietly drop the parity guarantee.
     """
     for parent in Path(__file__).resolve().parents:
-        if (parent / "AGENTS.md").is_file():
+        if (parent / "src/baas").is_dir() and (parent / "src/gateway").is_dir():
             return parent
-    raise RuntimeError("cannot locate repository root: no AGENTS.md above this file")
+    return None
+
+
+def _secbaas_source() -> Path:
+    root = _monorepo_root()
+    if root is None:
+        pytest.skip(
+            "gateway checked out without src/baas; parity is not checkable here"
+        )
+    source = root / _SECBAAS_RELPATH
+    if not source.is_file():
+        pytest.fail(
+            f"secbaas key generator not found at {source}. This copy's migration "
+            "compatibility is pinned against that file; if it moved, update "
+            "_SECBAAS_RELPATH rather than letting these checks lapse."
+        )
+    return source
 
 
 def _load_secbaas_generator(source: Path) -> ModuleType:
@@ -76,14 +103,17 @@ def _load_secbaas_generator(source: Path) -> ModuleType:
     return module
 
 
-def _secbaas_source() -> Path:
-    source = _repo_root() / _SECBAAS_RELPATH
-    assert source.is_file(), (
-        f"secbaas key generator not found at {source}. This copy's migration "
-        "compatibility is pinned against that file; if it moved, update "
-        "_SECBAAS_RELPATH rather than letting these checks lapse."
+def _split_stored_hash(stored: str) -> tuple[bytes, bytes]:
+    """Decode a stored hash strictly, so the encoding itself is pinned.
+
+    ``validate=True`` matters here: the default silently discards characters
+    outside the base64 alphabet, which would let a switch to ``urlsafe_b64encode``
+    pass these tests most of the time instead of failing deterministically.
+    """
+    salt_b64, dk_b64 = stored.split(":")
+    return base64.b64decode(salt_b64, validate=True), base64.b64decode(
+        dk_b64, validate=True
     )
-    return source
 
 
 def test_secbaas_produced_hash_verifies() -> None:
@@ -95,10 +125,14 @@ def test_secbaas_hash_rejects_a_different_key() -> None:
     assert APIKeyGenerator.verify_key("0" * 32, _SECBAAS_HASH) is False
 
 
-def test_secbaas_fixture_uses_documented_pbkdf2_parameters() -> None:
-    """Read side: recompute secbaas's derived key from the salt it carries."""
-    salt_b64, dk_b64 = _SECBAAS_HASH.split(":")
-    salt, stored_dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
+def test_pinned_fixture_is_internally_consistent() -> None:
+    """Authenticate the fixture constants themselves.
+
+    Runs no gateway code — it exists so that a mistyped or regenerated
+    ``_SECBAAS_HASH`` is caught as a bad fixture rather than surfacing later as a
+    confusing failure in the tests that do exercise the module.
+    """
+    salt, stored_dk = _split_stored_hash(_SECBAAS_HASH)
 
     assert len(salt) == 32
     assert len(stored_dk) == 32
@@ -111,16 +145,15 @@ def test_secbaas_fixture_uses_documented_pbkdf2_parameters() -> None:
 
 
 def test_hash_key_output_uses_documented_pbkdf2_parameters() -> None:
-    """Write side: the same pinning against *our* ``hash_key`` output.
+    """Pin the write side against our own ``hash_key`` output.
 
     Without this, weakening the salt width or the iteration count in this copy
-    passes every other test in any checkout that has no ``src/baas`` on disk —
-    the internal round-trips stay self-consistent under any parameter change
-    applied to ``hash_key`` and ``verify_key`` together.
+    passes every other test in a checkout with no ``src/baas`` on disk: the
+    internal round-trips stay self-consistent under any change applied to
+    ``hash_key`` and ``verify_key`` together, and the parity tests skip.
     """
     key = APIKeyGenerator.generate()
-    salt_b64, dk_b64 = APIKeyGenerator.hash_key(key).split(":")
-    salt, stored_dk = base64.b64decode(salt_b64), base64.b64decode(dk_b64)
+    salt, stored_dk = _split_stored_hash(APIKeyGenerator.hash_key(key))
 
     assert len(salt) == 32
     assert len(stored_dk) == 32
@@ -161,26 +194,18 @@ def test_verify_rejects_wrong_key() -> None:
 
 @pytest.mark.parametrize(
     "stored_hash",
-    ["", "not-a-hash", "no-colon-separator", "!!!:???", "onlysalt:", ":onlydk"],
+    [
+        "",  # empty column
+        "no-colon-separator",  # unpack fails: one field
+        "a:b:c",  # unpack fails: three fields, e.g. a migration concatenation
+        "!!!:???",  # decodes to empty, fails on length
+        "onlysalt:",
+        ":onlydk",
+    ],
 )
 def test_verify_rejects_unusable_stored_hash(stored_hash: str) -> None:
-    """A stored value that cannot yield a matching digest returns False.
-
-    Not "every corrupt value is rejected" — see
-    :func:`test_verify_tolerates_non_base64_noise_in_stored_hash`.
-    """
+    """A stored value that cannot yield a matching digest returns False, not raises."""
     assert APIKeyGenerator.verify_key(_SECBAAS_KEY, stored_hash) is False
-
-
-def test_verify_tolerates_non_base64_noise_in_stored_hash() -> None:
-    """Characterization of an upstream quirk, not an endorsement.
-
-    ``base64.b64decode`` defaults to non-validating, so characters outside the
-    alphabet are discarded rather than rejected: a stored hash corrupted *only*
-    by inserted punctuation decodes to the original bytes and still verifies.
-    Failing closed here means passing ``validate=True`` in secbaas's copy first.
-    """
-    assert APIKeyGenerator.verify_key(_SECBAAS_KEY, _SECBAAS_HASH + "!!!") is True
 
 
 @pytest.mark.parametrize(
@@ -200,18 +225,6 @@ def test_validate_format(candidate: str, expected: bool) -> None:
     assert APIKeyGenerator.validate_format(candidate) is expected
 
 
-def test_validate_format_accepts_a_trailing_newline() -> None:
-    """Characterization of an upstream quirk, not an endorsement.
-
-    ``re.match`` with a ``$`` anchor also matches immediately before a trailing
-    newline, so a 33-character value ending in ``\\n`` passes as a 32-char key
-    (``\\Z`` or ``re.fullmatch`` would not). Harmless where this predicate is
-    used for credential dispatch — both branches reject such a value — but wrong
-    if it is ever used to validate input. Fixing it means editing secbaas's copy.
-    """
-    assert APIKeyGenerator.validate_format("a" * 32 + "\n") is True
-
-
 def test_round_trip_against_secbaas_implementation() -> None:
     """Both directions: each implementation verifies the other's output."""
     secbaas = _load_secbaas_generator(_secbaas_source()).APIKeyGenerator
@@ -224,6 +237,12 @@ def test_round_trip_against_secbaas_implementation() -> None:
 
 
 def test_copy_is_byte_identical_to_secbaas_source() -> None:
-    """The copy must not drift; edit the scheme in both places or neither."""
-    ours = _repo_root() / _OURS_RELPATH
-    assert ours.read_bytes() == _secbaas_source().read_bytes()
+    """The copy must not drift; edit the scheme in both places or neither.
+
+    Anchored to the module actually imported by this suite, not to a path in the
+    source tree: under a non-editable install those are different files, and
+    comparing the tree would pass while the loaded code was stale.
+    """
+    loaded = inspect.getsourcefile(APIKeyGenerator)
+    assert loaded is not None
+    assert Path(loaded).read_bytes() == _secbaas_source().read_bytes()

--- a/src/gateway/tests/unit/plugins/test_app_legacy_token.py
+++ b/src/gateway/tests/unit/plugins/test_app_legacy_token.py
@@ -1,0 +1,194 @@
+"""DB-backed tests for the deprecated legacy-JWT path — the continuity guarantee.
+
+Seeds ``avernet_application`` the way it looked before the API-key scheme
+(``token`` holding a plaintext JWT, ``api_key_*`` NULL) and asserts such an app
+still authenticates. If these tests fail, shipping this change cuts off every
+credential holder who has not yet rotated.
+
+Delete this module together with ``AppRepository._by_legacy_token`` and the
+``token`` column once the deprecation warning has gone quiet in production.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from sqlalchemy import event
+
+from gateway.community.bootstrap import initialize_database
+from gateway.community.bootstrap._configs import DatabaseConfig
+from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
+from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
+from gateway.community.spi.app import RegisteredApp
+from gateway.community.spi.database import DataSourcePlugin
+
+# A real gateway-issued app token: HS256 JWT with claims
+# {"iss":"gateway","typ":"app","sub":"Legacy App","tenant":"t","iat":…,"jti":…}.
+# Its leading characters encode the header, which is why every such token shares
+# the prefix `eyJhbGci` and why these cannot be migrated onto prefix lookup.
+_LEGACY_JWT = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJhcmUifQ"
+    ".eyJpc3MiOiJnYXRld2F5IiwidHlwIjoiYXBwIiwic3ViIjoiTGVnYWN5IEFwcCIsInRlbmFudCI6"
+    "InQiLCJpYXQiOjE3MDAwMDAwMDAsImp0aSI6ImRlYWRiZWVmIn0"
+    ".Z3dGVzdHNpZ25hdHVyZV9ub3RfdmVyaWZpZWRfYnlfdGhlX2dhdGV3YXk"
+)
+_INACTIVE_JWT = _LEGACY_JWT[:-4] + "aaaa"
+_API_KEY = APIKeyGenerator.generate()
+
+
+@pytest.fixture(scope="module")
+def db() -> DataSourcePlugin:
+    plugin = initialize_database(
+        SqliteDatabasePlugin(), DatabaseConfig(plugin_type="SQLITE_ORM", db_url="")
+    )
+    with plugin.orm_session() as session:
+        # Seeded the old way: a plaintext token, no api_key_* columns.
+        session.add(
+            AppRow(
+                app_name="Legacy App",
+                app_type="assistant",
+                token=_LEGACY_JWT,
+                owners="org-legacy",
+                tenant="t",
+            )
+        )
+        session.add(
+            AppRow(
+                app_name="Dormant Legacy App",
+                app_type="assistant",
+                token=_INACTIVE_JWT,
+                owners="org-legacy",
+                tenant="t",
+                status="INACTIVE",
+            )
+        )
+        # ...alongside a row on the new scheme, in the same table.
+        session.add(
+            AppRow(
+                app_name="Modern App",
+                app_type="assistant",
+                api_key_hash=APIKeyGenerator.hash_key(_API_KEY),
+                api_key_prefix=_API_KEY[:8],
+                owners="org-modern",
+                tenant="t2",
+            )
+        )
+    return plugin
+
+
+@pytest.fixture(scope="module")
+def registry(db: DataSourcePlugin) -> AppRepository:
+    return AppRepository(db)
+
+
+async def test_legacy_jwt_still_resolves_its_app(registry: AppRepository) -> None:
+    """The whole point of the transition window."""
+    assert await registry.find_app_by_credential(_LEGACY_JWT) == RegisteredApp(
+        id=1,
+        app_name="Legacy App",
+        owners="org-legacy",
+        app_type="assistant",
+        tenant="t",
+    )
+
+
+async def test_unknown_jwt_returns_none(registry: AppRepository) -> None:
+    """Soft miss, so another Bearer-based chain may still claim it (US27)."""
+    assert await registry.find_app_by_credential(_LEGACY_JWT[:-4] + "zzzz") is None
+
+
+async def test_inactive_legacy_row_returns_none(registry: AppRepository) -> None:
+    """Behavior change: the old lookup ignored status. Confirmed safe — the
+    non-ACTIVE population in the real table is zero."""
+    assert await registry.find_app_by_credential(_INACTIVE_JWT) is None
+
+
+async def test_legacy_resolution_warns_with_the_app_identity(
+    registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warning is what tells us when the path is safe to delete."""
+    with caplog.at_level(logging.WARNING):
+        assert await registry.find_app_by_credential(_LEGACY_JWT) is not None
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "deprecated" in message
+    assert "Legacy App" in message  # identifies who still needs rotating
+
+
+async def test_api_key_resolution_does_not_warn(
+    registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Only the legacy path is noisy, or the signal is worthless."""
+    with caplog.at_level(logging.WARNING):
+        assert await registry.find_app_by_credential(_API_KEY) is not None
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+async def test_both_credential_forms_coexist(registry: AppRepository) -> None:
+    """One table, two schemes, each resolving to its own app."""
+    legacy = await registry.find_app_by_credential(_LEGACY_JWT)
+    modern = await registry.find_app_by_credential(_API_KEY)
+
+    assert legacy is not None and modern is not None
+    assert legacy.app_name == "Legacy App"
+    assert modern.app_name == "Modern App"
+
+
+async def test_an_api_key_never_takes_the_legacy_path(
+    db: DataSourcePlugin, registry: AppRepository
+) -> None:
+    """Format dispatch is total: a 32-char key stored as a legacy token is
+    looked up as an API key and therefore does not resolve."""
+    stray = APIKeyGenerator.generate()
+    with db.orm_session() as session:
+        session.add(
+            AppRow(
+                app_name="Misfiled App",
+                app_type="assistant",
+                token=stray,  # a key sitting in the legacy column
+                owners="org-1",
+                tenant="t",
+            )
+        )
+    assert await registry.find_app_by_credential(stray) is None
+
+
+async def test_trailing_newline_authenticates_on_neither_path(
+    registry: AppRepository,
+) -> None:
+    """``validate_format`` accepts a trailing newline (an upstream quirk), so a
+    newline-suffixed key routes to the API-key branch. It must still be refused
+    — and a newline-suffixed JWT must not match the legacy row either."""
+    assert await registry.find_app_by_credential(_API_KEY + "\n") is None
+    assert await registry.find_app_by_credential(_LEGACY_JWT + "\n") is None
+
+
+@pytest.mark.parametrize("credential", [_API_KEY, _LEGACY_JWT])
+async def test_resolution_issues_exactly_one_query(
+    db: DataSourcePlugin, registry: AppRepository, credential: str
+) -> None:
+    """No try-then-fallback: dispatch picks a path up front.
+
+    Guards the hot path — a fallback would mean two queries per request for
+    every API key, plus a wasted PBKDF2 on misses.
+    """
+    selects: list[str] = []
+
+    with db.orm_session() as session:
+        engine = session.bind
+
+    def _count(conn, cursor, statement, params, context, executemany) -> None:  # noqa: ANN001
+        if statement.lstrip().upper().startswith("SELECT"):
+            selects.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _count)
+    try:
+        assert await registry.find_app_by_credential(credential) is not None
+    finally:
+        event.remove(engine, "before_cursor_execute", _count)
+
+    assert len(selects) == 1, f"expected one lookup, got {len(selects)}"

--- a/src/gateway/tests/unit/plugins/test_app_legacy_token.py
+++ b/src/gateway/tests/unit/plugins/test_app_legacy_token.py
@@ -12,6 +12,7 @@ Delete this module together with ``AppRepository._by_legacy_token`` and the
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 
 import pytest
 from sqlalchemy import event
@@ -19,6 +20,7 @@ from sqlalchemy import event
 from gateway.community.bootstrap import initialize_database
 from gateway.community.bootstrap._configs import DatabaseConfig
 from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
+from gateway.community.core.app import _repository as app_repository
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.spi.app import RegisteredApp
 from gateway.community.spi.database import DataSourcePlugin
@@ -104,6 +106,16 @@ async def test_inactive_legacy_row_returns_none(registry: AppRepository) -> None
     assert await registry.find_app_by_credential(_INACTIVE_JWT) is None
 
 
+@pytest.fixture(autouse=True)
+def _reset_warned_apps() -> Iterator[None]:
+    """The warn-once ledger is module state keyed on surrogate ids, which restart
+    at 1 in every fresh in-memory DB. Clear on both sides so entries cannot leak
+    between tests or into another module."""
+    app_repository._warned_legacy_apps.clear()
+    yield
+    app_repository._warned_legacy_apps.clear()
+
+
 async def test_legacy_resolution_warns_with_the_app_identity(
     registry: AppRepository, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -116,6 +128,18 @@ async def test_legacy_resolution_warns_with_the_app_identity(
     message = warnings[0].getMessage()
     assert "deprecated" in message
     assert "Legacy App" in message  # identifies who still needs rotating
+
+
+async def test_legacy_warning_is_emitted_once_per_app_not_once_per_request(
+    registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A busy un-rotated app would otherwise emit millions of lines a day and
+    bury the quiet app that also needs rotating."""
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            assert await registry.find_app_by_credential(_LEGACY_JWT) is not None
+
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
 
 
 async def test_api_key_resolution_does_not_warn(

--- a/src/gateway/tests/unit/plugins/test_app_legacy_token.py
+++ b/src/gateway/tests/unit/plugins/test_app_legacy_token.py
@@ -108,12 +108,12 @@ async def test_inactive_legacy_row_returns_none(registry: AppRepository) -> None
 
 @pytest.fixture(autouse=True)
 def _reset_warned_apps() -> Iterator[None]:
-    """The warn-once ledger is module state keyed on surrogate ids, which restart
-    at 1 in every fresh in-memory DB. Clear on both sides so entries cannot leak
+    """The report ledger is module state keyed on surrogate ids, which restart at
+    1 in every fresh in-memory DB. Clear on both sides so entries cannot leak
     between tests or into another module."""
-    app_repository._warned_legacy_apps.clear()
+    app_repository._last_reported.clear()
     yield
-    app_repository._warned_legacy_apps.clear()
+    app_repository._last_reported.clear()
 
 
 async def test_legacy_resolution_warns_with_the_app_identity(

--- a/src/gateway/tests/unit/plugins/test_app_registrar.py
+++ b/src/gateway/tests/unit/plugins/test_app_registrar.py
@@ -9,6 +9,7 @@ from gateway.community.bootstrap._configs import DatabaseConfig
 from gateway.community.core.app import APIKeyGenerator, AppRegistrar, AppRepository
 from gateway.community.core.app._orm import AppRow
 from gateway.community.core.app._registrar import IssuedApp, PrefixAllocationError
+from gateway.community.core.app._repository import PrefixTakenError
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.spi.database import DataSourcePlugin
 
@@ -132,3 +133,45 @@ async def test_registration_succeeds_on_a_later_attempt() -> None:
     assert len(repository.checked) == 2
     assert repository.stored == 1
     assert issued.api_key[:8] == repository.checked[1]
+
+
+async def test_prefix_taken_at_insert_is_retried() -> None:
+    """The check-then-insert race: two concurrent registrations can both pass
+    ``exists_prefix``, so the loser must retry rather than 500."""
+
+    class _LosesFirstRace(_CollidingRepository):
+        async def exists_prefix(self, api_key_prefix: str) -> bool:
+            self.checked.append(api_key_prefix)
+            return False  # nothing seen yet — but someone else is inserting
+
+        async def store(self, **kwargs: object) -> int:
+            self.stored += 1
+            if self.stored == 1:
+                raise PrefixTakenError("raced")
+            return 7
+
+    repository = _LosesFirstRace()
+    issued = await AppRegistrar(repository).register(  # type: ignore[arg-type]
+        "X", "org", "assistant", "t", creator="a"
+    )
+
+    assert repository.stored == 2  # first insert lost the race, second won
+    assert issued.id == 7
+
+
+async def test_persistent_insert_races_fail_without_a_partial_write() -> None:
+    class _AlwaysRaced(_CollidingRepository):
+        async def exists_prefix(self, api_key_prefix: str) -> bool:
+            self.checked.append(api_key_prefix)
+            return False
+
+        async def store(self, **kwargs: object) -> int:
+            self.stored += 1
+            raise PrefixTakenError("raced")
+
+    repository = _AlwaysRaced()
+    with pytest.raises(PrefixAllocationError):
+        await AppRegistrar(repository).register(  # type: ignore[arg-type]
+            "X", "org", "assistant", "t", creator="a"
+        )
+    assert repository.stored == 3  # three attempts, all lost

--- a/src/gateway/tests/unit/plugins/test_app_registrar.py
+++ b/src/gateway/tests/unit/plugins/test_app_registrar.py
@@ -1,22 +1,16 @@
-"""Unit tests for AppRegistrar (mints JWT, persists row, returns record)."""
+"""Unit tests for AppRegistrar (mints an API key, persists its hash, returns the record)."""
 
 from __future__ import annotations
 
-import jwt
 import pytest
 
 from gateway.community.bootstrap import initialize_database
 from gateway.community.bootstrap._configs import DatabaseConfig
-from gateway.community.core.app import AppRegistrar, AppRepository
-from gateway.community.core.app._registrar import IssuedApp
+from gateway.community.core.app import APIKeyGenerator, AppRegistrar, AppRepository
+from gateway.community.core.app._orm import AppRow
+from gateway.community.core.app._registrar import IssuedApp, PrefixAllocationError
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
-from gateway.community.plugins.principal_signer.bare import (
-    BarePrincipalSigner,
-    PrincipalSignerConfig,
-)
 from gateway.community.spi.database import DataSourcePlugin
-
-_FIXED_NOW = 1_700_000_000
 
 
 @pytest.fixture
@@ -28,11 +22,7 @@ def db() -> DataSourcePlugin:
 
 @pytest.fixture
 def registrar(db: DataSourcePlugin) -> AppRegistrar:
-    return AppRegistrar(
-        AppRepository(db),
-        BarePrincipalSigner(PrincipalSignerConfig(signing_key="k")),
-        clock=lambda: _FIXED_NOW,
-    )
+    return AppRegistrar(AppRepository(db))
 
 
 async def test_register_persists_row_and_returns_record(
@@ -47,34 +37,98 @@ async def test_register_persists_row_and_returns_record(
     assert issued.owners == "org-1"
     assert issued.app_type == "assistant"
     assert issued.tenant == "t1"
-    assert issued.token
-
-    rec = await AppRepository(db).find_app_by_token(issued.token)
-    assert rec is not None
-    assert rec.id == issued.id
-    assert rec.app_name == "X App"
-    assert rec.tenant == "t1"
 
     # The registering caller is recorded as both creator and modifier (non-empty),
     # never a fabricated default.
     with db.orm_session() as session:
-        from gateway.community.core.app._orm import AppRow
-
         row = session.get(AppRow, issued.id)
+        assert row is not None
         assert row.creator == "alice"
         assert row.modifier == "alice"
 
 
-async def test_register_token_has_expected_claims_and_no_exp(
-    registrar: AppRegistrar,
+async def test_issued_key_is_32_char_base62(registrar: AppRegistrar) -> None:
+    issued = await registrar.register("X App", "org-1", "assistant", "t1", creator="a")
+    assert len(issued.api_key) == 32
+    assert APIKeyGenerator.validate_format(issued.api_key) is True
+
+
+async def test_only_the_hash_is_persisted(
+    registrar: AppRegistrar, db: DataSourcePlugin
 ) -> None:
-    issued = await registrar.register(
-        "X App", "org-1", "assistant", "t1", creator="alice"
+    """The plaintext key must not be recoverable from the registry."""
+    issued = await registrar.register("X App", "org-1", "assistant", "t1", creator="a")
+
+    with db.orm_session() as session:
+        row = session.get(AppRow, issued.id)
+        assert row is not None
+        assert row.token is None  # no JWT is ever minted now
+        assert row.api_key_prefix == issued.api_key[:8]
+        assert row.api_key_hash is not None
+        assert issued.api_key not in row.api_key_hash
+
+
+async def test_issued_key_authenticates(
+    registrar: AppRegistrar, db: DataSourcePlugin
+) -> None:
+    """Mint → verify closed loop, through the same repository a request uses."""
+    issued = await registrar.register("X App", "org-1", "assistant", "t1", creator="a")
+
+    record = await AppRepository(db).find_app_by_credential(issued.api_key)
+    assert record is not None
+    assert record.id == issued.id
+    assert record.app_name == "X App"
+    assert record.tenant == "t1"
+
+
+async def test_two_registrations_get_different_keys(registrar: AppRegistrar) -> None:
+    first = await registrar.register("A", "org", "assistant", "t", creator="a")
+    second = await registrar.register("B", "org", "assistant", "t", creator="a")
+    assert first.api_key != second.api_key
+    assert first.api_key[:8] != second.api_key[:8]
+
+
+class _CollidingRepository:
+    """Reports every prefix as taken, and records what was attempted."""
+
+    def __init__(self) -> None:
+        self.checked: list[str] = []
+        self.stored = 0
+
+    async def exists_prefix(self, api_key_prefix: str) -> bool:
+        self.checked.append(api_key_prefix)
+        return True
+
+    async def store(self, **_kwargs: object) -> int:
+        self.stored += 1
+        return 1
+
+
+async def test_prefix_collision_retries_then_fails_without_writing() -> None:
+    repository = _CollidingRepository()
+    registrar = AppRegistrar(repository)  # type: ignore[arg-type]
+
+    with pytest.raises(PrefixAllocationError):
+        await registrar.register("X", "org", "assistant", "t", creator="a")
+
+    assert len(repository.checked) == 3  # three attempts, then give up
+    assert len(set(repository.checked)) == 3  # a fresh key each time
+    assert repository.stored == 0  # nothing partially written
+
+
+async def test_registration_succeeds_on_a_later_attempt() -> None:
+    """A collision is retried, not fatal."""
+
+    class _CollidesOnce(_CollidingRepository):
+        async def exists_prefix(self, api_key_prefix: str) -> bool:
+            self.checked.append(api_key_prefix)
+            return len(self.checked) == 1
+
+    repository = _CollidesOnce()
+    issued = await AppRegistrar(repository).register(  # type: ignore[arg-type]
+        "X", "org", "assistant", "t", creator="a"
     )
-    decoded = jwt.decode(issued.token, "k", algorithms=["HS256"])
-    assert decoded["typ"] == "app"
-    assert decoded["sub"] == "X App"
-    assert decoded["tenant"] == "t1"
-    assert decoded["iat"] == _FIXED_NOW
-    assert "exp" not in decoded
-    assert isinstance(decoded["jti"], str) and decoded["jti"]
+
+    assert len(repository.checked) == 2
+    assert repository.stored == 1
+    assert issued.api_key[:8] == repository.checked[1]

--- a/src/gateway/tests/unit/plugins/test_app_registry_db.py
+++ b/src/gateway/tests/unit/plugins/test_app_registry_db.py
@@ -179,8 +179,9 @@ async def test_duplicate_prefix_raises_prefix_taken_error(
 ) -> None:
     """The real IntegrityError path, not a fake raising the domain error.
 
-    Guards the constraint-name discrimination in ``store``: without it the
-    registrar retries any write failure and reports prefix exhaustion.
+    Guards ``store``'s collision oracle — the ``exists_prefix`` re-read that
+    decides whether a failed insert is retryable. Without it the registrar
+    retries every write failure and reports prefix exhaustion.
     """
     repository = AppRepository(db)
     key = APIKeyGenerator.generate()
@@ -204,7 +205,8 @@ async def test_non_collision_integrity_errors_are_not_disguised(
     key = APIKeyGenerator.generate()
     # PrefixTakenError is a RuntimeError, so binding IntegrityError here is
     # itself the assertion: a regression that relabelled every IntegrityError
-    # would escape this ``raises`` rather than satisfy it.
+    # would escape this ``raises`` rather than satisfy it. Deliberately not
+    # asserting on the driver's message, which differs per backend.
     with pytest.raises(IntegrityError) as caught:
         await AppRepository(db).store(
             api_key_hash=APIKeyGenerator.hash_key(key),
@@ -214,7 +216,7 @@ async def test_non_collision_integrity_errors_are_not_disguised(
             app_type="assistant",
             tenant="t",
         )
-    assert "app_name" in str(caught.value.orig)
+    assert not isinstance(caught.value, PrefixTakenError)  # nosec: see above
 
 
 async def test_malformed_hash_is_reported_not_silently_rejected(
@@ -339,12 +341,6 @@ async def test_verification_does_not_stall_the_event_loop(
     APIKeyGenerator.verify_key(_ACTIVE_KEY, _ACTIVE_HASH)
     derivation = time.perf_counter() - start
     budget = derivation * 0.5
-    if budget <= heartbeat_period * 2:
-        pytest.skip(
-            f"a {derivation * 1000:.0f}ms derivation leaves a {budget * 1000:.0f}ms "
-            f"budget, under the {heartbeat_period * 1000:.0f}ms heartbeat floor — "
-            "correct code would fail this bound"
-        )
 
     longest_gap = 0.0
 
@@ -359,7 +355,17 @@ async def test_verification_does_not_stall_the_event_loop(
 
     beat = asyncio.create_task(heartbeat())
     try:
-        await asyncio.sleep(0.02)
+        # Warm-up doubles as calibration: whatever the loop's idle scheduling
+        # jitter is on this machine, the budget has to clear it comfortably or
+        # the assertion measures noise rather than blocking.
+        await asyncio.sleep(0.05)
+        idle_jitter = longest_gap
+        if budget <= idle_jitter * 2:
+            pytest.skip(
+                f"idle jitter is {idle_jitter * 1000:.0f}ms against a "
+                f"{budget * 1000:.0f}ms budget — too noisy here to tell a stall "
+                "from scheduling delay"
+            )
         longest_gap = 0.0
         assert await registry.find_app_by_credential(_ACTIVE_KEY) is not None
         # Yield before cancelling: the heartbeat records a gap only when it next

--- a/src/gateway/tests/unit/plugins/test_app_registry_db.py
+++ b/src/gateway/tests/unit/plugins/test_app_registry_db.py
@@ -7,13 +7,23 @@ and presents the plaintext key the way a caller would.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import os
+import time
 from collections.abc import Iterator
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from gateway.community.bootstrap import initialize_database
 from gateway.community.bootstrap._configs import DatabaseConfig
-from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
+from gateway.community.core.app import (
+    APIKeyGenerator,
+    AppRepository,
+    AppRow,
+    PrefixTakenError,
+)
 from gateway.community.core.app import _repository as app_repository
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.spi.app import RegisteredApp
@@ -59,13 +69,16 @@ def registry(db: DataSourcePlugin) -> AppRepository:
 
 
 @pytest.fixture(autouse=True)
-def _reset_report_ledgers() -> Iterator[None]:
-    """The report-once ledgers are module state keyed on surrogate ids, which
-    restart at 1 in every fresh in-memory DB. Clear on both sides so entries
-    cannot leak between tests or into another module."""
-    app_repository._reported_corrupt_apps.clear()
+def _reset_report_ledger() -> Iterator[None]:
+    """The report ledger is module state; clear it on both sides.
+
+    Keyed on (kind, datasource, surrogate id), and surrogate ids restart at 1 in
+    every fresh in-memory DB, so a leaked entry would silently suppress another
+    test's expected log — passing or failing on collection order.
+    """
+    app_repository._last_reported.clear()
     yield
-    app_repository._reported_corrupt_apps.clear()
+    app_repository._last_reported.clear()
 
 
 async def test_correct_key_resolves_active_seeded_app(registry: AppRepository) -> None:
@@ -169,8 +182,6 @@ async def test_duplicate_prefix_raises_prefix_taken_error(
     Guards the constraint-name discrimination in ``store``: without it the
     registrar retries any write failure and reports prefix exhaustion.
     """
-    from gateway.community.core.app import PrefixTakenError
-
     repository = AppRepository(db)
     key = APIKeyGenerator.generate()
     common = dict(
@@ -190,11 +201,10 @@ async def test_non_collision_integrity_errors_are_not_disguised(
     db: DataSourcePlugin,
 ) -> None:
     """A NOT NULL violation must surface as itself, not as a prefix collision."""
-    from sqlalchemy.exc import IntegrityError
-
-    from gateway.community.core.app import PrefixTakenError
-
     key = APIKeyGenerator.generate()
+    # PrefixTakenError is a RuntimeError, so binding IntegrityError here is
+    # itself the assertion: a regression that relabelled every IntegrityError
+    # would escape this ``raises`` rather than satisfy it.
     with pytest.raises(IntegrityError) as caught:
         await AppRepository(db).store(
             api_key_hash=APIKeyGenerator.hash_key(key),
@@ -204,15 +214,13 @@ async def test_non_collision_integrity_errors_are_not_disguised(
             app_type="assistant",
             tenant="t",
         )
-    assert not isinstance(caught.value, PrefixTakenError)
+    assert "app_name" in str(caught.value.orig)
 
 
 async def test_malformed_hash_is_reported_not_silently_rejected(
     db: DataSourcePlugin, registry: AppRepository, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A hash missing its separator reads as a wrong key without this check."""
-    import logging
-
     key = APIKeyGenerator.generate()
     with db.orm_session() as session:
         session.add(
@@ -238,8 +246,6 @@ async def test_corrupt_row_error_is_logged_once_per_app(
     db: DataSourcePlugin, registry: AppRepository, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A corrupt row can never authenticate, so its client retries forever."""
-    import logging
-
     key = APIKeyGenerator.generate()
     with db.orm_session() as session:
         session.add(
@@ -268,8 +274,6 @@ async def test_corrupt_row_is_logged_as_an_error(
     It fails closed either way, but silently would leave an operator staring at
     a healthy-looking row and an app that cannot authenticate.
     """
-    import logging
-
     key = APIKeyGenerator.generate()
     with db.orm_session() as session:
         session.add(
@@ -320,10 +324,6 @@ async def test_verification_does_not_stall_the_event_loop(
         ``cpu_count`` reports the machine's cores and would let the guard pass on a
         pinned runner, then fail the assertion against correct code.
     """
-    import asyncio
-    import os
-    import time
-
     available = (
         len(os.sched_getaffinity(0))
         if hasattr(os, "sched_getaffinity")
@@ -334,10 +334,17 @@ async def test_verification_does_not_stall_the_event_loop(
             f"needs >1 usable core to tell stalling from starvation (have {available})"
         )
 
+    heartbeat_period = 0.005
     start = time.perf_counter()
     APIKeyGenerator.verify_key(_ACTIVE_KEY, _ACTIVE_HASH)
     derivation = time.perf_counter() - start
     budget = derivation * 0.5
+    if budget <= heartbeat_period * 2:
+        pytest.skip(
+            f"a {derivation * 1000:.0f}ms derivation leaves a {budget * 1000:.0f}ms "
+            f"budget, under the {heartbeat_period * 1000:.0f}ms heartbeat floor — "
+            "correct code would fail this bound"
+        )
 
     longest_gap = 0.0
 
@@ -345,7 +352,7 @@ async def test_verification_does_not_stall_the_event_loop(
         nonlocal longest_gap
         previous = time.perf_counter()
         while True:
-            await asyncio.sleep(0.005)
+            await asyncio.sleep(heartbeat_period)
             now = time.perf_counter()
             longest_gap = max(longest_gap, now - previous)
             previous = now

--- a/src/gateway/tests/unit/plugins/test_app_registry_db.py
+++ b/src/gateway/tests/unit/plugins/test_app_registry_db.py
@@ -1,4 +1,9 @@
-"""DB-backed tests for ``AppRepository`` (queries the seeded ``avernet_application`` table)."""
+"""DB-backed tests for ``AppRepository``'s API-key path.
+
+Seeds ``avernet_application`` the way the registrar and the secbaas migration
+both do — a PBKDF2 hash plus the key's 8-character prefix, never the plaintext —
+and presents the plaintext key the way a caller would.
+"""
 
 from __future__ import annotations
 
@@ -6,31 +11,49 @@ import pytest
 
 from gateway.community.bootstrap import initialize_database
 from gateway.community.bootstrap._configs import DatabaseConfig
-from gateway.community.core.app import AppRepository, AppRow
+from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.spi.app import RegisteredApp
+from gateway.community.spi.database import DataSourcePlugin
+
+_ACTIVE_KEY = APIKeyGenerator.generate()
+_INACTIVE_KEY = APIKeyGenerator.generate()
+_REVOKED_KEY = APIKeyGenerator.generate()
+
+
+def _seed(session, key: str, *, app_name: str, status: str = "ACTIVE") -> None:
+    session.add(
+        AppRow(
+            app_name=app_name,
+            app_type="assistant",
+            api_key_hash=APIKeyGenerator.hash_key(key),
+            api_key_prefix=key[:8],
+            owners="org-1",
+            tenant="t",
+            status=status,
+        )
+    )
 
 
 @pytest.fixture(scope="module")
-def registry() -> AppRepository:
-    db = SqliteDatabasePlugin()
-    initialize_database(db, DatabaseConfig(plugin_type="SQLITE_ORM", db_url=""))
-    with db.orm_session() as session:
-        session.add(
-            AppRow(
-                app_name="Demo App",
-                app_type="assistant",
-                token="app-key",
-                owners="org-1",
-                tenant="t",
-            )
-        )
+def db() -> DataSourcePlugin:
+    plugin = initialize_database(
+        SqliteDatabasePlugin(), DatabaseConfig(plugin_type="SQLITE_ORM", db_url="")
+    )
+    with plugin.orm_session() as session:
+        _seed(session, _ACTIVE_KEY, app_name="Demo App")
+        _seed(session, _INACTIVE_KEY, app_name="Dormant App", status="INACTIVE")
+        _seed(session, _REVOKED_KEY, app_name="Revoked App", status="REVOKED")
+    return plugin
+
+
+@pytest.fixture(scope="module")
+def registry(db: DataSourcePlugin) -> AppRepository:
     return AppRepository(db)
 
 
-async def test_known_token_resolves_seeded_app(registry: AppRepository) -> None:
-    app = await registry.find_app_by_token("app-key")
-    assert app == RegisteredApp(
+async def test_correct_key_resolves_active_seeded_app(registry: AppRepository) -> None:
+    assert await registry.find_app_by_credential(_ACTIVE_KEY) == RegisteredApp(
         id=1,
         app_name="Demo App",
         owners="org-1",
@@ -39,5 +62,84 @@ async def test_known_token_resolves_seeded_app(registry: AppRepository) -> None:
     )
 
 
-async def test_unknown_token_returns_none(registry: AppRepository) -> None:
-    assert await registry.find_app_by_token("nope") is None
+async def test_wrong_key_with_known_prefix_returns_none(
+    registry: AppRepository,
+) -> None:
+    """The prefix locates the row; only the hash decides. This is the whole point."""
+    impostor = _ACTIVE_KEY[:8] + APIKeyGenerator.generate()[8:]
+    assert impostor != _ACTIVE_KEY
+    assert await registry.find_app_by_credential(impostor) is None
+
+
+async def test_unknown_key_returns_none(registry: AppRepository) -> None:
+    assert await registry.find_app_by_credential(APIKeyGenerator.generate()) is None
+
+
+@pytest.mark.parametrize("status", ["INACTIVE", "REVOKED"])
+async def test_non_active_rows_return_none(
+    registry: AppRepository, status: str
+) -> None:
+    """A correct key is still refused when its app is not ACTIVE."""
+    key = _INACTIVE_KEY if status == "INACTIVE" else _REVOKED_KEY
+    assert await registry.find_app_by_credential(key) is None
+
+
+@pytest.mark.parametrize("credential", ["", "short", "1234567"])
+async def test_credentials_too_short_return_none(
+    registry: AppRepository, credential: str
+) -> None:
+    """Rejected before any query — there is no prefix to look up."""
+    assert await registry.find_app_by_credential(credential) is None
+
+
+async def test_row_with_prefix_but_no_hash_returns_none(
+    db: DataSourcePlugin, registry: AppRepository
+) -> None:
+    """A malformed row fails closed rather than raising."""
+    key = APIKeyGenerator.generate()
+    with db.orm_session() as session:
+        session.add(
+            AppRow(
+                app_name="Broken App",
+                app_type="assistant",
+                api_key_hash=None,
+                api_key_prefix=key[:8],
+                owners="org-1",
+                tenant="t",
+            )
+        )
+    assert await registry.find_app_by_credential(key) is None
+
+
+async def test_exists_prefix(registry: AppRepository) -> None:
+    assert await registry.exists_prefix(_ACTIVE_KEY[:8]) is True
+    assert await registry.exists_prefix(APIKeyGenerator.generate()[:8]) is False
+
+
+async def test_exists_prefix_sees_non_active_rows(registry: AppRepository) -> None:
+    """Collision checking must ignore status, or a new key could shadow an old row."""
+    assert await registry.exists_prefix(_REVOKED_KEY[:8]) is True
+
+
+async def test_store_persists_only_the_hash(db: DataSourcePlugin) -> None:
+    key = APIKeyGenerator.generate()
+    repository = AppRepository(db)
+    app_id = await repository.store(
+        api_key_hash=APIKeyGenerator.hash_key(key),
+        api_key_prefix=key[:8],
+        app_name="Stored App",
+        owners="org-2",
+        app_type="assistant",
+        tenant="t2",
+        creator="alice",
+        modifier="alice",
+    )
+
+    with db.orm_session() as session:
+        row = session.get(AppRow, app_id)
+        assert row is not None
+        assert row.api_key_prefix == key[:8]
+        assert row.token is None
+        assert key not in (row.api_key_hash or "")  # no plaintext anywhere
+
+    assert await repository.find_app_by_credential(key) is not None

--- a/src/gateway/tests/unit/plugins/test_app_registry_db.py
+++ b/src/gateway/tests/unit/plugins/test_app_registry_db.py
@@ -7,16 +7,20 @@ and presents the plaintext key the way a caller would.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from gateway.community.bootstrap import initialize_database
 from gateway.community.bootstrap._configs import DatabaseConfig
 from gateway.community.core.app import APIKeyGenerator, AppRepository, AppRow
+from gateway.community.core.app import _repository as app_repository
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.spi.app import RegisteredApp
 from gateway.community.spi.database import DataSourcePlugin
 
 _ACTIVE_KEY = APIKeyGenerator.generate()
+_ACTIVE_HASH = APIKeyGenerator.hash_key(_ACTIVE_KEY)
 _INACTIVE_KEY = APIKeyGenerator.generate()
 _REVOKED_KEY = APIKeyGenerator.generate()
 
@@ -26,7 +30,9 @@ def _seed(session, key: str, *, app_name: str, status: str = "ACTIVE") -> None:
         AppRow(
             app_name=app_name,
             app_type="assistant",
-            api_key_hash=APIKeyGenerator.hash_key(key),
+            api_key_hash=_ACTIVE_HASH
+            if key == _ACTIVE_KEY
+            else APIKeyGenerator.hash_key(key),
             api_key_prefix=key[:8],
             owners="org-1",
             tenant="t",
@@ -50,6 +56,16 @@ def db() -> DataSourcePlugin:
 @pytest.fixture(scope="module")
 def registry(db: DataSourcePlugin) -> AppRepository:
     return AppRepository(db)
+
+
+@pytest.fixture(autouse=True)
+def _reset_report_ledgers() -> Iterator[None]:
+    """The report-once ledgers are module state keyed on surrogate ids, which
+    restart at 1 in every fresh in-memory DB. Clear on both sides so entries
+    cannot leak between tests or into another module."""
+    app_repository._reported_corrupt_apps.clear()
+    yield
+    app_repository._reported_corrupt_apps.clear()
 
 
 async def test_correct_key_resolves_active_seeded_app(registry: AppRepository) -> None:
@@ -143,3 +159,210 @@ async def test_store_persists_only_the_hash(db: DataSourcePlugin) -> None:
         assert key not in (row.api_key_hash or "")  # no plaintext anywhere
 
     assert await repository.find_app_by_credential(key) is not None
+
+
+async def test_duplicate_prefix_raises_prefix_taken_error(
+    db: DataSourcePlugin,
+) -> None:
+    """The real IntegrityError path, not a fake raising the domain error.
+
+    Guards the constraint-name discrimination in ``store``: without it the
+    registrar retries any write failure and reports prefix exhaustion.
+    """
+    from gateway.community.core.app import PrefixTakenError
+
+    repository = AppRepository(db)
+    key = APIKeyGenerator.generate()
+    common = dict(
+        api_key_hash=APIKeyGenerator.hash_key(key),
+        api_key_prefix=key[:8],
+        owners="o",
+        app_type="assistant",
+        tenant="t",
+    )
+    await repository.store(app_name="First", **common)
+
+    with pytest.raises(PrefixTakenError):
+        await repository.store(app_name="Second", **common)
+
+
+async def test_non_collision_integrity_errors_are_not_disguised(
+    db: DataSourcePlugin,
+) -> None:
+    """A NOT NULL violation must surface as itself, not as a prefix collision."""
+    from sqlalchemy.exc import IntegrityError
+
+    from gateway.community.core.app import PrefixTakenError
+
+    key = APIKeyGenerator.generate()
+    with pytest.raises(IntegrityError) as caught:
+        await AppRepository(db).store(
+            api_key_hash=APIKeyGenerator.hash_key(key),
+            api_key_prefix=key[:8],
+            app_name=None,  # type: ignore[arg-type]
+            owners="o",
+            app_type="assistant",
+            tenant="t",
+        )
+    assert not isinstance(caught.value, PrefixTakenError)
+
+
+async def test_malformed_hash_is_reported_not_silently_rejected(
+    db: DataSourcePlugin, registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A hash missing its separator reads as a wrong key without this check."""
+    import logging
+
+    key = APIKeyGenerator.generate()
+    with db.orm_session() as session:
+        session.add(
+            AppRow(
+                app_name="Malformed App",
+                app_type="assistant",
+                api_key_hash="no-separator-here",
+                api_key_prefix=key[:8],
+                owners="org-1",
+                tenant="t",
+            )
+        )
+
+    with caplog.at_level(logging.ERROR):
+        assert await registry.find_app_by_credential(key) is None
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert "Malformed App" in errors[0].getMessage()
+
+
+async def test_corrupt_row_error_is_logged_once_per_app(
+    db: DataSourcePlugin, registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A corrupt row can never authenticate, so its client retries forever."""
+    import logging
+
+    key = APIKeyGenerator.generate()
+    with db.orm_session() as session:
+        session.add(
+            AppRow(
+                app_name="Repeatedly Corrupt App",
+                app_type="assistant",
+                api_key_hash=None,
+                api_key_prefix=key[:8],
+                owners="org-1",
+                tenant="t",
+            )
+        )
+
+    with caplog.at_level(logging.ERROR):
+        for _ in range(5):
+            assert await registry.find_app_by_credential(key) is None
+
+    assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 1
+
+
+async def test_corrupt_row_is_logged_as_an_error(
+    db: DataSourcePlugin, registry: AppRepository, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A prefix with no hash breaks the table's one-credential-form invariant.
+
+    It fails closed either way, but silently would leave an operator staring at
+    a healthy-looking row and an app that cannot authenticate.
+    """
+    import logging
+
+    key = APIKeyGenerator.generate()
+    with db.orm_session() as session:
+        session.add(
+            AppRow(
+                app_name="Corrupt App",
+                app_type="assistant",
+                api_key_hash=None,
+                api_key_prefix=key[:8],
+                owners="org-1",
+                tenant="t",
+            )
+        )
+
+    with caplog.at_level(logging.ERROR):
+        assert await registry.find_app_by_credential(key) is None
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert "Corrupt App" in errors[0].getMessage()
+
+
+async def test_verification_does_not_stall_the_event_loop(
+    registry: AppRepository,
+) -> None:
+    """PBKDF2 must not run on the event loop.
+
+        Measures the property directly — the longest the loop goes without servicing
+        a 5ms heartbeat — rather than inferring it from wall-clock speedup. Speedup
+        needs a second core to appear, and ``os.cpu_count()`` does not see cgroup or
+        affinity limits, so a CPU-count guard silently reports the wrong answer on a
+        constrained runner. A stall is visible on any number of cores.
+
+    Calibrated against a *direct* ``verify_key`` call, not against a repository
+        lookup: timing the lookup would include the very derivation under test, so a
+        blocking implementation would raise its own bound and pass.
+
+        One verification at a time, deliberately. Enough concurrent derivations to
+        saturate every core starve the loop thread even when the work is correctly
+        off it, so a concurrent version measures CPU saturation rather than
+        blocking. With a single derivation on a worker thread there is always a core
+        for the loop, so the two cases separate cleanly: correct code idles at the
+        ~5ms heartbeat, blocking code stalls for the whole derivation.
+
+        Skipped on a single core, where the property is unobservable: the loop
+        thread competes with the worker threads for the one CPU, so starvation is
+        indistinguishable from blocking. ``sched_getaffinity`` rather than
+        ``cpu_count`` because only the former sees affinity and cgroup limits —
+        ``cpu_count`` reports the machine's cores and would let the guard pass on a
+        pinned runner, then fail the assertion against correct code.
+    """
+    import asyncio
+    import os
+    import time
+
+    available = (
+        len(os.sched_getaffinity(0))
+        if hasattr(os, "sched_getaffinity")
+        else (os.cpu_count() or 1)
+    )
+    if available < 2:
+        pytest.skip(
+            f"needs >1 usable core to tell stalling from starvation (have {available})"
+        )
+
+    start = time.perf_counter()
+    APIKeyGenerator.verify_key(_ACTIVE_KEY, _ACTIVE_HASH)
+    derivation = time.perf_counter() - start
+    budget = derivation * 0.5
+
+    longest_gap = 0.0
+
+    async def heartbeat() -> None:
+        nonlocal longest_gap
+        previous = time.perf_counter()
+        while True:
+            await asyncio.sleep(0.005)
+            now = time.perf_counter()
+            longest_gap = max(longest_gap, now - previous)
+            previous = now
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        await asyncio.sleep(0.02)
+        longest_gap = 0.0
+        assert await registry.find_app_by_credential(_ACTIVE_KEY) is not None
+        # Yield before cancelling: the heartbeat records a gap only when it next
+        # runs, so cancelling straight away discards the very stall under test.
+        await asyncio.sleep(0.01)
+    finally:
+        beat.cancel()
+
+    assert longest_gap < budget, (
+        f"the loop went {longest_gap * 1000:.0f}ms without running a coroutine, "
+        f"against a {budget * 1000:.0f}ms budget (half of a {derivation * 1000:.0f}ms "
+        "derivation) — verification is running on the event loop"
+    )

--- a/src/gateway/tests/unit/plugins/test_app_token_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_app_token_strategy.py
@@ -25,8 +25,8 @@ class _FakeAppRegistry:
         tenant="t",
     )
 
-    async def find_app_by_token(self, token: str) -> RegisteredApp | None:
-        return self._APP if token == "app-key" else None
+    async def find_app_by_credential(self, credential: str) -> RegisteredApp | None:
+        return self._APP if credential == "app-key" else None
 
 
 def _strat() -> AppTokenStrategy:


### PR DESCRIPTION
## Problem

The gateway registers a third-party app by minting a signed JWT and storing it in plaintext as `avernet_application.token`, resolving presented tokens by exact string match. secbaas's API-gateway key service instead issues 32-char base62 API keys stored only as salted PBKDF2 hashes with 8-char prefix lookup. The secbaas `baas_api_key` records are being migrated into `avernet_application`, and those keys — whose plaintext only the holders have — must keep authenticating unchanged. That requires the gateway to generate, store, and verify credentials with byte-for-byte the same scheme.

Existing gateway-issued JWT holders must not break either, and their tokens **cannot** be converted into the new scheme. The scheme locates a record by the credential's first 8 characters, but every JWT this gateway issues begins with the same base64-encoded header: signing five tokens for different apps and tenants with the real signer yields **one** distinct prefix (`eyJhbGci`) across all five. They would violate the prefix uniqueness constraint and be indistinguishable at lookup. That finding is what shaped the design.

## Solution

Adopt the secbaas `APIKeyGenerator` scheme verbatim, with a transition window for existing JWT holders.

- **Copy** of `APIKeyGenerator` into `core/app/_key_gen.py` — identical in code, translated in prose. The gateway has no dependency on the baas package, so the class is copied, and it is pinned from both ends: a `(key, hash)` fixture produced by *running* the real secbaas implementation, an explicit recomputation of PBKDF2 from the stored salt, a both-direction round trip, and a parity check comparing the two modules as syntax trees with docstrings stripped. The stored hash records only its salt, so the digest, iteration count and encoding are implicit constants; drift in any of them would silently invalidate every migrated record. Comments and docstrings are the only thing allowed to differ, so this copy reads in English like the rest of the gateway; a second guard fails if a wholesale re-copy of upstream restores the Chinese prose.
- **Schema:** `api_key_hash` + `api_key_prefix` (nullable, prefix unique, `utf8mb4_bin`), with `token` retained as a nullable deprecated column. `002_application_api_key.sql` carries the change to already-deployed databases — `001` is `CREATE TABLE IF NOT EXISTS` and migrates nobody.
- **Lookup:** `find_app_by_token` → `find_app_by_credential`. Prefix lookup, `ACTIVE`-only gate, constant-time hash compare. Verification runs via `asyncio.to_thread`: PBKDF2 is ~30ms of CPU and inline it blocks the entire event loop (measured — ten concurrent verifications stalled every other coroutine for 307ms).
- **Continuity:** legacy JWTs resolve through a deprecated exact-match path, selected by credential *format* rather than by fallback (`validate_format` is a total discriminator — a JWT always contains `.`), so each request makes exactly one query. Every still-unrotated app re-warns at most once per five minutes, which is the deletion criterion.
- **Registration** mints keys with collision retry around the insert, persists only hash + prefix, and returns `api_key` once. `PrincipalSigner` is dropped from the registrar; it still serves principal assertions and access-key issuance.

Rejected: converting existing JWTs (prefix collision, above); using the JWT's random signature tail as its prefix (works, but a permanent lookup branch for a population that should shrink to zero); importing the generator from baas; hard cutover.

## Validation

- Full gateway gate green: **870/870 cases, 95.10% line coverage, 96.15% changed-line coverage**, plus lint/format and E2E.
- Also run pinned to a single CPU, where the loop-stall test skips rather than reporting a false failure.
- All twelve spec acceptance criteria walked end-to-end against a live database and the real secbaas implementation.
- Key guards are mutation-verified, not assumed: weakening the salt, switching the base64 alphabet, reverting verification onto the event loop, weakening the iteration count, and re-copying upstream verbatim each fail their test deterministically, while a comment-only edit passes.
- Six review rounds; each round's findings were reproduced before fixing, and several review claims were measured and found wrong before being acted on.
- **Not verified:** the migration SQL has not been executed against a live MySQL — no daemon is available in the authoring environment. `sqlparse` confirms one statement with the six alter actions in the intended order; `sqlglot` cannot parse multi-action `ALTER`s at all (a minimal valid control case falls back identically), so it offers no signal. Worth one run against a real instance before deploying.

## Compatibility and risk

- **No credential stops working.** Existing JWT holders authenticate through the deprecated path; migrated secbaas keys work on arrival. Uniform `ACTIVE` gating is a behavior change for the legacy path — confirmed safe, the non-`ACTIVE` population is zero.
- **Breaking for admin-API callers:** `POST /admin/apps` returns `api_key` instead of `token`, and `status` is constrained to `ACTIVE`/`INACTIVE`.
- **Schema is additive** apart from the token index, below; rollback leaves two unused nullable columns.
- **`002` is a single `ALTER`**, so MySQL 8's atomic DDL makes it all-or-nothing rather than half-applied. It drops `uk_avernet_application_token` and re-adds it over a 700-character prefix: making `token` nullable rebuilds the column and any index over it, and that index spanned the full `varchar(1024)` — 4096 bytes at utf8mb4, past InnoDB's 3072-byte limit, so the rebuild would otherwise fail. Uniqueness is unaffected in practice, since gateway-issued app tokens are ~261 characters. `001` gets the same prefix form; the full-width index had made that file non-executable against MySQL 8 InnoDB.
- Deleting the deprecated path is a follow-up gated on the warning going quiet.

## Open for reviewer adjudication

One Codex finding is **disputed, not fixed** — that renaming the `AppRegistry` port method breaks external implementations. The evidence in the thread: `app_registry` is not a plugin selector (those are `database`, `forwarder`, `cache_plugin`, `auth`, `secret_resolver`), is not entry-point exposed (groups are `gateway.runner`/`logger`/`tracer`), and has exactly one implementation in the repo. A compatibility alias would also be harmful rather than safe: this change moves the storage format, so an implementation still on `find_app_by_token` would match a `token` column that new registrations leave `NULL` — silently authenticating nobody registered after the deploy. If an out-of-tree implementation does exist, it needs a coordinated update regardless of the method name; please say so on the thread and I'll revisit.

## Spec

`src/gateway/specs/2026-08-13-application-api-key-credentials/` (spec.md / plan.md / tasks.md). `plan.md` also records two upstream defects in the copied scheme that code parity forbids fixing here, one upstream documentation defect carried across rather than silently corrected, and the one-directional CI gap on the parity guard.