### PR TITLE
fix(singlebox): make Claude Code installation optional

### DIFF
--- a/scripts/MODULES.md
+++ b/scripts/MODULES.md
@@ -241,7 +241,7 @@ foo_help() {
 1. **模块只 check 不装** — `_setup()` 检查工具是否存在，失败时提示 `$0 install-tools`，不自动安装
 2. **`_prereqs()` 只检不装** — 声明服务外部依赖，按服务粒度执行，不自动安装
 3. **start 是纯启动** — `_start()` 不含隐式 setup/check/依赖安装，依赖由 `start_service()` 自动调用 `_prereqs()` 守护。不要在 `_start()` 中调用 `_setup()` 或 `uv sync`/`cargo build`
-4. **toolchain 负责安装** — `install-tools` 命令安装/升级工具链，幂等；`setup [service|group|all]` 检查+编译依赖，默认当前 all 组
+4. **toolchain 负责安装** — `install-tools` 命令安装/升级工具链，幂等；Claude Code 为选装项（提示 `[Y/n]`，输入 `n` 跳过）；`setup [service|group|all]` 检查+编译依赖，默认当前 all 组
 5. **模块是集成层** — 委托服务自身脚本 (`src/*/scripts/`) 或自己实现
 6. **utils.sh 纯函数** — 无状态，不被 ≥2 个模块用则留在模块内
 7. **双 source 守卫** — 每个文件开头 `_XXX_SH_LOADED` 防重复加载

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -5,7 +5,7 @@ set -e
 #
 # Usage:
 #   ./scripts/singlebox.sh                              # Default standalone local stack (setup current all group + start current all group)
-#   ./scripts/singlebox.sh install-tools                # Install/upgrade dev tools (including Claude Code)
+#   ./scripts/singlebox.sh install-tools                # Install/upgrade dev tools (Claude Code is optional)
 #   ./scripts/singlebox.sh setup [service|group|all]    # Prepare artifacts/config/links; rebuild stale binaries
 #   ./scripts/singlebox.sh start [service|group|all]    # Start target (default: current all group)
 #   ./scripts/singlebox.sh stop [service|group|all]     # Stop target (default: current all group)
@@ -405,7 +405,7 @@ show_help() {
     echo "  --standalone, -s Compatibility alias for the default mode"
     echo ""
     echo "Commands:"
-    echo "  install-tools                  Install/upgrade dev tools (node, npm, uv, openclaw, Claude Code, ...)"
+    echo "  install-tools                  Install/upgrade dev tools (node, npm, uv, openclaw, optional Claude Code, ...)"
     echo "  setup [service|group|all]      Prepare artifacts/config/links; rebuild stale binaries"
     echo "  start [service|group|all]      Start target (default: current all group)"
     echo "  stop [service|group|all]       Stop target (default: current all group)"

--- a/scripts/test_singlebox_toolchain.sh
+++ b/scripts/test_singlebox_toolchain.sh
@@ -94,6 +94,81 @@ test_claude_code_existing_cli_skips_install() (
     assert_eq "$cli_path" "$CLAUDE_CODE_PATH" "existing Claude Code path"
 )
 
+test_claude_code_default_response_installs_missing_cli() (
+    local temp_dir bin_dir args_path
+    temp_dir="$(mktemp -d)"
+    bin_dir="${temp_dir}/bin"
+    TEST_CLAUDE_CLI_PATH="${bin_dir}/claude"
+    args_path="${temp_dir}/npm-args"
+    mkdir -p "$bin_dir"
+
+    export PATH="${bin_dir}:/usr/bin:/bin"
+    export TEST_CLAUDE_CLI_PATH
+    unset CLAUDE_CODE_PATH
+    npm() {
+        if [ "$1" = "prefix" ] && [ "$2" = "-g" ]; then
+            printf '%s\n' "$temp_dir"
+            return 0
+        fi
+        assert_eq "install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com" "$*" "Claude Code npm install arguments"
+        printf '%s\n' "$*" > "$args_path"
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$TEST_CLAUDE_CLI_PATH"
+        chmod +x "$TEST_CLAUDE_CLI_PATH"
+    }
+
+    setup_claude_code < <(printf '\n') || fail "empty response should install missing Claude Code"
+    assert_eq "install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com" "$(<"$args_path")" "recorded Claude Code npm install arguments"
+)
+
+test_claude_code_decline_skips_install() (
+    local temp_dir
+    temp_dir="$(mktemp -d)"
+
+    export PATH="/usr/bin:/bin"
+    unset CLAUDE_CODE_PATH
+    npm() {
+        if [ "$1" = "prefix" ] && [ "$2" = "-g" ]; then
+            printf '%s\n' "$temp_dir"
+            return 0
+        fi
+        fail "npm install should not run when Claude Code installation is declined"
+    }
+
+    setup_claude_code < <(printf 'n\n') || fail "declining Claude Code should allow the toolchain to continue"
+    [ -z "${CLAUDE_CODE_PATH:-}" ] || fail "Claude Code path should remain unset when installation is declined"
+)
+
+test_toolchain_setup_continues_after_claude_code_skip() (
+    local temp_dir completed_steps=""
+    temp_dir="$(mktemp -d)"
+
+    record_step() {
+        completed_steps+="${completed_steps:+,}$1"
+    }
+    _apply_cargo_mirror_config() { :; }
+    setup_system_dependencies() { record_step system; }
+    setup_node() { record_step node; }
+    ensure_npm_available() { record_step npm; }
+    ensure_uv() { record_step uv; }
+    ensure_uv_managed_python() { record_step python; }
+    check_python_version_file() { :; }
+    setup_openclaw() { record_step openclaw; }
+    setup_rust() { record_step rust; }
+    setup_protobuf_interactive() { record_step protobuf; }
+    export PATH="/usr/bin:/bin"
+    unset CLAUDE_CODE_PATH
+    npm() {
+        if [ "$1" = "prefix" ] && [ "$2" = "-g" ]; then
+            printf '%s\n' "$temp_dir"
+            return 0
+        fi
+        fail "npm install should not run when Claude Code installation is declined"
+    }
+
+    toolchain_setup < <(printf 'n\n') || fail "declining Claude Code should not stop toolchain setup"
+    assert_eq "system,node,npm,uv,python,openclaw,rust,protobuf" "$completed_steps" "steps after declining Claude Code"
+)
+
 test_claude_code_installs_missing_cli() (
     local temp_dir bin_dir args_path
     temp_dir="$(mktemp -d)"
@@ -197,6 +272,9 @@ test_manual_install_hints
 test_basic_build_environment_on_current_host
 test_failed_install_prints_manual_command
 test_claude_code_existing_cli_skips_install
+test_claude_code_default_response_installs_missing_cli
+test_claude_code_decline_skips_install
+test_toolchain_setup_continues_after_claude_code_skip
 test_claude_code_installs_missing_cli
 test_claude_code_install_fails_without_resolved_cli
 test_load_rust_environment

--- a/scripts/toolchain.sh
+++ b/scripts/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/toolchain.sh — Development toolchain management
 # Handles installation and verification of dev tools:
-# node, npm, uv, python, protoc, openclaw, claude code, rust/cargo
+# node, npm, uv, python, protoc, openclaw, optional claude code, rust/cargo
 #
 # toolchain_setup()  → Check and install all tools (idempotent, skip-if-present)
 # toolchain_check()  → Check only, return 1 if missing (dry-run, no install)
@@ -35,6 +35,13 @@ confirm_tool_install() {
     echo -e "${YELLOW}${prompt} [y/N]${NC}"
     read -r response || response=""
     [[ "$response" =~ ^[Yy]$ ]]
+}
+
+confirm_claude_code_install() {
+    local response
+    echo -e "${YELLOW}Install Claude Code now? [Y/n]${NC}"
+    read -r response || response=""
+    [[ ! "$response" =~ ^[Nn]$ ]]
 }
 
 # ============ System build prerequisites ============
@@ -680,10 +687,9 @@ setup_claude_code() {
     fi
 
     log_warn "Claude Code CLI not found."
-    if ! confirm_tool_install "Install Claude Code now?"; then
-        log_error "Claude Code is required for hybrid Claude relay. Install it manually:"
-        log_error "  npm install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com"
-        return 1
+    if ! confirm_claude_code_install; then
+        log_warn "Skipping optional Claude Code installation."
+        return 0
     fi
 
     install_claude_code || return 1
@@ -1040,5 +1046,5 @@ toolchain_setup() {
 
 # 工具链帮助
 toolchain_help() {
-    echo "toolchain - Development tools (node, npm, uv, python, protoc, openclaw, claude code, rust)"
+    echo "toolchain - Development tools (node, npm, uv, python, protoc, openclaw, optional claude code, rust)"
 }

--- a/spec/pipeline/cc-oc-local-model/009-pr-report.md
+++ b/spec/pipeline/cc-oc-local-model/009-pr-report.md
@@ -4,7 +4,7 @@
 
 - Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/verify-cc-oc-local-model-dev-20260815` / `inclusionAI/Avernet`
 - Head / base: `verify/cc-oc-local-model-dev-20260815` / `dev`
-- PR: `NOT_CREATED`
+- PR: [#1069](https://github.com/inclusionAI/Avernet/pull/1069)
 - PR title: `fix(singlebox): make Claude Code installation optional`
 - PR description sections: Problem / Solution / Validation / Compatibility and risk
 - 人工意见模式: auto
@@ -15,7 +15,8 @@
 |---|---|---|
 | HEAD 归属有效 | `origin/dev` 与当前 HEAD 的 merge-base 均为 `eba0ccfedd54767301ebe72a7f92423c2d06e9c1` | 当前 topic 分支从目标 `dev` 分出。 |
 | 变更范围 | `scripts/toolchain.sh`、`scripts/test_singlebox_toolchain.sh`、`scripts/singlebox.sh`、`scripts/MODULES.md` | Claude Code 安装确认逻辑、帮助文本及对应 Shell 回归测试。 |
-| 同分支 PR | `gh pr list --head verify/cc-oc-local-model-dev-20260815 --base dev --state open` 返回 0 项 | 提交与推送后创建新的 PR。 |
+| PR 元数据 | [#1069](https://github.com/inclusionAI/Avernet/pull/1069) | `OPEN`；head 为 `verify/cc-oc-local-model-dev-20260815`，base 为 `dev`，标题和必填说明段落已核验。 |
+| 已发布 HEAD | `14c1a46f5864e14ae572a094d73b4867025a6267` | 提交 `fix(singlebox): make Claude Code installation optional` 已推送。 |
 | 本地验证 | `bash -n ...`、`git diff --check`、`bash scripts/test_singlebox_toolchain.sh` | 全部通过；本机未安装 `shellcheck`。 |
 | 运行时诊断 | 跳过时输出 `Skipping optional Claude Code installation.` | 仅记录选装项被跳过，未添加无关日志。 |
 
@@ -23,24 +24,25 @@
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | - | - | 待 PR 创建 | 尚无远端 review。 | - | - |
+| 1 | - | - | CLEAR | 创建后查询到 0 条 review 和 0 条 inline review comment。 | - | - |
 
 ## ACI/CI
 
 | Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
 |---|---|---|---|---|---|
-| 远端门禁 | NOT_STARTED | - | PR 尚未创建。 | - | 本地 Shell 回归已通过。 |
+| [Singlebox coverage](https://github.com/inclusionAI/Avernet/actions/runs/31863984719/job/94961967226) | PENDING | GitHub Actions | 运行中。 | - | 不能以本地 Shell 回归替代。 |
+| BCS e2e、BCS/Backend/Engine/BaaS/Gateway unit tests | PASS | GitHub Actions | - | - | 六项均为 `SUCCESS`。 |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | - | - | 待 PR 创建 | 尚无远端评论。 | - | - |
+| 1 | - | - | CLEAR | 创建后查询到 0 条 issue comment。 | - | - |
 
 ## 当前结论
 
-- PR: NOT_CREATED
+- PR: OPEN ([#1069](https://github.com/inclusionAI/Avernet/pull/1069))
 - 自动意见: CLEAR
-- ACI/CI: NOT_STARTED
+- ACI/CI: PENDING（Singlebox coverage）
 - 人工意见: CLEAR
-- 下一步: 提交、推送 topic 分支并向 `dev` 创建 PR。
+- 下一步: 等待 Singlebox coverage 完成；GitHub 当前还显示 `REVIEW_REQUIRED`。

--- a/spec/pipeline/cc-oc-local-model/009-pr-report.md
+++ b/spec/pipeline/cc-oc-local-model/009-pr-report.md
@@ -1,0 +1,46 @@
+# PR 收敛报告：cc-oc-local-model
+
+## 范围
+
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/verify-cc-oc-local-model-dev-20260815` / `inclusionAI/Avernet`
+- Head / base: `verify/cc-oc-local-model-dev-20260815` / `dev`
+- PR: `NOT_CREATED`
+- PR title: `fix(singlebox): make Claude Code installation optional`
+- PR description sections: Problem / Solution / Validation / Compatibility and risk
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| HEAD 归属有效 | `origin/dev` 与当前 HEAD 的 merge-base 均为 `eba0ccfedd54767301ebe72a7f92423c2d06e9c1` | 当前 topic 分支从目标 `dev` 分出。 |
+| 变更范围 | `scripts/toolchain.sh`、`scripts/test_singlebox_toolchain.sh`、`scripts/singlebox.sh`、`scripts/MODULES.md` | Claude Code 安装确认逻辑、帮助文本及对应 Shell 回归测试。 |
+| 同分支 PR | `gh pr list --head verify/cc-oc-local-model-dev-20260815 --base dev --state open` 返回 0 项 | 提交与推送后创建新的 PR。 |
+| 本地验证 | `bash -n ...`、`git diff --check`、`bash scripts/test_singlebox_toolchain.sh` | 全部通过；本机未安装 `shellcheck`。 |
+| 运行时诊断 | 跳过时输出 `Skipping optional Claude Code installation.` | 仅记录选装项被跳过，未添加无关日志。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | - | - | 待 PR 创建 | 尚无远端 review。 | - | - |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| 远端门禁 | NOT_STARTED | - | PR 尚未创建。 | - | 本地 Shell 回归已通过。 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | - | - | 待 PR 创建 | 尚无远端评论。 | - | - |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: CLEAR
+- ACI/CI: NOT_STARTED
+- 人工意见: CLEAR
+- 下一步: 提交、推送 topic 分支并向 `dev` 创建 PR。


### PR DESCRIPTION
## Problem

When Claude Code was not installed, `./scripts/singlebox.sh install-tools` treated both an explicit `n` and an empty response as an error. This stopped the rest of the toolchain setup even for developers who did not need Claude Code.

## Solution

- Make Claude Code an optional `install-tools` component with a dedicated `[Y/n]` prompt.
- Install it for `y` or an empty response; log and continue for an explicit `n`.
- Add shell regression coverage for the default install path, the declined path, and continued setup after a decline.

## Validation

- `bash -n scripts/toolchain.sh scripts/singlebox.sh scripts/test_singlebox_toolchain.sh` — pass.
- `git diff --check` — pass.
- `bash scripts/test_singlebox_toolchain.sh` — pass.
- `./scripts/singlebox.sh --help` — confirms Claude Code is documented as optional.
- `shellcheck` was not run because it is not installed on the local machine.

## Compatibility and risk

Existing Claude Code installations remain detected without prompting. Developers who explicitly decline installation keep an unavailable Claude Code CLI, so any later workflow that requires that CLI must install it before use.
