### PR TITLE
fix: chown aicoding build rsync outputs

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -776,6 +776,9 @@ class BotBuildService:
             excludes = []
             for pattern in (build_plan.rsync_excludes if build_plan else []):
                 excludes.append(f"--exclude={pattern}")
+            chown_args = []
+            if build_plan and build_plan.rsync_chown:
+                chown_args.append(f"--chown={build_plan.rsync_chown}")
 
             # 构建 rsync 命令
             cmd = [
@@ -788,6 +791,7 @@ class BotBuildService:
                 # earlier partial artifact, otherwise Pool active roots can
                 # expose the full repository through a stale bridge.
                 "--delete-excluded",
+                *chown_args,
                 *excludes,
                 f"{source_dir}/",
                 f"{target_dir}/",
@@ -814,6 +818,7 @@ class BotBuildService:
                         "-av",
                         "--delete",
                         "--delete-excluded",
+                        *chown_args,
                         *excludes,
                         f"{extra_source}/",
                         f"{extra_target}/",

--- a/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
@@ -39,6 +39,9 @@ class EngineBuildPlan:
     # 两者同时为空时跳过额外同步。
     extra_sync_source_relpath: str = ""
     extra_sync_target_relpath: str = ""
+    # Optional rsync --chown value applied to both main and extra sync.
+    # Empty string preserves rsync archive-mode owner/group behavior.
+    rsync_chown: str = ""
 
 
 @runtime_checkable

--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -78,6 +78,7 @@ def _make_aicoding_build_plan(rsync_excludes: list[str]) -> EngineBuildPlan:
         extra_sync_source_relpath=".claude",
         extra_sync_target_relpath="claude",
         rsync_excludes=rsync_excludes,
+        rsync_chown="admin:admin",
     )
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_extra_sync.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_extra_sync.py
@@ -28,6 +28,7 @@ def _make_plan(
     extra_src: str = "",
     extra_tgt: str = "",
     excludes: list[str] | None = None,
+    rsync_chown: str = "",
 ) -> EngineBuildPlan:
     return EngineBuildPlan(
         engine_type="claude_code",
@@ -40,6 +41,7 @@ def _make_plan(
         rsync_excludes=excludes or ["projects", "sessions"],
         extra_sync_source_relpath=extra_src,
         extra_sync_target_relpath=extra_tgt,
+        rsync_chown=rsync_chown,
     )
 
 
@@ -154,6 +156,44 @@ class TestMigrateBotInstanceExtraSync:
         assert extra_cmd[-1] == expected_tgt
         # target 子目录应被自动创建
         assert (target_dir / "claude").is_dir()
+
+
+    def test_applies_plan_rsync_chown_to_main_and_extra_sync(self, tmp_path: Path):
+        service = _make_service()
+        service._run_local_command = MagicMock(return_value=None)
+
+        source_dir, target_dir = _seed_dirs(tmp_path, with_extra_source=True)
+        plan = _make_plan(
+            extra_src=".claude",
+            extra_tgt="claude",
+            excludes=["projects"],
+            rsync_chown="admin:admin",
+        )
+
+        ok = service._migrate_bot_instance(
+            device_id="dev1",
+            source_dir=source_dir,
+            target_dir=target_dir,
+            version_str="v1",
+            is_nas=True,
+            nas_storage_id=str(source_dir),
+            build_plan=plan,
+            provider=MagicMock(),
+        )
+
+        assert ok is True
+        main_cmd = next(
+            call.kwargs["cmd"]
+            for call in service._run_local_command.call_args_list
+            if call.kwargs.get("command_name") == "rsync"
+        )
+        extra_cmd = next(
+            call.kwargs["cmd"]
+            for call in service._run_local_command.call_args_list
+            if call.kwargs.get("command_name") == "rsync (extra)"
+        )
+        assert "--chown=admin:admin" in main_cmd
+        assert "--chown=admin:admin" in extra_cmd
 
     def test_skips_when_extra_source_missing(self, tmp_path: Path):
         # 配置了 extra sync 但源不存在 → 跳过该项，不影响主 rsync。

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -197,6 +197,16 @@ class TestAICodingProvider:
         assert plan.extra_sync_source_relpath == ".claude"
         assert plan.extra_sync_target_relpath == "claude"
 
+    def test_build_plan_sets_aicoding_rsync_chown(self):
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        plan = provider.get_build_plan()
+
+        assert plan.rsync_chown == "admin:admin"
+
+    def test_other_engine_build_plans_keep_default_rsync_owner(self):
+        assert OpenClawSandboxProvider(workspace=_workspace()).get_build_plan().rsync_chown == ""
+        assert ClaudeCodeSandboxProvider(workspace=_workspace()).get_build_plan().rsync_chown == ""
+
     def test_default_read_only_rules_include_workspace_files(self):
         provider = AICodingSandboxProvider(workspace=_workspace())
         rule_paths = {r.path for r in provider.get_default_read_only_rules()}


### PR DESCRIPTION
线上问题修复：aicoding 构建产物中部分配置文件因源端为 root:root，被 sudo rsync -av 原样保留 owner/group，导致发布产物权限不一致。\n\n修复内容：\n- 在 EngineBuildPlan 增加可选 rsync_chown 配置。\n- aicoding build plan 配置 rsync_chown=admin:admin。\n- BotBuildService 主 rsync 和 extra rsync 根据 build plan 自动追加 --chown。\n- openclaw / claude_code 默认 rsync_chown 为空，不改变原行为。\n\n验证：\n- PYTHONPATH=src:. uv run pytest tests/community/core/workspace/test_engine_sandbox_providers.py tests/community/core/service_bot/services/test_bot_build_service_extra_sync.py tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py -q\n- 74 passed