### PR TITLE
refactor(baas): canonicalize logger names to reduce log-file fragmentation

### DIFF
--- a/src/baas/src/secbaas/community/CLAUDE.md
+++ b/src/baas/src/secbaas/community/CLAUDE.md
@@ -16,3 +16,29 @@
    - ✅ `from secbaas.core.service.api_gateway._repository import APIKeyRecord` inside `api/api_gateway/_model.py` — OK because `_model.py` is private
 
 4. **Public `__init__.py` files must only import from public package paths** or from their own package's private modules via relative imports.
+
+## Logger Naming
+
+Logger names directly become log file names (`{name}.log`). Prefer reusing an existing canonical name over adding a new one to reduce log-file fragmentation.
+
+**Whitelist** — `ALLOWED_LOGGER_NAMES` in `tests/architecture/test_logger_usage.py`:
+
+| Canonical Name | Directory Coverage |
+|---|---|
+| `core-service` | `core/service/**` (except bot_run, scheduler), `core/service/paas/**`, `core/service/health_check/paas/**`, `plugins/sandbox/k8s/real/_client_manager.py`, `adapters/web/websocket/**` |
+| `orm` | `core/repository/**`, `core/database/_manager.py` |
+| `router` | `adapters/web/routers/**` (except open_api, gateway, admin), `core/service/callback/**` |
+| `router-open-api` | `routers/open_api/**` |
+| `router-gateway` | `routers/gateway/**` |
+| `router-admin` | `routers/admin/**` |
+| `core-bot-run` | `core/service/bot_run/**`, `plugins/bot/engine_adapter/**` |
+| `core-scheduler` | `core/service/scheduler/**` |
+| `database` | `core/database/**`, `plugins/database/**` |
+| `plugin-sandbox` | `plugins/sandbox/**` (all sandbox plugins) |
+| `plugin-bot-service` | `plugins/bot_service/**` |
+| `plugin-auth` | `plugins/auth/**` |
+| `bootstrap` | `bootstrap/**` |
+| `config` | `config/**` |
+| `webserver` | `adapters/web/app.py` |
+
+**Style rule**: names must match `^[a-z][a-z0-9-]*$` — lowercase, hyphens allowed, no underscores or uppercase. Adding a new name requires updating `ALLOWED_LOGGER_NAMES` in the architecture test.

--- a/src/baas/src/secbaas/community/adapters/web/websocket/local_management_ws.py
+++ b/src/baas/src/secbaas/community/adapters/web/websocket/local_management_ws.py
@@ -49,7 +49,7 @@ from fastapi import (
 from secbaas.community.bootstrap import ApplicationContainer
 from secbaas.community.logger import get_logger
 
-logger = get_logger("local_management_ws")
+logger = get_logger("core-service")
 
 
 router = APIRouter(tags=["Local Management WebSocket"])

--- a/src/baas/src/secbaas/community/bootstrap/_cron.py
+++ b/src/baas/src/secbaas/community/bootstrap/_cron.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from secbaas.community.core.service.scheduler import AppScheduler, ScheduledTask
 from secbaas.community.logger import get_logger
 
-log = get_logger("bootstrap-cron")
+log = get_logger("bootstrap")
 
 
 class CronLifecycle:

--- a/src/baas/src/secbaas/community/bootstrap/_lifecycle.py
+++ b/src/baas/src/secbaas/community/bootstrap/_lifecycle.py
@@ -12,7 +12,7 @@ from secbaas.community.logger import get_logger
 
 from ._configs import DatabaseConfig
 
-logger = get_logger("bootstrap-lifecycle")
+logger = get_logger("bootstrap")
 
 
 @runtime_checkable

--- a/src/baas/src/secbaas/community/config/_config_loader.py
+++ b/src/baas/src/secbaas/community/config/_config_loader.py
@@ -7,7 +7,7 @@ from secbaas.community.logger import get_logger
 
 from ._models import Config
 
-logger = get_logger("config_loader")
+logger = get_logger("config")
 
 
 class ConfigLoader:

--- a/src/baas/src/secbaas/community/config/_config_utils.py
+++ b/src/baas/src/secbaas/community/config/_config_utils.py
@@ -22,7 +22,7 @@ from secbaas.community.logger import get_logger
 from ._config_loader import ConfigLoader
 from ._models import Config
 
-logger = get_logger("config_utils")
+logger = get_logger("config")
 
 # ---------------------------------------------------------------------------
 # Singleton config holder

--- a/src/baas/src/secbaas/community/core/database/_manager.py
+++ b/src/baas/src/secbaas/community/core/database/_manager.py
@@ -22,7 +22,7 @@ from sqlalchemy.pool import NullPool, QueuePool, StaticPool
 from secbaas.community.logger import get_logger
 
 logger = get_logger("database")
-_error_logger = get_logger("orm-error")
+_error_logger = get_logger("orm")
 
 
 class DatabaseManager:

--- a/src/baas/src/secbaas/community/core/repository/__init__.py
+++ b/src/baas/src/secbaas/community/core/repository/__init__.py
@@ -51,7 +51,7 @@ def with_orm_session[
 
     from secbaas.community.logger import get_logger
 
-    _perf_logger = get_logger("orm-timing")
+    _perf_logger = get_logger("orm")
 
     @wraps(func)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> R:

--- a/src/baas/src/secbaas/community/core/repository/ac_bot/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/ac_bot/_orm_repository.py
@@ -11,7 +11,7 @@ from ._orm_model import AcBotModel
 from ._protocol import AcBotRepository
 from ._record import AcBotRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmAcBotRepository(OrmConnectionMixin, AcBotRepository):

--- a/src/baas/src/secbaas/community/core/repository/ac_bot_publish/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/ac_bot_publish/_orm_repository.py
@@ -10,7 +10,7 @@ from secbaas.community.logger import get_logger
 from ._orm_model import AcBotPublishModel
 from ._protocol import AcBotPublishRepository
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmAcBotPublishRepository(OrmConnectionMixin, AcBotPublishRepository):

--- a/src/baas/src/secbaas/community/core/repository/api_gateway/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/api_gateway/_orm_repository.py
@@ -9,7 +9,7 @@ from ._orm_model import APIKeyModel
 from ._protocol import APIKeyRepository
 from ._record import APIKeyRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmAPIKeyRepository(OrmConnectionMixin, APIKeyRepository):

--- a/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot/_orm_repository.py
@@ -11,7 +11,7 @@ from ._orm_model import BotModel
 from ._protocol import BotRepository
 from ._record import BotRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotRepository(OrmConnectionMixin, BotRepository):

--- a/src/baas/src/secbaas/community/core/repository/bot_device_rel/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_device_rel/_orm_repository.py
@@ -7,7 +7,7 @@ from ._orm_model import BotDeviceRelModel
 from ._protocol import BotDeviceRelRepository
 from ._record import BotDeviceRelRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotDeviceRelRepository(OrmConnectionMixin, BotDeviceRelRepository):

--- a/src/baas/src/secbaas/community/core/repository/bot_qpm/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_qpm/_orm_repository.py
@@ -10,7 +10,7 @@ from ._orm_model import BotQpmConfigModel
 from ._protocol import BotQpmRepository
 from ._record import BotQpmRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotQpmRepository(BotQpmRepository, OrmConnectionMixin):

--- a/src/baas/src/secbaas/community/core/repository/bot_run/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run/_orm_repository.py
@@ -8,7 +8,7 @@ from ._orm_model import BotRunModel
 from ._protocol import BotRunRepository
 from ._record import BotRunRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotRunRepository(OrmConnectionMixin, BotRunRepository):

--- a/src/baas/src/secbaas/community/core/repository/bot_run_queue/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_queue/_orm_repository.py
@@ -11,7 +11,7 @@ from ._orm_model import BotRunQueueModel
 from ._protocol import BotRunQueueRepository
 from ._record import BotRunQueueRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotRunQueueRepository(OrmConnectionMixin, BotRunQueueRepository):

--- a/src/baas/src/secbaas/community/core/repository/bot_run_queue_chunk/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_queue_chunk/_orm_repository.py
@@ -6,7 +6,7 @@ from secbaas.community.logger import get_logger
 from ._orm_model import BotRunQueueChunkModel
 from ._record import BotRunQueueChunkRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotRunQueueChunkRepository(OrmConnectionMixin):

--- a/src/baas/src/secbaas/community/core/repository/bot_session/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_session/_orm_repository.py
@@ -10,7 +10,7 @@ from ._orm_model import BotSessionModel
 from ._protocol import BotSessionRepository
 from ._record import BotSessionRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmBotSessionRepository(OrmConnectionMixin, BotSessionRepository):

--- a/src/baas/src/secbaas/community/core/repository/device/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_orm_model.py
@@ -9,7 +9,7 @@ from secbaas.community.spi.database import Base
 
 from ._record import DeviceRecord
 
-logger = get_logger("orm-model")
+logger = get_logger("orm")
 
 
 class DeviceModel(Base):

--- a/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
@@ -11,7 +11,7 @@ from ._orm_model import DeviceModel
 from ._protocol import DeviceRepository
 from ._record import DeviceRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmDeviceRepository(OrmConnectionMixin, DeviceRepository):

--- a/src/baas/src/secbaas/community/core/repository/device_binding/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/device_binding/_orm_repository.py
@@ -16,7 +16,7 @@ from ._orm_model import DeviceBindingModel
 from ._protocol import DeviceBindingRepository
 from ._record import DeviceBindingRecord, DeviceBindingStatus
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmDeviceBindingRepository(OrmConnectionMixin, DeviceBindingRepository):

--- a/src/baas/src/secbaas/community/core/repository/device_template/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/device_template/_orm_repository.py
@@ -7,7 +7,7 @@ from ._orm_model import DeviceTemplateModel
 from ._protocol import DeviceTemplateRepository
 from ._record import DeviceTemplateRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmDeviceTemplateRepository(OrmConnectionMixin, DeviceTemplateRepository):

--- a/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/distributed_lock/_orm_repository.py
@@ -13,7 +13,7 @@ from ._orm_model import DistributedLockModel
 from ._protocol import DistributedLockRepository
 from ._record import LockRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 def _is_lock_wait_timeout(exc: Exception) -> bool:

--- a/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/file_transfer_ticket/_orm_repository.py
@@ -12,7 +12,7 @@ from ._protocol import (
 )
 from ._record import TicketRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 # Upload path: CREATED->UPLOADING->UPLOAD_COMPLETED->PULLING->DONE
 # Retention path: CREATED->UPLOADING->UPLOAD_COMPLETED->DONE (device_path IS NULL)  [Phase 69]

--- a/src/baas/src/secbaas/community/core/repository/local_user_machine/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/local_user_machine/_orm_repository.py
@@ -11,7 +11,7 @@ from ._protocol import (
 )
 from ._record import LocalUserMachineRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmLocalUserMachineRepository(OrmConnectionMixin, LocalUserMachineRepository):

--- a/src/baas/src/secbaas/community/core/repository/local_user_machine/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/local_user_machine/_protocol.py
@@ -9,7 +9,7 @@ from secbaas.community.logger import get_logger
 
 from ._record import LocalUserMachineRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 @runtime_checkable

--- a/src/baas/src/secbaas/community/core/repository/local_user_machine/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/local_user_machine/_record.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from secbaas.community.logger import get_logger
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 @dataclass(slots=True)

--- a/src/baas/src/secbaas/community/core/repository/publish/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/publish/_orm_repository.py
@@ -7,7 +7,7 @@ from ._orm_model import PublishModel
 from ._protocol import PublishRepository
 from ._record import PublishRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmPublishRepository(OrmConnectionMixin, PublishRepository):

--- a/src/baas/src/secbaas/community/core/repository/publish_batch/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/publish_batch/_orm_repository.py
@@ -9,7 +9,7 @@ from ._orm_model import PublishBatchModel
 from ._protocol import PublishBatchRepository
 from ._record import PublishBatchRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmPublishBatchRepository(OrmConnectionMixin, PublishBatchRepository):

--- a/src/baas/src/secbaas/community/core/repository/publish_record/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/publish_record/_orm_repository.py
@@ -7,7 +7,7 @@ from ._orm_model import PublishRecordModel
 from ._protocol import PublishRecordRepository
 from ._record import PublishRecordRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmPublishRecordRepository(OrmConnectionMixin, PublishRecordRepository):

--- a/src/baas/src/secbaas/community/core/repository/resource_key/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/resource_key/_orm_repository.py
@@ -7,7 +7,7 @@ from ._orm_model import ResourceKeyBotMappingModel, ResourceKeyModel
 from ._protocol import ResourceKeyRepository
 from ._record import ResourceKeyRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmResourceKeyRepository(OrmConnectionMixin, ResourceKeyRepository):

--- a/src/baas/src/secbaas/community/core/repository/session_file_ticket/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/session_file_ticket/_orm_repository.py
@@ -12,7 +12,7 @@ from ._protocol import (
 )
 from ._record import SessionTicketRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 # Upload path:  CREATED -> UPLOADING -> DONE  (fast: CREATED -> DONE)
 # Cancel path:  CREATED/UPLOADING -> CANCELLED

--- a/src/baas/src/secbaas/community/core/repository/system_config/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/system_config/_orm_repository.py
@@ -5,7 +5,7 @@ from ._orm_model import SystemConfigModel
 from ._protocol import SystemConfigRepository
 from ._record import SystemConfigRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmSystemConfigRepository(OrmConnectionMixin, SystemConfigRepository):

--- a/src/baas/src/secbaas/community/core/repository/tenant/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/tenant/_orm_repository.py
@@ -4,7 +4,7 @@ from secbaas.community.logger import get_logger
 from ._orm_model import TenantModel
 from ._protocol import TenantRepository
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 
 class OrmTenantRepository(OrmConnectionMixin, TenantRepository):

--- a/src/baas/src/secbaas/community/core/repository/ws_relay_session/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/ws_relay_session/_orm_repository.py
@@ -11,7 +11,7 @@ from ._orm_model import WsRelaySessionModel
 from ._protocol import WsRelaySessionRepository
 from ._record import WsRelaySessionRecord
 
-log = get_logger("orm-repository")
+log = get_logger("orm")
 
 # Valid state transitions for _validate_transition
 # Same-status transitions are idempotent (no-op)

--- a/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
+++ b/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
@@ -23,7 +23,7 @@ from ._models import CallbackPayload, CallbackResult
 if TYPE_CHECKING:
     from secbaas.community.core.repository.bot_run import BotRunRepository
 
-logger = get_logger("http-callback")
+logger = get_logger("router")
 
 _DEFAULT_TIMEOUT: float = 10.0
 

--- a/src/baas/src/secbaas/community/core/service/health_check/paas/_docker_paas_health_provider.py
+++ b/src/baas/src/secbaas/community/core/service/health_check/paas/_docker_paas_health_provider.py
@@ -16,7 +16,7 @@ from ._paas_health_provider import PaaSHealthProvider
 if TYPE_CHECKING:
     from secbaas.community.core.service.paas import PaasServiceFacade
 
-log = get_logger("docker-paas-health-provider")
+log = get_logger("core-service")
 
 
 class EchoHealthChecker:
@@ -236,7 +236,7 @@ class DockerPaaSHealthProvider(PaaSHealthProvider):
                 health_endpoint=health_endpoint,
             ),
         }
-        self._logger = get_logger("docker-paas-health-provider")
+        self._logger = get_logger("core-service")
 
     async def check_health(
         self,

--- a/src/baas/src/secbaas/community/core/service/paas/_standalone_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_standalone_paas_service.py
@@ -79,7 +79,7 @@ class StandalonePaasService(PaasService):
         self._credentials = credentials
         self._health_endpoint = health_endpoint
         self._health_timeout_seconds = health_timeout_seconds
-        self._logger = get_logger("standalone_paas_service")
+        self._logger = get_logger("core-service")
 
     # ------------------------------------------------------------------
     # ABC methods: credential / platform identity

--- a/src/baas/src/secbaas/community/plugins/auth/oauth/_oauth_client.py
+++ b/src/baas/src/secbaas/community/plugins/auth/oauth/_oauth_client.py
@@ -11,7 +11,7 @@ from secbaas.community.config import ConfigLoader
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.auth import AuthUser
 
-logger = get_logger("plugin-auth-oauth")
+logger = get_logger("plugin-auth")
 
 
 class OAuthClient:

--- a/src/baas/src/secbaas/community/plugins/auth/oauth/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/auth/oauth/_plugin.py
@@ -7,7 +7,7 @@ from secbaas.community.spi.auth import AuthPlugin, AuthUser
 
 from ._oauth_client import OAuthClient
 
-logger = get_logger("plugin-auth-oauth")
+logger = get_logger("plugin-auth")
 
 
 class OAuthPlugin(AuthPlugin):

--- a/src/baas/src/secbaas/community/plugins/bot_service/local/_local_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/local/_local_plugin.py
@@ -21,7 +21,7 @@ from secbaas.community.spi.bot_service import (
     LogRelationPayload,
 )
 
-logger = get_logger("plugin-bot-service-local")
+logger = get_logger("plugin-bot-service")
 
 
 class LocalBotServicePlugin(BotServicePlugin):

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
@@ -25,7 +25,7 @@ from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
 if TYPE_CHECKING:
     from secbaas.community.api.device_manage import ArcaCredentials
 
-logger = get_logger("plugin-sandbox-arca")
+logger = get_logger("plugin-sandbox")
 
 
 class StubSandboxInfo:

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
@@ -11,7 +11,7 @@ from secbaas.community.api.device_manage import (
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.sandbox.arca import ArcaSandbox
 
-logger = get_logger("plugin-sandbox-arca-local-docker")
+logger = get_logger("plugin-sandbox")
 
 
 class LocalDockerArcaSandbox(ArcaSandbox):

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox_plugin.py
@@ -21,7 +21,7 @@ from ._sandbox import LocalDockerArcaSandbox
 if TYPE_CHECKING:
     from secbaas.community.api.device_manage import ArcaCredentials
 
-logger = get_logger("plugin-sandbox-arca-local-docker")
+logger = get_logger("plugin-sandbox")
 
 
 class LocalDockerArcaSandboxPlugin(ArcaSandboxPlugin):

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_process_manager.py
@@ -48,7 +48,7 @@ from secbaas.community.logger import get_logger
 
 from ._errors import DeviceAllocateError
 
-logger = get_logger("plugin-sandbox-arca-local-proc")
+logger = get_logger("plugin-sandbox")
 
 # Port ranges for dynamically allocated processes.
 ADAPTER_PORT_START = 20010

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
@@ -15,7 +15,7 @@ from secbaas.community.spi.sandbox.arca import ArcaSandbox
 if TYPE_CHECKING:
     from ._process_manager import ProcessEntry
 
-logger = get_logger("plugin-sandbox-arca-local-proc")
+logger = get_logger("plugin-sandbox")
 
 
 class LocalProcessSandboxInfo:

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox_plugin.py
@@ -23,7 +23,7 @@ from ._process_manager import LocalProcessManager
 from ._sandbox import LocalProcessArcaSandbox
 from ._workspace import resolve_workspace_dir, setup_workspace_dirs
 
-logger = get_logger("plugin-sandbox-arca-local-proc")
+logger = get_logger("plugin-sandbox")
 
 # 引擎类型映射
 ENGINE_MAP = {

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_workspace.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_workspace.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from secbaas.community.config import ConfigPath, get_config, get_config_by_path
 from secbaas.community.logger import get_logger
 
-logger = get_logger("plugin-sandbox-arca-local-proc")
+logger = get_logger("plugin-sandbox")
 
 
 def resolve_workspace_dir(metadata: dict[str, str], bot_id: str) -> Path:

--- a/src/baas/src/secbaas/community/plugins/sandbox/docker/real/_real_docker_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/docker/real/_real_docker_sandbox_plugin.py
@@ -28,7 +28,7 @@ from secbaas.community.api.device_manage import ErrorCode, PaasError
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.sandbox.docker import DockerSandbox, DockerSandboxPlugin
 
-logger = get_logger("plugin-sandbox-docker-real")
+logger = get_logger("plugin-sandbox")
 
 
 def _import_docker() -> None:
@@ -72,7 +72,7 @@ class RealDockerSandbox(DockerSandbox):
         self._sandbox_id = sandbox_id
         self._container = container
         self._host_port = host_port
-        self._logger = get_logger("plugin-sandbox-docker-real")
+        self._logger = get_logger("plugin-sandbox")
 
     @property
     def is_ready(self) -> bool:
@@ -304,7 +304,7 @@ class RealDockerSandboxPlugin(DockerSandboxPlugin):
 
     def __init__(self) -> None:
         self._client: Any = None
-        self._logger = get_logger("plugin-sandbox-docker-real")
+        self._logger = get_logger("plugin-sandbox")
 
     # ------------------------------------------------------------------
     # Lazy client initialization (per D-09, D-13)

--- a/src/baas/src/secbaas/community/plugins/sandbox/docker/stub/_stub_docker_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/docker/stub/_stub_docker_sandbox_plugin.py
@@ -15,7 +15,7 @@ from secbaas.community.api.bot_runtime import HttpConnectionInfo, WsConnectionIn
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.sandbox.docker import DockerSandbox, DockerSandboxPlugin
 
-logger = get_logger("plugin-sandbox-docker-stub")
+logger = get_logger("plugin-sandbox")
 
 
 class StubCommandResult:

--- a/src/baas/src/secbaas/community/plugins/sandbox/k8s/real/_client_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/k8s/real/_client_manager.py
@@ -18,7 +18,7 @@ from secbaas.community.logger import get_logger
 if TYPE_CHECKING:
     from kubernetes.client import ApiClient
 
-logger = get_logger("paas-k8s-client")
+logger = get_logger("core-service")
 
 RETRYABLE_K8S_STATUSES: frozenset[int] = frozenset({409, 429, 503})
 _DEFAULT_RETRY_MAX_ATTEMPTS = 3

--- a/src/baas/src/secbaas/community/plugins/sandbox/k8s/real/_real_k8s_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/k8s/real/_real_k8s_sandbox.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from secbaas.community.api.device_manage import K8sCredentials
     from secbaas.community.plugins.sandbox.k8s.real import K8sClientManager
 
-logger = get_logger("plugin-sandbox-k8s-real")
+logger = get_logger("plugin-sandbox")
 
 _RFC1123_PATTERN = re.compile(r"[^a-z0-9-]")
 _MULTI_DASH_PATTERN = re.compile(r"-+")

--- a/src/baas/src/secbaas/community/plugins/sandbox/k8s/stub/_stub_k8s_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/k8s/stub/_stub_k8s_sandbox.py
@@ -19,7 +19,7 @@ from secbaas.community.spi.sandbox.k8s import K8sSandbox, K8sSandboxPlugin
 if TYPE_CHECKING:
     from secbaas.community.api.device_manage import K8sCredentials
 
-logger = get_logger("plugin-sandbox-K8S")
+logger = get_logger("plugin-sandbox")
 
 
 class StubCommandResult:

--- a/src/baas/src/secbaas/community/plugins/sandbox/poolab/_stub.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/poolab/_stub.py
@@ -26,7 +26,7 @@ from secbaas.community.spi.sandbox.poolab import PoolabSandboxPlugin
 if TYPE_CHECKING:
     pass
 
-logger = get_logger("plugin-sandbox-poolab")
+logger = get_logger("plugin-sandbox")
 
 
 class StubPoolabSandboxPlugin(PoolabSandboxPlugin):

--- a/src/baas/src/secbaas/community/plugins/sandbox/teclaw/_stub.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/teclaw/_stub.py
@@ -21,7 +21,7 @@ from secbaas.community.spi.bot.teclaw import (
     TeClawBotPlugin,
 )
 
-logger = get_logger("plugin-bot-teclaw")
+logger = get_logger("plugin-sandbox")
 
 
 class StubTeClawBotPlugin(TeClawBotPlugin):

--- a/src/baas/src/secbaas/community/plugins/sandbox/utils/arca_utils.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/utils/arca_utils.py
@@ -14,7 +14,7 @@ from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 from secbaas.community.spi.secret import SecretStorePlugin
 
-logger = get_logger("plugin-sandbox-arca")
+logger = get_logger("plugin-sandbox")
 
 _ARCA_PROXY_HOST_MAP: dict[str, ConfigPath] = {
     "dev": ConfigPath.AGENTCLAW_PROXY_HOST_DEV,

--- a/src/baas/tests/architecture/test_logger_usage.py
+++ b/src/baas/tests/architecture/test_logger_usage.py
@@ -72,3 +72,92 @@ def test_no_direct_logging_getlogger_outside_legacy_layers():
             + "\n\nUse secbaas.logger.get_logger() instead of "
             "logging.getLogger() to keep logger backends swappable."
         )
+
+
+# --- Canonical logger name whitelist ---
+
+ALLOWED_LOGGER_NAMES = frozenset(
+    {
+        "core-service",
+        "orm",
+        "router",
+        "router-open-api",
+        "router-gateway",
+        "router-admin",
+        "core-bot-run",
+        "core-scheduler",
+        "database",
+        "plugin-sandbox",
+        "plugin-bot-service",
+        "plugin-auth",
+        "bootstrap",
+        "config",
+        "webserver",
+    }
+)
+
+CANONICAL_NAME_PATTERN = r"^[a-z][a-z0-9-]*$"
+
+
+def test_logger_names_are_canonical():
+    """All ``get_logger("...")`` calls must use a canonical name from the
+    whitelist and match the naming style ``^[a-z][a-z0-9-]*$``.
+
+    Logger names become log file names (``{name}.log``); reusing existing
+    canonical names reduces log-file fragmentation.  Adding a new name
+    requires updating ``ALLOWED_LOGGER_NAMES`` in this test.
+    """
+    import re
+
+    name_violations: list[str] = []
+    style_violations: list[str] = []
+
+    for py_file in sorted(SECBAAS.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+
+        rel_path = str(py_file.relative_to(SECBAAS))
+
+        try:
+            source = py_file.read_text()
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            # Match get_logger("...")
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "get_logger"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                name = node.args[0].value
+                if name not in ALLOWED_LOGGER_NAMES:
+                    name_violations.append(
+                        f'  {rel_path}:{node.lineno}: get_logger("{name}")'
+                    )
+                if not re.match(CANONICAL_NAME_PATTERN, name):
+                    style_violations.append(
+                        f'  {rel_path}:{node.lineno}: get_logger("{name}") '
+                        f"does not match {CANONICAL_NAME_PATTERN}"
+                    )
+
+    messages = []
+    if name_violations:
+        messages.append(
+            f"\n{len(name_violations)} call(s) use non-canonical logger names:\n"
+            + "\n".join(name_violations)
+            + "\n\nAllowed names: "
+            + ", ".join(sorted(ALLOWED_LOGGER_NAMES))
+        )
+    if style_violations:
+        messages.append(
+            f"\n{len(style_violations)} call(s) violate the naming style:\n"
+            + "\n".join(style_violations)
+        )
+    if messages:
+        raise AssertionError("\n".join(messages))

--- a/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+++ b/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
@@ -208,9 +208,7 @@ async def test_handle_chat_send_deliver_fails(
     mock_run_repo.update_error.side_effect = _update_error
     mock_run_repo.get_by_run_id.return_value = failed_run
 
-    with patch(
-        "secbaas.community.core.service.bcn._bcn_service.logger"
-    ) as mock_logger:
+    with patch("secbaas.community.core.service.bcn._bcn_service.logger") as mock_logger:
         result = await service.handle_chat_send(_make_chat_send_input())
         assert result.ok is True  # acknowledgement remains fire-and-forget
         await asyncio.wait_for(callback_sent.wait(), timeout=1)

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -276,7 +276,9 @@ class TestSessionRoutingAffinityPrefix:
         for sid in ("bcs-sess-123", "agent:main:bcs-sess-123"):
             await service._resolve_ws_connection_for_binding(binding, session_id=sid)
             affinities.append(
-                wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs["device_affinity"]
+                wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs[
+                    "device_affinity"
+                ]
             )
         assert affinities == ["bcs-sess-123", "bcs-sess-123"]
 


### PR DESCRIPTION
## Summary

Canonicalize all `get_logger()` calls in the baas target module to use short, whitelisted logger names instead of compound names that produce fragmented log files.

## Changes

- Renamed logger names across 55 source files to their canonical short form (e.g. `"orm-repository"` -> `"orm"`, `"plugin-sandbox-arca-local-proc"` -> `"plugin-sandbox"`, `"bootstrap-cron"` -> `"bootstrap"`)
- Added architecture test `test_logger_names_are_canonical` that enforces a fixed whitelist (`ALLOWED_LOGGER_NAMES`) and naming style `^[a-z][a-z0-9-]*$`
- Updated 2 unit-test files that referenced old logger names

## Canonical Name Mapping

| Old Name | New Name |
|---|---|
| `orm-repository` | `orm` |
| `plugin-sandbox-arca-*` | `plugin-sandbox` |
| `plugin-bot-service-*` | `plugin-bot-service` |
| `plugin-auth-*` | `plugin-auth` |
| `bootstrap-cron` | `bootstrap` |
| `bootstrap-lifecycle` | `bootstrap` |
| `config-loader` / `config-utils` | `config` |
| `core-service-*` | `core-service` |
| `core-bot-run-*` | `core-bot-run` |
| `database-manager` | `database` |
| `router-*` | respective canonical router name |

## Test Results

- 8144 passed, 0 failed, 3 skipped
- No new failures introduced

## Privacy Scan

- No introduced findings
- 3 preexisting baseline warnings (not introduced by this change)

## Review

- 0 blocking issues, 0 P0/P1/P2/P3 findings