### PR TITLE
fix(devices): serialize BaaS container initialization

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_container_init.py
@@ -29,7 +29,7 @@ class BaasContainerInitializer:
         admins: list[str] | None,
         codefuse_token: str | None = None,
     ) -> None:
-        """Execute the 6-step init sequence inside the BaaS container."""
+        """Execute the ordered init sequence inside the BaaS container."""
         entity_id = device.device_props.get("entity_id")
         entity_type = device.device_props.get("entity_type")
         client_id = device.device_props.get("client_id", "")
@@ -41,6 +41,7 @@ class BaasContainerInitializer:
         self._ensure_baas_engine_dirs(bot_uuid, engine)
         self._create_baas_skill_symlink_conf(bot_uuid, symbol)
         self._write_codefuse_token(bot_uuid, codefuse_token)
+        self._wait_for_baas_supervisor(bot_uuid)
         self._start_baas_sandbox_service(
             bot_uuid=bot_uuid,
             client_id=client_id,
@@ -63,51 +64,128 @@ class BaasContainerInitializer:
 
         write_codefuse_token_baas(self._baas_service, bot_uuid, codefuse_token)
 
-    def _run_baas_bootstrap(self, bot_uuid: str) -> None:
-        self._baas_service.exec_command_on_bot(
+    def _exec_checked(
+        self,
+        *,
+        bot_uuid: str,
+        cmd: str,
+        timeout_seconds: int,
+        step: str,
+    ) -> dict:
+        """Execute one required initialization step and fail on non-zero exit."""
+        result = self._baas_service.exec_command_on_bot(
             bot_uuid=bot_uuid,
-            cmd="bash /home/admin/bin/bootstrap_minimal.sh",
-            timeout_seconds=60,
+            cmd=cmd,
+            timeout_seconds=timeout_seconds,
         )
-        logger.info("[_run_baas_bootstrap] done: bot_uuid=%s", bot_uuid)
+        exit_code = result.get("exit_code", -1) if isinstance(result, dict) else -1
+        if exit_code != 0:
+            stderr = result.get("stderr", "") if isinstance(result, dict) else ""
+            stderr_tail = str(stderr or "")[-1000:]
+            raise RuntimeError(
+                f"BaaS container init step failed: step={step} "
+                f"bot_uuid={bot_uuid} exit_code={exit_code} stderr={stderr_tail}"
+            )
+        logger.info(
+            "[BaasContainerInitializer] step completed: step=%s bot_uuid=%s",
+            step,
+            bot_uuid,
+        )
+        return result
+
+    def _run_baas_bootstrap(self, bot_uuid: str) -> None:
+        # The image root_init process can bootstrap the same checkout. Wait for
+        # image initialization before running the Backend compensation step so
+        # install_engine never observes a checkout being replaced concurrently.
+        cmd = (
+            "_agentclaw_image_ready=0; "
+            "for _agentclaw_wait in $(seq 1 120); do "
+            "if [ -f /var/run/agentclaw/.install_dependency_file ] || "
+            '[ "$(cat /proc/1/comm 2>/dev/null)" = "supervisord" ]; then '
+            "_agentclaw_image_ready=1; break; "
+            "fi; "
+            "sleep 1; "
+            "done; "
+            'if [ "$_agentclaw_image_ready" != "1" ]; then '
+            "echo '[bootstrap] container image initialization timed out' >&2; "
+            "exit 1; "
+            "fi; "
+            "bash /home/admin/bin/bootstrap_minimal.sh"
+        )
+        self._exec_checked(
+            bot_uuid=bot_uuid,
+            cmd=cmd,
+            timeout_seconds=300,
+            step="bootstrap",
+        )
 
     def _run_baas_install_engine(self, bot_uuid: str) -> None:
-        self._baas_service.exec_command_on_bot(
-            bot_uuid=bot_uuid,
-            cmd="nohup bash /home/admin/bin/install_engine.sh >> /home/admin/logs/install_engine.log 2>&1 &",
-            timeout_seconds=30,
+        cmd = (
+            "mkdir -p /home/admin/logs && "
+            "if [ -f /home/admin/bin/install_engine.sh ]; then "
+            "bash /home/admin/bin/install_engine.sh "
+            ">> /home/admin/logs/install_engine.log 2>&1; "
+            "else echo '[install_engine] script not found, skip'; fi"
         )
-        logger.info("[_run_baas_install_engine] dispatched: bot_uuid=%s", bot_uuid)
+        self._exec_checked(
+            bot_uuid=bot_uuid,
+            cmd=cmd,
+            timeout_seconds=300,
+            step="install_engine",
+        )
 
     def _run_baas_setup_sync_service(self, bot_uuid: str, engine: str) -> None:
         cmd = (
-            f"nohup bash /home/admin/bin/setup_supervisor_sync_service.sh {engine} "
-            f">> /home/admin/logs/setup_supervisor_sync_service.log 2>&1 &"
+            "mkdir -p /home/admin/logs && "
+            f"bash /home/admin/bin/setup_supervisor_sync_service.sh {engine} "
+            f">> /home/admin/logs/setup_supervisor_sync_service.log 2>&1"
         )
-        self._baas_service.exec_command_on_bot(
+        self._exec_checked(
             bot_uuid=bot_uuid,
             cmd=cmd,
-            timeout_seconds=30,
+            timeout_seconds=120,
+            step="setup_supervisor_sync_service",
         )
-        logger.info("[_run_baas_setup_sync_service] dispatched: bot_uuid=%s", bot_uuid)
 
     def _ensure_baas_engine_dirs(self, bot_uuid: str, engine: str) -> None:
         cmd = (
-            "mkdir -p $(dirname /home/admin/logs/engine_dirs_setup.log) && "
-            f"nohup bash /home/admin/bin/setup_engine_dirs.sh {engine} "
-            f">> /home/admin/logs/engine_dirs_setup.log 2>&1 &"
+            "mkdir -p /home/admin/logs && "
+            f"bash /home/admin/bin/setup_engine_dirs.sh {engine} "
+            f">> /home/admin/logs/engine_dirs_setup.log 2>&1"
         )
         try:
-            self._baas_service.exec_command_on_bot(
+            self._exec_checked(
                 bot_uuid=bot_uuid,
                 cmd=cmd,
-                timeout_seconds=30,
+                timeout_seconds=120,
+                step="setup_engine_dirs",
             )
-            logger.info("[_ensure_baas_engine_dirs] dispatched: bot_uuid=%s", bot_uuid)
-        except Exception as e:
-            logger.warning("[_ensure_baas_engine_dirs] failed (non-fatal): %s", e)
+        except Exception as exc:
+            logger.warning(
+                "[_ensure_baas_engine_dirs] failed (non-fatal): bot_uuid=%s error=%s",
+                bot_uuid,
+                exc,
+            )
 
-    def _create_baas_skill_symlink_conf(self, bot_uuid: str, symbol: str | None) -> None:
+    def _wait_for_baas_supervisor(self, bot_uuid: str) -> None:
+        cmd = (
+            "for _agentclaw_wait in $(seq 1 60); do "
+            "if supervisorctl pid >/dev/null 2>&1; then exit 0; fi; "
+            "sleep 1; "
+            "done; "
+            "echo '[supervisor] readiness timed out' >&2; "
+            "exit 1"
+        )
+        self._exec_checked(
+            bot_uuid=bot_uuid,
+            cmd=cmd,
+            timeout_seconds=70,
+            step="wait_supervisor_ready",
+        )
+
+    def _create_baas_skill_symlink_conf(
+        self, bot_uuid: str, symbol: str | None
+    ) -> None:
         mappings = _deserialize_symbol(symbol)
         if not mappings:
             return
@@ -157,23 +235,23 @@ class BaasContainerInitializer:
             cmd += f" --admins {admins}"
 
         start_cmd = f"nohup {cmd} >> /home/admin/start.log 2>&1 &"
-        self._baas_service.exec_command_on_bot(
+        self._exec_checked(
             bot_uuid=bot_uuid,
             cmd=start_cmd,
             timeout_seconds=30,
+            step="start_service",
         )
-        logger.info("[_start_baas_sandbox_service] dispatched: bot_uuid=%s", bot_uuid)
 
         watchdog_cmd = (
             f"nohup /home/admin/bin/starting_watchdog.sh --token {token} --client_id {client_id} "
             ">> /home/admin/logs/starting_watchdog.log 2>&1 &"
         )
-        self._baas_service.exec_command_on_bot(
+        self._exec_checked(
             bot_uuid=bot_uuid,
             cmd=watchdog_cmd,
             timeout_seconds=30,
+            step="starting_watchdog",
         )
-        logger.info("[_start_baas_sandbox_service] watchdog dispatched: bot_uuid=%s", bot_uuid)
 
 
 def _deserialize_symbol(symbol: str | None) -> list[SynlinkMappingInfo]:

--- a/src/backend/tests/community/core/devices/services/test_baas_container_init.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_container_init.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.devices.models import AllocatedDevice
+from agentclaw.community.core.devices.services.baas_container_init import (
+    BaasContainerInitializer,
+    _deserialize_symbol,
+)
+
+
+def _device(*, symbol: str | None = None) -> AllocatedDevice:
+    props = {
+        "entity_id": "u-1",
+        "entity_type": "staff",
+        "client_id": "client-1",
+    }
+    if symbol is not None:
+        props["symbol"] = symbol
+    return AllocatedDevice(
+        device_id="BOT-1",
+        device_provider="baas",
+        device_props=props,
+    )
+
+
+def _initializer() -> tuple[BaasContainerInitializer, MagicMock]:
+    baas = MagicMock()
+    baas.exec_command_on_bot.return_value = {
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": "",
+    }
+    return BaasContainerInitializer(baas), baas
+
+
+def test_run_serializes_required_steps_before_starting_services() -> None:
+    initializer, baas = _initializer()
+    symbol = json.dumps(
+        [{"source": "./skills-local/demo", "target": "/runtime/skills/demo"}]
+    )
+
+    initializer.run(
+        bot_uuid="BOT-1",
+        device=_device(symbol=symbol),
+        engine="openclaw",
+        bot_type="desktop",
+        bot_id="bot-1",
+        owner_id="u-1",
+        callback_token="callback-token",
+        admins=["admin-1", "admin-2"],
+    )
+
+    calls = baas.exec_command_on_bot.call_args_list
+    commands = [call.kwargs["cmd"] for call in calls]
+    assert "install_dependency_file" in commands[0]
+    assert "bootstrap_minimal.sh" in commands[0]
+    assert "nohup" not in commands[1]
+    assert "if [ -f /home/admin/bin/install_engine.sh ]" in commands[1]
+    assert "install_engine.sh" in commands[1]
+    assert "nohup" not in commands[2]
+    assert "setup_supervisor_sync_service.sh openclaw" in commands[2]
+    assert "nohup" not in commands[3]
+    assert "setup_engine_dirs.sh openclaw" in commands[3]
+    assert "skill-symlinks.conf" in commands[4]
+    assert "supervisorctl pid" in commands[5]
+    assert "nohup /home/admin/bin/start_service.sh" in commands[6]
+    assert "--entity_id u-1 --entity_type staff" in commands[6]
+    assert "--admins admin-1,admin-2" in commands[6]
+    assert "starting_watchdog.sh" in commands[7]
+    assert [call.kwargs["timeout_seconds"] for call in calls] == [
+        300,
+        300,
+        120,
+        120,
+        30,
+        70,
+        30,
+        30,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("failed_step", "expected_calls"),
+    [
+        ("bootstrap", 1),
+        ("install_engine", 2),
+        ("setup_supervisor_sync_service", 3),
+        ("wait_supervisor_ready", 5),
+        ("start_service", 6),
+    ],
+)
+def test_required_step_failure_stops_later_steps(
+    failed_step: str,
+    expected_calls: int,
+) -> None:
+    initializer, baas = _initializer()
+
+    def execute(**kwargs):
+        command = kwargs["cmd"]
+        matches = {
+            "bootstrap": "bootstrap_minimal.sh",
+            "install_engine": "install_engine.sh",
+            "setup_supervisor_sync_service": "setup_supervisor_sync_service.sh",
+            "wait_supervisor_ready": "supervisorctl pid",
+            "start_service": "start_service.sh",
+        }
+        if matches[failed_step] in command:
+            return {"exit_code": 9, "stderr": f"{failed_step} failed"}
+        return {"exit_code": 0, "stdout": "", "stderr": ""}
+
+    baas.exec_command_on_bot.side_effect = execute
+
+    with pytest.raises(RuntimeError, match=failed_step):
+        initializer.run(
+            bot_uuid="BOT-1",
+            device=_device(),
+            engine="openclaw",
+            bot_type="desktop",
+            bot_id="bot-1",
+            owner_id="u-1",
+            callback_token="callback-token",
+            admins=None,
+        )
+
+    assert baas.exec_command_on_bot.call_count == expected_calls
+    commands = [call.kwargs["cmd"] for call in baas.exec_command_on_bot.call_args_list]
+    assert not any("starting_watchdog.sh" in command for command in commands)
+
+
+def test_engine_dir_failure_remains_non_fatal() -> None:
+    initializer, baas = _initializer()
+
+    def execute(**kwargs):
+        if "setup_engine_dirs.sh" in kwargs["cmd"]:
+            return {"exit_code": 7, "stderr": "legacy image has no setup"}
+        return {"exit_code": 0, "stdout": "", "stderr": ""}
+
+    baas.exec_command_on_bot.side_effect = execute
+
+    initializer.run(
+        bot_uuid="BOT-1",
+        device=_device(),
+        engine="openclaw",
+        bot_type="desktop",
+        bot_id="bot-1",
+        owner_id="u-1",
+        callback_token="callback-token",
+        admins=None,
+    )
+
+    commands = [call.kwargs["cmd"] for call in baas.exec_command_on_bot.call_args_list]
+    assert any("supervisorctl pid" in command for command in commands)
+    assert any("start_service.sh" in command for command in commands)
+    assert any("starting_watchdog.sh" in command for command in commands)
+
+
+def test_exec_checked_rejects_missing_exit_code_and_non_dict_results() -> None:
+    initializer, baas = _initializer()
+    baas.exec_command_on_bot.side_effect = [{}, None]
+
+    with pytest.raises(RuntimeError, match="exit_code=-1"):
+        initializer._exec_checked(
+            bot_uuid="BOT-1",
+            cmd="first",
+            timeout_seconds=1,
+            step="first",
+        )
+    with pytest.raises(RuntimeError, match="exit_code=-1"):
+        initializer._exec_checked(
+            bot_uuid="BOT-1",
+            cmd="second",
+            timeout_seconds=1,
+            step="second",
+        )
+
+
+def test_start_service_omits_optional_arguments_when_absent() -> None:
+    initializer, baas = _initializer()
+
+    initializer._start_baas_sandbox_service(
+        bot_uuid="BOT-1",
+        client_id="client-1",
+        engine="openclaw",
+    )
+
+    start_command = baas.exec_command_on_bot.call_args_list[0].kwargs["cmd"]
+    assert "--bot_type" not in start_command
+    assert "--bot_id" not in start_command
+    assert "--owner_id" not in start_command
+    assert "--entity_id" not in start_command
+    assert "--stage" not in start_command
+    assert "--admins" not in start_command
+
+
+def test_empty_symbol_skips_config_and_deserializer_handles_invalid_values() -> None:
+    initializer, baas = _initializer()
+
+    initializer._create_baas_skill_symlink_conf("BOT-1", None)
+
+    baas.exec_command_on_bot.assert_not_called()
+    assert _deserialize_symbol(None) == []
+    assert _deserialize_symbol([]) == []  # type: ignore[arg-type]
+    assert _deserialize_symbol("not-json") == []

--- a/src/backend/tests/community/core/devices/services/test_baas_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_device_service.py
@@ -1554,6 +1554,7 @@ class TestInitStepEdgeCases:
         """Lines 511,513,515,519: optional cmd args are appended."""
         baas = MagicMock()
         baas._baas_api_base = "http://baas.local"
+        baas.exec_command_on_bot.return_value = {"exit_code": 0}
         svc = _make_service(baas_service=baas)
 
         svc._start_baas_sandbox_service(

--- a/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_publish_task_handlers.py
@@ -55,9 +55,15 @@ def _make_baas_device_service(
     vault: TokenVault | None = None,
     template_service: MagicMock | None = None,
 ) -> BaasDeviceService:
+    baas_service = MagicMock()
+    baas_service.exec_command_on_bot.return_value = {
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": "",
+    }
     return BaasDeviceService(
         repository=repo,
-        baas_service=MagicMock(),
+        baas_service=baas_service,
         bot_query=bot_query or MagicMock(),
         bot_sync=MagicMock(),
         oss_record_repo=MagicMock(),


### PR DESCRIPTION
- 等待镜像初始化完成后再执行 Backend bootstrap，避免两个初始化流程并发操作。
  - install_engine.sh、Supervisor 同步服务安装等步骤改为同步执行。
  - 启动业务服务前，明确等待 supervisorctl 可用。
  - 必要步骤返回非零退出码时立即失败，不再继续启动后续服务。
  
  
 解决的问题：初始化脚本并发执行，导致 start_service 在 Supervisor 未就绪时启动，出现 /tmp/supervisor.sock 不存在，最终容器启动失败。