### PR TITLE
fix(service-bot): reschedule transient online deploy preflights

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/errors.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/errors.py
@@ -14,6 +14,12 @@ class PublishFlowServiceError(Exception):
     pass
 
 
+class OnlineDeployDeferredError(PublishFlowServiceError):
+    """The online deploy must wait without failing the publish record."""
+
+    pass
+
+
 class DraftRestoreRetryableError(PublishFlowServiceError):
     """Draft restore failed in an in-doubt/transient external-workflow window.
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -288,15 +288,22 @@ class RestartMixin:
         if not migration_path and not config_artifact:
             return {"success": False, "message": f"Missing build artifact: publish_id={publish_id}"}
 
-        # Mark restart in progress, and note that every failure return above this
-        # point leaves it untouched — the restart task's failure branch relies on
-        # that to avoid clearing a concurrent restart's marker. Cleared on an
-        # observed terminal workflow by sync_restart_progress, which the restart
-        # poll now drives.
-        def _set_restarting_flag(latest_ext: dict) -> None:
-            latest_ext.setdefault("restart", {})["restarting"] = True
-
-        self._mutate_and_update_ext(publish_id=publish_id, mutator=_set_restarting_flag)
+        # Resolve the online target before marking the restart in progress. A
+        # deferred liveness read (STOPPING / missing status / transient BaaS
+        # failure) means no restart workflow was submitted; setting the marker
+        # earlier could combine it with a stale restart.<stage> handle and make
+        # redelivery incorrectly skip this restart as already submitted.
+        decision = None
+        if stage_enum == PublishStage.ONLINE:
+            decision = self._decide_online_deploy(publish_record, bot)
+            if decision not in (
+                OnlineDeployDecision.UPGRADE,
+                OnlineDeployDecision.RETIRE_THEN_FIRST_RELEASE,
+                OnlineDeployDecision.FIRST_RELEASE,
+            ):
+                raise PublishFlowServiceError(
+                    f"Unhandled online deploy decision: {decision}"
+                )
 
         version = f"{publish_record.version}"
         # STORED overrides slot: reproduce what was promoted (not a live re-fetch),
@@ -304,6 +311,16 @@ class RestartMixin:
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
         skills_env = service_skills_env_from_ext(publish_record.ext, bot)
         image_pin = self.resolve_publish_image_pin(publish_record)
+
+        # All local preflight checks, including the online liveness decision and
+        # delivery resolution, passed. Mark the restart in progress immediately
+        # before entering the crash-recovery / external-mutation section. Cleared
+        # on an observed terminal workflow by sync_restart_progress, which the
+        # restart poll drives.
+        def _set_restarting_flag(latest_ext: dict) -> None:
+            latest_ext.setdefault("restart", {})["restarting"] = True
+
+        self._mutate_and_update_ext(publish_id=publish_id, mutator=_set_restarting_flag)
 
         # A prior recreate that crashed between its ext write and its
         # complete_operation left a dangling op. That crashed leg IS this restart
@@ -334,15 +351,6 @@ class RestartMixin:
         # op's workflow id) does not read a stale earlier restart, and instead
         # falls back to the ``ext.restart`` handle the recreate writes.
         if stage_enum == PublishStage.ONLINE:
-            decision = self._decide_online_deploy(publish_record, bot)
-            if decision not in (
-                OnlineDeployDecision.UPGRADE,
-                OnlineDeployDecision.RETIRE_THEN_FIRST_RELEASE,
-                OnlineDeployDecision.FIRST_RELEASE,
-            ):
-                raise PublishFlowServiceError(
-                    f"Unhandled online deploy decision: {decision}"
-                )
             if decision != OnlineDeployDecision.UPGRADE:
                 # Release the record's now-stale online binding before recreating
                 # (the recreate below mints a fresh one and rewrites

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/tasks.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/tasks.py
@@ -36,7 +36,9 @@ publish record) returns ``Fail`` so the task row lands terminally FAILED with th
 error in ``last_error`` — mirroring the domain failure the phase already recorded
 on the publish record — instead of a semantically dishonest SUCCEEDED. Domain
 retry stays user-driven (``retry()`` enqueues a fresh task); the worker never
-re-runs a failed stage on its own.
+re-runs a failed stage on its own. A deferred online-deploy preflight is different:
+no mutation was submitted and the domain state remains valid, so online-release
+and restart return ``Reschedule`` and recheck it at the BaaS polling cadence.
 """
 from __future__ import annotations
 
@@ -50,6 +52,7 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     DraftRestoreRetryableError,
+    OnlineDeployDeferredError,
 )
 from agentclaw.community.core.task_queue.types import (
     Complete,
@@ -81,8 +84,10 @@ DESTROY_TASK = "service_bot.publish.destroy"
 EVAL_TEARDOWN_TASK = "service_bot.publish.eval_teardown"
 APPROVAL_TRIGGER_TASK = "service_bot.publish.approval_trigger"
 
-# Give-up horizons (DB-enforced). Build+release can be slow; the poll waits on the
-# BaaS workflow, matching the devices poll deadline.
+# Give-up horizons (DB-enforced). Build+verify release can be slow but does not
+# poll before submission. Online release and restart can now defer their liveness
+# preflight, so their enqueue functions use the same 24h horizon as the workflow
+# polls instead of timing out in ONLINE_PUB / before restart submission at 1h.
 _STAGE_TASK_DEADLINE_SECONDS = 3600
 _POLL_TASK_DEADLINE_SECONDS = 86400
 _POLL_DELAY_SECONDS = 8.0
@@ -149,7 +154,7 @@ def enqueue_online_release(
     task_queue_service.enqueue(
         ONLINE_RELEASE_TASK,
         build_stage_payload(publish_id=publish_id, operator=operator),
-        deadline_seconds=_STAGE_TASK_DEADLINE_SECONDS,
+        deadline_seconds=_POLL_TASK_DEADLINE_SECONDS,
     )
 
 
@@ -201,7 +206,7 @@ def enqueue_restart(
     task_queue_service.enqueue(
         RESTART_TASK,
         build_restart_payload(publish_id=publish_id, stage=stage, operator=operator),
-        deadline_seconds=_STAGE_TASK_DEADLINE_SECONDS,
+        deadline_seconds=_RESTART_POLL_TASK_DEADLINE_SECONDS,
     )
 
 
@@ -356,7 +361,15 @@ class PublishOnlineReleaseHandler(_PublishTaskBase):
         if status == PublishStatus.ONLINE_PUB and not self._flow.is_current_online_deployment(
             publish_id
         ):
-            release_result = await self._flow.execute_release_phase(record, operator)
+            try:
+                release_result = await self._flow.execute_release_phase(record, operator)
+            except OnlineDeployDeferredError as exc:
+                logger.info(
+                    "[PublishOnlineReleaseHandler] deferring publish_id=%s: %s",
+                    publish_id,
+                    exc,
+                )
+                return Reschedule(_POLL_DELAY_SECONDS)
             if release_result.status != PublishStatus.ONLINE_PUB:
                 return Fail(
                     f"online release failed: publish_id={publish_id}, {release_result.message}"
@@ -401,9 +414,18 @@ class PublishRestartHandler(_PublishTaskBase):
             enqueue_restart_poll(self._task_queue_service, publish_id=publish_id)
             return Complete()
 
-        result = await self._flow.execute_restart(
-            publish_id=publish_id, stage=stage, operator=operator
-        )
+        try:
+            result = await self._flow.execute_restart(
+                publish_id=publish_id, stage=stage, operator=operator
+            )
+        except OnlineDeployDeferredError as exc:
+            logger.info(
+                "[PublishRestartHandler] deferring publish_id=%s stage=%s: %s",
+                publish_id,
+                stage,
+                exc,
+            )
+            return Reschedule(_POLL_DELAY_SECONDS)
         if not result or not result.get("success"):
             message = (result or {}).get("message", "unknown error")
             # Deliberately does NOT touch ext.restart.restarting. Every

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
@@ -21,8 +21,11 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     RUNTIME_KIND_TECLAW,
 )
+from agentclaw.community.core.service_bot.services.baas_service import (
+    BaasServiceError,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
-    PublishFlowServiceError,
+    OnlineDeployDeferredError,
 )
 from agentclaw.community.core.service_bot.types import (
     OnlineDeployDecision,
@@ -179,9 +182,9 @@ class UpgradeResolutionMixin:
         - no candidate / ``RELEASED`` / ``DESTROYING`` → ``FIRST_RELEASE``
           (nothing live to reuse or orphan).
         - ``ACTIVE`` → ``UPGRADE`` (re-deliver in place; works for both providers).
-        - ``STOPPING`` → raise (wait): a STOP publish is still in flight, and BaaS
+        - ``STOPPING`` → defer: a STOP publish is still in flight, and BaaS
           rejects any new publish of a different type while it runs, so neither an
-          UPGRADE nor a retire could land — the durable task retries until it
+          UPGRADE nor a retire could land — the durable task reschedules until it
           settles to ``STOPPED``.
         - ``FAILED`` / ``STOPPED`` → ``UPGRADE`` for ``baas``/ARCA (the UPDATE
           destroys+recreates the device in place and recovers it), but
@@ -191,9 +194,9 @@ class UpgradeResolutionMixin:
           atom / progress poll settles a still-provisioning bot).
 
         ``get_bot`` already normalizes a genuine 404 to ``{"status":"RELEASED"}``,
-        so a raised error here means a transient/non-404 BaaS failure — NOT that
-        the candidate is gone. We let it propagate so the durable task retries the
-        status read rather than creating a replacement for a possibly-live bot.
+        so a BaaS error here means a transient/non-404 failure — NOT that the
+        candidate is gone. We classify it as deferred so the durable task
+        reschedules the status read rather than replacing a possibly-live bot.
         An empty/absent status on a *successful* envelope is likewise ambiguous
         (``get_bot`` returns the response ``data`` which defaults to ``{}``), so
         we refuse to treat it as gone and raise so the task retries — only an
@@ -203,17 +206,23 @@ class UpgradeResolutionMixin:
         if not bot_uuid:
             return OnlineDeployDecision.FIRST_RELEASE
 
-        # No try/except: a raised error is a transient/non-404 failure (a real 404
-        # is already normalized to RELEASED); propagate so the deploy retries.
-        baas_bot = self._baas_service.get_bot(bot_uuid=bot_uuid)
+        try:
+            baas_bot = self._baas_service.get_bot(bot_uuid=bot_uuid)
+        except BaasServiceError as exc:
+            # A real 404 is normalized to RELEASED by BaasService. Other BaaS
+            # read failures leave the candidate's liveness unknown, so defer
+            # instead of either replacing it or failing the publish record.
+            raise OnlineDeployDeferredError(
+                f"BaaS get_bot failed for candidate bot_uuid={bot_uuid}: {exc}"
+            ) from exc
         status = (baas_bot or {}).get("status")
 
         if not status:
             # A genuine 404 is already normalized to RELEASED; an empty/absent
             # status from a 200 envelope is ambiguous — NOT proof the candidate is
-            # gone. Refuse to recreate on it; raise so the durable task retries the
-            # status read rather than replacing a possibly-live bot.
-            raise PublishFlowServiceError(
+            # gone. Refuse to recreate on it; defer so the durable task reschedules
+            # the status read rather than replacing a possibly-live bot.
+            raise OnlineDeployDeferredError(
                 f"BaaS get_bot returned no status for candidate "
                 f"bot_uuid={bot_uuid}; refusing to treat as gone"
             )
@@ -225,8 +234,8 @@ class UpgradeResolutionMixin:
             # A STOP publish is still in flight; BaaS create_publish rejects any
             # new publish of a different type (UPGRADE's UPDATE or a retire's
             # DESTROY) while it runs. Wait for it to settle to STOPPED — raise so
-            # the durable task retries rather than issuing a doomed publish.
-            raise PublishFlowServiceError(
+            # the durable task reschedules rather than issuing a doomed publish.
+            raise OnlineDeployDeferredError(
                 f"candidate bot_uuid={bot_uuid} is STOPPING (teardown publish in "
                 f"flight); retry once it settles"
             )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -38,6 +38,7 @@ from agentclaw.community.core.service_bot.types import (
 )
 from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
+    OnlineDeployDeferredError,
     PublishFlowServiceError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.ext_state import (
@@ -765,6 +766,11 @@ class PublishFlowService(
                 f"Unhandled online deploy decision: {decision}"
             )
 
+        except OnlineDeployDeferredError:
+            # A live reuse candidate is temporarily unavailable for another
+            # deploy. Keep ONLINE_PUB intact so the durable task can reschedule
+            # this same release instead of turning a healthy wait into FAILED.
+            raise
         except Exception as e:
             logger.error(f"[PublishFlowService] Release failed: {e}")
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -765,11 +765,7 @@ class PublishFlowService(
             raise PublishFlowServiceError(
                 f"Unhandled online deploy decision: {decision}"
             )
-
         except OnlineDeployDeferredError:
-            # A live reuse candidate is temporarily unavailable for another
-            # deploy. Keep ONLINE_PUB intact so the durable task can reschedule
-            # this same release instead of turning a healthy wait into FAILED.
             raise
         except Exception as e:
             logger.error(f"[PublishFlowService] Release failed: {e}")

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService, BotBuildServiceError
+from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePolicyState,
     ServiceBotImagePin,
@@ -32,6 +33,7 @@ from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     DraftRestoreRetryableError,
+    OnlineDeployDeferredError,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.operation_runner import (
     operation_request_id,
@@ -449,9 +451,9 @@ def test_decide_online_deploy_no_candidate_is_first_release():
     baas_service.get_bot.assert_not_called()
 
 
-def test_decide_online_deploy_get_bot_error_propagates():
+def test_decide_online_deploy_get_bot_error_defers():
     # get_bot normalizes a real 404 to RELEASED; a raised error is transient/
-    # non-404, so it must propagate (durable task retries the status read) rather
+    # non-404, so it must defer (durable task reschedules the status read) rather
     # than be treated as "gone" and create a replacement for a possibly-live bot.
     publish_service = Mock()
     build_service = Mock()
@@ -460,9 +462,23 @@ def test_decide_online_deploy_get_bot_error_propagates():
 
     publish_record = _make_publish_record(ext={'binding': {'online': 99}})
     publish_service.get_device_binding_by_id.return_value = Mock(device_id='BOT-cand')
-    baas_service.get_bot.side_effect = RuntimeError("baas unreachable")
+    baas_service.get_bot.side_effect = BaasServiceError("baas unreachable")
 
-    with pytest.raises(RuntimeError, match="baas unreachable"):
+    with pytest.raises(OnlineDeployDeferredError, match="baas unreachable"):
+        svc._decide_online_deploy(publish_record, {'bot_id': 'b'})
+
+
+def test_decide_online_deploy_unexpected_get_bot_error_propagates():
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    publish_record = _make_publish_record(ext={'binding': {'online': 99}})
+    publish_service.get_device_binding_by_id.return_value = Mock(device_id='BOT-cand')
+    baas_service.get_bot.side_effect = RuntimeError("programming error")
+
+    with pytest.raises(RuntimeError, match="programming error"):
         svc._decide_online_deploy(publish_record, {'bot_id': 'b'})
 
 
@@ -470,7 +486,7 @@ def test_decide_online_deploy_get_bot_error_propagates():
 def test_decide_online_deploy_stopping_waits(provider):
     # STOPPING has an active STOP publish in flight; BaaS create_publish rejects
     # any new publish of a different type (UPGRADE's UPDATE or a retire's DESTROY)
-    # while it runs. The decision must WAIT (raise so the durable task retries)
+    # while it runs. The decision must WAIT (defer so the task reschedules)
     # rather than issue a doomed publish — for BOTH providers, no retire.
     publish_service = Mock()
     build_service = Mock()
@@ -482,15 +498,15 @@ def test_decide_online_deploy_stopping_waits(provider):
     baas_service.get_bot.return_value = {'status': 'STOPPING'}
     baas_service.resolve_container_provider.return_value = provider
 
-    with pytest.raises(PublishFlowServiceError, match="STOPPING"):
+    with pytest.raises(OnlineDeployDeferredError, match="STOPPING"):
         svc._decide_online_deploy(publish_record, {'bot_id': 'b'})
     build_service.retire_superseded_bot.assert_not_called()
 
 
-def test_decide_online_deploy_missing_status_propagates():
+def test_decide_online_deploy_missing_status_defers():
     # A *successful* envelope with no status (get_bot returns `data`, which
     # defaults to {}) is ambiguous — NOT proof the candidate is gone. It must
-    # raise (durable task retries) rather than map to FIRST_RELEASE and create a
+    # defer (durable task reschedules) rather than map to FIRST_RELEASE and create a
     # replacement for a possibly-live bot. Only a real 404 (already normalized to
     # RELEASED) or an explicit terminal status recreates.
     publish_service = Mock()
@@ -502,13 +518,84 @@ def test_decide_online_deploy_missing_status_propagates():
     publish_service.get_device_binding_by_id.return_value = Mock(device_id='BOT-cand')
     baas_service.get_bot.return_value = {}  # 200 envelope, empty data → no status
 
-    with pytest.raises(PublishFlowServiceError, match="no status"):
+    with pytest.raises(OnlineDeployDeferredError, match="no status"):
         svc._decide_online_deploy(publish_record, {'bot_id': 'b'})
     build_service.retire_superseded_bot.assert_not_called()
 
 
 # (#197 all-auto) approve_baas_publish was removed — every BaaS mutation is
 # auto-approved server-side, so there is no client approve method to test.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("baas_bot", "error_pattern"),
+    [({"status": "STOPPING"}, "STOPPING"), ({}, "no status")],
+)
+async def test_execute_release_phase_wait_state_preserves_online_pub_for_reschedule(
+    baas_bot, error_pattern
+):
+    """Ambiguous candidate liveness is a wait state, not a failed release.
+
+    The durable handler must get a retryable signal while the publish record
+    remains in ONLINE_PUB; otherwise the task cannot safely resume after the
+    candidate bot finishes stopping.
+    """
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    publish_record = _make_publish_record(
+        status=PublishStatus.ONLINE_PUB.value,
+        source_bot_id="bot-source",
+        ext={"migration_path": "/m", "binding": {"online": 99}},
+    )
+    publish_service.get_device_binding_by_id.return_value = Mock(
+        device_id="BOT-stopping"
+    )
+    baas_service.get_bot.return_value = baas_bot
+    bot_service = Mock()
+    bot_service.get_bot.return_value = {"bot_id": "bot-source"}
+    svc._bot_service = bot_service
+    svc._get_latest_ext = Mock(return_value=copy.deepcopy(publish_record.ext))
+    svc._update_publish_status = Mock()
+
+    with pytest.raises(OnlineDeployDeferredError, match=error_pattern):
+        await svc.execute_release_phase(publish_record, operator="op")
+
+    assert publish_record.status == PublishStatus.ONLINE_PUB.value
+    svc._update_publish_status.assert_not_called()
+    build_service.retire_superseded_bot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_release_phase_get_bot_failure_preserves_online_pub_for_reschedule():
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    svc = _pf(publish_service, build_service, baas_service, Mock(), _arca_router(build_service))
+
+    publish_record = _make_publish_record(
+        status=PublishStatus.ONLINE_PUB.value,
+        source_bot_id="bot-source",
+        ext={"migration_path": "/m", "binding": {"online": 99}},
+    )
+    publish_service.get_device_binding_by_id.return_value = Mock(
+        device_id="BOT-unreachable"
+    )
+    baas_service.get_bot.side_effect = BaasServiceError("baas unreachable")
+    bot_service = Mock()
+    bot_service.get_bot.return_value = {"bot_id": "bot-source"}
+    svc._bot_service = bot_service
+    svc._get_latest_ext = Mock(return_value=copy.deepcopy(publish_record.ext))
+    svc._update_publish_status = Mock()
+
+    with pytest.raises(OnlineDeployDeferredError, match="baas unreachable"):
+        await svc.execute_release_phase(publish_record, operator="op")
+
+    assert publish_record.status == PublishStatus.ONLINE_PUB.value
+    svc._update_publish_status.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -673,6 +760,8 @@ async def test_execute_release_phase_unhandled_decision_fails_loudly():
 
     assert result.status == PublishStatus.FAILED
     assert "Unhandled online deploy decision" in result.message
+    assert svc._update_publish_status.call_args.kwargs["target_status"] == PublishStatus.FAILED
+    assert svc._update_publish_status.call_args.kwargs["source_status"] == PublishStatus.ONLINE_PUB
     svc._execute_first_release.assert_not_awaited()
     svc._execute_upgrade_release.assert_not_awaited()
 
@@ -1130,6 +1219,41 @@ async def test_restart_sets_restarting_flag_in_ext():
     assert len(mutate_calls) >= 1
     first_ext = mutate_calls[0]
     assert first_ext.get("restart", {}).get("restarting") is True
+
+
+@pytest.mark.asyncio
+async def test_restart_stopping_defers_before_setting_restarting_flag():
+    """A deferred preflight must not masquerade as a submitted restart.
+
+    In particular, a stale ``ext.restart.online`` from an older restart must not
+    combine with a newly-set ``restarting`` flag and trip the task redelivery
+    guard, which would skip the new restart entirely.
+    """
+    publish_service = Mock()
+    build_service = Mock()
+    baas_service = Mock()
+    baas_service.get_bot.return_value = {"status": "STOPPING"}
+    svc = _pf(
+        publish_service, build_service, baas_service, Mock(), _arca_router(build_service)
+    )
+    record = _make_publish_record(
+        status=PublishStatus.SUCCESS.value,
+        ext={
+            "binding": {"online": 1},
+            "migration_path": "/path/to/artifact",
+            "restart": {"online": 123},
+        },
+    )
+    _setup_restart(svc, record, bot_uuid="BOT-stopping")
+
+    with pytest.raises(OnlineDeployDeferredError, match="STOPPING"):
+        await svc.execute_restart(publish_id=1, stage="online", operator="op")
+
+    assert record.status == PublishStatus.SUCCESS.value
+    svc._mutate_and_update_ext.assert_not_called()
+    build_service.upgrade_async.assert_not_called()
+    build_service.release_async.assert_not_called()
+    build_service.retire_superseded_bot.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/service_bot/services/test_publish_tasks.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_tasks.py
@@ -6,6 +6,9 @@ import pytest
 
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.task_queue.types import Complete, Fail, Reschedule
+from agentclaw.community.core.service_bot.services.publish_flow.errors import (
+    OnlineDeployDeferredError,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
     PROGRESS_POLL_TASK,
     RESTART_POLL_TASK,
@@ -14,6 +17,10 @@ from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
     PublishRestartHandler,
     PublishRestartPollHandler,
     PublishVerifyFlowHandler,
+    _POLL_TASK_DEADLINE_SECONDS,
+    _RESTART_POLL_TASK_DEADLINE_SECONDS,
+    enqueue_online_release,
+    enqueue_restart,
 )
 
 
@@ -29,6 +36,7 @@ class _FakeFlow:
         build_fails=False,
         verify_release_fails=False,
         online_release_fails=False,
+        online_defer_attempts=0,
         sync_to=None,
         online_recorded=False,
     ):
@@ -38,6 +46,7 @@ class _FakeFlow:
         self._build_fails = build_fails
         self._verify_release_fails = verify_release_fails
         self._online_release_fails = online_release_fails
+        self._online_defer_attempts = online_defer_attempts
         self._sync_to = sync_to  # status to move to when advance_publish_progress runs
         # Whether ext.publish.online is already recorded (the online-release
         # idempotency marker the online_release task guards on).
@@ -72,6 +81,9 @@ class _FakeFlow:
 
     async def execute_release_phase(self, record, operator):
         self.calls.append("online_release")
+        if self._online_defer_attempts:
+            self._online_defer_attempts -= 1
+            raise OnlineDeployDeferredError("candidate is STOPPING")
         if self._online_release_fails:
             self.status = PublishStatus.FAILED.value
             return SimpleNamespace(status=PublishStatus.FAILED, message="online boom")
@@ -93,6 +105,20 @@ def _handlers(flow):
         PublishOnlineReleaseHandler(flow=flow, task_queue_service=tq),
         PublishProgressPollHandler(flow=flow, task_queue_service=tq, poll_delay_seconds=1.0),
         tq,
+    )
+
+
+def test_deferred_deploy_tasks_use_poll_horizon_deadlines():
+    tq = Mock()
+
+    enqueue_online_release(tq, publish_id=1, operator="op")
+    assert tq.enqueue.call_args.kwargs["deadline_seconds"] == _POLL_TASK_DEADLINE_SECONDS
+
+    tq.reset_mock()
+    enqueue_restart(tq, publish_id=1, stage="online", operator="op")
+    assert (
+        tq.enqueue.call_args.kwargs["deadline_seconds"]
+        == _RESTART_POLL_TASK_DEADLINE_SECONDS
     )
 
 
@@ -231,6 +257,27 @@ def test_online_release_failure_fails_task_without_poll():
     tq.enqueue.assert_not_called()
 
 
+def test_online_release_reschedules_without_state_change_then_completes():
+    flow = _FakeFlow(PublishStatus.ONLINE_PUB, online_defer_attempts=1)
+    _verify, online, _poll, tq = _handlers(flow)
+
+    waiting = online.handle({"publish_id": 1, "operator": "op"})
+
+    assert isinstance(waiting, Reschedule)
+    assert flow.status == PublishStatus.ONLINE_PUB.value
+    assert flow._online_recorded is False
+    tq.enqueue.assert_not_called()
+
+    completed = online.handle({"publish_id": 1, "operator": "op"})
+
+    assert isinstance(completed, Complete)
+    assert flow.status == PublishStatus.ONLINE_PUB.value
+    assert flow._online_recorded is True
+    assert flow.calls == ["online_release", "online_release"]
+    tq.enqueue.assert_called_once()
+    assert tq.enqueue.call_args.args[0] == PROGRESS_POLL_TASK
+
+
 def test_online_release_missing_record_fails_task():
     flow = _FakeFlow(PublishStatus.ONLINE_PUB, missing=True)
     _verify, online, _poll, tq = _handlers(flow)
@@ -310,6 +357,7 @@ class _FakeRestartFlow:
         sync_statuses=None,
         missing=False,
         unreconciled=False,
+        restart_defer_attempts=0,
     ):
         self.calls: list[str] = []
         self.restarting = restarting
@@ -318,6 +366,8 @@ class _FakeRestartFlow:
         # Whether the record already carries a submitted-but-unreconciled
         # restart for the stage — the redelivery guard's signal.
         self._unreconciled = unreconciled
+        self._restart_defer_attempts = restart_defer_attempts
+        self.status = PublishStatus.SUCCESS.value
         # Successive BaaS statuses returned by sync_restart_progress; the last one
         # repeats. ``None`` models the no-data early returns (unresolved workflow
         # id / progress-fetch error).
@@ -326,13 +376,16 @@ class _FakeRestartFlow:
     def get_publish_record(self, publish_id):
         if self._missing:
             return None
-        return SimpleNamespace(id=publish_id, status=PublishStatus.SUCCESS.value)
+        return SimpleNamespace(id=publish_id, status=self.status)
 
     def has_unreconciled_restart(self, publish_id, stage):
         return self._unreconciled
 
     async def execute_restart(self, *, publish_id, stage, operator):
         self.calls.append("execute_restart")
+        if self._restart_defer_attempts:
+            self._restart_defer_attempts -= 1
+            raise OnlineDeployDeferredError("candidate is STOPPING")
         if not self._restart_succeeds:
             return {"success": False, "message": "restart boom"}
         return {"success": True, "message": "Restart submitted", "stage": stage}
@@ -370,6 +423,29 @@ def test_restart_success_enqueues_restart_poll():
     tq.enqueue.assert_called_once()
     assert tq.enqueue.call_args.args[0] == RESTART_POLL_TASK
     assert tq.enqueue.call_args.args[1] == {"publish_id": 1}
+
+
+def test_restart_reschedules_without_publish_state_change_then_completes():
+    flow = _FakeRestartFlow(restart_defer_attempts=1)
+    restart, _poll, tq = _restart_handlers(flow)
+
+    waiting = restart.handle(
+        {"publish_id": 1, "stage": "online", "operator": "op"}
+    )
+
+    assert isinstance(waiting, Reschedule)
+    assert flow.status == PublishStatus.SUCCESS.value
+    tq.enqueue.assert_not_called()
+
+    completed = restart.handle(
+        {"publish_id": 1, "stage": "online", "operator": "op"}
+    )
+
+    assert isinstance(completed, Complete)
+    assert flow.status == PublishStatus.SUCCESS.value
+    assert flow.calls == ["execute_restart", "execute_restart"]
+    tq.enqueue.assert_called_once()
+    assert tq.enqueue.call_args.args[0] == RESTART_POLL_TASK
 
 
 def test_restart_poll_enqueue_failure_propagates():


### PR DESCRIPTION
## Problem

This happens when an online publish or online restart has an existing reuse candidate resolved from `ext.binding.online` (on the current publish record or the previous publish record), but that candidate cannot be classified safely yet.

The concrete trigger window is:

1. an earlier online Bot is being stopped, and a new online publish or restart starts before the STOP workflow settles;
2. `BaasService.get_bot()` therefore returns `STOPPING`; or
3. the same liveness read returns a successful envelope without `status`, or fails with a non-404 `BaasServiceError`.

A genuine 404 is already normalized by `BaasService` to `RELEASED`, so these cases do **not** prove that the candidate is gone. They also cannot safely submit another mutation: while `STOPPING`, BaaS rejects a publish of a different type, so neither UPDATE nor retire-and-recreate can proceed.

### Existing behavior

For online release, `_decide_online_deploy()` raised to wait, but `execute_release_phase()` caught that signal in its generic failure handler:

```text
ONLINE_PUB
  -> candidate is STOPPING / status is ambiguous
  -> generic release exception handler
  -> publish record is persisted as FAILED
  -> online-release task returns Fail
```

No deploy mutation was submitted, but the publish was reported as failed and required a user-driven retry after the candidate settled.

The restart path had a second state hazard. It wrote `ext.restart.restarting = true` before the same online liveness decision. If the decision deferred and `ext.restart.online` still contained an older workflow handle, a redelivery could combine the new marker with the stale handle, classify the restart as already submitted, and skip the actual restart.

## Root cause

The publish flow had no dedicated control signal for “preflight is healthy but temporarily undecidable.” A deferred liveness read therefore shared the same exception path as a real release failure, and restart state was marked before preflight had established that a workflow could be submitted.

## Solution

- Add the internal `OnlineDeployDeferredError` control signal.
- Classify only these known liveness cases as deferred:
  - candidate status is `STOPPING`;
  - the BaaS response has no status;
  - `get_bot` raises `BaasServiceError`.
- Let the deferred signal bypass `execute_release_phase()`'s `FAILED` persistence.
- Translate it to `Reschedule` in both online-release and restart task handlers.
- Move `ext.restart.restarting = true` after online liveness and local delivery preflight pass, immediately before crash-recovery/external-mutation work.
- Give online-release and restart tasks the existing 24-hour poll horizon, because `Reschedule` does not extend the original task deadline.
- Keep unexpected exceptions and actual release failures on the existing failure path.

## State transition audit

| Path | Before | After |
| --- | --- | --- |
| Online release, deferred liveness | `ONLINE_PUB -> FAILED`, task `Fail` | publish remains `ONLINE_PUB`, task `Reschedule` |
| Online release after candidate settles | manual retry required | task re-runs, submits the release, then the existing progress poll drives `ONLINE_PUB -> SUCCESS` |
| Restart, deferred liveness | publish status unchanged, but `restarting=true` could be written without a submitted workflow | publish status and restart marker both remain unchanged; task `Reschedule` |
| Actual release failure / unknown decision | `ONLINE_PUB -> FAILED` | unchanged |

This PR does not add or change any Bot status, publish-status enum, database schema, API contract, configuration, or migration. `OnlineDeployDeferredError` is an internal Python control signal only.

## Validation

- `pytest tests/community/core/service_bot/services tests/community/core/task_queue -q`: **851 passed**
- Focused state-machine tests cover:
  - `STOPPING`, missing status, and transient BaaS reads preserving `ONLINE_PUB`;
  - deferred online release rescheduling and completing after the next attempt;
  - deferred restart preserving `PublishStatus` and not setting `restarting`;
  - permanent/unexpected failures remaining failures;
  - online-release/restart using the 24-hour poll deadline.
- `ruff check` on all changed Python files: passed.
- `git diff --check`: passed.
- Repository pre-push Python SAST gate: passed.
- Independent code review: approved after the task-deadline regression was added.

Addresses item 3 of #523.