### PR TITLE
refactor(backend): make the openapi resources group files-only

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -152,7 +152,7 @@ _Ordered by priority tier._
 |---|---|---|---|---|---|
 | bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE — PR #494 merged 2026-07-29** (13/13 endpoints) | ~~Track A stage 1~~ ✅ |
 | mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ✅ **DONE — PR #610** (6/6 endpoints) | ~~Track A stage 5~~ ✅ (PR #564) |
-| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS (PARTIAL) — 9 handlers all wired but DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0); Track B all 9 endpoints wired stub→service; gated on auth workstream (gateway principal seam) + DDL deploy before public exposure |
+| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS (PARTIAL) — 7 handlers all wired but DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0); Track B all 7 endpoints wired stub→service, files-only and path-addressed; gated on auth workstream (gateway principal seam) + DDL deploy before public exposure |
 | routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` *(stub)* | ⬜ TODO | Track A routines (lucas-xzp) |
 | channels | — | ❌ **REMOVED (2026-08-03)** | *(deleted)* | Router, schemas and both published paths deleted — see the channels section below | n/a |
 | identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` *(stub)* | ⬜ TODO | bots isolation (Stage 1 ✅) |
@@ -697,13 +697,17 @@ scope by. They still require an authenticated caller — that is
 | `GET /openapi/v1/bots/mcp/servers/{server_code}` | Same |
 | `GET /openapi/v1/bots/mcp/tenants` | Same |
 
-Note what is *not* on that list: `list_resources`, `create_resource`,
-`get_resource` and `update_resource` also do not use the value, but they take it
-anyway. They are user-scoped in principle and merely fail to enforce it today —
-they scope on a caller-supplied `bot_id` without checking the caller owns that
-bot, the gap `specs/2026-08-02-public-api-user-only-principal/` records. Closing
-it later should be a change to those handlers, not a required parameter added to
-four public operations.
+Note what is *not* on that list: four resources handlers (`list_resources`,
+`create_resource`, `get_resource`, `update_resource`) used to take the value
+without using it — user-scoped in principle, scoping on a caller-supplied
+`bot_id` without checking the caller owns that bot, the gap
+`specs/2026-08-02-public-api-user-only-principal/` records. Three of them went
+with the link resources they served, and the surviving `list_resources` now
+consumes the value: every files-only handler resolves the workspace through
+`_file_coords(bot_id, owner_id, …)`, so the parameter reaches the seam rather
+than being accepted and dropped. The ownership gap itself is unchanged — the
+`bot_id` is still caller-supplied — and closing it remains a change to those
+handlers, not a new parameter.
 
 **Bot Logs is a different exclusion, and the sharpest thing to know here.**
 `GET /openapi/v1/bots/logs/traces` has taken a required `user_id` since #692 —
@@ -1076,23 +1080,38 @@ strict enums (`PROD`/`PRE`, `SSE`/`STREAMABLE_HTTP`). **Preserved fail-open:** a
 marketplace outage still reports the caller as permitted (advisory endpoint; the
 MCP server enforces) — pinned by a test so it reads as a decision, not a bug._
 
-### 🟩 lucas-xzp · P1 — resources (9 endpoints) · `openapi_v1/resources/router.py`
-Unified file/link/folder abstraction; storage location never exposed.
+### 🟩 lucas-xzp · P1 — resources (7 endpoints) · `openapi_v1/resources/router.py`
+The bot's workspace files and folders; storage location never exposed. Every
+operation is addressed by a workspace-relative `path` query parameter, and
+`bot_id` + `user_id` are required on all seven.
 | Method | Path | Purpose | Success |
 |---|---|---|---|
-| GET | `/openapi/v1/bots/resources` | List (`bot_id`, `type`, paged) | `Envelope[Page[Resource]]` |
-| GET | `/openapi/v1/bots/resources/check-name` | Name availability (`name`) | `Envelope[NameCheck]` |
-| POST | `/openapi/v1/bots/resources` | Create (file placeholder / link / folder) | `201 Envelope[Resource]` |
-| POST | `/openapi/v1/bots/resources/upload` | Upload raw bytes as a resource (`application/octet-stream`) | `201 Envelope[Resource]` |
-| GET | `/openapi/v1/bots/resources/{resource_id}` | Get | `Envelope[Resource]` |
-| PUT | `/openapi/v1/bots/resources/{resource_id}` | Update | `Envelope[Resource]` |
-| DELETE | `/openapi/v1/bots/resources/{resource_id}` | Delete | `Envelope[Deleted]` |
-| GET | `/openapi/v1/bots/resources/{resource_id}/download` | Download bytes (**raw, not enveloped**) | `application/octet-stream` |
-| GET | `/openapi/v1/bots/resources/{resource_id}/preview` | Preview | `Envelope[Preview]` |
+| GET | `/openapi/v1/bots/resources` | List a directory (`path`, `type`, paged) | `Envelope[Page[FileEntry]]` |
+| GET | `/openapi/v1/bots/resources/stat` | One entry's metadata (`path`) | `Envelope[FileEntry]` |
+| POST | `/openapi/v1/bots/resources/upload` | Upload raw bytes (`application/octet-stream`, `overwrite`) | `201 Envelope[FileEntry]` |
+| GET | `/openapi/v1/bots/resources/download` | Download bytes (**raw, not enveloped**) | `application/octet-stream` |
+| GET | `/openapi/v1/bots/resources/preview` | Preview as text (1 MB cap → 413) | `Envelope[Preview]` |
+| POST | `/openapi/v1/bots/resources/mkdir` | Create a directory | `201 Envelope[FileEntry]` |
+| DELETE | `/openapi/v1/bots/resources` | Delete a file or directory | `Envelope[Deleted]` |
 
 _Note: upload is finalized as a raw `application/octet-stream` body (not
 multipart). This diverges from PR #363's multipart summary — implementation
 follows the route; switching to multipart would be a contract change._
+
+_Note: the group carries **no record ids**. #1001 made the engine the source of
+truth for files, which left `resource_id` permanently empty on every file
+response and three id-addressed routes that only ever resolved link records.
+Links left this surface, so the id left the contract rather than being reported
+as `""` — an empty string standing in for "no id" is a sentinel a caller cannot
+tell from a real address until it fails. `GET /stat` replaces both the
+id-addressed single lookup and `check-name`: it answers existence against the
+workspace, the same authority the listing reads, so the two cannot disagree._
+
+_Note: `Page` here is applied by the backend over a whole directory listing —
+the engine's `ListDirRequest` carries no page, limit or cursor. `page_size`
+bounds the response, not the device round trip, and a later page costs what the
+first one costs. That is proportionate only because listing is non-recursive; a
+`recursive=true` option would have to revisit it._
 
 ### 🟪 totalfrank + lucas-xzp · P3 — skills, co-owned (six ratified operations) · `openapi_v1/skills/router.py`
 

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -130,7 +130,7 @@ _按优先级分层排序。_
 |---|---|---|---|---|---|
 | bots | totalfrank | P1 | `openapi_v1/bots/router.py` | ✅ **DONE —— PR #494 已于 2026-07-29 合并**（13/13 端点） | ~~Track A 阶段 1~~ ✅ |
 | mcp | totalfrank | P1 | `openapi_v1/mcp/router.py` | ✅ **DONE —— PR #610**（6/6 端点） | ~~Track A 阶段 5~~ ✅（PR #564） |
-| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS（PARTIAL）— 9 handler 全接通但 DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0)，Track B 全 9 端点接通 stub→service；待 auth workstream(gateway principal seam) 落地 + DDL 部署后才可对外 |
+| resources | lucas-xzp | P1 | `openapi_v1/resources/router.py` | 🔧 IN PROGRESS（PARTIAL）— 7 handler 全接通但 DEFINITION-ONLY / NOT PUBLIC-READY | Track A resources ✅(Phase 0)，Track B 全 7 端点接通 stub→service，仅文件、按路径寻址；待 auth workstream(gateway principal seam) 落地 + DDL 部署后才可对外 |
 | routines | lucas-xzp | P1 | `openapi_v1/routines/router.py` | 🔧 IN PROGRESS（PARTIAL）— 7 handler 全接通但 NOT PUBLIC-READY | Track A routines 无表靠 ac_bots 间接隔离；Track B 7 端点接通；待 gateway principal seam + tenant resolver 落地后才可对外 |
 | channels | —— | ❌ **已删除（2026-08-03）** | *(已删除)* | 路由、schema 与两条已发布路径均删除 —— 见下方 channels 小节 | 不适用 |
 | identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` | 🔧 IN PROGRESS（PARTIAL）— 3 handler 全接通但 NOT PUBLIC-READY | bots 隔离（Stage 1 ✅）；Track B 3 端点接通；待 gateway principal seam + tenant resolver 落地后才可对外 |
@@ -721,21 +721,31 @@ _已定案的决策（PR #610）：路径保持嵌套（`/openapi/v1/bots/mcp/..
 调用者"有权限"（该端点仅供参考，真正的强制点是 MCP 服务器本身）—— 已用测试钉住，使其读起来
 是一个决策而非 bug。_
 
-### 🟩 lucas-xzp · P1 —— resources（9 个端点）· `openapi_v1/resources/router.py`
-文件/链接/文件夹的统一抽象；存储位置从不暴露。
+### 🟩 lucas-xzp · P1 —— resources（7 个端点）· `openapi_v1/resources/router.py`
+Bot 工作区的文件与目录；存储位置从不暴露。所有操作都以工作区相对路径 `path`
+查询参数寻址，七个端点均要求 `bot_id` 与 `user_id`。
 | 方法 | 路径 | 用途 | 成功响应 |
 |---|---|---|---|
-| GET | `/openapi/v1/bots/resources` | 列表（`bot_id`、`type`、分页） | `Envelope[Page[Resource]]` |
-| GET | `/openapi/v1/bots/resources/check-name` | 重名检查（`name`） | `Envelope[NameCheck]` |
-| POST | `/openapi/v1/bots/resources` | 创建（文件占位 / 链接 / 文件夹） | `201 Envelope[Resource]` |
-| POST | `/openapi/v1/bots/resources/upload` | 上传原始字节为资源（`application/octet-stream`） | `201 Envelope[Resource]` |
-| GET | `/openapi/v1/bots/resources/{resource_id}` | 获取 | `Envelope[Resource]` |
-| PUT | `/openapi/v1/bots/resources/{resource_id}` | 更新 | `Envelope[Resource]` |
-| DELETE | `/openapi/v1/bots/resources/{resource_id}` | 删除 | `Envelope[Deleted]` |
-| GET | `/openapi/v1/bots/resources/{resource_id}/download` | 下载字节（**原始，不走信封**） | `application/octet-stream` |
-| GET | `/openapi/v1/bots/resources/{resource_id}/preview` | 预览 | `Envelope[Preview]` |
+| GET | `/openapi/v1/bots/resources` | 列目录（`path`、`type`、分页） | `Envelope[Page[FileEntry]]` |
+| GET | `/openapi/v1/bots/resources/stat` | 单个条目的元数据（`path`） | `Envelope[FileEntry]` |
+| POST | `/openapi/v1/bots/resources/upload` | 上传原始字节（`application/octet-stream`、`overwrite`） | `201 Envelope[FileEntry]` |
+| GET | `/openapi/v1/bots/resources/download` | 下载字节（**原始，不走信封**） | `application/octet-stream` |
+| GET | `/openapi/v1/bots/resources/preview` | 文本预览（1 MB 上限 → 413） | `Envelope[Preview]` |
+| POST | `/openapi/v1/bots/resources/mkdir` | 创建目录 | `201 Envelope[FileEntry]` |
+| DELETE | `/openapi/v1/bots/resources` | 删除文件或目录 | `Envelope[Deleted]` |
 
 _注：upload 已定稿为原始 `application/octet-stream` body（非 multipart）。与 PR #363 总览的 multipart 描述不一致——实现以路由为准，若后续需改 multipart 是契约 PR。_
+
+_注：本组**不再有记录 id**。#1001 让 engine 成为文件的唯一真源，于是 `resource_id`
+在每个文件响应里恒为空，而三个 id 寻址路由实际只解析 link 记录。link 已移出本面，
+因此 id 直接退出契约，而不是继续以 `""` 上报——用空串代表"没有 id"是一个哨兵值，
+调用方在失败之前无法把它与真实地址区分开。`GET /stat` 同时取代了 id 寻址的单条查询
+与 `check-name`：它向工作区回答存在性，与列表读取同一个真源，两者不可能互相矛盾。_
+
+_注：这里的 `Page` 是后端在整个目录列表上做的切片——engine 的 `ListDirRequest`
+没有 page/limit/cursor。`page_size` 约束的是响应体，而不是设备往返；翻到后面的页
+与第一页开销相同。这只有在列表非递归时才成比例；若将来加 `recursive=true`，必须
+一并重新审视分页。_
 
 ### 🟪 totalfrank + lucas-xzp · P3 —— skills，共担（六个已定案操作）· `openapi_v1/skills/router.py`
 

--- a/src/backend/specs/2026-08-12-openapi-resources-engine-backed/plan.md
+++ b/src/backend/specs/2026-08-12-openapi-resources-engine-backed/plan.md
@@ -2,6 +2,24 @@
 
 Spec: [`spec.md`](./spec.md) · Issue: [inclusionAI/Avernet#1000](https://github.com/inclusionAI/Avernet/issues/1000)
 
+> **⚠️ Partially superseded by
+> [#1043](https://github.com/inclusionAI/Avernet/pull/1043) (2026-08-14)** —
+> see the annotations in [`spec.md`](./spec.md) for the reasoning. The route
+> table below and the schema notes are the parts that no longer describe the
+> served contract: links left this API, so `POST ""`, `GET`/`PUT`/`DELETE
+> /{resource_id}` and `GET /check-name` are gone, `GET /stat?path=` was added,
+> and `resource_id` / `source` / `gmt_create` / `gmt_modified` left the response
+> model rather than being reported empty. The root cause, the device-seam
+> analysis, and the record-retention rationale are unchanged and still govern.
+>
+> Two notes below are worth reading as predictions that came true rather than as
+> stale text: the schema section calls a shared file/link model "the floor for a
+> single shared model … removing it means splitting the schema into file and
+> link variants, which is a larger contract change than this one", and the route
+> table warns that literal routes must be declared before `/{resource_id}`.
+> #1043 made the split, which retired the ordering hazard along with the
+> catch-all route.
+
 ## Root cause
 
 The OpenAPI path **uses the same device-filesystem seam** as the console — the

--- a/src/backend/specs/2026-08-12-openapi-resources-engine-backed/spec.md
+++ b/src/backend/specs/2026-08-12-openapi-resources-engine-backed/spec.md
@@ -2,6 +2,16 @@
 
 Tracking issue: [inclusionAI/Avernet#1000](https://github.com/inclusionAI/Avernet/issues/1000)
 
+> **⚠️ Partially superseded by
+> [#1043](https://github.com/inclusionAI/Avernet/pull/1043) (2026-08-14).**
+> Two of this spec's decisions were reversed when the resources group became
+> files-only: **G7** (links unaffected, record-addressed) and the deferral of
+> **`GET /stat?path=`**. Both are annotated in place below rather than rewritten,
+> so this stays an accurate record of what #1001 shipped. Everything else —
+> G1–G6, G8, and every file behavior in the table — still holds and was carried
+> forward unchanged. Read the annotations before treating any statement here as
+> the current contract.
+
 ## Problem
 
 Files uploaded through the public resources API never reach the bot's workspace.
@@ -75,6 +85,17 @@ duplicate check would answer 409.
 **G7. Link resources are unaffected.** A link has no file; it remains
 record-backed and record-addressed.
 
+> **Superseded by [#1043](https://github.com/inclusionAI/Avernet/pull/1043).**
+> Links left the OpenAPI resources group entirely, so nothing on that surface is
+> record-addressed any more: `POST ""`, `GET`/`PUT`/`DELETE /{resource_id}` and
+> `check-name` were removed with them, and `resource_id` left the response
+> contract rather than staying present-but-empty. G7 held for exactly as long as
+> the group served two kinds of resource. The *reasoning* survives the reversal —
+> a link genuinely has no file, so a record id genuinely is its only possible
+> address; what changed is that this API no longer serves links at all. The
+> console's `/api/resources` surface still does, through its own router and the
+> same link service methods, unchanged.
+
 **G8. The endpoint is covered by tests** for both success and failure, replacing
 its coverage-baseline entry.
 
@@ -90,7 +111,11 @@ its coverage-baseline entry.
 | Listing | records only | workspace contents, enriched from records where one exists |
 | Bot-created files | invisible to the API | fully usable |
 | File addressing | by record id | **by path** |
-| Link addressing | by record id | unchanged |
+| Link addressing | by record id | unchanged ¹ |
+
+¹ *Superseded by [#1043](https://github.com/inclusionAI/Avernet/pull/1043): links
+are no longer served by this API, so it has no link addressing to speak of. See
+the G7 annotation.*
 
 ### Contract change
 
@@ -101,6 +126,11 @@ operations are already path-addressed.
 Record ids remain the addressing scheme for links. Record ids that previously
 referred to files stop resolving — on `GET`, `PUT` and `DELETE /{resource_id}`
 alike, so that no record-addressed operation still accepts a file.
+
+> **Superseded by [#1043](https://github.com/inclusionAI/Avernet/pull/1043):**
+> those three operations no longer exist here. Making file ids stop resolving
+> while the routes stayed was the halfway state this spec could reach without
+> touching links; removing links removed the routes.
 
 **Single-file lookup is dropped rather than re-addressed.** *(Corrected during
 review — this section originally claimed four operations changed shape, which
@@ -116,6 +146,15 @@ Adding `GET /stat?path=` would close it and is cheap. It is left out because it
 would widen a public contract beyond what the issue asked for, on a surface still
 gated as not-public-ready; the call belongs to the issue owner rather than to
 this change.
+
+> **The issue owner made that call: `GET /stat?path=` shipped in
+> [#1043](https://github.com/inclusionAI/Avernet/pull/1043).** It also absorbed
+> `check-name`, which had been asking the same existence question through a
+> second addressing mode. It is resolved by listing the parent directory and
+> selecting the entry, so `stat` and the listing read one seam and cannot report
+> different types or sizes for the same file — and no provider gains a method
+> (`DeviceFileSystem` has no stat). The "extra call and client-side filtering"
+> cost described just above is therefore gone.
 
 This is a breaking change to a surface that is **not yet exposed to external
 callers** — the router carries a standing "NOT PUBLIC-READY" gate pending the

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -136,22 +136,18 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("GET", "/openapi/v1/bots/identity/{bot_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/identity/{bot_id}/{file_type}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("PUT", "/openapi/v1/bots/identity/{bot_id}/{file_type}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    # resources — ``bot_id`` is a required query parameter on all eleven.
-    # The file operations are addressed by workspace path rather than by record
-    # id: a record id cannot address a file the bot created itself. Every one of
-    # them still resolves its workspace from the caller-supplied ``bot_id``, so
-    # they carry the same own-bot grant check as the record-addressed routes.
+    # resources — ``bot_id`` is a required query parameter on all seven, and
+    # every one of them is addressed by workspace path. There are no record-id
+    # routes left: a record id cannot address a file the bot created itself, and
+    # links are no longer part of this group. Each resolves its workspace from
+    # the caller-supplied ``bot_id``, so each carries the own-bot grant check.
     ("GET", "/openapi/v1/bots/resources"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/resources"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("DELETE", "/openapi/v1/bots/resources"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/resources/check-name"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    ("GET", "/openapi/v1/bots/resources/stat"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("POST", "/openapi/v1/bots/resources/upload"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/resources/download"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/resources/preview"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("POST", "/openapi/v1/bots/resources/mkdir"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/resources/{resource_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("PUT", "/openapi/v1/bots/resources/{resource_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("DELETE", "/openapi/v1/bots/resources/{resource_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     # routines — query ``bot_id``, except the create, which carries it in the
     # body and is checked in the handler (see ``BODY_BOT_ID_OPERATIONS``).
     ("GET", "/openapi/v1/bots/routines"): AdmissionMode.GRANT_CHECKED_OWN_BOT,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -462,6 +462,25 @@ async def upload_resource(
             # safe to do unconditionally on this branch — ``delete_file_record``
             # reports "nothing matched" with a ``False`` rather than raising, and
             # a bot-created file being overwritten never had a row to begin with.
+            #
+            # This is a *reduction*, not a guarantee, and the difference matters.
+            # The drop and the insert are two statements with no lock between
+            # them, so two overwrites racing on one path can both drop, then both
+            # insert, and leave two live rows — the publish pipeline would list
+            # the file twice. Without the drop the same race leaves three, so
+            # this strictly improves it, but it does not close it.
+            #
+            # It is the same race the duplicate check above already documents,
+            # one table down: concurrent *fresh* uploads to an absent path both
+            # pass ``exists``, both write, and both insert, which is the
+            # pre-existing behaviour this branch inherits rather than introduces.
+            # Closing it properly needs a uniqueness constraint on
+            # ``(bolt_id, path)`` plus an upsert in the repository — a DDL on
+            # ``ac_resource``, a table the console and the publish pipeline share.
+            # That has to be deployed before code that depends on it (see the
+            # module docstring's Phase 0 note on ``avernet_tenant``: code first /
+            # DDL later breaks bot reads), so it is not an adapter-level fix and
+            # is deliberately not attempted here.
             await factory.create(bot_id=bot_id).delete_file_record(path=safe)
         await factory.create(bot_id=bot_id).record_uploaded_file(
             path=info["path"],

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -1,17 +1,24 @@
 """Resources group — ``/openapi/v1/bots/resources``.
 
-A unified abstraction over files and links (a Yuque doc is a ``link`` resource);
-the storage location is never exposed. All 9 handlers are wired to the slim
-``core/resources/service.py`` ``ResourceService`` via ``ResourceServiceFactory``;
-no legacy router private helper is imported (arch Rule 7 — thin adapter).
+The bot's workspace files and folders. The engine is the source of truth: every
+handler resolves against the workspace, and every entry is addressed by its
+workspace-relative ``path``. The storage location is never exposed.
 
-⚠️ STATUS: definition-only / NOT PUBLIC-READY. The handlers are wired to the
-slim ``ResourceService`` and exercise the real service at the integration level,
-but this surface is gated on the auth workstream before it is exposed to any
-external tenant: ``require_principal`` is still a ``None`` stub, so the gateway's
-signed-Principal seam is not in place yet. Do NOT expose to external callers
-until that lands (see ``openapi_v1/dependencies.py`` and the cross-team tenant
-isolation track in ``src/backend/docs/openapi-v1/README.zh-CN.md``).
+**There are no record ids on this surface.** ``#1001`` made the filesystem
+authoritative for files, which left ``resource_id`` present but permanently
+empty on every file response, and three id-addressed routes that only ever
+resolved link records. Links are no longer part of this group, so the id is gone
+from the contract rather than reported as ``""`` — an empty string standing in
+for "no id" is a sentinel pretending to be an address, and a caller cannot tell
+it from a real one until it fails.
+
+⚠️ STATUS: definition-only / NOT PUBLIC-READY. The handlers exercise the real
+services at the integration level, but this surface is gated on the auth
+workstream before it is exposed to any external tenant: ``require_principal`` is
+still a ``None`` stub, so the gateway's signed-Principal seam is not in place
+yet. Do NOT expose to external callers until that lands (see
+``openapi_v1/dependencies.py`` and the cross-team tenant isolation track in
+``src/backend/docs/openapi-v1/README.zh-CN.md``).
 
 Gates / follow-ups (block public-readiness, NOT a silent deployment):
 - Owner/identity comes from ``UserIdDep`` — the request's own ``user_id``
@@ -23,21 +30,26 @@ Gates / follow-ups (block public-readiness, NOT a silent deployment):
   Phase 0 plan) — code first / DDL later breaks bot reads with a missing column.
 - device_fs resolution lives in the adapter (Rule 7 transport concern); a
   service owns the read/write via the opaque ``device_fs`` argument.
+
+Records are still written on upload, and that is not a contradiction of the
+above: the publish pipeline builds a released bot's manifest from them, so bytes
+with no row publish as a bot silently missing that file. The row is that
+pipeline's input, never a source this API reads back. "Files have no id in the
+API" is not "files have no record".
 """
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 import httpx
-from fastapi import APIRouter, Body, HTTPException, Path, Query, Request, Response
+from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 
 from agentclaw.community.api.resource_service import ResourceServiceFactoryProtocol
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Deleted,
     Envelope,
     ErrorEnvelope,
-    NameCheck,
     Page,
     PageParamsDep,
     error_example,
@@ -69,69 +81,9 @@ from agentclaw.community.core.services.resource_file_service import (
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 
-from .schemas import Preview, Resource, ResourceCreate, ResourceType, ResourceUpdate
-
-# ── openapi_v1 envelope + field-mapping helpers (Phase 1) ───────────
-from agentclaw.community.core.resources.models import Resource as _LegacyResource
-from agentclaw.community.core.resources.models import ResourceType as _LegacyType
+from .schemas import FileEntry, Preview, ResourceType
 
 logger = get_logger()
-
-
-# legacy ResourceType → openapi ResourceType. R1a: legacy URL 归并进 openapi LINK.
-# NODE/DATABASE/API 不在 openapi 契约 —— 读路径若出现,退回 LINK(读 list 不该报错);
-# create 路径本期只接 LINK,不会经过这里。(legacy 无 FOLDER 枚举值,故无 mapping。)
-_TYPE_MAP: dict[_LegacyType, ResourceType] = {
-    _LegacyType.FILE: ResourceType.FILE,
-    _LegacyType.LINK: ResourceType.LINK,
-    _LegacyType.URL: ResourceType.LINK,
-}
-
-# openapi ResourceType → legacy ResourceType. R1a: openapi LINK 归并 legacy URL +
-# LINK —— filter 侧本期只匹配 LINK(URL fan-out is a follow-up, see
-# `_legacy_type_for` callers). openapi FOLDER has no legacy equivalent (no row
-# in the legacy enum), so it's intentionally absent: list filters to empty and
-# create raises 501 — they never reach the service with FOLDER.
-_OPENAPI_TO_LEGACY_TYPE: dict[ResourceType, _LegacyType] = {
-    ResourceType.FILE: _LegacyType.FILE,
-    ResourceType.LINK: _LegacyType.LINK,
-}
-
-
-def _legacy_type_for(openapi_type: ResourceType | None) -> _LegacyType | None:
-    """Map an openapi ResourceType to the legacy ResourceType the slim service expects.
-
-    Returns None when:
-    - ``openapi_type`` is None (no filter — caller passes None through), or
-    - ``openapi_type`` is FOLDER: there is no legacy equivalent (FOLDER is an
-      openapi-only type with no backing enum value). Callers that must NOT
-      fall through to "no filter" (list_resources) distinguish these two None
-      cases via the ``type`` argument directly — see list_resources handler.
-    """
-    if openapi_type is None:
-        return None
-    return _OPENAPI_TO_LEGACY_TYPE.get(openapi_type)
-
-
-def _to_openapi_resource(legacy: _LegacyResource) -> Resource:
-    """Map a legacy domain Resource → public openapi Resource schema.
-
-    Flattens type-specific attributes (url/size) to top-level fields and never
-    exposes the storage location. Per arch Rule 7 (mapping = protocol concern).
-    """
-    return Resource(
-        resource_id=str(legacy.id) if legacy.id is not None else "",
-        name=legacy.name or "",
-        type=_TYPE_MAP.get(legacy.resource_type, ResourceType.LINK),
-        source=legacy.source,
-        url=legacy.url,
-        size=legacy.size if legacy.resource_type == _LegacyType.FILE else None,
-        # ``None``, not ``""``: the field is nullable now, and an empty string is
-        # a sentinel pretending to be a timestamp. Absent means absent.
-        gmt_create=legacy.gmt_created.isoformat() if legacy.gmt_created else None,
-        gmt_modified=legacy.gmt_modified.isoformat() if legacy.gmt_modified else None,
-    )
-
 
 #: Preview cap, legacy parity with the former service-level default.
 _PREVIEW_MAX_BYTES = 1_048_576
@@ -191,6 +143,18 @@ def _safe_path(path: str) -> str:
     return "/".join(segments)
 
 
+def _require_path(path: str) -> str:
+    """``_safe_path``, refusing the empty result.
+
+    Every endpoint but the listing addresses one entry, and the workspace root
+    is not one: there is nothing to download, delete or stat about it.
+    """
+    safe = _safe_path(path)
+    if not safe:
+        raise InvalidResourcePathError("path is required")
+    return safe
+
+
 def _reject_read_only(safe: str) -> None:
     """Refuse a path the read-only policy protects, with the console's 403.
 
@@ -236,6 +200,57 @@ def _file_coords(
     return ("staff", owner_id, engine_type)
 
 
+def _to_file_entry(entry: dict[str, Any]) -> FileEntry:
+    """Map a ``ResourceFileService.list_dir`` entry to the public schema.
+
+    ``list_dir`` already returns a workspace-relative ``path`` (it applies
+    ``_rel_path`` itself) and keeps the engine-view container path under a
+    separate ``absolute_path``. Recomputing the former here would discard the
+    correct value in favour of a reconstruction; reporting the latter would leak
+    the container's storage layout.
+    """
+    is_dir = bool(entry.get("is_dir"))
+    return FileEntry(
+        path=entry.get("path", ""),
+        name=entry.get("name", ""),
+        type=ResourceType.FOLDER if is_dir else ResourceType.FILE,
+        size=entry.get("size") if not is_dir else None,
+    )
+
+
+async def _list_dir_or_empty(
+    file_svc: ResourceFileService,
+    *,
+    bot_id: str,
+    owner_id: str,
+    bot_repo: BotRepository,
+    path: str,
+) -> list[dict[str, Any]]:
+    """One directory's entries, treating an absent directory as empty.
+
+    The baas providers re-raise an upstream 404 rather than answering "nothing
+    there", and that loudness is load-bearing at the device
+    (``baas_device_filesystem.py:68``). It is only here that a 404 stops being a
+    failure: the providers that return ``None`` already produce an empty listing
+    for an absent directory, so without this the same request is a 500 on baas
+    and an empty page everywhere else. Every other status still propagates.
+    """
+    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    try:
+        listed = await file_svc.list_dir(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            bot_id=bot_id,
+            engine_type=engine_type,
+            path=path,
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 404:
+            raise
+        return []
+    return listed or []
+
+
 router = APIRouter(prefix="/openapi/v1/bots/resources", tags=["resources"])
 
 #: The query parameter addressing a file or folder, documented once. Kept as an
@@ -250,18 +265,8 @@ FilePathQuery = Annotated[
     ),
 ]
 
-#: The path parameter naming a link resource, documented once.
-ResourceIdPath = Annotated[
-    str,
-    Path(
-        description="The link resource's id, as returned by the listing or "
-        "create response (decimal digits, e.g. '42'). Files and folders "
-        "have no id — address them by `path` on the path-based endpoints."
-    ),
-]
 
-
-@router.get("", response_model=Envelope[Page[Resource]])
+@router.get("", response_model=Envelope[Page[FileEntry]])
 @envelope_errors
 async def list_resources(
     page: PageParamsDep,
@@ -274,231 +279,90 @@ async def list_resources(
     type: Annotated[
         ResourceType | None,
         Query(
-            description="Filter: 'file' or 'folder' lists only workspace "
-            "entries of that kind; 'link' returns only the bot's links "
-            "(path is then ignored). Omit for everything."
+            description="Filter: 'file' lists only files, 'folder' only "
+            "directories. Omit for both."
         ),
     ] = None,
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
-) -> Envelope[Page[Resource]]:
-    """List a directory of the bot's workspace, plus the bot's link resources.
+) -> Envelope[Page[FileEntry]]:
+    """List a directory of the bot's workspace.
 
-    Files and folders come from the **workspace**, never from records. That is
-    what makes a file the bot produced itself a first-class resource: it has no
-    record and never will, and a record-backed listing simply could not see it.
-    It also removes the divergence the other direction — a record whose bytes are
-    not where it claims can no longer be reported as a file that exists.
+    Entries come from the **workspace**, never from records. That is what makes
+    a file the bot produced itself a first-class resource: it has no record and
+    never will, and a record-backed listing simply could not see it. It also
+    removes the divergence the other direction — a record whose bytes are not
+    where it claims can no longer be reported as a file that exists.
 
-    Links are the exception, and not an inconsistency: a link has no file and no
-    presence on any device, so the record *is* the resource. They are read from
-    the repo and appended.
+    The path parameter selects the directory (empty = workspace root). Listing
+    is non-recursive, which bounds the device round trip this endpoint makes.
 
-    The path parameter selects the directory (empty = workspace root).
-    Listing is non-recursive, which bounds the device round trip this
-    endpoint makes.
+    Paging is applied by this server over the whole directory, because the
+    engine's listing API takes no page, limit or cursor: `page_size` bounds the
+    response, not the work. Requesting a later page costs exactly what the
+    first one costs.
     """
     safe = _safe_path(path)
-    entries: list[Resource] = []
-    if type is None or type in (ResourceType.FILE, ResourceType.FOLDER):
-        entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
-        try:
-            listed = await file_svc.list_dir(
-                entity_type=entity_type,
-                entity_id=entity_id,
-                bot_id=bot_id,
-                engine_type=engine_type,
-                path=safe,
-            )
-        except httpx.HTTPStatusError as exc:
-            # Same normalization the read path does, for the same reason: the
-            # baas providers re-raise an upstream 404 rather than answering
-            # "nothing there", and that loudness is load-bearing at the device.
-            # An absent directory is an ordinary answer here, and the providers
-            # that return ``None`` already produce an empty page for it — so
-            # without this the same request is a 500 on baas and an empty page
-            # everywhere else. Every other status still propagates.
-            if exc.response.status_code != 404:
-                raise
-            listed = []
-        for entry in listed or []:
-            is_dir = bool(entry.get("is_dir"))
-            entry_type = ResourceType.FOLDER if is_dir else ResourceType.FILE
-            if type is not None and entry_type != type:
-                continue
-            entries.append(
-                Resource(
-                    # No record backs a workspace entry, so there is no id to
-                    # report and no source or timestamps to report either — the
-                    # device's listing carries none.
-                    resource_id="",
-                    name=entry.get("name", ""),
-                    type=entry_type,
-                    size=entry.get("size") if not is_dir else None,
-                    # ``ResourceFileService.list_dir`` already returns a
-                    # workspace-relative ``path`` (it applies ``_rel_path``
-                    # itself) and keeps the engine-view container path under a
-                    # separate ``absolute_path``. Recomputing it here would
-                    # discard the correct value in favour of a reconstruction.
-                    path=entry.get("path", ""),
-                )
-            )
+    listed = await _list_dir_or_empty(
+        file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=safe
+    )
+    entries = [_to_file_entry(entry) for entry in listed]
+    if type is not None:
+        entries = [entry for entry in entries if entry.type == type]
 
-    if type is None or type == ResourceType.LINK:
-        service = factory.create(bot_id=bot_id)
-        # Unfiltered on the repo side, then narrowed by the *mapped* type. Two
-        # legacy types collapse into openapi LINK — ``LINK`` and the older
-        # ``URL`` — so filtering the query on either one alone silently drops
-        # the other. FILE rows are excluded here rather than merged: for files
-        # the workspace is authoritative, and a row whose bytes are not where it
-        # claims must not be reported as a file that exists.
-        entries.extend(
-            _to_openapi_resource(r)
-            for r in service.list_resources()
-            if _TYPE_MAP.get(r.resource_type) == ResourceType.LINK
-        )
-
-    # Paginated here rather than pushed down: the page spans two sources, one of
-    # which is a directory listing with no offset to push a bound into.
+    # Sliced here rather than pushed down, and that is only sound because the
+    # listing is non-recursive: one directory is a bounded fetch, so holding it
+    # whole to serve a page of it is proportionate. A ``recursive=true`` option
+    # would break that assumption — it would pull an entire workspace into
+    # memory per request — so adding one means revisiting this, not just adding
+    # a parameter. See the engine's ``ListDirRequest``, which has no paging
+    # fields to push a bound into.
     start = (page.page - 1) * page.page_size
     return page_envelope(
         len(entries), entries[start : start + page.page_size], request
     )
 
 
-@router.get("/check-name", response_model=Envelope[NameCheck])
+@router.get("/stat", response_model=Envelope[FileEntry])
 @envelope_errors
-async def check_resource_name(
+async def stat_resource(
     owner_id: UserIdDep,
+    path: FilePathQuery,
     request: Request,
-    # Annotated defaults rather than ``Query(...)`` defaults: FastAPI treats
-    # them as query parameters either way, and the plain default keeps the
-    # handler directly callable in tests without a ``Query`` sentinel standing
-    # in for a string.
-    name: Annotated[
-        str,
-        Query(
-            description="Link name to check against the bot's link records "
-            "(exact, case-sensitive match). Supply this or path."
-        ),
-    ] = "",
-    path: Annotated[
-        str,
-        Query(
-            description="Workspace-relative path to check for a file or "
-            "folder, e.g. 'docs/spec.md'. When given, the file check runs "
-            "and name is ignored."
-        ),
-    ] = "",
-    type: Annotated[
-        ResourceType | None,
-        Query(
-            description="Addressing hint: 'file' or 'folder' forces the "
-            "workspace check; otherwise a supplied path decides."
-        ),
-    ] = None,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
-) -> Envelope[NameCheck]:
-    """Whether a resource already exists.
+) -> Envelope[FileEntry]:
+    """One file or folder's metadata, addressed by path.
 
-    Two parameters because there are two kinds of resource, addressed
-    differently. A file or folder is checked against the workspace by path —
-    the same question the upload asks before writing, answered by the same
-    authority, so the two can never disagree. A link is checked by name
-    against the records, because a link has no file. Supplying path gets the
-    file check; otherwise it is the link check.
+    Answers the questions a listing answers, for a single entry: whether it is
+    there at all (404 if not), whether it is a file or a folder, and how big it
+    is. The workspace root has no entry of its own, so `path` is required here
+    even though the listing accepts an empty one.
+
+    Entries the listing hides — dotfiles, and the workspace-root identity files
+    — are 404 here too, so the two surfaces agree on what exists.
     """
-    # Splitting the two surfaces entirely would be cleaner than one endpoint
-    # with two addressing modes, but that is a larger contract change than
-    # this one.
-    # Neither addressing mode supplied. Both parameters carry plain defaults so
-    # that one may be omitted, which costs FastAPI's required-parameter check —
-    # so the "at least one" rule is enforced here instead. Without it the link
-    # branch asks the repository about the empty name and answers a cheerful
-    # ``exists=false`` to a request that named no resource at all.
-    if not name and not path:
-        raise InvalidResourcePathError("name or path is required")
-    if path or type == ResourceType.FILE or type == ResourceType.FOLDER:
-        safe = _safe_path(path or name)
-        if not safe:
-            raise InvalidResourcePathError("path is required")
-        entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
-        exists = await file_svc.exists(
-            entity_type=entity_type,
-            entity_id=entity_id,
-            bot_id=bot_id,
-            engine_type=engine_type,
-            path=safe,
-        )
-        return envelope(NameCheck(name=safe, exists=exists), request)
-
-    service = factory.create(bot_id=bot_id)
-    # owner_id is the request's own ``user_id`` — fail-closed, since neither a
-    # missing parameter nor one naming another user reaches this line.
-    exists = await service.check_name_exists(
-        name=name,
-        resource_type=_LegacyType.LINK,
-        parent_path=None,
-        user_id=owner_id,
+    # Resolved by listing the parent and picking the entry out, rather than by a
+    # dedicated device call: it is the same seam the listing reads, so stat and
+    # list cannot report different types or sizes for the same file. It also
+    # needs no new provider method — ``DeviceFileSystem`` has no stat, and
+    # adding one to three providers to save a filter would be the larger change.
+    safe = _require_path(path)
+    parent = safe.rsplit("/", 1)[0] if "/" in safe else ""
+    listed = await _list_dir_or_empty(
+        file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=parent
     )
-    return envelope(NameCheck(name=name, exists=exists), request)
-
-
-@router.post("", status_code=201, response_model=Envelope[Resource])
-@envelope_errors
-async def create_resource(
-    body: ResourceCreate,
-    user_id: UserIdDep,
-    request: Request,
-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
-) -> Envelope[Resource]:
-    """Create a resource (file placeholder, link, or folder).
-
-    Phase 1: only LINK supported. FILE → use POST /upload (Phase 3);
-    FOLDER → create_directory (Phase 3, device_fs branch). Duplicate name
-    surfaces as ValueError from the service → 409 Conflict (legacy parity).
-    """
-    del user_id  # not-yet-enforced ownership — see list_resources
-    if body.type == ResourceType.FILE:
-        raise HTTPException(
-            status_code=400,
-            detail="Use POST /openapi/v1/bots/resources/upload for file resources",
-        )
-    if body.type == ResourceType.FOLDER:
-        raise HTTPException(
-            status_code=501,
-            detail="Create folder not supported yet (Phase 3)",
-        )
-    if not body.url:
-        raise HTTPException(
-            status_code=400, detail="url is required for link resources"
-        )
-
-    effective_bot_id = bot_id
-    service = factory.create(bot_id=effective_bot_id)
-    # DuplicateResourceError propagates to @envelope_errors → 409 fixed message
-    # (no str(exc) leakage, unlike the prior hand-translation).
-    r = await service.create_url_resource(
-        name=body.name,
-        url=body.url,
-        # parent_path intentionally NOT forwarded: the openapi ResourceCreate
-        # schema carries `parent_id` (a pending follow-up — its ID-vs-path
-        # semantics aren't settled). Passing a half-defined value would risk
-        # a wrong-attribute write; link scoping by bot_id is sufficient now.
-        parent_path=None,
-    )
-    return created(_to_openapi_resource(r), request)
+    for entry in listed:
+        if entry.get("path") == safe:
+            return envelope(_to_file_entry(entry), request)
+    raise HTTPException(status_code=404, detail="Resource not found")
 
 
 @router.post(
     "/upload",
     status_code=201,
-    response_model=Envelope[Resource],
+    response_model=Envelope[FileEntry],
     responses=_READ_ONLY_RESPONSE,
 )
 @envelope_errors
@@ -508,26 +372,33 @@ async def upload_resource(
     content: Annotated[bytes, Body(media_type="application/octet-stream")],
     request: Request,
     bot_id: str = Query(..., description="Bot ID this resource belongs to."),
+    overwrite: Annotated[
+        bool,
+        Query(
+            description="Replace the file if the path is already occupied. "
+            "Defaults to false, which answers 409 instead. Has no effect on a "
+            "free path."
+        ),
+    ] = False,
     factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
     bot_repo: BotRepository = Injected(BotRepository),
     file_svc: ResourceFileService = Injected(ResourceFileService),
-) -> Envelope[Resource]:
+) -> Envelope[FileEntry]:
     """Upload a file's raw bytes into the bot's workspace.
 
     The body is the file's raw bytes (content type application/octet-stream),
     not a multipart form. The path is workspace-relative and carries its own
     directories ('docs/spec/a.txt'); intermediate ones are created as needed
     — there is no separate name or parent-directory parameter. An occupied
-    path answers 409; the size limit is 500 MB, and only common document,
-    code, image and archive extensions are accepted (400 otherwise).
+    path answers 409 unless `overwrite` is set; the size limit is 500 MB, and
+    only common document, code, image and archive extensions are accepted
+    (400 otherwise).
     """
     # The write goes through ResourceFileService, the same service the console
     # uses, so both surfaces compose the workspace address identically and
     # cannot drift. owner_id comes from the request's user_id (UserIdDep),
     # fail-closed — mirroring the bots router.
-    safe = _safe_path(path)
-    if not safe:
-        raise InvalidResourcePathError("path is required")
+    safe = _require_path(path)
     _reject_read_only(safe)
     entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
     # Duplicate detection against the workspace, not the record table. Uploading
@@ -543,13 +414,14 @@ async def upload_resource(
     # changed. Closing it needs an exclusive-create on the engine's write API,
     # since ``DeviceFileSystem`` has no conditional-create to make the check and
     # the write one operation; see the spec's known-limitation section.
-    if await file_svc.exists(
+    occupied = await file_svc.exists(
         entity_type=entity_type,
         entity_id=entity_id,
         bot_id=bot_id,
         engine_type=engine_type,
         path=safe,
-    ):
+    )
+    if occupied and not overwrite:
         raise DuplicateResourceError(f"Resource already exists: {safe}")
     try:
         info = await file_svc.upload_file(
@@ -581,11 +453,16 @@ async def upload_resource(
 
     # The record is not decoration: the publish pipeline builds a released bot's
     # manifest from it, so bytes without a row publish as a bot silently missing
-    # that file. Reporting 201 and moving on would leave exactly that, and the
-    # obvious repair — upload it again — cannot work, because the file is now on
-    # disk and the duplicate check answers 409. So the write is rolled back and
-    # the request fails: a retry then finds a clean slate and succeeds.
+    # that file.
     try:
+        if occupied:
+            # Replacing, so the prior row for this path goes first:
+            # ``record_uploaded_file`` always inserts, and a second row for one
+            # path would publish the file twice in the manifest. Dropping it is
+            # safe to do unconditionally on this branch — ``delete_file_record``
+            # reports "nothing matched" with a ``False`` rather than raising, and
+            # a bot-created file being overwritten never had a row to begin with.
+            await factory.create(bot_id=bot_id).delete_file_record(path=safe)
         await factory.create(bot_id=bot_id).record_uploaded_file(
             path=info["path"],
             size=info.get("size", len(content)),
@@ -594,9 +471,26 @@ async def upload_resource(
         )
     except Exception:
         logger.exception(
-            "[upload_resource] record failed; rolling back the file at %s",
-            info["path"],
+            "[upload_resource] record failed for %s", info["path"]
         )
+        if occupied:
+            # No rollback when replacing, deliberately. The prior bytes are
+            # already gone — that is what the caller asked for — so deleting the
+            # file now would destroy content instead of restoring it. The retry
+            # is the repair here and it is not blocked: an overwrite does not
+            # 409, so calling it again rewrites the bytes and writes the row.
+            logger.error(
+                "[upload_resource] %s was replaced but has no record; "
+                "retry the overwrite to restore it",
+                info["path"],
+            )
+            raise HTTPException(status_code=502, detail="Upload storage failed")
+        # A fresh upload rolls back instead, because its retry *is* blocked:
+        # reporting 201 would leave bytes with no row, and the obvious repair —
+        # upload it again — cannot work, since the file is now on disk and the
+        # duplicate check answers 409. Rolling the write back gives the retry a
+        # clean slate.
+        #
         # A refused rollback is reported by a ``False`` return, not by raising,
         # so catching only exceptions would miss half of it. Both arms land in
         # the same state and get the same log line: the file is on disk with no
@@ -626,31 +520,16 @@ async def upload_resource(
         raise HTTPException(status_code=502, detail="Upload storage failed")
 
     # Built from the workspace, not from the row that was just written — the row
-    # is the publish pipeline's input, not a source this API reads back. Reading
-    # it would make the upload the one file response shaped differently from
-    # every other: a listing of this same file reports an empty ``resource_id``
-    # and no source or timestamps, and the id echoed here could not address
-    # anything anyway, since every file operation is path-addressed and
-    # ``GET /{resource_id}`` 404s a file row. ``path`` is the usable handle.
+    # is the publish pipeline's input, not a source this API reads back.
     return created(
-        Resource(
-            resource_id="",
+        FileEntry(
+            path=info["path"],
             name=info["name"],
             type=ResourceType.FILE,
             size=info.get("size", len(content)),
-            path=info["path"],
         ),
         request,
     )
-
-
-# ── file operations, addressed by workspace-relative path ────────────
-#
-# These are declared before ``/{resource_id}`` so their literal segments win the
-# match, exactly as ``/check-name`` and ``/upload`` already do. A file has no
-# record id to address it by — the workspace is the source of truth, and a file
-# the bot created itself never had a record at all — so ``?path=`` is the
-# address, matching the console's own file surface.
 
 
 async def _read_file_or_404(
@@ -662,9 +541,7 @@ async def _read_file_or_404(
     path: str,
 ) -> bytes:
     """Bytes at ``path``, or 404. Shared by download and preview."""
-    safe = _safe_path(path)
-    if not safe:
-        raise InvalidResourcePathError("path is required")
+    safe = _require_path(path)
     entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
     try:
         content = await file_svc.read_file(
@@ -730,9 +607,6 @@ async def download_file(
 
     Raw bytes, not an envelope — the body is the file.
     """
-    # Replaces the former /{resource_id}/download: a record id cannot address
-    # a file the bot created itself, and the record is no longer what decides
-    # existence.
     content = await _read_file_or_404(
         file_svc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo, path=path
     )
@@ -767,11 +641,54 @@ async def preview_file(
         )
     return envelope(
         Preview(
-            resource_id="",
+            path=_safe_path(path),
             content_type="application/octet-stream",
             # ``replace`` rather than raising: a preview of a mostly-text file
             # with a stray byte is useful; a 500 is not.
             content=content.decode("utf-8", errors="replace"),
+        ),
+        request,
+    )
+
+
+@router.post(
+    "/mkdir",
+    status_code=201,
+    response_model=Envelope[FileEntry],
+    responses=_READ_ONLY_RESPONSE,
+)
+@envelope_errors
+async def create_directory(
+    owner_id: UserIdDep,
+    path: FilePathQuery,
+    request: Request,
+    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
+    bot_repo: BotRepository = Injected(BotRepository),
+    file_svc: ResourceFileService = Injected(ResourceFileService),
+) -> Envelope[FileEntry]:
+    """Create a directory in the bot's workspace, addressed by path.
+
+    Intermediate directories are created as needed. Directories exist on the
+    workspace filesystem only and are reported by listing it — they have no
+    record.
+    """
+    # No FOLDER record is written: giving directories records would reintroduce
+    # exactly the record-vs-filesystem divergence this change removed.
+    safe = _require_path(path)
+    _reject_read_only(safe)
+    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    await file_svc.create_directory(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        path=safe,
+    )
+    return created(
+        FileEntry(
+            path=safe,
+            name=safe.rsplit("/", 1)[-1],
+            type=ResourceType.FOLDER,
         ),
         request,
     )
@@ -798,9 +715,7 @@ async def delete_file(
     record that is not there is not an error — a file the bot created never had
     one.
     """
-    safe = _safe_path(path)
-    if not safe:
-        raise InvalidResourcePathError("path is required")
+    safe = _require_path(path)
     # Same read-only policy the console's delete enforces
     # (``adapters/http/resources/file_router.py:381``) — dotfiles and the
     # workspace-root identity files. Addressing by path is what makes these
@@ -839,153 +754,4 @@ async def delete_file(
         path=safe,
     ):
         raise HTTPException(status_code=502, detail="Delete storage failed")
-    return deleted_envelope(request)
-
-
-@router.post(
-    "/mkdir",
-    status_code=201,
-    response_model=Envelope[Resource],
-    responses=_READ_ONLY_RESPONSE,
-)
-@envelope_errors
-async def create_directory(
-    owner_id: UserIdDep,
-    path: FilePathQuery,
-    request: Request,
-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    bot_repo: BotRepository = Injected(BotRepository),
-    file_svc: ResourceFileService = Injected(ResourceFileService),
-) -> Envelope[Resource]:
-    """Create a directory in the bot's workspace, addressed by path.
-
-    Intermediate directories are created as needed. Directories exist on the
-    workspace filesystem only and are reported by listing it — they have no
-    record and no resource id.
-    """
-    # No FOLDER record is written, and the create endpoint's type=folder still
-    # returns 501: giving directories records would reintroduce exactly the
-    # record-vs-filesystem divergence this change removed.
-    safe = _safe_path(path)
-    if not safe:
-        raise InvalidResourcePathError("path is required")
-    _reject_read_only(safe)
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
-    await file_svc.create_directory(
-        entity_type=entity_type,
-        entity_id=entity_id,
-        bot_id=bot_id,
-        engine_type=engine_type,
-        path=safe,
-    )
-    return created(
-        Resource(
-            resource_id="",
-            name=safe.rsplit("/", 1)[-1],
-            type=ResourceType.FOLDER,
-            path=safe,
-        ),
-        request,
-    )
-
-
-@router.get("/{resource_id}", response_model=Envelope[Resource])
-@envelope_errors
-async def get_resource(
-    resource_id: ResourceIdPath,
-    user_id: UserIdDep,
-    request: Request,
-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
-) -> Envelope[Resource]:
-    """Get a link resource by id.
-
-    Only links are served by id — a file's id answers 404 here. A file's
-    address is its path: the listing shows it, and download/preview serve it.
-    """
-    # Serving a file from its record would report size and name from a row
-    # nothing keeps in step with the workspace, which is the divergence this
-    # change removed.
-    del user_id  # not-yet-enforced ownership — see list_resources
-    effective_bot_id = bot_id
-    service = factory.create(bot_id=effective_bot_id)
-    # NOTE: ``get_resource`` on the concrete service is SYNC (unlike
-    # ``check_name_exists`` which is async) — do NOT `await` it.
-    r = service.get_resource(resource_id)
-    if r is None or r.resource_type == _LegacyType.FILE:
-        raise HTTPException(status_code=404, detail="Resource not found")
-    return envelope(_to_openapi_resource(r), request)
-
-
-@router.put("/{resource_id}", response_model=Envelope[Resource])
-@envelope_errors
-async def update_resource(
-    resource_id: ResourceIdPath,
-    body: ResourceUpdate,
-    user_id: UserIdDep,
-    request: Request,
-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
-) -> Envelope[Resource]:
-    """Rename a link resource and/or change its URL, by id.
-
-    Only links are updatable by id — a file's id answers 404. A name or URL
-    clash with an existing link answers 409.
-    """
-    # link_type is intentionally not exposed on the openapi contract.
-    # ValueError from the service (not found / url clash) → 409 Conflict, per
-    # legacy + create parity. A file id 404s, completing what GET and DELETE
-    # /{resource_id} already do: update_link_resource checks no type, so a
-    # stale file id would otherwise rename a FILE row that nothing reads.
-    del user_id  # not-yet-enforced ownership — see list_resources
-    effective_bot_id = bot_id
-    service = factory.create(bot_id=effective_bot_id)
-    existing = service.get_resource(resource_id)
-    if existing is not None and existing.resource_type == _LegacyType.FILE:
-        raise HTTPException(status_code=404, detail="Resource not found")
-    # ResourceNotFoundError (404) / DuplicateResourceError (409) propagate to
-    # @envelope_errors with fixed messages — no str(exc) leakage. The prior
-    # hand-translation also wrongly mapped not-found → 409; this fixes that.
-    r = await service.update_link_resource(
-        resource_id=resource_id,
-        name=body.name,
-        url=body.url,
-    )
-    return envelope(_to_openapi_resource(r), request)
-
-@router.delete("/{resource_id}", response_model=Envelope[Deleted])
-@envelope_errors
-async def delete_resource(
-    resource_id: ResourceIdPath,
-    owner_id: UserIdDep,
-    request: Request,
-    bot_id: str = Query(..., description="Bot ID this resource belongs to."),
-    factory: ResourceServiceFactoryProtocol = Injected(ResourceServiceFactoryProtocol),
-) -> Envelope[Deleted]:
-    """Delete a link resource by id.
-
-    Only links are deleted by id — files and folders are deleted through the
-    path-addressed delete. A file's id answers 404. Works whether or not the
-    bot currently has a live device.
-    """
-    # A link has no file, so the record is the resource and the record id is
-    # the only address it can have; a stale file id from before the change
-    # resolves to nothing and 404s, which is the right answer for it too. No
-    # device is touched, so this must not require a bound one: the former
-    # unconditional resolve_for_bot raised DeviceNotBoundError (409) on an
-    # unbound bot even for a link.
-    service = factory.create(bot_id=bot_id)
-    # Refuse a FILE row explicitly. ``delete_resource`` would otherwise accept
-    # one, skip the device because ``device_fs`` is None, soft-delete the row and
-    # report success — so a stale file id would still "work" while leaving the
-    # workspace file in place, which is precisely the record-says-one-thing,
-    # workspace-says-another divergence this change exists to remove. 404 rather
-    # than a distinct status: to this route a file id is simply not a resource it
-    # addresses, and the file's own address is ``DELETE ""?path=``.
-    existing = service.get_resource(resource_id)
-    if existing is not None and existing.resource_type == _LegacyType.FILE:
-        raise HTTPException(status_code=404, detail="Resource not found")
-    ok = await service.delete_resource(resource_id, device_fs=None)
-    if not ok:
-        raise HTTPException(status_code=404, detail="Resource not found")
     return deleted_envelope(request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/schemas.py
@@ -1,8 +1,12 @@
-"""Request/response models for the resources group (unified files + links).
+"""Request/response models for the resources group (workspace files).
 
 Docstrings and field descriptions here are published verbatim into the OpenAPI
 document external tenants read — keep them caller-facing prose. Rationale and
 internal names belong in ``#`` comments.
+
+Every model here describes something read from the bot's workspace, so none of
+them carries a record id: the engine is the source of truth, and `path` is the
+address. Link resources are not part of this surface.
 """
 
 from __future__ import annotations
@@ -13,24 +17,19 @@ from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
 
 
 class ResourceType(_DocumentedEnum):
-    """A resource is a file, an external link, or a folder."""
+    """A resource is a file or a folder in the bot's workspace."""
 
     FILE = "file"
-    LINK = "link"
     FOLDER = "folder"
 
     __descriptions__ = {
-        "file": "A file in the bot's workspace, addressed by its "
-        "workspace-relative path.",
-        "link": "An external URL saved for the bot, addressed by its "
-        "resource id.",
-        "folder": "A directory in the bot's workspace, addressed by its "
-        "workspace-relative path.",
+        "file": "A file in the bot's workspace.",
+        "folder": "A directory in the bot's workspace.",
     }
 
 
-class Resource(BaseModel):
-    """A resource: a file or folder in the bot's workspace, or an external link.
+class FileEntry(BaseModel):
+    """A file or folder in the bot's workspace.
 
     The container's own storage layout is never exposed — `path` is relative to
     the workspace root, not to any real filesystem the bot runs on.
@@ -39,149 +38,62 @@ class Resource(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "resource_id": "",
+                "path": "docs/spec.md",
                 "name": "spec.md",
                 "type": "file",
-                "source": None,
-                "url": None,
                 "size": 2048,
-                "path": "docs/spec.md",
-                "gmt_create": None,
-                "gmt_modified": None,
             }
         }
     )
 
-    resource_id: str = Field(
-        description="Identifier of the resource's stored record — decimal "
-        "digits for a link, e.g. '42'. Empty for files and folders, which "
-        "have no record: address those by `path` instead."
+    # Required, unlike every other field: it is the address every endpoint in
+    # this group accepts, so an entry without one describes something the
+    # caller cannot then act on.
+    path: str = Field(
+        description="Workspace-relative path, e.g. 'docs/spec/a.txt' — the "
+        "whole path, not the directory. This is the addressing key: pass it "
+        "as `path` on stat, download, preview, upload, mkdir and delete, "
+        "exactly as listed."
     )
     name: str = Field(
-        description="Display name. For a file or folder this is the last "
-        "segment of `path`; a link has only a name."
+        description="Display name — the last segment of `path`."
     )
-    type: ResourceType = Field(description="What kind of resource this is.")
-    # Pass-through of the record's provenance column; only links surface a
-    # record on this API, so files/folders read null here.
-    source: str | None = Field(
-        default=None,
-        description="How the resource record came to exist — e.g. 'manual' "
-        "for a link created through this API, 'upload' for an uploaded "
-        "file's record. Null for files and folders read straight from the "
-        "workspace, which have no record.",
-    )
-    url: str | None = Field(
-        default=None,
-        description="The link's URL; null for files and folders.",
-    )
+    type: ResourceType = Field(description="What kind of entry this is.")
     size: int | None = Field(
         default=None,
-        description="Size in bytes; null when not reported (links, and "
-        "entries whose listing carries no size).",
+        description="Size in bytes. Null for folders, and for files whose "
+        "listing carries no size — not every engine reports one.",
     )
-    path: str | None = Field(
-        default=None,
-        description="Workspace-relative path of a file or folder, e.g. "
-        "'docs/spec/a.txt' — the whole path, not the directory; `name` is "
-        "its last segment. This is the addressing key: pass it as `path` on "
-        "download, preview, upload and delete exactly as listed. Null for "
-        "links.",
-    )
-    gmt_create: str | None = Field(
-        default=None,
-        description="When the record was created (ISO 8601, no timezone "
-        "designator). Null for files and folders read straight from the "
-        "workspace — their listing carries no timestamps.",
-    )
-    gmt_modified: str | None = Field(
-        default=None,
-        description="When the record last changed (ISO 8601, no timezone "
-        "designator); null for files and folders read straight from the "
-        "workspace.",
-    )
-    # Timestamp field names kept DB-flavoured on purpose: they are the
-    # prevailing openapi_v1 convention (sessions, routines), and renaming only
-    # this group would deepen the split with `skills`, which uses
-    # created_at/updated_at.
-
-
-class ResourceCreate(BaseModel):
-    """Create a link resource.
-
-    Only links are created here: files are created through the upload
-    endpoint (a file request answers 400 pointing there), and folders through
-    the mkdir endpoint (a folder request answers 501).
-    """
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "name": "Team wiki",
-                "type": "link",
-                "url": "https://wiki.example.com/team",
-            }
-        }
-    )
-
-    name: str = Field(
-        description="Display name for the link; a duplicate of an existing "
-        "link answers 409."
-    )
-    type: ResourceType = Field(
-        description="What to create. Only 'link' is accepted here — see the "
-        "model description for where files and folders are created."
-    )
-    url: str | None = Field(
-        default=None,
-        description="The URL the link points to. Required when type is "
-        "'link' (400 when missing).",
-    )
-    parent_id: str | None = Field(
-        default=None,
-        description="Accepted for compatibility and currently ignored — "
-        "links are not placed in folders.",
-    )
-
-
-class ResourceUpdate(BaseModel):
-    """Partial update of a link resource. Omitted fields are left unchanged."""
-
-    model_config = ConfigDict(
-        json_schema_extra={"example": {"name": "Team wiki (new)"}}
-    )
-
-    name: str | None = Field(
-        default=None, description="New display name; omit to keep."
-    )
-    url: str | None = Field(default=None, description="New URL; omit to keep.")
+    # Deliberately absent: ``modified_at`` and ``readonly``.
+    #
+    # ``ResourceFileService.list_dir`` computes both, and both are dropped here
+    # on purpose. ``modified_at`` is provider-dependent — the local device's
+    # listing returns name/path/is_dir only — and a field populated on some
+    # engines and null on others is the shape the engine-backed spec (G6)
+    # rejected. ``readonly`` is always false in a listing: ``is_readonly``
+    # matches dotfiles and workspace-root identity files, and ``list_dir``
+    # filters both out before it is ever consulted.
 
 
 class Preview(BaseModel):
-    """A file's preview content."""
+    """A file's content, decoded as text."""
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "resource_id": "",
+                "path": "docs/spec.md",
                 "content_type": "application/octet-stream",
-                "preview_url": None,
                 "content": "# Spec\nThe gateway forwards…",
             }
         }
     )
 
-    resource_id: str = Field(
-        description="Always empty — previews address files by their `path`."
+    path: str = Field(
+        description="Workspace-relative path of the previewed file, as given."
     )
     content_type: str = Field(
         description="MIME label of the returned content; currently always "
         "'application/octet-stream' — the server does not classify further."
-    )
-    preview_url: str | None = Field(
-        default=None,
-        description="Reserved for a URL-based preview; currently always null "
-        "— the content is returned inline instead.",
     )
     content: str | None = Field(
         default=None,

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -1665,9 +1665,16 @@ async def test_real_factory_service_supports_every_handler_path_e2e():
 
 
 @pytest.mark.asyncio
-async def test_overwrite_leaves_one_live_record_for_the_path_e2e():
-    """Against the real service: the replaced row is soft-deleted and exactly one
-    live row remains, so the publish manifest lists the file once."""
+async def test_sequential_overwrite_leaves_one_live_record_for_the_path_e2e():
+    """Against the real service: the replaced row is soft-deleted and one live
+    row remains, so the publish manifest lists the file once.
+
+    **Sequential**, and the name says so deliberately. The drop and the insert
+    are two statements with no lock between them, so concurrent overwrites on one
+    path can still leave two live rows — see the router comment. Naming this
+    ``leaves_one_live_record`` unqualified would read as a concurrency invariant
+    the code does not provide.
+    """
     factory, repo = _real_factory_with_inmemory_repo()
     file_svc = _StubReadFileService({})
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -1,8 +1,14 @@
-"""openapi_v1 resources handler unit tests: mapping + handler behavior."""
+"""openapi_v1 resources handler unit tests.
+
+The group is files-only: every handler is addressed by a workspace-relative
+``path``, and no response carries a record id. Tests that covered link
+resources, the id-addressed get/update/delete, and ``check-name`` went with the
+contract they were testing — ``stat`` answers the existence question those asked,
+against the workspace rather than the record table.
+"""
 
 import json
 import logging
-from datetime import datetime
 from types import SimpleNamespace
 from typing import List
 
@@ -16,61 +22,26 @@ from agentclaw.community.adapters.http.openapi_v1.principal import require_user_
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     CODE_CREATED,
     CODE_OK,
-    Deleted,
     Envelope,
-    NameCheck,
-    Page,
     PageParams,
 )
 from agentclaw.community.adapters.http.openapi_v1.resources.router import (
-    _to_openapi_resource,
-    check_resource_name,
     create_directory,
-    create_resource,
     delete_file,
-    delete_resource,
     download_file,
-    get_resource,
     list_resources,
     preview_file,
-    update_resource,
+    stat_resource,
     upload_resource,
 )
 from agentclaw.community.adapters.http.openapi_v1.resources.schemas import (
-    Preview,
-    ResourceCreate,
-    ResourceUpdate,
+    FileEntry,
     ResourceType as OpenapiType,
 )
 from agentclaw.community.core.resources.factory import ResourceServiceFactory
-from agentclaw.community.core.resources.models import (
-    Resource,
-    ResourceType as LegacyType,
-    create_link_resource,
-)
 from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
-from agentclaw.community.core.resources.service import (
-    DuplicateResourceError,
-    FileTooLargeError,
-    ResourceNotFoundError,
-)
-
-
-def _legacy(**ov) -> Resource:
-    base = dict(
-        id=1,
-        name="r",
-        resource_type=LegacyType.LINK,
-        attributes={"url": "https://example.com", "link_type": "external"},
-        user_id="u",
-        created_by="c",
-        source="yuque",
-        bolt_id="bot-a",
-    )
-    base.update(ov)
-    return Resource(**base)
 
 
 def _request_scope() -> dict:
@@ -103,72 +74,37 @@ def _request_with_trace(trace_id: str) -> Request:
     return req
 
 
-def test_to_openapi_resource_maps_basic_fields():
-    o = _to_openapi_resource(_legacy())
-    assert o.resource_id == "1"
-    assert o.name == "r"
-    assert o.source == "yuque"
-    assert o.type == OpenapiType.LINK
+def _http_status(code: int) -> httpx.HTTPStatusError:
+    """The error a baas provider re-raises from the upstream file API."""
+    request = httpx.Request("POST", "http://baas/api/file/read")
+    return httpx.HTTPStatusError(
+        f"HTTP {code}", request=request, response=httpx.Response(code, request=request)
+    )
 
 
-def test_to_openapi_resource_url_flattened():
-    assert _to_openapi_resource(_legacy()).url == "https://example.com"
+async def _async_true() -> bool:
+    return True
 
 
-def test_to_openapi_resource_file_has_size():
-    r = _legacy(resource_type=LegacyType.FILE, attributes={"path": "/p", "size": 42})
-    o = _to_openapi_resource(r)
-    assert o.type == OpenapiType.FILE
-    assert o.size == 42
-
-
-def test_to_openapi_resource_iso_timestamps():
-    ts = datetime(2026, 7, 28, 10, 0)
-    o = _to_openapi_resource(_legacy(gmt_created=ts, gmt_modified=ts))
-    assert o.gmt_create == ts.isoformat()
-    assert o.gmt_modified == ts.isoformat()
-
-
-# ── list_resources handler wiring (Phase 1 Task 2) ──────────────────────
+# ── stubs ────────────────────────────────────────────────────────────
 #
-# Direct handler invocation (退路 B per task spec): bypasses FastAPI's
-# dependency wiring and supplies a stub factory. `principal` is `Any`, so
-# `None` is an acceptable stand-in. Handlers take a required `request: Request`
-# (mirroring the bots router); tests pass a `SimpleNamespace` stub whose
-# `state.trace_id` is either unset (empty `request_id`) or set to a known
-# value (asserted into the envelope via `responses.envelope`).
+# Direct handler invocation, bypassing FastAPI's dependency wiring: handlers
+# take a required ``request: Request`` (mirroring the bots router), whose
+# ``state.trace_id`` is either unset (empty ``request_id``) or set to a known
+# value asserted into the envelope.
 
 
 class _StubService:
-    """Minimal stub satisfying the ResourceServiceProtocol list_resources seam."""
+    """The two record methods the handlers still call.
 
-    def __init__(self, items: List[Resource]) -> None:
-        self._items = items
-        self.last_call_kwargs: dict = {}
+    Nothing else: the record is the publish pipeline's input, and this API never
+    reads one back. A stub with a ``get_resource`` or ``create_url_resource`` on
+    it would suggest otherwise.
+    """
+
+    def __init__(self) -> None:
         self.recorded: List[dict] = []
         self.record_deletes: List[str] = []
-        self.deleted: List[str] = []
-
-    def list_resources(self, *args, **kwargs):
-        self.last_call_kwargs = dict(kwargs)
-        items = self._items
-        limit = kwargs.get("limit")
-        offset = kwargs.get("offset", 0) or 0
-        if limit:
-            items = items[offset : offset + limit]
-        return items
-
-    def count_resources(self, *, resource_type=None) -> int:
-        return len(self._items)
-
-    def get_resource(self, resource_id):
-        # Sync lookup (matches concrete ResourceService.get_resource).
-        # Captures the call kwargs so tests can assert what was passed.
-        self.last_call_kwargs = dict(resource_id=resource_id)
-        for r in self._items:
-            if str(r.id) == str(resource_id):
-                return r
-        return None
 
     async def record_uploaded_file(
         self, *, path, size, user_id=None, created_by=None, source="upload"
@@ -176,987 +112,40 @@ class _StubService:
         self.recorded.append(
             {"path": path, "size": size, "user_id": user_id, "created_by": created_by}
         )
-        return _legacy(
-            id="rec-1",
-            name=path.rsplit("/", 1)[-1],
-            resource_type=LegacyType.FILE,
-            attributes={"path": path, "size": size},
-            source=source,
-        )
+        return SimpleNamespace(id="rec-1", name=path.rsplit("/", 1)[-1])
 
     async def delete_file_record(self, *, path) -> bool:
         self.record_deletes.append(path)
         return True
 
-    async def check_name_exists(
-        self,
-        *,
-        name: str,
-        resource_type,
-        parent_path=None,
-        user_id=None,
-        exclude_id=None,
-    ):
-        self.last_call_kwargs = dict(
-            name=name,
-            resource_type=resource_type,
-            parent_path=parent_path,
-            user_id=user_id,
-            exclude_id=exclude_id,
-        )
-        # Names equal to "taken" are considered to already exist; everything
-        # else is available. This lets one stub satisfy both exists-branches.
-        return name == "taken"
-
-    async def create_url_resource(
-        self,
-        *,
-        name: str,
-        url: str,
-        method: str = "GET",
-        headers=None,
-        parent_path=None,
-        user_id=None,
-        created_by=None,
-    ):
-        """Mirrors the real service seam: returns a LINK Resource for new names,
-        raises ValueError for the reserved "taken" name (duplicate → 409 at the
-        handler)."""
-        self.last_call_kwargs = dict(
-            name=name,
-            url=url,
-            method=method,
-            parent_path=parent_path,
-            user_id=user_id,
-            created_by=created_by,
-        )
-        if name == "taken":
-            raise DuplicateResourceError(f"Resource '{name}' already exists")
-        # Return a LINK Resource with the url in attributes (matches how the
-        # real create_url_resource populates it; _to_openapi_resource flattens
-        # url/size out of attributes).
-        return Resource(
-            id=1,
-            name=name,
-            resource_type=LegacyType.LINK,
-            attributes={"url": url, "link_type": "external"},
-            user_id=user_id,
-            source=created_by,
-        )
-
-    async def update_link_resource(
-        self,
-        *,
-        resource_id: str,
-        link_type=None,
-        url=None,
-        name=None,
-    ):
-        """Mirrors the real service seam: raises ValueError for not-found /
-        URL conflict → 409 at the handler; otherwise returns a LINK Resource
-        reflecting the requested rename/url change."""
-        self.last_call_kwargs = dict(
-            resource_id=resource_id,
-            link_type=link_type,
-            url=url,
-            name=name,
-        )
-        # resource_id == "0" simulates a missing record (service raises
-        # ResourceNotFoundError → 404 via @envelope_errors).
-        if str(resource_id) == "0":
-            raise ResourceNotFoundError("Resource not found")
-        # url == "conflict" simulates a URL uniqueness violation.
-        if url == "conflict":
-            raise DuplicateResourceError("URL already exists")
-        return Resource(
-            id=int(resource_id),
-            name=name or "r",
-            resource_type=LegacyType.LINK,
-            attributes={"url": url or "https://x.com", "link_type": "external"},
-        )
-
-    async def delete_resource(
-        self,
-        resource_id: str,
-        *,
-        device_fs=None,
-    ) -> bool:
-        """Mirror of the concrete ResourceService.delete_resource seam.
-
-        ASYNC now (Phase 3 slim service awaits device_fs.delete_file for
-        file resources) — the handler must ``await`` it. Returns True for
-        any id except ``"0"``, which simulates a not-found record → the
-        handler maps False → 404.
-        """
-        self.last_call_kwargs = dict(resource_id=resource_id)
-        self.last_call_device_fs = device_fs
-        self.deleted.append(str(resource_id))
-        return str(resource_id) != "0"
-
-    async def upload_file(
-        self,
-        *,
-        data: bytes,
-        filename: str,
-        parent_path: str = "",
-        user_id=None,
-        device_fs=None,
-    ) -> Resource:
-        """Mirror of the concrete ResourceService.upload_file seam.
-
-        ASYNC — the handler must ``await`` it (parallel to delete_resource).
-        Raises ValueError on the reserved "taken" filename to exercise the
-        duplicate-name → 409 path; otherwise returns a FILE Resource with
-        path/size attributes that ``_to_openapi_resource`` flattens.
-        """
-        self.last_call_kwargs = dict(
-            data=data,
-            filename=filename,
-            parent_path=parent_path,
-            user_id=user_id,
-        )
-        self.last_call_device_fs = device_fs
-        if filename == "taken":
-            raise DuplicateResourceError(f"Resource '{filename}' already exists")
-        return Resource(
-            id=1,
-            name=filename,
-            resource_type=LegacyType.FILE,
-            attributes={"path": f"/{filename}", "size": len(data)},
-        )
-
-    async def download_resource(
-        self,
-        resource_id: str,
-        *,
-        device_fs=None,
-    ) -> tuple[bytes, str] | None:
-        """Mirror of the concrete ResourceService.download_resource seam.
-
-        ASYNC — the handler must ``await`` it (parallel to upload_file /
-        unlike sync delete_resource). Returns ``None`` for ``resource_id
-        == "0"`` to exercise the not-found / not-a-file / unreadable
-        collapse-to-404 path; otherwise returns a fixed ``(bytes, mime)``
-        pair. The stub does NOT call ``device_fs.read_file`` — handler
-        wiring (device_fs forward + 404 mapping) is what's under test here,
-        not the device_fs read path.
-        """
-        self.last_call_kwargs = dict(resource_id=resource_id)
-        self.last_call_device_fs = device_fs
-        if str(resource_id) == "0":
-            return None
-        return (b"file content", "application/pdf")
-
-    async def preview_resource(
-        self,
-        resource_id: str,
-        *,
-        device_fs=None,
-        max_size: int = 1_048_576,
-    ) -> dict | None:
-        """Mirror of the concrete ResourceService.preview_resource seam.
-
-        ASYNC — the handler must ``await`` it (parallel to upload_file /
-        download_resource). Returns a fixed ``{content, content_type,
-        size}`` dict for the happy path; returns ``None`` for
-        ``resource_id == "0"`` (not-found / not-a-file / directory /
-        unreadable / empty collapse-to-404); raises ``ValueError`` for
-        ``resource_id == "too-large"`` to exercise the >1 MB cap → 413
-        path. Like the download stub, it does NOT call
-        ``device_fs.read_file`` — handler wiring (device_fs forward,
-        ValueError → 413, None → 404) is what's under test here.
-        """
-        self.last_call_kwargs = dict(resource_id=resource_id, max_size=max_size)
-        self.last_call_device_fs = device_fs
-        if str(resource_id) == "0":
-            return None
-        if str(resource_id) == "too-large":
-            raise FileTooLargeError(
-                f"File too large for preview (max {max_size} bytes)"
-            )
-        return {"content": "preview body", "content_type": "text/plain", "size": 12}
-
 
 class _StubFactory:
     """Captures bot_id passed to create(); returns the configured service."""
 
-    def __init__(self, service: _StubService) -> None:
-        self._service = service
+    def __init__(self, service: _StubService | None = None) -> None:
+        self._service = service or _StubService()
         self.created_bot_ids: list[str] = []
 
     def create(self, *, bot_id: str) -> _StubService:
         self.created_bot_ids.append(bot_id)
         return self._service
 
-@pytest.mark.asyncio
-async def test_list_returns_workspace_entries_not_records():
-    """Files and folders come from the workspace. A record-backed listing could
-    not see a file the bot produced itself — it has no record and never will."""
-    file_svc = _StubListFileService([
-        _listed("notes.md", rel="notes.md", size=12),
-        _listed("docs", rel="docs", is_dir=True),
-    ])
-
-    env = await list_resources(
-        page=PageParams(),
-        owner_id="u1",
-        bot_id="bot-x",
-        path="",
-        type=None,
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert env.data.total == 2
-    by_name = {i.name: i for i in env.data.items}
-    assert by_name["notes.md"].type == OpenapiType.FILE
-    assert by_name["notes.md"].path == "notes.md"
-    assert by_name["notes.md"].size == 12
-    assert by_name["docs"].type == OpenapiType.FOLDER
-    # No record backs a workspace entry.
-    assert all(i.resource_id == "" for i in env.data.items)
-    assert all(i.gmt_create is None for i in env.data.items)
-
-
-@pytest.mark.asyncio
-async def test_list_joins_the_listed_directory_onto_entry_paths():
-    """The device reports ``relative_path`` relative to the listed directory, so
-    listing ``a/b`` must yield ``a/b/c.txt`` — the address a client hands back."""
-    file_svc = _StubListFileService([
-        _listed("c.txt", rel="a/b/c.txt"),
-    ])
-
-    env = await list_resources(
-        page=PageParams(),
-        owner_id="u1",
-        bot_id="bot-x",
-        path="a/b",
-        type=None,
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert env.data.items[0].path == "a/b/c.txt"
-    assert file_svc.listed == ["a/b"]
-
-
-@pytest.mark.asyncio
-async def test_list_never_exposes_the_container_path():
-    """The entry's own ``path`` is the engine-view absolute container path and
-    must not cross a public API."""
-    file_svc = _StubListFileService([
-        _listed("c.txt", rel="c.txt"),
-    ])
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([])), bot_repo=_StubBotRepo(),
-        file_svc=file_svc, request=_request_without_trace(),
-    )
-
-    assert "/home/admin" not in (env.data.items[0].path or "")
-
-
-@pytest.mark.asyncio
-async def test_list_appends_links_which_have_no_file():
-    """A link has no file and no device presence, so the record is the resource."""
-    link = _legacy(id="l1", name="wiki")
-    file_svc = _StubListFileService([
-        _listed("a.txt", rel="a.txt"),
-    ])
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([link])), bot_repo=_StubBotRepo(),
-        file_svc=file_svc, request=_request_without_trace(),
-    )
-
-    kinds = {i.type for i in env.data.items}
-    assert kinds == {OpenapiType.FILE, OpenapiType.LINK}
-    assert env.data.total == 2
-
-
-@pytest.mark.asyncio
-async def test_list_includes_legacy_url_rows_as_links():
-    """Two legacy types collapse into openapi LINK — ``LINK`` and the older
-    ``URL`` — so narrowing the repo query to either one silently drops the
-    other. Rows are fetched unfiltered and narrowed by the *mapped* type."""
-    url_row = _legacy(id="u9", name="yuque-doc", resource_type=LegacyType.URL)
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([url_row])), bot_repo=_StubBotRepo(),
-        file_svc=_StubListFileService([]), request=_request_without_trace(),
-    )
-
-    assert [i.name for i in env.data.items] == ["yuque-doc"]
-    assert env.data.items[0].type == OpenapiType.LINK
-
-
-@pytest.mark.asyncio
-async def test_list_never_reports_file_rows():
-    """A record is not evidence a file exists — that is the divergence this
-    change removes. File rows are excluded; the workspace half is authoritative."""
-    file_row = _legacy(id="f1", name="ghost.txt", resource_type=LegacyType.FILE,
-                       attributes={"path": "ghost.txt"})
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([file_row])), bot_repo=_StubBotRepo(),
-        file_svc=_StubListFileService([]), request=_request_without_trace(),
-    )
-
-    assert env.data.items == []
-
-
-@pytest.mark.asyncio
-async def test_list_folder_filter_returns_directories():
-    """FOLDER used to short-circuit to an empty page — there were no folder rows
-    to return. Directories are real on the filesystem, so it now returns them."""
-    file_svc = _StubListFileService([
-        _listed("docs", rel="docs", is_dir=True),
-        _listed("a.txt", rel="a.txt"),
-    ])
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="",
-        type=OpenapiType.FOLDER,
-        factory=_StubFactory(_StubService([_legacy(id="l1", name="wiki")])),
-        bot_repo=_StubBotRepo(), file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert [i.name for i in env.data.items] == ["docs"]
-
-
-@pytest.mark.asyncio
-async def test_list_link_filter_does_not_touch_the_device():
-    file_svc = _StubListFileService([
-        _listed("a.txt", rel="a.txt"),
-    ])
-
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="",
-        type=OpenapiType.LINK,
-        factory=_StubFactory(_StubService([_legacy(id="l1", name="wiki")])),
-        bot_repo=_StubBotRepo(), file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert [i.type for i in env.data.items] == [OpenapiType.LINK]
-    assert file_svc.listed == []  # no device round trip for a link-only listing
-
-
-@pytest.mark.asyncio
-async def test_list_paginates_across_both_sources():
-    file_svc = _StubListFileService([
-        _listed(f"f{n}.txt", rel=f"f{n}.txt") for n in range(3)
-    ])
-
-    env = await list_resources(
-        page=PageParams(page=2, page_size=2),
-        owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([_legacy(id="l1", name="wiki")])),
-        bot_repo=_StubBotRepo(), file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    # total spans the merged view; the page is the slice.
-    assert env.data.total == 4
-    assert len(env.data.items) == 2
-
-
-@pytest.mark.asyncio
-async def test_list_reads_x_trace_id_from_request():
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([])), bot_repo=_StubBotRepo(),
-        file_svc=_StubListFileService([]),
-        request=_request_with_trace("trace-list-1"),
-    )
-    assert env.request_id == "trace-list-1"
-
-
-@pytest.mark.asyncio
-async def test_list_empty_workspace_returns_empty_page():
-    env = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
-        factory=_StubFactory(_StubService([])), bot_repo=_StubBotRepo(),
-        file_svc=_StubListFileService([]), request=_request_without_trace(),
-    )
-    assert env.data.total == 0
-    assert env.data.items == []
-
-
-@pytest.mark.asyncio
-async def test_list_of_an_absent_directory_is_an_empty_page_not_a_500():
-    """The baas providers re-raise the upstream 404 instead of answering
-    "nothing there", while providers returning ``None`` already produce an empty
-    page — so without normalizing, the same request is a 500 on one and an empty
-    page on the others."""
-
-    class _MissingDirService:
-        async def list_dir(self, **_kw):
-            raise _http_status(404)
-
-    env = await list_resources(
-        page=PageParams(page=1, page_size=10),
-        owner_id="u1",
-        bot_id="bot-x",
-        path="nope",
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=_MissingDirService(),
-        request=_request_without_trace(),
-    )
-
-    assert env.data.total == 0
-    assert env.data.items == []
-
-
-@pytest.mark.asyncio
-async def test_list_does_not_swallow_other_upstream_statuses():
-    """Only 404 is an ordinary answer; an upstream fault must still surface."""
-
-    class _FailingDirService:
-        async def list_dir(self, **_kw):
-            raise _http_status(503)
-
-    with pytest.raises(httpx.HTTPStatusError):
-        await list_resources(
-            page=PageParams(page=1, page_size=10),
-            owner_id="u1",
-            bot_id="bot-x",
-            path="docs",
-            factory=_StubFactory(_StubService([])),
-            bot_repo=_StubBotRepo(),
-            file_svc=_FailingDirService(),
-            request=_request_without_trace(),
-        )
-
-
-@pytest.mark.asyncio
-async def test_list_rejects_a_directory_escaping_the_workspace():
-    file_svc = _StubListFileService([])
-
-    resp = await list_resources(
-        page=PageParams(), owner_id="u1", bot_id="bot-x", path="../../etc",
-        type=None, factory=_StubFactory(_StubService([])), bot_repo=_StubBotRepo(),
-        file_svc=file_svc, request=_request_without_trace(),
-    )
-
-    assert resp.status_code == 400
-    assert file_svc.listed == []
-
-# ── check_resource_name: files ask the workspace, links ask the records ──
-
-
-@pytest.mark.asyncio
-async def test_check_name_asks_the_workspace_for_a_file_path():
-    """Same question the upload asks before writing, answered by the same
-    authority — so the two can never disagree."""
-    file_svc = _StubFileService(existing={"docs/a.txt"})
-
-    env = await check_resource_name(
-        path="docs/a.txt",
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert env.data.exists is True
-    assert file_svc.exists_calls == ["docs/a.txt"]
-
-
-@pytest.mark.asyncio
-async def test_check_name_reports_a_free_path_as_available():
-    env = await check_resource_name(
-        path="docs/new.txt",
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=_StubFileService(existing=set()),
-        request=_request_without_trace(),
-    )
-    assert env.data.exists is False
-
-
-@pytest.mark.asyncio
-async def test_check_name_rejects_a_path_escaping_the_workspace():
-    file_svc = _StubFileService()
-
-    resp = await check_resource_name(
-        path="../../etc/passwd",
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert resp.status_code == 400
-    assert file_svc.exists_calls == []
-
-
-@pytest.mark.asyncio
-async def test_check_name_asks_the_records_for_a_link():
-    """A link has no file, so the record is the only place to look."""
-    service = _StubService([])
-    file_svc = _StubFileService()
-
-    env = await check_resource_name(
-        name="wiki",
-        type=OpenapiType.LINK,
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(service),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    assert env.data.name == "wiki"
-    assert service.last_call_kwargs.get("resource_type") == LegacyType.LINK
-    assert service.last_call_kwargs.get("user_id") == "u1"
-    # No device round trip for a link check.
-    assert file_svc.exists_calls == []
-
-
-@pytest.mark.asyncio
-async def test_check_name_requires_one_of_the_two_addressing_modes():
-    """Both parameters carry plain defaults so either may be omitted, which
-    costs FastAPI's required-parameter check. Without the handler's own rule the
-    link branch asks the repository about the empty name and answers a cheerful
-    ``exists=false`` to a request that named no resource."""
-    service = _StubService([])
-    file_svc = _StubFileService()
-
-    resp = await check_resource_name(
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(service),
-        bot_repo=_StubBotRepo(),
-        file_svc=file_svc,
-        request=_request_without_trace(),
-    )
-
-    # ``@envelope_errors`` maps InvalidResourcePathError to a 400 envelope.
-    assert resp.status_code == 400
-    assert service.last_call_kwargs == {}
-    assert file_svc.exists_calls == []
-
-
-@pytest.mark.asyncio
-async def test_check_name_reads_x_trace_id_from_request():
-    env = await check_resource_name(
-        path="a.txt",
-        owner_id="u1",
-        bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
-        bot_repo=_StubBotRepo(),
-        file_svc=_StubFileService(),
-        request=_request_with_trace("trace-cn-1"),
-    )
-    assert env.request_id == "trace-cn-1"
-
-# ── get_resource handler wiring (Phase 1 Task 4) ─────────────────────────
-#
-# Same stub-factory pattern as Tasks 2/3. Note: `get_resource` on the
-# concrete service is SYNC (unlike `check_name_exists` which is async);
-# the handler therefore must NOT `await` it. `_StubService.get_resource`
-# mirrors that contract.
-
-
-@pytest.mark.asyncio
-async def test_get_resource_returns_envelope_when_found():
-    service = _StubService([_legacy(id=1, name="r")])
-    factory = _StubFactory(service)
-
-    env = await get_resource(
-        resource_id="1",
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-
-    assert isinstance(env, Envelope)
-    assert env.code == CODE_OK
-    assert env.message == "OK"
-    assert env.data is not None
-    assert env.data.resource_id == "1"
-    assert env.data.name == "r"
-    assert env.data.type == OpenapiType.LINK
-    assert env.data.url == "https://example.com"
-    assert env.request_id == ""  # no request context
-
-
-@pytest.mark.asyncio
-async def test_get_resource_raises_404_when_missing():
-    factory = _StubFactory(_StubService([]))
-
-    with pytest.raises(HTTPException) as exc:
-        await get_resource(
-            resource_id="999",
-            user_id="u1",
-            bot_id=None,
-            factory=factory,
-            request=_request_without_trace(),
-        )
-
-    assert exc.value.status_code == 404
-    assert exc.value.detail == "Resource not found"
-
-
-@pytest.mark.asyncio
-async def test_get_resource_404s_a_file_id():
-    """A file's fields come from the workspace, never from a row. Serving one
-    from its record would report a name and size nothing keeps in step with the
-    device — the divergence this change removes. Its address is its path."""
-    service = _StubService(
-        [_legacy(id=7, name="a.txt", resource_type=LegacyType.FILE)]
-    )
-
-    with pytest.raises(HTTPException) as exc:
-        await get_resource(
-            resource_id="7",
-            user_id="u1",
-            bot_id="bot-x",
-            factory=_StubFactory(service),
-            request=_request_without_trace(),
-        )
-
-    assert exc.value.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_get_resource_reads_x_trace_id_from_request():
-    factory = _StubFactory(_StubService([_legacy(id=1)]))
-    request = _request_with_trace("trace-get-1")
-
-    env = await get_resource(
-        resource_id="1",
-        user_id="u1",
-        bot_id="bot-a",
-        factory=factory,
-        request=request,
-    )
-
-    assert env.request_id == "trace-get-1"
-
-
-# ── create_resource (Phase 1, LINK-only) ───────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_create_link_returns_201_envelope():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceCreate(name="mylink", type=OpenapiType.LINK, url="https://x.com")
-
-    env = await create_resource(
-        body=body,
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-
-    assert env.code == CODE_CREATED
-    assert env.data.resource_id == "1"
-    assert env.data.type == OpenapiType.LINK
-    assert env.data.url == "https://x.com"
-    # bot_id flowed through to factory.create
-    assert factory.created_bot_ids == ["bot-x"]
-
-
-@pytest.mark.asyncio
-async def test_create_file_points_to_upload_with_400():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceCreate(name="f", type=OpenapiType.FILE)
-
-    with pytest.raises(HTTPException) as exc:
-        await create_resource(
-            body=body,
-            user_id="u1",
-            bot_id=None,
-            factory=factory,
-            request=_request_without_trace(),
-        )
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_create_folder_is_not_yet_supported_501():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceCreate(name="d", type=OpenapiType.FOLDER)
-
-    with pytest.raises(HTTPException) as exc:
-        await create_resource(
-            body=body,
-            user_id="u1",
-            bot_id=None,
-            factory=factory,
-            request=_request_without_trace(),
-        )
-    assert exc.value.status_code == 501
-
-
-@pytest.mark.asyncio
-async def test_create_link_without_url_is_400():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceCreate(name="link", type=OpenapiType.LINK, url=None)
-
-    with pytest.raises(HTTPException) as exc:
-        await create_resource(
-            body=body,
-            user_id="u1",
-            bot_id=None,
-            factory=factory,
-            request=_request_without_trace(),
-        )
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.asyncio
-async def test_create_link_duplicate_name_is_409():
-    service = _StubService(
-        []
-    )  # create_url_resource raises ValueError for name=="taken"
-    factory = _StubFactory(service)
-    body = ResourceCreate(name="taken", type=OpenapiType.LINK, url="https://x.com")
-
-    resp = await create_resource(
-        body=body,
-        user_id="u1",
-        bot_id=None,
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    assert resp.status_code == 409
-    assert json.loads(resp.body)["message"] == "Resource already exists"
-
-
-# ── update_resource (Phase 3 Task 1, LINK-only) ─────────────────────
-#
-# Same direct-handler-invocation pattern as Phase 1 handlers: bypass
-# FastAPI DI, supply a stub factory. `_StubService.update_link_resource`
-# raises ValueError for not-found / URL conflict → 409 Conflict (legacy +
-# create parity). link_type is intentionally not exposed on the openapi
-# ResourceUpdate contract; the service still accepts it but the handler
-# never forwards it.
-
-
-@pytest.mark.asyncio
-async def test_update_link_returns_200_envelope():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceUpdate(name="renamed", url="https://new.com")
-
-    env = await update_resource(
-        resource_id="1",
-        body=body,
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-
-    assert env.code == CODE_OK
-    assert env.message == "OK"
-    assert env.data is not None
-    assert env.data.resource_id == "1"
-    assert env.data.name == "renamed"
-    assert env.data.type == OpenapiType.LINK
-    assert env.data.url == "https://new.com"
-    # bot_id flowed through to factory.create
-    assert factory.created_bot_ids == ["bot-x"]
-    # service received the rename + url, not link_type (contract doesn't expose it)
-    assert service.last_call_kwargs.get("name") == "renamed"
-    assert service.last_call_kwargs.get("url") == "https://new.com"
-
-
-@pytest.mark.asyncio
-async def test_update_resource_404s_a_file_id():
-    """Completes what GET and DELETE /{resource_id} already do.
-    ``update_link_resource`` checks no type, so a stale file id would rename a
-    FILE row that nothing reads — the response would even show the new name,
-    while the workspace every file response is built from is untouched."""
-    service = _StubService(
-        [_legacy(id=7, name="a.txt", resource_type=LegacyType.FILE)]
-    )
-
-    with pytest.raises(HTTPException) as exc:
-        await update_resource(
-            resource_id="7",
-            body=ResourceUpdate(name="renamed", url=None),
-            user_id="u1",
-            bot_id="bot-x",
-            factory=_StubFactory(service),
-            request=_request_without_trace(),
-        )
-
-    assert exc.value.status_code == 404
-
-
-@pytest.mark.asyncio
-async def test_update_link_raises_409_when_not_found():
-    service = _StubService([])  # resource_id="0" → not-found ValueError
-    factory = _StubFactory(service)
-    body = ResourceUpdate(name="x")
-
-    resp = await update_resource(
-        resource_id="0",
-        body=body,
-        user_id="u1",
-        bot_id=None,
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    # not-found now maps to 404 (was wrongly 409 via hand-translation) with a
-    # fixed "Not found" message — cross-bot and missing are indistinguishable.
-    assert resp.status_code == 404
-    assert json.loads(resp.body)["message"] == "Not found"
-
-
-@pytest.mark.asyncio
-async def test_update_link_raises_409_on_url_conflict():
-    service = _StubService([])
-    factory = _StubFactory(service)
-    body = ResourceUpdate(url="conflict")
-
-    resp = await update_resource(
-        resource_id="1",
-        body=body,
-        user_id="u1",
-        bot_id=None,
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    assert resp.status_code == 409
-    assert json.loads(resp.body)["message"] == "Resource already exists"
-
-
-@pytest.mark.asyncio
-async def test_update_link_reads_x_trace_id_from_request():
-    factory = _StubFactory(_StubService([]))
-    request = _request_with_trace("trace-upd-1")
-    body = ResourceUpdate(name="renamed")
-
-    env = await update_resource(
-        resource_id="1",
-        body=body,
-        user_id="u1",
-        bot_id="bot-a",
-        factory=factory,
-        request=request,
-    )
-
-    assert env.request_id == "trace-upd-1"
-
-
-# ── delete_resource (Phase 3 Task 2 — first real device_fs handler) ────
-#
-# The device_fs resolution chain (principal → owner_id → resolver →
-# dispatcher → device_fs) is stubbed per-dependency to keep this a handler
-# unit test, not an integration test. owner_id comes from the verified
-# principal (caller_owner_id — fail-closed, bots parity); bot_repo stays
-# injected but is no longer used to fetch owner. delete_resource on the
-# concrete service is SYNC; the handler must NOT `await` it.
-# DeviceNotBoundError from resolver is out of scope here — the stub resolver
-# never raises.
-
 
 class _StubBotRepo:
-    """Two-method stub feeding the handler + get_device_info.
+    """Minimal ``BotRepository`` for ``_file_coords`` → ``resolve_engine_for_bot``."""
 
-    get_by_id returns the bot record dict (with ``owner_id``) or None;
-    get_device_provider_by_bot_id_and_owner returns the device binding
-    tuple (``{device_provider, sandbox_id}``) that get_device_info reads.
-    """
+    def __init__(self, active_engine: str = "aicoding"):
+        self._bot = {"active_engine": active_engine}
 
-    def __init__(self, bot_dict=None, device_info=None):
-        self._bot = bot_dict
-        self._device_info = device_info
+    def get_by_id_and_owner(self, bot_id, owner_id):
+        return self._bot
 
     def get_by_id(self, bot_id):
         return self._bot
 
-    def get_device_provider_by_bot_id_and_owner(self, bot_id, owner_id):
-        return self._device_info
-
-
-class _StubResolver:
-    """resolve_for_bot returns a minimal ctx object the dispatcher accepts."""
-
-    def resolve_for_bot(self, bot_id, user_id, *, device_uuid=None):
-        return SimpleNamespace(provider="arca", device_id="dev-1")
-
-
-class _StubDispatcher:
-    """dispatch returns the configured device_fs regardless of ctx."""
-
-    def __init__(self, device_fs):
-        self._fs = device_fs
-
-    def dispatch(self, ctx):
-        return self._fs
-
-
-class _StubDeviceFs:
-    """Records paths handed to delete_file / write_file / read_file; no real I/O."""
-
-    def __init__(self):
-        self.deleted_paths: list[str] = []
-        self.read_paths: list[str] = []
-        self.written: list[tuple[str, bytes]] = []
-        self._files: dict[str, bytes] = {}
-
-    async def delete_file(self, path):
-        self.deleted_paths.append(path)
-        self._files.pop(path, None)
-
-    async def write_file(self, path, data):
-        """Stub for the upload write seam. Records the write and stores the
-        bytes so a subsequent read_file round-trips them (integration tests
-        that exercise the real slim service's upload→download path get the
-        same bytes back, not a fixed payload)."""
-        self.written.append((path, data))
-        self._files[path] = data
-
-    async def read_file(self, file_path, *, enforce_download_limit=False):
-        """Stub for the preview / download read seam.
-
-        Records the path and returns the stored payload (from a prior
-        write_file) so integration tests get a real round-trip; falls back
-        to a fixed non-empty payload for stub-service tests that never
-        write first. Returns ``b""`` for paths ending in ``"missing"`` to
-        exercise the empty-content branch of the concrete service (legacy
-        parity: empty → 404, not an empty preview body).
-        """
-        self.read_paths.append(file_path)
-        if file_path in self._files:
-            return self._files[file_path]
-        if file_path.endswith("missing"):
-            return b""
-        return b"device-fs bytes"
-
 
 class _StubFileService:
-    """Stands in for ``ResourceFileService`` — the engine seam the file handlers
-    now delegate to.
+    """Stands in for ``ResourceFileService`` — the engine seam the handlers use.
 
     Records the workspace-relative paths it is handed, so a test can assert what
     address reached the device without reaching a device at all. ``existing``
@@ -1215,14 +204,20 @@ class _StubListFileService:
     Building the stub from the real shape matters: an earlier version returned
     the raw device shape, so the handler's path handling was asserted against a
     listing production never emits.
+
+    ``entries`` may be a flat list (returned for any directory) or a dict keyed
+    by the listed directory, which is what ``stat`` needs — it lists the
+    *parent* and picks the entry out.
     """
 
-    def __init__(self, entries: List[dict]):
+    def __init__(self, entries: List[dict] | dict[str, List[dict]]):
         self._entries = entries
         self.listed: List[str] = []
 
     async def list_dir(self, *, path, **_kw) -> List[dict]:
         self.listed.append(path)
+        if isinstance(self._entries, dict):
+            return self._entries.get(path, [])
         return self._entries
 
 
@@ -1240,84 +235,473 @@ def _listed(name: str, *, rel: str, is_dir: bool = False, size: int | None = 1) 
     }
 
 
-class _StubBotRepo:
-    """Minimal ``BotRepository`` for ``_file_coords`` → ``resolve_engine_for_bot``."""
+class _StubReadFileService(_StubFileService):
+    """Adds a readable workspace to the upload stub."""
 
-    def __init__(self, active_engine: str = "aicoding"):
-        self._bot = {"active_engine": active_engine}
+    def __init__(
+        self,
+        files: dict[str, bytes] | None = None,
+        *,
+        read_raises: Exception | None = None,
+        delete_raises: Exception | None = None,
+    ):
+        super().__init__(
+            existing=set((files or {}).keys()), delete_raises=delete_raises
+        )
+        self._files = dict(files or {})
+        self.read_raises = read_raises
+        self.read_paths: List[str] = []
+        self.deleted_paths: List[str] = []
+        self.made_dirs: List[str] = []
 
-    def get_by_id_and_owner(self, bot_id, owner_id):
-        return self._bot
+    async def exists(self, *, path, **_kw) -> bool:
+        """Occupancy follows the stored bytes, so an upload then a delete leave
+        the workspace in the state the handlers expect."""
+        self.exists_calls.append(path)
+        return path in self._files
 
-    def get_by_id(self, bot_id):
-        return self._bot
+    async def upload_file(self, **kwargs) -> dict:
+        info = await super().upload_file(**kwargs)
+        self._files[info["path"]] = kwargs["data"]
+        return info
+
+    async def read_file(self, *, path, enforce_download_limit=False, **_kw):
+        self.read_paths.append(path)
+        if self.read_raises is not None:
+            raise self.read_raises
+        return self._files.get(path)
+
+    async def delete(self, *, path, **_kw) -> bool:
+        self.deleted_paths.append(path)
+        if self.delete_raises is not None:
+            raise self.delete_raises
+        # The real service answers False when the device refused, so the stub
+        # reports the removal rather than returning None.
+        return self._files.pop(path, None) is not None
+
+    async def create_directory(self, *, path, **_kw):
+        self.made_dirs.append(path)
+
+    async def list_dir(self, *, path, **_kw) -> List[dict]:
+        """Whatever has been written, as the listing of its directory."""
+        out = []
+        for stored, data in self._files.items():
+            parent = stored.rsplit("/", 1)[0] if "/" in stored else ""
+            if parent == path:
+                out.append(
+                    _listed(
+                        stored.rsplit("/", 1)[-1], rel=stored, size=len(data)
+                    )
+                )
+        return out
 
 
-_DEFAULT_BOT = {"owner_id": "own-a", "bot_id": "b"}
-_DEFAULT_DEVICE_INFO = {"device_provider": "arca", "sandbox_id": "sb-1"}
+# ── the contract: no record ids anywhere on this surface ─────────────
 
 
-def _delete_deps(*, bot_dict=_DEFAULT_BOT, device_info=None, service=None):
-    """Bundle the three device_fs deps + a stub factory in one call site.
+def test_the_file_entry_schema_carries_no_record_id():
+    """``resource_id`` is gone from the contract rather than reported as ``""``.
 
-    Returns ``(factory, resolver, dispatcher, device_fs)``. ``bot_repo`` is no
-    longer in the bundle — the handlers no longer inject ``BotRepository``
-    (dead: the bot lookup lives in ``resolver.resolve_for_bot``). ``bot_dict``
-    / ``device_info`` are accepted for back-compat with call sites that still
-    pass them, but are unused now.
+    An empty string standing in for "no id" is a sentinel pretending to be an
+    address: a generated client sees a non-optional string and cannot express
+    absence except by comparing against a magic value. The same rule the router
+    already applied to the timestamps.
     """
-    device_fs = _StubDeviceFs()
-    return (
-        _StubFactory(service or _StubService([])),
-        _StubResolver(),
-        _StubDispatcher(device_fs),
-        device_fs,
-    )
+    assert set(FileEntry.model_fields) == {"path", "name", "type", "size"}
+
+
+def test_the_resource_type_enum_is_files_and_folders_only():
+    assert {t.value for t in OpenapiType} == {"file", "folder"}
+
+
+# ── list_resources ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_delete_returns_200_envelope_with_deleted_true():
-    service = _StubService([])
-    factory, resolver, dispatcher, device_fs = _delete_deps(service=service)
+async def test_list_returns_workspace_entries():
+    """Entries come from the workspace. A record-backed listing could not see a
+    file the bot produced itself — it has no record and never will."""
+    file_svc = _StubListFileService([
+        _listed("notes.md", rel="notes.md", size=12),
+        _listed("docs", rel="docs", is_dir=True),
+    ])
 
-    env = await delete_resource(
-        resource_id="1",
+    env = await list_resources(
+        page=PageParams(),
         owner_id="u1",
         bot_id="bot-x",
-        factory=factory,
+        path="",
+        type=None,
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
         request=_request_without_trace(),
     )
 
-    assert isinstance(env, Envelope)
+    assert env.data.total == 2
+    by_name = {i.name: i for i in env.data.items}
+    assert by_name["notes.md"].type == OpenapiType.FILE
+    assert by_name["notes.md"].path == "notes.md"
+    assert by_name["notes.md"].size == 12
+    assert by_name["docs"].type == OpenapiType.FOLDER
+    # A folder has no size to report, whatever the listing carried.
+    assert by_name["docs"].size is None
+
+
+@pytest.mark.asyncio
+async def test_list_joins_the_listed_directory_onto_entry_paths():
+    """The device reports ``relative_path`` relative to the listed directory, so
+    listing ``a/b`` must yield ``a/b/c.txt`` — the address a client hands back."""
+    file_svc = _StubListFileService([
+        _listed("c.txt", rel="a/b/c.txt"),
+    ])
+
+    env = await list_resources(
+        page=PageParams(),
+        owner_id="u1",
+        bot_id="bot-x",
+        path="a/b",
+        type=None,
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.items[0].path == "a/b/c.txt"
+    assert file_svc.listed == ["a/b"]
+
+
+@pytest.mark.asyncio
+async def test_list_never_exposes_the_container_path():
+    """The entry's ``absolute_path`` is the engine-view container path and must
+    not cross a public API."""
+    file_svc = _StubListFileService([
+        _listed("c.txt", rel="c.txt"),
+    ])
+
+    env = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
+        bot_repo=_StubBotRepo(), file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert "/home/admin" not in (env.data.items[0].path or "")
+
+
+@pytest.mark.asyncio
+async def test_list_folder_filter_returns_directories():
+    file_svc = _StubListFileService([
+        _listed("docs", rel="docs", is_dir=True),
+        _listed("a.txt", rel="a.txt"),
+    ])
+
+    env = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="",
+        type=OpenapiType.FOLDER,
+        bot_repo=_StubBotRepo(), file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert [i.name for i in env.data.items] == ["docs"]
+
+
+@pytest.mark.asyncio
+async def test_list_file_filter_excludes_directories():
+    file_svc = _StubListFileService([
+        _listed("docs", rel="docs", is_dir=True),
+        _listed("a.txt", rel="a.txt"),
+    ])
+
+    env = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="",
+        type=OpenapiType.FILE,
+        bot_repo=_StubBotRepo(), file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert [i.name for i in env.data.items] == ["a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_list_paginates_the_directory_in_memory():
+    """The engine's ``ListDirRequest`` carries no page, limit or cursor, so the
+    whole directory is fetched and sliced here. ``total`` is therefore exact —
+    and a later page costs exactly what the first one costs."""
+    file_svc = _StubListFileService([
+        _listed(f"f{n}.txt", rel=f"f{n}.txt") for n in range(5)
+    ])
+
+    env = await list_resources(
+        page=PageParams(page=2, page_size=2),
+        owner_id="u1", bot_id="bot-x", path="", type=None,
+        bot_repo=_StubBotRepo(), file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 5
+    assert [i.name for i in env.data.items] == ["f2.txt", "f3.txt"]
+    # One directory fetch, whichever page was asked for.
+    assert file_svc.listed == [""]
+
+
+@pytest.mark.asyncio
+async def test_list_reads_x_trace_id_from_request():
+    env = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
+        bot_repo=_StubBotRepo(), file_svc=_StubListFileService([]),
+        request=_request_with_trace("trace-list-1"),
+    )
+    assert env.request_id == "trace-list-1"
+
+
+@pytest.mark.asyncio
+async def test_list_empty_workspace_returns_empty_page():
+    env = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="", type=None,
+        bot_repo=_StubBotRepo(), file_svc=_StubListFileService([]),
+        request=_request_without_trace(),
+    )
+    assert env.data.total == 0
+    assert env.data.items == []
+
+
+@pytest.mark.asyncio
+async def test_list_of_an_absent_directory_is_an_empty_page_not_a_500():
+    """The baas providers re-raise the upstream 404 instead of answering
+    "nothing there", while providers returning ``None`` already produce an empty
+    page — so without normalizing, the same request is a 500 on one and an empty
+    page on the others."""
+
+    class _MissingDirService:
+        async def list_dir(self, **_kw):
+            raise _http_status(404)
+
+    env = await list_resources(
+        page=PageParams(page=1, page_size=10),
+        owner_id="u1",
+        bot_id="bot-x",
+        path="nope",
+        bot_repo=_StubBotRepo(),
+        file_svc=_MissingDirService(),
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 0
+    assert env.data.items == []
+
+
+@pytest.mark.asyncio
+async def test_list_does_not_swallow_other_upstream_statuses():
+    """Only 404 is an ordinary answer; an upstream fault must still surface."""
+
+    class _FailingDirService:
+        async def list_dir(self, **_kw):
+            raise _http_status(503)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await list_resources(
+            page=PageParams(page=1, page_size=10),
+            owner_id="u1",
+            bot_id="bot-x",
+            path="docs",
+            bot_repo=_StubBotRepo(),
+            file_svc=_FailingDirService(),
+            request=_request_without_trace(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_rejects_a_directory_escaping_the_workspace():
+    file_svc = _StubListFileService([])
+
+    resp = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="../../etc",
+        type=None, bot_repo=_StubBotRepo(),
+        file_svc=file_svc, request=_request_without_trace(),
+    )
+
+    assert resp.status_code == 400
+    assert file_svc.listed == []
+
+
+# ── stat: one entry, addressed by path ───────────────────────────────
+#
+# Replaces both ``GET /{resource_id}`` (which could not address a file at all)
+# and ``check-name`` (which asked the same existence question two ways). It is
+# resolved by listing the parent, so stat and list read the same seam and cannot
+# report different types or sizes for one file.
+
+
+@pytest.mark.asyncio
+async def test_stat_returns_the_entry_for_a_path():
+    file_svc = _StubListFileService({
+        "docs": [
+            _listed("a.txt", rel="docs/a.txt", size=42),
+            _listed("b.txt", rel="docs/b.txt", size=7),
+        ]
+    })
+
+    env = await stat_resource(
+        path="docs/a.txt",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
     assert env.code == CODE_OK
-    assert env.message == "OK"
-    assert env.data is not None
-    assert isinstance(env.data, Deleted)
-    assert env.data.deleted is True
-    # No device is threaded any more: this endpoint is link-only, and a link has
-    # no file to remove. Files are deleted through DELETE ""?path=.
-    assert service.last_call_device_fs is None
-    # service received the resource_id (no device_provider/sandbox_id on
-    # the slim contract — device_fs is the sole device boundary)
-    assert service.last_call_kwargs.get("resource_id") == "1"
-    # bot_id flowed through to factory.create
-    assert factory.created_bot_ids == ["bot-x"]
+    assert env.data.path == "docs/a.txt"
+    assert env.data.name == "a.txt"
+    assert env.data.type == OpenapiType.FILE
+    assert env.data.size == 42
+    # The *parent* is listed, not the file itself.
+    assert file_svc.listed == ["docs"]
+
+
+@pytest.mark.asyncio
+async def test_stat_of_a_root_level_entry_lists_the_workspace_root():
+    file_svc = _StubListFileService({"": [_listed("notes.md", rel="notes.md")]})
+
+    env = await stat_resource(
+        path="notes.md",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.path == "notes.md"
+    assert file_svc.listed == [""]
+
+
+@pytest.mark.asyncio
+async def test_stat_reports_a_directory_as_a_folder():
+    file_svc = _StubListFileService({"": [_listed("docs", rel="docs", is_dir=True)]})
+
+    env = await stat_resource(
+        path="docs",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.type == OpenapiType.FOLDER
+    assert env.data.size is None
+
+
+@pytest.mark.asyncio
+async def test_stat_404s_a_path_that_is_not_there():
+    file_svc = _StubListFileService({"docs": [_listed("a.txt", rel="docs/a.txt")]})
+
+    with pytest.raises(HTTPException) as exc:
+        await stat_resource(
+            path="docs/gone.txt",
+            owner_id="u1",
+            bot_id="bot-x",
+            bot_repo=_StubBotRepo(),
+            file_svc=file_svc,
+            request=_request_without_trace(),
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stat_404s_when_the_parent_directory_is_absent():
+    """An absent parent lists empty rather than raising, so the entry is simply
+    not found — the same answer as an absent leaf."""
+
+    class _MissingDirService:
+        async def list_dir(self, **_kw):
+            raise _http_status(404)
+
+    with pytest.raises(HTTPException) as exc:
+        await stat_resource(
+            path="nope/a.txt",
+            owner_id="u1",
+            bot_id="bot-x",
+            bot_repo=_StubBotRepo(),
+            file_svc=_MissingDirService(),
+            request=_request_without_trace(),
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stat_requires_a_path():
+    """The workspace root has no entry of its own — there is nothing to report
+    about it — so the empty path the listing accepts is refused here."""
+    resp = await stat_resource(
+        path="",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=_StubListFileService([]),
+        request=_request_without_trace(),
+    )
+
+    assert resp.status_code == 400
+    assert json.loads(resp.body)["message"] == "Invalid resource path"
+
+
+@pytest.mark.asyncio
+async def test_stat_rejects_a_path_escaping_the_workspace():
+    file_svc = _StubListFileService([])
+
+    resp = await stat_resource(
+        path="../../etc/passwd",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert resp.status_code == 400
+    assert file_svc.listed == []
+
+
+@pytest.mark.asyncio
+async def test_stat_and_list_agree_because_they_read_one_seam():
+    """The pair that used to diverge: a record said one thing and the workspace
+    another. Both now come from ``list_dir``, so they cannot."""
+    entries = {"docs": [_listed("a.txt", rel="docs/a.txt", size=99)]}
+
+    listed = await list_resources(
+        page=PageParams(), owner_id="u1", bot_id="bot-x", path="docs", type=None,
+        bot_repo=_StubBotRepo(), file_svc=_StubListFileService(entries),
+        request=_request_without_trace(),
+    )
+    statted = await stat_resource(
+        path="docs/a.txt", owner_id="u1", bot_id="bot-x",
+        bot_repo=_StubBotRepo(), file_svc=_StubListFileService(entries),
+        request=_request_without_trace(),
+    )
+
+    assert listed.data.items[0] == statted.data
+
+
+# ── the shared user_id dependency ────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_no_handler_can_fall_back_to_a_bot_derived_owner():
     """Owner-scoped routes take their owner from the request, or answer 401.
 
-    Four handlers used to be handed the principal and resolve the owner
-    themselves, and this file checked each one refused a ``None`` principal —
-    the property being that ``owner_id`` is never quietly recovered from
-    ``bot_repo.get_by_id`` for a caller who supplied no identity. The resolution
-    has since moved into ``require_user_id``, one dependency the whole surface
-    shares, so four copies of that check would only re-test the same function.
+    Handlers used to be handed the principal and resolve the owner themselves,
+    and this file checked each one refused a ``None`` principal — the property
+    being that ``owner_id`` is never quietly recovered from ``bot_repo`` for a
+    caller who supplied no identity. The resolution has since moved into
+    ``require_user_id``, one dependency the whole surface shares, so per-handler
+    copies would only re-test the same function.
 
     What still needs checking is that no route escapes it. A resources route
     added later without the dependency is exactly the silent fallback the
-    original four existed to prevent, so the guard is asserted over the mounted
+    original checks existed to prevent, so the guard is asserted over the mounted
     routes rather than per handler — and the fail-closed half is asserted once,
     on the seam itself.
     """
@@ -1326,11 +710,14 @@ async def test_no_handler_can_fall_back_to_a_bot_derived_owner():
         for route in _api_routes(build_public_router())
         if route.path.startswith("/openapi/v1/bots/resources")
     ]
-    # 11 routes: the id-addressed download and preview were replaced by the
-    # path-addressed download / preview / delete / mkdir. The count is a
-    # tripwire — a resources route added without the shared user_id dependency
-    # is exactly the silent owner fallback this guard exists to prevent.
-    assert len(mounted) == 11, [r.path for r in mounted]
+    # 7 routes, all path-addressed. The count is a tripwire — a resources route
+    # added without the shared user_id dependency is exactly the silent owner
+    # fallback this guard exists to prevent.
+    assert len(mounted) == 7, [r.path for r in mounted]
+    # And none of them is addressed by a record id: the group has no path
+    # parameters at all now, so a future ``/{resource_id}`` cannot creep back in
+    # without this failing.
+    assert not [r for r in mounted if "{" in r.path], [r.path for r in mounted]
 
     def guarded(dependant) -> bool:
         return dependant.call is require_user_id or any(
@@ -1358,76 +745,7 @@ def _api_routes(router_) -> list:
     return found
 
 
-@pytest.mark.asyncio
-async def test_delete_raises_404_when_resource_missing():
-    # service.delete_resource returns False for resource_id == "0"
-    service = _StubService([])
-    factory, resolver, dispatcher, _ = _delete_deps(service=service)
-
-    with pytest.raises(HTTPException) as exc:
-        await delete_resource(
-            resource_id="0",
-            owner_id="u1",
-            bot_id="bot-a",
-            factory=factory,
-            request=_request_without_trace(),
-        )
-
-    assert exc.value.status_code == 404
-    assert exc.value.detail == "Resource not found"
-
-
-@pytest.mark.asyncio
-async def test_delete_resource_404s_a_file_id_without_dropping_the_row():
-    """Without the refusal the row would soft-delete and the handler would
-    report success while the workspace file stayed put — a stale file id that
-    "works" and quietly widens the divergence. The file's address is its path."""
-    service = _StubService(
-        [_legacy(id=7, name="a.txt", resource_type=LegacyType.FILE)]
-    )
-
-    with pytest.raises(HTTPException) as exc:
-        await delete_resource(
-            resource_id="7",
-            owner_id="u1",
-            bot_id="bot-x",
-            factory=_StubFactory(service),
-            request=_request_without_trace(),
-        )
-
-    assert exc.value.status_code == 404
-    assert service.deleted == []  # the row is untouched
-
-
-@pytest.mark.asyncio
-async def test_delete_reads_x_trace_id_from_request():
-    factory, resolver, dispatcher, _ = _delete_deps()
-    request = _request_with_trace("trace-del-1")
-
-    env = await delete_resource(
-        resource_id="1",
-        owner_id="u1",
-        bot_id="bot-a",
-        factory=factory,
-        request=request,
-    )
-
-    assert env.request_id == "trace-del-1"
-
-
-# ── upload_resource (Phase 3 Task 3 — second real device_fs handler) ──
-#
-# Same device_fs resolution chain as Task 2 delete (principal → owner_id
-# → resolver.resolve_for_bot → dispatcher.dispatch → device_fs), but
-# upload does NOT call get_device_info (that's a delete-only concern for
-# picking arca/local). upload_file on the concrete service is ASYNC — the
-# handler must ``await`` it. ValueError (duplicate name) → 409 Conflict
-# (legacy + create parity).
-#
-# Reuses the ``_delete_deps`` helper — the 4 device_fs stubs it bundles
-# (factory/bot_repo/resolver/dispatcher/device_fs) are device_fs-wiring-
-# generic, not delete-specific. The name is a Task 2 artifact; renaming
-# would churn Task 2 tests without value.
+# ── upload_resource ──────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -1439,7 +757,7 @@ async def test_upload_hands_the_workspace_relative_path_to_the_engine_seam():
         content=b"file bytes",
         owner_id="u1",
         bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
+        factory=_StubFactory(),
         bot_repo=_StubBotRepo(),
         file_svc=file_svc,
         request=_request_without_trace(),
@@ -1474,7 +792,7 @@ async def test_upload_keeps_the_directories_carried_by_the_path():
         content=b"x",
         owner_id="u1",
         bot_id="bot-x",
-        factory=_StubFactory(_StubService([])),
+        factory=_StubFactory(),
         bot_repo=_StubBotRepo(),
         file_svc=file_svc,
         request=_request_without_trace(),
@@ -1515,7 +833,7 @@ async def test_upload_403s_a_read_only_path(path):
             content=b"x",
             owner_id="u1",
             bot_id="bot-x",
-            factory=_StubFactory(_StubService([])),
+            factory=_StubFactory(),
             bot_repo=_StubBotRepo(),
             file_svc=file_svc,
             request=_request_without_trace(),
@@ -1588,6 +906,105 @@ async def test_upload_409_when_the_path_is_already_taken():
 
 
 @pytest.mark.asyncio
+async def test_upload_overwrite_replaces_an_occupied_path():
+    """Without this the only way to change a file's content is delete-then-upload
+    — two calls, racy, and the file is gone outright if the second one fails."""
+    service = _StubService()
+    file_svc = _StubReadFileService({"docs/a.txt": b"old"})
+
+    env = await upload_resource(
+        path="docs/a.txt",
+        content=b"new bytes",
+        overwrite=True,
+        owner_id="u1",
+        bot_id="bot-x",
+        factory=_StubFactory(service),
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert env.code == CODE_CREATED
+    assert env.data.path == "docs/a.txt"
+    assert file_svc._files["docs/a.txt"] == b"new bytes"
+
+
+@pytest.mark.asyncio
+async def test_upload_overwrite_replaces_the_record_rather_than_adding_one():
+    """``record_uploaded_file`` always inserts, so leaving the prior row would
+    give one path two rows — and publish the file twice in the manifest."""
+    service = _StubService()
+
+    await upload_resource(
+        path="docs/a.txt",
+        content=b"new",
+        overwrite=True,
+        owner_id="u1",
+        bot_id="bot-x",
+        factory=_StubFactory(service),
+        bot_repo=_StubBotRepo(),
+        file_svc=_StubReadFileService({"docs/a.txt": b"old"}),
+        request=_request_without_trace(),
+    )
+
+    assert service.record_deletes == ["docs/a.txt"]
+    assert [r["path"] for r in service.recorded] == ["docs/a.txt"]
+
+
+@pytest.mark.asyncio
+async def test_upload_without_overwrite_leaves_the_record_alone():
+    """A fresh upload has no prior row to drop, and dropping on this branch
+    would delete rows for a path the caller was refused anyway."""
+    service = _StubService()
+
+    await upload_resource(
+        path="docs/new.txt",
+        content=b"x",
+        owner_id="u1",
+        bot_id="bot-x",
+        factory=_StubFactory(service),
+        bot_repo=_StubBotRepo(),
+        file_svc=_StubReadFileService({}),
+        request=_request_without_trace(),
+    )
+
+    assert service.record_deletes == []
+    assert [r["path"] for r in service.recorded] == ["docs/new.txt"]
+
+
+@pytest.mark.asyncio
+async def test_upload_overwrite_does_not_roll_the_file_back_on_a_record_failure():
+    """A fresh upload rolls back because its retry is blocked by the 409. An
+    overwrite's prior bytes are already gone, so deleting the file would destroy
+    content rather than restore it — and the retry is not blocked, because an
+    overwrite does not 409. So the bytes stay and the caller is told to retry."""
+
+    class _ExplodingFactory:
+        def create(self, *, bot_id):
+            raise RuntimeError("repo down")
+
+    file_svc = _StubReadFileService({"a.txt": b"old"})
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt",
+            content=b"new",
+            overwrite=True,
+            owner_id="u1",
+            bot_id="bot-x",
+            factory=_ExplodingFactory(),
+            bot_repo=_StubBotRepo(),
+            file_svc=file_svc,
+            request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 502
+    # The new bytes are still there — not deleted out from under the caller.
+    assert file_svc.deleted_paths == []
+    assert file_svc._files["a.txt"] == b"new"
+
+
+@pytest.mark.asyncio
 async def test_upload_same_leaf_name_in_two_directories_does_not_collide():
     """The old row-level ``(name, parent_path)`` check reported these as a
     duplicate; two distinct paths are two distinct files."""
@@ -1598,7 +1015,7 @@ async def test_upload_same_leaf_name_in_two_directories_does_not_collide():
         content=b"x",
         owner_id="u1",
         bot_id="bot-a",
-        factory=_StubFactory(_StubService([])),
+        factory=_StubFactory(),
         bot_repo=_StubBotRepo(),
         file_svc=file_svc,
         request=_request_without_trace(),
@@ -1653,7 +1070,7 @@ async def test_upload_reads_x_trace_id_from_request():
         content=b"x",
         owner_id="u1",
         bot_id="bot-a",
-        factory=_StubFactory(_StubService([])),
+        factory=_StubFactory(),
         bot_repo=_StubBotRepo(),
         file_svc=_StubFileService(),
         request=_request_with_trace("trace-up-1"),
@@ -1661,61 +1078,8 @@ async def test_upload_reads_x_trace_id_from_request():
 
     assert env.request_id == "trace-up-1"
 
+
 # ── file read: download / preview, addressed by workspace path ───────
-#
-# These replaced the id-addressed ``/{resource_id}/download`` and
-# ``/preview``. A record id cannot address a file the bot created itself, and
-# the record no longer decides existence, so the workspace path is the address.
-# The handlers reach the device through ``ResourceFileService``, so the tests
-# assert on the workspace-relative path handed to that seam.
-
-
-class _StubReadFileService(_StubFileService):
-    """Adds a readable workspace to the upload stub."""
-
-    def __init__(
-        self,
-        files: dict[str, bytes] | None = None,
-        *,
-        read_raises: Exception | None = None,
-        delete_raises: Exception | None = None,
-    ):
-        super().__init__(
-            existing=set((files or {}).keys()), delete_raises=delete_raises
-        )
-        self._files = dict(files or {})
-        self.read_raises = read_raises
-        self.read_paths: List[str] = []
-        self.deleted_paths: List[str] = []
-        self.made_dirs: List[str] = []
-
-    async def exists(self, *, path, **_kw) -> bool:
-        """Occupancy follows the stored bytes, so an upload then a delete leave
-        the workspace in the state the handlers expect."""
-        self.exists_calls.append(path)
-        return path in self._files
-
-    async def upload_file(self, **kwargs) -> dict:
-        info = await super().upload_file(**kwargs)
-        self._files[info["path"]] = kwargs["data"]
-        return info
-
-    async def read_file(self, *, path, enforce_download_limit=False, **_kw):
-        self.read_paths.append(path)
-        if self.read_raises is not None:
-            raise self.read_raises
-        return self._files.get(path)
-
-    async def delete(self, *, path, **_kw) -> bool:
-        self.deleted_paths.append(path)
-        if self.delete_raises is not None:
-            raise self.delete_raises
-        # The real service answers False when the device refused, so the stub
-        # reports the removal rather than returning None.
-        return self._files.pop(path, None) is not None
-
-    async def create_directory(self, *, path, **_kw):
-        self.made_dirs.append(path)
 
 
 @pytest.mark.asyncio
@@ -1783,6 +1147,9 @@ async def test_preview_returns_decoded_content():
     assert env.code == CODE_OK
     assert env.data.content == "hello"
     assert env.data.content_type == "application/octet-stream"
+    # The preview reports the path it was asked for, so the response names the
+    # address the caller can reuse — there is no id to name it by.
+    assert env.data.path == "a.txt"
 
 
 @pytest.mark.asyncio
@@ -1802,14 +1169,6 @@ async def test_preview_413_when_over_the_cap():
     # could mistake for the whole file.
     assert resp.status_code == 413
     assert json.loads(resp.body)["message"] == "File too large for preview"
-
-
-def _http_status(code: int) -> httpx.HTTPStatusError:
-    """The error a baas provider re-raises from the upstream file API."""
-    request = httpx.Request("POST", "http://baas/api/file/read")
-    return httpx.HTTPStatusError(
-        f"HTTP {code}", request=request, response=httpx.Response(code, request=request)
-    )
 
 
 @pytest.mark.asyncio
@@ -1922,17 +1281,11 @@ async def test_preview_decodes_invalid_utf8_rather_than_failing():
 async def test_delete_file_removes_it_from_the_workspace():
     file_svc = _StubReadFileService({"docs/a.txt": b"x"})
 
-    class _NoopFactory:
-        def create(self, *, bot_id):
-            return SimpleNamespace(
-                delete_file_record=lambda **kw: _async_true()
-            )
-
     env = await delete_file(
         path="docs/a.txt",
         owner_id="u1",
         bot_id="bot-x",
-        factory=_NoopFactory(),
+        factory=_StubFactory(),
         bot_repo=_StubBotRepo(),
         file_svc=file_svc,
         request=_request_without_trace(),
@@ -2040,16 +1393,12 @@ async def test_delete_file_502_when_the_device_refuses():
 
     file_svc = _RefusingFileService({"docs/a.txt": b"x"})
 
-    class _NoopFactory:
-        def create(self, *, bot_id):
-            return SimpleNamespace(delete_file_record=lambda **kw: _async_true())
-
     with pytest.raises(HTTPException) as exc:
         await delete_file(
             path="docs/a.txt",
             owner_id="u1",
             bot_id="bot-x",
-            factory=_NoopFactory(),
+            factory=_StubFactory(),
             bot_repo=_StubBotRepo(),
             file_svc=file_svc,
             request=_request_without_trace(),
@@ -2091,34 +1440,25 @@ async def test_mkdir_creates_a_directory_without_a_record():
     assert env.code == CODE_CREATED
     assert env.data.type == OpenapiType.FOLDER
     assert env.data.path == "docs/spec"
-    # Physical only — no record, so no record id.
-    assert env.data.resource_id == ""
+    assert env.data.name == "spec"
     assert file_svc.made_dirs == ["docs/spec"]
 
 
-async def _async_true() -> bool:
-    return True
-
-
-# ── End-to-end integration (review #8) ──────────────────────────────
+# ── End-to-end integration ──────────────────────────────────────────
 #
-# The stub-service unit tests above pass even when the real factory's
-# service is missing methods (the stub supplies them). This block uses the
-# REAL ``ResourceServiceFactory`` (factory.create → real slim
-# ``ResourceService``, not a stub) backed by a REAL in-memory repository
-# (non-mock, so the slim service's real create/get/delete logic actually
-# runs) + a stub device_fs. A missing method or a handler↔service signature
-# mismatch fails here instead of in production.
+# The stub-service tests above pass even when the real factory's service is
+# missing methods (the stub supplies them). This block uses the REAL
+# ``ResourceServiceFactory`` (factory.create → real slim ``ResourceService``)
+# backed by a REAL in-memory repository, so the record writes the publish
+# pipeline depends on actually run. A missing method or a handler↔service
+# signature mismatch fails here instead of in production.
 
 
 class _InMemoryResourceRepo:
     """Minimal real ``ResourceRepositoryProtocol`` for integration tests.
 
     Non-mock: create stores a row, get_by_id reads it back, delete
-    soft-deletes it. The slim service's real logic runs against this, so
-    the create→get→list→delete round-trip is exercised end-to-end
-    (only the storage layer is faked — everything above it is production
-    code).
+    soft-deletes it. The slim service's real logic runs against this.
     """
 
     def __init__(self) -> None:
@@ -2210,11 +1550,10 @@ def _real_factory_with_inmemory_repo() -> tuple[
 ]:
     """Construct the REAL factory backed by a real in-memory repository.
 
-    ``ResourceServiceFactory.__init__`` is ``@inject``-decorated, but
-    direct construction with an explicit ``repository=`` bypasses injection
-    (same path the injector takes in prod). ``factory.create(bot_id=…)``
-    returns the real slim ``ResourceService`` — the exact object the
-    openapi_v1 handlers receive.
+    ``ResourceServiceFactory.__init__`` is ``@inject``-decorated, but direct
+    construction with an explicit ``repository=`` bypasses injection (same path
+    the injector takes in prod). ``factory.create(bot_id=…)`` returns the real
+    slim ``ResourceService`` — the exact object the openapi_v1 handlers receive.
     """
     repo = _InMemoryResourceRepo()
     factory = ResourceServiceFactory(repository=repo)
@@ -2222,72 +1561,14 @@ def _real_factory_with_inmemory_repo() -> tuple[
 
 
 @pytest.mark.asyncio
-async def test_real_factory_service_supports_all_handler_methods_e2e():
-    """End-to-end: real factory → real slim service → all 5 new methods.
-
-    Exercises the full create→get→list→upload→download→preview→delete
-    round-trip through:
-
-    - the REAL ``ResourceServiceFactory.create`` (factory bug surface),
-    - the REAL slim ``ResourceService`` (the 5 methods added in review #4),
-    - a REAL in-memory repository (create/get/delete actually run),
-    - a stub device_fs (file bytes round-trip through write_file/read_file).
-
-    A missing method on the slim service (the review #4 bug) or a
-    handler↔service signature mismatch (review #8) fails here.
-    """
+async def test_real_factory_service_supports_every_handler_path_e2e():
+    """upload → stat → list → download → preview → delete → re-upload, through
+    the REAL factory and slim service against a real in-memory repository."""
     factory, repo = _real_factory_with_inmemory_repo()
-    device_fs = _StubDeviceFs()
-
-    resolver = _StubResolver()
-    dispatcher = _StubDispatcher(device_fs)
-
-    # 1. create a LINK via the create handler (exercises factory.create →
-    #    service.create_url_resource, already present on the slim service).
-    env = await create_resource(
-        body=ResourceCreate(name="doc", type=OpenapiType.LINK, url="https://x.com"),
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    assert env.code == CODE_CREATED
-    link_id = env.data.resource_id
-    assert link_id  # factory really persisted via repo.create
-
-    # 2. get it back (exercises factory.create → service.get_resource —
-    #    the new slim method). The real repo round-trips the stored row.
-    env = await get_resource(
-        resource_id=link_id,
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    assert env.code == CODE_OK
-    assert env.data.resource_id == link_id
-    assert env.data.name == "doc"
-    assert env.data.type == OpenapiType.LINK
-    assert env.data.url == "https://x.com"
-
-    # 3. list — the link comes from the real repo (a link has no file), and the
-    #    workspace half comes from the device.
-    env = await list_resources(
-        page=PageParams(),
-        owner_id="u1",
-        bot_id="bot-x",
-        path="",
-        type=None,
-        factory=factory,
-        bot_repo=_StubBotRepo(),
-        file_svc=_StubListFileService([]),
-        request=_request_without_trace(),
-    )
-    assert env.data.total >= 1
-    assert any(item.resource_id == link_id for item in env.data.items)
-    # 4. upload a FILE by workspace path (real factory writes the enrichment
-    #    record; the engine seam is stubbed, since a device is not under test).
     file_svc = _StubReadFileService({})
+
+    # 1. upload a file by workspace path; the real factory writes the record the
+    #    publish pipeline reads.
     env = await upload_resource(
         path="docs/hello.txt",
         content=b"file bytes",
@@ -2302,15 +1583,39 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     assert env.data.type == OpenapiType.FILE
     assert env.data.path == "docs/hello.txt"
     assert env.data.size == len(b"file bytes")
-    # The real repo stored the record, with the uploader the console reads.
     file_row = list(repo._rows.values())[-1]
     assert file_row["attributes"]["path"] == "docs/hello.txt"
     assert file_row["user_id"] == "u1"
 
-    # 5. download it back by the same path the upload reported — the address a
-    #    client actually round-trips.
+    # 2. stat it back by the path the upload reported — the address a client
+    #    actually round-trips.
+    env_s = await stat_resource(
+        path="docs/hello.txt",
+        owner_id="u1",
+        bot_id="bot-x",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+    assert env_s.data.path == "docs/hello.txt"
+    assert env_s.data.size == len(b"file bytes")
+
+    # 3. list its directory.
+    env_l = await list_resources(
+        page=PageParams(),
+        owner_id="u1",
+        bot_id="bot-x",
+        path="docs",
+        type=None,
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+    assert [i.path for i in env_l.data.items] == ["docs/hello.txt"]
+
+    # 4. download and preview it.
     response = await download_file(
-        path=env.data.path,
+        path="docs/hello.txt",
         owner_id="u1",
         bot_id="bot-x",
         bot_repo=_StubBotRepo(),
@@ -2319,7 +1624,6 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     )
     assert response.body == b"file bytes"
 
-    # 6. preview it.
     env_p = await preview_file(
         path="docs/hello.txt",
         owner_id="u1",
@@ -2330,7 +1634,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     )
     assert env_p.data.content == "file bytes"
 
-    # 7. delete it — the file goes, and the real record goes with it.
+    # 5. delete it — the file goes, and the real record goes with it.
     rows_before = len([r for r in repo._rows.values() if r.get("status") != "deleted"])
     env_d = await delete_file(
         path="docs/hello.txt",
@@ -2346,7 +1650,7 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     rows_after = len([r for r in repo._rows.values() if r.get("status") != "deleted"])
     assert rows_after == rows_before - 1
 
-    # 8. the path is free again, so the same upload succeeds rather than 409ing.
+    # 6. the path is free again, so the same upload succeeds rather than 409ing.
     env2 = await upload_resource(
         path="docs/hello.txt",
         content=b"again",
@@ -2359,85 +1663,37 @@ async def test_real_factory_service_supports_all_handler_methods_e2e():
     )
     assert env2.code == CODE_CREATED
 
-# ── Fix #2 (review round-2): cross-bot ownership isolation ──────────
-#
-# get / delete / download / preview had ZERO bolt_id ownership check
-# (round-1 regression): the only guard before round-2 was
-# update_link_resource. A cross-bot resource_id would happily read /
-# delete / download / preview a foreign bot's resource. Fix #2 collapses
-# cross-bot access to None (→404 for get/download/preview) / False
-# (→404 for delete), matching update_link_resource's invariant. These
-# tests back the check with the REAL slim service + REAL in-memory repo
-# so the bug surface is exactly what production sees.
 
+@pytest.mark.asyncio
+async def test_overwrite_leaves_one_live_record_for_the_path_e2e():
+    """Against the real service: the replaced row is soft-deleted and exactly one
+    live row remains, so the publish manifest lists the file once."""
+    factory, repo = _real_factory_with_inmemory_repo()
+    file_svc = _StubReadFileService({})
 
-def _seed_foreign_resource(repo, *, bolt_id="other-bot") -> str:
-    """Insert a row owned by a foreign bolt_id and return its str(id).
-
-    Mirrors the shape ``_dict_to_resource`` accepts (Resource.id is
-    Optional[Any] so int ids are fine; the store path uses str keys).
-    """
-    from datetime import datetime
-
-    ts = datetime(2026, 7, 28, 10, 0).isoformat()
-    stored = repo.create(
-        {
-            "name": "foreign-link",
-            "resource_type": "link",
-            "status": "active",
-            "gmt_created": ts,
-            "gmt_modified": ts,
-            "attributes": {"url": "https://foreign.example", "link_type": "external"},
-            "user_id": "u-foreign",
-            "bolt_id": bolt_id,
-        }
+    await upload_resource(
+        path="docs/a.txt", content=b"one", owner_id="u1", bot_id="bot-x",
+        factory=factory, bot_repo=_StubBotRepo(), file_svc=file_svc,
+        request=_request_without_trace(),
     )
-    return str(stored["id"])
+    await upload_resource(
+        path="docs/a.txt", content=b"two", overwrite=True, owner_id="u1",
+        bot_id="bot-x", factory=factory, bot_repo=_StubBotRepo(),
+        file_svc=file_svc, request=_request_without_trace(),
+    )
 
+    live = [
+        r for r in repo._rows.values()
+        if r.get("status") != "deleted"
+        and (r.get("attributes") or {}).get("path") == "docs/a.txt"
+    ]
+    assert len(live) == 1
+    assert file_svc._files["docs/a.txt"] == b"two"
 
-@pytest.mark.asyncio
-async def test_get_resource_returns_404_for_cross_bot_resource_id():
-    factory, repo = _real_factory_with_inmemory_repo()
-    foreign_id = _seed_foreign_resource(repo)
-
-    with pytest.raises(HTTPException) as exc:
-        await get_resource(
-            resource_id=foreign_id,
-            user_id="u1",
-            bot_id="bot-x",
-            factory=factory,
-            request=_request_without_trace(),
-        )
-    assert exc.value.status_code == 404
-    assert exc.value.detail == "Resource not found"
-
-
-@pytest.mark.asyncio
-async def test_delete_resource_returns_404_for_cross_bot_resource_id():
-    factory, repo = _real_factory_with_inmemory_repo()
-    foreign_id = _seed_foreign_resource(repo)
-
-    resolver = _StubResolver()
-    dispatcher = _StubDispatcher(_StubDeviceFs())
-
-    with pytest.raises(HTTPException) as exc:
-        await delete_resource(
-            resource_id=foreign_id,
-            owner_id="u1",
-            bot_id="bot-x",
-            factory=factory,
-            request=_request_without_trace(),
-        )
-    assert exc.value.status_code == 404
-    assert exc.value.detail == "Resource not found"
-    # Foreign row must NOT be soft-deleted by the cross-bot delete call.
-    row = repo.get_by_id(foreign_id)
-    assert row.get("status") == "active"
 
 @pytest.mark.asyncio
 async def test_file_reads_are_scoped_to_the_requested_bot():
-    """Replaces the cross-bot ``resource_id`` isolation tests for download and
-    preview.
+    """Replaces the cross-bot ``resource_id`` isolation tests.
 
     Those guarded against reading another bot's file by passing its record id.
     Path addressing removes the vector rather than guarding it: there is no
@@ -2460,49 +1716,7 @@ async def test_file_reads_are_scoped_to_the_requested_bot():
 
 
 @pytest.mark.asyncio
-async def test_same_bot_get_works_after_isolation_invariant():
-    """Control: same-bot read still returns 200 — the ownership guard
-    doesn't accidentally quarantine the bot's own resources."""
-    factory, repo = _real_factory_with_inmemory_repo()
-    own_id = _seed_foreign_resource(repo, bolt_id="bot-x")
-
-    env = await get_resource(
-        resource_id=own_id,
-        user_id="u1",
-        bot_id="bot-x",
-        factory=factory,
-        request=_request_without_trace(),
-    )
-    assert env.code == CODE_OK
-    assert env.data.resource_id == own_id
-    assert env.data.type == OpenapiType.LINK
-
-
-# ── Fix #3 (review round-2): upload surfaces device_fs write failure as 502 ─
-#
-# Round-1 ``upload_file`` did ``try ... except Exception: logger.warning(...)``
-# around ``device_fs.write_file`` then ran ``repo.create`` anyway — file
-# write failed but the handler returned 201 with a phantom record pointing
-# at a path with no bytes. Fix #3 lets the write exception bubble so the
-# handler is the single translation point: any non-ValueError from
-# ``upload_file`` → 502 Bad Gateway AND no DB row created.
-
-
-class _FailingDeviceFs:
-    """device_fs stub where every op raises — exercises the 502 path."""
-
-    async def write_file(self, path, data):
-        raise OSError("disk full")
-
-    async def read_file(self, file_path, *, enforce_download_limit=False):
-        raise OSError("disk read failure")
-
-    async def delete_file(self, path):
-        raise OSError("disk delete failure")
-
-
-@pytest.mark.asyncio
-async def test_upload_returns_502_when_the_device_write_fails():
+async def test_upload_returns_502_when_the_device_write_fails_e2e():
     factory, repo = _real_factory_with_inmemory_repo()
     rows_before = len(repo._rows)
 
@@ -2543,11 +1757,6 @@ async def test_upload_records_the_uploader_for_the_console():
 
     assert env.code == CODE_CREATED
     assert env.data.path == "docs/a.txt"
-    # The row is written but never read back: the response is built from the
-    # workspace, so it reports the same empty id and null source/timestamps a
-    # listing of this file would. See
-    # ``test_upload_reports_the_file_the_way_a_listing_would``.
-    assert env.data.resource_id == ""
     row = list(repo._rows.values())[-1]
     assert row["user_id"] == "u1"
     assert row["created_by"] == "u1"
@@ -2561,9 +1770,7 @@ async def test_upload_records_the_uploader_for_the_console():
 async def test_upload_reports_the_file_the_way_a_listing_would():
     """The row is the publish pipeline's input, not something this API reads
     back. Sourcing the response from it would make the upload the one file
-    response shaped differently from every other — and the id it echoed could
-    not address anything anyway, since files are path-addressed and
-    ``GET /{resource_id}`` 404s a file row."""
+    response shaped differently from every other."""
     factory, _ = _real_factory_with_inmemory_repo()
 
     env = await upload_resource(
@@ -2577,10 +1784,6 @@ async def test_upload_reports_the_file_the_way_a_listing_would():
         request=_request_without_trace(),
     )
 
-    assert env.data.resource_id == ""
-    assert env.data.source is None
-    assert env.data.gmt_create is None
-    assert env.data.gmt_modified is None
     # What the caller can actually use: the path, which every file endpoint takes.
     assert env.data.path == "docs/a.txt"
     assert env.data.name == "a.txt"
@@ -2682,13 +1885,13 @@ async def test_upload_still_fails_when_the_rollback_itself_fails():
 
 
 @pytest.mark.asyncio
-async def test_upload_409_takes_precedence_over_502_path():
+async def test_upload_409_takes_precedence_over_the_502_path():
     """With both conditions live (occupied path AND a failing device), the
     occupancy check runs first, so the 409 surfaces — not the 502. Pins the
     ordering: an upload must never attempt a write it would refuse anyway.
 
-    Occupancy is now decided by the workspace rather than by a row, so the seed
-    is a file present on the device, not a record.
+    Occupancy is decided by the workspace rather than by a row, so the seed is a
+    file present on the device, not a record.
     """
     factory, repo = _real_factory_with_inmemory_repo()
     rows_before = len(repo._rows)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -300,9 +300,15 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: them, all four taking ``bot_id`` as a query parameter — which is what it is
 #: there, since the address is the file's path and not the bot's.
 #:
+#: ``query`` then moved 20 → 16 when the resources group became files-only: the
+#: five record-addressed operations went with the links they served (``POST ""``,
+#: ``GET``/``PUT``/``DELETE /{resource_id}``, ``check-name``) and ``GET /stat``
+#: replaced them, all query-addressed like the rest of the group. ``path`` is
+#: untouched by that: those five carried ``{resource_id}``, never a ``{bot_id}``.
+#:
 #: ``path`` moved 31 → 34 with the startup-script operations (GET/PUT/DELETE on
 #: ``/bots/{bot_id}/startup-script``) — all three address a bot, none moved.
-_BOT_ID_PLACEMENT = {"path": 34, "query": 20, "none": 21}
+_BOT_ID_PLACEMENT = {"path": 34, "query": 16, "none": 21}
 
 
 def _schema() -> dict:
@@ -350,15 +356,22 @@ def test_the_pinned_number_of_operations_take_it():
     (#1000): four new operations (``DELETE ""``, ``/download``, ``/preview``,
     ``/mkdir``) replaced two id-addressed ones, and every one of them takes the
     caller's ``user_id`` like the rest of the user-scoped surface.
+
+    65 → 61 when the resources group became files-only: five record-addressed
+    operations were removed and ``GET /stat`` added. A *drop* is the direction
+    this pin exists to catch, so it is worth saying plainly that this one is
+    intended — the five went away with the link resources they served, not by
+    losing the dependency.
     """
     taking = [
         1
         for path, method, operation in _operations(_schema())
         if _user_scoped(path, method) and _param(operation, USER_ID_QUERY)
     ]
-    # 60 on the merge base, +3 for the startup-script operations and +2 for the
-    # resources file endpoints re-addressed by workspace path (#1000).
-    assert len(taking) == 65
+    # 60 on the merge base, +3 for the startup-script operations, +2 for the
+    # resources file endpoints re-addressed by workspace path (#1000), then -4
+    # for the files-only resources group.
+    assert len(taking) == 61
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/framework/coverage_baseline.txt
+++ b/src/backend/tests/community/framework/coverage_baseline.txt
@@ -27,6 +27,14 @@
 # unit tests in tests/community/adapters/http/openapi_v1/resources/. Hand edited
 # rather than regenerated, to keep these notes.
 #
+# 2026-08-14: the resources group became files-only, so the record-addressed
+# routes went with the links they served: `POST ""`, `GET/PUT/DELETE
+# /{resource_id}` and `check-name` are removed (five lines), and `GET /stat`
+# takes over the single-entry lookup (one line, landing here for the same single
+# reason as every other /openapi/v1 entry above -- no principal minter in the
+# harness). Net debt shrinks by four; nothing tracked here was left uncovered at
+# a new address. Hand edited rather than regenerated, to keep these notes.
+#
 # Comments survive hand edits; `python -m tests.community.framework.coverage_gate
 # --regen` rewrites the file and drops them.
 #
@@ -49,7 +57,6 @@ DELETE /api/skillsets/{skill_set_id}/skills/{skill_id}: missing [happy, error]
 DELETE /api/skillsets/{skill_set_id}: missing [happy, error]
 DELETE /api/v1/expert-chats/{bot_id}/{owner_id}/session: missing [happy, error]
 DELETE /api/v1/expert-chats/{bot_id}/{owner_id}: missing [happy, error]
-DELETE /openapi/v1/bots/resources/{resource_id}: missing [happy, error]
 DELETE /openapi/v1/bots/resources: missing [happy, error]
 DELETE /openapi/v1/bots/routines/{routine_id}: missing [happy, error]
 DELETE /openapi/v1/bots/sessions/{bot_id}/{session_id}/messages: missing [happy, error]
@@ -187,10 +194,9 @@ GET /openapi/v1/bots/mcp/servers/{server_code}/permissions: missing [happy, erro
 GET /openapi/v1/bots/mcp/servers/{server_code}: missing [happy, error]
 GET /openapi/v1/bots/mcp/servers: missing [happy, error]
 GET /openapi/v1/bots/mcp/tenants: missing [happy, error]
-GET /openapi/v1/bots/resources/check-name: missing [happy, error]
 GET /openapi/v1/bots/resources/download: missing [happy, error]
 GET /openapi/v1/bots/resources/preview: missing [happy, error]
-GET /openapi/v1/bots/resources/{resource_id}: missing [happy, error]
+GET /openapi/v1/bots/resources/stat: missing [happy, error]
 GET /openapi/v1/bots/resources: missing [happy, error]
 GET /openapi/v1/bots/routines/{routine_id}/runs: missing [happy, error]
 GET /openapi/v1/bots/routines/{routine_id}: missing [happy, error]
@@ -357,7 +363,6 @@ POST /api/v1/skill-center/sync: missing [happy, error]
 POST /api/v1/token/exchange: missing [happy, error]
 POST /openapi/v1/bots/resources/mkdir: missing [happy, error]
 POST /openapi/v1/bots/resources/upload: missing [happy, error]
-POST /openapi/v1/bots/resources: missing [happy, error]
 POST /openapi/v1/bots/routines/{routine_id}/run: missing [happy, error]
 POST /openapi/v1/bots/routines: missing [happy, error]
 POST /openapi/v1/bots/{bot_id}/authorized-apps: missing [happy, error]
@@ -376,7 +381,6 @@ PUT /api/skills/{skill_uuid}/members/{user_id}/role: missing [happy, error]
 PUT /api/skillsets/{skill_set_id}: missing [happy, error]
 PUT /openapi/v1/bots/identity/{bot_id}/{file_type}: missing [happy, error]
 PUT /openapi/v1/bots/mcp/servers/{server_code}/config: missing [happy, error]
-PUT /openapi/v1/bots/resources/{resource_id}: missing [happy, error]
 PUT /openapi/v1/bots/approvals/{bot_id}/mode: missing [happy, error]
 PUT /openapi/v1/bots/{bot_id}/engine-config: missing [happy, error]
 PUT /openapi/v1/bots/{bot_id}: missing [happy, error]

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -1660,6 +1660,48 @@
         "title": "Envelope[EngineStatus]",
         "type": "object"
       },
+      "Envelope_FileEntry_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FileEntry"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[FileEntry]",
+        "type": "object"
+      },
       "Envelope_HelloWorld_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2206,6 +2248,48 @@
         "title": "Envelope[Page[Bot]]",
         "type": "object"
       },
+      "Envelope_Page_FileEntry__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Page_FileEntry_"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Page[FileEntry]]",
+        "type": "object"
+      },
       "Envelope_Page_McpServer__": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2288,48 +2372,6 @@
           "request_id"
         ],
         "title": "Envelope[Page[Model]]",
-        "type": "object"
-      },
-      "Envelope_Page_Resource__": {
-        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
-        "properties": {
-          "code": {
-            "description": "6-digit code: HTTP status (3) + business subcode (3).",
-            "example": 200000,
-            "title": "Code",
-            "type": "integer"
-          },
-          "data": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Page_Resource_"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Response payload; present but null on errors or empty results."
-          },
-          "message": {
-            "description": "Human-readable status; always English (e.g. \"OK\").",
-            "example": "OK",
-            "title": "Message",
-            "type": "string"
-          },
-          "request_id": {
-            "description": "Trace id; mirrors the X-Trace-Id response header.",
-            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
-            "title": "Request Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "code",
-          "message",
-          "data",
-          "request_id"
-        ],
-        "title": "Envelope[Page[Resource]]",
         "type": "object"
       },
       "Envelope_Page_RoutineRun__": {
@@ -2540,48 +2582,6 @@
           "request_id"
         ],
         "title": "Envelope[Preview]",
-        "type": "object"
-      },
-      "Envelope_Resource_": {
-        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
-        "properties": {
-          "code": {
-            "description": "6-digit code: HTTP status (3) + business subcode (3).",
-            "example": 200000,
-            "title": "Code",
-            "type": "integer"
-          },
-          "data": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Resource"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Response payload; present but null on errors or empty results."
-          },
-          "message": {
-            "description": "Human-readable status; always English (e.g. \"OK\").",
-            "example": "OK",
-            "title": "Message",
-            "type": "string"
-          },
-          "request_id": {
-            "description": "Trace id; mirrors the X-Trace-Id response header.",
-            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
-            "title": "Request Id",
-            "type": "string"
-          }
-        },
-        "required": [
-          "code",
-          "message",
-          "data",
-          "request_id"
-        ],
-        "title": "Envelope[Resource]",
         "type": "object"
       },
       "Envelope_RoutineRun_": {
@@ -3177,6 +3177,50 @@
           "request_id"
         ],
         "title": "ErrorEnvelope",
+        "type": "object"
+      },
+      "FileEntry": {
+        "description": "A file or folder in the bot's workspace.\n\nThe container's own storage layout is never exposed — `path` is relative to\nthe workspace root, not to any real filesystem the bot runs on.",
+        "example": {
+          "name": "spec.md",
+          "path": "docs/spec.md",
+          "size": 2048,
+          "type": "file"
+        },
+        "properties": {
+          "name": {
+            "description": "Display name — the last segment of `path`.",
+            "title": "Name",
+            "type": "string"
+          },
+          "path": {
+            "description": "Workspace-relative path, e.g. 'docs/spec/a.txt' — the whole path, not the directory. This is the addressing key: pass it as `path` on stat, download, preview, upload, mkdir and delete, exactly as listed.",
+            "title": "Path",
+            "type": "string"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Size in bytes. Null for folders, and for files whose listing carries no size — not every engine reports one.",
+            "title": "Size"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ResourceType",
+            "description": "What kind of entry this is."
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "type"
+        ],
+        "title": "FileEntry",
         "type": "object"
       },
       "HelloWorld": {
@@ -4041,6 +4085,31 @@
         "title": "Page[Bot]",
         "type": "object"
       },
+      "Page_FileEntry_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
+        "properties": {
+          "items": {
+            "description": "Items on the current page (present, possibly empty).",
+            "items": {
+              "$ref": "#/components/schemas/FileEntry"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Total number of items matching the query.",
+            "example": 1,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "Page[FileEntry]",
+        "type": "object"
+      },
       "Page_McpServer_": {
         "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
@@ -4089,31 +4158,6 @@
           "items"
         ],
         "title": "Page[Model]",
-        "type": "object"
-      },
-      "Page_Resource_": {
-        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
-        "properties": {
-          "items": {
-            "description": "Items on the current page (present, possibly empty).",
-            "items": {
-              "$ref": "#/components/schemas/Resource"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "total": {
-            "description": "Total number of items matching the query.",
-            "example": 1,
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "total",
-          "items"
-        ],
-        "title": "Page[Resource]",
         "type": "object"
       },
       "Page_RoutineRun_": {
@@ -4217,11 +4261,11 @@
         "type": "object"
       },
       "Preview": {
-        "description": "A file's preview content.",
+        "description": "A file's content, decoded as text.",
         "example": {
           "content": "# Spec\nThe gateway forwards…",
           "content_type": "application/octet-stream",
-          "resource_id": ""
+          "path": "docs/spec.md"
         },
         "properties": {
           "content": {
@@ -4241,243 +4285,39 @@
             "title": "Content Type",
             "type": "string"
           },
-          "preview_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Reserved for a URL-based preview; currently always null — the content is returned inline instead.",
-            "title": "Preview Url"
-          },
-          "resource_id": {
-            "description": "Always empty — previews address files by their `path`.",
-            "title": "Resource Id",
+          "path": {
+            "description": "Workspace-relative path of the previewed file, as given.",
+            "title": "Path",
             "type": "string"
           }
         },
         "required": [
-          "resource_id",
+          "path",
           "content_type"
         ],
         "title": "Preview",
         "type": "object"
       },
-      "Resource": {
-        "description": "A resource: a file or folder in the bot's workspace, or an external link.\n\nThe container's own storage layout is never exposed — `path` is relative to\nthe workspace root, not to any real filesystem the bot runs on.",
-        "example": {
-          "name": "spec.md",
-          "path": "docs/spec.md",
-          "resource_id": "",
-          "size": 2048,
-          "type": "file"
-        },
-        "properties": {
-          "gmt_create": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "When the record was created (ISO 8601, no timezone designator). Null for files and folders read straight from the workspace — their listing carries no timestamps.",
-            "title": "Gmt Create"
-          },
-          "gmt_modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "When the record last changed (ISO 8601, no timezone designator); null for files and folders read straight from the workspace.",
-            "title": "Gmt Modified"
-          },
-          "name": {
-            "description": "Display name. For a file or folder this is the last segment of `path`; a link has only a name.",
-            "title": "Name",
-            "type": "string"
-          },
-          "path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Workspace-relative path of a file or folder, e.g. 'docs/spec/a.txt' — the whole path, not the directory; `name` is its last segment. This is the addressing key: pass it as `path` on download, preview, upload and delete exactly as listed. Null for links.",
-            "title": "Path"
-          },
-          "resource_id": {
-            "description": "Identifier of the resource's stored record — decimal digits for a link, e.g. '42'. Empty for files and folders, which have no record: address those by `path` instead.",
-            "title": "Resource Id",
-            "type": "string"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Size in bytes; null when not reported (links, and entries whose listing carries no size).",
-            "title": "Size"
-          },
-          "source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "How the resource record came to exist — e.g. 'manual' for a link created through this API, 'upload' for an uploaded file's record. Null for files and folders read straight from the workspace, which have no record.",
-            "title": "Source"
-          },
-          "type": {
-            "$ref": "#/components/schemas/ResourceType",
-            "description": "What kind of resource this is."
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The link's URL; null for files and folders.",
-            "title": "Url"
-          }
-        },
-        "required": [
-          "resource_id",
-          "name",
-          "type"
-        ],
-        "title": "Resource",
-        "type": "object"
-      },
-      "ResourceCreate": {
-        "description": "Create a link resource.\n\nOnly links are created here: files are created through the upload\nendpoint (a file request answers 400 pointing there), and folders through\nthe mkdir endpoint (a folder request answers 501).",
-        "example": {
-          "name": "Team wiki",
-          "type": "link",
-          "url": "https://wiki.example.com/team"
-        },
-        "properties": {
-          "name": {
-            "description": "Display name for the link; a duplicate of an existing link answers 409.",
-            "title": "Name",
-            "type": "string"
-          },
-          "parent_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Accepted for compatibility and currently ignored — links are not placed in folders.",
-            "title": "Parent Id"
-          },
-          "type": {
-            "$ref": "#/components/schemas/ResourceType",
-            "description": "What to create. Only 'link' is accepted here — see the model description for where files and folders are created."
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The URL the link points to. Required when type is 'link' (400 when missing).",
-            "title": "Url"
-          }
-        },
-        "required": [
-          "name",
-          "type"
-        ],
-        "title": "ResourceCreate",
-        "type": "object"
-      },
       "ResourceType": {
-        "description": "A resource is a file, an external link, or a folder.",
+        "description": "A resource is a file or a folder in the bot's workspace.",
         "enum": [
           "file",
-          "link",
           "folder"
         ],
         "title": "ResourceType",
         "type": "string",
         "x-enum-descriptions": [
-          "A file in the bot's workspace, addressed by its workspace-relative path.",
-          "An external URL saved for the bot, addressed by its resource id.",
-          "A directory in the bot's workspace, addressed by its workspace-relative path."
+          "A file in the bot's workspace.",
+          "A directory in the bot's workspace."
         ],
         "x-enum-varnames": [
           "FILE",
-          "LINK",
           "FOLDER"
         ],
         "x-enumNames": [
           "FILE",
-          "LINK",
           "FOLDER"
         ]
-      },
-      "ResourceUpdate": {
-        "description": "Partial update of a link resource. Omitted fields are left unchanged.",
-        "example": {
-          "name": "Team wiki (new)"
-        },
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "New display name; omit to keep.",
-            "title": "Name"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "New URL; omit to keep.",
-            "title": "Url"
-          }
-        },
-        "title": "ResourceUpdate",
-        "type": "object"
       },
       "Routine": {
         "description": "A scheduled task run by a bot.",
@@ -10933,7 +10773,7 @@
         ]
       },
       "get": {
-        "description": "List a directory of the bot's workspace, plus the bot's link resources.\n\nFiles and folders come from the **workspace**, never from records. That is\nwhat makes a file the bot produced itself a first-class resource: it has no\nrecord and never will, and a record-backed listing simply could not see it.\nIt also removes the divergence the other direction — a record whose bytes are\nnot where it claims can no longer be reported as a file that exists.\n\nLinks are the exception, and not an inconsistency: a link has no file and no\npresence on any device, so the record *is* the resource. They are read from\nthe repo and appended.\n\nThe path parameter selects the directory (empty = workspace root).\nListing is non-recursive, which bounds the device round trip this\nendpoint makes.",
+        "description": "List a directory of the bot's workspace.\n\nEntries come from the **workspace**, never from records. That is what makes\na file the bot produced itself a first-class resource: it has no record and\nnever will, and a record-backed listing simply could not see it. It also\nremoves the divergence the other direction — a record whose bytes are not\nwhere it claims can no longer be reported as a file that exists.\n\nThe path parameter selects the directory (empty = workspace root). Listing\nis non-recursive, which bounds the device round trip this endpoint makes.\n\nPaging is applied by this server over the whole directory, because the\nengine's listing API takes no page, limit or cursor: `page_size` bounds the\nresponse, not the work. Requesting a later page costs exactly what the\nfirst one costs.",
         "operationId": "list_resources_openapi_v1_bots_resources_get",
         "parameters": [
           {
@@ -10960,7 +10800,7 @@
             }
           },
           {
-            "description": "Filter: 'file' or 'folder' lists only workspace entries of that kind; 'link' returns only the bot's links (path is then ignored). Omit for everything.",
+            "description": "Filter: 'file' lists only files, 'folder' only directories. Omit for both.",
             "in": "query",
             "name": "type",
             "required": false,
@@ -10973,7 +10813,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter: 'file' or 'folder' lists only workspace entries of that kind; 'link' returns only the bot's links (path is then ignored). Omit for everything.",
+              "description": "Filter: 'file' lists only files, 'folder' only directories. Omit for both.",
               "title": "Type"
             }
           },
@@ -11022,7 +10862,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Envelope_Page_Resource__"
+                  "$ref": "#/components/schemas/Envelope_Page_FileEntry__"
                 }
               }
             },
@@ -11150,390 +10990,6 @@
           }
         },
         "summary": "List Resources",
-        "tags": [
-          "resources"
-        ]
-      },
-      "post": {
-        "description": "Create a resource (file placeholder, link, or folder).\n\nPhase 1: only LINK supported. FILE → use POST /upload (Phase 3);\nFOLDER → create_directory (Phase 3, device_fs branch). Duplicate name\nsurfaces as ValueError from the service → 409 Conflict (legacy parity).",
-        "operationId": "create_resource_openapi_v1_bots_resources_post",
-        "parameters": [
-          {
-            "description": "Bot ID this resource belongs to.",
-            "in": "query",
-            "name": "bot_id",
-            "required": true,
-            "schema": {
-              "description": "Bot ID this resource belongs to.",
-              "title": "Bot Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResourceCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_Resource_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          }
-        },
-        "summary": "Create Resource",
-        "tags": [
-          "resources"
-        ]
-      }
-    },
-    "/openapi/v1/bots/resources/check-name": {
-      "get": {
-        "description": "Whether a resource already exists.\n\nTwo parameters because there are two kinds of resource, addressed\ndifferently. A file or folder is checked against the workspace by path —\nthe same question the upload asks before writing, answered by the same\nauthority, so the two can never disagree. A link is checked by name\nagainst the records, because a link has no file. Supplying path gets the\nfile check; otherwise it is the link check.",
-        "operationId": "check_resource_name_openapi_v1_bots_resources_check_name_get",
-        "parameters": [
-          {
-            "description": "Link name to check against the bot's link records (exact, case-sensitive match). Supply this or path.",
-            "in": "query",
-            "name": "name",
-            "required": false,
-            "schema": {
-              "default": "",
-              "description": "Link name to check against the bot's link records (exact, case-sensitive match). Supply this or path.",
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Workspace-relative path to check for a file or folder, e.g. 'docs/spec.md'. When given, the file check runs and name is ignored.",
-            "in": "query",
-            "name": "path",
-            "required": false,
-            "schema": {
-              "default": "",
-              "description": "Workspace-relative path to check for a file or folder, e.g. 'docs/spec.md'. When given, the file check runs and name is ignored.",
-              "title": "Path",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Addressing hint: 'file' or 'folder' forces the workspace check; otherwise a supplied path decides.",
-            "in": "query",
-            "name": "type",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/ResourceType"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Addressing hint: 'file' or 'folder' forces the workspace check; otherwise a supplied path decides.",
-              "title": "Type"
-            }
-          },
-          {
-            "description": "Bot ID this resource belongs to.",
-            "in": "query",
-            "name": "bot_id",
-            "required": true,
-            "schema": {
-              "description": "Bot ID this resource belongs to.",
-              "title": "Bot Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_NameCheck_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          }
-        },
-        "summary": "Check Resource Name",
         "tags": [
           "resources"
         ]
@@ -11733,7 +11189,7 @@
     },
     "/openapi/v1/bots/resources/mkdir": {
       "post": {
-        "description": "Create a directory in the bot's workspace, addressed by path.\n\nIntermediate directories are created as needed. Directories exist on the\nworkspace filesystem only and are reported by listing it — they have no\nrecord and no resource id.",
+        "description": "Create a directory in the bot's workspace, addressed by path.\n\nIntermediate directories are created as needed. Directories exist on the\nworkspace filesystem only and are reported by listing it — they have no\nrecord.",
         "operationId": "create_directory_openapi_v1_bots_resources_mkdir_post",
         "parameters": [
           {
@@ -11776,7 +11232,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Envelope_Resource_"
+                  "$ref": "#/components/schemas/Envelope_FileEntry_"
                 }
               }
             },
@@ -12102,10 +11558,10 @@
         ]
       }
     },
-    "/openapi/v1/bots/resources/upload": {
-      "post": {
-        "description": "Upload a file's raw bytes into the bot's workspace.\n\nThe body is the file's raw bytes (content type application/octet-stream),\nnot a multipart form. The path is workspace-relative and carries its own\ndirectories ('docs/spec/a.txt'); intermediate ones are created as needed\n— there is no separate name or parent-directory parameter. An occupied\npath answers 409; the size limit is 500 MB, and only common document,\ncode, image and archive extensions are accepted (400 otherwise).",
-        "operationId": "upload_resource_openapi_v1_bots_resources_upload_post",
+    "/openapi/v1/bots/resources/stat": {
+      "get": {
+        "description": "One file or folder's metadata, addressed by path.\n\nAnswers the questions a listing answers, for a single entry: whether it is\nthere at all (404 if not), whether it is a file or a folder, and how big it\nis. The workspace root has no entry of its own, so `path` is required here\neven though the listing accepts an empty one.\n\nEntries the listing hides — dotfiles, and the workspace-root identity files\n— are 404 here too, so the two surfaces agree on what exists.",
+        "operationId": "stat_resource_openapi_v1_bots_resources_stat_get",
         "parameters": [
           {
             "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
@@ -12142,6 +11598,196 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_FileEntry_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Stat Resource",
+        "tags": [
+          "resources"
+        ]
+      }
+    },
+    "/openapi/v1/bots/resources/upload": {
+      "post": {
+        "description": "Upload a file's raw bytes into the bot's workspace.\n\nThe body is the file's raw bytes (content type application/octet-stream),\nnot a multipart form. The path is workspace-relative and carries its own\ndirectories ('docs/spec/a.txt'); intermediate ones are created as needed\n— there is no separate name or parent-directory parameter. An occupied\npath answers 409 unless `overwrite` is set; the size limit is 500 MB, and\nonly common document, code, image and archive extensions are accepted\n(400 otherwise).",
+        "operationId": "upload_resource_openapi_v1_bots_resources_upload_post",
+        "parameters": [
+          {
+            "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
+            "in": "query",
+            "name": "path",
+            "required": true,
+            "schema": {
+              "description": "Workspace-relative path of the file or folder, e.g. 'docs/spec/a.txt' — exactly as returned in a listing entry's `path`. A leading slash is tolerated; '..' segments are refused (400).",
+              "title": "Path",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Bot ID this resource belongs to.",
+            "in": "query",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "Bot ID this resource belongs to.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Replace the file if the path is already occupied. Defaults to false, which answers 409 instead. Has no effect on a free path.",
+            "in": "query",
+            "name": "overwrite",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Replace the file if the path is already occupied. Defaults to false, which answers 409 instead. Has no effect on a free path.",
+              "title": "Overwrite",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/octet-stream": {
@@ -12159,7 +11805,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Envelope_Resource_"
+                  "$ref": "#/components/schemas/Envelope_FileEntry_"
                 }
               }
             },
@@ -12287,546 +11933,6 @@
           }
         },
         "summary": "Upload Resource",
-        "tags": [
-          "resources"
-        ]
-      }
-    },
-    "/openapi/v1/bots/resources/{resource_id}": {
-      "delete": {
-        "description": "Delete a link resource by id.\n\nOnly links are deleted by id — files and folders are deleted through the\npath-addressed delete. A file's id answers 404. Works whether or not the\nbot currently has a live device.",
-        "operationId": "delete_resource_openapi_v1_bots_resources__resource_id__delete",
-        "parameters": [
-          {
-            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-            "in": "path",
-            "name": "resource_id",
-            "required": true,
-            "schema": {
-              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-              "title": "Resource Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Bot ID this resource belongs to.",
-            "in": "query",
-            "name": "bot_id",
-            "required": true,
-            "schema": {
-              "description": "Bot ID this resource belongs to.",
-              "title": "Bot Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_Deleted_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          }
-        },
-        "summary": "Delete Resource",
-        "tags": [
-          "resources"
-        ]
-      },
-      "get": {
-        "description": "Get a link resource by id.\n\nOnly links are served by id — a file's id answers 404 here. A file's\naddress is its path: the listing shows it, and download/preview serve it.",
-        "operationId": "get_resource_openapi_v1_bots_resources__resource_id__get",
-        "parameters": [
-          {
-            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-            "in": "path",
-            "name": "resource_id",
-            "required": true,
-            "schema": {
-              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-              "title": "Resource Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Bot ID this resource belongs to.",
-            "in": "query",
-            "name": "bot_id",
-            "required": true,
-            "schema": {
-              "description": "Bot ID this resource belongs to.",
-              "title": "Bot Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_Resource_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          }
-        },
-        "summary": "Get Resource",
-        "tags": [
-          "resources"
-        ]
-      },
-      "put": {
-        "description": "Rename a link resource and/or change its URL, by id.\n\nOnly links are updatable by id — a file's id answers 404. A name or URL\nclash with an existing link answers 409.",
-        "operationId": "update_resource_openapi_v1_bots_resources__resource_id__put",
-        "parameters": [
-          {
-            "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-            "in": "path",
-            "name": "resource_id",
-            "required": true,
-            "schema": {
-              "description": "The link resource's id, as returned by the listing or create response (decimal digits, e.g. '42'). Files and folders have no id — address them by `path` on the path-based endpoints.",
-              "title": "Resource Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Bot ID this resource belongs to.",
-            "in": "query",
-            "name": "bot_id",
-            "required": true,
-            "schema": {
-              "description": "Bot ID this resource belongs to.",
-              "title": "Bot Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ResourceUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Envelope_Resource_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 400000,
-                  "message": "Bad Request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 401000,
-                  "message": "Unauthorized",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Missing or invalid credentials"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 403000,
-                  "message": "Forbidden",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "The user_id names a user the authenticated caller may not act for"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 404000,
-                  "message": "Not found",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Not found — also returned when the resource exists but does not belong to the caller"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 409000,
-                  "message": "Conflict",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Conflicts with current state"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 422000,
-                  "message": "Invalid request",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Request failed validation"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 500000,
-                  "message": "Internal Server Error",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Internal error"
-          },
-          "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
-          }
-        },
-        "summary": "Update Resource",
         "tags": [
           "resources"
         ]


### PR DESCRIPTION
## Problem

`#1001` made the engine the source of truth for files, but the contract still
carried the record-addressed model it replaced:

- **`resource_id` was a required, non-nullable field that was always `""`** for
  files and folders (`router.py:333/638/883`, declared required at
  `schemas.py:55`). A generated client saw a non-optional string and could not
  express "no id" except by comparing against a magic empty value. The same file
  already rejected this pattern eight lines away, for the timestamps: *"`None`,
  not `""`: … an empty string is a sentinel pretending to be a timestamp."*
- **Three id-addressed routes remained** (`GET`/`PUT`/`DELETE /{resource_id}`),
  serving only link records, alongside six path-addressed ones. Two deletes sat
  on adjacent URLs with different addressing.
- **`/{resource_id}` was a trailing catch-all.** Every literal segment only
  matched because it was declared above it, and a caller guessing
  `GET /resources/docs/spec.md` got a 404 from the *link* lookup.
- **Files could not be fetched individually at all.** `spec.md` named this and
  deferred `GET /stat?path=` as the issue owner's call.
- **Dead fields:** `Preview.resource_id` (documented "Always empty") and
  `ResourceCreate.parent_id` ("Accepted for compatibility and currently
  ignored").
- **Docs had already drifted** — `docs/openapi-v1/README.md` still listed
  `GET /{resource_id}/download` and `/preview`, deleted by `#1001`.

## Solution

Links leave this surface, so the id leaves the contract rather than being
reported as `""`. Eleven operations become seven, every one addressed by a
workspace-relative `path`, with `bot_id` and `user_id` required throughout.

| Method | Path | Required | Optional |
|---|---|---|---|
| `GET` | `/openapi/v1/bots/resources` | `bot_id`, `user_id` | `path`, `type`, `page`, `page_size` |
| `GET` | `/openapi/v1/bots/resources/stat` | `bot_id`, `user_id`, `path` | — |
| `POST` | `/openapi/v1/bots/resources/upload` | `bot_id`, `user_id`, `path` | `overwrite` |
| `GET` | `/openapi/v1/bots/resources/download` | `bot_id`, `user_id`, `path` | — |
| `GET` | `/openapi/v1/bots/resources/preview` | `bot_id`, `user_id`, `path` | — |
| `POST` | `/openapi/v1/bots/resources/mkdir` | `bot_id`, `user_id`, `path` | — |
| `DELETE` | `/openapi/v1/bots/resources` | `bot_id`, `user_id`, `path` | — |

`Resource` becomes `FileEntry` — `path` (now required; it is the addressing
key), `name`, `type`, `size`. `resource_id`, `source`, `url`, `gmt_create` and
`gmt_modified` are gone, along with `ResourceType.LINK`, `ResourceCreate`,
`ResourceUpdate`, `Preview.resource_id` and `Preview.preview_url`.

**`GET /stat` replaces both the id-addressed lookup and `check-name`.** It is
resolved by listing the parent and picking the entry out, so stat and list read
one seam and cannot report different types or sizes for the same file — and it
needs no new provider method (`DeviceFileSystem` has no stat; adding one to
three providers to save a filter would be the larger change). `check-name`'s two
addressing modes collapse into it: a 200/404 answers the same question against
the same authority.

**`POST /upload` gains `?overwrite=`.** Replacing a file previously meant
delete-then-upload — racy, and the file is gone outright if the second call
fails. The overwrite branch drops the prior record before writing the new one
(`record_uploaded_file` always inserts, so a second row would publish the file
twice in the manifest) and deliberately does **not** roll the file back on a
record failure: the prior bytes are already gone, so deleting would destroy
content rather than restore it, and the retry is not blocked because an
overwrite does not 409.

**Deliberately still absent:** `modified_at` is provider-dependent
(`local_device_filesystem._pathlib_list_dir` returns no mtime), and a field
populated on some engines and null on others is what `spec.md` G6 rejected;
`readonly` is always `false` in a listing, since `list_dir` filters out dotfiles
and root identity files before `is_readonly` is consulted.

**Records still get written on upload.** They are the publish pipeline's input —
"files have no id in the API" is not "files have no record".

Rejected: renaming the group to `files` (touches the admission table, gateway
schema, console and docs for zero client capability, and forecloses re-adding
links under `/resources/links/`); `/{path:path}` addressing (encoding `/` in a
segment, and no way to express the workspace root).

## Validation

- `tests/community/adapters/http/openapi_v1/resources/` — **76 passed**,
  rewritten for the new contract: `stat` (7 cases incl. parent-listing, absent
  parent, root-level entry, and stat/list agreement), `overwrite` (replace,
  record replacement, no-rollback-on-record-failure, e2e single-live-row), and a
  schema test pinning that `FileEntry` has no `resource_id`.
- `tests/community/adapters/ tests/community/architecture tests/community/framework`
  — **1296 passed**. `test_admission_inventory` asserts the `ADMISSION` table and
  live routes match in both directions; the route tripwire now pins 7 and
  additionally asserts no route in the group carries a path parameter, so a
  future `/{resource_id}` cannot creep back.
- Full `tests/community/` — **11670 passed, 4 failed**. Two failures are the
  pinned counts in `test_explicit_user_id.py`, updated in this change (65 → 61
  operations, `bot_id` `query` 20 → 16). The other two
  (`test_bot_build_service_skill_artifact.py`) are **pre-existing and unrelated**
  — verified failing identically on a stashed tree; `rsync` is not installed in
  this container.
- `src/gateway` — **817 passed**; the 11 failures (ruff formatting, health
  endpoints needing a live server) reproduce on a clean tree.
- `ruff check` clean on every file touched. `scripts/ci/python_sast_local.sh
  src/backend` flags nothing in the changed files.
- Gateway schema regenerated via `dump_openapi.py` + `gate_and_publish_openapi.py`.
  The gate reported exactly the 14 intended breaks and nothing else, then
  published with `--allow-breaking`.

## Compatibility and risk

Breaking, and intentionally taken now: the surface is gated **NOT PUBLIC-READY**
pending the auth workstream (`require_principal` is still a `None` stub), so no
external tenant is on it. Every break here is free today and expensive later.

Five operations are removed (`POST ""`, `GET`/`PUT`/`DELETE /{resource_id}`,
`GET /check-name`) and one added. `ADMISSION` goes 11 → 7 entries;
`coverage_baseline.txt` net −4 (hand edited to preserve its notes). The console's
`/api/resources` surface has its own router and still uses the link service
methods this stops calling — unchanged. Rollback is a revert of the commit plus a
re-publish of the gateway schema.

## Related issues

Follows `#1001` / `#1000`; implements the `GET /stat` follow-up that
`specs/2026-08-12-openapi-resources-engine-backed/spec.md` explicitly deferred to
the issue owner.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFeC1PtakRrsdhnh9mLorA)_