### PR TITLE
fix(singlebox): align hybrid runtimes with local model config

### DIFF
--- a/scripts/4bots_merchant_operations_profile/README.md
+++ b/scripts/4bots_merchant_operations_profile/README.md
@@ -104,16 +104,14 @@ Profile 不预置本次活动的目标值、店主预算、授权阈值、异常
 ./scripts/singlebox.sh install-tools
 ```
 
-然后直接启动；`start hybrid` 会自动完成项目 setup，只传 profile 时全部 Bot 使用 OpenClaw：
+然后直接启动；`start hybrid` 会自动完成项目 setup，并默认加载本目录的全部 OpenClaw Bot：
 
 ```bash
-./scripts/singlebox.sh start hybrid \
-  --profile-dir scripts/4bots_merchant_operations_profile
+./scripts/singlebox.sh start hybrid
 ```
 
 停止服务：
 
 ```bash
-./scripts/singlebox.sh stop hybrid \
-  --profile-dir scripts/4bots_merchant_operations_profile
+./scripts/singlebox.sh stop hybrid
 ```

--- a/scripts/4bots_merchant_operations_profile_for_claude/README.md
+++ b/scripts/4bots_merchant_operations_profile_for_claude/README.md
@@ -1,7 +1,9 @@
 # 平台数据分析 Claude Code Profile
 
-此 profile 用于 `hybrid` 的 Claude Code 数据分析 Bot。模型和认证沿用本机
-Claude 配置；不在该目录保存凭据。`CLAUDE.md` 是受控角色 prompt 的入口。
+此 profile 用于 `hybrid` 的 Claude Code 数据分析 Bot。模型沿用 Singlebox
+本次选择的配置：`manual` 模式读取仓库根目录 `.env.local`，`home` 模式读取
+本机 OpenClaw 配置。Claude Code 的本机认证配置不会写入该目录。
+`CLAUDE.md` 是受控角色 prompt 的入口。
 
 ## 本地启动
 

--- a/scripts/4bots_merchant_operations_profile_for_claude/bots.json
+++ b/scripts/4bots_merchant_operations_profile_for_claude/bots.json
@@ -16,7 +16,6 @@
         "relay_port": 18900,
         "claude_config_dir": "~/.claude-platform-data",
         "workspace": "~/.teamclaw/claude-workspaces/platform-data",
-        "model": "Kimi-K2.6",
         "permission_mode": "bypassPermissions",
         "system_prompt_md": "platform-data/CLAUDE.md"
       }

--- a/scripts/modules/bcsfuse.sh
+++ b/scripts/modules/bcsfuse.sh
@@ -35,7 +35,11 @@ bcsfuse_load_env() {
     # Its generated BCSFuse env file may predate that policy, so restore the
     # five SOP model selectors only after that file has been loaded.
     if [ "${HYBRID_CLAUDE_ACTIVE:-${MERCHANT_HYBRID_ACTIVE:-0}}" = "1" ]; then
-        local hybrid_model="${HYBRID_MODEL_ID:-Kimi-K2.6}"
+        local hybrid_model="${HYBRID_MODEL_ID:-${OPENCLAW_OPENAI_MODEL_ID:-}}"
+        if [ -z "$hybrid_model" ]; then
+            log_error "Hybrid model policy has no model resolved from the selected Singlebox configuration"
+            return 1
+        fi
         export LLM_FAST_MODEL="$hybrid_model"
         export LLM_BALANCED_MODEL="$hybrid_model"
         export LLM_REASONING_MODEL="$hybrid_model"

--- a/scripts/modules/claude_profile.sh
+++ b/scripts/modules/claude_profile.sh
@@ -69,7 +69,7 @@ if bot["source"] != "platform-data" or bot["profile"] != "platform-data-analyst"
     raise SystemExit("Claude profile must define platform-data analyst")
 
 runtime = bot["runtime"]
-required_runtime = {"type", "relay_port", "claude_config_dir", "workspace", "model", "permission_mode", "system_prompt_md"}
+required_runtime = {"type", "relay_port", "claude_config_dir", "workspace", "permission_mode", "system_prompt_md"}
 if not isinstance(runtime, dict) or set(runtime) != required_runtime:
     raise SystemExit("Claude runtime fields are invalid")
 if runtime["type"] != "claude_code" or runtime["relay_port"] != 18900:
@@ -83,8 +83,6 @@ for field in ("claude_config_dir", "workspace", "system_prompt_md"):
 for field in ("claude_config_dir", "workspace"):
     if not os.path.isabs(os.path.expanduser(runtime[field])):
         raise SystemExit(f"runtime.{field} must resolve to an absolute path")
-if runtime["model"] != "Kimi-K2.6":
-    raise SystemExit("runtime.model must be Kimi-K2.6 for hybrid Claude mode")
 
 prompt_rel = runtime["system_prompt_md"]
 if os.path.isabs(prompt_rel) or ".." in Path(prompt_rel).parts or Path(prompt_rel).suffix.lower() != ".md":
@@ -107,22 +105,26 @@ PY
 }
 
 # Emits unit-separator-delimited source/name/summary/port/config/workspace/model/prompt/permission.
+# The model is resolved from the selected Singlebox runtime configuration, not
+# persisted in the reusable Claude role profile.
 claude_profile_entries() {
-    local manifest
+    local manifest runtime_model
     manifest="$(claude_profile_manifest)" || return 1
-    python3 - "$manifest" <<'PY'
+    runtime_model="${HYBRID_MODEL_ID:-${OPENCLAW_OPENAI_MODEL_ID:-}}"
+    python3 - "$manifest" "$runtime_model" <<'PY'
 import json
 import os
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as stream:
     root = json.load(stream)
+runtime_model = sys.argv[2]
 bot = root["bots"][0]
 runtime = bot["runtime"]
 values = [
     bot["source"], bot["name"], bot["summary"], str(runtime["relay_port"]),
     os.path.expanduser(runtime["claude_config_dir"]), os.path.expanduser(runtime["workspace"]),
-    runtime["model"], os.path.join(os.path.dirname(os.path.abspath(sys.argv[1])), runtime["system_prompt_md"]),
+    runtime_model, os.path.join(os.path.dirname(os.path.abspath(sys.argv[1])), runtime["system_prompt_md"]),
     runtime["permission_mode"],
 ]
 if any("\x1f" in value or "\t" in value or "\n" in value or "\r" in value for value in values):

--- a/scripts/modules/claude_relays.sh
+++ b/scripts/modules/claude_relays.sh
@@ -72,6 +72,10 @@ claude_relays_start() {
     claude_relays_setup || return 1
     local role name summary port config_dir workspace model prompt_file permission pid_file cli model_source
     IFS=$'\x1f' read -r role name summary port config_dir workspace model prompt_file permission < <(claude_profile_entries)
+    [ -n "$model" ] || {
+        log_error "Claude relay model was not resolved from the selected Singlebox configuration"
+        return 1
+    }
     cli="$(claude_relay_cli)" || return 1
     mkdir -p "$config_dir" "$workspace" "$(claude_relay_data_dir "$role")" "$(claude_relay_log_dir "$role")" "$CLAUDE_RELAY_STATE_DIR" "$LOG_DIR"
     pid_file="$(claude_relay_pid_file "$role")"

--- a/scripts/modules/hybrid.sh
+++ b/scripts/modules/hybrid.sh
@@ -14,7 +14,6 @@ HYBRID_CLAUDE_STOP_ORDER=(frontend bcs_baas_provider claude_bots bots bcsfuse bc
 HYBRID_SETUP_ORDER=()
 HYBRID_START_ORDER=()
 HYBRID_STOP_ORDER=()
-HYBRID_MODEL_ID="Kimi-K2.6"
 HYBRID_STATE_FILE="${HYBRID_STATE_FILE:-${DEP_DIR}/hybrid.state.json}"
 
 hybrid_claude_enabled() {
@@ -135,7 +134,7 @@ hybrid_restore_runtime_state() {
 
 hybrid_apply_model_policy() {
     hybrid_claude_enabled || return 0
-    local config_file primary provider primary_model tmp_file
+    local config_file primary provider primary_model
     config_file="${SINGLEBOX_MODEL_CONFIG_FILE:-}"
     [ -n "$config_file" ] && [ -f "$config_file" ] || {
         log_error "hybrid Claude model policy requires the prepared runtime model config"
@@ -155,36 +154,22 @@ hybrid_apply_model_policy() {
         log_error "hybrid Claude model policy cannot find the configured model provider"
         return 1
     fi
-
-    tmp_file="${config_file}.hybrid.$$.tmp"
-    umask 077
-    if ! jq --arg provider "$provider" --arg primary_model "$primary_model" --arg model "$HYBRID_MODEL_ID" '
-        .models.providers[$provider].models |= (
-          . as $models
-          | if any(.[]?; .id == $model) then .
-            else (($models | map(select(.id == $primary_model))[0]) // {}) as $template
-              | . + [($template + {id: $model, name: $model})]
-            end
-        )
-        | .agents.defaults.model.primary = ($provider + "/" + $model)
-        | .agents.defaults.models = ((.agents.defaults.models // {}) + {
-            ($provider + "/" + $model): {alias: $model}
-          })
-    ' "$config_file" > "$tmp_file"; then
-        rm -f "$tmp_file"
-        log_error "hybrid Claude model policy failed to update the runtime model config"
+    if ! jq -e --arg provider "$provider" --arg model "$primary_model" '
+        any(.models.providers[$provider].models[]?; .id == $model)
+    ' "$config_file" >/dev/null; then
+        log_error "hybrid Claude model policy cannot find the configured primary model"
         return 1
     fi
-    chmod 600 "$tmp_file"
-    mv "$tmp_file" "$config_file"
 
-    export SINGLEBOX_REQUIRED_OPENCLAW_MODEL="${provider}/${HYBRID_MODEL_ID}"
-    export LLM_FAST_MODEL="$HYBRID_MODEL_ID"
-    export LLM_BALANCED_MODEL="$HYBRID_MODEL_ID"
-    export LLM_REASONING_MODEL="$HYBRID_MODEL_ID"
-    export LLM_LONG_CONTEXT_MODEL="$HYBRID_MODEL_ID"
-    export LLM_EXTRACTION_MODEL="$HYBRID_MODEL_ID"
-    log_info "Hybrid Claude model policy: OpenClaw, Claude Code, and SOP use ${HYBRID_MODEL_ID} (provider=${provider})"
+    HYBRID_MODEL_ID="$primary_model"
+    export HYBRID_MODEL_ID
+    export SINGLEBOX_REQUIRED_OPENCLAW_MODEL="$primary"
+    export LLM_FAST_MODEL="$primary_model"
+    export LLM_BALANCED_MODEL="$primary_model"
+    export LLM_REASONING_MODEL="$primary_model"
+    export LLM_LONG_CONTEXT_MODEL="$primary_model"
+    export LLM_EXTRACTION_MODEL="$primary_model"
+    log_info "Hybrid model policy: OpenClaw, Claude Code, and SOP use configured primary ${primary}"
 }
 
 hybrid_validate_profiles() {

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -79,7 +79,7 @@ BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
 CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-}"
 BCN_PLUGIN_SOURCE="${BCN_PLUGIN_SOURCE:-source}"
 BCN_PLUGIN_VERSION="${BCN_PLUGIN_VERSION:-latest}"
-MERCHANT_HYBRID_DEFAULT_PROFILE_DIR="scripts/4bots_merchant_operations_profile"
+HYBRID_DEFAULT_PROFILE_DIR="scripts/4bots_merchant_operations_profile"
 MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE="platform-data"
 MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR="scripts/4bots_merchant_operations_profile_for_claude"
 
@@ -444,8 +444,7 @@ show_help() {
     echo "  $0 restart bots                Restart only the 5 local bot gateways"
     echo "  $0 start bots --profile-dir scripts/8bots_micro_merchant_profile"
     echo "  $0 start bcs_frontend --profile-dir scripts/4bots_merchant_operations_profile"
-    echo "  $0 start merchant_hybrid          Start merchant hybrid with its default profiles"
-    echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile"
+    echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid"
     echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile --exclusive-profile-dir platform-data --claude-profile-dir scripts/4bots_merchant_operations_profile_for_claude"
     echo "  $0 restart bcs_bots            Restart BCS + 5 local bot gateways"
     echo "  $0 clean bcs                   Clean only local BCS runtime data"
@@ -470,7 +469,7 @@ validate_hybrid_profile_options() {
     fi
 }
 
-apply_merchant_hybrid_profile_defaults() {
+apply_hybrid_profile_defaults() {
     local target_command="$1"
     shift
 
@@ -481,14 +480,25 @@ apply_merchant_hybrid_profile_defaults() {
             return 0
             ;;
     esac
-    if [ "$#" -ne 1 ] || [ "$1" != "merchant_hybrid" ]; then
+    if [ "$#" -ne 1 ]; then
         return 0
     fi
 
-    BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_PROFILE_DIR}}"
-    BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-${MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE}}"
-    CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR}}"
-    log_info "merchant_hybrid profile configuration resolved excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE} claude_profile_enabled=true"
+    case "$1" in
+        hybrid)
+            local claude_profile_enabled=false
+            BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${HYBRID_DEFAULT_PROFILE_DIR}}"
+            [ -n "${CLAUDE_PROFILE_DIR:-}" ] && claude_profile_enabled=true
+            log_info "hybrid profile configuration resolved claude_profile_enabled=${claude_profile_enabled}"
+            ;;
+        merchant_hybrid)
+            # Deprecated compatibility mode keeps the original mixed-profile defaults.
+            BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${HYBRID_DEFAULT_PROFILE_DIR}}"
+            BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-${MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE}}"
+            CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR}}"
+            log_info "merchant_hybrid profile configuration resolved excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE} claude_profile_enabled=true"
+            ;;
+    esac
 }
 
 # 编译插编 bcs 到 target/cov-e2e/llvm-cov-target/ 并 export BCS_BIN/LLVM_PROFILE_FILE。
@@ -831,7 +841,7 @@ main() {
     if [ ${#services[@]} -eq 0 ]; then
         services=(all)
     fi
-    apply_merchant_hybrid_profile_defaults "$command" "${services[@]}"
+    apply_hybrid_profile_defaults "$command" "${services[@]}"
     if [ -n "${BOTS_PROFILE_DIR:-}" ]; then
         for svc in "${services[@]}"; do
             # --profile-dir / BOTS_PROFILE_DIR is primarily for the bots target,

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -53,49 +53,42 @@ done
 grep -Fq 'skills/bcs-coordination/references/custom-collaboration.md' "$MANAGER_WORKSPACE/AGENTS.md"
 grep -Fq 'skills/bcs-coordination/references/custom-collaboration-schema.md' "$MANAGER_WORKSPACE/TOOLS.md"
 
+grep -Fq 'AskUserQuestion' "$CLAUDE_PROFILE/platform-data/CLAUDE.md"
+jq -e '.bots[0].runtime | has("model") | not' "$CLAUDE_PROFILE/bots.json" >/dev/null
+
+MODEL_CONFIG="$TMP/model-config.json"
+export OPENCLAW_OPENAI_PROVIDER_ID="openai-compatible"
+export OPENCLAW_OPENAI_BASE_URL="https://model.example.test/v1"
+export OPENCLAW_OPENAI_API_KEY="test-token"
+export OPENCLAW_OPENAI_MODEL_ID="glm-local"
+export OPENCLAW_OPENAI_MODEL_NAME="GLM Local"
+singlebox_model_config_write_manual "$MODEL_CONFIG"
+export SINGLEBOX_MODEL_CONFIG_FILE="$MODEL_CONFIG"
+model_config_before="$(shasum -a 256 "$MODEL_CONFIG" | awk '{print $1}')"
+hybrid_apply_model_policy
+model_config_after="$(shasum -a 256 "$MODEL_CONFIG" | awk '{print $1}')"
+[[ "$model_config_after" == "$model_config_before" ]]
+jq -e '
+  .agents.defaults.model.primary == "openai-compatible/glm-local"
+  and .agents.defaults.models["openai-compatible/glm-local"].alias == "GLM Local"
+  and ([.models.providers["openai-compatible"].models[].id] == ["glm-local"])
+' "$MODEL_CONFIG" >/dev/null
+[[ "$HYBRID_MODEL_ID" == "glm-local" ]]
+[[ "$SINGLEBOX_REQUIRED_OPENCLAW_MODEL" == "openai-compatible/glm-local" ]]
+[[ "$LLM_FAST_MODEL" == "glm-local" ]]
+[[ "$LLM_BALANCED_MODEL" == "glm-local" ]]
+[[ "$LLM_REASONING_MODEL" == "glm-local" ]]
+[[ "$LLM_LONG_CONTEXT_MODEL" == "glm-local" ]]
+[[ "$LLM_EXTRACTION_MODEL" == "glm-local" ]]
+
 IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission < <(claude_profile_entries)
 [[ "$role" == "platform-data" ]]
 [[ "$port" == "18900" ]]
-[[ "$model" == "Kimi-K2.6" ]]
+[[ "$model" == "glm-local" ]]
 [[ "$permission" == "bypassPermissions" ]]
 [[ "$config_dir" == "$TMP/claude-config" ]]
 [[ "$workspace" == "$TMP/claude-workspace" ]]
 [[ "$prompt" == "$CLAUDE_PROFILE/platform-data/CLAUDE.md" ]]
-grep -Fq 'AskUserQuestion' "$CLAUDE_PROFILE/platform-data/CLAUDE.md"
-
-MODEL_CONFIG="$TMP/model-config.json"
-cat > "$MODEL_CONFIG" <<'JSON'
-{
-  "models": {
-    "providers": {
-      "antchat": {
-        "models": [
-          {"id": "Kimi-K2.5", "name": "Kimi-K2.5", "input": ["text"]}
-        ]
-      }
-    }
-  },
-  "agents": {
-    "defaults": {
-      "model": {"primary": "antchat/Kimi-K2.5"},
-      "models": {"antchat/Kimi-K2.5": {"alias": "Kimi-K2.5"}}
-    }
-  }
-}
-JSON
-export SINGLEBOX_MODEL_CONFIG_FILE="$MODEL_CONFIG"
-hybrid_apply_model_policy
-jq -e '
-  .agents.defaults.model.primary == "antchat/Kimi-K2.6"
-  and .agents.defaults.models["antchat/Kimi-K2.6"].alias == "Kimi-K2.6"
-  and ([.models.providers.antchat.models[].id] | index("Kimi-K2.6")) != null
-' "$MODEL_CONFIG" >/dev/null
-[[ "$SINGLEBOX_REQUIRED_OPENCLAW_MODEL" == "antchat/Kimi-K2.6" ]]
-[[ "$LLM_FAST_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_BALANCED_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_REASONING_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_LONG_CONTEXT_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_EXTRACTION_MODEL" == "Kimi-K2.6" ]]
 
 export BCSFUSE_RUNTIME_DIR="$TMP/bcsfuse-runtime"
 mkdir -p "$BCSFUSE_RUNTIME_DIR/env"
@@ -116,11 +109,11 @@ bcsfuse_load_env
 
 export HYBRID_CLAUDE_ACTIVE=1
 bcsfuse_load_env
-[[ "$LLM_FAST_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_BALANCED_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_REASONING_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_LONG_CONTEXT_MODEL" == "Kimi-K2.6" ]]
-[[ "$LLM_EXTRACTION_MODEL" == "Kimi-K2.6" ]]
+[[ "$LLM_FAST_MODEL" == "glm-local" ]]
+[[ "$LLM_BALANCED_MODEL" == "glm-local" ]]
+[[ "$LLM_REASONING_MODEL" == "glm-local" ]]
+[[ "$LLM_LONG_CONTEXT_MODEL" == "glm-local" ]]
+[[ "$LLM_EXTRACTION_MODEL" == "glm-local" ]]
 
 unset BOTS_EXCLUDED_PROFILE_SOURCE
 [[ "$(bots_dynamic_count)" == "4" ]]
@@ -241,18 +234,31 @@ test_provider_bot_registration_keeps_profile_display_name() (
 
 test_provider_bot_registration_keeps_profile_display_name
 
-test_merchant_hybrid_profile_defaults() (
+test_hybrid_profile_defaults() (
     log_info() { :; }
 
     unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
-    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    apply_hybrid_profile_defaults start hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
+    [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
+    [ -z "${CLAUDE_PROFILE_DIR:-}" ]
+
+    unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    BOTS_PROFILE_DIR="scripts/custom_profile"
+    apply_hybrid_profile_defaults start hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
+    [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
+    [ -z "${CLAUDE_PROFILE_DIR:-}" ]
+
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
     [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
     [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
 
     unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
     BOTS_PROFILE_DIR="scripts/custom_profile"
-    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
     [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
     [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
@@ -260,19 +266,24 @@ test_merchant_hybrid_profile_defaults() (
     BOTS_PROFILE_DIR="scripts/custom_profile"
     BOTS_EXCLUDED_PROFILE_SOURCE="custom-platform-data"
     CLAUDE_PROFILE_DIR="scripts/custom_claude_profile"
-    apply_merchant_hybrid_profile_defaults start merchant_hybrid
+    apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
     [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "custom-platform-data" ]
     [ "$CLAUDE_PROFILE_DIR" = "scripts/custom_claude_profile" ]
 
     unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
-    apply_merchant_hybrid_profile_defaults status merchant_hybrid
+    apply_hybrid_profile_defaults status hybrid
+    [ -z "${BOTS_PROFILE_DIR:-}" ]
+    [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
+    [ -z "${CLAUDE_PROFILE_DIR:-}" ]
+
+    apply_hybrid_profile_defaults status merchant_hybrid
     [ -z "${BOTS_PROFILE_DIR:-}" ]
     [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
     [ -z "${CLAUDE_PROFILE_DIR:-}" ]
 )
 
-test_merchant_hybrid_profile_defaults
+test_hybrid_profile_defaults
 
 events="$TMP/events"
 hybrid_port_preflight() { return 0; }


### PR DESCRIPTION
## Problem

Hybrid startup hardcoded `Kimi-K2.6` for OpenClaw, Claude Code, and BCSFuse. This overrode the model selected through Singlebox configuration and caused `404 Model not exist` errors when manual mode configured another model, such as `glm-5.2` from `.env.local`.

Hybrid startup also required an explicit merchant profile path even for the default OpenClaw-only setup.

## Solution

- Use the primary model resolved by Singlebox as the hybrid runtime model.
- Preserve the generated OpenClaw model configuration instead of rewriting it.
- Resolve the Claude Code relay model dynamically rather than storing a fixed model in its profile.
- Apply the same resolved model to BCSFuse SOP model roles.
- Fail early when the selected model cannot be resolved.
- Default `start hybrid` to the merchant operations OpenClaw profile.
- Preserve `merchant_hybrid` as a deprecated compatibility mode for the mixed OpenClaw and Claude Code setup.
- Update profile documentation and hybrid regression coverage.

In manual mode, OpenClaw, Claude Code, and BCSFuse now use the model selected through `.env.local`.

## Validation

- `env LC_ALL=C LC_CTYPE=C LANG=C bash scripts/test_hybrid.sh`
- `env LC_ALL=C LC_CTYPE=C LANG=C bash scripts/test_singlebox_model_config.sh`
- `env LC_ALL=C LC_CTYPE=C LANG=C bash scripts/test_singlebox_bcs_runtime_config.sh`
- Shell syntax validation for the modified scripts
- `git diff --check`

All checks passed.

## Compatibility and risk

The legacy `merchant_hybrid` command remains available and retains its mixed-profile defaults. Existing explicit hybrid profile options continue to work.

The main behavior change is that hybrid startup no longer forces `Kimi-K2.6`; it now honors the model selected by the active Singlebox configuration.