### PR TITLE
fix: sync aicoding local skills in prepub builds

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/service_bot/router_build.py
+++ b/src/backend/src/agentclaw/community/adapters/http/service_bot/router_build.py
@@ -301,6 +301,7 @@ async def get_bot_rsync_excludes(
     user: AuthenticatedUser = Depends(get_current_user),
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
+    registry: EngineSandboxRegistry = Injected(EngineSandboxRegistry),
 ) -> ApiResponse:
     """获取Bot的rsync excludes配置信息。
 
@@ -345,16 +346,9 @@ async def get_bot_rsync_excludes(
         # 2. 解析引擎类型
         engine_type = resolve_engine_for_bot(bot_id, owner_id, bot_repo=bot_repo)
 
-        # 3. 获取引擎默认配置
-        from agentclaw.community.core.workspace.engines.openclaw import _OPENCLAW_RSYNC_EXCLUDES
-        from agentclaw.community.core.workspace.engines.claude_code import _CLAUDE_CODE_RSYNC_EXCLUDES
-
-        if engine_type == "openclaw":
-            default_excludes = list(_OPENCLAW_RSYNC_EXCLUDES)
-        elif engine_type == "claude_code":
-            default_excludes = list(_CLAUDE_CODE_RSYNC_EXCLUDES)
-        else:
-            default_excludes = []
+        # 3. 通过引擎 provider 获取默认配置，避免在路由层硬编码具体引擎。
+        provider = registry.resolve(engine_type)
+        default_excludes = list(provider.get_build_plan().rsync_excludes)
 
         # 4. 解析Bot自定义配置
         from agentclaw.community.core.workspace.engines import parse_build_rsync_excludes_from_ext

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -21,6 +21,7 @@ user_config:
   workspace:
     openclaw_root: "./data/workspace/openclaw"
     claude_code_root: "./data/workspace/claude_code"
+    aicoding_root: "./data/workspace/aicoding"
 
   # Operator whitelist gating admin endpoints. Empty = no privileged operators
   # by default; a community deployment lists its own admin subject ids.

--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -89,6 +89,7 @@ user_config:
     env_folder: "aidesktop_singlebox"
     openclaw_root: "~/.openclaw"
     claude_code_root: "~/.claude_code"
+    aicoding_root: "~/.aicoding"
 
   openclaw:
     skills_repo_url: "git@code.teamclaw.com:security_release/aiworkbench.git"

--- a/src/backend/src/agentclaw/community/configs/application-test.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-test.yaml
@@ -28,6 +28,7 @@ user_config:
   workspace:
     openclaw_root: "~/.openclaw"
     claude_code_root: "~/.claude_code"
+    aicoding_root: "~/.aicoding"
 
   # Yuque binding-verify endpoint — neutral stand-in; the suite mocks the HTTP call,
   # so only the config key's presence matters (the yuque verify endpoint reads it).

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -80,6 +80,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     def engine_type(self) -> str:
         return self._engine_type
 
+    def resolve_bot_engine(self, bot: dict[str, Any]) -> str | None:
+        active_engine = bot.get("active_engine")
+        active_engine = active_engine if isinstance(active_engine, str) else None
+        if self.should_use_aicoding_runtime_engine(
+            active_engine=active_engine,
+            template_type=bot.get("template_type"),
+        ):
+            return AICODING_ENGINE_TYPE
+        return active_engine
+
     @staticmethod
     def normalize_engine_type(
         engine_type: str | None, *, default: str = "openclaw"
@@ -95,19 +105,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return template_type in CODING_TEMPLATE_TYPES
 
     @classmethod
-    def should_use_aicoding_baas_bucket(
+    def should_use_aicoding_runtime_engine(
         cls,
         *,
         active_engine: str | None,
         template_type: str | None,
     ) -> bool:
-        """Whether this context should select the aicoding BaaS bucket.
-
-        BaaS bucket routing is an image/runtime selection policy: all explicit
-        claude_code template-factory types except normalCC reuse the aicoding
-        BaaS template bucket. It only depends on active_engine + template_type;
-        caller/create routing may only have template_type available.
-        """
+        """Whether this bot should use the aicoding runtime engine."""
         if (
             cls.normalize_engine_type(active_engine, default="")
             != CLAUDE_CODE_ENGINE_TYPE
@@ -117,6 +121,19 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return bool(
             normalized_template_type
             and normalized_template_type != NORMAL_CC_TEMPLATE_TYPE
+        )
+
+    @classmethod
+    def should_use_aicoding_baas_bucket(
+        cls,
+        *,
+        active_engine: str | None,
+        template_type: str | None,
+    ) -> bool:
+        """Whether this context should select the aicoding BaaS bucket."""
+        return cls.should_use_aicoding_runtime_engine(
+            active_engine=active_engine,
+            template_type=template_type,
         )
 
     @classmethod

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -16,6 +16,10 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     def engine_type(self) -> str:
         return self._engine_type
 
+    def resolve_bot_engine(self, bot: dict[str, object]) -> str | None:
+        engine = bot.get("active_engine")
+        return engine if isinstance(engine, str) else None
+
     def build_extra_envs(self, ctx: BotProvisioningContext) -> dict[str, str] | None:
         return None
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -59,6 +59,10 @@ class EngineProvisioningStrategy(ABC):
         """Stable identifier this strategy is registered under."""
 
     @abstractmethod
+    def resolve_bot_engine(self, bot: Dict[str, Any]) -> str | None:
+        """Resolve the effective runtime engine for a bot record."""
+
+    @abstractmethod
     def build_extra_envs(self, ctx: BotProvisioningContext) -> Dict[str, str] | None:
         """Return extra env vars to inject into the runtime container."""
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -160,6 +160,12 @@ class EngineProvisioningRegistry:
         """
         return self._strategies.get(engine_type, self._default)
 
+    def resolve_bot_engine(self, bot: dict[str, Any]) -> str | None:
+        """Resolve the effective runtime engine for a bot record."""
+        active_engine = bot.get("active_engine")
+        strategy = self.resolve(normalize_engine_type(active_engine, default=""))
+        return strategy.resolve_bot_engine(bot)
+
     def resolve_for_context(
         self, ctx: BotProvisioningContext
     ) -> EngineProvisioningStrategy:
@@ -205,6 +211,11 @@ _REGISTRY: EngineProvisioningRegistry = _build_default_registry()
 def get_engine_provisioning_registry() -> EngineProvisioningRegistry:
     """Return the process-wide strategy registry."""
     return _REGISTRY
+
+
+def resolve_bot_engine(bot: dict[str, Any]) -> str | None:
+    """Resolve the effective runtime engine for a bot record."""
+    return get_engine_provisioning_registry().resolve_bot_engine(bot)
 
 
 def _build_default_baas_engine_bucket_resolver_registry() -> (
@@ -477,6 +488,7 @@ __all__ = [
     "get_engine_provisioning_registry",
     "normalize_engine_type",
     "resolve_baas_engine_bucket",
+    "resolve_bot_engine",
     "resolve_default_capabilities_engine_bucket",
     "resolve_provisioning",
     "resolve_outbound_rule_envelope",

--- a/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
@@ -1,13 +1,13 @@
 """Engine type resolution helper.
 
 Frontend should not be required to know a bot's engine type — the backend
-resolves it from `bot_id` per the multi-engine API design
-(see docs/resource-management-api.md). API endpoints call this helper to
-turn (bot_id, owner_id, optional override) into a concrete engine type.
+resolves it from `bot_id`. API endpoints call this helper to turn
+(bot_id, owner_id, optional override) into the effective engine type used by
+workspace/resource routing.
 
 Resolution order:
   1. Explicit override (operator/debug use); empty string treated as no override.
-  2. Bot record's active_engine.
+  2. Bot record's active_engine, after applying registered engine routing policy.
   3. DEFAULT_ENGINE_TYPE.
 """
 from __future__ import annotations
@@ -15,6 +15,9 @@ from __future__ import annotations
 from typing import Optional
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AicodingProvisioningStrategy,
+)
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.log import get_logger
 
@@ -68,13 +71,10 @@ def resolve_engine_for_bot(
     if bot:
         active = bot.get("active_engine")
         if active:
-            template_type = bot.get("template_type")
-            if (
-                active == "claude_code"
-                and template_type
-                and str(template_type).strip().lower() != "normalcc"
-            ):
-                return "aicoding"
-            return active
+            routed_engine = AicodingProvisioningStrategy.resolve_baas_engine_bucket(
+                active_engine=active,
+                template_type=bot.get("template_type"),
+            )
+            return routed_engine or active
 
     return DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 from typing import Optional
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
-    AicodingProvisioningStrategy,
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_bot_engine,
 )
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.log import get_logger
@@ -71,10 +71,6 @@ def resolve_engine_for_bot(
     if bot:
         active = bot.get("active_engine")
         if active:
-            routed_engine = AicodingProvisioningStrategy.resolve_baas_engine_bucket(
-                active_engine=active,
-                template_type=bot.get("template_type"),
-            )
-            return routed_engine or active
+            return resolve_bot_engine(bot) or active
 
     return DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/engine_resolver.py
@@ -68,6 +68,13 @@ def resolve_engine_for_bot(
     if bot:
         active = bot.get("active_engine")
         if active:
+            template_type = bot.get("template_type")
+            if (
+                active == "claude_code"
+                and template_type
+                and str(template_type).strip().lower() != "normalcc"
+            ):
+                return "aicoding"
             return active
 
     return DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -25,8 +25,8 @@ from injector import inject
 
 from agentclaw.community.api.channel_service import ChannelServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
-    AicodingProvisioningStrategy,
+from agentclaw.community.core.bot_management.engines.registry import (
+    resolve_bot_engine,
 )
 from agentclaw.community.core.bot_management.services.engine_resolver import (
     resolve_engine_for_bot,
@@ -156,11 +156,7 @@ class BotBuildService:
 
     def _resolve_sandbox_provider(self, bot: Dict[str, Any]) -> EngineSandboxProvider:
         engine_type = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
-        routed_engine = AicodingProvisioningStrategy.resolve_baas_engine_bucket(
-            active_engine=engine_type,
-            template_type=bot.get("template_type"),
-        )
-        engine_type = routed_engine or engine_type
+        engine_type = resolve_bot_engine(bot) or engine_type
 
         try:
             return self._sandbox_registry.resolve(engine_type)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -25,7 +25,6 @@ from injector import inject
 
 from agentclaw.community.api.channel_service import ChannelServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.bot_management.services.engine_resolver import resolve_engine_for_bot
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
 from agentclaw.community.core.devices.services.device_service import DeviceService
 from agentclaw.community.core.service_bot.services.baas_service import (
@@ -150,24 +149,19 @@ class BotBuildService:
         return self._device_binding_repo
 
     def _resolve_sandbox_provider(self, bot: Dict[str, Any]) -> EngineSandboxProvider:
-        engine_type = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+        active_engine = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+        template_type = bot.get("template_type")
+        if (
+            active_engine == "claude_code"
+            and template_type
+            and str(template_type).strip().lower() != "normalcc"
+        ):
+            active_engine = "aicoding"
+
         try:
-            return self._sandbox_registry.resolve(engine_type)
+            return self._sandbox_registry.resolve(active_engine)
         except Exception:
-            bot_id = bot.get("bot_id")
-            entity_id = bot.get("entity_id", "")
-            entity_type = bot.get("entity_type", "staff")
-            try:
-                resolved_engine = resolve_engine_for_bot(
-                    bot_id,
-                    entity_id,
-                    bot=bot,
-                    default_engine=engine_type,
-                    entity_type=entity_type,
-                )
-                return self._sandbox_registry.resolve(resolved_engine)
-            except Exception:
-                return self._sandbox_registry.resolve(DEFAULT_ENGINE_TYPE)
+            return self._sandbox_registry.resolve(DEFAULT_ENGINE_TYPE)
 
     def generate_request_id(
         self,
@@ -792,45 +786,30 @@ class BotBuildService:
                 error_message="rsync migration failed",
             )
 
-            # 额外同步目录：支持单条旧配置与多条新配置。
-            extra_sync_items: list[tuple[str, str]] = []
-            if build_plan and getattr(build_plan, "extra_sync_items", None):
-                extra_sync_items = list(build_plan.extra_sync_items)
-            elif build_plan:
-                extra_src_rel = build_plan.extra_sync_source_relpath
-                extra_tgt_rel = build_plan.extra_sync_target_relpath
-                if extra_src_rel and extra_tgt_rel:
-                    extra_sync_items = [(extra_src_rel, extra_tgt_rel)]
+            # 额外同步目录：例如 claude_code 需要把 source_dir 同级的 .claude
+            # 同步到目标 claude_code/claude 下。
+            if build_plan and build_plan.extra_sync_source_relpath and build_plan.extra_sync_target_relpath:
+                extra_source = source_dir.parent / build_plan.extra_sync_source_relpath
+                extra_target = target_dir / build_plan.extra_sync_target_relpath
 
-            for extra_src_rel, extra_tgt_rel in extra_sync_items:
-                extra_source = source_dir.parent / extra_src_rel
-                extra_target = target_dir / extra_tgt_rel
+                if extra_source.exists():
+                    extra_target.mkdir(parents=True, exist_ok=True)
 
-                if not extra_source.exists():
-                    logger.info(
-                        "[BotBuildService._migrate_bot_instance] "
-                        "skip missing extra sync source: %s",
-                        extra_source,
+                    extra_cmd = [
+                        "sudo",
+                        "rsync",
+                        "-av",
+                        "--delete",
+                        "--delete-excluded",
+                        *excludes,
+                        f"{extra_source}/",
+                        f"{extra_target}/",
+                    ]
+                    self._run_local_command(
+                        cmd=extra_cmd,
+                        command_name="rsync (extra)",
+                        error_message="rsync extra sync failed",
                     )
-                    continue
-
-                extra_target.mkdir(parents=True, exist_ok=True)
-
-                extra_cmd = [
-                    "sudo",
-                    "rsync",
-                    "-av",
-                    "--delete",
-                    "--delete-excluded",
-                    *excludes,
-                    f"{extra_source}/",
-                    f"{extra_target}/",
-                ]
-                self._run_local_command(
-                    cmd=extra_cmd,
-                    command_name="rsync (extra)",
-                    error_message="rsync extra sync failed",
-                )
 
             logger.info(
                 f"[BotBuildService._migrate_bot_instance] "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -25,6 +25,12 @@ from injector import inject
 
 from agentclaw.community.api.channel_service import ChannelServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AicodingProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.services.engine_resolver import (
+    resolve_engine_for_bot,
+)
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
 from agentclaw.community.core.devices.services.device_service import DeviceService
 from agentclaw.community.core.service_bot.services.baas_service import (
@@ -149,18 +155,28 @@ class BotBuildService:
         return self._device_binding_repo
 
     def _resolve_sandbox_provider(self, bot: Dict[str, Any]) -> EngineSandboxProvider:
-        active_engine = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
-        template_type = bot.get("template_type")
-        if (
-            active_engine == "claude_code"
-            and template_type
-            and str(template_type).strip().lower() != "normalcc"
-        ):
-            active_engine = "aicoding"
+        engine_type = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
+        routed_engine = AicodingProvisioningStrategy.resolve_baas_engine_bucket(
+            active_engine=engine_type,
+            template_type=bot.get("template_type"),
+        )
+        engine_type = routed_engine or engine_type
 
         try:
-            return self._sandbox_registry.resolve(active_engine)
+            return self._sandbox_registry.resolve(engine_type)
         except Exception:
+            bot_id = bot.get("bot_id")
+            owner_id = bot.get("owner_id") or bot.get("entity_id")
+            if self._bot_repository is not None:
+                try:
+                    resolved_engine = resolve_engine_for_bot(
+                        bot_id,
+                        owner_id,
+                        bot_repo=self._bot_repository,
+                    )
+                    return self._sandbox_registry.resolve(resolved_engine)
+                except Exception:
+                    pass
             return self._sandbox_registry.resolve(DEFAULT_ENGINE_TYPE)
 
     def generate_request_id(

--- a/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 
@@ -39,8 +39,6 @@ class EngineBuildPlan:
     # 两者同时为空时跳过额外同步。
     extra_sync_source_relpath: str = ""
     extra_sync_target_relpath: str = ""
-    # 新增：支持多条额外同步目录。优先由 BotBuildService 读取此字段。
-    extra_sync_items: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
 
 @runtime_checkable

--- a/src/backend/src/agentclaw/community/core/workspace/engines/__init__.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -46,4 +47,5 @@ def create_engine_sandbox_registry(
     registry = EngineSandboxRegistry()
     registry.register(OpenClawSandboxProvider(workspace=workspace))
     registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
+    registry.register(AICodingSandboxProvider(workspace=workspace))
     return registry

--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -11,26 +11,26 @@ logger = get_logger()
 
 # ============================================================================
 # TODO(claude-code-sandbox-recheck): 以下字段当前沿用自 OpenClawSandboxProvider,
-# 尚未按 claude_code 引擎的真实 VM 目录约定逐项核对。待拿到 start_service.sh /
-# finalize.sh 已就位的 claude_code 引擎目录权威清单后,单独开 change 复评估并调整。
+# 尚未按 aicoding 引擎的真实 VM 目录约定逐项核对。待拿到 start_service.sh /
+# finalize.sh 已就位的 aicoding 引擎目录权威清单后,单独开 change 复评估并调整。
 #
 # 待复评估字段（不在本 change 内修改值,仅记录）:
-#   - _CLAUDE_CODE_RSYNC_EXCLUDES: 与 openclaw 几乎相同,仅去掉了
+#   - _AICODING_RSYNC_EXCLUDES: 与 openclaw 几乎相同,仅去掉了
 #       "workspace/.openclaw/" 和 "workspace/skills/.skills-repo*"。
-#       claude_code 是否有引擎专属临时目录需要新增排除?
+#       aicoding 是否有引擎专属临时目录需要新增排除?
 #   - _DEFAULT_RULES: 路径名已替换,但缺少 openclaw 的
-#       "agents/*/agent/models.json" 规则。claude_code 是否需要等价规则?
-#   - _BUILD_PLAN.workspace_subdir = "workspace": 是否符合 claude_code 实际布局?
+#       "agents/*/agent/models.json" 规则。aicoding 是否需要等价规则?
+#   - _BUILD_PLAN.workspace_subdir = "workspace": 是否符合 aicoding 实际布局?
 #   - _BUILD_PLAN.mcp_config_relpath = "workspace/config/mcporter.json":
 #       finalize.sh 双目录软链接的落点是否就是这里?
 #   - _BUILD_PLAN.skill_source_relpath / skill_target_relpath = "workspace/skills":
-#       是否与 claude_code 引擎 skills 目录布局一致?
+#       是否与 aicoding 引擎 skills 目录布局一致?
 #
 # _SANDBOX_ROOT / _LOCAL_ROOT 已与 start_service.sh / finalize.sh 对齐,不需复评估。
 # ============================================================================
 
 
-_CLAUDE_CODE_RSYNC_EXCLUDES = [
+_AICODING_RSYNC_EXCLUDES = [
     "workspace/.claude",
     "projects",
     "sessions",
@@ -39,12 +39,12 @@ _CLAUDE_CODE_RSYNC_EXCLUDES = [
     "backups",
     "telemetry",
     "session-env",
-    # 锚定到 source 根: 主 rsync(source=.claude_code/)需要排掉根下的 OSS 挂载点
-    # .claude_code/skills-repo; 但 extra_sync(source=.claude/)的同一份 excludes
+    # 锚定到 source 根: 主 rsync(source=.aicoding/)需要排掉根下的 OSS 挂载点
+    # .aicoding/skills-repo; 但 extra_sync(source=.claude/)的同一份 excludes
     # 不该误伤 .claude/skills/skills-repo 这条转接软链(它在草稿态有,build 后必须
     # 跟着进 NFS 副本,否则装载到预发容器后 .claude/skills/ 下所有具体 skill 软链
     # 全 dangling)。"skills-repo" 无锚定会任意层级匹配,加 leading / 锚定 source
-    # 根: 主 rsync 仍排 .claude_code/skills-repo (✅ 行为不变);
+    # 根: 主 rsync 仍排 .aicoding/skills-repo (✅ 行为不变);
     # extra_sync 的 .claude/ 根下没有 skills-repo,exclude 打不到,转接软链能正确同步。
     "/skills-repo",
     "enterprise_device_key.pem",
@@ -72,7 +72,7 @@ _CLAUDE_CODE_RSYNC_EXCLUDES = [
 ]
 
 
-_CLAUDE_CODE_DEFAULT_RULES = [
+_AICODING_DEFAULT_RULES = [
     ReadOnlyRule(path="workspace/config/mcporter.json", rule_type="file"),
     ReadOnlyRule(path="workspace/*.md", rule_type="glob"),
     ReadOnlyRule(path="/home/admin/.mcporter/mcporter.json", rule_type="file"),
@@ -86,12 +86,12 @@ _CLAUDE_CODE_DEFAULT_RULES = [
 ]
 
 
-def _make_claude_code_build_plan(rsync_excludes: list[str]) -> EngineBuildPlan:
+def _make_aicoding_build_plan(rsync_excludes: list[str]) -> EngineBuildPlan:
     """Factory function to create build plan with given excludes."""
     return EngineBuildPlan(
-        engine_type="claude_code",
-        source_root_name=".claude_code",
-        migration_subpath="claude_code",
+        engine_type="aicoding",
+        source_root_name=".aicoding",
+        migration_subpath="aicoding",
         workspace_subdir="workspace",
         mcp_config_relpath="workspace/config/mcporter.json",
         skill_source_relpath="workspace/skills",
@@ -102,15 +102,15 @@ def _make_claude_code_build_plan(rsync_excludes: list[str]) -> EngineBuildPlan:
     )
 
 
-_CLAUDE_CODE_BUILD_PLAN = _make_claude_code_build_plan(list(_CLAUDE_CODE_RSYNC_EXCLUDES))
+_AICODING_BUILD_PLAN = _make_aicoding_build_plan(list(_AICODING_RSYNC_EXCLUDES))
 
 
-class ClaudeCodeSandboxProvider:
-    """Workspace provider for the Claude Code engine.
+class AICodingSandboxProvider:
+    """Workspace provider for the AICoding engine.
 
     The base path comes from the injected :class:`WorkspaceConfig`;
     application-prod.yaml leaves it at the sandbox mount, dev/local
-    overrides it to the dev's home (`~/.claude_code`). The provider
+    overrides it to the dev's home (`~/.aicoding`). The provider
     does not branch on runtime mode.
     """
 
@@ -119,29 +119,29 @@ class ClaudeCodeSandboxProvider:
 
     @property
     def engine_type(self) -> str:
-        return "claude_code"
+        return "aicoding"
 
     def get_base_path(self) -> str:
-        return self._workspace.claude_code_root
+        return self._workspace.aicoding_root
 
     def get_sessions_dir(self) -> str:
-        return f"{self._workspace.claude_code_session_root}/projects"
+        return f"{self._workspace.aicoding_root}/projects"
 
     def get_default_read_only_rules(self) -> list[ReadOnlyRule]:
-        return list(_CLAUDE_CODE_DEFAULT_RULES)
+        return list(_AICODING_DEFAULT_RULES)
 
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
-        excludes = list(_CLAUDE_CODE_RSYNC_EXCLUDES)
+        excludes = list(_AICODING_RSYNC_EXCLUDES)
         if build_rsync_excludes_append:
             # 合并并去重，保持顺序：默认值在前，自定义项追加
             for item in build_rsync_excludes_append:
                 if item not in excludes:
                     excludes.append(item)
-        return _make_claude_code_build_plan(excludes)
+        return _make_aicoding_build_plan(excludes)
 
     def _normalize_sub_path(self, sub_path: str) -> str:
         if not sub_path:
@@ -163,7 +163,7 @@ class ClaudeCodeSandboxProvider:
     ) -> list[DirectoryItem]:
         sub_path = self._normalize_sub_path(sub_path)
         items: list[DirectoryItem] = []
-        base_path = self._workspace.claude_code_root
+        base_path = self._workspace.aicoding_root
 
         if device_fs is not None:
             async def walk(current_sub_path: str) -> None:
@@ -196,7 +196,7 @@ class ClaudeCodeSandboxProvider:
             await walk(sub_path)
             return items
 
-        # No sandbox binding — walk the local filesystem at claude_code_root.
+        # No sandbox binding — walk the local filesystem at aicoding_root.
         root = Path(base_path)
         local_target = root / sub_path if sub_path else root
         if local_target.exists() and local_target.is_dir():
@@ -206,7 +206,7 @@ class ClaudeCodeSandboxProvider:
                 items.append(DirectoryItem(name=entry.name, path=rel, is_dir=entry.is_dir()))
         else:
             logger.info(
-                "[ClaudeCodeSandboxProvider.list_directory] No sandbox binding and "
+                "[AICodingSandboxProvider.list_directory] No sandbox binding and "
                 "local root %s does not exist; returning empty tree",
                 root,
             )

--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -9,27 +9,6 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 
-# ============================================================================
-# TODO(claude-code-sandbox-recheck): 以下字段当前沿用自 OpenClawSandboxProvider,
-# 尚未按 aicoding 引擎的真实 VM 目录约定逐项核对。待拿到 start_service.sh /
-# finalize.sh 已就位的 aicoding 引擎目录权威清单后,单独开 change 复评估并调整。
-#
-# 待复评估字段（不在本 change 内修改值,仅记录）:
-#   - _AICODING_RSYNC_EXCLUDES: 与 openclaw 几乎相同,仅去掉了
-#       "workspace/.openclaw/" 和 "workspace/skills/.skills-repo*"。
-#       aicoding 是否有引擎专属临时目录需要新增排除?
-#   - _DEFAULT_RULES: 路径名已替换,但缺少 openclaw 的
-#       "agents/*/agent/models.json" 规则。aicoding 是否需要等价规则?
-#   - _BUILD_PLAN.workspace_subdir = "workspace": 是否符合 aicoding 实际布局?
-#   - _BUILD_PLAN.mcp_config_relpath = "workspace/config/mcporter.json":
-#       finalize.sh 双目录软链接的落点是否就是这里?
-#   - _BUILD_PLAN.skill_source_relpath / skill_target_relpath = "workspace/skills":
-#       是否与 aicoding 引擎 skills 目录布局一致?
-#
-# _SANDBOX_ROOT / _LOCAL_ROOT 已与 start_service.sh / finalize.sh 对齐,不需复评估。
-# ============================================================================
-
-
 _AICODING_RSYNC_EXCLUDES = [
     "workspace/.claude",
     "projects",

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -464,11 +464,13 @@ class WorkspaceConfig:
             from the YAML override). Source: ``user_config.workspace``
             block in ``application.yaml``.
         claude_code_root: Same shape, for Claude Code bots.
+        aicoding_root: Same shape, for AICoding bots.
     """
 
     openclaw_root: str = "/home/admin/.openclaw"
     claude_code_root: str = "/home/admin/.claude_code"
     claude_code_session_root: str = "/home/admin/.claude"
+    aicoding_root: str = "/home/admin/.aicoding"
 
 
 # ── Dormant bot recycle ──────────────────────────────────────────────────

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -84,6 +84,9 @@ class ConfigModule(Module):
             claude_code_root=_expand(
                 block.get("claude_code_root"), defaults.claude_code_root
             ),
+            aicoding_root=_expand(
+                block.get("aicoding_root"), defaults.aicoding_root
+            ),
         )
 
     # ── Access policy ───────────────────────────────────────────────

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -114,6 +114,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "./data/workspace/aicoding",
       "claude_code_root": "./data/workspace/claude_code",
       "openclaw_root": "./data/workspace/openclaw"
     }
@@ -247,6 +248,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "data/workspace/aicoding",
       "claude_code_root": "data/workspace/claude_code",
       "claude_code_session_root": "/home/admin/.claude",
       "openclaw_root": "data/workspace/openclaw"

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -216,6 +216,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "env_folder": "aidesktop_singlebox",
       "openclaw_root": "~/.openclaw"
@@ -350,6 +351,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "claude_code_session_root": "/home/admin/.claude",
       "openclaw_root": "~/.openclaw"

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -83,6 +83,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "openclaw_root": "~/.openclaw"
     },
@@ -217,6 +218,7 @@
       "operator_names": []
     },
     "workspace": {
+      "aicoding_root": "~/.aicoding",
       "claude_code_root": "~/.claude_code",
       "claude_code_session_root": "/home/admin/.claude",
       "openclaw_root": "~/.openclaw"

--- a/src/backend/tests/community/core/bot_management/services/test_engine_resolver.py
+++ b/src/backend/tests/community/core/bot_management/services/test_engine_resolver.py
@@ -67,6 +67,24 @@ class TestOwnerExactMatch:
         assert result == DEFAULT_ENGINE_TYPE
 
 
+
+
+class TestClaudeCodeTemplateRouting:
+    def test_claude_code_non_normalcc_routes_to_aicoding(self):
+        bot = {"active_engine": "claude_code", "template_type": "generalCC"}
+        repo = _make_repo(owner_bot=bot)
+        result = resolve_engine_for_bot(
+            bot_id="bot_x", owner_id="owner_1", bot_repo=repo
+        )
+        assert result == "aicoding"
+
+    def test_claude_code_normalcc_stays_claude_code(self):
+        bot = {"active_engine": "claude_code", "template_type": "normalCC"}
+        repo = _make_repo(owner_bot=bot)
+        result = resolve_engine_for_bot(
+            bot_id="bot_x", owner_id="owner_1", bot_repo=repo
+        )
+        assert result == "claude_code"
 class TestCollaboratorFallback:
     def test_collaborator_falls_back_to_get_by_id(self):
         """Collaborator's owner_id doesn't match → Step 1 returns None → fallback to get_by_id."""

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
@@ -10,6 +10,7 @@ import pytest
 from agentclaw.community.core.common_config import CommonWhiteListService
 from agentclaw.community.core.service_bot.services.baas_service import BaasService, Storage
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -25,6 +26,7 @@ def _make_registry() -> EngineSandboxRegistry:
     registry = EngineSandboxRegistry()
     registry.register(OpenClawSandboxProvider(workspace=workspace))
     registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
+    registry.register(AICodingSandboxProvider(workspace=workspace))
     return registry
 
 
@@ -36,8 +38,9 @@ def _make_storage_path() -> MagicMock:
 
 
 def _make_service(storage_path=None, bot_repo=None, common_whitelist_service=None) -> BaasService:
+    startup_script_reader = MagicMock()
+    startup_script_reader.get_body.return_value = ""
     return BaasService(
-        startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
         baas_api_base="http://test",
         tenant="test",
         template_uuid="test",
@@ -53,6 +56,7 @@ def _make_service(storage_path=None, bot_repo=None, common_whitelist_service=Non
         common_whitelist_service=common_whitelist_service or MagicMock(spec=CommonWhiteListService),
         outbound_rule_provider=NoopOutboundRuleProvider(),
         secret_resolver=MagicMock(),
+        startup_script_reader=startup_script_reader,
     )
 
 
@@ -218,8 +222,9 @@ class TestSetupSessionsDirEngineAware:
         registry = EngineSandboxRegistry()
         registry.register(custom_provider)
 
+        startup_script_reader = MagicMock()
+        startup_script_reader.get_body.return_value = ""
         service = BaasService(
-            startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
             baas_api_base="http://test",
             tenant="test",
             template_uuid="test",
@@ -235,6 +240,7 @@ class TestSetupSessionsDirEngineAware:
             common_whitelist_service=MagicMock(),
             secret_resolver=MagicMock(),
             outbound_rule_provider=MagicMock(),
+            startup_script_reader=startup_script_reader,
         )
 
         storage = service._setup_sessions_dir(
@@ -253,7 +259,6 @@ class TestBuildCreateBotPayloadStorageWhitelist:
     def _build_payload(self, service: BaasService):
         return service._build_create_bot_payload(
             bot={
-                "id": 501,
                 "bot_id": "b1",
                 "bot_name": "bot-one",
                 "entity_id": "u1",
@@ -381,7 +386,6 @@ class TestBuildCreateBotPayloadStorageWhitelist:
 
         payload = service._build_create_bot_payload(
             bot={
-                "id": 501,
                 "bot_id": "b1",
                 "bot_name": "bot-one",
                 "entity_id": "u1",
@@ -525,7 +529,6 @@ def test_build_create_bot_payload_rewrites_migration_path_to_opt_when_mount_home
     )
     payload = service._build_create_bot_payload(
         bot={
-            "id": 501,
             "bot_id": "b1",
             "bot_name": "bot-one",
             "entity_id": "u1",
@@ -555,7 +558,6 @@ def test_build_create_bot_payload_rewrites_opt_migration_path_back_to_home_admin
     )
     payload = service._build_create_bot_payload(
         bot={
-            "id": 501,
             "bot_id": "b1",
             "bot_name": "bot-one",
             "entity_id": "u1",

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_read_only_rules.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_read_only_rules.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
+from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -15,12 +16,14 @@ def _make_registry() -> EngineSandboxRegistry:
     registry = EngineSandboxRegistry()
     registry.register(OpenClawSandboxProvider(workspace=workspace))
     registry.register(ClaudeCodeSandboxProvider(workspace=workspace))
+    registry.register(AICodingSandboxProvider(workspace=workspace))
     return registry
 
 
 def _make_service(bot_repo=None) -> BaasService:
+    startup_script_reader = MagicMock()
+    startup_script_reader.get_body.return_value = ""
     return BaasService(
-        startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
         baas_api_base="http://test",
         tenant="test",
         template_uuid="test",
@@ -36,6 +39,7 @@ def _make_service(bot_repo=None) -> BaasService:
         secret_resolver=MagicMock(),
         common_whitelist_service=MagicMock(),
         outbound_rule_provider=MagicMock(),
+        startup_script_reader=startup_script_reader,
     )
 
 
@@ -43,7 +47,6 @@ class TestGetSetReadOnlyRule:
     def test_openclaw_default_rules(self):
         bot_repo = MagicMock()
         bot_repo.get_by_id_and_owner.return_value = {
-            "id": 501,
             "bot_id": "bot-1",
             "active_engine": "openclaw",
             "ext": {},
@@ -63,7 +66,6 @@ class TestGetSetReadOnlyRule:
         # workspace/config/mcporter.json。
         bot_repo = MagicMock()
         bot_repo.get_by_id_and_owner.return_value = {
-            "id": 501,
             "bot_id": "bot-1",
             "active_engine": "claude_code",
             "ext": {},
@@ -85,7 +87,6 @@ class TestGetSetReadOnlyRule:
     def test_custom_rules_support_absolute_and_relative_paths(self):
         bot_repo = MagicMock()
         bot_repo.get_by_id_and_owner.return_value = {
-            "id": 501,
             "bot_id": "bot-1",
             "active_engine": "claude_code",
             "ext": {

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
@@ -206,3 +206,44 @@ class TestBotBuildServiceRsyncExcludesConfig:
         mock_provider.get_build_plan.assert_called_once()
         call_kwargs = mock_provider.get_build_plan.call_args[1]
         assert call_kwargs["build_rsync_excludes_append"] is None
+
+    def test_build_resolve_sandbox_provider_uses_resolver_for_template_routing(self):
+        bot = {
+            "bot_id": "test-bot-id",
+            "entity_id": "test-entity-id",
+            "entity_type": "staff",
+            "device_id": "test-device-id",
+            "active_engine": "claude_code",
+            "template_type": "generalCC",
+        }
+
+        mock_provider = MagicMock()
+        mock_build_plan = EngineBuildPlan(
+            engine_type="aicoding",
+            source_root_name=".aicoding",
+            migration_subpath="aicoding",
+            workspace_subdir="workspace",
+            mcp_config_relpath="workspace/config/mcporter.json",
+            skill_source_relpath="workspace/skills",
+            skill_target_relpath="workspace/skills",
+            rsync_excludes=["workspace/memory/", "logs/"],
+        )
+        mock_provider.get_build_plan.return_value = mock_build_plan
+
+        service = _make_service()
+        service._sandbox_registry = MagicMock()
+        service._sandbox_registry.resolve.return_value = mock_provider
+        service._bot_repository = MagicMock()
+        service._bot_repository.get_by_id_and_owner.return_value = bot
+        service._bot_repository.get_by_id.return_value = bot
+        service._migrate_bot_instance = MagicMock(return_value=True)
+        service._generate_mcp_config = MagicMock(return_value=True)
+        service._generate_openclaw_stage_configs = MagicMock(return_value=True)
+        service._get_migration_path_base = MagicMock(return_value="/fake/path")
+
+        try:
+            service.build(bot, version=1)
+        except Exception:
+            pass
+
+        service._sandbox_registry.resolve.assert_any_call("aicoding")

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
@@ -247,3 +247,59 @@ class TestBotBuildServiceRsyncExcludesConfig:
             pass
 
         service._sandbox_registry.resolve.assert_any_call("aicoding")
+
+
+def test_resolve_sandbox_provider_retries_repo_resolved_engine_before_default():
+    service = BotBuildService.__new__(BotBuildService)
+    service._bot_repository = MagicMock()
+    service._bot_repository.get_by_id_and_owner.return_value = {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "active_engine": "claude_code",
+        "template_type": "normalCC",
+    }
+    service._bot_repository.get_by_id.return_value = service._bot_repository.get_by_id_and_owner.return_value
+
+    default_provider = MagicMock(name="default_provider")
+    repo_provider = MagicMock(name="repo_provider")
+    service._sandbox_registry = MagicMock()
+    service._sandbox_registry.resolve.side_effect = [RuntimeError("missing routed provider"), repo_provider]
+
+    provider = service._resolve_sandbox_provider({
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "active_engine": "unknown_engine",
+    })
+
+    assert provider is repo_provider
+    assert service._sandbox_registry.resolve.call_args_list == [
+        (("unknown_engine",),),
+        (("claude_code",),),
+    ]
+    default_provider.assert_not_called()
+
+
+def test_resolve_sandbox_provider_falls_back_to_default_when_retry_fails():
+    service = BotBuildService.__new__(BotBuildService)
+    service._bot_repository = MagicMock()
+    service._bot_repository.get_by_id_and_owner.side_effect = RuntimeError("repo unavailable")
+    service._bot_repository.get_by_id.side_effect = RuntimeError("repo unavailable")
+
+    default_provider = MagicMock(name="default_provider")
+    service._sandbox_registry = MagicMock()
+    service._sandbox_registry.resolve.side_effect = [
+        RuntimeError("missing first provider"),
+        default_provider,
+    ]
+
+    provider = service._resolve_sandbox_provider({
+        "bot_id": "bot-1",
+        "entity_id": "owner-1",
+        "active_engine": "unknown_engine",
+    })
+
+    assert provider is default_provider
+    assert service._sandbox_registry.resolve.call_args_list == [
+        (("unknown_engine",),),
+        (("openclaw",),),
+    ]

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -536,3 +536,104 @@ class TestParseRsyncExcludesFromExt:
         ext = {"build_rsync_excludes": ["valid", {"invalid": "dict"}, ["nested"], True]}
         result = parse_build_rsync_excludes_from_ext(ext)
         assert result == ["valid"]
+
+
+@pytest.mark.unit
+class TestAICodingProviderChangedLineCoverage:
+    def test_base_path_engine_type_and_build_plan_merge(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+
+        assert provider.engine_type == "aicoding"
+        assert provider.get_base_path() == "/home/admin/.aicoding"
+
+        plan = provider.get_build_plan([
+            "workspace/memory/",
+            "custom-aicoding/",
+        ])
+        assert plan.engine_type == "aicoding"
+        assert plan.rsync_excludes.count("workspace/memory/") == 1
+        assert plan.rsync_excludes[-1] == "custom-aicoding/"
+
+    def test_normalize_sub_path_accepts_dot_empty_and_nested_path(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+
+        assert provider._normalize_sub_path("") == ""
+        assert provider._normalize_sub_path(".") == ""
+        assert provider._normalize_sub_path("workspace/skills") == "workspace/skills"
+
+    def test_normalize_sub_path_rejects_invalid_paths(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+
+        with pytest.raises(ValueError):
+            provider._normalize_sub_path("bad\x00path")
+        with pytest.raises(ValueError):
+            provider._normalize_sub_path("/absolute")
+        with pytest.raises(ValueError):
+            provider._normalize_sub_path("../escape")
+
+    @pytest.mark.asyncio
+    async def test_list_directory_with_device_fs_walks_recursively(self):
+        base = cfg.WorkspaceConfig().aicoding_root
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        items = await provider.list_directory(
+            recursive=True,
+            device_fs=_device_fs({
+                base: [
+                    {"name": "workspace", "is_dir": True},
+                    {"name": "README.md", "is_dir": False},
+                    {"name": "", "is_dir": False},
+                ],
+                f"{base}/workspace": [
+                    {"name": "skills", "is_dir": True},
+                ],
+                f"{base}/workspace/skills": [],
+            }),
+        )
+
+        assert {item.path for item in items} == {
+            "workspace",
+            "README.md",
+            "workspace/skills",
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_directory_with_device_fs_non_recursive_keeps_top_level(self):
+        base = cfg.WorkspaceConfig().aicoding_root
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        items = await provider.list_directory(
+            recursive=False,
+            device_fs=_device_fs({
+                base: [
+                    {"name": "workspace", "is_dir": True},
+                ],
+                f"{base}/workspace": [
+                    {"name": "nested.txt", "is_dir": False},
+                ],
+            }),
+        )
+
+        assert [item.path for item in items] == ["workspace"]
+
+    @pytest.mark.asyncio
+    async def test_list_directory_walks_local_filesystem(self, tmp_path):
+        root = tmp_path / ".aicoding"
+        workspace_dir = root / "workspace"
+        workspace_dir.mkdir(parents=True)
+        (workspace_dir / "file.txt").write_text("data")
+        provider = AICodingSandboxProvider(
+            workspace=cfg.WorkspaceConfig(aicoding_root=str(root)),
+        )
+
+        non_recursive = await provider.list_directory(recursive=False)
+        recursive = await provider.list_directory(recursive=True)
+
+        assert {item.path for item in non_recursive} == {"workspace"}
+        assert {item.path for item in recursive} == {"workspace", "workspace/file.txt"}
+
+    @pytest.mark.asyncio
+    async def test_list_directory_missing_local_root_returns_empty(self, tmp_path):
+        provider = AICodingSandboxProvider(
+            workspace=cfg.WorkspaceConfig(aicoding_root=str(tmp_path / "missing")),
+        )
+
+        assert await provider.list_directory() == []

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import pytest
 
+from agentclaw.community.core.workspace.engines.aicoding import AICodingSandboxProvider
 from agentclaw.community.core.workspace.engines.claude_code import ClaudeCodeSandboxProvider
 from agentclaw.community.core.workspace.engines.openclaw import OpenClawSandboxProvider
 from agentclaw.community.di import config as cfg
@@ -106,10 +107,6 @@ class TestClaudeCodeProvider:
 
         assert plan.extra_sync_source_relpath == ".claude"
         assert plan.extra_sync_target_relpath == "claude"
-        assert plan.extra_sync_items == (
-            (".claude", "claude"),
-            (".aicoding/workspace/skills/skills-local", "workspace/skills/skills-local"),
-        )
 
     def test_build_snapshot_excludes_pool_shared_repo(self):
         provider = ClaudeCodeSandboxProvider(workspace=_workspace())
@@ -173,6 +170,45 @@ class TestClaudeCodeProvider:
         assert "skills-repo" not in excludes, \
             'unanchored "skills-repo" exclude regressed — must use "/skills-repo"'
 
+
+
+
+@pytest.mark.unit
+class TestAICodingProvider:
+    def test_get_sessions_dir_uses_session_root_projects(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+
+        assert provider.get_sessions_dir() == "/home/admin/.aicoding/projects"
+
+    def test_build_plan_uses_aicoding_source_root(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        plan = provider.get_build_plan()
+
+        assert plan.engine_type == "aicoding"
+        assert plan.source_root_name == ".aicoding"
+        assert plan.workspace_subdir == "workspace"
+        assert plan.skill_source_relpath == "workspace/skills"
+        assert plan.skill_target_relpath == "workspace/skills"
+
+    def test_build_plan_keeps_extra_sync_from_claude(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        plan = provider.get_build_plan()
+
+        assert plan.extra_sync_source_relpath == ".claude"
+        assert plan.extra_sync_target_relpath == "claude"
+
+    def test_default_read_only_rules_include_workspace_files(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        rule_paths = {r.path for r in provider.get_default_read_only_rules()}
+
+        for path in (
+            "workspace/config/mcporter.json",
+            "workspace/.claude/settings.json",
+            "workspace/.claude/models.json",
+            "workspace/.claude/config.json",
+            "workspace/skills-local",
+        ):
+            assert path in rule_paths
 
 _OPENCLAW_ROOT = cfg.WorkspaceConfig().openclaw_root
 _CLAUDE_CODE_ROOT = cfg.WorkspaceConfig().claude_code_root


### PR DESCRIPTION
## Summary\n- Add an aicoding workspace provider/build plan using .aicoding/workspace.\n- Route claude_code bots with non-normalCC template_type to the aicoding provider during build and config lookup.\n- Remove router-level rsync exclude hardcoding by reading defaults from the resolved provider.\n\n## Online issue fix\nThis fixes the online/prepub issue where aicoding local skills under .aicoding/workspace/skills/skills-local were not synchronized into prepub build artifacts.\n\n## Validation\n- uv run pytest tests/community/core/workspace/test_engine_sandbox_providers.py tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py tests/community/core/bot_management/services/test_engine_resolver.py\n- uv run pytest tests/community/core/bot_management/services/test_engine_resolver.py tests/community/core/workspace/test_engine_sandbox_providers.py tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py tests/community/core/service_bot/services/test_baas_service_read_only_rules.py\n- uv run pytest tests/community/endpoints/test_service_bot_rsync_excludes.py