### PR TITLE
fix(claude-relay): forward manual model configuration

### DIFF
--- a/scripts/modules/claude_relays.sh
+++ b/scripts/modules/claude_relays.sh
@@ -67,6 +67,27 @@ claude_relays_prereqs() {
     claude_relay_cli >/dev/null || return 1
 }
 
+claude_relays_manual_model_env() {
+    CLAUDE_RELAY_MANUAL_MODEL_ENV=()
+    [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" = "manual" ] || return 0
+
+    local base_url="${OPENCLAW_OPENAI_BASE_URL:-}"
+    local api_key="${OPENCLAW_OPENAI_API_KEY:-}"
+    local model="$1"
+    if [ -z "$base_url" ] || [ -z "$api_key" ] || [ -z "$model" ]; then
+        log_error "Claude relay manual model configuration is incomplete"
+        return 1
+    fi
+
+    CLAUDE_RELAY_MANUAL_MODEL_ENV=(
+        "ANTHROPIC_BASE_URL=${base_url}"
+        "ANTHROPIC_AUTH_TOKEN=${api_key}"
+        "ANTHROPIC_MODEL=${model}"
+        "ANTHROPIC_SMALL_FAST_MODEL=${model}"
+    )
+    log_info "Claude relay model provider resolved from manual configuration (model=${model})"
+}
+
 claude_relays_start() {
     claude_relays_enabled || return 0
     claude_relays_setup || return 1
@@ -86,7 +107,8 @@ claude_relays_start() {
     stop_port_processes_if_owned "$port" "$PROJECT_ROOT" "Claude ${role} relay" || true
     require_port_available_after_owned_stop "$port" "Claude ${role} relay" || return 1
     model_source=""
-    if [ ! -f "${config_dir}/settings.json" ] && [ -f "$HOME/.claude/settings.json" ]; then
+    claude_relays_manual_model_env "$model" || return 1
+    if [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" != "manual" ] && [ ! -f "${config_dir}/settings.json" ] && [ -f "$HOME/.claude/settings.json" ]; then
         model_source="$HOME/.claude/settings.json"
     fi
     log_info "Starting Claude relay role=${role} port=${port}"
@@ -97,6 +119,7 @@ claude_relays_start() {
             RELAY_DATA_DIR="$(claude_relay_data_dir "$role")" RELAY_LOG_DIR="$(claude_relay_log_dir "$role")" \
             RELAY_SYSTEM_PROMPT_FILE="$prompt_file" RELAY_SYSTEM_PROMPT_ROOT="$(dirname "$prompt_file")" \
             CLAUDE_CODE_PATH="$cli" \
+            "${CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" \
             perl -MPOSIX=setsid -e 'setsid() or die "setsid failed: $!\\n"; exec @ARGV' node dist/esm/server.js
     ) </dev/null >> "$CLAUDE_RELAY_LOG" 2>&1 &
     printf '%s\n' "$!" > "$pid_file"

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -90,6 +90,16 @@ IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission <
 [[ "$workspace" == "$TMP/claude-workspace" ]]
 [[ "$prompt" == "$CLAUDE_PROFILE/platform-data/CLAUDE.md" ]]
 
+export SINGLEBOX_MODEL_CONFIG_MODE="manual"
+claude_relays_manual_model_env "$model"
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_BASE_URL=https://model.example.test/v1"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_AUTH_TOKEN=test-token"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_MODEL=glm-local"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_SMALL_FAST_MODEL=glm-local"* ]]
+export SINGLEBOX_MODEL_CONFIG_MODE="home"
+claude_relays_manual_model_env "$model"
+[[ "${#CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" == "0" ]]
+
 export BCSFUSE_RUNTIME_DIR="$TMP/bcsfuse-runtime"
 mkdir -p "$BCSFUSE_RUNTIME_DIR/env"
 cat > "$BCSFUSE_RUNTIME_DIR/env/.env.local" <<'ENV'

--- a/spec/pipeline/claude-hybrid-manual-env/001-spec-output.md
+++ b/spec/pipeline/claude-hybrid-manual-env/001-spec-output.md
@@ -1,0 +1,22 @@
+---
+agent: tc-review
+status: approved-by-request
+created: 2026-08-14
+---
+
+# Claude hybrid manual model environment
+
+## 需求
+
+在基于 `origin/dev` 的 Avernet worktree 中，使用 `./scripts/singlebox.sh start hybrid` 启动已启用 Claude profile 的混合栈时，Claude Code 必须复用 manual 模式的 `.env.local` 模型配置。
+
+## 实施范围
+
+- 仅在 `SINGLEBOX_MODEL_CONFIG_MODE=manual` 时，将已经校验的 `OPENCLAW_OPENAI_BASE_URL`、`OPENCLAW_OPENAI_API_KEY` 与当前解析的模型传给 Claude relay，分别映射为 Claude Code 的 `ANTHROPIC_BASE_URL`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_MODEL` 和 `ANTHROPIC_SMALL_FAST_MODEL`。
+- manual 模式不再让本机或 role 的 `settings.json` 覆盖上述 relay 配置。
+- 保持 home、mock 和非 Claude hybrid 的现有行为；不写入或记录任何凭据。
+
+## 验收
+
+- `scripts/test_hybrid.sh` 断言 manual 映射完整、可用，且非 manual 模式没有 relay 覆盖项。
+- 执行 Bash 语法检查和相关 shell 回归；检查 diff 中不出现凭据或无关改动。

--- a/spec/pipeline/claude-hybrid-manual-env/002-code-report.md
+++ b/spec/pipeline/claude-hybrid-manual-env/002-code-report.md
@@ -1,0 +1,32 @@
+---
+agent: tc-code
+status: completed
+created: 2026-08-14
+iteration: 1
+---
+
+# 编码报告
+
+## Worktree
+
+- 路径：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/claude-hybrid-manual-env-20260814`
+- 分支：`codex/claude-hybrid-manual-env-20260814`
+- 基线：`origin/dev` 的 `7682a96c7c423f982bd8ecff7da1740805f5dee9`
+
+## 改动
+
+- `claude_relays_manual_model_env` 仅在 manual 模式构建 Claude Code provider 环境。
+- relay 启动时将 manual 的 endpoint、token 和解析后的模型注入到 Claude Code 子进程，并避免导入 settings 文件中的 provider 字段覆盖它们。
+- 新增 shell 回归，覆盖 manual 映射和非 manual 空映射。
+
+## 安全边界
+
+- 凭据只作为子进程环境变量传递；日志仅记录模式和模型名。
+- 未写入 `.env.local`、Claude settings 或生成的运行时配置。
+
+## 验证
+
+- `bash -n scripts/modules/claude_relays.sh scripts/test_hybrid.sh`
+- `bash scripts/test_hybrid.sh`
+- `bash scripts/test_singlebox_model_config.sh`
+- `git diff --check`

--- a/spec/pipeline/claude-hybrid-manual-env/003-review-report.md
+++ b/spec/pipeline/claude-hybrid-manual-env/003-review-report.md
@@ -1,0 +1,23 @@
+---
+agent: tc-main-agent
+status: pass
+created: 2026-08-14
+---
+
+# Code review（主流程复核）
+
+## 结论
+
+PASS。
+
+## 检查项
+
+- manual 模式需要的三项 `OPENCLAW_OPENAI_*` 已在既有准备阶段校验；relay 再次 fail-closed，避免以不完整 provider 配置启动。
+- 映射只在 manual 模式生效；home、mock 和 OpenClaw-only hybrid 保持原路径。
+- settings provider source 在 manual 模式置空，避免 gateway 侧重新加载而覆盖显式映射。
+- API key 不进入命令行参数、日志或仓库文件，只进入 relay 子进程环境。
+- Bash 数组通过 `env` 的逐元素参数传递，能够保留 URL、token 中的特殊字符。
+
+## 残余风险
+
+真实服务启动需要用户在 worktree 的 `.env.local` 或调用 shell 中提供完整 manual 配置；该文件当前不存在，因此未进行外部模型连通性验证。

--- a/spec/pipeline/claude-hybrid-manual-env/003b-regression-report.md
+++ b/spec/pipeline/claude-hybrid-manual-env/003b-regression-report.md
@@ -1,0 +1,23 @@
+---
+agent: tc-main-agent
+status: pass
+created: 2026-08-14
+---
+
+# Focused regression report
+
+## 通过
+
+- `bash -n scripts/modules/claude_relays.sh scripts/test_hybrid.sh`
+- `bash scripts/test_hybrid.sh`
+- `bash scripts/test_singlebox_model_config.sh`
+- `git diff --check`
+
+## 启动前置校验
+
+在不含 `.env.local` 的全新 worktree 中，以 manual 模式执行含 Claude profile 的 `start hybrid` 预检，命令在“缺少 required model config”阶段退出，未启动服务、未占用端口。
+
+## 未执行
+
+- 未运行完整 singlebox 服务栈：本 worktree 没有用户的 manual endpoint/key/model 配置，不能安全完成真实外部模型调用。
+- `shellcheck` 未安装，已由 Bash 语法检查替代。

--- a/spec/pipeline/claude-hybrid-manual-env/009-pr-report.md
+++ b/spec/pipeline/claude-hybrid-manual-env/009-pr-report.md
@@ -1,0 +1,43 @@
+# PR 收敛报告：claude-hybrid-manual-env
+
+## 范围
+
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/claude-hybrid-manual-env-20260814` / `inclusionAI/Avernet`
+- Head / base: `codex/claude-hybrid-manual-env-20260814` / `dev`
+- PR: `NOT_CREATED`
+- PR title: `fix(claude-relay): forward manual model configuration`
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| HEAD 归属有效 | 当前分支基于 `origin/dev` 的 `7682a96c7` | 只包含 Claude relay manual provider 环境改动及本任务报告。 |
+| 匹配 PR | 无 | 创建前 `gh pr list --head codex/claude-hybrid-manual-env-20260814 --base dev --state open` 返回空数组。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | - | - | 待 PR 创建 | 尚无远端评审。 | - | - |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| 远端 ACI/CI | PENDING | 尚未创建 PR | 无远端 job | - | 本地 shell 回归已通过，不能替代远端门禁。 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | - | - | 待 PR 创建 | 尚无远端评论。 | - | - |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: CLEAR
+- ACI/CI: PENDING
+- 人工意见: CLEAR
+- 下一步: 提交、推送 topic 分支并创建以 `dev` 为 base 的 PR。

--- a/spec/pipeline/claude-hybrid-manual-env/009-pr-report.md
+++ b/spec/pipeline/claude-hybrid-manual-env/009-pr-report.md
@@ -4,7 +4,7 @@
 
 - Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/claude-hybrid-manual-env-20260814` / `inclusionAI/Avernet`
 - Head / base: `codex/claude-hybrid-manual-env-20260814` / `dev`
-- PR: `NOT_CREATED`
+- PR: `https://github.com/inclusionAI/Avernet/pull/1057`
 - PR title: `fix(claude-relay): forward manual model configuration`
 - PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
 - 人工意见模式: auto
@@ -13,31 +13,33 @@
 
 | 结果 | 证据 | 说明 |
 |---|---|---|
-| HEAD 归属有效 | 当前分支基于 `origin/dev` 的 `7682a96c7` | 只包含 Claude relay manual provider 环境改动及本任务报告。 |
-| 匹配 PR | 无 | 创建前 `gh pr list --head codex/claude-hybrid-manual-env-20260814 --base dev --state open` 返回空数组。 |
+| HEAD 归属有效 | `c9fec937fc8e77445e3ce9267b703c6c73e7ffea` | 当前分支基于 `origin/dev` 的 `7682a96c7`，提交只包含 Claude relay manual provider 环境改动及本任务报告。 |
+| PR 元数据 | [#1057](https://github.com/inclusionAI/Avernet/pull/1057) | `OPEN`；head 为 `codex/claude-hybrid-manual-env-20260814`，base 为 `dev`，标题与必填说明段落已核验。 |
 
 ## 自动意见
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | - | - | 待 PR 创建 | 尚无远端评审。 | - | - |
+| 1 | - | - | CLEAR | 创建后查询到 0 条 review，未发现机器人评审。 | - | - |
 
 ## ACI/CI
 
 | Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
 |---|---|---|---|---|---|
-| 远端 ACI/CI | PENDING | 尚未创建 PR | 无远端 job | - | 本地 shell 回归已通过，不能替代远端门禁。 |
+| Singlebox coverage | PENDING | [GitHub Actions job](https://github.com/inclusionAI/Avernet/actions/runs/31790815235/job/94737063617) | 运行中 | - | 不能以本地 shell 回归替代。 |
+| BCS e2e (coverage gated) | PASS | GitHub Actions | - | - | SUCCESS。 |
+| BCS / Backend / Engine / BaaS / Gateway unit tests | PASS | GitHub Actions | - | - | 五项均为 SUCCESS。 |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | - | - | 待 PR 创建 | 尚无远端评论。 | - | - |
+| 1 | - | - | CLEAR | 创建后查询到 0 条 issue comment。 | - | - |
 
 ## 当前结论
 
-- PR: NOT_CREATED
+- PR: OPEN ([#1057](https://github.com/inclusionAI/Avernet/pull/1057))
 - 自动意见: CLEAR
 - ACI/CI: PENDING
 - 人工意见: CLEAR
-- 下一步: 提交、推送 topic 分支并创建以 `dev` 为 base 的 PR。
+- 下一步: 等待 Singlebox coverage 完成；该分支保护规则当前仍显示 REVIEW_REQUIRED。


### PR DESCRIPTION
## Problem

When a hybrid stack enables its Claude Code profile in manual model-config mode, OpenClaw and BCSFuse reuse the configured endpoint, credential, and model, but the Claude relay can still source provider settings elsewhere. That leaves the Claude Code path inconsistent with the manual configuration.

## Solution

- Map the already-validated manual OpenClaw endpoint, token, and resolved model to the Claude Code relay provider environment.
- Keep the mapping scoped to `SINGLEBOX_MODEL_CONFIG_MODE=manual` and prevent settings-source provider fields from overriding it in that mode.
- Add hybrid shell coverage for the manual mapping and the non-manual no-op behavior.

## Validation

- `bash -n scripts/modules/claude_relays.sh scripts/test_hybrid.sh`
- `bash scripts/test_hybrid.sh`
- `bash scripts/test_singlebox_model_config.sh`
- manual-mode startup preflight confirms missing local configuration fails before any service starts
- `git diff --check`

## Compatibility and risk

Home, mock, and OpenClaw-only hybrid flows retain their existing configuration paths. A full live-stack run was not performed because this clean worktree has no local manual model configuration; runtime validation requires the operator-provided `.env.local` or equivalent shell environment.

## Spec

`spec/pipeline/claude-hybrid-manual-env/001-spec-output.md`
