### PR TITLE
fix(bcs): restore Bot-owner invitation authorization

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
@@ -39,7 +39,7 @@ use bcs_service_api::application::v1::{
     RejectFriendRequest, require_authenticated_user, require_human,
 };
 use bcs_service_api::{
-    BotRegistryCoreService, FriendCoreService, FriendRequestCoreService,
+    ActorKind, BotRegistryCoreService, FriendCoreService, FriendRequestCoreService,
     FriendRequest as DomainFriendRequest, FriendRequestDirection as DomainFriendRequestDirection,
     Friendship as DomainFriendship, Group as DomainGroup, GroupCoreService, GroupKind,
     GroupStatus, GroupStrategy, InviteService, InviteUseCaseError, JoinByInviteCommand,
@@ -129,15 +129,35 @@ impl InvitationFriendshipServiceImpl {
     }
 
     /// Manager of a group: driver, originator, or ManagerWorker manager.
-    /// Mirrors `bcs-app-group::can_manage_group`.
-    fn can_manage_group(principal: &Principal, group: &DomainGroup) -> bool {
+    /// A Human may also act for an owned driver/originator Bot, preserving the
+    /// legacy invitation authorization contract.
+    async fn can_manage_group(
+        &self,
+        principal: &Principal,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
         let actor_id = principal.actor_id();
-        actor_id == group.driver_bot
+        if actor_id == group.driver_bot
             || actor_id == group.originator()
             || (group.group_strategy == GroupStrategy::ManagerWorker
                 && group.participants.iter().any(|p| {
                     p.bot_uuid == actor_id && p.role == ParticipantRole::Manager
                 }))
+        {
+            return Ok(true);
+        }
+        let Principal::Human(human) = principal else {
+            return Ok(false);
+        };
+        let owned_bots = self
+            .registry
+            .try_list_bots_by_creator(&human.subject.id)
+            .await
+            .map_err(map_service_error)?;
+        Ok(owned_bots.iter().any(|bot| {
+            bot.actor_kind == ActorKind::Bot
+                && (bot.bot_uuid == group.driver_bot || bot.bot_uuid == group.originator())
+        }))
     }
 
     async fn load_manageable_group(
@@ -156,7 +176,7 @@ impl InvitationFriendshipServiceImpl {
                     format!("Group '{group_id}' was not found"),
                 )
             })?;
-        if !Self::can_manage_group(principal, &group) {
+        if !self.can_manage_group(principal, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator, driver, or manager may manage this Group",
             ));
@@ -265,7 +285,7 @@ impl InvitationService for InvitationFriendshipServiceImpl {
                     format!("Group '{}' was not found", session.group_id),
                 )
             })?;
-        if !Self::can_manage_group(&principal, &group) {
+        if !self.can_manage_group(&principal, &group).await? {
             return Err(ApplicationError::forbidden(
                 "Only the Group originator, driver, or manager may manage Sessions",
             ));

--- a/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
@@ -175,6 +175,23 @@ impl Fixture {
         self.groups.upsert(group).await.expect("store group");
     }
 
+    async fn store_legacy_group(
+        &self,
+        group_id: &str,
+        driver_bot: &str,
+        originator_actor: &str,
+    ) {
+        let mut group = Group::new(
+            group_id,
+            driver_bot,
+            vec![Participant::bot(driver_bot, ParticipantRole::Driver)],
+        );
+        group.originator = Some(originator_actor.to_string());
+        group.label = Some(group_id.to_string());
+        group.group_strategy = GroupStrategy::Chat;
+        self.groups.upsert(group).await.expect("store legacy group");
+    }
+
     /// Helper for Vcj6P: store a group whose `status` is set to a non-active
     /// value so the V1 mint paths reject with `conflict`.
     async fn store_group_with_status(
@@ -407,6 +424,28 @@ async fn create_group_invitation_manager_ok() {
 }
 
 #[tokio::test]
+async fn human_owner_of_legacy_group_originator_bot_can_create_group_invitation() {
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+    fx.add_bot("bot-b").await;
+    fx.store_legacy_group("grp-1", "bot-b", "bot-a")
+        .await;
+
+    let invitation = fx
+        .service
+        .create_group_invitation(CreateGroupInvitation {
+            caller: Fixture::human_principal("staff-1"),
+            group_id: "grp-1".to_string(),
+            expires_in_seconds: None,
+        })
+        .await
+        .expect("Human owner may act for the group originator Bot");
+
+    assert_eq!(invitation.target_type, InvitationTargetType::Group);
+    assert_eq!(invitation.target_id, "grp-1");
+}
+
+#[tokio::test]
 async fn create_group_invitation_non_manager_forbidden() {
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
@@ -492,6 +531,28 @@ async fn create_session_invitation_manager_ok() {
         .expect("token decodes");
     assert_eq!(payload.id, session_id);
     assert_eq!(payload.target_type, Some(InviteTargetType::Session));
+}
+
+#[tokio::test]
+async fn human_owner_of_legacy_group_driver_bot_can_create_session_invitation() {
+    let fx = Fixture::new().await;
+    fx.add_bot("bot-a").await;
+    fx.store_legacy_group("grp-1", "bot-a", "human_other")
+        .await;
+    let session_id = fx.create_session("grp-1", "bot-a").await;
+
+    let invitation = fx
+        .service
+        .create_session_invitation(CreateSessionInvitation {
+            caller: Fixture::human_principal("staff-1"),
+            session_id: session_id.clone(),
+            expires_in_seconds: None,
+        })
+        .await
+        .expect("Human owner may act for the session's group driver Bot");
+
+    assert_eq!(invitation.target_type, InvitationTargetType::Session);
+    assert_eq!(invitation.target_id, session_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Legacy BCS invitation authorization lets an authenticated Human create Group and Session invitations when the Human owns the Group driver or originator Bot. The V1 invitation facade only compared the Human Actor ID directly with the Group management Actor IDs. For legacy-shaped Groups whose driver or originator is a Bot, the V1 API therefore returned `403 Forbidden` to the Bot owner.

## Solution

- Extend the V1 invitation management check to resolve Bots owned by the authenticated Human through the registry.
- Authorize the Human when an owned Bot matches the Group driver or originator.
- Preserve the existing direct driver, originator, and ManagerWorker manager paths.
- Add regression coverage for Group invitations through an owned originator Bot and Session invitations through an owned driver Bot.

The change intentionally does not admit Bot-only callers or unrelated Humans, and it does not change invitation token, DM Group, or inactive Group behavior.

## Validation

Before publication, the following focused checks passed:

- `cargo test -p bcs-app-invitation` — 35 tests passed.
- `cargo test -p bcs-api-http --test invitation_routes` — 10 tests passed.
- `git diff --check` — passed.

No additional verification was run during commit/push, per explicit request. The repository pre-push hook ran in lint-only mode and skipped BCS tests/coverage/E2E.

## Compatibility and risk

This restores compatibility with the legacy invitation authorization contract for Bot-managed Groups. The permission expansion is limited to exact `created_by` ownership of the Group driver or originator Bot. Registry lookup failures propagate as application errors rather than silently granting access.

Rollback is a single-commit revert.

## Related issues

Closes #1032.