### PR TITLE
fix(singlebox): align merchant hybrid bot profiles

### DIFF
--- a/scripts/modules/bcs_baas_provider.sh
+++ b/scripts/modules/bcs_baas_provider.sh
@@ -146,7 +146,7 @@ bcs_baas_provider_register() {
     local role bot_id name provider_ref payload bot_response runtime_token bot_uuid visibility state_bots='[]'
     while IFS=$'\t' read -r role bot_id name; do
         provider_ref="${bot_id}:${entity_id}"
-        payload="$(jq -n --arg name "${name}（当前）" --arg ref "$provider_ref" --arg owner "$owner" '{name: $name, provider_bot_ref: $ref, owners: [$owner], summary: "Local Claude Code platform data bot", domains: ["claude_code", "local-commerce"], skills: ["chat", "data-analysis"], scopes: ["local"]}')"
+        payload="$(jq -n --arg name "$name" --arg ref "$provider_ref" --arg owner "$owner" '{name: $name, provider_bot_ref: $ref, owners: [$owner], summary: "Local Claude Code platform data bot", domains: ["claude_code", "local-commerce"], skills: ["chat", "data-analysis"], scopes: ["local"]}')"
         bot_response="$(curl --noproxy '*' --connect-timeout 2 --max-time 20 -fsS -X POST "http://127.0.0.1:${BCS_PORT}/providers/${provider_id}/bots" -H "Authorization: Bearer ${provider_admin_token}" -H 'Content-Type: application/json' -d "$payload")" || return 1
         runtime_token="$(jq -r '.bot_runtime_token // empty' <<< "$bot_response")"
         bot_uuid="$(jq -r '.bot_uuid // empty' <<< "$bot_response")"
@@ -155,6 +155,7 @@ bcs_baas_provider_register() {
         jq -e '.success == true and .data.visibility == "public"' <<< "$visibility" >/dev/null || { log_error "BCS Provider bot is not discoverable"; return 1; }
         bcs_baas_provider_add_bot_token "$role" "$provider_ref" "$runtime_token" || return 1
         state_bots="$(jq -c --arg role "$role" --arg ref "$provider_ref" --arg uuid "$bot_uuid" '. + [{role: $role, provider_bot_ref: $ref, bot_uuid: $uuid}]' <<< "$state_bots")"
+        log_info "Registered local Claude Provider bot role=${role} bot_uuid=${bot_uuid} visibility=public"
     done < <(jq -r '.bots[] | [.role, .bot_id, .name] | @tsv' "$CLAUDE_BOTS_STATE_FILE")
     umask 077
     jq -n --arg provider_id "$provider_id" --arg owner "$owner" --argjson bots "$state_bots" '{provider_id: $provider_id, bcs_owner_id: $owner, bots: $bots}' > "$BCS_BAAS_PROVIDER_STATE_FILE"

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -79,6 +79,9 @@ BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
 CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-}"
 BCN_PLUGIN_SOURCE="${BCN_PLUGIN_SOURCE:-source}"
 BCN_PLUGIN_VERSION="${BCN_PLUGIN_VERSION:-latest}"
+MERCHANT_HYBRID_DEFAULT_PROFILE_DIR="scripts/4bots_merchant_operations_profile"
+MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE="platform-data"
+MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR="scripts/4bots_merchant_operations_profile_for_claude"
 
 # openclaw 配置目录和模板路径
 OPENCLAW_CONFIG_DIR="${HOME}/.openclaw"
@@ -441,6 +444,7 @@ show_help() {
     echo "  $0 restart bots                Restart only the 5 local bot gateways"
     echo "  $0 start bots --profile-dir scripts/8bots_micro_merchant_profile"
     echo "  $0 start bcs_frontend --profile-dir scripts/4bots_merchant_operations_profile"
+    echo "  $0 start merchant_hybrid          Start merchant hybrid with its default profiles"
     echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile"
     echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile --exclusive-profile-dir platform-data --claude-profile-dir scripts/4bots_merchant_operations_profile_for_claude"
     echo "  $0 restart bcs_bots            Restart BCS + 5 local bot gateways"
@@ -464,6 +468,27 @@ validate_hybrid_profile_options() {
             return 1
         fi
     fi
+}
+
+apply_merchant_hybrid_profile_defaults() {
+    local target_command="$1"
+    shift
+
+    case "$target_command" in
+        setup|start|restart)
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+    if [ "$#" -ne 1 ] || [ "$1" != "merchant_hybrid" ]; then
+        return 0
+    fi
+
+    BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_PROFILE_DIR}}"
+    BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-${MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE}}"
+    CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR}}"
+    log_info "merchant_hybrid profile configuration resolved excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE} claude_profile_enabled=true"
 }
 
 # 编译插编 bcs 到 target/cov-e2e/llvm-cov-target/ 并 export BCS_BIN/LLVM_PROFILE_FILE。
@@ -806,6 +831,7 @@ main() {
     if [ ${#services[@]} -eq 0 ]; then
         services=(all)
     fi
+    apply_merchant_hybrid_profile_defaults "$command" "${services[@]}"
     if [ -n "${BOTS_PROFILE_DIR:-}" ]; then
         for svc in "${services[@]}"; do
             # --profile-dir / BOTS_PROFILE_DIR is primarily for the bots target,

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -184,6 +184,96 @@ with open(path, 'w', encoding='utf-8') as stream:
     json.dump(profile, stream)
 PY
 
+test_provider_bot_registration_keeps_profile_display_name() (
+    export CLAUDE_BOTS_STATE_FILE="$TMP/claude-bots-state.json"
+    export BCS_BAAS_PROVIDER_STATE_FILE="$TMP/provider-state.json"
+    export BCS_BAAS_PROVIDER_TOKEN_FILE="$TMP/provider-tokens.json"
+    export BCS_PORT=21000
+
+    printf '%s\n' '{"entity_id":"mock-user","bots":[{"role":"platform-data","bot_id":"bot-data","name":"平台数据分析"}]}' \
+        > "$CLAUDE_BOTS_STATE_FILE"
+
+    local captured_provider_bot_payload
+    captured_provider_bot_payload="$TMP/provider-bot-payload.json"
+
+    bcs_baas_provider_bcs_owner_id() { printf '%s\n' '001'; }
+    bcs_baas_provider_update_tokens() { :; }
+    bcs_baas_provider_add_bot_token() { :; }
+    log_info() { :; }
+    curl() {
+        local data='' url=''
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -d)
+                    data="$2"
+                    shift 2
+                    ;;
+                http://*|https://*)
+                    url="$1"
+                    shift
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        case "$url" in
+            */providers)
+                printf '%s\n' '{"provider_id":"provider-test","provider_admin_token":"provider-admin-test","bcs_to_provider_token":"bcs-to-provider-test"}'
+                ;;
+            */providers/provider-test/bots)
+                printf '%s' "$data" > "$captured_provider_bot_payload"
+                printf '%s\n' '{"bot_runtime_token":"bot-runtime-test","bot_uuid":"bot-provider-test"}'
+                ;;
+            */bots/bot-provider-test/visibility)
+                printf '%s\n' '{"success":true,"data":{"visibility":"public"}}'
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+
+    bcs_baas_provider_register
+    [ "$(jq -r '.name' "$captured_provider_bot_payload")" = '平台数据分析' ]
+    ! jq -e '.name | contains("（当前）")' "$captured_provider_bot_payload" >/dev/null
+)
+
+test_provider_bot_registration_keeps_profile_display_name
+
+test_merchant_hybrid_profile_defaults() (
+    log_info() { :; }
+
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
+
+    unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    BOTS_PROFILE_DIR="scripts/custom_profile"
+    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
+
+    BOTS_PROFILE_DIR="scripts/custom_profile"
+    BOTS_EXCLUDED_PROFILE_SOURCE="custom-platform-data"
+    CLAUDE_PROFILE_DIR="scripts/custom_claude_profile"
+    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "custom-platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "scripts/custom_claude_profile" ]
+
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    apply_merchant_hybrid_profile_defaults status merchant_hybrid
+    [ -z "${BOTS_PROFILE_DIR:-}" ]
+    [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
+    [ -z "${CLAUDE_PROFILE_DIR:-}" ]
+)
+
+test_merchant_hybrid_profile_defaults
+
 events="$TMP/events"
 hybrid_port_preflight() { return 0; }
 check_prereqs_for_services() { return 97; }

--- a/spec/pipeline/hybrid-singlebox-defaults/009-pr-report.md
+++ b/spec/pipeline/hybrid-singlebox-defaults/009-pr-report.md
@@ -1,0 +1,46 @@
+# PR 收敛报告：hybrid-singlebox-defaults
+
+## 范围
+
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/hybrid-singlebox-debug-dev-20260814` / `inclusionAI/Avernet`
+- Head / base: `debug/hybrid-singlebox-dev-20260814` / `dev`
+- PR: 创建前未发现同 head/base 的 PR
+- PR title: `fix(singlebox): align merchant hybrid bot profiles`
+- PR description sections: Problem / Solution / Validation / Compatibility and risk
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| 仓库与目标分支已核验 | 当前 HEAD、`origin/dev` 与 merge base 均为 `81cb9696d` | 当前分支不是目标分支，且从 `dev` 基线创建。 |
+| 任务范围已核验 | 三个脚本文件的未提交 diff | 仅包含 Provider 展示名与 `merchant_hybrid` 启动默认值及其 shell 回归。 |
+| 匹配 PR | `gh pr list --head ... --base dev --state all` 返回空数组 | 可在推送后创建新 PR。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 无 | - | 待 PR 创建 | 尚无可查询的自动评审意见。 | - | - |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| 本地 hybrid shell 回归 | PASS | `bash scripts/test_hybrid.sh` | - | 待提交 | 通过。 |
+| Shell 语法与差异检查 | PASS | `bash -n ...`、`git diff --check` | - | 待提交 | 通过。 |
+| 远端 CI | PENDING | PR 尚未创建 | 尚无远端 job。 | - | PR 创建后查询。 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 无 | - | 待 PR 创建 | 尚无可查询的人工意见。 | - | - |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: CLEAR
+- ACI/CI: PENDING
+- 人工意见: CLEAR
+- 下一步: 仅暂存任务文件，创建提交并推送 topic 分支。

--- a/spec/pipeline/hybrid-singlebox-defaults/009-pr-report.md
+++ b/spec/pipeline/hybrid-singlebox-defaults/009-pr-report.md
@@ -4,7 +4,7 @@
 
 - Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/hybrid-singlebox-debug-dev-20260814` / `inclusionAI/Avernet`
 - Head / base: `debug/hybrid-singlebox-dev-20260814` / `dev`
-- PR: 创建前未发现同 head/base 的 PR
+- PR: https://github.com/inclusionAI/Avernet/pull/1045
 - PR title: `fix(singlebox): align merchant hybrid bot profiles`
 - PR description sections: Problem / Solution / Validation / Compatibility and risk
 - 人工意见模式: auto
@@ -15,13 +15,16 @@
 |---|---|---|
 | 仓库与目标分支已核验 | 当前 HEAD、`origin/dev` 与 merge base 均为 `81cb9696d` | 当前分支不是目标分支，且从 `dev` 基线创建。 |
 | 任务范围已核验 | 三个脚本文件的未提交 diff | 仅包含 Provider 展示名与 `merchant_hybrid` 启动默认值及其 shell 回归。 |
-| 匹配 PR | `gh pr list --head ... --base dev --state all` 返回空数组 | 可在推送后创建新 PR。 |
+| 匹配 PR | `gh pr list --head ... --base dev --state all` 返回空数组 | 推送后已创建新的 PR。 |
+| PR 元数据 | PR #1045 的 title、body、head、base | 标题与四个必填说明段落均与已核验 diff 一致。 |
+| 代码变更提交 | `db6c05972` | 已推送的首个聚焦提交。 |
+| 人工 review | 两个 `User` 类型 APPROVED review | 均未提出需要处理的修改意见。 |
 
 ## 自动意见
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 无 | - | 待 PR 创建 | 尚无可查询的自动评审意见。 | - | - |
+| 1 | 无 | - | CLEAR | reviews、issue comments 与 inline comments 均为空。 | - | - |
 
 ## ACI/CI
 
@@ -29,18 +32,25 @@
 |---|---|---|---|---|---|
 | 本地 hybrid shell 回归 | PASS | `bash scripts/test_hybrid.sh` | - | 待提交 | 通过。 |
 | Shell 语法与差异检查 | PASS | `bash -n ...`、`git diff --check` | - | 待提交 | 通过。 |
-| 远端 CI | PENDING | PR 尚未创建 | 尚无远端 job。 | - | PR 创建后查询。 |
+| BCS unit tests | PASS | GitHub Actions `BCS unit tests` | - | `db6c05972` | 已完成且成功。 |
+| Backend unit tests | PASS | GitHub Actions `Backend unit tests` | - | `db6c05972` | 已完成且成功。 |
+| Engine unit tests | PASS | GitHub Actions `Engine unit tests` | - | `db6c05972` | 已完成且成功。 |
+| BaaS unit tests | PASS | GitHub Actions `BaaS unit tests` | - | `db6c05972` | 已完成且成功。 |
+| Gateway unit tests | PASS | GitHub Actions `Gateway unit tests` | - | `db6c05972` | 已完成且成功。 |
+| BCS e2e (coverage gated) | PASS | GitHub Actions `BCS e2e (coverage gated)` | - | `db6c05972` | 已完成且成功。 |
+| Singlebox coverage | PENDING | GitHub Actions `Singlebox coverage` | 正在执行 `Run singlebox coverage`。 | - | 等待终态。 |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 无 | - | 待 PR 创建 | 尚无可查询的人工意见。 | - | - |
+| 1 | cassiuscai | https://github.com/inclusionAI/Avernet/pull/1045#pullrequestreview-4933875774 | APPROVED | 空正文批准，无修改项。 | - | - |
+| 1 | totalfrank | https://github.com/inclusionAI/Avernet/pull/1045#pullrequestreview-4933895725 | APPROVED | `LGTM`，无修改项。 | - | - |
 
 ## 当前结论
 
-- PR: NOT_CREATED
+- PR: OPEN
 - 自动意见: CLEAR
 - ACI/CI: PENDING
 - 人工意见: CLEAR
-- 下一步: 仅暂存任务文件，创建提交并推送 topic 分支。
+- 下一步: 等待当前 head 的远端检查完成，并在有评审意见时按自动模式处理。


### PR DESCRIPTION
## Problem

`merchant_hybrid` required a long profile-configuration command for its normal local startup, while the local Claude Provider Bot registration appended a display-only `（当前）` suffix instead of preserving the profile name.

## Solution

- Default the merchant operations OpenClaw profile, `platform-data` exclusion, and Claude profile for `setup`, `start`, and `restart merchant_hybrid`.
- Preserve explicitly supplied profile values and keep `stop`/`status` on their saved runtime-state path.
- Register the Provider Bot using its profile display name and add low-sensitivity lifecycle diagnostics.
- Add shell regressions for the registration payload and default, partial override, full override, and status behaviors.

## Validation

- `bash scripts/test_hybrid.sh` — passed.
- `bash -n scripts/singlebox.sh scripts/test_hybrid.sh scripts/modules/bcs_baas_provider.sh` — passed.
- `git diff --check` — passed.
- `./scripts/singlebox.sh --help | rg -F 'start merchant_hybrid'` — passed.

## Compatibility and risk

The defaults apply only when the requested target is exactly `merchant_hybrid`; other hybrid invocations are unchanged. Existing Provider registrations receive the profile name on their next controlled registration or restart; this PR does not restart local services.
