### PR TITLE
fix: pass service bot publish sandbox envs

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -466,6 +466,7 @@ class BotBuildService:
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
         runtime_kind: str | None = None,
+        template_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """发布 Bot 到 BaaS 层。
 
@@ -563,8 +564,15 @@ class BotBuildService:
                 )
                 if template_uuid is not None:
                     create_kwargs["template_uuid"] = template_uuid
+                if template_config:
+                    create_kwargs["template_config"] = dict(template_config)
                 if docker_image:
-                    create_kwargs["template_config"] = {"image": docker_image}
+                    # Preserve template_config sandbox overrides (envs/resource_spec)
+                    # while applying the publish-time image pin with highest priority.
+                    create_kwargs["template_config"] = {
+                        **create_kwargs.get("template_config", {}),
+                        "image": docker_image,
+                    }
                 new_bot = self._baas_service.create_bot(**create_kwargs)
 
             bot_uuid = new_bot.get("bot_uuid")
@@ -594,6 +602,7 @@ class BotBuildService:
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
         runtime_kind: str | None = None,
+        template_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """异步发布 Bot 到 BaaS 层。
 
@@ -634,6 +643,7 @@ class BotBuildService:
             extra_envs=extra_envs,
             docker_image=docker_image,
             runtime_kind=runtime_kind,
+            template_config=template_config,
         )
 
     def _run_local_command(
@@ -1045,6 +1055,7 @@ class BotBuildService:
             extra_envs: Optional[Dict[str, Any]] = None,
             docker_image: str | None = None,
             runtime_kind: str | None = None,
+            template_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """升级 Bot 到 BaaS 层（复用现有 Bot）。
 
@@ -1121,8 +1132,15 @@ class BotBuildService:
                 )
                 if template_uuid is not None:
                     upgrade_kwargs["template_uuid"] = template_uuid
+                if template_config:
+                    upgrade_kwargs["template_config"] = dict(template_config)
                 if docker_image:
-                    upgrade_kwargs["template_config"] = {"image": docker_image}
+                    # Preserve template_config sandbox overrides (envs/resource_spec)
+                    # while applying the publish-time image pin with highest priority.
+                    upgrade_kwargs["template_config"] = {
+                        **upgrade_kwargs.get("template_config", {}),
+                        "image": docker_image,
+                    }
                 upgrade_result = self._baas_service.upgrade_bot(**upgrade_kwargs)
 
             logger.info(
@@ -1542,6 +1560,7 @@ class BotBuildService:
         extra_envs: Optional[Dict[str, Any]] = None,
         docker_image: str | None = None,
         runtime_kind: str | None = None,
+        template_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """异步升级 Bot 到 BaaS 层。
 
@@ -1566,4 +1585,5 @@ class BotBuildService:
             extra_envs=extra_envs,
             docker_image=docker_image,
             runtime_kind=runtime_kind,
+            template_config=template_config,
         )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_publish_env.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_publish_env.py
@@ -1,0 +1,93 @@
+"""Environment-variable contract for service-bot deploy operations.
+
+Service-bot publish/restart/rollback paths provision containers through
+``BotBuildService`` directly, so they must compose the same engine-owned
+``extra_envs`` that personal create/restart paths get from BotService, and
+forward the source bot's ``template_config`` sandbox overrides separately.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.bot_management.engines import resolve_provisioning
+from agentclaw.community.log import get_logger
+
+from .service_skills_manifest import service_skills_env_from_ext
+
+logger = get_logger()
+
+
+def _engine_extra_envs_from_bot(bot: dict[str, Any]) -> dict[str, str]:
+    """Build engine-owned extra envs from the live source-bot metadata.
+
+    ``BotService.get_bot`` attaches ``template_config`` for bot detail reads; if a
+    legacy caller only has ``template_type`` the aicoding/claude_code strategy can
+    still emit the legacy BOT_TYPE env.  Fail soft to match the personal
+    create/restart behavior: environment derivation must not block publishing.
+    """
+    try:
+        template_config = bot.get("template_config")
+        if not isinstance(template_config, dict):
+            template_config = None
+
+        bot_id = str(bot.get("bot_id") or "")
+        owner_id = str(bot.get("owner_id") or bot.get("entity_id") or "")
+        bot_type = str(bot.get("bot_type") or "service")
+        active_engine = bot.get("active_engine") or bot.get("engine_type")
+        template_type = bot.get("template_type")
+
+        ctx, strategy = resolve_provisioning(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            bot_type=bot_type,
+            active_engine=active_engine if isinstance(active_engine, str) else None,
+            template_type=template_type if isinstance(template_type, str) else None,
+            template_config=template_config,
+        )
+        envs = strategy.build_extra_envs(ctx)
+        if envs:
+            logger.info(
+                "[service_publish_extra_envs] engine extra_envs resolved: bot_id=%s env_keys=%s",
+                bot_id,
+                sorted(envs.keys()),
+            )
+            return dict(envs)
+    except Exception as exc:
+        logger.warning(
+            "[service_publish_extra_envs] failed to build engine extra_envs: bot_id=%s error=%s",
+            bot.get("bot_id"),
+            exc,
+        )
+    return {}
+
+
+def service_publish_template_config(bot: dict[str, Any]) -> dict[str, Any] | None:
+    """Return source-bot template_config for BaaS sandbox overrides.
+
+    Keep this separate from ``extra_envs`` to match personal bot create/restart:
+    BaaS merges ``template_config.envs`` after ``extra_envs`` and also consumes
+    image/resource_spec overrides at the sandbox edge.
+    """
+    template_config = bot.get("template_config")
+    if not isinstance(template_config, dict) or not template_config:
+        return None
+    return dict(template_config)
+
+
+def service_publish_extra_envs(
+    ext: dict[str, Any] | None,
+    bot: dict[str, Any],
+) -> dict[str, str]:
+    """Compose service publish envs for create/upgrade/restart/rollback.
+
+    The immutable service Skills layout remains present for every service
+    deploy.  Engine-owned envs (BOT_TYPE, AIX_DEVFLOW_INFO, GIT_ADDRESSES,
+    RELAY_DEFAULT_*) are layered on top so service-bot pre-publish uses the same
+    AIX/coding runtime contract as normal personal bot create/restart.
+    """
+    envs = dict(service_skills_env_from_ext(ext, bot))
+    envs.update(_engine_extra_envs_from_bot(bot))
+    return envs
+
+
+__all__ = ["service_publish_extra_envs", "service_publish_template_config"]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -10,6 +10,9 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
+from agentclaw.community.core.service_bot.services.deploy.service_publish_env import (
+    service_publish_template_config,
+)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -98,6 +101,7 @@ class EvalPublishMixin:
                 ext_info=ext_info,
                 docker_image=image_pin.docker_image,
                 runtime_kind=self.resolve_publish_runtime_kind(publish_record),
+                template_config=service_publish_template_config(bot),
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -46,8 +46,9 @@ from agentclaw.community.core.service_bot.services.publish_flow.operation_runner
     TargetBotGoneError,
     acquire_deploy_workflow,
 )
-from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
-    service_skills_env_from_ext,
+from agentclaw.community.core.service_bot.services.deploy.service_publish_env import (
+    service_publish_extra_envs,
+    service_publish_template_config,
 )
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
@@ -181,7 +182,7 @@ class ReleaseStageRunner:
         is no config_artifact."""
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
-        skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        skills_env = service_publish_extra_envs(publish_record.ext, bot)
         image_pin = self._ops.resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
@@ -208,6 +209,7 @@ class ReleaseStageRunner:
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
                 runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
+                template_config=service_publish_template_config(bot),
             )
             if spec.first_release_passes_version:
                 release_kwargs["version"] = f"{publish_record.version}"
@@ -282,7 +284,7 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
-        skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        skills_env = service_publish_extra_envs(publish_record.ext, bot)
         image_pin = self._ops.resolve_publish_image_pin(publish_record)
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
@@ -308,6 +310,7 @@ class ReleaseStageRunner:
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
                 runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
+                template_config=service_publish_template_config(bot),
             )
 
         try:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -6,8 +6,9 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishOperationState,
     PublishStatus,
 )
-from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
-    service_skills_env_from_ext,
+from agentclaw.community.core.service_bot.services.deploy.service_publish_env import (
+    service_publish_extra_envs,
+    service_publish_template_config,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
@@ -302,7 +303,7 @@ class RestartMixin:
         # STORED overrides slot: reproduce what was promoted (not a live re-fetch),
         # so restarting a non-latest stage never delivers another stage's channels.
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
-        skills_env = service_skills_env_from_ext(publish_record.ext, bot)
+        skills_env = service_publish_extra_envs(publish_record.ext, bot)
         image_pin = self.resolve_publish_image_pin(publish_record)
 
         # A prior recreate that crashed between its ext write and its
@@ -402,6 +403,7 @@ class RestartMixin:
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
                 runtime_kind=self.resolve_publish_runtime_kind(publish_record),
+                template_config=service_publish_template_config(bot),
             )
         # NOTE: transient errors out of the atom are NOT caught + failed here. A
         # genuine crash leaves the op non-terminal so the durable task retry
@@ -582,6 +584,7 @@ class RestartMixin:
                 extra_envs=skills_env,
                 docker_image=docker_image,
                 runtime_kind=self.resolve_publish_runtime_kind(publish_record),
+                template_config=service_publish_template_config(bot),
             )
 
         op = await acquire_deploy_workflow(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -13,8 +13,9 @@ from agentclaw.community.core.service_bot.schemas.publish_schemas import Publish
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     PublishNotFoundError,
 )
-from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
-    service_skills_env_from_ext,
+from agentclaw.community.core.service_bot.services.deploy.service_publish_env import (
+    service_publish_extra_envs,
+    service_publish_template_config,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
@@ -114,7 +115,7 @@ class RollbackOpsMixin:
         # longer silently ship the raw artifact (the single-config-slot hazard).
         version = f"{target_record.version}"
         delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
-        skills_env = service_skills_env_from_ext(target_ext, bot)
+        skills_env = service_publish_extra_envs(target_ext, bot)
         image_pin = self.resolve_publish_image_pin(target_record)
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
@@ -140,6 +141,7 @@ class RollbackOpsMixin:
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
                 runtime_kind=self.resolve_publish_runtime_kind(target_record),
+                template_config=service_publish_template_config(bot),
             )
 
         op = await self._operation_runner.acquire_workflow(op, _issue)

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py
@@ -111,6 +111,38 @@ def test_release_routes_arca_pinned_image_to_template_config():
 
 
 @pytest.mark.unit
+def test_release_routes_arca_merges_template_config_and_pinned_image():
+    svc, baas = _svc("baas")
+    template_config = {
+        "envs": {
+            "AIX_MOS_PLUGIN": "true",
+            "AIX_SKIP_DAEMON": "true",
+            "AIX_SKIP_HARNESS": "true",
+            "BOT_TEMP_INSTALL_SKILL": '["aixcoding-skill"]',
+        },
+        "resource_spec": {"cpu": 2, "memory": 4096},
+        "image": "registry/template:old",
+    }
+
+    svc.release(
+        _BOT,
+        user_id="u1",
+        migration_path="/m/1",
+        publish_stage=PublishStage.VERIFY,
+        extra_envs={"BOT_TYPE": "application"},
+        template_config=template_config,
+        docker_image="registry/arca:v2",
+    )
+
+    kwargs = baas.create_bot.call_args.kwargs
+    assert kwargs["extra_envs"] == {"BOT_TYPE": "application"}
+    assert kwargs["template_config"] == {
+        **template_config,
+        "image": "registry/arca:v2",
+    }
+
+
+@pytest.mark.unit
 def test_release_routes_arca_with_template_uuid_from_system_config():
     resolver = _template_resolver()
     svc, baas = _svc("baas", baas_template_resolver=resolver)
@@ -191,6 +223,34 @@ def test_upgrade_routes_arca_pinned_image_to_template_config():
 
     assert baas.upgrade_bot.call_args.kwargs["template_config"] == {
         "image": "registry/arca:v2"
+    }
+
+
+@pytest.mark.unit
+def test_upgrade_routes_arca_merges_template_config_and_pinned_image():
+    svc, baas = _svc("baas")
+    template_config = {
+        "envs": {"BOT_TEMP_INSTALL_SKILL": '["aixcoding-skill"]'},
+        "resource_spec": {"cpu": 2, "memory": 4096},
+        "image": "registry/template:old",
+    }
+
+    svc.upgrade(
+        "BOT-a",
+        _BOT,
+        user_id="u1",
+        migration_path="/m/1",
+        publish_stage=PublishStage.ONLINE,
+        extra_envs={"BOT_TYPE": "application"},
+        template_config=template_config,
+        docker_image="registry/arca:v2",
+    )
+
+    kwargs = baas.upgrade_bot.call_args.kwargs
+    assert kwargs["extra_envs"] == {"BOT_TYPE": "application"}
+    assert kwargs["template_config"] == {
+        **template_config,
+        "image": "registry/arca:v2",
     }
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -272,6 +272,105 @@ def test_bot_build_service_upgrade_raises_for_other_errors():
 
 
 @pytest.mark.asyncio
+async def test_verify_first_release_injects_engine_extra_envs_for_service_coding_bot():
+    publish_service = Mock()
+    publish_service.create_device_binding.return_value = 55
+    build_service = Mock()
+    build_service.release_async = AsyncMock(return_value={"bot_uuid": "BOT-1", "publish_id": 9})
+    svc = _pf(publish_service, build_service, Mock(), Mock(), _arca_router(build_service))
+    svc._ext_state.get_latest_ext = Mock(return_value={"migration_path": "/snapshot/1/openclaw"})
+    svc._ext_state.update_status = Mock()
+
+    record = _make_publish_record(
+        status=PublishStatus.BUILT.value,
+        ext={"migration_path": "/snapshot/1/openclaw"},
+    )
+
+    await svc._execute_verify_first_release(
+        publish_record=record,
+        operator="op",
+        migration_path="/snapshot/1/openclaw",
+        bot={
+            "bot_id": "b2",
+            "owner_id": "u1",
+            "bot_type": "service",
+            "active_engine": "claude_code",
+            "template_type": "applicationCoding",
+            "template_config": {
+                "devflow_workflow": {"path": "devflow/app.yaml"},
+                "backend_repo": [{"repo_url": "git@x/y.git"}],
+                "model": "antchat/Ling-2.6-1T",
+                "runtime": "python",
+            },
+        },
+    )
+
+    assert build_service.release_async.await_args.kwargs["extra_envs"] == {
+        "AGENTCLAW_SKILLS_LAYOUT": "legacy",
+        "BOT_TYPE": "application",
+        "AIX_DEVFLOW_INFO": "devflow/app.yaml",
+        "GIT_ADDRESSES": '["git@x/y.git"]',
+        "RELAY_DEFAULT_MODEL": "antchat/Ling-2.6-1T",
+        "RELAY_DEFAULT_RUNTIME": "python",
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_upgrade_preserves_skills_env_and_injects_engine_extra_envs():
+    publish_service = Mock()
+    build_service = Mock()
+    build_service.upgrade_async = AsyncMock(return_value={"publish_id": 9})
+    svc = _pf(publish_service, build_service, Mock(), Mock(), _arca_router(build_service))
+    svc._ext_state.get_latest_ext = Mock(return_value={
+        "migration_path": "/snapshot/1/openclaw",
+        "skills_manifest": {
+            "schema_version": 1,
+            "engine": "claude_code",
+            "active_layout": "pool",
+            "layout_contract_version": "skills-pool-p3-v1",
+        },
+    })
+    svc._ext_state.update_status = Mock()
+    svc.refresh_publish_handle = Mock()
+
+    record = _make_publish_record(
+        status=PublishStatus.BUILT.value,
+        ext={
+            "migration_path": "/snapshot/1/openclaw",
+            "skills_manifest": {
+                "schema_version": 1,
+                "engine": "claude_code",
+                "active_layout": "pool",
+                "layout_contract_version": "skills-pool-p3-v1",
+            },
+        },
+    )
+
+    await svc._execute_verify_upgrade(
+        publish_record=record,
+        operator="op",
+        migration_path="/snapshot/1/openclaw",
+        bot={
+            "bot_id": "b2",
+            "owner_id": "u1",
+            "bot_type": "service",
+            "active_engine": "claude_code",
+            "template_type": "applicationCoding",
+            "template_config": {"model": "m1"},
+        },
+        bot_uuid="BOT-old",
+        verify_binding_id=123,
+    )
+
+    assert build_service.upgrade_async.await_args.kwargs["extra_envs"] == {
+        "AGENTCLAW_SKILLS_LAYOUT": "pool",
+        "AGENTCLAW_SKILLS_LAYOUT_CONTRACT_VERSION": "skills-pool-p3-v1",
+        "BOT_TYPE": "application",
+        "RELAY_DEFAULT_MODEL": "m1",
+    }
+
+
+@pytest.mark.asyncio
 async def test_execute_verify_upgrade_falls_back_to_first_release_on_bot_not_found():
     publish_service = Mock()
     build_service = Mock()


### PR DESCRIPTION
## Summary\n- compose service-bot publish extra_envs from skills env and engine provisioning envs\n- forward source bot template_config separately so BaaS can apply template_config.envs/image/resource_spec sandbox overrides\n- preserve publish image pin priority over template_config.image\n\n## Test\n- uv run pytest tests/community/core/service_bot/services/test_bot_build_service_teclaw_routing.py tests/community/core/service_bot/services/test_publish_flow_service.py -q