### PR TITLE
fix(singlebox): stabilize hybrid startup and remote demo access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ BCS_PORT=21000
 # Frontend port. Docker uses the same value inside the container and on the host.
 FRONTEND_PORT=8000
 
+# Public frontend base URL used in BCS-generated group chat links. Set this on
+# remote hosts so bcs-cli does not return localhost URLs.
+# BCS_BOTCHAT_URL=https://workbench.example.com
+
 # Local mock display name when SERVER_ENV=local.
 BCS_MOCK_USER_NICK_NAME="Turing"
 
@@ -42,6 +46,22 @@ OPENCLAW_ENABLE_THINKING=false
 # OPENCLAW_OPENAI_MODEL_ID=
 # OPENCLAW_OPENAI_MODEL_NAME=
 # OPENCLAW_OPENAI_MODEL_API=openai-completions
+
+# ====== Optional: Claude Code in hybrid mode ======
+
+# Claude Code sends Anthropic Messages API requests. Configure an
+# Anthropic-compatible endpoint separately; do not reuse an OpenAI-compatible
+# OPENCLAW_OPENAI_BASE_URL unless that gateway explicitly supports both APIs.
+# If omitted during an interactive start, Singlebox shows the OpenAI URL and
+# lets you enter an Anthropic-compatible replacement once. The answer applies
+# to that process only and is not written back to .env.local.
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
+# Use ANTHROPIC_AUTH_TOKEN for an LLM gateway, or ANTHROPIC_API_KEY for the
+# Anthropic API. If neither is set, the OpenAI API key is reused as the gateway
+# token. ANTHROPIC_MODEL likewise defaults to OPENCLAW_OPENAI_MODEL_ID.
+# ANTHROPIC_AUTH_TOKEN=
+# ANTHROPIC_API_KEY=
+# ANTHROPIC_MODEL=
 
 # When BASE_URL, API_KEY, and MODEL_ID are all set, singlebox also uses this
 # OpenAI-compatible provider for the local BCS state-machine judge. The API key

--- a/scripts/4bots_merchant_operations_profile_for_claude/README.md
+++ b/scripts/4bots_merchant_operations_profile_for_claude/README.md
@@ -1,8 +1,8 @@
 # 平台数据分析 Claude Code Profile
 
-此 profile 用于 `hybrid` 的 Claude Code 数据分析 Bot。模型沿用 Singlebox
-本次选择的配置：`manual` 模式读取仓库根目录 `.env.local`，`home` 模式读取
-本机 OpenClaw 配置。Claude Code 的本机认证配置不会写入该目录。
+此 profile 用于 `hybrid` 的 Claude Code 数据分析 Bot。默认从仓库根目录
+`.env.local` 读取独立的 Anthropic-compatible 模型配置，不复用 OpenClaw 的
+OpenAI-compatible endpoint。Claude Code 的本机认证配置不会写入该目录。
 `CLAUDE.md` 是受控角色 prompt 的入口。
 
 ## 本地启动
@@ -31,8 +31,8 @@
 
 三个 profile 参数全部传入时，OpenClaw profile 中被排除的一个 source
 由 Claude profile 中同 source 的唯一一个 Bot 替代。此时不再询问是否使用
-Claude Code，但仍会检测本机安装，并询问是否用 `.env.local` 替换 Claude Code
-的模型配置：
+Claude Code，但仍会检测本机安装。Claude Code 的模型配置默认直接读取
+`.env.local`：
 
 ```bash
 ./scripts/singlebox.sh start hybrid \
@@ -42,15 +42,25 @@ Claude Code，但仍会检测本机安装，并询问是否用 `.env.local` 替�
 ```
 
 如果本机没有 `claude` 命令，启动流程会询问是否通过 npm 安装；拒绝安装会取消
-本次启动。选择不使用 `.env.local` 时，只读取用户自己的 Claude Code 模型配置，
-不会改写 `~/.claude/settings.json`。
+本次启动。OpenClaw 使用 `OPENCLAW_OPENAI_*`。Claude Code 的
+`ANTHROPIC_MODEL` 和 `ANTHROPIC_AUTH_TOKEN` 未配置时，分别沿用 OpenClaw 的模型
+和 API key；已有 `ANTHROPIC_API_KEY` 时不会被覆盖。`ANTHROPIC_BASE_URL` 未配置时，
+交互式启动会展示当前 OpenAI URL，并允许输入一次 Anthropic-compatible URL；直接
+回车则沿用展示值。该 URL 必须支持 Anthropic Messages API，输入仅对本次启动有效，
+不会写回 `.env.local`。非交互启动必须显式配置 `ANTHROPIC_BASE_URL`。
+
+如需显式使用用户自己的 Claude Code 配置，可设置
+`HYBRID_CLAUDE_CONFIG_MODE=user`；脚本不会改写 `~/.claude/settings.json`。
+
+不带 profile 参数执行 `restart hybrid` 时，脚本直接恢复上次成功 `start hybrid`
+保存的运行模式、profiles、模型配置模式和 Anthropic base URL，不再询问以上选项。
+如果没有可恢复状态，会要求先执行一次 `start hybrid`，而不是重新猜测配置。
 
 非交互环境可以显式设置：
 
 ```bash
 HYBRID_USE_CLAUDE_CODE=yes \
 HYBRID_INSTALL_CLAUDE_CODE=yes \
-HYBRID_CLAUDE_CONFIG_MODE=env-local \
 ./scripts/singlebox.sh start hybrid
 ```
 

--- a/scripts/4bots_merchant_operations_profile_for_claude/README.md
+++ b/scripts/4bots_merchant_operations_profile_for_claude/README.md
@@ -13,7 +13,26 @@
 ./scripts/singlebox.sh install-tools
 ```
 
-然后直接启动；`start hybrid` 会自动完成项目 setup：
+然后直接启动；不加 profile 参数时，`hybrid` 和兼容别名
+`merchant_hybrid` 会先询问是否使用 Claude Code。选择使用时启动
+3 个 OpenClaw Bot + 1 个 Claude Code Bot；选择不使用时，4 个 Bot
+全部使用 OpenClaw：
+
+```bash
+./scripts/singlebox.sh start hybrid
+```
+
+只传 `--profile-dir` 时，该 profile 中的 Bot 全部按 OpenClaw 启动：
+
+```bash
+./scripts/singlebox.sh start hybrid \
+  --profile-dir scripts/4bots_merchant_operations_profile
+```
+
+三个 profile 参数全部传入时，OpenClaw profile 中被排除的一个 source
+由 Claude profile 中同 source 的唯一一个 Bot 替代。此时不再询问是否使用
+Claude Code，但仍会检测本机安装，并询问是否用 `.env.local` 替换 Claude Code
+的模型配置：
 
 ```bash
 ./scripts/singlebox.sh start hybrid \
@@ -21,3 +40,18 @@
   --exclusive-profile-dir platform-data \
   --claude-profile-dir scripts/4bots_merchant_operations_profile_for_claude
 ```
+
+如果本机没有 `claude` 命令，启动流程会询问是否通过 npm 安装；拒绝安装会取消
+本次启动。选择不使用 `.env.local` 时，只读取用户自己的 Claude Code 模型配置，
+不会改写 `~/.claude/settings.json`。
+
+非交互环境可以显式设置：
+
+```bash
+HYBRID_USE_CLAUDE_CODE=yes \
+HYBRID_INSTALL_CLAUDE_CODE=yes \
+HYBRID_CLAUDE_CONFIG_MODE=env-local \
+./scripts/singlebox.sh start hybrid
+```
+
+其中 `HYBRID_CLAUDE_CONFIG_MODE` 可选 `env-local` 或 `user`。

--- a/scripts/modules/bcs.sh
+++ b/scripts/modules/bcs.sh
@@ -90,6 +90,7 @@ prepare_bcs_runtime_config() {
     local local_config="${config_dir}/bcs-config-local.toml"
     local bcs_url="http://127.0.0.1:${BCS_PORT}"
     local bcs_bind="${BCS_BIND:-}"
+    local bcs_botchat_url="${BCS_BOTCHAT_URL:-}"
     local bcs_mock_user_id="${BCS_MOCK_USER_ID:-}"
     local bcs_mock_user_name="${BCS_MOCK_USER_NICK_NAME:-}"
     # BCS_BOT_PROFILE_DIR is the explicit override. If the caller used the
@@ -137,6 +138,11 @@ prepare_bcs_runtime_config() {
         local escaped_bind
         escaped_bind="$(toml_sed_replacement "$bcs_bind")"
         sed_args+=("-e" "s|^bind = \".*\"$|bind = \"${escaped_bind}\"|")
+    fi
+    if [ -n "$bcs_botchat_url" ]; then
+        local escaped_botchat_url
+        escaped_botchat_url="$(toml_sed_replacement "$bcs_botchat_url")"
+        sed_args+=("-e" "s|^botchat_url = \".*\"$|botchat_url = \"${escaped_botchat_url}\"|")
     fi
     if [ -n "$bcs_mock_user_id" ]; then
         local escaped_mock_user_id

--- a/scripts/modules/bcs_baas_provider.sh
+++ b/scripts/modules/bcs_baas_provider.sh
@@ -80,6 +80,25 @@ bcs_baas_provider_clear_registration() {
     chmod 600 "$BCS_BAAS_PROVIDER_TOKEN_FILE"
 }
 
+bcs_baas_provider_clear_bot_tokens() {
+    [ -f "$BCS_BAAS_PROVIDER_TOKEN_FILE" ] || return 0
+    jq '.provider_bots = {}' \
+        "$BCS_BAAS_PROVIDER_TOKEN_FILE" > "${BCS_BAAS_PROVIDER_TOKEN_FILE}.tmp" || return 1
+    mv "${BCS_BAAS_PROVIDER_TOKEN_FILE}.tmp" "$BCS_BAAS_PROVIDER_TOKEN_FILE"
+    chmod 600 "$BCS_BAAS_PROVIDER_TOKEN_FILE"
+}
+
+bcs_baas_provider_registration_valid() {
+    [ -f "$BCS_BAAS_PROVIDER_TOKEN_FILE" ] || return 1
+    local provider_id provider_admin_token
+    provider_id="$(jq -r '.provider_id // empty' "$BCS_BAAS_PROVIDER_TOKEN_FILE")"
+    provider_admin_token="$(jq -r '.provider_admin_token // empty' "$BCS_BAAS_PROVIDER_TOKEN_FILE")"
+    [ -n "$provider_id" ] && [ -n "$provider_admin_token" ] || return 1
+    curl --noproxy '*' --connect-timeout 2 --max-time 10 -fsS \
+        "http://127.0.0.1:${BCS_PORT}/providers/${provider_id}" \
+        -H "Authorization: Bearer ${provider_admin_token}" >/dev/null
+}
+
 bcs_baas_provider_healthy() {
     node - "$BCS_BAAS_PROVIDER_PORT" <<'NODE' >/dev/null 2>&1
 const http2 = require('node:http2');
@@ -126,22 +145,39 @@ bcs_baas_provider_cleanup_registration() {
             "http://127.0.0.1:${BCS_PORT}/providers/${encoded_id}/bots/${encoded_ref}" \
             -H "Authorization: Bearer ${provider_admin_token}" >/dev/null || return 1
     done < <(jq -r '.bots[]?.provider_bot_ref // empty' "$BCS_BAAS_PROVIDER_STATE_FILE")
-    bcs_baas_provider_clear_registration || return 1
+    # BCS does not expose Provider deletion. Retain the Provider credentials so
+    # the next hybrid start can reuse the same record instead of accumulating
+    # orphaned duplicate Providers on every restart.
+    bcs_baas_provider_clear_bot_tokens || return 1
     rm -f "$BCS_BAAS_PROVIDER_STATE_FILE"
-    log_info "Removed the current merchant Claude Provider registration"
+    log_info "Removed the current merchant Claude Provider bot registration"
 }
 
 bcs_baas_provider_register() {
     local entity_id owner provider_payload response provider_id provider_admin_token bcs_token
     entity_id="$(jq -r '.entity_id' "$CLAUDE_BOTS_STATE_FILE")"
     owner="$(bcs_baas_provider_bcs_owner_id)"
-    provider_payload="$(jq -n --arg webhook "http://127.0.0.1:${BCS_BAAS_PROVIDER_PORT}/webhook" '{name: "singlebox-merchant-claude", webhook_url: $webhook, auth: {mode: "static_bearer"}, protocol_version: "2.0"}')"
-    response="$(curl --noproxy '*' --connect-timeout 2 --max-time 20 -fsS -X POST "http://127.0.0.1:${BCS_PORT}/providers" -H "X-Mock-User-Id: ${owner}" -H 'Content-Type: application/json' -d "$provider_payload")" || return 1
-    provider_id="$(jq -r '.provider_id // empty' <<< "$response")"
-    provider_admin_token="$(jq -r '.provider_admin_token // empty' <<< "$response")"
-    bcs_token="$(jq -r '.bcs_to_provider_token // empty' <<< "$response")"
-    [ -n "$provider_id" ] && [ -n "$provider_admin_token" ] && [ -n "$bcs_token" ] || { log_error "BCS Provider registration returned incomplete metadata"; return 1; }
-    bcs_baas_provider_update_tokens "$provider_id" "$provider_admin_token" "$bcs_token" || return 1
+    if bcs_baas_provider_registration_valid; then
+        provider_id="$(jq -r '.provider_id' "$BCS_BAAS_PROVIDER_TOKEN_FILE")"
+        provider_admin_token="$(jq -r '.provider_admin_token' "$BCS_BAAS_PROVIDER_TOKEN_FILE")"
+        bcs_token="$(jq -r '.bcs_to_provider_token' "$BCS_BAAS_PROVIDER_TOKEN_FILE")"
+        [ -n "$bcs_token" ] || { log_error "Stored BCS Provider registration is incomplete"; return 1; }
+        log_info "Reusing local merchant Claude Provider ${provider_id}"
+    else
+        if [ -f "$BCS_BAAS_PROVIDER_TOKEN_FILE" ] && \
+           [ -n "$(jq -r '.provider_id // empty' "$BCS_BAAS_PROVIDER_TOKEN_FILE")" ]; then
+            log_warn "Stored merchant Claude Provider registration is no longer valid; creating a replacement"
+            bcs_baas_provider_clear_registration || return 1
+            rm -f "$BCS_BAAS_PROVIDER_STATE_FILE"
+        fi
+        provider_payload="$(jq -n --arg webhook "http://127.0.0.1:${BCS_BAAS_PROVIDER_PORT}/webhook" '{name: "singlebox-merchant-claude", webhook_url: $webhook, auth: {mode: "static_bearer"}, protocol_version: "2.0"}')"
+        response="$(curl --noproxy '*' --connect-timeout 2 --max-time 20 -fsS -X POST "http://127.0.0.1:${BCS_PORT}/providers" -H "X-Mock-User-Id: ${owner}" -H 'Content-Type: application/json' -d "$provider_payload")" || return 1
+        provider_id="$(jq -r '.provider_id // empty' <<< "$response")"
+        provider_admin_token="$(jq -r '.provider_admin_token // empty' <<< "$response")"
+        bcs_token="$(jq -r '.bcs_to_provider_token // empty' <<< "$response")"
+        [ -n "$provider_id" ] && [ -n "$provider_admin_token" ] && [ -n "$bcs_token" ] || { log_error "BCS Provider registration returned incomplete metadata"; return 1; }
+        bcs_baas_provider_update_tokens "$provider_id" "$provider_admin_token" "$bcs_token" || return 1
+    fi
 
     local role bot_id name provider_ref payload bot_response runtime_token bot_uuid visibility state_bots='[]'
     while IFS=$'\t' read -r role bot_id name; do
@@ -171,7 +207,13 @@ bcs_baas_provider_start() {
     [ -f "$CLAUDE_BOTS_STATE_FILE" ] || { log_error "Claude bot state is missing"; return 1; }
     bcs_baas_provider_prepare_runtime_tokens || return 1
     if [ -f "$BCS_BAAS_PROVIDER_STATE_FILE" ]; then
-        bcs_baas_provider_cleanup_registration || { log_error "Refusing duplicate Provider registration while cleanup is incomplete"; return 1; }
+        if bcs_baas_provider_registration_valid; then
+            bcs_baas_provider_cleanup_registration || { log_error "Refusing to replace a Provider bot registration while cleanup is incomplete"; return 1; }
+        else
+            log_warn "Discarding stale local Provider state after BCS data changed"
+            bcs_baas_provider_clear_registration || return 1
+            rm -f "$BCS_BAAS_PROVIDER_STATE_FILE"
+        fi
     fi
     mkdir -p "$LOG_DIR"
     stop_port_processes_if_owned "$BCS_BAAS_PROVIDER_PORT" "$PROJECT_ROOT" "BCS BaaS Provider bridge" || true
@@ -197,6 +239,27 @@ bcs_baas_provider_stop() {
     stop_port_processes_if_owned "$BCS_BAAS_PROVIDER_PORT" "$PROJECT_ROOT" "BCS BaaS Provider bridge" || true
     rm -f "$BCS_BAAS_PROVIDER_PID_FILE"
     if bcs_ready; then bcs_baas_provider_cleanup_registration || return 1; fi
+}
+
+bcs_baas_provider_clean() {
+    local pid
+    if [ -f "$BCS_BAAS_PROVIDER_PID_FILE" ]; then
+        pid="$(cat "$BCS_BAAS_PROVIDER_PID_FILE" 2>/dev/null || true)"
+        stop_process_if_owned "$pid" "$PROJECT_ROOT" "BCS BaaS Provider bridge" || return 1
+    fi
+    stop_port_processes_if_owned "$BCS_BAAS_PROVIDER_PORT" "$PROJECT_ROOT" "BCS BaaS Provider bridge" || true
+    rm -f "$BCS_BAAS_PROVIDER_PID_FILE"
+    if [ -f "$BCS_BAAS_PROVIDER_STATE_FILE" ]; then
+        if bcs_ready && bcs_baas_provider_registration_valid; then
+            bcs_baas_provider_cleanup_registration || return 1
+        elif bcs_ready; then
+            log_warn "Discarding stale local Provider bot state after BCS data changed"
+            bcs_baas_provider_clear_registration || return 1
+            rm -f "$BCS_BAAS_PROVIDER_STATE_FILE"
+        else
+            log_warn "BCS is not running; preserving Provider bot state for cleanup on the next hybrid start"
+        fi
+    fi
 }
 
 bcs_baas_provider_ready() {

--- a/scripts/modules/bots.sh
+++ b/scripts/modules/bots.sh
@@ -1755,6 +1755,9 @@ bots_restart() {
 }
 
 bots_clean() {
+    if type -t hybrid_clean_attached_claude_runtime >/dev/null; then
+        hybrid_clean_attached_claude_runtime || return 1
+    fi
     if bots_dynamic_enabled; then
         bots_dynamic_clean
         return

--- a/scripts/modules/claude_bots.sh
+++ b/scripts/modules/claude_bots.sh
@@ -79,8 +79,8 @@ claude_bots_start() {
     baas_ready || { log_error "BAAS is not ready; cannot create Claude bot"; return 1; }
     mkdir -p "$LOG_DIR"
     : > "$CLAUDE_BOTS_LOG"
-    local role name summary port rest entity_id bot_id
-    IFS=$'\x1f' read -r role name summary port rest < <(claude_profile_entries)
+    local role name summary port config_dir workspace model prompt_file permission entity_id bot_id
+    IFS=$'\x1f' read -r role name summary port config_dir workspace model prompt_file permission < <(claude_profile_entries)
     entity_id="$(claude_profile_entity_id)"
     bot_id="$(claude_bots_find_existing "$name" "$entity_id")"
     if [ -z "$bot_id" ]; then
@@ -90,8 +90,14 @@ claude_bots_start() {
     [ -n "$bot_id" ] || { log_error "Failed to create Claude bot; check ${CLAUDE_BOTS_LOG}"; return 1; }
     claude_bots_wait_ready "$bot_id" "$entity_id" || return 1
     umask 077
-    jq -n --arg entity_id "$entity_id" --arg entity_type "$(claude_profile_entity_type)" --arg role "$role" --arg bot_id "$bot_id" --arg name "$name" --argjson relay_port "$port" \
-        '{entity_id: $entity_id, entity_type: $entity_type, bots: [{role: $role, bot_id: $bot_id, name: $name, relay_port: $relay_port}]}' > "$CLAUDE_BOTS_STATE_FILE"
+    jq -n --arg entity_id "$entity_id" --arg entity_type "$(claude_profile_entity_type)" \
+        --arg bots_profile_dir "${BOTS_PROFILE_DIR:-}" --arg claude_profile_dir "${CLAUDE_PROFILE_DIR:-}" \
+        --arg claude_config_dir "$config_dir" --arg workspace "$workspace" \
+        --arg role "$role" --arg bot_id "$bot_id" --arg name "$name" --argjson relay_port "$port" \
+        '{entity_id: $entity_id, entity_type: $entity_type, bots_profile_dir: $bots_profile_dir,
+          claude_profile_dir: $claude_profile_dir, claude_config_dir: $claude_config_dir,
+          workspace: $workspace,
+          bots: [{role: $role, bot_id: $bot_id, name: $name, relay_port: $relay_port}]}' > "$CLAUDE_BOTS_STATE_FILE"
     chmod 600 "$CLAUDE_BOTS_STATE_FILE"
     log_info "Started one Claude Code normalCC bot on relay ${port}"
 }
@@ -99,6 +105,42 @@ claude_bots_start() {
 claude_bots_stop() {
     claude_bots_enabled || return 0
     log_info "Claude adapter remains managed by BAAS until BAAS stops"
+}
+
+claude_bots_runtime_path_safe_to_clean() {
+    local runtime_path="$1"
+    case "$runtime_path" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    case "${runtime_path%/}" in
+        ""|/|"${HOME%/}"|"${HOME%/}/.claude"|"${PROJECT_ROOT%/}"|"${SCRIPT_DIR%/}"|"${DEP_DIR%/}")
+            return 1
+            ;;
+    esac
+}
+
+claude_bots_clean() {
+    [ -f "$CLAUDE_BOTS_STATE_FILE" ] || return 0
+    local config_dir workspace runtime_path label
+    config_dir="$(jq -r '.claude_config_dir // empty' "$CLAUDE_BOTS_STATE_FILE")"
+    workspace="$(jq -r '.workspace // empty' "$CLAUDE_BOTS_STATE_FILE")"
+    if { [ -z "$config_dir" ] || [ -z "$workspace" ]; } && claude_profile_enabled; then
+        local role name summary port model prompt_file permission
+        IFS=$'\x1f' read -r role name summary port config_dir workspace model prompt_file permission < <(claude_profile_entries)
+    fi
+
+    for label in config workspace; do
+        if [ "$label" = config ]; then runtime_path="$config_dir"; else runtime_path="$workspace"; fi
+        [ -n "$runtime_path" ] || continue
+        if ! claude_bots_runtime_path_safe_to_clean "$runtime_path"; then
+            log_error "Refusing to clean unsafe Claude ${label} path: ${runtime_path}"
+            return 1
+        fi
+        rm -rf "$runtime_path"
+        log_info "Cleaned Claude ${label} path: ${runtime_path}"
+    done
+    rm -f "$CLAUDE_BOTS_STATE_FILE"
 }
 
 claude_bots_ready() {

--- a/scripts/modules/claude_profile.sh
+++ b/scripts/modules/claude_profile.sh
@@ -110,7 +110,11 @@ PY
 claude_profile_entries() {
     local manifest runtime_model
     manifest="$(claude_profile_manifest)" || return 1
-    runtime_model="${HYBRID_MODEL_ID:-${OPENCLAW_OPENAI_MODEL_ID:-}}"
+    if [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" = "user" ]; then
+        runtime_model=""
+    else
+        runtime_model="${HYBRID_MODEL_ID:-${OPENCLAW_OPENAI_MODEL_ID:-}}"
+    fi
     python3 - "$manifest" "$runtime_model" <<'PY'
 import json
 import os

--- a/scripts/modules/claude_profile.sh
+++ b/scripts/modules/claude_profile.sh
@@ -105,15 +105,15 @@ PY
 }
 
 # Emits unit-separator-delimited source/name/summary/port/config/workspace/model/prompt/permission.
-# The model is resolved from the selected Singlebox runtime configuration, not
-# persisted in the reusable Claude role profile.
+# The model is resolved from the runtime environment, not persisted in the
+# reusable Claude role profile.
 claude_profile_entries() {
     local manifest runtime_model
     manifest="$(claude_profile_manifest)" || return 1
     if [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" = "user" ]; then
         runtime_model=""
     else
-        runtime_model="${HYBRID_MODEL_ID:-${OPENCLAW_OPENAI_MODEL_ID:-}}"
+        runtime_model="${ANTHROPIC_MODEL:-}"
     fi
     python3 - "$manifest" "$runtime_model" <<'PY'
 import json

--- a/scripts/modules/claude_relays.sh
+++ b/scripts/modules/claude_relays.sh
@@ -37,13 +37,38 @@ claude_relay_wait_ready() {
     return 1
 }
 
-claude_relay_cli() {
+claude_relay_find_cli() {
     local candidate
     for candidate in "${CLAUDE_CODE_PATH:-}" "$(command -v claude 2>/dev/null || true)"; do
         [ -n "$candidate" ] && [ -x "$candidate" ] && { printf '%s\n' "$candidate"; return 0; }
     done
+    return 1
+}
+
+claude_relay_cli() {
+    claude_relay_find_cli && return 0
     log_error "No usable Claude CLI found; set CLAUDE_CODE_PATH or install claude"
     return 1
+}
+
+claude_relay_install_cli() {
+    if ! command -v npm >/dev/null 2>&1; then
+        log_error "npm is required to install Claude Code. Run: ./scripts/singlebox.sh install-tools"
+        return 1
+    fi
+
+    log_info "Installing Claude Code with npm..."
+    if ! npm install -g @anthropic-ai/claude-code --registry="${NPM_REGISTRY_URL}"; then
+        log_error "Claude Code installation failed. Install it manually with:"
+        log_error "  npm install -g @anthropic-ai/claude-code"
+        return 1
+    fi
+    hash -r 2>/dev/null || true
+    if ! claude_relay_find_cli >/dev/null; then
+        log_error "Claude Code was installed but the claude executable is not in PATH."
+        return 1
+    fi
+    log_info "Claude Code installed successfully."
 }
 
 claude_relays_setup() {
@@ -69,6 +94,7 @@ claude_relays_prereqs() {
 
 claude_relays_manual_model_env() {
     CLAUDE_RELAY_MANUAL_MODEL_ENV=()
+    [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" != "user" ] || return 0
     [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" = "manual" ] || return 0
 
     local base_url="${OPENCLAW_OPENAI_BASE_URL:-}"
@@ -93,10 +119,10 @@ claude_relays_start() {
     claude_relays_setup || return 1
     local role name summary port config_dir workspace model prompt_file permission pid_file cli model_source
     IFS=$'\x1f' read -r role name summary port config_dir workspace model prompt_file permission < <(claude_profile_entries)
-    [ -n "$model" ] || {
+    if [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" != "user" ] && [ -z "$model" ]; then
         log_error "Claude relay model was not resolved from the selected Singlebox configuration"
         return 1
-    }
+    fi
     cli="$(claude_relay_cli)" || return 1
     mkdir -p "$config_dir" "$workspace" "$(claude_relay_data_dir "$role")" "$(claude_relay_log_dir "$role")" "$CLAUDE_RELAY_STATE_DIR" "$LOG_DIR"
     pid_file="$(claude_relay_pid_file "$role")"
@@ -108,14 +134,19 @@ claude_relays_start() {
     require_port_available_after_owned_stop "$port" "Claude ${role} relay" || return 1
     model_source=""
     claude_relays_manual_model_env "$model" || return 1
-    if [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" != "manual" ] && [ ! -f "${config_dir}/settings.json" ] && [ -f "$HOME/.claude/settings.json" ]; then
+    if [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" = "user" ] && [ -f "$HOME/.claude/settings.json" ]; then
+        model_source="$HOME/.claude/settings.json"
+    elif [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" != "manual" ] && [ ! -f "${config_dir}/settings.json" ] && [ -f "$HOME/.claude/settings.json" ]; then
         model_source="$HOME/.claude/settings.json"
     fi
+    local relay_default_model_env=()
+    [ -n "$model" ] && relay_default_model_env=("RELAY_DEFAULT_MODEL=${model}")
     log_info "Starting Claude relay role=${role} port=${port}"
     (
         cd "$CLAUDE_RELAY_GATEWAY_DIR"
         exec env PORT="$port" RELAY_CLAUDE_CONFIG_DIR="$config_dir" RELAY_MODEL_SETTINGS_SOURCE="$model_source" \
-            RELAY_DEFAULT_MODEL="$model" RELAY_DEFAULT_PERMISSION_MODE="$permission" RELAY_DEFAULT_CWD="$workspace" \
+            "${relay_default_model_env[@]}" \
+            RELAY_DEFAULT_PERMISSION_MODE="$permission" RELAY_DEFAULT_CWD="$workspace" \
             RELAY_DATA_DIR="$(claude_relay_data_dir "$role")" RELAY_LOG_DIR="$(claude_relay_log_dir "$role")" \
             RELAY_SYSTEM_PROMPT_FILE="$prompt_file" RELAY_SYSTEM_PROMPT_ROOT="$(dirname "$prompt_file")" \
             CLAUDE_CODE_PATH="$cli" \

--- a/scripts/modules/claude_relays.sh
+++ b/scripts/modules/claude_relays.sh
@@ -92,26 +92,83 @@ claude_relays_prereqs() {
     claude_relay_cli >/dev/null || return 1
 }
 
+claude_relay_prompt_anthropic_base_url() {
+    local openai_base_url="${OPENCLAW_OPENAI_BASE_URL:-}"
+    local answer=""
+    [ -n "$openai_base_url" ] || {
+        log_error "ANTHROPIC_BASE_URL is not set and no OPENCLAW_OPENAI_BASE_URL is available as an editing hint."
+        return 1
+    }
+
+    log_warn "ANTHROPIC_BASE_URL is not set."
+    log_warn "Current OpenAI-compatible URL: ${openai_base_url}"
+    log_warn "Claude Code requires this URL to support the Anthropic Messages API."
+    if [ ! -t 0 ] || [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+        log_error "Set ANTHROPIC_BASE_URL explicitly for non-interactive startup."
+        return 1
+    fi
+
+    printf 'Anthropic-compatible base URL [%s]: ' "$openai_base_url" >&2
+    read -r answer </dev/tty || return 1
+    ANTHROPIC_BASE_URL="${answer:-$openai_base_url}"
+    export ANTHROPIC_BASE_URL
+}
+
+claude_relay_prepare_env_local_model() {
+    if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        ANTHROPIC_AUTH_TOKEN="${OPENCLAW_OPENAI_API_KEY:-}"
+        export ANTHROPIC_AUTH_TOKEN
+        [ -n "$ANTHROPIC_AUTH_TOKEN" ] && log_info "Claude Code auth token defaults to OPENCLAW_OPENAI_API_KEY."
+    fi
+    if [ -z "${ANTHROPIC_MODEL:-}" ]; then
+        ANTHROPIC_MODEL="${OPENCLAW_OPENAI_MODEL_ID:-}"
+        export ANTHROPIC_MODEL
+        [ -n "$ANTHROPIC_MODEL" ] && log_info "Claude Code model defaults to OPENCLAW_OPENAI_MODEL_ID (${ANTHROPIC_MODEL})."
+    fi
+    if [ -z "${ANTHROPIC_BASE_URL:-}" ]; then
+        if [ "${HYBRID_RESTART_FROM_STATE:-0}" = "1" ]; then
+            log_error "The previous hybrid runtime has no reusable ANTHROPIC_BASE_URL; restart will not prompt for a replacement."
+            log_error "Run start hybrid once to choose and save an Anthropic-compatible URL."
+            return 1
+        fi
+        claude_relay_prompt_anthropic_base_url || return 1
+    fi
+    claude_relay_validate_env_local_model
+}
+
+claude_relay_validate_env_local_model() {
+    local missing=()
+    [ -n "${ANTHROPIC_MODEL:-}" ] || missing+=(ANTHROPIC_MODEL)
+    if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+        missing+=("ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY")
+    fi
+    [ -n "${ANTHROPIC_BASE_URL:-}" ] || missing+=(ANTHROPIC_BASE_URL)
+    if [ "${#missing[@]}" -gt 0 ]; then
+        log_error "Claude Code .env.local configuration is incomplete: ${missing[*]}"
+        log_error "Claude Code requires an Anthropic-compatible Messages API endpoint."
+        log_error "If the upstream only supports OpenAI APIs, configure an Anthropic-compatible gateway and set ANTHROPIC_BASE_URL to it."
+        return 1
+    fi
+}
+
 claude_relays_manual_model_env() {
     CLAUDE_RELAY_MANUAL_MODEL_ENV=()
     [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" != "user" ] || return 0
     [ "${SINGLEBOX_MODEL_CONFIG_MODE:-}" = "manual" ] || return 0
 
-    local base_url="${OPENCLAW_OPENAI_BASE_URL:-}"
-    local api_key="${OPENCLAW_OPENAI_API_KEY:-}"
-    local model="$1"
-    if [ -z "$base_url" ] || [ -z "$api_key" ] || [ -z "$model" ]; then
-        log_error "Claude relay manual model configuration is incomplete"
-        return 1
+    claude_relay_validate_env_local_model || return 1
+    local model="${ANTHROPIC_MODEL}"
+    [ -n "${ANTHROPIC_BASE_URL:-}" ] && CLAUDE_RELAY_MANUAL_MODEL_ENV+=("ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL}")
+    if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+        CLAUDE_RELAY_MANUAL_MODEL_ENV+=("ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN}")
+    else
+        CLAUDE_RELAY_MANUAL_MODEL_ENV+=("ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}")
     fi
-
-    CLAUDE_RELAY_MANUAL_MODEL_ENV=(
-        "ANTHROPIC_BASE_URL=${base_url}"
-        "ANTHROPIC_AUTH_TOKEN=${api_key}"
+    CLAUDE_RELAY_MANUAL_MODEL_ENV+=(
         "ANTHROPIC_MODEL=${model}"
         "ANTHROPIC_SMALL_FAST_MODEL=${model}"
     )
-    log_info "Claude relay model provider resolved from manual configuration (model=${model})"
+    log_info "Claude relay model provider resolved from .env.local Anthropic configuration (model=${model})"
 }
 
 claude_relays_start() {

--- a/scripts/modules/claude_relays.sh
+++ b/scripts/modules/claude_relays.sh
@@ -52,7 +52,7 @@ claude_relays_setup() {
     [ -f "${CLAUDE_RELAY_GATEWAY_DIR}/package.json" ] || { log_error "Vendored Claude gateway missing"; return 1; }
     if [ ! -f "${CLAUDE_RELAY_GATEWAY_DIR}/dist/esm/server.js" ] || find "${CLAUDE_RELAY_GATEWAY_DIR}/src" -type f -newer "${CLAUDE_RELAY_GATEWAY_DIR}/dist/esm/server.js" -print -quit | grep -q .; then
         log_info "Building vendored Claude Code gateway..."
-        (cd "$CLAUDE_RELAY_GATEWAY_DIR" && npm install --include=dev --ignore-scripts --no-audit --no-fund && npm run prepublishOnly) >> "$CLAUDE_RELAY_LOG" 2>&1 || {
+        (cd "$CLAUDE_RELAY_GATEWAY_DIR" && npm install --include=dev --ignore-scripts --no-audit --no-fund --registry="${NPM_REGISTRY_URL}" && npm run prepublishOnly) >> "$CLAUDE_RELAY_LOG" 2>&1 || {
             log_error "Claude gateway build failed; check ${CLAUDE_RELAY_LOG}"
             return 1
         }
@@ -133,6 +133,20 @@ claude_relays_stop() {
     pid_file="$(claude_relay_pid_file "$role")"
     [ -f "$pid_file" ] && stop_process_if_owned "$(cat "$pid_file" 2>/dev/null || true)" "$PROJECT_ROOT" "Claude ${role} relay" || true
     rm -f "$pid_file"
+}
+
+claude_relays_clean() {
+    local pid_file pid
+    if [ -d "$CLAUDE_RELAY_STATE_DIR" ]; then
+        for pid_file in "$CLAUDE_RELAY_STATE_DIR"/*.pid; do
+            [ -f "$pid_file" ] || continue
+            pid="$(cat "$pid_file" 2>/dev/null || true)"
+            stop_process_if_owned "$pid" "$PROJECT_ROOT" "Claude relay" || return 1
+            rm -f "$pid_file"
+        done
+        rm -rf "$CLAUDE_RELAY_STATE_DIR"
+    fi
+    rm -f "$CLAUDE_RELAY_LOG"
 }
 
 claude_relays_ready() {

--- a/scripts/modules/hybrid.sh
+++ b/scripts/modules/hybrid.sh
@@ -50,8 +50,14 @@ hybrid_profile_paths_match() {
 }
 
 hybrid_save_runtime_state() {
-    local mode="openclaw" tmp_file
-    hybrid_claude_enabled && mode="claude"
+    local mode="openclaw" tmp_file claude_config_mode="" anthropic_base_url=""
+    if hybrid_claude_enabled; then
+        mode="claude"
+        claude_config_mode="${HYBRID_CLAUDE_CONFIG_MODE:-env-local}"
+        if [ "$claude_config_mode" = "env-local" ]; then
+            anthropic_base_url="${ANTHROPIC_BASE_URL:-}"
+        fi
+    fi
     tmp_file="${HYBRID_STATE_FILE}.$$.tmp"
     mkdir -p "$(dirname "$HYBRID_STATE_FILE")"
     umask 077
@@ -60,7 +66,18 @@ hybrid_save_runtime_state() {
         --arg bots_profile_dir "${BOTS_PROFILE_DIR}" \
         --arg excluded_profile_source "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" \
         --arg claude_profile_dir "${CLAUDE_PROFILE_DIR:-}" \
-        '{mode: $mode, bots_profile_dir: $bots_profile_dir, excluded_profile_source: $excluded_profile_source, claude_profile_dir: $claude_profile_dir}' \
+        --arg claude_config_mode "$claude_config_mode" \
+        --arg anthropic_base_url "$anthropic_base_url" \
+        --arg singlebox_model_config_mode "${SINGLEBOX_MODEL_CONFIG_MODE:-}" \
+        '{
+          mode: $mode,
+          bots_profile_dir: $bots_profile_dir,
+          excluded_profile_source: $excluded_profile_source,
+          claude_profile_dir: $claude_profile_dir,
+          claude_config_mode: $claude_config_mode,
+          anthropic_base_url: $anthropic_base_url,
+          singlebox_model_config_mode: $singlebox_model_config_mode
+        }' \
         > "$tmp_file"; then
         rm -f "$tmp_file"
         log_error "Failed to save hybrid runtime state"
@@ -86,6 +103,11 @@ hybrid_restore_runtime_state() {
         and ((.bots_profile_dir | length) > 0)
         and ((.excluded_profile_source | type) == "string")
         and ((.claude_profile_dir | type) == "string")
+        and (((.claude_config_mode // "") | type) == "string")
+        and (((.anthropic_base_url // "") | type) == "string")
+        and (((.singlebox_model_config_mode // "") | type) == "string")
+        and ((.claude_config_mode // "") as $value | ($value == "" or $value == "env-local" or $value == "user"))
+        and ((.singlebox_model_config_mode // "") as $value | ($value == "" or $value == "mock" or $value == "manual" or $value == "home"))
         and (if .mode == "claude"
              then ((.excluded_profile_source | length) > 0) and ((.claude_profile_dir | length) > 0)
              else .excluded_profile_source == "" and .claude_profile_dir == ""
@@ -96,10 +118,18 @@ hybrid_restore_runtime_state() {
     fi
 
     local mode state_bots_profile state_excluded_profile state_claude_profile
+    local state_claude_config_mode state_anthropic_base_url state_model_config_mode
     mode="$(jq -r '.mode' "$HYBRID_STATE_FILE")"
     state_bots_profile="$(jq -r '.bots_profile_dir' "$HYBRID_STATE_FILE")"
     state_excluded_profile="$(jq -r '.excluded_profile_source' "$HYBRID_STATE_FILE")"
     state_claude_profile="$(jq -r '.claude_profile_dir' "$HYBRID_STATE_FILE")"
+    state_claude_config_mode="$(jq -r '.claude_config_mode // empty' "$HYBRID_STATE_FILE")"
+    state_anthropic_base_url="$(jq -r '.anthropic_base_url // empty' "$HYBRID_STATE_FILE")"
+    state_model_config_mode="$(jq -r '.singlebox_model_config_mode // empty' "$HYBRID_STATE_FILE")"
+    if [ "$mode" = "claude" ]; then
+        state_claude_config_mode="${state_claude_config_mode:-env-local}"
+        state_model_config_mode="${state_model_config_mode:-manual}"
+    fi
 
     if [ -n "${BOTS_PROFILE_DIR:-}" ] && ! hybrid_profile_paths_match "$BOTS_PROFILE_DIR" "$state_bots_profile"; then
         log_error "--profile-dir does not match the active hybrid runtime"
@@ -123,6 +153,14 @@ hybrid_restore_runtime_state() {
         fi
         export BOTS_EXCLUDED_PROFILE_SOURCE="$state_excluded_profile"
         export CLAUDE_PROFILE_DIR="$state_claude_profile"
+        if [ -n "$state_claude_config_mode" ] && \
+           { [ "${HYBRID_RESTART_FROM_STATE:-0}" = "1" ] || [ -z "${HYBRID_CLAUDE_CONFIG_MODE:-}" ]; }; then
+            export HYBRID_CLAUDE_CONFIG_MODE="$state_claude_config_mode"
+        fi
+        if [ -n "$state_anthropic_base_url" ] && \
+           { [ "${HYBRID_RESTART_FROM_STATE:-0}" = "1" ] || [ -z "${ANTHROPIC_BASE_URL:-}" ]; }; then
+            export ANTHROPIC_BASE_URL="$state_anthropic_base_url"
+        fi
     else
         if [ -n "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] || [ -n "${CLAUDE_PROFILE_DIR:-}" ]; then
             log_error "Claude profile options do not match the active OpenClaw-only hybrid runtime"
@@ -130,11 +168,86 @@ hybrid_restore_runtime_state() {
         fi
         unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
     fi
+    if [ -n "$state_model_config_mode" ] && \
+       { [ "${HYBRID_RESTART_FROM_STATE:-0}" = "1" ] || [ -z "${SINGLEBOX_MODEL_CONFIG_MODE:-}" ]; }; then
+        export SINGLEBOX_MODEL_CONFIG_MODE="$state_model_config_mode"
+    fi
+}
+
+hybrid_runtime_state_differs_from_requested() {
+    [ -f "$HYBRID_STATE_FILE" ] || return 1
+
+    local requested_mode="openclaw" state_mode state_bots_profile state_excluded_profile state_claude_profile
+    hybrid_claude_enabled && requested_mode="claude"
+    state_mode="$(jq -r '.mode // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)"
+    state_bots_profile="$(jq -r '.bots_profile_dir // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)"
+    state_excluded_profile="$(jq -r '.excluded_profile_source // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)"
+    state_claude_profile="$(jq -r '.claude_profile_dir // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)"
+
+    [ "$requested_mode" != "$state_mode" ] && return 0
+    hybrid_profile_paths_match "${BOTS_PROFILE_DIR:-}" "$state_bots_profile" || return 0
+    if [ "$requested_mode" = "claude" ]; then
+        [ "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" = "$state_excluded_profile" ] || return 0
+        hybrid_profile_paths_match "${CLAUDE_PROFILE_DIR:-}" "$state_claude_profile" || return 0
+    fi
+    return 1
+}
+
+hybrid_stop_active_runtime_preserving_requested() {
+    local requested_bots_profile="${BOTS_PROFILE_DIR:-}"
+    local requested_excluded_profile="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
+    local requested_claude_profile="${CLAUDE_PROFILE_DIR:-}"
+    local requested_claude_config_mode="${HYBRID_CLAUDE_CONFIG_MODE:-}"
+    local requested_anthropic_base_url="${ANTHROPIC_BASE_URL:-}"
+    local requested_model_config_mode="${SINGLEBOX_MODEL_CONFIG_MODE:-}"
+    local rc=0
+
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    hybrid_stop || rc=$?
+
+    export BOTS_PROFILE_DIR="$requested_bots_profile"
+    if [ -n "$requested_excluded_profile" ]; then
+        export BOTS_EXCLUDED_PROFILE_SOURCE="$requested_excluded_profile"
+    else
+        unset BOTS_EXCLUDED_PROFILE_SOURCE
+    fi
+    if [ -n "$requested_claude_profile" ]; then
+        export CLAUDE_PROFILE_DIR="$requested_claude_profile"
+    else
+        unset CLAUDE_PROFILE_DIR
+    fi
+    if [ -n "$requested_claude_config_mode" ]; then
+        export HYBRID_CLAUDE_CONFIG_MODE="$requested_claude_config_mode"
+    else
+        unset HYBRID_CLAUDE_CONFIG_MODE
+    fi
+    if [ -n "$requested_anthropic_base_url" ]; then
+        export ANTHROPIC_BASE_URL="$requested_anthropic_base_url"
+    else
+        unset ANTHROPIC_BASE_URL
+    fi
+    if [ -n "$requested_model_config_mode" ]; then
+        export SINGLEBOX_MODEL_CONFIG_MODE="$requested_model_config_mode"
+    else
+        unset SINGLEBOX_MODEL_CONFIG_MODE
+    fi
+    return "$rc"
+}
+
+hybrid_prepare_requested_runtime() {
+    [ "${HYBRID_RUNTIME_SELECTION_EXPLICIT:-0}" = "1" ] || return 0
+    hybrid_runtime_state_differs_from_requested || return 0
+
+    # Validate the requested replacement before stopping the active runtime.
+    hybrid_configure_mode
+    hybrid_validate_profiles || return 1
+    log_info "Hybrid runtime selection changed; stopping the active runtime before switching modes."
+    hybrid_stop_active_runtime_preserving_requested
 }
 
 hybrid_apply_model_policy() {
     hybrid_claude_enabled || return 0
-    local config_file primary provider primary_model
+    local config_file primary provider primary_model claude_model
     config_file="${SINGLEBOX_MODEL_CONFIG_FILE:-}"
     [ -n "$config_file" ] && [ -f "$config_file" ] || {
         log_error "hybrid Claude model policy requires the prepared runtime model config"
@@ -171,9 +284,14 @@ hybrid_apply_model_policy() {
         unset HYBRID_MODEL_ID
         log_info "Hybrid model policy: OpenClaw and SOP use configured primary ${primary}; Claude Code keeps the user's configuration"
     else
+        claude_model="${ANTHROPIC_MODEL:-}"
+        [ -n "$claude_model" ] || {
+            log_error "Hybrid Claude mode requires ANTHROPIC_MODEL in .env.local"
+            return 1
+        }
         HYBRID_MODEL_ID="$primary_model"
         export HYBRID_MODEL_ID
-        log_info "Hybrid model policy: OpenClaw, Claude Code, and SOP use configured primary ${primary}"
+        log_info "Hybrid model policy: OpenClaw and SOP use ${primary}; Claude Code uses Anthropic-compatible model ${claude_model}"
     fi
 }
 
@@ -231,6 +349,7 @@ hybrid_port_preflight() {
 }
 
 hybrid_prereqs() {
+    hybrid_prepare_requested_runtime || return 1
     hybrid_restore_runtime_state || return 1
     hybrid_configure_mode
     hybrid_validate_profiles || return 1
@@ -248,6 +367,7 @@ hybrid_runtime_prereqs() {
 hybrid_start() {
     # `start hybrid` is intentionally self-contained after install-tools: setup
     # creates missing venvs, builds artifacts, and prepares runtime config.
+    hybrid_prepare_requested_runtime || return 1
     hybrid_restore_runtime_state || return 1
     hybrid_setup || return 1
     hybrid_runtime_prereqs || return 1
@@ -305,31 +425,12 @@ hybrid_restart() {
         return
     fi
 
-    local requested_bots_profile="${BOTS_PROFILE_DIR:-}"
-    local requested_excluded_profile="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
-    local requested_claude_profile="${CLAUDE_PROFILE_DIR:-}"
-    local requested_claude_config_mode="${HYBRID_CLAUDE_CONFIG_MODE:-}"
-
-    hybrid_stop || return 1
+    if [ -f "$HYBRID_STATE_FILE" ]; then
+        hybrid_stop_active_runtime_preserving_requested || return 1
+    else
+        hybrid_stop || return 1
+    fi
     sleep 2
-
-    BOTS_PROFILE_DIR="$requested_bots_profile"
-    if [ -n "$requested_excluded_profile" ]; then
-        BOTS_EXCLUDED_PROFILE_SOURCE="$requested_excluded_profile"
-    else
-        unset BOTS_EXCLUDED_PROFILE_SOURCE
-    fi
-    if [ -n "$requested_claude_profile" ]; then
-        CLAUDE_PROFILE_DIR="$requested_claude_profile"
-    else
-        unset CLAUDE_PROFILE_DIR
-    fi
-    if [ -n "$requested_claude_config_mode" ]; then
-        HYBRID_CLAUDE_CONFIG_MODE="$requested_claude_config_mode"
-    else
-        unset HYBRID_CLAUDE_CONFIG_MODE
-    fi
-
     hybrid_start
 }
 

--- a/scripts/modules/hybrid.sh
+++ b/scripts/modules/hybrid.sh
@@ -325,6 +325,55 @@ hybrid_status() {
     for service in "${HYBRID_START_ORDER[@]}"; do type -t "${service}_status" >/dev/null && "${service}_status"; done
 }
 
+hybrid_claude_runtime_matches_bot_profile() {
+    [ -n "${BOTS_PROFILE_DIR:-}" ] || return 1
+    local state_profile=""
+    if [ -f "$CLAUDE_BOTS_STATE_FILE" ]; then
+        state_profile="$(jq -r '.bots_profile_dir // empty' "$CLAUDE_BOTS_STATE_FILE" 2>/dev/null || true)"
+    fi
+    if [ -z "$state_profile" ] && [ -f "$HYBRID_STATE_FILE" ] && \
+       [ "$(jq -r '.mode // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)" = claude ]; then
+        state_profile="$(jq -r '.bots_profile_dir // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)"
+    fi
+    if [ -n "$state_profile" ]; then
+        hybrid_profile_paths_match "$BOTS_PROFILE_DIR" "$state_profile"
+        return
+    fi
+
+    # Compatibility for runtime state written before profile association was
+    # recorded. The legacy mixed demo was the only Claude hybrid profile.
+    [ -f "$CLAUDE_BOTS_STATE_FILE" ] && \
+        hybrid_profile_paths_match "$BOTS_PROFILE_DIR" "$HYBRID_DEFAULT_PROFILE_DIR"
+}
+
+hybrid_clean_attached_claude_runtime() (
+    hybrid_claude_runtime_matches_bot_profile || return 0
+
+    if [ -f "$CLAUDE_BOTS_STATE_FILE" ]; then
+        local state_claude_profile
+        state_claude_profile="$(jq -r '.claude_profile_dir // empty' "$CLAUDE_BOTS_STATE_FILE" 2>/dev/null || true)"
+        [ -n "$state_claude_profile" ] && export CLAUDE_PROFILE_DIR="$state_claude_profile"
+    fi
+    if [ -z "${CLAUDE_PROFILE_DIR:-}" ] && [ -f "$HYBRID_STATE_FILE" ] && \
+       [ "$(jq -r '.mode // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)" = claude ]; then
+        export CLAUDE_PROFILE_DIR="$(jq -r '.claude_profile_dir // empty' "$HYBRID_STATE_FILE")"
+    fi
+    if [ -z "${CLAUDE_PROFILE_DIR:-}" ] && \
+       hybrid_profile_paths_match "$BOTS_PROFILE_DIR" "$HYBRID_DEFAULT_PROFILE_DIR"; then
+        export CLAUDE_PROFILE_DIR="$MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR"
+    fi
+
+    log_info "Cleaning Claude runtime attached to bot profile ${BOTS_PROFILE_DIR}..."
+    bcs_baas_provider_clean || return 1
+    claude_relays_clean || return 1
+    claude_bots_clean || return 1
+    if [ -f "$HYBRID_STATE_FILE" ] && \
+       [ "$(jq -r '.mode // empty' "$HYBRID_STATE_FILE" 2>/dev/null || true)" = claude ]; then
+        hybrid_clear_runtime_state
+    fi
+    log_info "Claude runtime data cleaned"
+)
+
 hybrid_help() {
     echo "hybrid - OpenClaw profile stack with optional Claude Code replacement profiles"
 }

--- a/scripts/modules/hybrid.sh
+++ b/scripts/modules/hybrid.sh
@@ -161,15 +161,20 @@ hybrid_apply_model_policy() {
         return 1
     fi
 
-    HYBRID_MODEL_ID="$primary_model"
-    export HYBRID_MODEL_ID
     export SINGLEBOX_REQUIRED_OPENCLAW_MODEL="$primary"
     export LLM_FAST_MODEL="$primary_model"
     export LLM_BALANCED_MODEL="$primary_model"
     export LLM_REASONING_MODEL="$primary_model"
     export LLM_LONG_CONTEXT_MODEL="$primary_model"
     export LLM_EXTRACTION_MODEL="$primary_model"
-    log_info "Hybrid model policy: OpenClaw, Claude Code, and SOP use configured primary ${primary}"
+    if [ "${HYBRID_CLAUDE_CONFIG_MODE:-}" = "user" ]; then
+        unset HYBRID_MODEL_ID
+        log_info "Hybrid model policy: OpenClaw and SOP use configured primary ${primary}; Claude Code keeps the user's configuration"
+    else
+        HYBRID_MODEL_ID="$primary_model"
+        export HYBRID_MODEL_ID
+        log_info "Hybrid model policy: OpenClaw, Claude Code, and SOP use configured primary ${primary}"
+    fi
 }
 
 hybrid_validate_profiles() {
@@ -295,7 +300,37 @@ hybrid_stop() {
 }
 
 hybrid_restart() {
-    hybrid_stop && sleep 2 && hybrid_start
+    if [ "${HYBRID_RUNTIME_SELECTION_EXPLICIT:-0}" != "1" ]; then
+        hybrid_stop && sleep 2 && hybrid_start
+        return
+    fi
+
+    local requested_bots_profile="${BOTS_PROFILE_DIR:-}"
+    local requested_excluded_profile="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
+    local requested_claude_profile="${CLAUDE_PROFILE_DIR:-}"
+    local requested_claude_config_mode="${HYBRID_CLAUDE_CONFIG_MODE:-}"
+
+    hybrid_stop || return 1
+    sleep 2
+
+    BOTS_PROFILE_DIR="$requested_bots_profile"
+    if [ -n "$requested_excluded_profile" ]; then
+        BOTS_EXCLUDED_PROFILE_SOURCE="$requested_excluded_profile"
+    else
+        unset BOTS_EXCLUDED_PROFILE_SOURCE
+    fi
+    if [ -n "$requested_claude_profile" ]; then
+        CLAUDE_PROFILE_DIR="$requested_claude_profile"
+    else
+        unset CLAUDE_PROFILE_DIR
+    fi
+    if [ -n "$requested_claude_config_mode" ]; then
+        HYBRID_CLAUDE_CONFIG_MODE="$requested_claude_config_mode"
+    else
+        unset HYBRID_CLAUDE_CONFIG_MODE
+    fi
+
+    hybrid_start
 }
 
 hybrid_setup() {

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -77,6 +77,10 @@ CHAT_ENGINE="${CHAT_ENGINE:-openclaw}"
 BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-}"
 BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
 CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-}"
+HYBRID_USE_CLAUDE_CODE="${HYBRID_USE_CLAUDE_CODE:-}"
+HYBRID_INSTALL_CLAUDE_CODE="${HYBRID_INSTALL_CLAUDE_CODE:-}"
+HYBRID_CLAUDE_CONFIG_MODE="${HYBRID_CLAUDE_CONFIG_MODE:-}"
+HYBRID_RUNTIME_SELECTION_EXPLICIT="${HYBRID_RUNTIME_SELECTION_EXPLICIT:-0}"
 BCN_PLUGIN_SOURCE="${BCN_PLUGIN_SOURCE:-source}"
 BCN_PLUGIN_VERSION="${BCN_PLUGIN_VERSION:-latest}"
 HYBRID_DEFAULT_PROFILE_DIR="scripts/4bots_merchant_operations_profile"
@@ -420,6 +424,9 @@ show_help() {
     echo "  --profile-dir DIR            Bot persona source dir for bots, hybrid, bcs_frontend, or bcsfuse; requires DIR/bots.json"
     echo "  --exclusive-profile-dir SOURCE Exclude one OpenClaw profile source; only valid for hybrid with --claude-profile-dir"
     echo "  --claude-profile-dir DIR     Optional Claude Code profile source dir for hybrid; requires --exclusive-profile-dir"
+    echo "                                  Hybrid env controls: HYBRID_USE_CLAUDE_CODE=yes|no,"
+    echo "                                  HYBRID_INSTALL_CLAUDE_CODE=yes|no,"
+    echo "                                  HYBRID_CLAUDE_CONFIG_MODE=env-local|user"
     echo "  --bcs-auto-onboard            Legacy compatibility flag; use bcs_bots for BCS + bots"
     echo "  --no-bcs-auto-onboard         Legacy compatibility flag; use bcs for BCS-only"
     echo "  --with-bcs-coverage           Build instrumented bcs (target/cov-e2e) for e2e line coverage"
@@ -450,6 +457,7 @@ show_help() {
     echo "  $0 start bots --profile-dir scripts/8bots_micro_merchant_profile"
     echo "  $0 start bcs_frontend --profile-dir scripts/4bots_merchant_operations_profile"
     echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid"
+    echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile"
     echo "  SINGLEBOX_MODEL_CONFIG_MODE=home SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1 $0 start hybrid --profile-dir scripts/4bots_merchant_operations_profile --exclusive-profile-dir platform-data --claude-profile-dir scripts/4bots_merchant_operations_profile_for_claude"
     echo "  $0 restart bcs_bots            Restart BCS + 5 local bot gateways"
     echo "  $0 clean bcs                   Clean only local BCS runtime data"
@@ -466,12 +474,59 @@ validate_hybrid_profile_options() {
         log_error "--exclusive-profile-dir and --claude-profile-dir must be provided together"
         return 1
     fi
+    if { [ -n "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] || [ -n "${CLAUDE_PROFILE_DIR:-}" ]; } && \
+       [ -z "${BOTS_PROFILE_DIR:-}" ]; then
+        log_error "hybrid custom Claude mode requires --profile-dir, --exclusive-profile-dir, and --claude-profile-dir together"
+        return 1
+    fi
     if [ -n "${CLAUDE_PROFILE_DIR:-}" ]; then
         if [ "$#" -ne 1 ] || { [ "$1" != hybrid ] && [ "$1" != merchant_hybrid ]; }; then
             log_error "--claude-profile-dir and --exclusive-profile-dir only support hybrid"
             return 1
         fi
     fi
+}
+
+hybrid_confirm_choice() {
+    local configured_value="$1"
+    local prompt="$2"
+    local answer=""
+
+    case "$configured_value" in
+        1|true|TRUE|yes|YES|y|Y)
+            return 0
+            ;;
+        0|false|FALSE|no|NO|n|N)
+            return 1
+            ;;
+        '')
+            ;;
+        *)
+            log_error "Invalid yes/no value: ${configured_value}"
+            return 2
+            ;;
+    esac
+
+    if [ -t 0 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf '%s [y/N]: ' "$prompt" >&2
+        read -r answer </dev/tty || return 2
+        case "$answer" in
+            Y|y|YES|Yes|yes)
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    fi
+
+    log_error "Interactive confirmation required: ${prompt}"
+    return 2
+}
+
+hybrid_enable_default_claude_profile() {
+    BOTS_EXCLUDED_PROFILE_SOURCE="${MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE}"
+    CLAUDE_PROFILE_DIR="${MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR}"
 }
 
 apply_hybrid_profile_defaults() {
@@ -490,20 +545,122 @@ apply_hybrid_profile_defaults() {
     fi
 
     case "$1" in
-        hybrid)
-            local claude_profile_enabled=false
-            BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${HYBRID_DEFAULT_PROFILE_DIR}}"
-            [ -n "${CLAUDE_PROFILE_DIR:-}" ] && claude_profile_enabled=true
-            log_info "hybrid profile configuration resolved claude_profile_enabled=${claude_profile_enabled}"
-            ;;
-        merchant_hybrid)
-            # Deprecated compatibility mode keeps the original mixed-profile defaults.
-            BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-${HYBRID_DEFAULT_PROFILE_DIR}}"
-            BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-${MERCHANT_HYBRID_DEFAULT_EXCLUDED_PROFILE_SOURCE}}"
-            CLAUDE_PROFILE_DIR="${CLAUDE_PROFILE_DIR:-${MERCHANT_HYBRID_DEFAULT_CLAUDE_PROFILE_DIR}}"
-            log_info "merchant_hybrid profile configuration resolved excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE} claude_profile_enabled=true"
+        hybrid|merchant_hybrid)
+            if [ -z "${BOTS_PROFILE_DIR:-}" ] && \
+               [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] && \
+               [ -z "${CLAUDE_PROFILE_DIR:-}" ]; then
+                BOTS_PROFILE_DIR="${HYBRID_DEFAULT_PROFILE_DIR}"
+                local choice_rc=0
+                hybrid_confirm_choice "${HYBRID_USE_CLAUDE_CODE:-}" "Use Claude Code for the platform-data bot?" || choice_rc=$?
+                case "$choice_rc" in
+                    0)
+                        HYBRID_USE_CLAUDE_CODE=1
+                        hybrid_enable_default_claude_profile
+                        log_info "hybrid profile configuration resolved mode=default-mixed excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE}"
+                        ;;
+                    1)
+                        HYBRID_USE_CLAUDE_CODE=0
+                        log_info "hybrid profile configuration resolved mode=default-openclaw-only"
+                        ;;
+                    *)
+                        log_error "Set HYBRID_USE_CLAUDE_CODE=yes or no for non-interactive startup."
+                        return 1
+                        ;;
+                esac
+                HYBRID_RUNTIME_SELECTION_EXPLICIT=1
+                export HYBRID_USE_CLAUDE_CODE HYBRID_RUNTIME_SELECTION_EXPLICIT
+            elif [ -n "${BOTS_PROFILE_DIR:-}" ] && \
+                 [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] && \
+                 [ -z "${CLAUDE_PROFILE_DIR:-}" ]; then
+                HYBRID_RUNTIME_SELECTION_EXPLICIT=1
+                export HYBRID_RUNTIME_SELECTION_EXPLICIT
+                log_info "hybrid profile configuration resolved mode=openclaw-only"
+            elif [ -n "${BOTS_PROFILE_DIR:-}" ] && \
+                 [ -n "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] && \
+                 [ -n "${CLAUDE_PROFILE_DIR:-}" ]; then
+                HYBRID_RUNTIME_SELECTION_EXPLICIT=1
+                export HYBRID_RUNTIME_SELECTION_EXPLICIT
+                log_info "hybrid profile configuration resolved mode=custom-mixed excluded_source=${BOTS_EXCLUDED_PROFILE_SOURCE}"
+            fi
             ;;
     esac
+}
+
+prepare_hybrid_claude_runtime_choice() {
+    local target_command="$1"
+    shift
+
+    case "$target_command" in
+        setup|start|restart)
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+    if [ "$#" -ne 1 ] || { [ "$1" != hybrid ] && [ "$1" != merchant_hybrid ]; }; then
+        return 0
+    fi
+    [ -n "${CLAUDE_PROFILE_DIR:-}" ] || return 0
+
+    local claude_cli=""
+    claude_cli="$(claude_relay_find_cli 2>/dev/null || true)"
+    if [ -z "$claude_cli" ]; then
+        local install_rc=0
+        hybrid_confirm_choice "${HYBRID_INSTALL_CLAUDE_CODE:-}" "Claude Code was not found. Install it now?" || install_rc=$?
+        case "$install_rc" in
+            0)
+                claude_relay_install_cli || return 1
+                claude_cli="$(claude_relay_find_cli 2>/dev/null || true)"
+                ;;
+            1)
+                log_error "Claude Code is required for this hybrid configuration; startup cancelled."
+                return 1
+                ;;
+            *)
+                log_error "Set HYBRID_INSTALL_CLAUDE_CODE=yes or no for non-interactive startup."
+                return 1
+                ;;
+        esac
+    fi
+    [ -n "$claude_cli" ] || {
+        log_error "Claude Code installation completed but the claude executable is still unavailable."
+        return 1
+    }
+    log_info "Claude Code found: ${claude_cli}"
+
+    case "${HYBRID_CLAUDE_CONFIG_MODE:-}" in
+        env|env-local|manual)
+            HYBRID_CLAUDE_CONFIG_MODE="env-local"
+            ;;
+        user)
+            ;;
+        '')
+            local replace_rc=0
+            hybrid_confirm_choice "" "Replace Claude Code model configuration with values from .env.local?" || replace_rc=$?
+            case "$replace_rc" in
+                0) HYBRID_CLAUDE_CONFIG_MODE="env-local" ;;
+                1) HYBRID_CLAUDE_CONFIG_MODE="user" ;;
+                *)
+                    log_error "Set HYBRID_CLAUDE_CONFIG_MODE=env-local or user for non-interactive startup."
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            log_error "Invalid HYBRID_CLAUDE_CONFIG_MODE: ${HYBRID_CLAUDE_CONFIG_MODE}"
+            log_error "Valid values: env-local, user"
+            return 1
+            ;;
+    esac
+
+    if [ "$HYBRID_CLAUDE_CONFIG_MODE" = "env-local" ]; then
+        SINGLEBOX_MODEL_CONFIG_MODE="manual"
+        export SINGLEBOX_MODEL_CONFIG_MODE
+        log_info "Claude Code model configuration will use .env.local."
+    else
+        log_info "Claude Code will keep the user's model configuration."
+    fi
+    export HYBRID_CLAUDE_CONFIG_MODE
 }
 
 # 编译插编 bcs 到 target/cov-e2e/llvm-cov-target/ 并 export BCS_BIN/LLVM_PROFILE_FILE。
@@ -846,7 +1003,7 @@ main() {
     if [ ${#services[@]} -eq 0 ]; then
         services=(all)
     fi
-    apply_hybrid_profile_defaults "$command" "${services[@]}"
+    apply_hybrid_profile_defaults "$command" "${services[@]}" || exit 1
     if [ -n "${BOTS_PROFILE_DIR:-}" ]; then
         for svc in "${services[@]}"; do
             # --profile-dir / BOTS_PROFILE_DIR is primarily for the bots target,
@@ -863,6 +1020,7 @@ main() {
         done
     fi
     validate_hybrid_profile_options "${services[@]}" || exit 1
+    prepare_hybrid_claude_runtime_choice "$command" "${services[@]}" || exit 1
     if [ "$STANDALONE_MODE" = true ]; then
         export SINGLEBOX_MODE=standalone
     else

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -144,6 +144,11 @@ mkdir -p "${RUNTIME_DATA_DIR}"
 source "${SCRIPT_DIR}/utils.sh"
 apply_cn_mirror_overrides
 source "${SCRIPT_DIR}/toolchain.sh"
+# rustup updates shell profiles for future terminals, but a prior
+# `singlebox.sh install-tools` process cannot mutate its parent shell. Load the
+# user-local Rust environment for every Singlebox invocation so a subsequent
+# setup/start command can use Cargo immediately.
+load_rust_environment
 source "${SCRIPT_DIR}/modules/model_config.sh"
 
 # Service modules

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -81,6 +81,10 @@ HYBRID_USE_CLAUDE_CODE="${HYBRID_USE_CLAUDE_CODE:-}"
 HYBRID_INSTALL_CLAUDE_CODE="${HYBRID_INSTALL_CLAUDE_CODE:-}"
 HYBRID_CLAUDE_CONFIG_MODE="${HYBRID_CLAUDE_CONFIG_MODE:-}"
 HYBRID_RUNTIME_SELECTION_EXPLICIT="${HYBRID_RUNTIME_SELECTION_EXPLICIT:-0}"
+HYBRID_PROFILE_OPTIONS_EXPLICIT="${HYBRID_PROFILE_OPTIONS_EXPLICIT:-0}"
+if [ -n "${BOTS_PROFILE_DIR:-}" ] || [ -n "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ] || [ -n "${CLAUDE_PROFILE_DIR:-}" ]; then
+    HYBRID_PROFILE_OPTIONS_EXPLICIT=1
+fi
 BCN_PLUGIN_SOURCE="${BCN_PLUGIN_SOURCE:-source}"
 BCN_PLUGIN_VERSION="${BCN_PLUGIN_VERSION:-latest}"
 HYBRID_DEFAULT_PROFILE_DIR="scripts/4bots_merchant_operations_profile"
@@ -544,6 +548,29 @@ apply_hybrid_profile_defaults() {
         return 0
     fi
 
+    if [ "$target_command" = "restart" ] && \
+       { [ "$1" = hybrid ] || [ "$1" = merchant_hybrid ]; } && \
+       [ "${HYBRID_PROFILE_OPTIONS_EXPLICIT:-0}" != "1" ]; then
+        if [ ! -f "$HYBRID_STATE_FILE" ]; then
+            log_error "No active hybrid runtime state to restart. Run start hybrid first."
+            return 1
+        fi
+        HYBRID_RESTART_FROM_STATE=1
+        export HYBRID_RESTART_FROM_STATE
+        hybrid_restore_runtime_state || return 1
+        if [ -z "${SINGLEBOX_MODEL_CONFIG_MODE:-}" ]; then
+            log_error "The previous hybrid runtime does not record its model configuration mode."
+            log_error "Run start hybrid once to create restartable runtime state."
+            return 1
+        fi
+        if [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "home" ]; then
+            SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED=1
+            export SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED
+        fi
+        log_info "hybrid restart restored the previous runtime selection without prompting"
+        return 0
+    fi
+
     case "$1" in
         hybrid|merchant_hybrid)
             if [ -z "${BOTS_PROFILE_DIR:-}" ] && \
@@ -605,6 +632,11 @@ prepare_hybrid_claude_runtime_choice() {
     local claude_cli=""
     claude_cli="$(claude_relay_find_cli 2>/dev/null || true)"
     if [ -z "$claude_cli" ]; then
+        if [ "${HYBRID_RESTART_FROM_STATE:-0}" = "1" ]; then
+            log_error "Claude Code from the previous hybrid runtime is no longer available; restart will not install it interactively."
+            log_error "Run start hybrid to repair or change the runtime selection."
+            return 1
+        fi
         local install_rc=0
         hybrid_confirm_choice "${HYBRID_INSTALL_CLAUDE_CODE:-}" "Claude Code was not found. Install it now?" || install_rc=$?
         case "$install_rc" in
@@ -635,16 +667,7 @@ prepare_hybrid_claude_runtime_choice() {
         user)
             ;;
         '')
-            local replace_rc=0
-            hybrid_confirm_choice "" "Replace Claude Code model configuration with values from .env.local?" || replace_rc=$?
-            case "$replace_rc" in
-                0) HYBRID_CLAUDE_CONFIG_MODE="env-local" ;;
-                1) HYBRID_CLAUDE_CONFIG_MODE="user" ;;
-                *)
-                    log_error "Set HYBRID_CLAUDE_CONFIG_MODE=env-local or user for non-interactive startup."
-                    return 1
-                    ;;
-            esac
+            HYBRID_CLAUDE_CONFIG_MODE="env-local"
             ;;
         *)
             log_error "Invalid HYBRID_CLAUDE_CONFIG_MODE: ${HYBRID_CLAUDE_CONFIG_MODE}"
@@ -656,7 +679,8 @@ prepare_hybrid_claude_runtime_choice() {
     if [ "$HYBRID_CLAUDE_CONFIG_MODE" = "env-local" ]; then
         SINGLEBOX_MODEL_CONFIG_MODE="manual"
         export SINGLEBOX_MODEL_CONFIG_MODE
-        log_info "Claude Code model configuration will use .env.local."
+        claude_relay_prepare_env_local_model || return 1
+        log_info "Claude Code model configuration uses .env.local by default."
     else
         log_info "Claude Code will keep the user's model configuration."
     fi
@@ -893,6 +917,7 @@ main() {
                     exit 1
                 fi
                 BOTS_PROFILE_DIR="$2"
+                HYBRID_PROFILE_OPTIONS_EXPLICIT=1
                 shift 2
                 ;;
             --exclusive-profile-dir)
@@ -902,6 +927,7 @@ main() {
                     exit 1
                 fi
                 BOTS_EXCLUDED_PROFILE_SOURCE="$2"
+                HYBRID_PROFILE_OPTIONS_EXPLICIT=1
                 shift 2
                 ;;
             --claude-profile-dir)
@@ -911,6 +937,7 @@ main() {
                     exit 1
                 fi
                 CLAUDE_PROFILE_DIR="$2"
+                HYBRID_PROFILE_OPTIONS_EXPLICIT=1
                 shift 2
                 ;;
             --bcs-auto-onboard)

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -100,6 +100,27 @@ export SINGLEBOX_MODEL_CONFIG_MODE="home"
 claude_relays_manual_model_env "$model"
 [[ "${#CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" == "0" ]]
 
+test_claude_relay_build_uses_configured_registry() (
+    local gateway="$TMP/claude-relay-gateway"
+    local npm_calls="$TMP/claude-relay-npm-calls"
+    mkdir -p "$gateway/src"
+    printf '%s\n' '{}' > "$gateway/package.json"
+    printf '%s\n' 'source' > "$gateway/src/server.ts"
+
+    CLAUDE_RELAY_GATEWAY_DIR="$gateway"
+    CLAUDE_RELAY_LOG="$TMP/claude-relay.log"
+    NPM_REGISTRY_URL="https://registry.example.test"
+    claude_relays_enabled() { return 0; }
+    claude_profile_validate_config() { return 0; }
+    npm() { printf '%s\n' "$*" >> "$npm_calls"; }
+
+    claude_relays_setup
+    grep -Fxq 'install --include=dev --ignore-scripts --no-audit --no-fund --registry=https://registry.example.test' "$npm_calls"
+    grep -Fxq 'run prepublishOnly' "$npm_calls"
+)
+
+test_claude_relay_build_uses_configured_registry
+
 export BCSFUSE_RUNTIME_DIR="$TMP/bcsfuse-runtime"
 mkdir -p "$BCSFUSE_RUNTIME_DIR/env"
 cat > "$BCSFUSE_RUNTIME_DIR/env/.env.local" <<'ENV'
@@ -243,6 +264,152 @@ test_provider_bot_registration_keeps_profile_display_name() (
 )
 
 test_provider_bot_registration_keeps_profile_display_name
+
+test_provider_registration_is_reused_across_restarts() (
+    export CLAUDE_BOTS_STATE_FILE="$TMP/reuse-claude-bots-state.json"
+    export BCS_BAAS_PROVIDER_STATE_FILE="$TMP/reuse-provider-state.json"
+    export BCS_BAAS_PROVIDER_TOKEN_FILE="$TMP/reuse-provider-tokens.json"
+    export BCS_PORT=21000
+    local calls="$TMP/reuse-provider-calls"
+
+    printf '%s\n' '{"entity_id":"mock-user","bots":[{"role":"platform-data","bot_id":"bot-data","name":"平台数据分析"}]}' \
+        > "$CLAUDE_BOTS_STATE_FILE"
+    printf '%s\n' '{"baas_token":"baas","provider_id":"provider-existing","provider_admin_token":"provider-admin","bcs_to_provider_token":"bcs-token","provider_bots":{}}' \
+        > "$BCS_BAAS_PROVIDER_TOKEN_FILE"
+
+    bcs_baas_provider_bcs_owner_id() { printf '%s\n' '001'; }
+    bcs_baas_provider_add_bot_token() { :; }
+    log_info() { :; }
+    curl() {
+        local method=GET url=''
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                -X)
+                    method="$2"
+                    shift 2
+                    ;;
+                -d)
+                    shift 2
+                    ;;
+                http://*|https://*)
+                    url="$1"
+                    shift
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        printf '%s %s\n' "$method" "$url" >> "$calls"
+        case "$method $url" in
+            "GET http://127.0.0.1:21000/providers/provider-existing")
+                printf '%s\n' '{"provider_id":"provider-existing"}'
+                ;;
+            "POST http://127.0.0.1:21000/providers/provider-existing/bots")
+                printf '%s\n' '{"bot_runtime_token":"bot-runtime","bot_uuid":"bot-provider"}'
+                ;;
+            "PUT http://127.0.0.1:21000/bots/bot-provider/visibility")
+                printf '%s\n' '{"success":true,"data":{"visibility":"public"}}'
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+
+    bcs_baas_provider_register
+    grep -Fxq 'GET http://127.0.0.1:21000/providers/provider-existing' "$calls"
+    grep -Fxq 'POST http://127.0.0.1:21000/providers/provider-existing/bots' "$calls"
+    ! grep -Fxq 'POST http://127.0.0.1:21000/providers' "$calls"
+    [ "$(jq -r '.provider_id' "$BCS_BAAS_PROVIDER_STATE_FILE")" = provider-existing ]
+)
+
+test_provider_registration_is_reused_across_restarts
+
+test_provider_bot_cleanup_preserves_provider_credentials() (
+    export BCS_BAAS_PROVIDER_STATE_FILE="$TMP/cleanup-provider-state.json"
+    export BCS_BAAS_PROVIDER_TOKEN_FILE="$TMP/cleanup-provider-tokens.json"
+    export BCS_PORT=21000
+    local calls="$TMP/cleanup-provider-calls"
+
+    printf '%s\n' '{"provider_id":"provider-existing","bots":[{"provider_bot_ref":"bot-data:mock-user"}]}' \
+        > "$BCS_BAAS_PROVIDER_STATE_FILE"
+    printf '%s\n' '{"baas_token":"baas","provider_id":"provider-existing","provider_admin_token":"provider-admin","bcs_to_provider_token":"bcs-token","provider_bots":{"platform-data":{"provider_bot_ref":"bot-data:mock-user","bot_runtime_token":"runtime"}}}' \
+        > "$BCS_BAAS_PROVIDER_TOKEN_FILE"
+
+    log_info() { :; }
+    curl() {
+        printf '%s\n' "$*" >> "$calls"
+        printf '%s\n' '{}'
+    }
+
+    bcs_baas_provider_cleanup_registration
+    [ ! -f "$BCS_BAAS_PROVIDER_STATE_FILE" ]
+    jq -e '
+      .provider_id == "provider-existing"
+      and .provider_admin_token == "provider-admin"
+      and .bcs_to_provider_token == "bcs-token"
+      and (.provider_bots | length) == 0
+    ' "$BCS_BAAS_PROVIDER_TOKEN_FILE" >/dev/null
+    grep -Fq '/providers/provider-existing/bots/bot-data%3Amock-user' "$calls"
+)
+
+test_provider_bot_cleanup_preserves_provider_credentials
+
+test_clean_bots_removes_attached_claude_runtime() (
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    export CLAUDE_BOTS_STATE_FILE="$TMP/clean-claude-bots-state.json"
+    export HYBRID_STATE_FILE="$TMP/clean-hybrid-state.json"
+    local config_dir="$TMP/clean-claude-config"
+    local workspace="$TMP/clean-claude-workspace"
+    local events="$TMP/clean-claude-events"
+    mkdir -p "$config_dir" "$workspace"
+    printf '%s\n' '{"setting":true}' > "$config_dir/settings.json"
+    printf '%s\n' 'work' > "$workspace/work.txt"
+    jq -n \
+        --arg profile "$BOTS_PROFILE_DIR" \
+        --arg claude_profile "$CLAUDE_PROFILE" \
+        --arg config "$config_dir" \
+        --arg workspace "$workspace" \
+        '{bots_profile_dir: $profile, claude_profile_dir: $claude_profile,
+          claude_config_dir: $config, workspace: $workspace, bots: []}' \
+        > "$CLAUDE_BOTS_STATE_FILE"
+    jq -n \
+        --arg profile "$BOTS_PROFILE_DIR" \
+        --arg claude_profile "$CLAUDE_PROFILE" \
+        '{mode: "claude", bots_profile_dir: $profile, excluded_profile_source: "platform-data",
+          claude_profile_dir: $claude_profile}' \
+        > "$HYBRID_STATE_FILE"
+
+    bcs_baas_provider_clean() { printf '%s\n' provider >> "$events"; }
+    claude_relays_clean() { printf '%s\n' relay >> "$events"; }
+    log_info() { :; }
+
+    hybrid_clean_attached_claude_runtime
+    [ "$(cat "$events")" = $'provider\nrelay' ]
+    [ ! -e "$config_dir" ]
+    [ ! -e "$workspace" ]
+    [ ! -f "$CLAUDE_BOTS_STATE_FILE" ]
+    [ ! -f "$HYBRID_STATE_FILE" ]
+)
+
+test_clean_bots_removes_attached_claude_runtime
+
+test_claude_clean_rejects_broad_paths() (
+    export CLAUDE_BOTS_STATE_FILE="$TMP/unsafe-clean-claude-bots-state.json"
+    jq -n --arg home "$HOME" \
+        '{claude_config_dir: $home, workspace: "/", bots: []}' \
+        > "$CLAUDE_BOTS_STATE_FILE"
+    log_error() { :; }
+
+    if claude_bots_clean; then
+        echo 'Claude cleanup unexpectedly accepted a broad runtime path' >&2
+        exit 1
+    fi
+    [ -f "$CLAUDE_BOTS_STATE_FILE" ]
+)
+
+test_claude_clean_rejects_broad_paths
 
 test_hybrid_profile_defaults() (
     log_info() { :; }

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -62,6 +62,9 @@ export OPENCLAW_OPENAI_BASE_URL="https://model.example.test/v1"
 export OPENCLAW_OPENAI_API_KEY="test-token"
 export OPENCLAW_OPENAI_MODEL_ID="glm-local"
 export OPENCLAW_OPENAI_MODEL_NAME="GLM Local"
+export ANTHROPIC_BASE_URL="https://anthropic-gateway.example.test"
+export ANTHROPIC_AUTH_TOKEN="anthropic-test-token"
+export ANTHROPIC_MODEL="glm-claude"
 singlebox_model_config_write_manual "$MODEL_CONFIG"
 export SINGLEBOX_MODEL_CONFIG_FILE="$MODEL_CONFIG"
 model_config_before="$(shasum -a 256 "$MODEL_CONFIG" | awk '{print $1}')"
@@ -92,7 +95,7 @@ hybrid_apply_model_policy
 IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission < <(claude_profile_entries)
 [[ "$role" == "platform-data" ]]
 [[ "$port" == "18900" ]]
-[[ "$model" == "glm-local" ]]
+[[ "$model" == "glm-claude" ]]
 [[ "$permission" == "bypassPermissions" ]]
 [[ "$config_dir" == "$TMP/claude-config" ]]
 [[ "$workspace" == "$TMP/claude-workspace" ]]
@@ -101,10 +104,10 @@ IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission <
 export SINGLEBOX_MODEL_CONFIG_MODE="manual"
 unset HYBRID_CLAUDE_CONFIG_MODE
 claude_relays_manual_model_env "$model"
-[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_BASE_URL=https://model.example.test/v1"* ]]
-[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_AUTH_TOKEN=test-token"* ]]
-[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_MODEL=glm-local"* ]]
-[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_SMALL_FAST_MODEL=glm-local"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_BASE_URL=https://anthropic-gateway.example.test"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_AUTH_TOKEN=anthropic-test-token"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_MODEL=glm-claude"* ]]
+[[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_SMALL_FAST_MODEL=glm-claude"* ]]
 export HYBRID_CLAUDE_CONFIG_MODE="user"
 claude_relays_manual_model_env "$model"
 [[ "${#CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" == "0" ]]
@@ -499,12 +502,108 @@ test_hybrid_profile_defaults() (
 
 test_hybrid_profile_defaults
 
+test_hybrid_restart_restores_previous_selection_without_prompts() (
+    log_info() { :; }
+    local restart_state="$TMP/hybrid-restart-state.json"
+    HYBRID_STATE_FILE="$restart_state"
+    jq -n \
+        --arg bots_profile "$ROOT/scripts/4bots_merchant_operations_profile" \
+        --arg claude_profile "$CLAUDE_PROFILE" \
+        '{
+          mode: "claude",
+          bots_profile_dir: $bots_profile,
+          excluded_profile_source: "platform-data",
+          claude_profile_dir: $claude_profile,
+          claude_config_mode: "env-local",
+          anthropic_base_url: "https://saved-anthropic-gateway.example.test",
+          singlebox_model_config_mode: "manual"
+        }' > "$restart_state"
+    HYBRID_PROFILE_OPTIONS_EXPLICIT=0
+    HYBRID_RUNTIME_SELECTION_EXPLICIT=0
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    unset HYBRID_CLAUDE_CONFIG_MODE HYBRID_RESTART_FROM_STATE SINGLEBOX_MODEL_CONFIG_MODE
+    unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_MODEL
+    hybrid_confirm_choice() {
+        echo 'unexpected restart confirmation prompt' >&2
+        return 2
+    }
+    claude_relay_prompt_anthropic_base_url() {
+        echo 'unexpected restart base URL prompt' >&2
+        return 2
+    }
+    claude_relay_find_cli() { printf '%s\n' "$TMP/fake-claude"; }
+
+    apply_hybrid_profile_defaults restart hybrid
+    [ "$HYBRID_RESTART_FROM_STATE" = "1" ]
+    [ "$BOTS_PROFILE_DIR" = "$ROOT/scripts/4bots_merchant_operations_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "$CLAUDE_PROFILE" ]
+    [ "$HYBRID_CLAUDE_CONFIG_MODE" = "env-local" ]
+    [ "$ANTHROPIC_BASE_URL" = "https://saved-anthropic-gateway.example.test" ]
+    [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "manual" ]
+
+    prepare_hybrid_claude_runtime_choice restart hybrid
+    [ "$ANTHROPIC_AUTH_TOKEN" = "$OPENCLAW_OPENAI_API_KEY" ]
+    [ "$ANTHROPIC_MODEL" = "$OPENCLAW_OPENAI_MODEL_ID" ]
+)
+
+test_hybrid_restart_restores_previous_selection_without_prompts
+
+test_hybrid_restart_restores_home_model_confirmation() (
+    log_info() { :; }
+    HYBRID_STATE_FILE="$TMP/hybrid-restart-home-state.json"
+    jq -n \
+        --arg bots_profile "$ROOT/scripts/4bots_merchant_operations_profile" \
+        '{
+          mode: "openclaw",
+          bots_profile_dir: $bots_profile,
+          excluded_profile_source: "",
+          claude_profile_dir: "",
+          claude_config_mode: "",
+          anthropic_base_url: "",
+          singlebox_model_config_mode: "home"
+        }' > "$HYBRID_STATE_FILE"
+    HYBRID_PROFILE_OPTIONS_EXPLICIT=0
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    unset HYBRID_RESTART_FROM_STATE SINGLEBOX_MODEL_CONFIG_MODE SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED
+
+    apply_hybrid_profile_defaults restart hybrid
+    [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "home" ]
+    [ "$SINGLEBOX_MODEL_CONFIG_HOME_CONFIRMED" = "1" ]
+)
+
+test_hybrid_restart_restores_home_model_confirmation
+
+test_hybrid_restart_without_state_is_rejected() (
+    log_error() { :; }
+    HYBRID_STATE_FILE="$TMP/missing-hybrid-restart-state.json"
+    HYBRID_PROFILE_OPTIONS_EXPLICIT=0
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    if apply_hybrid_profile_defaults restart hybrid; then
+        echo 'hybrid restart without previous state unexpectedly accepted' >&2
+        exit 1
+    fi
+)
+
+test_hybrid_restart_without_state_is_rejected
+
 test_hybrid_claude_runtime_choice() (
     log_info() { :; }
     export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
     export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
     export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
     claude_relay_find_cli() { printf '%s\n' "$TMP/fake-claude"; }
+
+    hybrid_confirm_choice() {
+        echo 'unexpected model configuration prompt' >&2
+        return 2
+    }
+
+    export SINGLEBOX_MODEL_CONFIG_MODE="home"
+    unset HYBRID_CLAUDE_CONFIG_MODE
+    prepare_hybrid_claude_runtime_choice start hybrid
+    [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "manual" ]
+    [ "$HYBRID_CLAUDE_CONFIG_MODE" = "env-local" ]
 
     export SINGLEBOX_MODEL_CONFIG_MODE="home"
     export HYBRID_CLAUDE_CONFIG_MODE="user"
@@ -520,6 +619,45 @@ test_hybrid_claude_runtime_choice() (
 )
 
 test_hybrid_claude_runtime_choice
+
+test_hybrid_anthropic_defaults_and_base_url_edit() (
+    log_warn() { :; }
+    export OPENCLAW_OPENAI_BASE_URL="https://openai-upstream.example.test/v1"
+    export OPENCLAW_OPENAI_API_KEY="openai-fallback-token"
+    export OPENCLAW_OPENAI_MODEL_ID="openai-fallback-model"
+    unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_MODEL
+    local prompt_count=0
+    claude_relay_prompt_anthropic_base_url() {
+        prompt_count=$((prompt_count + 1))
+        ANTHROPIC_BASE_URL="https://edited-anthropic-gateway.example.test"
+        export ANTHROPIC_BASE_URL
+    }
+
+    claude_relay_prepare_env_local_model
+    [ "$prompt_count" = "1" ]
+    [ "$ANTHROPIC_BASE_URL" = "https://edited-anthropic-gateway.example.test" ]
+    [ "$ANTHROPIC_AUTH_TOKEN" = "openai-fallback-token" ]
+    [ "$ANTHROPIC_MODEL" = "openai-fallback-model" ]
+)
+
+test_hybrid_anthropic_defaults_and_base_url_edit
+
+test_hybrid_missing_anthropic_env_is_rejected() (
+    log_info() { :; }
+    log_error() { :; }
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
+    export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
+    unset HYBRID_CLAUDE_CONFIG_MODE ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_MODEL OPENCLAW_OPENAI_BASE_URL
+    claude_relay_find_cli() { printf '%s\n' "$TMP/fake-claude"; }
+
+    if prepare_hybrid_claude_runtime_choice start hybrid; then
+        echo 'incomplete Anthropic configuration unexpectedly accepted' >&2
+        exit 1
+    fi
+)
+
+test_hybrid_missing_anthropic_env_is_rejected
 
 test_hybrid_missing_claude_cancels_when_install_declined() (
     log_info() { :; }
@@ -575,6 +713,33 @@ for service in claude_relays baas backend bcs bcsfuse bots claude_bots bcs_baas_
     eval "${service}_status() { printf '%s\\n' 'status:${service}' >> \"\$events\"; }"
 done
 
+test_hybrid_explicit_selection_switches_active_runtime() (
+    HYBRID_STATE_FILE="$TMP/hybrid-transition-state.json"
+    HYBRID_RUNTIME_SELECTION_EXPLICIT=0
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR HYBRID_CLAUDE_ACTIVE MERCHANT_HYBRID_ACTIVE
+    : > "$events"
+    hybrid_start
+    [[ "$(jq -r '.mode' "$HYBRID_STATE_FILE")" == "openclaw" ]]
+
+    : > "$events"
+    HYBRID_RUNTIME_SELECTION_EXPLICIT=1
+    export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
+    export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
+    export HYBRID_CLAUDE_CONFIG_MODE="env-local"
+    hybrid_prereqs
+    expected_transition_stop=$'stop:frontend\nstop:bots\nstop:bcsfuse\nstop:bcs'
+    [[ "$(cat "$events")" == "$expected_transition_stop" ]]
+    [[ ! -f "$HYBRID_STATE_FILE" ]]
+    [[ "$BOTS_EXCLUDED_PROFILE_SOURCE" == "platform-data" ]]
+    [[ "$CLAUDE_PROFILE_DIR" == "$CLAUDE_PROFILE" ]]
+    [[ "$HYBRID_CLAUDE_CONFIG_MODE" == "env-local" ]]
+    [[ "${HYBRID_START_ORDER[*]}" == "${HYBRID_CLAUDE_START_ORDER[*]}" ]]
+)
+
+test_hybrid_explicit_selection_switches_active_runtime
+: > "$events"
+
 unset BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR HYBRID_CLAUDE_ACTIVE MERCHANT_HYBRID_ACTIVE
 hybrid_start
 expected_openclaw_start=$'setup:bcs\nsetup:bcsfuse\nsetup:bots\nsetup:frontend\nstart:bcs\nstart:bcsfuse\nstart:bots\nstart:frontend\nready'
@@ -594,6 +759,9 @@ hybrid_start
 expected_start=$'setup:claude_relays\nsetup:baas\nsetup:backend\nsetup:bcs\nsetup:bcsfuse\nsetup:bots\nsetup:claude_bots\nsetup:bcs_baas_provider\nsetup:frontend\nstart:claude_relays\nstart:baas\nstart:backend\nstart:bcs\nstart:bcsfuse\nstart:bots\nstart:claude_bots\nstart:bcs_baas_provider\nstart:frontend\nready'
 [[ "$(cat "$events")" == "$expected_start" ]]
 [[ "$(jq -r '.mode' "$HYBRID_STATE_FILE")" == "claude" ]]
+[[ "$(jq -r '.claude_config_mode' "$HYBRID_STATE_FILE")" == "env-local" ]]
+[[ "$(jq -r '.anthropic_base_url' "$HYBRID_STATE_FILE")" == "$ANTHROPIC_BASE_URL" ]]
+[[ "$(jq -r '.singlebox_model_config_mode' "$HYBRID_STATE_FILE")" == "$SINGLEBOX_MODEL_CONFIG_MODE" ]]
 expected_stop=$'stop:frontend\nstop:bcs_baas_provider\nstop:claude_bots\nstop:bots\nstop:bcsfuse\nstop:bcs\nstop:backend\nstop:baas\nstop:claude_relays'
 
 : > "$events"

--- a/scripts/test_hybrid.sh
+++ b/scripts/test_hybrid.sh
@@ -81,6 +81,14 @@ jq -e '
 [[ "$LLM_LONG_CONTEXT_MODEL" == "glm-local" ]]
 [[ "$LLM_EXTRACTION_MODEL" == "glm-local" ]]
 
+export HYBRID_CLAUDE_CONFIG_MODE="user"
+hybrid_apply_model_policy
+[[ -z "${HYBRID_MODEL_ID:-}" ]]
+[[ "$SINGLEBOX_REQUIRED_OPENCLAW_MODEL" == "openai-compatible/glm-local" ]]
+[[ "$LLM_FAST_MODEL" == "glm-local" ]]
+unset HYBRID_CLAUDE_CONFIG_MODE
+hybrid_apply_model_policy
+
 IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission < <(claude_profile_entries)
 [[ "$role" == "platform-data" ]]
 [[ "$port" == "18900" ]]
@@ -91,11 +99,18 @@ IFS=$'\x1f' read -r role _ _ port config_dir workspace model prompt permission <
 [[ "$prompt" == "$CLAUDE_PROFILE/platform-data/CLAUDE.md" ]]
 
 export SINGLEBOX_MODEL_CONFIG_MODE="manual"
+unset HYBRID_CLAUDE_CONFIG_MODE
 claude_relays_manual_model_env "$model"
 [[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_BASE_URL=https://model.example.test/v1"* ]]
 [[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_AUTH_TOKEN=test-token"* ]]
 [[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_MODEL=glm-local"* ]]
 [[ "${CLAUDE_RELAY_MANUAL_MODEL_ENV[*]}" == *"ANTHROPIC_SMALL_FAST_MODEL=glm-local"* ]]
+export HYBRID_CLAUDE_CONFIG_MODE="user"
+claude_relays_manual_model_env "$model"
+[[ "${#CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" == "0" ]]
+IFS=$'\x1f' read -r _ _ _ _ _ _ user_model _ _ < <(claude_profile_entries)
+[[ -z "$user_model" ]]
+unset HYBRID_CLAUDE_CONFIG_MODE
 export SINGLEBOX_MODEL_CONFIG_MODE="home"
 claude_relays_manual_model_env "$model"
 [[ "${#CLAUDE_RELAY_MANUAL_MODEL_ENV[@]}" == "0" ]]
@@ -180,6 +195,13 @@ if validate_hybrid_profile_options hybrid; then
 fi
 export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
 validate_hybrid_profile_options hybrid
+
+unset BOTS_PROFILE_DIR
+if validate_hybrid_profile_options hybrid; then
+    echo 'Claude replacement options without an OpenClaw profile unexpectedly accepted' >&2
+    exit 1
+fi
+export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
 
 python3 - "$CLAUDE_PROFILE/bots.json" <<'PY'
 import json
@@ -414,6 +436,14 @@ test_claude_clean_rejects_broad_paths
 test_hybrid_profile_defaults() (
     log_info() { :; }
 
+    export HYBRID_USE_CLAUDE_CODE=yes
+    unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
+    apply_hybrid_profile_defaults start hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
+
+    export HYBRID_USE_CLAUDE_CODE=no
     unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
     apply_hybrid_profile_defaults start hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
@@ -427,6 +457,7 @@ test_hybrid_profile_defaults() (
     [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
     [ -z "${CLAUDE_PROFILE_DIR:-}" ]
 
+    export HYBRID_USE_CLAUDE_CODE=yes
     unset BOTS_PROFILE_DIR BOTS_EXCLUDED_PROFILE_SOURCE CLAUDE_PROFILE_DIR
     apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile" ]
@@ -437,12 +468,18 @@ test_hybrid_profile_defaults() (
     BOTS_PROFILE_DIR="scripts/custom_profile"
     apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
-    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "platform-data" ]
-    [ "$CLAUDE_PROFILE_DIR" = "scripts/4bots_merchant_operations_profile_for_claude" ]
+    [ -z "${BOTS_EXCLUDED_PROFILE_SOURCE:-}" ]
+    [ -z "${CLAUDE_PROFILE_DIR:-}" ]
 
     BOTS_PROFILE_DIR="scripts/custom_profile"
     BOTS_EXCLUDED_PROFILE_SOURCE="custom-platform-data"
     CLAUDE_PROFILE_DIR="scripts/custom_claude_profile"
+    HYBRID_USE_CLAUDE_CODE="invalid-but-unused-for-explicit-claude"
+    apply_hybrid_profile_defaults start hybrid
+    [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
+    [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "custom-platform-data" ]
+    [ "$CLAUDE_PROFILE_DIR" = "scripts/custom_claude_profile" ]
+
     apply_hybrid_profile_defaults start merchant_hybrid
     [ "$BOTS_PROFILE_DIR" = "scripts/custom_profile" ]
     [ "$BOTS_EXCLUDED_PROFILE_SOURCE" = "custom-platform-data" ]
@@ -461,6 +498,68 @@ test_hybrid_profile_defaults() (
 )
 
 test_hybrid_profile_defaults
+
+test_hybrid_claude_runtime_choice() (
+    log_info() { :; }
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
+    export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
+    claude_relay_find_cli() { printf '%s\n' "$TMP/fake-claude"; }
+
+    export SINGLEBOX_MODEL_CONFIG_MODE="home"
+    export HYBRID_CLAUDE_CONFIG_MODE="user"
+    prepare_hybrid_claude_runtime_choice start hybrid
+    [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "home" ]
+    [ "$HYBRID_CLAUDE_CONFIG_MODE" = "user" ]
+
+    export SINGLEBOX_MODEL_CONFIG_MODE="home"
+    export HYBRID_CLAUDE_CONFIG_MODE="env-local"
+    prepare_hybrid_claude_runtime_choice start merchant_hybrid
+    [ "$SINGLEBOX_MODEL_CONFIG_MODE" = "manual" ]
+    [ "$HYBRID_CLAUDE_CONFIG_MODE" = "env-local" ]
+)
+
+test_hybrid_claude_runtime_choice
+
+test_hybrid_missing_claude_cancels_when_install_declined() (
+    log_info() { :; }
+    log_error() { :; }
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
+    export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
+    export HYBRID_INSTALL_CLAUDE_CODE=no
+    export HYBRID_CLAUDE_CONFIG_MODE=user
+    claude_relay_find_cli() { return 1; }
+
+    if prepare_hybrid_claude_runtime_choice start hybrid; then
+        echo 'missing Claude Code unexpectedly allowed after installation was declined' >&2
+        exit 1
+    fi
+)
+
+test_hybrid_missing_claude_cancels_when_install_declined
+
+test_hybrid_missing_claude_installs_when_accepted() (
+    log_info() { :; }
+    export BOTS_PROFILE_DIR="$ROOT/scripts/4bots_merchant_operations_profile"
+    export BOTS_EXCLUDED_PROFILE_SOURCE="platform-data"
+    export CLAUDE_PROFILE_DIR="$CLAUDE_PROFILE"
+    export HYBRID_INSTALL_CLAUDE_CODE=yes
+    export HYBRID_CLAUDE_CONFIG_MODE=user
+    local fake_cli="$TMP/installed-claude"
+    claude_relay_find_cli() {
+        [ -x "$fake_cli" ] && printf '%s\n' "$fake_cli"
+    }
+    claude_relay_install_cli() {
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$fake_cli"
+        chmod +x "$fake_cli"
+    }
+
+    prepare_hybrid_claude_runtime_choice start hybrid
+    [ -x "$fake_cli" ]
+)
+
+test_hybrid_missing_claude_installs_when_accepted
 
 events="$TMP/events"
 hybrid_port_preflight() { return 0; }

--- a/scripts/test_singlebox_bcs_runtime_config.sh
+++ b/scripts/test_singlebox_bcs_runtime_config.sh
@@ -34,6 +34,7 @@ write_local_template() {
 bind = "127.0.0.1"
 port = 21000
 bcs_endpoint = "http://127.0.0.1:21000"
+botchat_url = "http://localhost:8000"
 
 [llm]
 type = "openai_compatible"
@@ -57,7 +58,7 @@ reset_case() {
     write_local_template
     export BCS_CONFIG_DIR="${TEST_ROOT}/${name}"
     export BCS_SERVER_ENV="local"
-    unset BCS_E2E_MOCK_BASE_URL BCS_E2E_JUDGE_API_KEY
+    unset BCS_BOTCHAT_URL BCS_E2E_MOCK_BASE_URL BCS_E2E_JUDGE_API_KEY
     unset OPENCLAW_OPENAI_BASE_URL OPENCLAW_OPENAI_API_KEY OPENCLAW_OPENAI_MODEL_ID
 }
 
@@ -84,6 +85,16 @@ test_local_llm_stays_disabled_without_env_config() {
     assert_contains "${BCS_CONFIG_DIR}/bcs-config-local.toml" 'type = "none"'
     assert_not_contains "${BCS_CONFIG_DIR}/bcs-config.toml" 'legacy-template-secret'
     assert_not_contains "${BCS_CONFIG_DIR}/bcs-config-local.toml" 'legacy-template-secret'
+}
+
+test_botchat_url_can_be_overridden() {
+    reset_case "botchat-url"
+    export BCS_BOTCHAT_URL='https://workbench.example.test'
+
+    prepare_bcs_runtime_config
+
+    assert_contains "${BCS_CONFIG_DIR}/bcs-config.toml" 'botchat_url = "https://workbench.example.test"'
+    assert_contains "${BCS_CONFIG_DIR}/bcs-config-local.toml" 'botchat_url = "https://workbench.example.test"'
 }
 
 test_complete_env_config_enables_local_llm() {
@@ -133,6 +144,7 @@ test_e2e_mock_takes_precedence_over_env_config() {
 }
 
 test_local_llm_stays_disabled_without_env_config
+test_botchat_url_can_be_overridden
 test_complete_env_config_enables_local_llm
 test_partial_env_config_does_not_enable_local_llm
 test_e2e_mock_takes_precedence_over_env_config

--- a/scripts/test_singlebox_toolchain.sh
+++ b/scripts/test_singlebox_toolchain.sh
@@ -64,10 +64,30 @@ test_failed_install_prints_manual_command() {
   esac
 }
 
+test_load_rust_environment() (
+  local temp_cargo_home original_path
+  temp_cargo_home="$(mktemp -d)"
+  original_path="$PATH"
+  mkdir -p "${temp_cargo_home}/bin"
+  printf '%s\n' 'export TEST_RUST_ENV_LOADED=1' > "${temp_cargo_home}/env"
+
+  export CARGO_HOME="$temp_cargo_home"
+  unset TEST_RUST_ENV_LOADED
+  PATH="$original_path"
+  load_rust_environment
+
+  assert_eq "1" "${TEST_RUST_ENV_LOADED:-}" "Rust env file loaded"
+  case ":${PATH}:" in
+    *":${temp_cargo_home}/bin:"*) ;;
+    *) fail "Cargo bin missing from PATH after loading Rust environment" ;;
+  esac
+)
+
 test_command_package_mapping
 test_library_package_mapping
 test_manual_install_hints
 test_basic_build_environment_on_current_host
 test_failed_install_prints_manual_command
+test_load_rust_environment
 
 printf 'PASS: singlebox toolchain tests\n'

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -684,11 +684,27 @@ rustup_target_triple() {
     esac
 }
 
+load_rust_environment() {
+    local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+    local cargo_bin="${cargo_home}/bin"
+
+    if [ -f "${cargo_home}/env" ]; then
+        # shellcheck source=/dev/null
+        . "${cargo_home}/env"
+    fi
+    if [ -d "$cargo_bin" ]; then
+        case ":${PATH}:" in
+            *":${cargo_bin}:"*) ;;
+            *) export PATH="${cargo_bin}:${PATH}" ;;
+        esac
+    fi
+}
+
 load_existing_rust_from_home() {
     local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
     if [ -x "${cargo_home}/bin/cargo" ] && [ -x "${cargo_home}/bin/rustc" ]; then
         log_warn "Rust/Cargo found under ${cargo_home}/bin but not in current PATH."
-        export PATH="${cargo_home}/bin:${PATH}"
+        load_rust_environment
         if check_rust_installed; then
             log_info "Loaded Rust/Cargo from ${cargo_home}/bin for this shell."
             return 0
@@ -745,11 +761,7 @@ install_rust_via_rustup() {
         rm -rf "${work}"
     fi
 
-    if [ -f "${cargo_home}/env" ]; then
-        # shellcheck source=/dev/null
-        . "${cargo_home}/env"
-    fi
-    export PATH="${cargo_home}/bin:${PATH}"
+    load_rust_environment
 
     if check_rust_installed; then
         log_info "Rust/Cargo installed: $(rustc --version 2>&1 | head -1)"
@@ -899,6 +911,9 @@ toolchain_setup() {
     echo ""
 
     log_info "Toolchain setup complete!"
+    if [ -f "${CARGO_HOME:-$HOME/.cargo}/env" ]; then
+        log_info "To use Cargo directly in the invoking shell, run: source \"${CARGO_HOME:-$HOME/.cargo}/env\""
+    fi
     echo ""
 }
 

--- a/spec/pipeline/merchant-hybrid-base-on-dev/001-spec-output.md
+++ b/spec/pipeline/merchant-hybrid-base-on-dev/001-spec-output.md
@@ -45,14 +45,14 @@ session exists is appended to its JSONL leaf and retained in relay history.
 ## Model policy
 
 For this opt-in group, all four Bot defaults and the BCSFuse-backed SOP model
-roles use `Kimi-K2.6`.  The original OpenClaw profile remains unchanged.  At
-runtime, the launcher clones the configured home primary provider's existing
-model metadata into a `Kimi-K2.6` entry when necessary, makes that entry the
-generated OpenClaw default, and refreshes only the three active OpenClaw
-profiles.  The Claude profile explicitly supplies the same relay default.
-BCSFuse receives `Kimi-K2.6` for fast, balanced, reasoning, long-context and
-extraction roles.  Credentials and endpoints remain sourced from the local
-home configuration and are never written to version-controlled profile files.
+roles use the primary model selected by Singlebox. In `manual` mode that model
+comes from the repository-local `.env.local`; in `home` mode it comes from the
+imported OpenClaw configuration. The launcher validates the configured primary
+but does not synthesize another model or rewrite the generated OpenClaw
+default. The Claude relay receives the same model ID at runtime, while the
+reusable Claude role profile remains model-agnostic. Credentials and endpoints
+remain sourced from local runtime configuration and are never written to
+version-controlled profile files.
 
 ## Acceptance
 

--- a/src/frontend/config/config.local.ts
+++ b/src/frontend/config/config.local.ts
@@ -160,6 +160,7 @@ const BCS_TARGET = process.env.BCS_PORT
 const BCSFUSE_TARGET = process.env.BCSFUSE_PORT
   ? `http://127.0.0.1:${process.env.BCSFUSE_PORT}`
   : preset.servers.BCNFUSE || 'http://127.0.0.1:8765';
+const LOCAL_BCN_PORT = presetName === 'local' ? new URL(BCS_TARGET).port : '';
 
 if (process.env.BCS_PORT || process.env.BCSFUSE_PORT) {
   console.log(
@@ -358,8 +359,8 @@ export default defineConfig({
     // 用于 UmdLoader 的副屏 CDN 同源代理：dev 下把 fetch(cdn) 改写到 /__umd_cdn
     // 走 dev server 转发，绕过 CDN 的 CORS 白名单（生产不注入，直连原始 CDN）。
     UMD_CDN_PROXY: true,
-    // 群聊 WS 的 BCS 基址（含 BCS_PORT）。dev 下注入，让 connectionStore 直连
-    // ws://127.0.0.1:<BCS_PORT>/ws，跟随自定义端口；生产不注入，走 getServers().BCN。
-    DEV_BCN_BASE: BCS_TARGET,
+    // local demo 中浏览器用「页面 hostname + BCS 端口」连接群聊 WS。
+    // 只注入端口，避免把 127.0.0.1 带到远程访问者的浏览器。
+    LOCAL_BCN_PORT,
   },
 });

--- a/src/frontend/src/stores/__tests__/connectionStore.test.ts
+++ b/src/frontend/src/stores/__tests__/connectionStore.test.ts
@@ -1,0 +1,50 @@
+jest.mock('@/services/backend-api/BotController', () => ({
+  ENGINE_TYPE: { OPENCLAW: 'openclaw' },
+}));
+jest.mock('@/utils/env', () => ({
+  getProxypassAbsoluteUrl: (path: string) => `https://example.test${path}`,
+  getServers: () => ({ BCN: 'https://bcn.example.test' }),
+}));
+jest.mock('@/utils/platform', () => ({
+  getElectronEnv: () => null,
+  isElectron: () => false,
+}));
+
+import { selectBcnWebsocketUrl } from '../connectionStore';
+
+const setWindowLocation = (protocol: string, hostname: string) => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { protocol, hostname } },
+  });
+};
+
+describe('selectBcnWebsocketUrl', () => {
+  beforeEach(() => {
+    (globalThis as { LOCAL_BCN_PORT?: string }).LOCAL_BCN_PORT = '21000';
+  });
+
+  afterAll(() => {
+    delete (globalThis as { window?: Window }).window;
+    delete (globalThis as { LOCAL_BCN_PORT?: string }).LOCAL_BCN_PORT;
+  });
+
+  it('uses the page hostname and configured BCS port for a local HTTP demo', () => {
+    setWindowLocation('http:', 'demo.example.com');
+
+    expect(selectBcnWebsocketUrl()).toBe('ws://demo.example.com:21000/ws');
+  });
+
+  it('uses secure WebSocket when the local demo page uses HTTPS', () => {
+    setWindowLocation('https:', 'demo.example.com');
+
+    expect(selectBcnWebsocketUrl()).toBe('wss://demo.example.com:21000/ws');
+  });
+
+  it('uses the configured BCN server outside the local preset', () => {
+    delete (globalThis as { LOCAL_BCN_PORT?: string }).LOCAL_BCN_PORT;
+    setWindowLocation('https:', 'demo.example.com');
+
+    expect(selectBcnWebsocketUrl()).toBe('wss://bcn.example.test/ws');
+  });
+});

--- a/src/frontend/src/stores/connectionStore.ts
+++ b/src/frontend/src/stores/connectionStore.ts
@@ -183,36 +183,25 @@ export function selectWebsocketUrl(
   return `ws://localhost:20003${wsPath}`;
 }
 
-/**
- * 群聊 WS 的 BCS 基址（仅 dev 注入，见 config/config.local.ts 的 define）。
- * 值为含 BCS_PORT 的 BCS 地址（如 http://127.0.0.1:31000）。为真时聊天 WS 直连
- * ws://127.0.0.1:<BCS_PORT>/ws，跟随自定义端口，而非 bundle 里的静态 BCN 端口（默认 21000）。
- * 生产构建未注入该常量，typeof 守卫使本段被 tree-shake，走 getServers().BCN。
- */
-declare const DEV_BCN_BASE: string | undefined;
+/** local dev 注入的 BCS 端口；非 local 预设为空。 */
+declare const LOCAL_BCN_PORT: string | undefined;
 
-/**
- * 获取 BCN WebSocket URL（群聊用）
- * 根据 getServers() 配置动态构造 WebSocket 地址
- */
+/** 获取 BCN WebSocket URL（群聊用） */
 export function selectBcnWebsocketUrl(): string {
-  // dev：直连含 BCS_PORT 的本地 BCS（WS 不受 CORS 限制，可跨端口直连）。
-  if (typeof DEV_BCN_BASE !== 'undefined' && DEV_BCN_BASE) {
-    return `${DEV_BCN_BASE.replace(/^http/, 'ws')}/ws`;
+  // 外部用户访问开发机上的 local demo 时，hostname 是开发机，
+  // 而不是访问者电脑的 127.0.0.1。端口仍跟随 BCS_PORT。
+  if (typeof LOCAL_BCN_PORT !== 'undefined' && LOCAL_BCN_PORT) {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${window.location.hostname}:${LOCAL_BCN_PORT}/ws`;
   }
 
-  const servers = getServers();
-  const bcnServer = servers.BCN;
-
+  const bcnServer = getServers().BCN;
   if (!bcnServer) {
-    // 降级：BCN 未配置（真实环境 SERVERS.BCN 恒有值，此分支几乎不触发）
     console.warn('[connectionStore] BCN server not configured, using default');
     return 'ws://localhost:21000/ws';
   }
 
-  // 将 http/https 转换为 ws/wss
-  const wsUrl = bcnServer.replace(/^http/, 'ws');
-  return `${wsUrl}/ws`;
+  return `${bcnServer.replace(/^http/, 'ws')}/ws`;
 }
 
 // ─── 非 React 代码用的便捷方法 ──────────────────────────────


### PR DESCRIPTION
已提交，commit：

`91d1609c8 fix(singlebox): stabilize hybrid runtime configuration`

工作树已清理，尚未 push。

建议 PR 标题：

```text
fix(singlebox): stabilize hybrid startup and remote demo access
```

PR 描述：

```markdown
## Problem

The Singlebox hybrid workflow was fragile across clean installations, restarts, runtime-mode switches, and remote demo environments.

Key issues included:

- `hybrid` startup required unnecessary profile arguments and manual setup steps.
- Claude Code configuration could incorrectly reuse an OpenAI-compatible endpoint that did not support the Anthropic Messages API.
- Restarting hybrid lost the previously selected profiles and model configuration.
- Switching between OpenClaw-only and Claude hybrid modes could leave stale runtime and Provider state.
- Remote browsers attempted to connect to loopback BCS addresses, while generated group chat links still used `localhost`.
- Newly installed Rust tools were not immediately available to subsequent Singlebox commands.

## Solution

- Made `hybrid` the primary entry point with default profiles and optional Claude Code selection, while retaining `merchant_hybrid` as a deprecated-compatible alias.
- Added automatic prerequisite setup and optional Claude Code installation using the configured npm registry.
- Added dedicated `ANTHROPIC_*` configuration for Claude Code, including validation, interactive endpoint selection, and a user-config passthrough mode.
- Persisted hybrid runtime selection, profiles, model mode, and Anthropic endpoint so parameterless restarts can restore the previous configuration without prompting.
- Added safe runtime switching, Claude workspace cleanup, stale-state handling, and reusable BCS Provider registration.
- Updated local frontend WebSocket resolution to use the browser-visible hostname and configured BCS port.
- Added `BCS_BOTCHAT_URL` so remote Singlebox deployments can generate externally reachable group chat links.
- Reloaded the user-local Cargo environment on each Singlebox invocation.
- Updated the hybrid profile documentation and specification.

## Validation

- `LC_ALL=C LANG=C bash scripts/test_hybrid.sh`
- `LC_ALL=C LANG=C bash scripts/test_singlebox_bcs_runtime_config.sh`
- `LC_ALL=C LANG=C bash scripts/test_singlebox_toolchain.sh`
- `cd src/frontend && npm test -- --runInBand src/stores/__tests__/connectionStore.test.ts`
  - 1 suite passed
  - 3 tests passed
- Shell syntax checks for the changed launch scripts
- `git diff --check`

## Compatibility and risk

- `merchant_hybrid` remains available as a deprecated compatibility alias.
- Existing explicit three-profile hybrid startup remains supported.
- OpenClaw-only startup remains available without Claude-specific arguments.
- Existing Claude user configuration can be retained with `HYBRID_CLAUDE_CONFIG_MODE=user`.
- `BCS_BOTCHAT_URL` is optional; when unset, the existing configured `botchat_url` remains unchanged.
- Existing hybrid runtime state is accepted with backward-compatible defaults for newly added fields.

## Spec

Updated `spec/pipeline/merchant-hybrid-base-on-dev/001-spec-output.md` to reflect the runtime model configuration behavior.
```