### PR TITLE
fix(engine): materialize DingTalk HTTP attachments

### DIFF
--- a/src/engine/src/engine/community/api/routers/ws.py
+++ b/src/engine/src/engine/community/api/routers/ws.py
@@ -14,6 +14,9 @@ import time
 from fastapi import APIRouter, WebSocket
 
 from engine.community.api.transport.ws_server import get_server
+from engine.community.core.resource_materialization.service import (
+    ResourceMaterializationService,
+)
 from engine.community.di import Injected
 from engine.community.plugin_api.auth_gate.protocol import AuthGateService
 
@@ -22,8 +25,12 @@ log = logging.getLogger("engine-ws-router")
 router = APIRouter(tags=["ws"])
 
 
-async def _handle(ws: WebSocket, engine_name: str,
-                  auth_gate_service: AuthGateService) -> None:
+async def _handle(
+    ws: WebSocket,
+    engine_name: str,
+    auth_gate_service: AuthGateService,
+    resource_materialization_service: ResourceMaterializationService | None = None,
+) -> None:
     from engine.community.manager import EngineManager
 
     manager = EngineManager.get_instance()
@@ -41,7 +48,7 @@ async def _handle(ws: WebSocket, engine_name: str,
         return
     t_start = time.monotonic()
     log.info("[ws] %s connection accepted", engine_name)
-    server = get_server()
+    server = get_server(resource_materialization_service)
     await server.handle_connection(ws, auth_gate_service=auth_gate_service)
     latency_ms = int((time.monotonic() - t_start) * 1000)
     log.info("[ws] %s closed: latency=%dms", engine_name, latency_ms)
@@ -51,7 +58,14 @@ async def _handle(ws: WebSocket, engine_name: str,
 async def openclaw_ws(
     ws: WebSocket,
     auth_gate_service: AuthGateService = Injected(AuthGateService),
+    resource_materialization_service: ResourceMaterializationService = Injected(
+        ResourceMaterializationService
+    ),
 ) -> None:
-    await _handle(ws, "openclaw", auth_gate_service)
-
+    await _handle(
+        ws,
+        "openclaw",
+        auth_gate_service,
+        resource_materialization_service,
+    )
 

--- a/src/engine/src/engine/community/core/resource_materialization/models.py
+++ b/src/engine/src/engine/community/core/resource_materialization/models.py
@@ -69,12 +69,12 @@ class ChatAttachmentMaterializationRequest(BaseModel):
     def validate_temporary_url(cls, value: str) -> str:
         parsed = urlsplit(value)
         if (
-            parsed.scheme != "https"
+            parsed.scheme not in {"http", "https"}
             or not parsed.hostname
             or parsed.username is not None
             or parsed.password is not None
         ):
-            raise ValueError("temporary_url must be an HTTPS URL without userinfo")
+            raise ValueError("temporary_url must be an HTTP or HTTPS URL without userinfo")
         return value
 
 

--- a/src/engine/src/engine/community/plugins/resource_materialization.py
+++ b/src/engine/src/engine/community/plugins/resource_materialization.py
@@ -235,13 +235,13 @@ class HttpTemporaryUrlPullClient:
         parsed = urlsplit(value)
         host = parsed.hostname.lower() if parsed.hostname else ""
         if (
-            parsed.scheme != "https"
+            parsed.scheme not in {"http", "https"}
             or not host
             or parsed.username is not None
             or parsed.password is not None
         ):
             raise ValueError("untrusted temporary URL")
-        return host, parsed.port or 443
+        return host, parsed.port or (443 if parsed.scheme == "https" else 80)
 
     @staticmethod
     async def _resolve_public_ips(host: str, port: int) -> frozenset[str]:

--- a/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
+++ b/src/engine/src/engine/community/plugins/tests/test_resource_materialization.py
@@ -185,6 +185,39 @@ async def test_temporary_url_pull_accepts_any_public_https_host(tmp_path: Path):
     assert (tmp_path / "file.part").read_bytes() == b"file"
 
 
+@pytest.mark.asyncio
+async def test_temporary_url_pull_accepts_public_http_host_on_port_80(tmp_path: Path):
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, content=b"file")
+
+    client = HttpTemporaryUrlPullClient(
+        transport=httpx.MockTransport(handler),
+    )
+    request = ChatAttachmentMaterializationRequest(
+        attachment_id="att-1",
+        session_key="session-1",
+        filename="file.txt",
+        temporary_url="http://files.example/object?token=secret",
+        scope_key_hash="a" * 64,
+    )
+
+    with patch(
+        "engine.community.plugins.resource_materialization.socket.getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 80))],
+    ) as resolve:
+        await client.pull(request, tmp_path / "file.part")
+
+    resolve.assert_called_once_with("files.example", 80, type=1)
+    assert len(requests) == 1
+    assert requests[0].url.scheme == "http"
+    assert requests[0].url.host == "93.184.216.34"
+    assert requests[0].headers["host"] == "files.example"
+    assert (tmp_path / "file.part").read_bytes() == b"file"
+
+
 @pytest.mark.parametrize(
     "kwargs, message",
     [
@@ -210,6 +243,27 @@ def _chat_request() -> ChatAttachmentMaterializationRequest:
         temporary_url="https://files.example/object?token=secret",
         scope_key_hash="a" * 64,
     )
+
+
+@pytest.mark.parametrize(
+    "temporary_url",
+    [
+        "ftp://files.example/object",
+        "http://user@files.example/object",
+        "https://user:password@files.example/object",
+    ],
+)
+def test_chat_attachment_rejects_unsupported_or_userinfo_url(
+    temporary_url: str,
+) -> None:
+    with pytest.raises(ValueError, match="HTTP or HTTPS URL without userinfo"):
+        ChatAttachmentMaterializationRequest(
+            attachment_id="att-1",
+            session_key="session-1",
+            filename="file.txt",
+            temporary_url=temporary_url,
+            scope_key_hash="a" * 64,
+        )
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/tests/api/routers/test_ws_handle_coverage.py
+++ b/src/engine/src/engine/community/tests/api/routers/test_ws_handle_coverage.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from engine.community.api.routers.ws import _handle
+from engine.community.api.routers.ws import _handle, openclaw_ws
 
 
 class _FakeWS:
@@ -15,6 +15,26 @@ class _FakeWS:
         self.closed_with = None
     async def accept(self): self.accepted = True
     async def close(self, *, code, reason): self.closed_with = (code, reason)
+
+
+@pytest.mark.asyncio
+async def test_openclaw_ws_forwards_materialization_service():
+    ws = MagicMock()
+    auth = MagicMock()
+    materialization_service = MagicMock()
+
+    with patch(
+        "engine.community.api.routers.ws._handle",
+        new_callable=AsyncMock,
+    ) as handle_mock:
+        await openclaw_ws(ws, auth, materialization_service)
+
+    handle_mock.assert_awaited_once_with(
+        ws,
+        "openclaw",
+        auth,
+        materialization_service,
+    )
 
 
 @pytest.mark.asyncio
@@ -36,13 +56,18 @@ async def test_handle_delegates_when_engine_active():
     manager = MagicMock()
     manager.engine = "claude_code"  # active matches
     auth = MagicMock()
+    materialization_service = MagicMock()
     fake_server = MagicMock()
     fake_server.handle_connection = AsyncMock()
     with patch("engine.community.manager.EngineManager.get_instance", return_value=manager), \
-         patch("engine.community.api.routers.ws.get_server", return_value=fake_server):
-        await _handle(ws, "claude_code", auth)
+         patch(
+             "engine.community.api.routers.ws.get_server",
+             return_value=fake_server,
+         ) as get_server_mock:
+        await _handle(ws, "claude_code", auth, materialization_service)
     assert ws.accepted is False  # EngineWebSocketServer.handle_connection owns accept
     fake_server.handle_connection.assert_awaited_once()
     # verify delegate passes auth + ws through
     args, kwargs = fake_server.handle_connection.call_args
     assert kwargs.get("auth_gate_service") is auth
+    get_server_mock.assert_called_once_with(materialization_service)


### PR DESCRIPTION
## Problem

DingTalk DM/PerSender file callbacks can produce short-lived HTTP download URLs in the pre-release environment. Engine currently rejects non-HTTPS temporary URLs, and the mounted `/api/openclaw/ws` route does not inject the existing `ResourceMaterializationService`, so accepted file messages terminate with `File preparation is unavailable` before inference.

## Solution

- Accept both HTTP and HTTPS temporary attachment URLs while retaining URL parsing, no-userinfo validation, public-IP DNS validation, DNS pinning, redirect blocking, download timeout, and size limits.
- Select the protocol-appropriate default port (80 for HTTP, 443 for HTTPS).
- Inject the existing `ResourceMaterializationService` into the OpenClaw WebSocket route and pass it to the shared WebSocket server.
- Add focused tests for HTTP materialization, invalid URL forms, and route dependency forwarding.

## Validation

- `uv run --directory src/engine --with pytest --with pytest-asyncio --with socksio pytest -q ...`: 37 passed.
- `src/engine/scripts/ci_test.sh --base origin/REL20260814 --head HEAD`: 2325 passed, 5 deselected; case pass rate 100%; line coverage 92.89%; changed-line coverage 100%.
- `scripts/ci/python_sast_local.sh src/engine 1 --base origin/REL20260814 --head HEAD`: passed.
- Pre-release ARCA container smoke: DingTalk temporary URL materialized into the controlled session-files layout, `<file-ref>` reached OpenClaw, the file was read successfully, and BCS emitted a final response.

## Compatibility and risk

This expands the accepted temporary URL schemes to HTTP for constrained deployment environments. Existing SSRF protections remain active: every resolved address must be public, the connection is pinned to a validated IP, redirects are disabled, and response size/time are bounded. No new service or plugin API is introduced. Rollback is a revert of this commit.

## Related issues

- Dev counterpart: #1042