### PR TITLE
test(baas): whitelist arca-renew-digest logger name

### DIFF
--- a/src/baas/tests/architecture/test_logger_usage.py
+++ b/src/baas/tests/architecture/test_logger_usage.py
@@ -93,6 +93,10 @@ ALLOWED_LOGGER_NAMES = frozenset(
         "bootstrap",
         "config",
         "webserver",
+        # Digest stream deliberately kept out of the shared application logs:
+        # monitoring collects ``arca-renew-digest.log`` as a standalone,
+        # comma-separated feed of TTL renewal outcomes.
+        "arca-renew-digest",
     }
 )
 


### PR DESCRIPTION
## Problem

The BaaS unit test job on #1058 (release merge-back) fails:

```
FAILED tests/architecture/test_logger_usage.py::test_logger_names_are_canonical
1 call(s) use non-canonical logger names:
  core/service/health_check/sandbox/_sandbox_device_router.py:24: get_logger("arca-renew-digest")
```

Two changes landed on separate lines of history and only collide on merge:

- #1017 (release branch) added a dedicated `arca-renew-digest` logger in
  `_sandbox_device_router.py` for the TTL renewal digest feed.
- #1055 (dev) added `test_logger_names_are_canonical`, which enforces a fixed
  `ALLOWED_LOGGER_NAMES` whitelist that predates and therefore omits that name.

Neither change is wrong on its own; the merged tree just has a logger name the
gate has never seen. This is the only failure in the job — 8189 tests pass.

## Solution

Add `arca-renew-digest` to `ALLOWED_LOGGER_NAMES`, with a comment explaining why
it is a deliberate exception rather than fragmentation.

The alternative — renaming the logger to `core-service` — was rejected because
the separate name is load-bearing. `BareLoggerPlugin` writes one `{name}.log`
per logger name, so the digest lines land in `arca-renew-digest.log`, which
monitoring collects as a standalone comma-separated feed. Folding them into the
shared application log would break that collection for an already-released
feature. The test's own docstring prescribes this path: "Adding a new name
requires updating `ALLOWED_LOGGER_NAMES` in this test."

## Validation

- `test_logger_names_are_canonical` and
  `test_no_direct_logging_getlogger_outside_legacy_layers` executed directly
  against the merged tree — both pass (the module is stdlib-only).
- `ruff check` and `ruff format --check` on the changed file — clean.
- The full BaaS suite could not be run here: `uv sync` cannot reach the
  `mirrors.aliyun.com` index pinned in the lock file from this sandbox. The
  change touches only a test-side whitelist constant, and CI on this branch
  covers the rest.

## Compatibility and risk

Test-only change; no runtime, schema, or config impact. The whitelist gate stays
in force for every other logger name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmFkW7U3N4YtoJp4QjVHGg)_