### PR TITLE
feat(bcs): expose agent_code in organization candidate bots list

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/organizations.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/organizations.rs
@@ -410,6 +410,7 @@ fn candidate_to_response(bot: OrganizationCandidateBot) -> OrganizationCandidate
     OrganizationCandidateBotResponse {
         bot_uuid: bot.bot_uuid,
         provider_id: bot.provider_id,
+        agent_code: bot.agent_code,
         name: bot.capabilities.name,
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/organizations_contract.rs
@@ -234,6 +234,7 @@ impl OrganizationManagementService for RecordingOrganizationManagement {
         Ok(vec![OrganizationCandidateBot {
             bot_uuid: "bot-b".to_string(),
             provider_id: "provider-b".to_string(),
+            agent_code: Some("agent-code-b".to_string()),
             capabilities: bcs_service_api::BotCapabilities {
                 name: (!self.candidate_name_missing.load(Ordering::Relaxed))
                     .then(|| "Bot B".to_string()),
@@ -566,6 +567,7 @@ async fn candidate_bots_response_exposes_name_without_capabilities() {
         json!({
             "bot_uuid": "bot-b",
             "provider_id": "provider-b",
+            "agent_code": "agent-code-b",
             "name": "Bot B"
         })
     );

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/organizations.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/organizations.rs
@@ -106,6 +106,7 @@ pub struct OrganizationMemberListResponse {
 pub struct OrganizationCandidateBotResponse {
     pub bot_uuid: String,
     pub provider_id: String,
+    pub agent_code: Option<String>,
     pub name: Option<String>,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/organization.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/organization.rs
@@ -15,6 +15,11 @@ pub struct AuthorizedOrganizationPair {
 pub struct OrganizationCandidateBot {
     pub bot_uuid: String,
     pub provider_id: String,
+    /// Routing identifier sourced from the bot's security-gateway credentials,
+    /// mirroring [`OrganizationMemberBotDetail::agent_code`]. Deliberately read
+    /// through the dedicated `get_agent_credentials` accessor rather than from
+    /// `capabilities` so the sensitive `agent_token` is never exposed.
+    pub agent_code: Option<String>,
     pub capabilities: BotCapabilities,
 }
 

--- a/src/bcs/crates/services/bcs-organization/src/core.rs
+++ b/src/bcs/crates/services/bcs-organization/src/core.rs
@@ -787,9 +787,15 @@ impl OrganizationCoreService for OrganizationCore {
             if !matches_query(&record.bot_uuid, &capabilities, &query) {
                 continue;
             }
+            let agent_code = self
+                .registry
+                .get_agent_credentials(&record.bot_uuid)
+                .await
+                .and_then(|credentials| credentials.agent_code);
             candidates.push(OrganizationCandidateBot {
                 bot_uuid: record.bot_uuid,
                 provider_id: record.provider_id,
+                agent_code,
                 capabilities,
             });
         }
@@ -901,9 +907,15 @@ impl OrganizationCoreService for OrganizationCore {
                         None => continue,
                     },
                 };
+                let agent_code = self
+                    .registry
+                    .get_agent_credentials(&record.bot_uuid)
+                    .await
+                    .and_then(|credentials| credentials.agent_code);
                 bots.push(OrganizationCandidateBot {
                     bot_uuid: record.bot_uuid,
                     provider_id: record.provider_id,
+                    agent_code,
                     capabilities,
                 });
             }


### PR DESCRIPTION
## Problem

`GET /providers/{provider_id}/organization-candidate-bots` returned only `bot_uuid`, `provider_id`, and `name` per candidate bot. Callers that need a bot's security-gateway `agent_code` (already available from the single-bot candidate **detail** endpoint) had to issue an extra per-bot request, because the list response omitted it.

## Solution

Add `agent_code: Option<String>` to the candidate bot list path and project it in the route response, mirroring the candidate detail endpoint (`bcs-organization/src/core.rs` ~L837-850):

- Wire DTO `OrganizationCandidateBotResponse` (`bcs-protocol`) gains `agent_code`.
- Core type `OrganizationCandidateBot` (`bcs-service-api`) gains `agent_code`.
- `bcs-organization` core populates it in **both** candidate paths — `candidate_bots` and `candidate_bots_page` (store-optimized branch) — via `registry.get_agent_credentials(bot_uuid).agent_code`, the same dedicated accessor the detail flow uses.
- Route mapping `candidate_to_response` (`bcs-http`) emits the field.

`agent_code` is sourced from `get_agent_credentials` rather than from `capabilities` on purpose: the `agent_code` field on `BotCapabilities` is `skip_serializing`, and the dedicated accessor keeps the sensitive `agent_token` out of regular bot responses — the existing `must-not-leak-from-capabilities` canary encodes this rule. No store/SQL changes were needed; the registry accessor is the authoritative backfilled source.

`agent_code` serializes as `null` when a bot has no security-gateway credential, consistent with how `name` is `null` when absent.

Rejected alternative: joining `agent_code` in the store's `list_organization_candidate_bots` SQL. Rejected because `agent_code` is `skip_serializing` on `BotCapabilities`, so it is not reliably present in the `bot_info` JSON the store parses; the registry accessor is the correct, backfill-aware source (the detail endpoint already relies on it).

## Validation

- `cargo check --tests -p bcs-organization -p bcs-http -p bcs-service-api -p bcs-protocol`: clean.
- `cargo check --tests` on stub/referencing crates (`bcs-bot`, `bcs-message-flow`, `bcs-test-support`, `bcs-services-container`): clean.
- `cargo test -p bcs-organization candidate`: 4/4 pass, including `candidate_bots_include_manager_and_granted_bots_without_leaking_ungranted_provider_ids`.
- `cargo test -p bcs-http --test organizations_contract`: 24/24 pass, including the updated list exact-equality assertion (`"agent_code": "agent-code-b"`) and `candidate_bots_response_keeps_missing_name_as_null`.

Not run: full `cargo test --workspace` and acceptance E2E. Scope is a single additive optional response field; blast radius is limited to the two structures and their literal construction sites (all updated), so an additive field break would surface as a compile error, which the targeted `check --tests` covers.

## Compatibility and risk

Additive optional field on a read-only list response. Existing JSON consumers that key off `bot_uuid`/`provider_id`/`name` are unaffected; the field is `null` for bots without a credential. No schema, contract, or migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
