### PR TITLE
fix: scope Skills Pool edit guard to Pool participants

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -108,7 +108,10 @@ from agentclaw.community.core.resources.service import (
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillDuplicateError,
     LocalSkillActiveError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
     LocalSkillEditPausedError,
+    LocalSkillLayoutRollbackError,
     LocalSkillInvalidPackageError,
     LocalSkillNotFoundError,
     LocalSkillNotReadyError,
@@ -268,6 +271,9 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     LocalSkillTooLargeError: (413, "Skill package is too large"),
     LocalSkillStorageError: (502, "Skill storage operation failed"),
     LocalSkillRuntimeSyncError: (502, "Skill runtime synchronization failed"),
+    LocalSkillEditBusyError: (409, "Another Skill update is in progress"),
+    LocalSkillLayoutRollbackError: (409, "Skill layout rollback is in progress"),
+    LocalSkillEditLockUnavailableError: (503, "Skill update service is temporarily unavailable"),
     LocalSkillEditPausedError: (409, "Skill layout is being updated"),
     FileTooLargeError: (413, "File too large for preview"),
     # Startup script (issue #926): the body is refused at write time so a

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -53,5 +53,17 @@ class LocalSkillEditPausedError(Exception):
     """A Bot Skill layout operation currently owns the edit lock."""
 
 
+class LocalSkillEditBusyError(LocalSkillEditPausedError):
+    """Another Local Skill mutation is still in progress."""
+
+
+class LocalSkillLayoutRollbackError(LocalSkillEditPausedError):
+    """Pool-to-Legacy layout rollback currently owns the filesystem."""
+
+
+class LocalSkillEditLockUnavailableError(LocalSkillEditPausedError):
+    """The distributed lock backend is unavailable, so writes fail closed."""
+
+
 class ActiveSkillSetReferenceError(RuntimeError):
     """A Skill became referenced by an active custom SkillSet."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_delete_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_delete_service.py
@@ -16,7 +16,10 @@ from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillActiveError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
     LocalSkillEditPausedError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotFoundError,
     LocalSkillNotReadyError,
     LocalSkillStorageError,
@@ -29,8 +32,11 @@ from agentclaw.community.core.repository.protocols.skill_center import SkillSetR
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.errors import ActiveSkillSetReferenceError
 from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
     SkillsPoolEditPausedError,
+    SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
@@ -69,6 +75,12 @@ class LocalSkillDeleteService:
         scope = self._discover_scope(skill_id)
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
+        except SkillsPoolEditBusyError as exc:
+            raise LocalSkillEditBusyError() from exc
+        except SkillsPoolEditRollbackError as exc:
+            raise LocalSkillLayoutRollbackError() from exc
+        except SkillsPoolEditLockUnavailableError as exc:
+            raise LocalSkillEditLockUnavailableError() from exc
         except SkillsPoolEditPausedError as exc:
             raise LocalSkillEditPausedError() from exc
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -14,6 +14,9 @@ from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillEditPausedError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotFoundError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
@@ -29,8 +32,11 @@ from agentclaw.community.core.repository.protocols.skills_pool import (
     SkillsPoolSkillRepositoryProtocol,
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
     SkillsPoolEditPausedError,
+    SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
@@ -80,6 +86,12 @@ class LocalSkillStateService:
         scope = self._discover_scope(skill_id)
         try:
             lease = self._edit_guard.acquire_for_edit(scope=scope)
+        except SkillsPoolEditBusyError as exc:
+            raise LocalSkillEditBusyError() from exc
+        except SkillsPoolEditRollbackError as exc:
+            raise LocalSkillLayoutRollbackError() from exc
+        except SkillsPoolEditLockUnavailableError as exc:
+            raise LocalSkillEditLockUnavailableError() from exc
         except SkillsPoolEditPausedError as exc:
             raise LocalSkillEditPausedError() from exc
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -24,12 +24,15 @@ from agentclaw.community.core.repository.protocols.bot import BotCollabLogReposi
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillDuplicateError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
     LocalSkillEditPausedError,
     LocalSkillInvalidPackageError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
     LocalSkillTooLargeError,
+    LocalSkillLayoutRollbackError,
 )
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
@@ -41,8 +44,11 @@ from agentclaw.community.core.skill_center.factories import (
 )
 from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
 from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
     SkillsPoolEditPausedError,
+    SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 
@@ -95,6 +101,12 @@ class LocalSkillUploadService:
         scope = self._scope_for(initial_bot, bot_id)
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
+        except SkillsPoolEditBusyError as exc:
+            raise LocalSkillEditBusyError() from exc
+        except SkillsPoolEditRollbackError as exc:
+            raise LocalSkillLayoutRollbackError() from exc
+        except SkillsPoolEditLockUnavailableError as exc:
+            raise LocalSkillEditLockUnavailableError() from exc
         except SkillsPoolEditPausedError as exc:
             raise LocalSkillEditPausedError() from exc
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -2462,10 +2462,10 @@ class SkillSetSwitcher(_DeviceSyncMixin):
             )
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
-        except SkillsPoolEditPausedError:
+        except SkillsPoolEditPausedError as exc:
             return SwitchResult(
                 success=False,
-                message="Skills are temporarily read-only while layout work is running",
+                message=str(exc),
             )
         try:
             return await self._switch_to_skill_set_unlocked(
@@ -2659,10 +2659,10 @@ class SkillSetSwitcher(_DeviceSyncMixin):
             return await self._sync_skill_set_to_active_unlocked(skill_set_id, user_id)
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
-        except SkillsPoolEditPausedError:
+        except SkillsPoolEditPausedError as exc:
             return SwitchResult(
                 success=False,
-                message="Skills are temporarily read-only while layout work is running",
+                message=str(exc),
             )
         try:
             return await self._sync_skill_set_to_active_unlocked(skill_set_id, user_id)
@@ -2898,10 +2898,10 @@ class SkillSetActivator(_DeviceSyncMixin):
             )
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
-        except SkillsPoolEditPausedError:
+        except SkillsPoolEditPausedError as exc:
             return ActivateResult(
                 success=False,
-                message="Skills are temporarily read-only while layout work is running",
+                message=str(exc),
             )
         try:
             return await self._activate_skill_set_unlocked(
@@ -3038,10 +3038,10 @@ class SkillSetActivator(_DeviceSyncMixin):
             )
         try:
             lease = await self._edit_guard.acquire_for_edit_wait(scope=scope)
-        except SkillsPoolEditPausedError:
+        except SkillsPoolEditPausedError as exc:
             return DeactivateResult(
                 success=False,
-                message="Skills are temporarily read-only while layout work is running",
+                message=str(exc),
             )
         try:
             return await self._deactivate_skill_set_unlocked(

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -8,22 +8,42 @@ import time
 
 from injector import inject
 
+from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolLayoutRepositoryProtocol
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     SkillLayoutPhase,
 )
-from agentclaw.community.plugin_api.cache import CachePlugin
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.cache import (
+    CacheLockInfrastructureError,
+    CachePlugin,
+)
+
+
+logger = get_logger()
 
 
 class SkillsPoolEditPausedError(RuntimeError):
     """Raised when a local Skill mutation cannot safely start."""
 
 
+class SkillsPoolEditBusyError(SkillsPoolEditPausedError):
+    """Another ordinary Local Skill mutation owns the Bot lock."""
+
+
+class SkillsPoolEditRollbackError(SkillsPoolEditPausedError):
+    """A Pool-to-Legacy rollback owns the Bot filesystem."""
+
+
+class SkillsPoolEditLockUnavailableError(SkillsPoolEditPausedError):
+    """The distributed lock service is unavailable; fail closed."""
+
+
 @dataclass(frozen=True, slots=True)
 class SkillsPoolEditLease:
     key: str
-    token: str
+    token: str | None
 
 
 class SkillsPoolEditGuard:
@@ -41,9 +61,11 @@ class SkillsPoolEditGuard:
         *,
         cache: CachePlugin,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
+        bot_repository: BotRepository,
     ) -> None:
         self._cache = cache
         self._layouts = layout_repository
+        self._bots = bot_repository
 
     @staticmethod
     def _key(*, scope: BotSkillLayoutScope) -> str:
@@ -54,14 +76,39 @@ class SkillsPoolEditGuard:
         *,
         scope: BotSkillLayoutScope,
     ) -> SkillsPoolEditLease:
-        lease = self.acquire_for_rollback(scope=scope)
-        if lease is None:
-            raise SkillsPoolEditPausedError(
-                "Skills are temporarily read-only while layout work is running"
+        # Teclaw never participates in a Pool filesystem layout or its
+        # rollback.  Its draft-container I/O must therefore not be serialized
+        # behind a Pool-only lock held by an unrelated long-running upload.
+        if self._is_teclaw(scope):
+            return SkillsPoolEditLease(key="", token=None)
+
+        if self._is_rollback_phase(scope):
+            self._log_rejection(scope=scope, reason="rollback_phase")
+            raise SkillsPoolEditRollbackError(
+                "Skills are temporarily read-only during layout rollback"
             )
-        if self._layouts.get(scope).phase in self._ROLLBACK_PHASES:
+
+        try:
+            lease = self._acquire_for_edit(scope=scope)
+        except CacheLockInfrastructureError as exc:
+            self._log_rejection(scope=scope, reason="cache_unavailable")
+            raise SkillsPoolEditLockUnavailableError(
+                "Skill updates are temporarily unavailable because the lock service is unavailable"
+            ) from exc
+        if lease is None:
+            if self._is_rollback_phase(scope):
+                self._log_rejection(scope=scope, reason="rollback_phase")
+                raise SkillsPoolEditRollbackError(
+                    "Skills are temporarily read-only during layout rollback"
+                )
+            self._log_rejection(scope=scope, reason="lock_busy")
+            raise SkillsPoolEditBusyError(
+                "Another skill update is already in progress; please retry shortly"
+            )
+        if self._is_rollback_phase(scope):
             self.release(lease)
-            raise SkillsPoolEditPausedError(
+            self._log_rejection(scope=scope, reason="rollback_phase")
+            raise SkillsPoolEditRollbackError(
                 "Skills are temporarily read-only during layout rollback"
             )
         return lease
@@ -79,12 +126,16 @@ class SkillsPoolEditGuard:
         while True:
             try:
                 return self.acquire_for_edit(scope=scope)
-            except SkillsPoolEditPausedError:
-                if self._layouts.get(scope).phase in self._ROLLBACK_PHASES:
-                    raise
+            except SkillsPoolEditBusyError:
                 if time.monotonic() >= deadline:
                     raise
                 await asyncio.sleep(0.01)
+            except SkillsPoolEditPausedError:
+                # Rollback and cache failures must never be transformed into
+                # a 30-second ordinary-edit wait.
+                if self._is_rollback_phase(scope):
+                    raise
+                raise
 
     def acquire_for_rollback(
         self,
@@ -92,17 +143,58 @@ class SkillsPoolEditGuard:
         scope: BotSkillLayoutScope,
     ) -> SkillsPoolEditLease | None:
         key = self._key(scope=scope)
+        # Rollback has historically treated cache unavailability as a
+        # retryable ``EDIT_BUSY`` outcome.  Preserve that operator contract;
+        # only product-side edits need the more precise user-facing outcome.
         token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
         if token is None:
             return None
         return SkillsPoolEditLease(key=key, token=token)
 
+    def _acquire_for_edit(
+        self, *, scope: BotSkillLayoutScope
+    ) -> SkillsPoolEditLease | None:
+        key = self._key(scope=scope)
+        token = self._cache.acquire_lock_strict(key, ttl=self._LOCK_TTL_SECONDS)
+        if token is None:
+            return None
+        return SkillsPoolEditLease(key=key, token=token)
+
     def release(self, lease: SkillsPoolEditLease) -> bool:
+        if lease.token is None:
+            return True
         return self._cache.release_lock(lease.key, lease.token)
+
+    def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
+        return self._layouts.get(scope).phase in self._ROLLBACK_PHASES
+
+    def _is_teclaw(self, scope: BotSkillLayoutScope) -> bool:
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        return bool(
+            bot
+            and bot.get("env") == scope.env
+            and bot.get("active_engine") == "teclaw"
+        )
+
+    def _log_rejection(self, *, scope: BotSkillLayoutScope, reason: str) -> None:
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        engine = bot.get("active_engine") if bot else "unknown"
+        logger.warning(
+            "[skills_pool.edit_guard] edit rejected env=%s entity_id=%s "
+            "bot_id=%s engine=%s reason=%s",
+            scope.env,
+            scope.entity_id,
+            scope.bot_id,
+            engine,
+            reason,
+        )
 
 
 __all__ = [
     "SkillsPoolEditGuard",
+    "SkillsPoolEditBusyError",
+    "SkillsPoolEditLockUnavailableError",
     "SkillsPoolEditLease",
     "SkillsPoolEditPausedError",
+    "SkillsPoolEditRollbackError",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -8,8 +8,11 @@ import time
 
 from injector import inject
 
-from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolLayoutRepositoryProtocol
+from agentclaw.community.core.skills_pool.participation import (
+    SkillLayoutParticipation,
+    SkillLayoutParticipationResolver,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     SkillLayoutPhase,
@@ -61,11 +64,11 @@ class SkillsPoolEditGuard:
         *,
         cache: CachePlugin,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
-        bot_repository: BotRepository,
+        participation_resolver: SkillLayoutParticipationResolver,
     ) -> None:
         self._cache = cache
         self._layouts = layout_repository
-        self._bots = bot_repository
+        self._participation_resolver = participation_resolver
 
     @staticmethod
     def _key(*, scope: BotSkillLayoutScope) -> str:
@@ -76,14 +79,14 @@ class SkillsPoolEditGuard:
         *,
         scope: BotSkillLayoutScope,
     ) -> SkillsPoolEditLease:
-        # Teclaw never participates in a Pool filesystem layout or its
-        # rollback.  Its draft-container I/O must therefore not be serialized
-        # behind a Pool-only lock held by an unrelated long-running upload.
-        if self._is_teclaw(scope):
+        participation = self._participation_resolver.resolve(scope=scope)
+        if not participation.participates_in_pool_layout:
             return SkillsPoolEditLease(key="", token=None)
 
         if self._is_rollback_phase(scope):
-            self._log_rejection(scope=scope, reason="rollback_phase")
+            self._log_rejection(
+                scope=scope, participation=participation, reason="rollback_phase"
+            )
             raise SkillsPoolEditRollbackError(
                 "Skills are temporarily read-only during layout rollback"
             )
@@ -91,23 +94,31 @@ class SkillsPoolEditGuard:
         try:
             lease = self._acquire_for_edit(scope=scope)
         except CacheLockInfrastructureError as exc:
-            self._log_rejection(scope=scope, reason="cache_unavailable")
+            self._log_rejection(
+                scope=scope, participation=participation, reason="cache_unavailable"
+            )
             raise SkillsPoolEditLockUnavailableError(
                 "Skill updates are temporarily unavailable because the lock service is unavailable"
             ) from exc
         if lease is None:
             if self._is_rollback_phase(scope):
-                self._log_rejection(scope=scope, reason="rollback_phase")
+                self._log_rejection(
+                    scope=scope, participation=participation, reason="rollback_phase"
+                )
                 raise SkillsPoolEditRollbackError(
                     "Skills are temporarily read-only during layout rollback"
                 )
-            self._log_rejection(scope=scope, reason="lock_busy")
+            self._log_rejection(
+                scope=scope, participation=participation, reason="lock_busy"
+            )
             raise SkillsPoolEditBusyError(
                 "Another skill update is already in progress; please retry shortly"
             )
         if self._is_rollback_phase(scope):
             self.release(lease)
-            self._log_rejection(scope=scope, reason="rollback_phase")
+            self._log_rejection(
+                scope=scope, participation=participation, reason="rollback_phase"
+            )
             raise SkillsPoolEditRollbackError(
                 "Skills are temporarily read-only during layout rollback"
             )
@@ -168,24 +179,20 @@ class SkillsPoolEditGuard:
     def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
         return self._layouts.get(scope).phase in self._ROLLBACK_PHASES
 
-    def _is_teclaw(self, scope: BotSkillLayoutScope) -> bool:
-        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
-        return bool(
-            bot
-            and bot.get("env") == scope.env
-            and bot.get("active_engine") == "teclaw"
-        )
-
-    def _log_rejection(self, *, scope: BotSkillLayoutScope, reason: str) -> None:
-        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
-        engine = bot.get("active_engine") if bot else "unknown"
+    def _log_rejection(
+        self,
+        *,
+        scope: BotSkillLayoutScope,
+        participation: SkillLayoutParticipation,
+        reason: str,
+    ) -> None:
         logger.warning(
             "[skills_pool.edit_guard] edit rejected env=%s entity_id=%s "
-            "bot_id=%s engine=%s reason=%s",
+            "bot_id=%s layout_participation=%s reason=%s",
             scope.env,
             scope.entity_id,
             scope.bot_id,
-            engine,
+            participation.label,
             reason,
         )
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/participation.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/participation.py
@@ -1,0 +1,65 @@
+"""Resolve whether a Bot participates in the Skills Pool filesystem contract.
+
+The shared edit guard must not contain engine-specific policy.  This resolver
+keeps the conservative default in the domain layer and receives any explicit
+engine opt-out from the composition root.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, runtime_checkable
+
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+
+
+@dataclass(frozen=True, slots=True)
+class SkillLayoutParticipation:
+    """The layout policy selected for a Bot's current runtime engine."""
+
+    participates_in_pool_layout: bool
+    label: str
+
+
+@runtime_checkable
+class SkillLayoutParticipationResolver(Protocol):
+    """Port for resolving a Bot's layout participation policy."""
+
+    def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation: ...
+
+
+class BotEngineSkillLayoutParticipationResolver:
+    """Repository-backed, engine-agnostic implementation of the policy port.
+
+    Unknown, missing, or cross-environment Bot records intentionally resolve to
+    the supplied default policy.  Production wiring supplies a participating
+    default, so new engines cannot bypass the edit lock accidentally.
+    """
+
+    def __init__(
+        self,
+        *,
+        bot_repository: BotRepository,
+        default: SkillLayoutParticipation,
+        by_engine: Mapping[str, SkillLayoutParticipation],
+    ) -> None:
+        self._bots = bot_repository
+        self._default = default
+        self._by_engine = dict(by_engine)
+
+    def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation:
+        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
+        if not bot or bot.get("env") != scope.env:
+            return self._default
+        engine = bot.get("active_engine")
+        if not isinstance(engine, str):
+            return self._default
+        return self._by_engine.get(engine, self._default)
+
+
+__all__ = [
+    "BotEngineSkillLayoutParticipationResolver",
+    "SkillLayoutParticipation",
+    "SkillLayoutParticipationResolver",
+]

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -23,6 +23,11 @@ from agentclaw.community.core.skills_pool.claim_service import (
     SkillsPoolMigrationClaimService,
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+from agentclaw.community.core.skills_pool.participation import (
+    BotEngineSkillLayoutParticipationResolver,
+    SkillLayoutParticipation,
+    SkillLayoutParticipationResolver,
+)
 from agentclaw.community.core.skills_pool.operational_query import (
     SkillsPoolOperationalQuery,
 )
@@ -135,6 +140,30 @@ class SkillsPoolModule(Module):
             SkillsPoolRollbackService,
             to=SkillsPoolRollbackService,
             scope=singleton,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def skill_layout_participation_resolver(
+        self,
+        bot_repository: BotRepository,
+    ) -> SkillLayoutParticipationResolver:
+        return BotEngineSkillLayoutParticipationResolver(
+            bot_repository=bot_repository,
+            default=SkillLayoutParticipation(
+                participates_in_pool_layout=True,
+                label="default_pool_layout",
+            ),
+            # Teclaw owns an artifact-style filesystem and never enters the
+            # Pool migration or rollback state machine.  Keep that engine
+            # policy in composition, rather than the shared edit guard.
+            by_engine={
+                "teclaw": SkillLayoutParticipation(
+                    participates_in_pool_layout=False,
+                    label="teclaw_no_pool_layout",
+                )
+            },
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/plugin_api/cache.py
+++ b/src/backend/src/agentclaw/community/plugin_api/cache.py
@@ -5,6 +5,15 @@ from typing import Any, Dict, Optional, Protocol, runtime_checkable
 from agentclaw.community.plugin_api.base import Plugin
 
 
+class CacheLockInfrastructureError(RuntimeError):
+    """The cache backend could not answer a distributed-lock operation.
+
+    This is deliberately distinct from a healthy ``SET NX`` miss: callers
+    which protect data-plane mutations need to expose an infrastructure
+    failure instead of telling users that another request owns the lock.
+    """
+
+
 @runtime_checkable
 class CachePlugin(Plugin, Protocol):
     """Cache manager interface supporting KV operations and distributed locking."""
@@ -25,6 +34,15 @@ class CachePlugin(Plugin, Protocol):
         ...
 
     def acquire_lock(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        ...
+
+    def acquire_lock_strict(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        """Acquire a lock, raising ``CacheLockInfrastructureError`` on outage.
+
+        ``None`` means only that a healthy cache reports the lock as busy.
+        The legacy ``acquire_lock`` keeps its best-effort, ``None``-on-outage
+        contract for existing callers.
+        """
         ...
 
     def release_lock(self, lock_key: str, lock_value: str) -> bool:

--- a/src/backend/src/agentclaw/community/plugins/community/cache.py
+++ b/src/backend/src/agentclaw/community/plugins/community/cache.py
@@ -23,7 +23,10 @@ import uuid
 from typing import Any, Dict, Optional
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.cache import CachePlugin
+from agentclaw.community.plugin_api.cache import (
+    CacheLockInfrastructureError,
+    CachePlugin,
+)
 
 
 logger = get_logger()
@@ -87,24 +90,32 @@ class _RedisBackend:
             )
             return False
 
-    def acquire_lock(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+    def acquire_lock_strict(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        """Acquire a Redis lock without flattening an outage into ``None``."""
         try:
             token = _new_lock_token()
             ok = self._redis.set(f"lock:{lock_key}", token, nx=True, ex=ttl)
             if ok:
                 return token
-            # Healthy "lock busy": the key already exists, SET NX returned falsy.
             logger.debug(
                 "Cache acquire_lock: lock held by others, key=%s", lock_key
             )
             return None
-        except Exception as e:
+        except Exception as exc:
+            raise CacheLockInfrastructureError(
+                "cache lock backend is unavailable"
+            ) from exc
+
+    def acquire_lock(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        try:
+            return self.acquire_lock_strict(lock_key, ttl)
+        except CacheLockInfrastructureError as exc:
             # Infrastructure failure (Redis unreachable) — NOT lock contention.
             # Logged distinctly so it is not misread as "lock held".
             logger.error(
                 "[CACHE-INFRA-FAILURE] acquire_lock could not reach cache "
                 "backend (key=%s): %s — NOT a lock contention",
-                lock_key, e, exc_info=True,
+                lock_key, exc, exc_info=True,
             )
             return None
 
@@ -186,6 +197,9 @@ class _InProcessBackend:
             self._store[storage_key] = (token, time.time() + ttl)
         return token
 
+    def acquire_lock_strict(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        return self.acquire_lock(lock_key, ttl)
+
     def release_lock(self, lock_key: str, lock_value: str) -> bool:
         storage_key = f"lock:{lock_key}"
         with self._guard:
@@ -223,6 +237,9 @@ class CommunityCache(CachePlugin):
 
     def acquire_lock(self, lock_key: str, ttl: int = 30) -> Optional[str]:
         return self._backend.acquire_lock(lock_key, ttl)
+
+    def acquire_lock_strict(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        return self._backend.acquire_lock_strict(lock_key, ttl)
 
     def release_lock(self, lock_key: str, lock_value: str) -> bool:
         return self._backend.release_lock(lock_key, lock_value)

--- a/src/backend/src/agentclaw/community/plugins/local/cache.py
+++ b/src/backend/src/agentclaw/community/plugins/local/cache.py
@@ -70,6 +70,10 @@ class MemoryCachePlugin(MockSeam, CachePlugin):
             self._store[lock_storage_key] = (lock_value, time.time() + ttl)
         return lock_value
 
+    def acquire_lock_strict(self, lock_key: str, ttl: int = 30) -> Optional[str]:
+        """Local memory never has a separate cache infrastructure boundary."""
+        return self.acquire_lock(lock_key, ttl)
+
     def release_lock(self, lock_key: str, lock_value: str) -> bool:
         """释放分布式锁。"""
         lock_storage_key = f"lock:{lock_key}"

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -27,6 +27,11 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotPermissionError,
 )
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillLayoutRollbackError,
+)
 
 
 class _BotUpdate(BaseModel):
@@ -326,6 +331,21 @@ def _lookup(exc: Exception) -> tuple[int, str]:
         if isinstance(exc, error_type):
             return mapped
     raise AssertionError(f"{type(exc).__name__} is unmapped")
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (LocalSkillEditBusyError(), (409, "Another Skill update is in progress")),
+        (LocalSkillLayoutRollbackError(), (409, "Skill layout rollback is in progress")),
+        (
+            LocalSkillEditLockUnavailableError(),
+            (503, "Skill update service is temporarily unavailable"),
+        ),
+    ],
+)
+def test_local_skill_edit_errors_have_distinct_public_responses(error, expected):
+    assert _lookup(error) == expected
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/community/core/skill_center/test_local_skill_delete_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_delete_service.py
@@ -9,6 +9,9 @@ import pytest
 from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillActiveError,
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotReadyError,
     LocalSkillStorageError,
 )
@@ -16,6 +19,11 @@ from agentclaw.community.core.skill_center.services.local_skill_delete_service i
     LocalSkillDeleteService,
 )
 from agentclaw.community.core.skill_center.errors import ActiveSkillSetReferenceError
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
+    SkillsPoolEditLockUnavailableError,
+    SkillsPoolEditRollbackError,
+)
 
 
 class _Files:
@@ -238,7 +246,7 @@ class _Cleanup:
 
 def _service(
     *, active=False, fail_delete=False, active_during_delete=False,
-    on_acquire=None, status="ACTIVE", provider="local",
+    on_acquire=None, status="ACTIVE", provider="local", guard_error=None,
 ):
     files = _Files()
     skills = _Skills(
@@ -246,6 +254,10 @@ def _service(
         active_during_delete=active_during_delete,
     )
     guard = _Guard(on_acquire)
+    if guard_error is not None:
+        async def fail_acquire(*, scope):
+            raise guard_error
+        guard.acquire_for_edit_wait = fail_acquire
     cleanup = _Cleanup()
     service = LocalSkillDeleteService(
         skills,
@@ -272,6 +284,29 @@ async def test_inactive_delete_quarantines_then_removes_database_state_and_packa
     assert files.files == {}
     assert cleanup.work == []
     assert guard.events == [("dev", "owner", "bot"), "release"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("guard_error", "expected_error"),
+    [
+        (SkillsPoolEditBusyError("busy"), LocalSkillEditBusyError),
+        (SkillsPoolEditRollbackError("rollback"), LocalSkillLayoutRollbackError),
+        (
+            SkillsPoolEditLockUnavailableError("cache"),
+            LocalSkillEditLockUnavailableError,
+        ),
+    ],
+)
+async def test_delete_maps_guard_failures_to_public_domain_errors(
+    guard_error, expected_error
+):
+    service, _files, _skills, _guard, _cleanup = _service(
+        guard_error=guard_error
+    )
+
+    with pytest.raises(expected_error):
+        await service.delete_local_skill(skill_id="9", actor_id="owner")
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.skill_center.errors import (
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotFoundError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
@@ -16,6 +19,11 @@ from agentclaw.community.core.skill_center.services.local_skill_state_service im
 from agentclaw.community.core.skills_pool.models import (
     RegisteredSkillAsset,
     SkillMappingSourceLayout,
+)
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
+    SkillsPoolEditLockUnavailableError,
+    SkillsPoolEditRollbackError,
 )
 
 
@@ -199,10 +207,15 @@ def _service(
     collaborators=None,
     on_acquire=None,
     pool_layout: bool = False,
+    guard_error=None,
 ):
     skills = _Skills(active=active, git_path=git_path)
     sets = _Sets(skills, associated=associated)
     guard = _Guard(on_acquire)
+    if guard_error is not None:
+        def fail_acquire(*, scope):
+            raise guard_error
+        guard.acquire_for_edit = fail_acquire
     runtime = _Runtime(sync_success)
     factory = _Factory(runtime)
     service = LocalSkillStateService(
@@ -217,6 +230,31 @@ def _service(
         _Layouts(pool=pool_layout),
     )
     return service, skills, sets, guard, runtime, factory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("guard_error", "expected_error"),
+    [
+        (SkillsPoolEditBusyError("busy"), LocalSkillEditBusyError),
+        (SkillsPoolEditRollbackError("rollback"), LocalSkillLayoutRollbackError),
+        (
+            SkillsPoolEditLockUnavailableError("cache"),
+            LocalSkillEditLockUnavailableError,
+        ),
+    ],
+)
+async def test_state_change_maps_guard_failures_to_public_domain_errors(
+    guard_error, expected_error
+):
+    service, _skills, _sets, _guard, _runtime, _factory = _service(
+        guard_error=guard_error
+    )
+
+    with pytest.raises(expected_error):
+        await service.set_local_skill_active(
+            skill_id="9", actor_id="owner", active=True
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -31,6 +31,7 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditLockUnavailableError,
     SkillsPoolEditRollbackError,
 )
+from agentclaw.community.core.skills_pool.participation import SkillLayoutParticipation
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutState,
     SkillLayout,
@@ -1384,14 +1385,17 @@ class _YieldingFilesystem(_Filesystem):
 async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
     repo = _ConcurrentRepo()
     filesystem = _YieldingFilesystem()
-    class _Bots:
-        def get_by_id_and_entity(self, _bot_id, _entity_id):
-            return {"env": "pre", "active_engine": "openclaw"}
+    class _Participation:
+        def resolve(self, *, scope):
+            return SkillLayoutParticipation(
+                participates_in_pool_layout=True,
+                label="test_pool_layout",
+            )
 
     guard = SkillsPoolEditGuard(
         cache=_LockingCache(),
         layout_repository=_PoolLayouts(),
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
     package = _zip({"SKILL.md": b"name: upload-skill\ndescription: concurrent\n"})
     first, second = await asyncio.gather(

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -1311,6 +1311,9 @@ class _LockingCache:
         self.held[key] = "token"
         return "token"
 
+    def acquire_lock_strict(self, key, ttl=30):
+        return self.acquire_lock(key, ttl)
+
     def release_lock(self, key, token):
         if self.held.get(key) != token:
             return False
@@ -1340,7 +1343,15 @@ class _YieldingFilesystem(_Filesystem):
 async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
     repo = _ConcurrentRepo()
     filesystem = _YieldingFilesystem()
-    guard = SkillsPoolEditGuard(cache=_LockingCache(), layout_repository=_PoolLayouts())
+    class _Bots:
+        def get_by_id_and_entity(self, _bot_id, _entity_id):
+            return {"env": "pre", "active_engine": "openclaw"}
+
+    guard = SkillsPoolEditGuard(
+        cache=_LockingCache(),
+        layout_repository=_PoolLayouts(),
+        bot_repository=_Bots(),
+    )
     package = _zip({"SKILL.md": b"name: upload-skill\ndescription: concurrent\n"})
     first, second = await asyncio.gather(
         _replacement_service(

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -10,6 +10,9 @@ from types import SimpleNamespace
 import pytest
 
 from agentclaw.community.core.skill_center.errors import (
+    LocalSkillEditBusyError,
+    LocalSkillEditLockUnavailableError,
+    LocalSkillLayoutRollbackError,
     LocalSkillInvalidPackageError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
@@ -22,7 +25,12 @@ from agentclaw.community.core.skill_center.factories import LocalSkillPackageSto
 from agentclaw.community.core.skill_center.services import (
     local_skill_upload_service as upload_module,
 )
-from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
+    SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
+    SkillsPoolEditRollbackError,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutState,
     SkillLayout,
@@ -252,10 +260,13 @@ class _Audit:
 
 
 class _Guard:
-    def __init__(self):
+    def __init__(self, error=None):
         self._lock = asyncio.Lock()
+        self._error = error
 
     async def acquire_for_edit_wait(self, **_kwargs):
+        if self._error is not None:
+            raise self._error
         await self._lock.acquire()
         return object()
 
@@ -491,6 +502,7 @@ def _service(
     bot=None,
     factory=None,
     provider="local",
+    guard=None,
 ):
     return LocalSkillUploadService(
         repo or _Repo(),
@@ -500,10 +512,39 @@ def _service(
         factory or _Factory(filesystem),
         _RuntimeFactory(),
         audit or _Audit(),
-        _Guard(),
+        guard or _Guard(),
         _Cleanup(),
         lambda: _DeviceResolver(provider),
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("guard_error", "expected_error"),
+    [
+        (SkillsPoolEditBusyError("busy"), LocalSkillEditBusyError),
+        (SkillsPoolEditRollbackError("rollback"), LocalSkillLayoutRollbackError),
+        (
+            SkillsPoolEditLockUnavailableError("cache"),
+            LocalSkillEditLockUnavailableError,
+        ),
+    ],
+)
+async def test_upload_maps_guard_failures_to_public_domain_errors(
+    guard_error, expected_error
+):
+    service = _service(
+        _Filesystem(),
+        guard=_Guard(guard_error),
+    )
+
+    with pytest.raises(expected_error):
+        await service.upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip({"SKILL.md": b"name: upload-skill\ndescription: useful\n"}),
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -74,6 +74,21 @@ class _UnavailableCache(_Cache):
         raise CacheLockInfrastructureError("injected cache outage")
 
 
+class _RollbackAfterAcquireCache(_Cache):
+    def __init__(self, layouts: _Layouts) -> None:
+        super().__init__()
+        self._layouts = layouts
+
+    def acquire_lock_strict(self, key: str, ttl: int = 30) -> str | None:
+        token = super().acquire_lock_strict(key, ttl)
+        self._layouts.state = replace(
+            self._layouts.state,
+            target_layout=SkillLayout.LEGACY,
+            phase=SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+        )
+        return token
+
+
 def test_rollback_lease_excludes_new_local_edits() -> None:
     layouts = _Layouts()
     guard = SkillsPoolEditGuard(
@@ -143,6 +158,40 @@ def test_rollback_phase_rejects_edit_even_after_lock_becomes_available() -> None
         guard.acquire_for_edit(scope=SCOPE)
 
 
+def test_lock_contention_rechecks_for_a_rollback_before_reporting_busy() -> None:
+    layouts = _Layouts()
+    cache = _Cache()
+    guard = SkillsPoolEditGuard(
+        cache=cache,
+        layout_repository=layouts,
+        bot_repository=_Bots(),
+    )
+    assert cache.acquire_lock(guard._key(scope=SCOPE)) is not None
+    layouts.state = replace(
+        layouts.state,
+        target_layout=SkillLayout.LEGACY,
+        phase=SkillLayoutPhase.LEGACY_ROLLBACK_PREPARING,
+    )
+
+    with pytest.raises(SkillsPoolEditRollbackError, match="rollback"):
+        guard.acquire_for_edit(scope=SCOPE)
+
+
+def test_rollback_starting_after_lock_acquisition_releases_edit_lease() -> None:
+    layouts = _Layouts()
+    cache = _RollbackAfterAcquireCache(layouts)
+    guard = SkillsPoolEditGuard(
+        cache=cache,
+        layout_repository=layouts,
+        bot_repository=_Bots(),
+    )
+
+    with pytest.raises(SkillsPoolEditRollbackError, match="rollback"):
+        guard.acquire_for_edit(scope=SCOPE)
+
+    assert cache.held == {}
+
+
 def test_teclaw_bypasses_an_abandoned_pool_edit_lock() -> None:
     cache = _Cache()
     guard = SkillsPoolEditGuard(
@@ -172,3 +221,15 @@ def test_cache_outage_is_not_reported_as_lock_contention() -> None:
 
     with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
         guard.acquire_for_edit(scope=SCOPE)
+
+
+@pytest.mark.asyncio
+async def test_wait_does_not_retry_a_cache_outage_as_ordinary_contention() -> None:
+    guard = SkillsPoolEditGuard(
+        cache=_UnavailableCache(),
+        layout_repository=_Layouts(),
+        bot_repository=_Bots(),
+    )
+
+    with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
+        await guard.acquire_for_edit_wait(scope=SCOPE, timeout_seconds=0.1)

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -6,9 +6,12 @@ from dataclasses import replace
 import pytest
 
 from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
-    SkillsPoolEditPausedError,
+    SkillsPoolEditLockUnavailableError,
+    SkillsPoolEditRollbackError,
 )
+from agentclaw.community.plugin_api.cache import CacheLockInfrastructureError
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     BotSkillLayoutState,
@@ -29,6 +32,9 @@ class _Cache:
             return None
         self.held[key] = "token"
         return "token"
+
+    def acquire_lock_strict(self, key: str, ttl: int = 30) -> str | None:
+        return self.acquire_lock(key, ttl)
 
     def release_lock(self, key: str, token: str) -> bool:
         if self.held.get(key) != token:
@@ -53,16 +59,32 @@ class _Layouts:
         return self.state
 
 
+class _Bots:
+    def __init__(self, *, engine: str = "openclaw") -> None:
+        self.engine = engine
+
+    def get_by_id_and_entity(self, bot_id: str, entity_id: str):
+        assert bot_id == SCOPE.bot_id
+        assert entity_id == SCOPE.entity_id
+        return {"env": SCOPE.env, "active_engine": self.engine}
+
+
+class _UnavailableCache(_Cache):
+    def acquire_lock_strict(self, key: str, ttl: int = 30) -> str | None:
+        raise CacheLockInfrastructureError("injected cache outage")
+
+
 def test_rollback_lease_excludes_new_local_edits() -> None:
     layouts = _Layouts()
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=layouts,
+        bot_repository=_Bots(),
     )
     rollback_lease = guard.acquire_for_rollback(scope=SCOPE)
     assert rollback_lease is not None
 
-    with pytest.raises(SkillsPoolEditPausedError, match="read-only"):
+    with pytest.raises(SkillsPoolEditBusyError, match="Another skill update"):
         guard.acquire_for_edit(scope=SCOPE)
 
     assert guard.release(rollback_lease)
@@ -72,6 +94,7 @@ def test_lock_identity_includes_entity_for_reused_bot_ids() -> None:
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=_Layouts(),
+        bot_repository=_Bots(),
     )
     other_scope = replace(SCOPE, entity_id="entity-2")
 
@@ -88,6 +111,7 @@ async def test_waiting_edit_acquires_lock_after_ordinary_edit_releases() -> None
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=_Layouts(),
+        bot_repository=_Bots(),
     )
     first = guard.acquire_for_edit(scope=SCOPE)
 
@@ -112,7 +136,39 @@ def test_rollback_phase_rejects_edit_even_after_lock_becomes_available() -> None
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=layouts,
+        bot_repository=_Bots(),
     )
 
-    with pytest.raises(SkillsPoolEditPausedError, match="rollback"):
+    with pytest.raises(SkillsPoolEditRollbackError, match="rollback"):
+        guard.acquire_for_edit(scope=SCOPE)
+
+
+def test_teclaw_bypasses_an_abandoned_pool_edit_lock() -> None:
+    cache = _Cache()
+    guard = SkillsPoolEditGuard(
+        cache=cache,
+        layout_repository=_Layouts(),
+        bot_repository=_Bots(engine="teclaw"),
+    )
+    # Simulates a previous worker acquiring the legacy generic lock and then
+    # exiting before its finally block.  Teclaw never owns Pool rollback, so a
+    # current Teclaw write must not wait for that lock's TTL.
+    abandoned = cache.acquire_lock(guard._key(scope=SCOPE))
+    assert abandoned is not None
+
+    lease = guard.acquire_for_edit(scope=SCOPE)
+
+    assert lease.token is None
+    assert guard.release(lease) is True
+    assert cache.held
+
+
+def test_cache_outage_is_not_reported_as_lock_contention() -> None:
+    guard = SkillsPoolEditGuard(
+        cache=_UnavailableCache(),
+        layout_repository=_Layouts(),
+        bot_repository=_Bots(),
+    )
+
+    with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
         guard.acquire_for_edit(scope=SCOPE)

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditLockUnavailableError,
     SkillsPoolEditRollbackError,
 )
+from agentclaw.community.core.skills_pool.participation import SkillLayoutParticipation
 from agentclaw.community.plugin_api.cache import CacheLockInfrastructureError
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -59,14 +60,16 @@ class _Layouts:
         return self.state
 
 
-class _Bots:
-    def __init__(self, *, engine: str = "openclaw") -> None:
-        self.engine = engine
+class _Participation:
+    def __init__(self, *, participates: bool = True, label: str = "pool") -> None:
+        self._value = SkillLayoutParticipation(
+            participates_in_pool_layout=participates,
+            label=label,
+        )
 
-    def get_by_id_and_entity(self, bot_id: str, entity_id: str):
-        assert bot_id == SCOPE.bot_id
-        assert entity_id == SCOPE.entity_id
-        return {"env": SCOPE.env, "active_engine": self.engine}
+    def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation:
+        assert scope == SCOPE
+        return self._value
 
 
 class _UnavailableCache(_Cache):
@@ -94,7 +97,7 @@ def test_rollback_lease_excludes_new_local_edits() -> None:
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=layouts,
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
     rollback_lease = guard.acquire_for_rollback(scope=SCOPE)
     assert rollback_lease is not None
@@ -109,7 +112,7 @@ def test_lock_identity_includes_entity_for_reused_bot_ids() -> None:
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=_Layouts(),
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
     other_scope = replace(SCOPE, entity_id="entity-2")
 
@@ -126,7 +129,7 @@ async def test_waiting_edit_acquires_lock_after_ordinary_edit_releases() -> None
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=_Layouts(),
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
     first = guard.acquire_for_edit(scope=SCOPE)
 
@@ -151,7 +154,7 @@ def test_rollback_phase_rejects_edit_even_after_lock_becomes_available() -> None
     guard = SkillsPoolEditGuard(
         cache=_Cache(),
         layout_repository=layouts,
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
 
     with pytest.raises(SkillsPoolEditRollbackError, match="rollback"):
@@ -164,7 +167,7 @@ def test_lock_contention_rechecks_for_a_rollback_before_reporting_busy() -> None
     guard = SkillsPoolEditGuard(
         cache=cache,
         layout_repository=layouts,
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
     assert cache.acquire_lock(guard._key(scope=SCOPE)) is not None
     layouts.state = replace(
@@ -183,7 +186,7 @@ def test_rollback_starting_after_lock_acquisition_releases_edit_lease() -> None:
     guard = SkillsPoolEditGuard(
         cache=cache,
         layout_repository=layouts,
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
 
     with pytest.raises(SkillsPoolEditRollbackError, match="rollback"):
@@ -197,7 +200,9 @@ def test_teclaw_bypasses_an_abandoned_pool_edit_lock() -> None:
     guard = SkillsPoolEditGuard(
         cache=cache,
         layout_repository=_Layouts(),
-        bot_repository=_Bots(engine="teclaw"),
+        participation_resolver=_Participation(
+            participates=False, label="teclaw_no_pool_layout"
+        ),
     )
     # Simulates a previous worker acquiring the legacy generic lock and then
     # exiting before its finally block.  Teclaw never owns Pool rollback, so a
@@ -216,7 +221,7 @@ def test_cache_outage_is_not_reported_as_lock_contention() -> None:
     guard = SkillsPoolEditGuard(
         cache=_UnavailableCache(),
         layout_repository=_Layouts(),
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
 
     with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
@@ -228,7 +233,7 @@ async def test_wait_does_not_retry_a_cache_outage_as_ordinary_contention() -> No
     guard = SkillsPoolEditGuard(
         cache=_UnavailableCache(),
         layout_repository=_Layouts(),
-        bot_repository=_Bots(),
+        participation_resolver=_Participation(),
     )
 
     with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):

--- a/src/backend/tests/community/core/skills_pool/test_participation.py
+++ b/src/backend/tests/community/core/skills_pool/test_participation.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.skills_pool.participation import (
+    BotEngineSkillLayoutParticipationResolver,
+    SkillLayoutParticipation,
+)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.di.modules.skills_pool_module import SkillsPoolModule
+
+
+SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
+DEFAULT = SkillLayoutParticipation(
+    participates_in_pool_layout=True,
+    label="default_pool_layout",
+)
+NO_POOL = SkillLayoutParticipation(
+    participates_in_pool_layout=False,
+    label="artifact_layout",
+)
+
+
+class _Bots:
+    def __init__(self, bot: dict | None) -> None:
+        self._bot = bot
+
+    def get_by_id_and_entity(self, bot_id: str, entity_id: str) -> dict | None:
+        assert (bot_id, entity_id) == (SCOPE.bot_id, SCOPE.entity_id)
+        return self._bot
+
+
+def _resolver(bot: dict | None) -> BotEngineSkillLayoutParticipationResolver:
+    return BotEngineSkillLayoutParticipationResolver(
+        bot_repository=_Bots(bot),
+        default=DEFAULT,
+        by_engine={"artifact_engine": NO_POOL},
+    )
+
+
+def test_explicit_engine_policy_controls_layout_participation() -> None:
+    result = _resolver({"env": "pre", "active_engine": "artifact_engine"}).resolve(
+        scope=SCOPE
+    )
+
+    assert result is NO_POOL
+
+
+@pytest.mark.parametrize(
+    "bot",
+    [
+        None,
+        {"env": "prod", "active_engine": "artifact_engine"},
+        {"env": "pre"},
+        {"env": "pre", "active_engine": 123},
+        {"env": "pre", "active_engine": "unknown_engine"},
+    ],
+)
+def test_unknown_or_incomplete_bot_keeps_conservative_default(bot: dict | None) -> None:
+    result = _resolver(bot).resolve(scope=SCOPE)
+
+    assert result is DEFAULT
+
+
+def test_module_wires_artifact_engine_policy_outside_shared_guard() -> None:
+    resolver = SkillsPoolModule().skill_layout_participation_resolver(
+        _Bots({"env": "pre", "active_engine": "teclaw"})
+    )
+
+    result = resolver.resolve(scope=SCOPE)
+
+    assert result == SkillLayoutParticipation(
+        participates_in_pool_layout=False,
+        label="teclaw_no_pool_layout",
+    )

--- a/src/backend/tests/community/plugins/community/test_cache.py
+++ b/src/backend/tests/community/plugins/community/test_cache.py
@@ -11,6 +11,7 @@ import redis as real_redis
 
 import agentclaw.community.plugins.community.cache as cache_mod
 from agentclaw.community.plugins.community.cache import CommunityCache
+from agentclaw.community.plugin_api.cache import CacheLockInfrastructureError
 
 
 @pytest.fixture(params=["inproc", "redis"])
@@ -124,6 +125,8 @@ def test_redis_unreachable_degrades_without_raising(monkeypatch):
     assert cache.release_lock("L", "tok") is False  # eval+fallback both fail
     assert cache.get_json("k") is None
     assert cache.set_json("k", {"a": 1}) is False
+    with pytest.raises(CacheLockInfrastructureError):
+        cache.acquire_lock_strict("L")
 
 
 def test_set_json_non_serializable_returns_false(cache):


### PR DESCRIPTION
## Summary

- introduce a named SkillLayoutParticipation contract outside the shared edit guard
- wire Teclaw as a non-participating artifact-layout policy from the DI composition root
- retain the fail-closed default for every unconfigured engine and cover policy resolution

## Validation

- `uv run ruff check` (changed backend files)
- `uv run pytest -q tests/community/core/skills_pool/test_edit_guard.py tests/community/core/skills_pool/test_participation.py tests/community/core/skill_center/test_local_skill_upload_service.py` (72 passed)
- REL counterpart full backend CI: 11,720 passed; changed-line coverage 94.67%