### PR TITLE
feat(engine): accept namespace-relative file addresses alongside absolute ones

### DIFF
--- a/src/engine/src/engine/community/core/file/protocol.py
+++ b/src/engine/src/engine/community/core/file/protocol.py
@@ -4,8 +4,24 @@ FileService Protocol — engine-managed filesystem operations.
 Engines that own a workspace (OpenClaw under
 ``/home/admin/.openclaw/...``) implement this Protocol. The router
 collects HTTP form data / multipart uploads and hands paths +
-``bytes`` to the plugin; the plugin owns path translation
-(legacy ``/aidesktop/...`` → workspace) and the actual FS calls.
+``bytes`` to the plugin; the plugin owns path translation and the
+actual FS calls.
+
+Two address formats are accepted on every path argument (#1000):
+
+* **namespace-relative** — ``workspace/<rel>`` · ``identity/<rel>`` ·
+  ``config/<rel>``, a leading slash optional. The caller names a logical
+  location; the engine resolves it against its own layout and refuses
+  anything that escapes the namespace. This is the format new callers
+  should use, and the only one that does not require the caller to know
+  the container layout.
+* **absolute** — an OSS-view ``/aidesktop/...`` path the engine remaps, or
+  an already-engine-view path it uses as-is. Fully supported; this is what
+  today's callers send.
+
+A relative path with no namespace prefix is a :class:`ValueError`. It used
+to resolve against the engine process's working directory, which silently
+put the bytes outside the workspace (#1000).
 
 Errors are raised as standard exceptions; the router maps them to
 HTTP codes:

--- a/src/engine/src/engine/community/plugin_api/openclaw/file.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/file.py
@@ -5,6 +5,13 @@ File operations are local-infra: they work directly on the pod filesystem
 ``_convert_path`` path-rewrite logic lives in the port impl (it is
 a transport concern); the adapter builds core DTOs from the primitive
 dicts/bytes returned here.
+
+Every path argument below accepts either an absolute address (OSS-view
+``/aidesktop/...``, remapped; or an engine-view path, used as-is) or a
+namespace-relative one (``workspace/<rel>`` · ``identity/<rel>`` ·
+``config/<rel>``), which the port resolves against this engine's own layout
+and bounds to the namespace root. A relative path with no namespace prefix
+raises ``ValueError`` — see ``plugins/openclaw/_file.py`` for the contract.
 """
 from __future__ import annotations
 

--- a/src/engine/src/engine/community/plugins/openclaw/_file.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_file.py
@@ -3,6 +3,33 @@
 Also contains the module-level _convert_path helper and the
 _PATH_PREFIX_PATTERN/_PATH_PREFIX_NEW constants (relocated from
 engines/openclaw/file.py).
+
+Addressing (#1000)
+------------------
+``/api/file/*`` accepts two address formats, and this module is where they are
+told apart:
+
+* **namespace-relative** — ``workspace/<rel>`` · ``identity/<rel>`` ·
+  ``config`` (a leading slash is tolerated). The backend names a logical
+  location and *this engine* decides where it lands, so no caller has to know
+  the container layout. Resolution is bounded: the relative part may not carry
+  ``..``, and the result is asserted to sit under the namespace root.
+  ``workspace`` and ``identity`` are trees; ``config`` is the single
+  engine-owned config file, which is why it takes no caller-chosen leaf.
+* **absolute** — the OSS-view ``/aidesktop/...`` prefix (rewritten to the
+  engine-view root) and already-engine-view paths (passed through). This is the
+  format every current caller sends, and it keeps working byte-for-byte.
+
+The discriminator is *first path segment ∈ the namespace set*, never the
+inverse ("not ``/aidesktop`` ⇒ relative"): callers pass hardcoded
+container-absolute paths such as ``/home/admin/.openclaw/workspace/skills``, and
+an inverted rule would swallow them.
+
+A **bare relative path** — one with no namespace prefix — is refused rather than
+passed through. That is the one deliberate break with the old behavior: such a
+path used to resolve against the engine process's CWD, so an upload reported 201
+and landed outside the workspace, where neither the agent nor the NFS sync could
+see it (#1000).
 """
 from __future__ import annotations
 
@@ -13,7 +40,10 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from engine.community.plugin_api.workspace_root import workspace_root_strict
+from engine.community.plugin_api.workspace_root import (
+    workspace_root,
+    workspace_root_strict,
+)
 
 log = logging.getLogger("openclaw-port")
 
@@ -31,19 +61,169 @@ _SINGLEBOX_PATH_PATTERN = re.compile(
 )
 
 
-def _convert_path(target: str) -> Path:
-    """Rewrite OSS-view path prefix to engine-view per-bot path.
+# ── namespace-relative addressing (#1000) ────────────────────────────────────
 
-    Three branches (in order):
+# The engine namespaces the backend addresses files by. Mirrors the backend's
+# ``core/config_compose/teclaw_paths.py`` constants — the two sides of one wire
+# contract — and matches what teclaw's engine already accepts.
+_WORKSPACE_NS = "workspace"
+_IDENTITY_NS = "identity"
+_CONFIG_NS = "config"
+_ENGINE_NAMESPACES = (_WORKSPACE_NS, _IDENTITY_NS, _CONFIG_NS)
+
+# The single file the ``config`` namespace addresses on this engine. The backend
+# composes the same name today (``build_arca_config_mapper`` →
+# ``{bot_engine_dir}/openclaw.json``, matching ``get_engine_config_path``); owning
+# it here is what lets that mapper stop composing engine paths at all.
+_CONFIG_FILENAME = "openclaw.json"
+
+
+def _split_namespace(target: str) -> tuple[str, list[str]] | None:
+    """Split a namespace-relative address, or return ``None`` if it is not one.
+
+    ``"workspace/a/b.txt"`` and ``"/workspace/a/b.txt"`` both yield
+    ``("workspace", ["a", "b.txt"])``; the bare namespace yields an empty
+    segment list (it addresses the namespace root, which ``list_dir`` needs).
+    Empty and ``"."`` segments are dropped as the noise they are — a leading
+    slash or a doubled separator is not an attempt to leave the namespace.
+    ``".."`` segments are kept here and refused in :func:`_resolve_namespace`,
+    so the rejection names the offending input instead of silently rewriting the
+    address to a different valid one.
+    """
+    segments = [s for s in target.split("/") if s and s != "."]
+    if not segments or segments[0] not in _ENGINE_NAMESPACES:
+        return None
+    return segments[0], segments[1:]
+
+
+def _namespace_root(namespace: str) -> Path:
+    """The engine-view directory a namespace resolves against.
+
+    openclaw's per-bot layout, as composed today by the backend's
+    ``build_workspace_mapper`` / ``build_arca_identity_mapper`` /
+    ``build_arca_config_mapper`` and then folded to the engine view by branches 1
+    and 2 of :func:`_convert_path`:
+
+    * ``workspace`` → ``{engine_dir}/workspace``
+    * ``identity``  → ``{engine_dir}/workspace`` — openclaw keeps its identity
+      files (AGENTS.md, IDENTITY.md, …) in the workspace root, not in a separate
+      directory, so the two namespaces share a root on this engine.
+    * ``config``    → ``{engine_dir}`` — the engine config lives beside the
+      workspace as ``openclaw.json``. The namespace holds that one file; see
+      :func:`_resolve_namespace`.
+
+    The workspace root comes from :func:`workspace_root` — the engine's own
+    answer to "where is my workspace", the same one ``skills``,
+    ``session_files`` and ``resource_materialization`` resolve against. Deriving
+    it from anything else would let a file uploaded as ``workspace/x`` land
+    somewhere those services cannot see, which is the failure #1000 is about.
+
+    Raises:
+        RuntimeError: ``OPENCLAW_WORKSPACE_DIR`` is set to a relative path —
+            a baas spawn-time configuration error, failed explicitly rather
+            than resolved against the process CWD (same guard as branch 2).
+    """
+    root = workspace_root()
+    if not root.is_absolute():
+        raise RuntimeError(
+            f"OPENCLAW_WORKSPACE_DIR must be an absolute path, got {str(root)!r}. "
+            f"baas spawn-time should inject the resolved host absolute path."
+        )
+    if namespace == _CONFIG_NS:
+        return root.parent
+    return root
+
+
+def _resolve_namespace(namespace: str, segments: list[str]) -> Path:
+    """Join ``segments`` onto the namespace root, refusing anything that escapes.
+
+    Containment is **lexical**: ``".."`` is refused outright and the remaining
+    segments are joined onto the root, so no input can address outside it. The
+    result is deliberately *not* ``resolve()``-d against the filesystem — the
+    workspace legitimately contains symlinks that point outside it (the skills
+    bindpaths link ``workspace/skills/skills-local`` and ``…/skills-repo`` into
+    the skills pool), and following them would turn every skill file into an
+    apparent escape.
+
+    This bounds the *address*, not the process: the agent shares this
+    filesystem and can reach any of it directly. The guarantee is that a path
+    the backend names as ``<namespace>/…`` cannot resolve outside that
+    namespace — which is what makes the engine, rather than the caller, the one
+    place that decides where a logical path lands.
+
+    ``config`` is the exception, and deliberately so: it is not a tree the
+    caller populates but the one engine-owned config file, so it accepts exactly
+    two spellings — the bare namespace ``config`` and the explicit
+    ``config/openclaw.json`` — and refuses every other leaf. Both resolve to the
+    same file. Refusing rather than resolving matters because the backend
+    currently addresses this namespace with one canonical leaf for every
+    provider (``config/teclaw.json``, whose real filename its arca/baas mapper
+    then derives from ``engine_type`` and discards the leaf). Accepting that leaf
+    verbatim here would write a stray ``teclaw.json`` beside the real config and
+    report success — the config would simply never take effect, which is the same
+    silent-write failure #1000 is about.
+
+    Raises:
+        ValueError: a ``".."`` segment, a ``config`` address naming anything but
+            this engine's config file, or (defensively) a join that lands
+            outside the root. The router maps it to 400.
+    """
+    if any(s == ".." for s in segments):
+        raise ValueError(
+            f"path escapes the {namespace!r} namespace: "
+            f"{'/'.join([namespace, *segments])!r}"
+        )
+    if namespace == _CONFIG_NS:
+        if segments not in ([], [_CONFIG_FILENAME]):
+            raise ValueError(
+                f"the {_CONFIG_NS!r} namespace holds this engine's config file "
+                f"({_CONFIG_FILENAME!r}); address it as {_CONFIG_NS!r} or "
+                f"{f'{_CONFIG_NS}/{_CONFIG_FILENAME}'!r}, got "
+                f"{'/'.join([namespace, *segments])!r}"
+            )
+        return _namespace_root(namespace) / _CONFIG_FILENAME
+    root = _namespace_root(namespace)
+    resolved = root.joinpath(*segments) if segments else root
+    # Invariant, not input validation: with no ".." left this cannot fail. It is
+    # asserted so a future edit to the segment filter cannot quietly widen the
+    # namespace.
+    if resolved != root and not resolved.is_relative_to(root):
+        raise ValueError(
+            f"path escapes the {namespace!r} namespace: "
+            f"{'/'.join([namespace, *segments])!r}"
+        )
+    return resolved
+
+
+def _convert_path(target: str) -> Path:
+    """Resolve a wire address (OSS-view or namespace-relative) to an engine path.
+
+    Five branches (in order):
     1. 线上 ARCA pre/prod (原 regex): 折叠到 hardcode /home/admin/.openclaw/
        — 跟改造前完全一致,线上行为字节级不变。
     2. singlebox 多 bot: 折叠到 OPENCLAW_WORKSPACE_DIR 的父目录。
        env 必须由 baas spawn 时注入; regex 匹配但 env 未设 → RuntimeError
        (配置错误,显式失败而非隐式降级)。
-    3. 其他: passthrough(engine-view 直接路径或 desktop bot 路径)。
+    3. namespace-relative (#1000): ``workspace/`` · ``identity/`` · ``config/``
+       (前导 ``/`` 可选) → 由本 engine 决定落点, 并断言未越出 namespace root。
+    4. 其他绝对路径: passthrough(engine-view 直接路径或 desktop bot 路径)。
+    5. 其他相对路径: ValueError — 旧行为会 resolve 到进程 CWD, 静默落在
+       workspace 之外 (#1000)。
 
-    Relocated intact from ``engines/openclaw/file.py:_convert_path``,本次
-    扩展加入 singlebox 副分支以支持多 bot 共宿主下的 per-bot 隔离。
+    The namespace branch sits **after** the two OSS-view regexes and is keyed on
+    the first path segment, so every address that resolves today still resolves
+    to the same place: no OSS-view or engine-view absolute path starts with a
+    ``workspace`` / ``identity`` / ``config`` segment.
+
+    Relocated from ``engines/openclaw/file.py:_convert_path``, since extended
+    with the singlebox sub-branch (per-bot isolation on a shared host) and the
+    namespace-relative branch (#1000).
+
+    Raises:
+        ValueError: the address is namespace-relative and escapes its namespace,
+            or it is relative with no namespace prefix.
+        RuntimeError: a singlebox OSS-view path with no (or a relative)
+            ``OPENCLAW_WORKSPACE_DIR``.
     """
     original = target
     target = target.strip()
@@ -93,13 +273,41 @@ def _convert_path(target: str) -> Path:
         )
         return result
 
-    # Branch 3: passthrough
+    # Branch 3: namespace-relative (#1000)
+    parsed = _split_namespace(target)
+    if parsed is not None:
+        namespace, segments = parsed
+        result = _resolve_namespace(namespace, segments)
+        log.info(
+            "[_convert_path] branch=NAMESPACE ns=%s input=%r → %s",
+            namespace, original, result,
+        )
+        return result
+
+    # Branch 4: passthrough — an engine-view absolute path the caller resolved
+    # itself (desktop bot paths, hardcoded container paths).
     result = Path(target)
-    log.info(
-        "[_convert_path] branch=PASSTHROUGH input=%r → %s",
-        original, result,
+    if result.is_absolute():
+        log.info(
+            "[_convert_path] branch=PASSTHROUGH input=%r → %s",
+            original, result,
+        )
+        return result
+
+    # Branch 5: relative with no namespace — refused. Passing it through would
+    # resolve it against the engine process's CWD, which is outside the
+    # workspace and outside the NFS sync pair: the write reports success and the
+    # bytes are invisible to the agent and lost on container recycle (#1000).
+    log.error(
+        "[_convert_path] branch=RELATIVE_REJECTED input=%r → ValueError",
+        original,
     )
-    return result
+    namespaces = ", ".join(f"{ns}/" for ns in _ENGINE_NAMESPACES)
+    raise ValueError(
+        f"relative path without an engine namespace: {original!r}. "
+        f"Address it under one of {namespaces} — or pass an absolute "
+        f"engine path."
+    )
 
 
 class _FilePortMixin:

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_file_port_namespace.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_file_port_namespace.py
@@ -1,0 +1,366 @@
+"""Namespace-relative addressing for the OpenClaw file port (#1000).
+
+``/api/file/*`` accepts two address formats; these tests pin the new one and
+prove the old one is untouched:
+
+* ``workspace/<rel>`` · ``identity/<rel>`` · ``config/<rel>`` resolve against
+  this engine's own layout, and cannot address outside their namespace.
+* OSS-view and engine-view absolute paths resolve exactly as before — the
+  discriminator is the first path segment, so nothing that works today changes.
+* A bare relative path is refused instead of resolving against the engine
+  process's CWD, which is the silent data loss #1000 reported.
+
+The port methods are driven directly on ``OpenClawPluginImpl`` (no gateway or
+pool needed), with ``OPENCLAW_WORKSPACE_DIR`` pointed at ``tmp_path``.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from engine.community.plugins.openclaw._file import _convert_path
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
+
+
+@pytest.fixture
+def impl():
+    return OpenClawPluginImpl()
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A per-bot engine layout: ``{engine_dir}/workspace``, exported via env.
+
+    Mirrors what baas injects at spawn time, so the namespace roots resolve the
+    way they do on a real singlebox host.
+    """
+    root = tmp_path / "bolt_data" / "staff_1" / "bot-1" / "openclaw" / "workspace"
+    root.mkdir(parents=True)
+    with patch.dict(os.environ, {"OPENCLAW_WORKSPACE_DIR": str(root)}):
+        yield root
+
+
+# ── _convert_path: namespace resolution ──────────────────────────────────────
+
+
+def test_workspace_namespace_resolves_under_workspace_root(workspace):
+    assert _convert_path("workspace/docs/a.txt") == workspace / "docs" / "a.txt"
+
+
+def test_workspace_namespace_tolerates_leading_slash(workspace):
+    """Engines accept ``/workspace/<rel>``; the backend only emits the bare form."""
+    assert _convert_path("/workspace/docs/a.txt") == workspace / "docs" / "a.txt"
+
+
+def test_bare_workspace_namespace_is_the_workspace_root(workspace):
+    """``list_dir`` addresses the root as the bare namespace (no relative part)."""
+    assert _convert_path("workspace") == workspace
+
+
+def test_identity_namespace_shares_the_workspace_root(workspace):
+    """openclaw keeps identity files in the workspace root, not a separate dir.
+
+    Matches the backend's ``build_arca_identity_mapper``, which composes
+    ``{engine_dir}/workspace/<file>`` for openclaw.
+    """
+    assert _convert_path("identity/AGENTS.md") == workspace / "AGENTS.md"
+
+
+def test_config_namespace_resolves_beside_the_workspace(workspace):
+    """The engine config lives at ``{engine_dir}/openclaw.json``.
+
+    Same file the OSS-view address ``…/<bot>/openclaw/openclaw.json`` folds to.
+    """
+    assert _convert_path("config/openclaw.json") == workspace.parent / "openclaw.json"
+
+
+def test_config_namespace_spellings_agree(workspace):
+    assert _convert_path("config") == _convert_path("config/openclaw.json")
+
+
+def test_config_namespace_and_oss_view_address_the_same_file(workspace):
+    oss = (
+        "/aidesktop/aidesktop_singlebox/bolt_data/staff_1/bot-1/openclaw/openclaw.json"
+    )
+    assert _convert_path(oss) == _convert_path("config")
+
+
+def test_bare_config_namespace_is_the_engine_config_file(workspace):
+    """``config`` holds one file, so the bare namespace names it directly.
+
+    That spelling is what lets the backend address the config without knowing
+    any engine's filename.
+    """
+    assert _convert_path("config") == workspace.parent / "openclaw.json"
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["config/teclaw.json", "config/config.json", "config/sub/openclaw.json"],
+)
+def test_config_namespace_refuses_a_foreign_leaf(workspace, target):
+    """The backend addresses every provider's config as ``config/teclaw.json``
+    today and lets its arca/baas mapper derive the real filename. Writing that
+    leaf verbatim would drop a stray file beside the real config and report
+    success — silent, and exactly the failure #1000 is about."""
+    with pytest.raises(ValueError, match="holds this engine's config file"):
+        _convert_path(target)
+
+
+def test_namespace_normalizes_noise_segments(workspace):
+    """Empty and ``.`` segments are noise, not an escape attempt."""
+    assert _convert_path("workspace//docs/./a.txt") == workspace / "docs" / "a.txt"
+
+
+def test_namespace_strips_surrounding_whitespace(workspace):
+    assert _convert_path("  workspace/a.txt  ") == workspace / "a.txt"
+
+
+def test_namespace_and_oss_view_address_the_same_file(workspace):
+    """Both wire formats must land on one file — that is what makes the
+    backend's cutover a no-op for existing data."""
+    oss = (
+        "/aidesktop/aidesktop_singlebox/bolt_data/staff_1/bot-1/openclaw/"
+        "workspace/docs/a.txt"
+    )
+    assert _convert_path(oss) == _convert_path("workspace/docs/a.txt")
+
+
+# ── _convert_path: containment ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "workspace/../../etc/passwd",
+        "identity/../../../etc/passwd",
+        "config/../secrets.json",
+        "/workspace/../escape.txt",
+        "workspace/docs/../../escape.txt",
+    ],
+)
+def test_namespace_escape_raises_value_error(workspace, target):
+    with pytest.raises(ValueError, match="escapes the"):
+        _convert_path(target)
+
+
+def test_escape_error_names_the_namespace(workspace):
+    with pytest.raises(ValueError, match="'identity'"):
+        _convert_path("identity/../x")
+
+
+# ── _convert_path: env handling ──────────────────────────────────────────────
+
+
+def test_namespace_without_env_falls_back_to_home_layout(tmp_path):
+    """No ``OPENCLAW_WORKSPACE_DIR`` → the engine's default ``~/.openclaw``.
+
+    Same root ``workspace_root()`` hands every other engine service, so a file
+    uploaded as ``workspace/<rel>`` is the file those services then see.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "OPENCLAW_WORKSPACE_DIR"}
+    env["HOME"] = str(tmp_path)
+    with patch.dict(os.environ, env, clear=True):
+        engine_dir = tmp_path / ".openclaw"
+        assert _convert_path("workspace/a.txt") == engine_dir / "workspace" / "a.txt"
+        assert _convert_path("config") == engine_dir / "openclaw.json"
+
+
+def test_namespace_with_relative_env_raises_runtime_error():
+    """A relative ``OPENCLAW_WORKSPACE_DIR`` is a spawn-time config error.
+
+    Same guard the singlebox OSS-view branch applies — resolving it against the
+    process CWD is exactly the silent misplacement being removed.
+    """
+    with patch.dict(os.environ, {"OPENCLAW_WORKSPACE_DIR": "relative/openclaw/workspace"}):
+        with pytest.raises(RuntimeError, match="must be an absolute path"):
+            _convert_path("workspace/a.txt")
+
+
+# ── _convert_path: the absolute formats are untouched ────────────────────────
+
+
+def test_engine_view_absolute_path_still_passes_through(workspace):
+    """Callers pass hardcoded container paths; the discriminator must not eat
+    them. ``/home/admin/.openclaw/workspace`` contains a ``workspace`` segment
+    but does not *start* with one."""
+    target = "/home/admin/.openclaw/workspace/skills"
+    assert _convert_path(target) == Path(target)
+
+
+def test_prod_oss_view_path_still_folds_to_hardcoded_root(workspace):
+    """Branch 1 runs before the namespace branch and is env-independent."""
+    result = _convert_path(
+        "/aidesktop/aidesktop_prod/bolt_data/X/Y/openclaw/workspace/a.md"
+    )
+    assert result == Path("/home/admin/.openclaw/workspace/a.md")
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["Workspace/a.txt", "workspaces/a.txt", "work/space/a.txt"],
+)
+def test_near_miss_prefixes_are_not_namespaces(workspace, target):
+    """The namespace set is matched exactly — no case folding, no prefixing."""
+    with pytest.raises(ValueError, match="relative path without an engine namespace"):
+        _convert_path(target)
+
+
+# ── _convert_path: bare relative paths are refused ───────────────────────────
+
+
+@pytest.mark.parametrize("target", ["111.txt", "sub/dir/111.txt", "./111.txt"])
+def test_bare_relative_path_raises_value_error(workspace, target):
+    """#1000: these used to resolve against the engine process's CWD."""
+    with pytest.raises(ValueError, match="relative path without an engine namespace"):
+        _convert_path(target)
+
+
+def test_relative_rejection_names_the_namespaces(workspace):
+    with pytest.raises(ValueError, match="workspace/, identity/, config/"):
+        _convert_path("111.txt")
+
+
+# ── port methods over namespace addresses ────────────────────────────────────
+
+
+async def test_upload_namespace_path_lands_in_the_workspace(impl, workspace):
+    result = await impl.upload("workspace/docs/spec/a.txt", b"hello")
+
+    written = workspace / "docs" / "spec" / "a.txt"
+    assert written.read_bytes() == b"hello"
+    assert result["target_path"] == str(written)
+    assert result["size"] == 5
+    assert result["overwritten"] is False
+
+
+async def test_upload_namespace_path_echoes_an_absolute_target(impl, workspace):
+    """The echoed ``target_path`` is absolute, never the relative input.
+
+    The backend keys its rollout safety on exactly this: an engine that has not
+    learned the format echoes the relative path back, and the backend refuses
+    the response instead of recording a resource whose bytes went nowhere.
+    """
+    result = await impl.upload("workspace/a.txt", b"x")
+
+    assert Path(result["target_path"]).is_absolute()
+    assert result["target_path"] != "workspace/a.txt"
+
+
+async def test_upload_namespace_path_overwrites(impl, workspace):
+    (workspace / "a.txt").write_bytes(b"old")
+
+    result = await impl.upload("workspace/a.txt", b"new")
+
+    assert result["overwritten"] is True
+    assert (workspace / "a.txt").read_bytes() == b"new"
+
+
+async def test_upload_identity_namespace_writes_workspace_root_file(impl, workspace):
+    await impl.upload("identity/AGENTS.md", b"# agents")
+
+    assert (workspace / "AGENTS.md").read_bytes() == b"# agents"
+
+
+async def test_upload_config_namespace_writes_beside_the_workspace(impl, workspace):
+    await impl.upload("config/openclaw.json", b"{}")
+
+    assert (workspace.parent / "openclaw.json").read_bytes() == b"{}"
+
+
+async def test_upload_bare_config_namespace_writes_the_engine_config(impl, workspace):
+    await impl.upload("config", b'{"a": 1}')
+
+    assert (workspace.parent / "openclaw.json").read_bytes() == b'{"a": 1}'
+
+
+async def test_upload_foreign_config_leaf_writes_nothing(impl, workspace):
+    with pytest.raises(ValueError, match="holds this engine's config file"):
+        await impl.upload("config/teclaw.json", b"{}")
+
+    assert not (workspace.parent / "teclaw.json").exists()
+
+
+async def test_read_round_trip_over_namespace_path(impl, workspace):
+    await impl.upload("workspace/rt.bin", b"\xde\xad\xbe\xef")
+
+    assert await impl.read("workspace/rt.bin") == b"\xde\xad\xbe\xef"
+
+
+async def test_remove_over_namespace_path(impl, workspace):
+    (workspace / "gone.txt").write_bytes(b"x")
+
+    result = await impl.remove("workspace/gone.txt")
+
+    assert result["path_type"] == "file"
+    assert not (workspace / "gone.txt").exists()
+
+
+async def test_rmtree_over_namespace_path(impl, workspace):
+    tree = workspace / "tree"
+    (tree / "nested").mkdir(parents=True)
+    (tree / "nested" / "a.txt").write_bytes(b"x")
+
+    out = await impl.rmtree("workspace/tree")
+
+    assert out == str(tree)
+    assert not tree.exists()
+
+
+async def test_list_dir_over_bare_workspace_namespace(impl, workspace):
+    (workspace / "a.txt").write_bytes(b"1")
+    (workspace / "sub").mkdir()
+
+    result = await impl.list_dir("workspace")
+
+    assert result["dir_path"] == str(workspace)
+    assert sorted(e["name"] for e in result["files"]) == ["a.txt", "sub"]
+
+
+async def test_list_dir_over_namespace_subdirectory(impl, workspace):
+    sub = workspace / "docs"
+    sub.mkdir()
+    (sub / "a.txt").write_bytes(b"1")
+
+    result = await impl.list_dir("workspace/docs")
+
+    assert [e["relative_path"] for e in result["files"]] == ["a.txt"]
+
+
+async def test_namespace_read_follows_a_skill_symlink_out_of_the_workspace(
+    impl, workspace, tmp_path
+):
+    """Containment is lexical, and has to be: the skills bindpaths symlink
+    ``workspace/skills/skills-local`` into the pool, which lives outside the
+    workspace. Resolving symlinks before the containment check would make every
+    skill file look like an escape."""
+    pool = tmp_path / "skills-pool" / "local"
+    pool.mkdir(parents=True)
+    (pool / "SKILL.md").write_bytes(b"# skill")
+    skills = workspace / "skills"
+    skills.mkdir()
+    (skills / "skills-local").symlink_to(pool, target_is_directory=True)
+
+    assert await impl.read("workspace/skills/skills-local/SKILL.md") == b"# skill"
+
+
+async def test_upload_escaping_namespace_path_writes_nothing(impl, workspace, tmp_path):
+    outside = tmp_path / "outside.txt"
+
+    with pytest.raises(ValueError, match="escapes the"):
+        await impl.upload("workspace/../../../../outside.txt", b"x")
+
+    assert not outside.exists()
+
+
+async def test_upload_bare_relative_path_is_refused(impl, workspace):
+    """#1000's exact reproduction: a bare filename used to be written to the
+    engine process's CWD and reported as a success."""
+    with pytest.raises(ValueError, match="relative path without an engine namespace"):
+        await impl.upload("111.txt", b"x")
+
+    assert not (workspace / "111.txt").exists()
+    assert not (Path.cwd() / "111.txt").exists()


### PR DESCRIPTION
## Problem

`/api/file/*` on the openclaw engine only understands absolute addresses: the
OSS-view `/aidesktop/...` prefix it rewrites, and engine-view paths it passes
through. Anything else falls through to that passthrough and resolves against
the engine process's working directory — outside the workspace and outside the
`.aicoding` ↔ NFS rsync pair. A `POST /openapi/v1/bots/resources/upload` that
put a bare `111.txt` on the wire therefore answered `201`, wrote a DB row, and
left the bytes where neither the agent nor the sync could see them, lost on the
next container recycle. Confirmed on a pre bot (#1000): the only copy on disk
was at `/opt/OpenClawEnterprise/src/111.txt`, matching the uvicorn process CWD.

The addressing model behind that is the deeper problem. The backend composes an
OSS-view absolute path and the engine rewrites it back — two translation layers
that both have to know the container layout, and neither of which asserts the
result stays inside the workspace. `AGENTS.md` already states the rule this
violates: physical layout ownership belongs to Engine Runtime.

This is step 1 of the three-step rollout on #1000 — engine first, so the backend
can switch with no cross-repo ordering dependency, and the OSS-view format can
be retired later on its own schedule.

## Solution

`_convert_path` gains a namespace branch: `workspace/<rel>`, `identity/<rel>`
and `config` resolve against this engine's own layout, with the relative part
bounded to the namespace root. A leading slash is tolerated so the
engine-relative spelling teclaw already uses is accepted; the backend only ever
emits the slash-free form.

Roots follow the layout the backend's mappers compose today, so both wire
formats land on the same file:

| Namespace  | Root                     | Backend mapper it mirrors     |
| ---------- | ------------------------ | ----------------------------- |
| `workspace`| `{engine_dir}/workspace` | `build_workspace_mapper`      |
| `identity` | `{engine_dir}/workspace` | `build_arca_identity_mapper`  |
| `config`   | `{engine_dir}`           | `build_arca_config_mapper`    |

`identity` shares the workspace root because openclaw keeps its identity files
(`AGENTS.md`, `IDENTITY.md`, …) there rather than in a directory of their own.

Decisions worth calling out:

- **Discriminator is the first path segment**, checked after the two OSS-view
  regexes — never the inverse ("not `/aidesktop` ⇒ relative"). Callers pass
  hardcoded container paths like `/home/admin/.openclaw/workspace/skills`, which
  an inverted rule would swallow. Nothing that resolves today changes.
- **The workspace root comes from `workspace_root()`** — the engine's own answer,
  the same one `skills`, `session_files` and `resource_materialization` resolve
  against. Deriving it separately would reintroduce the #1000 failure in a new
  place: bytes written where those services cannot see them.
- **Containment is lexical.** `..` is refused and the remaining segments are
  joined onto the root, so no input can address outside it. The result is
  deliberately not `resolve()`-d: the skills bindpaths symlink
  `workspace/skills/skills-local` and `…/skills-repo` into the pool outside the
  workspace, and following symlinks first would make every skill file look like
  an escape. This bounds the address, not the process — the agent shares the
  filesystem and can reach any of it directly.
- **`config` addresses one file, not a tree.** It accepts the bare namespace or
  the explicit `config/openclaw.json`, both resolving to
  `{engine_dir}/openclaw.json`, and refuses any other leaf. Today the backend
  addresses every provider's config as `config/teclaw.json` and lets its
  arca/baas mapper derive the real filename from `engine_type`, discarding the
  leaf (there is already a `TODO` on that in `core/services/engine_config.py`).
  Resolving that leaf verbatim would write a stray `teclaw.json` beside the real
  config and report success — the config would simply never take effect, the
  same silent-write class as #1000. The bare spelling is what lets the backend's
  mapper stop composing engine paths at all.
- **A relative path with no namespace prefix is refused** rather than passed
  through. This is the one deliberate break with previous behavior, and it is
  the #1000 fix itself. Nothing in-repo sends one: `_skills` validates
  absoluteness before calling, `WorkspaceService` joins onto the workspace, and
  every backend mapper composes an absolute or namespace-relative path.

Rejected: patching the OpenAPI upload path to compose the same OSS-view string.
It keeps both translation layers, leaves the engine with no containment check,
and would have to be undone by this refactor anyway.

## Validation

Ran in `src/engine` (deps installed from `pypi.org` — the pinned `mirrors.aliyun.com`
index is blocked by this environment's egress policy, so `uv sync --frozen`
could not be used):

- `pytest` full engine suite — **2402 passed, 5 skipped**.
- New `plugins/openclaw/tests/test_file_port_namespace.py` — **47 passed**,
  covering: the three namespaces and their roots; the bare-namespace and
  leading-slash spellings; `.`/empty-segment normalization; namespace and
  OSS-view addresses proven to resolve to the same file; `..` escapes on every
  namespace; the foreign-`config`-leaf rejection; absent, relative and injected
  `OPENCLAW_WORKSPACE_DIR`; near-miss prefixes (`Workspace/`, `workspaces/`);
  bare relative rejection including the exact `111.txt` reproduction asserting
  nothing lands in CWD; a read through a skill symlink that points outside the
  workspace; and every port method (upload / read / remove / rmtree / list_dir)
  driven over namespace addresses.
- `flake8 --select` with the pre-push block-rule set on all changed files —
  clean.

Not run: `src/engine/scripts/ci_test.sh` (its changed-line coverage step needs
`uv sync --frozen` against the blocked index) and the Singlebox E2E gate, which
this change does not select.

## Compatibility and risk

Purely additive on the wire. Every address in use today — OSS-view pre/prod,
OSS-view singlebox, and engine-view absolute — resolves byte-for-byte as before,
which the existing `test_file_port.py` branch tests still pin.

The one behavior change is that a bare relative path now raises `ValueError`
(router → 400) instead of silently writing to the process CWD. That path only
ever produced lost data, so the failure it replaces was never a working case.

Rollback is reverting this commit; no schema, config, or migration impact, and
DB `path` semantics are untouched.

## Related issues

Part of #1000 (step 1 of 3: engine dual-mode → backend switch → retire the
absolute format). Follow-ups, unchanged by this PR:

- Backend switch (step 2) must emit `workspace/<rel>` / `identity/<file>` and
  address the config as the bare `config` namespace, and must assert the
  `target_path` echoed by `/api/file/upload` is absolute — an engine without
  this change echoes the relative input, so the backend fails loudly instead of
  recording a phantom resource.
- The same namespace branch in OCB's `corp/engines/{aicoding,claude_code,hermes}/file.py`
  is a separate session; this PR is the contract it mirrors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmTvLbYQE1typZYZQMHt4A)_