### PR TITLE
feat(baas): route claude_code active-engine to aicoding adapter by template_type

### DIFF
--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -32,8 +32,24 @@ logger = get_logger("plugin-bot-service")
 _SUPPORTED_RUNTIME_ENGINE_TYPES = frozenset(
     {"openclaw", "teclaw", "aicoding", "hermes", "claude_code"}
 )
+_CLAUDE_CODE_NORMAL_TEMPLATE = "normalCC"
 _BINDING_MAX_ATTEMPTS = 2
 _BINDING_RETRY_DELAY_SECONDS = 0.1
+
+
+def resolve_claude_code_engine(active_engine: str, template_type: str | None) -> str:
+    """Resolve the adapter engine for a ``claude_code`` active engine.
+
+    A ``claude_code`` active engine routes to the ``aicoding`` adapter while the
+    bot still carries a non-normal template, and to ``claude_code`` once the bot
+    uses the plain (``normalCC``) template. All other engines are unchanged.
+    """
+    if active_engine != "claude_code":
+        return active_engine
+    tt = template_type.strip() if isinstance(template_type, str) else ""
+    if tt and tt != _CLAUDE_CODE_NORMAL_TEMPLATE:
+        return "aicoding"
+    return "claude_code"
 
 
 class AiohttpBotServicePlugin(BotServicePlugin):
@@ -341,22 +357,27 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                         engine_type,
                     )
 
+            consumed_engine_type = resolve_claude_code_engine(
+                engine_type, inner.get("template_type")
+            )
+
             logger.info(
                 "[bot-service] get_binding raw: bot_id=%s engine_type=%r "
                 "active_runtime_engine_type=%r consumed_engine_type=%r "
-                "template_type=%r device_provider=%r",
+                "template_type=%r routed_engine_type=%r device_provider=%r",
                 resolved_bot_id,
                 original_engine_type,
                 runtime_engine_type,
                 engine_type,
                 inner.get("template_type"),
+                consumed_engine_type,
                 inner.get("device_provider"),
             )
             return BotBindingData(
                 bot_id=resolved_bot_id,
                 owner_id=inner.get("owner_id", owner_id),
                 bot_type=bot_type,
-                engine_type=engine_type,
+                engine_type=consumed_engine_type,
                 publish_id=inner.get("publish_id"),
                 publish_status=inner.get("publish_status"),
                 binding_id=inner.get("binding_id", 0),

--- a/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
+++ b/src/baas/tests/unit/plugins/bot_service/test_bot_service_plugin.py
@@ -22,6 +22,10 @@ from secbaas.community.plugins.bot_service import (
     LocalBotServicePlugin,
     StubBotServicePlugin,
 )
+from secbaas.community.plugins.bot_service.real._plugin import (
+    _CLAUDE_CODE_NORMAL_TEMPLATE,
+    resolve_claude_code_engine,
+)
 from secbaas.community.spi.bot_service import BotBindingData, LogRelationPayload
 
 # ==================== Tests: AiohttpBotServicePlugin construction ==============
@@ -945,7 +949,7 @@ class TestAiohttpBotServicePluginRuntimeEngineSelection:
             "owner_id": "20881234",
             "bot_type": "personal",
             "engine_type": "claude_code",
-            "template_type": "generCC",
+            "template_type": "normalCC",
             "binding_id": 101,
             "device_provider": "arca",
             "device_id": "ARCA-SANDBOX-001",
@@ -1019,3 +1023,61 @@ class TestAiohttpBotServicePluginRuntimeEngineSelection:
 
         assert result.engine_type == "claude_code"
         mock_logger.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("template_type", ["generCC", "  aicoding-default  "])
+    async def test_claude_code_with_non_normal_template_routes_to_aicoding(
+        self, template_type
+    ):
+        plugin = AiohttpBotServicePlugin(base_url="https://agentclaw.example.com")
+        plugin._get_binding_raw = AsyncMock(
+            return_value=self._binding_inner(template_type=template_type)
+        )
+
+        result = await plugin.get_binding("bot_personal_001", "20881234", "online")
+
+        assert result.engine_type == "aicoding"
+
+    @pytest.mark.asyncio
+    async def test_claude_code_original_with_normal_template_stays_claude_code(self):
+        plugin = AiohttpBotServicePlugin(base_url="https://agentclaw.example.com")
+        plugin._get_binding_raw = AsyncMock(
+            return_value=self._binding_inner(template_type="normalCC")
+        )
+
+        result = await plugin.get_binding("bot_personal_001", "20881234", "online")
+
+        assert result.engine_type == "claude_code"
+
+
+class TestResolveClaudeCodeEngine:
+    """Routing of a claude_code active engine by template_type."""
+
+    def test_claude_code_with_non_normal_template_routes_to_aicoding(self):
+        for template_type in ("generCC", "  aicoding-default  ", "other"):
+            assert (
+                resolve_claude_code_engine("claude_code", template_type) == "aicoding"
+            )
+
+    @pytest.mark.parametrize(
+        "template_type", [None, "", "   ", _CLAUDE_CODE_NORMAL_TEMPLATE]
+    )
+    def test_claude_code_with_empty_or_normal_template_stays_claude_code(
+        self, template_type
+    ):
+        assert resolve_claude_code_engine("claude_code", template_type) == "claude_code"
+
+    def test_claude_code_normal_template_is_whitespace_insensitive(self):
+        assert resolve_claude_code_engine("claude_code", " normalCC ") == "claude_code"
+
+    @pytest.mark.parametrize(
+        "active_engine", ["openclaw", "teclaw", "aicoding", "hermes"]
+    )
+    def test_non_claude_code_engine_unchanged_regardless_of_template(
+        self, active_engine
+    ):
+        for template_type in (None, "", "normalCC", "generCC", "  x  ", 123):
+            assert (
+                resolve_claude_code_engine(active_engine, template_type)
+                == active_engine
+            )


### PR DESCRIPTION
## Problem
The BaaS OpenAPI underlying routing always sends `active_engine="claude_code"`
to the claude_code adapter. Bots that still carry aicoding-style templates would
break during migration.

## Solution
Resolve the consumed engine once in `AiohttpBotServicePlugin.get_binding()` so a
claude_code active engine routes to the **aicoding** adapter when `template_type`
is non-empty and not `"normalCC"`, and to the **claude_code** adapter when
`template_type` is empty or `"normalCC"`. All other engines (`openclaw`,
`teclaw`, `hermes`, `aicoding`) are unchanged.

The resolved engine feeds both the adapter registry and the health/alive
checkers, keeping them consistent. Added a pure `resolve_claude_code_engine()`
helper plus unit and `get_binding()` integration tests.

## Validation
- `tests/unit/plugins/bot_service/test_bot_service_plugin.py`: 63 passed
- `engine_adapter` + `bot_service` suites: 92 passed
- `ruff check .`: passed
- `ruff format --check`: clean

## Compatibility and risk
- No public API, contract, or schema changes; internal routing semantics only.
- Existing claude_code bots with `normalCC`/empty templates behave as before.
- Rollback: revert this commit.

## Related issues
Closes #1054