### PR TITLE
fix(skills): retire local skill mappings through engine layout

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -39,6 +39,7 @@ consumes:
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
+  - agentclaw.community.core.repository.protocols.skills_pool    # Skills Pool repository contracts consumed by this module
   - agentclaw.community.core.access
   - agentclaw.community.core.base
   - agentclaw.community.core.bot_collaborator

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -20,13 +20,32 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillStorageError,
 )
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
     SkillsPoolEditPausedError,
 )
-from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    local_skill_name,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+    SkillMappingSourceLayout,
+)
+from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    runtime_uses_pool_paths,
+)
 
 
 class LocalSkillStateService:
@@ -41,6 +60,9 @@ class LocalSkillStateService:
         collaborator_service: CollaboratorServiceProtocol,
         skill_set_service_factory: SkillSetServiceFactory,
         edit_guard: SkillsPoolEditGuard,
+        pool_runtime: SkillsPoolRuntimeProtocol,
+        pool_skills: SkillsPoolSkillRepositoryProtocol,
+        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
@@ -48,6 +70,9 @@ class LocalSkillStateService:
         self._collaborators = collaborator_service
         self._skill_set_service_factory = skill_set_service_factory
         self._edit_guard = edit_guard
+        self._pool_runtime = pool_runtime
+        self._pool_skills = pool_skills
+        self._pool_layouts = pool_layouts
 
     async def set_local_skill_active(
         self, *, skill_id: str, actor_id: str, active: bool
@@ -85,30 +110,6 @@ class LocalSkillStateService:
                     skill_set_id=int(default_set["id"]),
                     skill_id=int(skill_id),
                 )
-                if not active:
-                    try:
-                        await self._cleanup_runtime_link(
-                            bot=bot,
-                            owner_id=owner_id,
-                            bot_id=bot_id,
-                            skill_name=str(skill["name"]),
-                        )
-                    except LocalSkillStorageError:
-                        try:
-                            self._write_desired_state(
-                                active=True,
-                                owner_id=owner_id,
-                                bot_id=bot_id,
-                                skill_set_id=int(default_set["id"]),
-                                skill_id=int(skill_id),
-                            )
-                        except Exception as exc:
-                            raise LocalSkillStorageError() from exc
-                        if not self._sync_runtime(
-                            bot=bot, owner_id=owner_id, bot_id=bot_id
-                        ):
-                            raise LocalSkillRuntimeSyncError()
-                        raise
             elif not active:
                 # ``get_bot_local_skill`` treats an exclusion from any former
                 # default set as inactive, while runtime mapping filters the
@@ -121,7 +122,18 @@ class LocalSkillStateService:
                     skill_set_id=int(default_set["id"]),
                     skill_id=int(skill_id),
                 )
-            if not self._sync_runtime(bot=bot, owner_id=owner_id, bot_id=bot_id):
+
+            if active:
+                synced = self._sync_runtime(bot=bot, owner_id=owner_id, bot_id=bot_id)
+            else:
+                synced = await self._reconcile_deactivation(
+                    scope=scope,
+                    bot=bot,
+                    skill=skill,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                )
+            if not synced:
                 if changed:
                     try:
                         self._write_desired_state(
@@ -133,9 +145,13 @@ class LocalSkillStateService:
                         )
                     except Exception as exc:
                         raise LocalSkillStorageError() from exc
-                    if not self._sync_runtime(
+                    # Restore through the established runtime synchronizer.
+                    # It owns each engine's actual active-root compatibility,
+                    # including Claude Code's historical workspace root.
+                    restored = self._sync_runtime(
                         bot=bot, owner_id=owner_id, bot_id=bot_id
-                    ):
+                    )
+                    if not restored:
                         raise LocalSkillRuntimeSyncError()
                 raise LocalSkillRuntimeSyncError()
             return {**skill, "active": active, "changed": changed}
@@ -249,21 +265,74 @@ class LocalSkillStateService:
         except Exception:
             return False
 
-    async def _cleanup_runtime_link(
-        self, *, bot: dict[str, Any], owner_id: str, bot_id: str, skill_name: str
-    ) -> None:
+    async def _reconcile_deactivation(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        bot: dict[str, Any],
+        skill: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+    ) -> bool:
         try:
-            service = self._skill_set_service_factory.create(
-                user_id=owner_id,
-                entity_id=str(bot["entity_id"]),
+            retired = RegisteredSkillAsset(
+                skill_id=int(skill["id"]),
+                name=str(skill["name"]),
+                git_path=str(skill["git_path"]),
+            )
+            retired_mapping = PoolSkillMapping(
+                corpus="local",
+                relative_path=local_skill_name(retired),
+                link_name=local_skill_name(retired),
+            )
+        except (KeyError, TypeError, ValueError):
+            return False
+        return await self._publish_current_mappings(
+            scope=scope,
+            bot=bot,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            retired_mappings=[retired_mapping],
+        )
+
+    async def _publish_current_mappings(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        bot: dict[str, Any],
+        owner_id: str,
+        bot_id: str,
+        retired_mappings: list[PoolSkillMapping] | None = None,
+    ) -> bool:
+        try:
+            mappings = build_logical_skill_mappings(
+                self._pool_skills.list_bot_active_assets(
+                    env=scope.env,
+                    bot_id=bot_id,
+                    user_id=owner_id,
+                    engine=str(bot["active_engine"]),
+                )
+            )
+            source_layout = (
+                SkillMappingSourceLayout.POOL
+                if runtime_uses_pool_paths(self._pool_layouts.get(scope))
+                else SkillMappingSourceLayout.LEGACY
+            )
+            retired = retired_mappings or []
+            if not await self._pool_runtime.publish_mappings(
                 bot_id=bot_id,
-                engine_type=bot.get("active_engine"),
-                entity_type=bot.get("entity_type"),
+                user_id=owner_id,
+                mappings=mappings,
+                retired_mappings=retired,
+                source_layout=source_layout,
+            ):
+                return False
+            return await self._pool_runtime.verify_mappings(
+                bot_id=bot_id,
+                user_id=owner_id,
+                mappings=mappings,
+                retired_mappings=retired,
+                source_layout=source_layout,
             )
-            cleaned = await service.skill_service.deactivate_skill(
-                skill_name, bolt_id=bot_id, user_id=owner_id
-            )
-            if not cleaned:
-                raise LocalSkillStorageError()
-        except Exception as exc:
-            raise LocalSkillStorageError() from exc
+        except Exception:
+            return False

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -123,6 +123,8 @@ from agentclaw.community.core.skill_center.services.skill_set_service import (
 )
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolLayoutRepositoryProtocol
+from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
+from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
 from agentclaw.community.core.skills_pool.reconcile_task import (
     SkillsPoolReconcileWakeupListener,
 )
@@ -349,6 +351,9 @@ class SkillCenterModule(Module):
         collaborator_service: CollaboratorServiceProtocol,
         skill_set_service_factory: SkillSetServiceFactory,
         edit_guard: SkillsPoolEditGuard,
+        pool_runtime: SkillsPoolRuntimeProtocol,
+        pool_skills: SkillsPoolSkillRepositoryProtocol,
+        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
     ) -> LocalSkillStateServiceProtocol:
         return LocalSkillStateService(
             skill_repo,
@@ -357,6 +362,9 @@ class SkillCenterModule(Module):
             collaborator_service,
             skill_set_service_factory,
             edit_guard,
+            pool_runtime,
+            pool_skills,
+            pool_layouts,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -647,7 +647,9 @@ async def test_state_command_cannot_cross_the_real_tenant_guard(tmp_path):
             return True
 
     factory = _Factory()
-    service = LocalSkillStateService(skills, sets, bots, object(), factory, _Guard())
+    service = LocalSkillStateService(
+        skills, sets, bots, object(), factory, _Guard(), object(), object(), object()
+    )
     with avernet_tenant_scope("tenant-b"):
         with pytest.raises(LocalSkillNotFoundError):
             await service.set_local_skill_active(

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from agentclaw.community.core.skill_center.errors import (
@@ -14,6 +12,10 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.skill_center.services.local_skill_state_service import (
     LocalSkillStateService,
+)
+from agentclaw.community.core.skills_pool.models import (
+    RegisteredSkillAsset,
+    SkillMappingSourceLayout,
 )
 
 
@@ -33,7 +35,7 @@ class _Skills:
         }
 
     def get_bot_local_skill(self, **kwargs):
-        if self.git_path != "local://one":
+        if not self.git_path.startswith("local://"):
             return None
         return {
             "id": "9",
@@ -43,6 +45,17 @@ class _Skills:
             "name": "one",
             "active": self.active,
         }
+
+    def list_bot_active_assets(self, **_kwargs):
+        if not self.active:
+            return []
+        return [
+            RegisteredSkillAsset(
+                skill_id=9,
+                name="one",
+                git_path=self.git_path,
+            )
+        ]
 
 
 class _Sets:
@@ -121,12 +134,48 @@ class _Runtime:
     def __init__(self, success: bool) -> None:
         self.success = success
         self.calls = 0
-        self.skill_service = MagicMock()
-        self.skill_service.deactivate_skill = AsyncMock(return_value=True)
+        self.publish_results = [True]
+        self.verify_results = [True]
+        self.publish_calls = []
+        self.verify_calls = []
 
     def sync_runtime(self):
         self.calls += 1
         return self.success
+
+    async def publish_mappings(self, **kwargs):
+        self.publish_calls.append(kwargs)
+        return self.publish_results.pop(0)
+
+    async def verify_mappings(self, **kwargs):
+        self.verify_calls.append(kwargs)
+        return self.verify_results.pop(0)
+
+
+class _Layouts:
+    def __init__(self, *, pool: bool = False) -> None:
+        self.pool = pool
+
+    def get(self, scope):
+        types = __import__(
+            "agentclaw.community.core.skills_pool.types",
+            fromlist=[
+                "BotSkillLayoutState",
+                "SkillLayout",
+                "SkillLayoutPhase",
+            ],
+        )
+        state = types.BotSkillLayoutState.legacy_default(scope)
+        if not self.pool:
+            return state
+        return types.BotSkillLayoutState(
+            scope=scope,
+            active_layout=types.SkillLayout.POOL,
+            target_layout=None,
+            phase=types.SkillLayoutPhase.POOL_ACTIVE,
+            migration_generation="generation",
+            persisted=True,
+        )
 
 
 class _Factory:
@@ -149,6 +198,7 @@ def _service(
     associated: bool = True,
     collaborators=None,
     on_acquire=None,
+    pool_layout: bool = False,
 ):
     skills = _Skills(active=active, git_path=git_path)
     sets = _Sets(skills, associated=associated)
@@ -156,7 +206,15 @@ def _service(
     runtime = _Runtime(sync_success)
     factory = _Factory(runtime)
     service = LocalSkillStateService(
-        skills, sets, _Bots(status, entity_id), collaborators or _Collaborators(), factory, guard
+        skills,
+        sets,
+        _Bots(status, entity_id),
+        collaborators or _Collaborators(),
+        factory,
+        guard,
+        runtime,
+        skills,
+        _Layouts(pool=pool_layout),
     )
     return service, skills, sets, guard, runtime, factory
 
@@ -230,34 +288,106 @@ async def test_idempotent_deactivate_normalizes_current_default_exclusion():
     assert result["active"] is False
     assert result["changed"] is False
     assert sets.events == ["add"]
-    assert runtime.calls == 1
+    assert runtime.calls == 0
+    assert len(runtime.publish_calls) == len(runtime.verify_calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_deactivate_removes_stale_runtime_link_before_sync():
+async def test_deactivate_retires_logical_mapping_without_legacy_file_delete():
     service, _skills, _sets, _guard, runtime, _factory = _service(active=True)
 
     await service.set_local_skill_active(skill_id="9", actor_id="owner", active=False)
 
-    runtime.skill_service.deactivate_skill.assert_awaited_once_with(
-        "one", bolt_id="bot", user_id="owner"
-    )
+    assert runtime.calls == 0
+    assert len(runtime.publish_calls) == len(runtime.verify_calls) == 1
+    call = runtime.publish_calls[0]
+    assert call["mappings"] == []
+    assert [mapping.to_dict() for mapping in call["retired_mappings"]] == [
+        {"corpus": "local", "relative_path": "one", "link_name": "one"}
+    ]
+    assert call["source_layout"] is SkillMappingSourceLayout.LEGACY
+
+
+@pytest.mark.asyncio
+async def test_deactivate_publish_failure_restores_desired_and_runtime_state():
+    service, skills, sets, _guard, runtime, _factory = _service(active=True)
+    runtime.publish_results = [False]
+
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await service.set_local_skill_active(
+            skill_id="9", actor_id="owner", active=False
+        )
+
+    assert sets.events == ["add", "remove"]
+    assert skills.active is True
+    assert len(runtime.publish_calls) == 1
+    assert runtime.verify_calls == []
     assert runtime.calls == 1
 
 
 @pytest.mark.asyncio
-async def test_deactivate_treats_false_stale_link_cleanup_as_storage_failure():
+async def test_deactivate_verify_failure_restores_through_engine_compatible_sync():
     service, skills, sets, _guard, runtime, _factory = _service(active=True)
-    runtime.skill_service.deactivate_skill.return_value = False
+    runtime.verify_results = [False]
 
-    with pytest.raises(LocalSkillStorageError):
-        await service.set_local_skill_active(skill_id="9", actor_id="owner", active=False)
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await service.set_local_skill_active(
+            skill_id="9", actor_id="owner", active=False
+        )
 
-    runtime.skill_service.deactivate_skill.assert_awaited_once_with(
-        "one", bolt_id="bot", user_id="owner"
-    )
     assert sets.events == ["add", "remove"]
     assert skills.active is True
+    assert len(runtime.publish_calls) == len(runtime.verify_calls) == 1
+    assert runtime.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_deactivate_mapping_repository_failure_fails_closed_and_restores_state():
+    service, skills, sets, _guard, runtime, _factory = _service(active=True)
+
+    def fail_to_list_active_assets(**_kwargs):
+        raise RuntimeError("repository unavailable")
+
+    skills.list_bot_active_assets = fail_to_list_active_assets
+
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await service.set_local_skill_active(
+            skill_id="9", actor_id="owner", active=False
+        )
+
+    assert sets.events == ["add", "remove"]
+    assert skills.active is True
+    assert runtime.publish_calls == []
+    assert runtime.verify_calls == []
+    assert runtime.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_deactivate_selects_pool_source_layout_after_cutover():
+    service, _skills, _sets, _guard, runtime, _factory = _service(
+        active=True, pool_layout=True
+    )
+
+    await service.set_local_skill_active(skill_id="9", actor_id="owner", active=False)
+
+    assert runtime.publish_calls[0]["source_layout"] is SkillMappingSourceLayout.POOL
+    assert runtime.verify_calls[0]["source_layout"] is SkillMappingSourceLayout.POOL
+
+
+@pytest.mark.asyncio
+async def test_deactivate_invalid_locator_fails_closed_and_restores_desired_state():
+    service, skills, sets, _guard, runtime, _factory = _service(
+        active=True, git_path="local://folder/../one"
+    )
+
+    with pytest.raises(LocalSkillRuntimeSyncError):
+        await service.set_local_skill_active(
+            skill_id="9", actor_id="owner", active=False
+        )
+
+    assert sets.events == ["add", "remove"]
+    assert skills.active is True
+    assert runtime.publish_calls == []
     assert runtime.calls == 1
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -19,6 +19,9 @@ from agentclaw.community.core.skill_center.services.local_skill_state_service im
 )
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
@@ -61,6 +64,12 @@ class _Runtime:
         self.success = success
 
     def sync_runtime(self) -> bool:
+        return self.success
+
+    async def publish_mappings(self, **_kwargs) -> bool:
+        return self.success
+
+    async def verify_mappings(self, **_kwargs) -> bool:
         return self.success
 
 
@@ -152,6 +161,7 @@ def _seed_state(world, *, runtime_success: bool) -> None:
         world.get(SkillSetRepository).add_default_skill_exclusion(
             _OWNER, _BOT_ID, int(skill_set["id"]), int(skill["id"])
         )
+    runtime_factory = _RuntimeFactory(runtime_success)
     world.injector.binder.bind(
         LocalSkillStateServiceProtocol,
         to=LocalSkillStateService(
@@ -159,8 +169,11 @@ def _seed_state(world, *, runtime_success: bool) -> None:
             world.get(SkillSetRepository),
             world.get(BotRepository),
             world.get(CollaboratorServiceProtocol),
-            _RuntimeFactory(runtime_success),
+            runtime_factory,
             _Guard(),
+            runtime_factory._runtime,
+            world.get(SkillRepository),
+            world.get(SkillsPoolLayoutRepositoryProtocol),
         ),
         scope=None,
     )

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -21,6 +21,7 @@ from engine.community.core.skills.layout_planner import (
 from engine.community.plugins.claude_code.layout_pool import (
     MappingSourceLayout,
     activate_claude_code_pool,
+    claude_code_retirement_active_roots,
     inspect_claude_code_runtime_layout,
     publish_claude_code_pool_mappings,
     rollback_claude_code_pool,
@@ -59,12 +60,16 @@ class _SkillsPortMixin:
         *,
         source_layout: MappingSourceLayout,
         key: str = "mappings",
+        retired: bool = False,
     ) -> ResolvedMappingPayload:
         return resolve_mapping_payload(
             engine="claude_code",
             source_layout=source_layout,
             payload=params.get(key, []),
             mapping_contract_version=params.get("mapping_contract_version"),
+            additional_retirement_roots=(
+                claude_code_retirement_active_roots() if retired else ()
+            ),
         )
 
     async def activate_pool_layout(
@@ -138,6 +143,7 @@ class _SkillsPortMixin:
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
             key="retired_mappings",
+            retired=True,
         )
         publish_kwargs: dict[str, Any] = {
             "mappings": list(resolved.mappings),
@@ -175,6 +181,7 @@ class _SkillsPortMixin:
                 params.get("source_layout", MappingSourceLayout.POOL.value)
             ),
             key="retired_mappings",
+            retired=True,
         )
         verify_kwargs: dict[str, Any] = {
             "mappings": list(resolved.mappings),

--- a/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
+++ b/src/engine/src/engine/community/plugins/claude_code/layout_pool.py
@@ -35,6 +35,15 @@ from engine.community.plugins.skills_pool.layout_probe import (
 )
 
 
+def claude_code_retirement_active_roots(
+    *,
+    home: str | Path = "/home/admin",
+) -> tuple[Path, ...]:
+    """Return Claude Code-owned historical active roots eligible for retirement."""
+
+    return (Path(home) / ".claude_code/workspace/skills",)
+
+
 def inspect_claude_code_runtime_layout(
     *,
     expected_contract_version: str = LAYOUT_CONTRACT_VERSION,
@@ -64,6 +73,7 @@ def publish_claude_code_pool_mappings(
         home=home,
         engine="claude_code",
         source_layout=source_layout,
+        additional_retirement_roots=claude_code_retirement_active_roots(home=home),
     )
 
 
@@ -80,6 +90,7 @@ def verify_claude_code_pool_mappings(
         home=home,
         engine="claude_code",
         source_layout=source_layout,
+        additional_retirement_roots=claude_code_retirement_active_roots(home=home),
     )
 
 
@@ -94,6 +105,7 @@ __all__ = [
     "RuntimeLayoutInspectionStatus",
     "SkillMapping",
     "activate_claude_code_pool",
+    "claude_code_retirement_active_roots",
     "inspect_claude_code_runtime_layout",
     "publish_claude_code_pool_mappings",
     "rollback_claude_code_pool",

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -903,10 +903,16 @@ def _mapping_plan(
     )
 
 
-def _mapping_target_invalid(layout: _Layout, target: Path) -> bool:
+def _mapping_target_invalid(
+    layout: _Layout,
+    target: Path,
+    *,
+    additional_retirement_roots: Sequence[Path] = (),
+) -> bool:
     return (
         not target.is_absolute()
-        or target.parent != layout.active_root
+        or target.parent
+        not in {layout.active_root, *additional_retirement_roots}
         or target
         in {
             layout.legacy_local,
@@ -944,6 +950,7 @@ def _retirement_plan(
     mappings: list[SkillMapping],
     retired_mappings: list[SkillMapping],
     source_layout: MappingSourceLayout,
+    additional_retirement_roots: Sequence[Path] = (),
 ) -> _MappingRetirementPlan:
     """Validate exact managed identities that may be removed.
 
@@ -979,7 +986,11 @@ def _retirement_plan(
                 if source_layout is MappingSourceLayout.LEGACY
                 else "source_outside_pool"
             )
-        elif _mapping_target_invalid(layout, target):
+        elif _mapping_target_invalid(
+            layout,
+            target,
+            additional_retirement_roots=additional_retirement_roots,
+        ):
             reason = "target_invalid"
         elif target in seen and seen[target] != source:
             reason = "retired_target_ambiguous"
@@ -2276,6 +2287,7 @@ def verify_skill_mappings(
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
+    additional_retirement_roots: Sequence[Path] = (),
 ) -> MappingVerificationResult:
     """验证受管激活入口精确解析到声明 layout 的 source。"""
 
@@ -2285,6 +2297,7 @@ def verify_skill_mappings(
         mappings=mappings,
         retired_mappings=list(retired_mappings),
         source_layout=source_layout,
+        additional_retirement_roots=additional_retirement_roots,
     )
     plan = _mapping_plan(
         layout=layout,
@@ -2331,6 +2344,7 @@ def publish_pool_mappings(
     home: str | Path = "/home/admin",
     engine: str = "openclaw",
     source_layout: MappingSourceLayout = MappingSourceLayout.POOL,
+    additional_retirement_roots: Sequence[Path] = (),
 ) -> MappingPublishResult:
     """按声明 layout 对齐全部受管 mapping，并保留外部入口。"""
 
@@ -2340,6 +2354,7 @@ def publish_pool_mappings(
         mappings=mappings,
         retired_mappings=list(retired_mappings),
         source_layout=source_layout,
+        additional_retirement_roots=additional_retirement_roots,
     )
     plan = _mapping_plan(
         layout=layout,

--- a/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -58,6 +59,7 @@ def resolve_mapping_payload(
     source_layout: MappingSourceLayout,
     payload: object,
     mapping_contract_version: str | None = None,
+    additional_retirement_roots: Sequence[Path] = (),
     home: Path = Path("/home/admin"),
 ) -> ResolvedMappingPayload:
     """Resolve logical v2 or legacy unversioned physical mappings.
@@ -140,13 +142,18 @@ def resolve_mapping_payload(
         if source_layout is MappingSourceLayout.POOL
         else plan.legacy_repo
     )
+    active_roots = [plan.active_root, *additional_retirement_roots]
     try:
-        resolved = resolve_skill_mappings(
-            active_root=plan.active_root,
-            local_root=local_root,
-            repo_root=repo_root,
-            mappings=logical,
-        )
+        resolved = [
+            mapping
+            for active_root in active_roots
+            for mapping in resolve_skill_mappings(
+                active_root=active_root,
+                local_root=local_root,
+                repo_root=repo_root,
+                mappings=logical,
+            )
+        ]
     except SkillLayoutResolutionError as error:
         raise InvalidPoolMappingRequestError(str(error)) from error
     return ResolvedMappingPayload(

--- a/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/tests/test_mapping_retirement.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from engine.community.plugins.claude_code.layout_pool import (
+    claude_code_retirement_active_roots,
+)
 from engine.community.plugins.skills_pool.layout_activation import (
+    MappingSourceLayout,
     SkillMapping,
     _Layout,
     publish_pool_mappings,
@@ -12,7 +16,7 @@ from engine.community.plugins.skills_pool.layout_activation import (
 )
 
 
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 def test_retired_product_mapping_is_removed_without_touching_other_entries(
     tmp_path: Path,
     engine: str,
@@ -68,7 +72,7 @@ def test_retired_product_mapping_is_removed_without_touching_other_entries(
     assert external_target.readlink() == external_source
 
 
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 def test_retired_mapping_allows_same_name_product_replacement(
     tmp_path: Path,
     engine: str,
@@ -125,7 +129,7 @@ def test_invalid_retired_mapping_fails_before_desired_mapping_mutation(
     assert not target.is_symlink()
 
 
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 def test_absent_retired_mapping_is_idempotent(
     tmp_path: Path,
     engine: str,
@@ -157,7 +161,7 @@ def test_absent_retired_mapping_is_idempotent(
     assert verified.valid
 
 
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 def test_retired_target_rebound_to_external_is_preserved(
     tmp_path: Path,
     engine: str,
@@ -184,7 +188,7 @@ def test_retired_target_rebound_to_external_is_preserved(
     assert target.readlink() == external_source
 
 
-@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
+@pytest.mark.parametrize("engine", ["openclaw", "claude_code", "aicoding", "hermes"])
 def test_retired_target_rebound_to_other_managed_identity_fails_before_mutation(
     tmp_path: Path,
     engine: str,
@@ -203,9 +207,7 @@ def test_retired_target_rebound_to_other_managed_identity_fails_before_mutation(
 
     published = publish_pool_mappings(
         mappings=[SkillMapping(str(desired_source), str(desired_target))],
-        retired_mappings=[
-            SkillMapping(str(old_source), str(retired_target))
-        ],
+        retired_mappings=[SkillMapping(str(old_source), str(retired_target))],
         home=home,
         engine=engine,
     )
@@ -215,3 +217,137 @@ def test_retired_target_rebound_to_other_managed_identity_fails_before_mutation(
     assert retired_target.is_symlink()
     assert retired_target.readlink() == other_source
     assert not desired_target.exists()
+
+
+def test_claude_code_legacy_retirement_removes_current_and_historical_links(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("claude_code", home)
+    source = layout.legacy_local / "financial-data-query"
+    source.mkdir(parents=True)
+    historical_root = claude_code_retirement_active_roots(home=home)[0]
+    for root in (layout.active_root, historical_root):
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "financial-data-query").symlink_to(source, target_is_directory=True)
+
+    retired = [
+        SkillMapping(str(source), str(layout.active_root / "financial-data-query")),
+        SkillMapping(
+            str(source),
+            str(historical_root / "financial-data-query"),
+        ),
+    ]
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=retired,
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+    verified = verify_skill_mappings(
+        mappings=[],
+        retired_mappings=retired,
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+
+    assert published.published
+    assert verified.valid
+    for root in (layout.active_root, historical_root):
+        assert not (root / "financial-data-query").is_symlink()
+
+
+def test_claude_code_historical_retirement_preserves_external_symlink(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("claude_code", home)
+    source = layout.legacy_local / "financial-data-query"
+    source.mkdir(parents=True)
+    layout.active_root.mkdir(parents=True, exist_ok=True)
+    historical_root = claude_code_retirement_active_roots(home=home)[0]
+    external = tmp_path / "external"
+    external.mkdir()
+    historical_root.mkdir(parents=True, exist_ok=True)
+    target = historical_root / "financial-data-query"
+    target.symlink_to(external, target_is_directory=True)
+
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=[SkillMapping(str(source), str(target))],
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+
+    assert published.published
+    assert target.readlink() == external
+
+
+def test_claude_code_historical_retirement_rejects_occupied_entry_before_mutation(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("claude_code", home)
+    source = layout.legacy_local / "financial-data-query"
+    source.mkdir(parents=True)
+    layout.active_root.mkdir(parents=True, exist_ok=True)
+    historical_root = claude_code_retirement_active_roots(home=home)[0]
+    historical_root.mkdir(parents=True, exist_ok=True)
+    occupied = historical_root / "financial-data-query"
+    occupied.write_text("user content")
+    desired_source = layout.legacy_local / "desired"
+    desired_source.mkdir()
+    desired_target = layout.active_root / "desired"
+
+    published = publish_pool_mappings(
+        mappings=[SkillMapping(str(desired_source), str(desired_target))],
+        retired_mappings=[SkillMapping(str(source), str(occupied))],
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+
+    assert not published.published
+    assert published.evidence["reason"] == "retired_mapping_invalid"
+    assert occupied.read_text() == "user content"
+    assert not desired_target.exists()
+
+
+def test_claude_code_historical_retirement_is_idempotent_when_absent(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home/admin"
+    layout = _Layout.for_engine("claude_code", home)
+    source = layout.legacy_local / "financial-data-query"
+    source.mkdir(parents=True)
+    layout.active_root.mkdir(parents=True, exist_ok=True)
+    historical_root = claude_code_retirement_active_roots(home=home)[0]
+    target = historical_root / "financial-data-query"
+
+    published = publish_pool_mappings(
+        mappings=[],
+        retired_mappings=[SkillMapping(str(source), str(target))],
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+    verified = verify_skill_mappings(
+        mappings=[],
+        retired_mappings=[SkillMapping(str(source), str(target))],
+        home=home,
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        additional_retirement_roots=(historical_root,),
+    )
+
+    assert published.published
+    assert published.evidence["retired_absent"] == [str(target)]
+    assert verified.valid

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 
 import pytest
+
 from engine.community.core.skills.exceptions import (
     InvalidPoolMappingRequestError,
 )
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
     SkillLayoutResolutionError,
+)
+from engine.community.plugins.claude_code.layout_pool import (
+    claude_code_retirement_active_roots,
 )
 from engine.community.plugins.skills_pool.layout_activation import (
     MappingSourceLayout,
@@ -214,3 +218,29 @@ def test_legacy_no_version_physical_payload_remains_compatible(
     assert resolved.mappings[0].target == "/active/writer"
     assert resolved.resolved_locators == ()
     assert _snapshot(tmp_path) == []
+
+
+def test_claude_code_retired_legacy_mapping_resolves_both_managed_active_roots(
+    tmp_path: Path,
+) -> None:
+    mapping = {
+        "corpus": "local",
+        "relative_path": "financial-data-query",
+        "link_name": "financial-data-query",
+    }
+
+    resolved = resolve_mapping_payload(
+        engine="claude_code",
+        source_layout=MappingSourceLayout.LEGACY,
+        payload=[mapping],
+        mapping_contract_version=MAPPING_CONTRACT_VERSION,
+        additional_retirement_roots=claude_code_retirement_active_roots(
+            home=tmp_path
+        ),
+        home=tmp_path,
+    )
+
+    assert [item.target for item in resolved.mappings] == [
+        str(tmp_path / ".claude/skills/financial-data-query"),
+        str(tmp_path / ".claude_code/workspace/skills/financial-data-query"),
+    ]


### PR DESCRIPTION
  - 新 OpenAPI 的 Local Skill deactivate 不再通过 Backend 拼接物理路径并调用 /api/file/rmtree。
  - 改为发布 logical mapping retirement，由 Engine Runtime 根据引擎布局解析并清理实际软链。
  - Claude Code 同时兼容：
      - 当前 active root：.claude/skills
      - 历史 active root：.claude_code/workspace/skills

  - 仅清理指向受管 Skill source 的软链：
      - 外部软链保留
      - 普通文件或目录不会误删
      - 路径不存在按幂等成功处理