### PR TITLE
fix(backend): read an unwritten engine config as empty, not 500

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -826,7 +826,12 @@ async def get_bot_engine_config(
         EngineConfigServiceProtocol
     ),
 ) -> Envelope[dict[str, Any]]:
-    """Read a bot's engine configuration (free-form JSON)."""
+    """Read a bot's engine configuration (free-form JSON).
+
+    A bot whose engine configuration has never been written reads as an empty
+    object — every engine keeps this configuration in a file its runtime creates
+    on first use, so "not configured yet" is an ordinary state, not an error.
+    """
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
     entity_id, entity_type, engine = _engine_config_target(bot)
     data = await engine_config_service.read_bot_config(

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
@@ -23,6 +23,45 @@ from agentclaw.community.core.devices.services.baas_invoke_transport import Baas
 logger = get_logger()
 
 
+# The transparent-proxy router answers 404 for its OWN routing failures, using these
+# markers in the error body. They mean "this bot/device is gone" — unavailability —
+# never "that file does not exist".
+_PROXY_ROUTING_ERRORS = frozenset({"BOT_NOT_FOUND", "NO_DEVICES_FOUND"})
+
+
+def _is_proxy_routing_failure(response: httpx.Response) -> bool:
+    """True when a 404 came from the transparent proxy rather than from the device.
+
+    ``DesktopBaasInvokeTransport`` reaches the device through secbaas'
+    ``/api/v1/bots/{tenant}/{bot_uuid}/invoke-http/{port}{path}`` router, which raises
+    ``HTTPException(404, detail={"error": "BOT_NOT_FOUND" | "NO_DEVICES_FOUND", ...})``
+    when it cannot route to a device — *before* the request reaches the device at all
+    (``invoke_http_in_bot``). A device that simply lacks the file also answers 404, and
+    the proxy passes that status straight through, so the status code alone cannot tell
+    "no such file" from "no such bot"; only the body can.
+
+    Anything that is not one of the proxy's own markers is read as the device's own
+    answer, because the proxy emits only these two 404s itself — every other 404
+    travelled through it from the device. (Its "no active devices" case is a 503, so it
+    never reaches this branch.)
+
+    The cloud ``BaasInvokeTransport`` does not use this router — it resolves the device
+    via ``get_http_info`` first and raises ``BaasServiceError`` when there is none — so
+    this only ever fires on the desktop path. Checking it unconditionally is still safe:
+    a device would not answer in the proxy's error shape.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    # FastAPI nests ``HTTPException(detail=...)`` under "detail"; tolerate a bare body.
+    detail = payload.get("detail")
+    candidates = (detail, payload) if isinstance(detail, dict) else (payload,)
+    return any(c.get("error") in _PROXY_ROUTING_ERRORS for c in candidates)
+
+
 class BaasDeviceFileSystem(DeviceFileSystem):
     """DeviceFileSystem — 业务逻辑层,transport 由 dispatcher 注入。
 
@@ -66,20 +105,27 @@ class BaasDeviceFileSystem(DeviceFileSystem):
             resp.raise_for_status()
             return resp.content
         except httpx.HTTPStatusError as e:
-            # An explicit 404 is the container answering "no such file", which the
+            # A 404 *from the device* is it answering "no such file", which the
             # ``DeviceFileSystem.read_file`` contract represents as ``None`` — the
             # same mapping ``TeclawDeviceFileSystem.read_file`` and
             # ``LocalDeviceFileSystem._baas_read_file`` (same ``/api/file/read``
             # endpoint) already apply. Keeping it here means core callers never have
             # to know this provider speaks HTTP.
             #
-            # Every other status still propagates, which is the point of the guard
-            # this replaces: a swallowed 401 (missing x-proxypass-token) used to
-            # return empty content that callers treated as "file gone", silently
-            # dropping promoted files at draft→verify. Translating *only* a verified
-            # 404 keeps that failure impossible while honouring the contract —
-            # absence and unavailability stay distinguishable.
-            if e.response.status_code == 404:
+            # Not every 404 is the device's, though: on the desktop path the
+            # transparent proxy answers 404 for its own routing failures, which mean
+            # the bot/device is gone. Those must keep raising — see
+            # ``_is_proxy_routing_failure``.
+            #
+            # Every other status propagates too, which is the point of the guard this
+            # replaces: a swallowed 401 (missing x-proxypass-token) used to return
+            # empty content that callers treated as "file gone", silently dropping
+            # promoted files at draft→verify. Translating *only* a verified
+            # device-level 404 keeps that failure impossible while honouring the
+            # contract — absence and unavailability stay distinguishable.
+            if e.response.status_code == 404 and not _is_proxy_routing_failure(
+                e.response
+            ):
                 logger.debug(
                     "[%s.read_file] not found: %s", type(self).__name__, file_path
                 )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_filesystem.py
@@ -66,10 +66,24 @@ class BaasDeviceFileSystem(DeviceFileSystem):
             resp.raise_for_status()
             return resp.content
         except httpx.HTTPStatusError as e:
-            # Never swallow — a swallowed 401 (missing x-proxypass-token) used to
+            # An explicit 404 is the container answering "no such file", which the
+            # ``DeviceFileSystem.read_file`` contract represents as ``None`` — the
+            # same mapping ``TeclawDeviceFileSystem.read_file`` and
+            # ``LocalDeviceFileSystem._baas_read_file`` (same ``/api/file/read``
+            # endpoint) already apply. Keeping it here means core callers never have
+            # to know this provider speaks HTTP.
+            #
+            # Every other status still propagates, which is the point of the guard
+            # this replaces: a swallowed 401 (missing x-proxypass-token) used to
             # return empty content that callers treated as "file gone", silently
-            # dropping promoted files at draft→verify. Surface every failure (404
-            # included) so the caller fails loudly; ``exists`` catches 404 itself.
+            # dropping promoted files at draft→verify. Translating *only* a verified
+            # 404 keeps that failure impossible while honouring the contract —
+            # absence and unavailability stay distinguishable.
+            if e.response.status_code == 404:
+                logger.debug(
+                    "[%s.read_file] not found: %s", type(self).__name__, file_path
+                )
+                return None
             logger.error(
                 "[%s.read_file] HTTP %d: %s",
                 type(self).__name__, e.response.status_code, file_path,
@@ -176,12 +190,10 @@ class BaasDeviceFileSystem(DeviceFileSystem):
     async def exists(self, path: str) -> bool:
         # ``exists`` is a boolean probe, so a genuine 404 is the answer (False), not
         # an error — but auth/server failures must still surface (don't swallow).
-        try:
-            if await self.read_file(path) is not None:
-                return True
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code != 404:
-                raise
+        # ``read_file`` already maps 404 → ``None``; anything it still raises is a
+        # non-404 failure that must propagate, so it is deliberately not caught here.
+        if await self.read_file(path) is not None:
+            return True
         try:
             files = await self.list_dir(path)
         except httpx.HTTPStatusError as e:

--- a/src/backend/src/agentclaw/community/core/services/engine_config.py
+++ b/src/backend/src/agentclaw/community/core/services/engine_config.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 
+import httpx
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -50,6 +51,33 @@ logger = get_logger()
 # — a smell. Cleaner: make `config` a leaf-less namespace where each provider's mapper
 # owns the full filename, so callers pass no provider-specific name. Solve separately.
 _CONFIG_LOGICAL_PATH = f"{CONFIG_NS}/{TECLAW_ENGINE_CONFIG_FILE}"
+
+
+async def _read_config_bytes(device_fs) -> bytes | None:
+    """The engine config file's bytes, or ``None`` when the device has no such file.
+
+    A bot whose engine config has never been written has no file to read, and the
+    providers disagree about how they say so: teclaw/local answer ``None``, while
+    arca/baas surface the container's HTTP 404 as ``httpx.HTTPStatusError`` — their
+    ``read_file`` re-raises *every* status on purpose, because a swallowed 401 once
+    read as "file gone" and silently dropped promoted files at draft→verify.
+
+    This domain's contract is "absent means empty" (see the ``{}`` promise on both
+    read methods), so the 404 is reconciled here, once, for every caller and every
+    provider — the same seam ``IdentityService._device_read`` closes for identity
+    files, and for the same reason: without it a bot that simply has no config yet
+    answers 500, because ``httpx.HTTPStatusError`` is not in ``ENVELOPE_ERRORS``.
+
+    Every other status still propagates. A proxy 401, a sandbox 5xx, or a device
+    that is not reachable is a real failure, and reporting it as an unconfigured
+    bot would invite the caller to overwrite a config they never managed to read.
+    """
+    try:
+        return await device_fs.read_file(_CONFIG_LOGICAL_PATH)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return None
+        raise
 
 
 def _decode_config(content_bytes: bytes | None) -> dict:
@@ -89,8 +117,10 @@ class EngineConfigService:
 
         Returns:
             The parsed config dict on success; ``{}`` **only** when the config file is
-            missing or empty on the device. Every other failure is surfaced (raised),
-            never collapsed into an empty result.
+            missing or empty on the device — including the provider 404 arca/baas
+            raise for an absent file, which :func:`_read_config_bytes` reconciles.
+            Every other failure is surfaced (raised), never collapsed into an empty
+            result.
 
         Raises:
             DeviceNotBoundError: there is no resolvable active-stage device binding —
@@ -100,6 +130,8 @@ class EngineConfigService:
                 error (not masked as an empty config).
             json.JSONDecodeError: the config file exists but is not valid JSON
                 (the caller maps this to a malformed-config error response).
+            httpx.HTTPStatusError: the device answered with a failing status other
+                than 404 — a proxy 401, a sandbox 5xx. Only 404 means "no config".
         """
         owner_id = record.owner_id
         bot_id = record.source_bot_id
@@ -130,7 +162,7 @@ class EngineConfigService:
             ctx, namespace=CONFIG_NS, entity_type=entity_type, entity_id=entity_id,
             bot_id=bot_id, engine_type=engine_type,
         )
-        content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
+        content_bytes = await _read_config_bytes(device_fs)
         return _decode_config(content_bytes)
 
     # ── bot-level (draft/current binding) read + write ───────────────────────
@@ -165,14 +197,16 @@ class EngineConfigService:
     ) -> dict:
         """Read a bot's engine config from its own device, provider-blind.
 
-        Returns the parsed dict; ``{}`` only when the file is missing/empty. Resolve
-        errors and ``json.JSONDecodeError`` propagate (the caller surfaces them).
+        Returns the parsed dict; ``{}`` only when the file is missing/empty — a bot
+        that has never had a config written reads as empty on every provider, not as
+        an error (see :func:`_read_config_bytes`). Resolve errors, a non-404 device
+        status, and ``json.JSONDecodeError`` propagate (the caller surfaces them).
         """
         device_fs = self._bot_config_device_fs(
             bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
             entity_type=entity_type, engine_type=engine_type,
         )
-        content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
+        content_bytes = await _read_config_bytes(device_fs)
         return _decode_config(content_bytes)
 
     async def write_bot_config(

--- a/src/backend/src/agentclaw/community/core/services/engine_config.py
+++ b/src/backend/src/agentclaw/community/core/services/engine_config.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 
-import httpx
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -51,33 +50,6 @@ logger = get_logger()
 # — a smell. Cleaner: make `config` a leaf-less namespace where each provider's mapper
 # owns the full filename, so callers pass no provider-specific name. Solve separately.
 _CONFIG_LOGICAL_PATH = f"{CONFIG_NS}/{TECLAW_ENGINE_CONFIG_FILE}"
-
-
-async def _read_config_bytes(device_fs) -> bytes | None:
-    """The engine config file's bytes, or ``None`` when the device has no such file.
-
-    A bot whose engine config has never been written has no file to read, and the
-    providers disagree about how they say so: teclaw/local answer ``None``, while
-    arca/baas surface the container's HTTP 404 as ``httpx.HTTPStatusError`` — their
-    ``read_file`` re-raises *every* status on purpose, because a swallowed 401 once
-    read as "file gone" and silently dropped promoted files at draft→verify.
-
-    This domain's contract is "absent means empty" (see the ``{}`` promise on both
-    read methods), so the 404 is reconciled here, once, for every caller and every
-    provider — the same seam ``IdentityService._device_read`` closes for identity
-    files, and for the same reason: without it a bot that simply has no config yet
-    answers 500, because ``httpx.HTTPStatusError`` is not in ``ENVELOPE_ERRORS``.
-
-    Every other status still propagates. A proxy 401, a sandbox 5xx, or a device
-    that is not reachable is a real failure, and reporting it as an unconfigured
-    bot would invite the caller to overwrite a config they never managed to read.
-    """
-    try:
-        return await device_fs.read_file(_CONFIG_LOGICAL_PATH)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
-            return None
-        raise
 
 
 def _decode_config(content_bytes: bytes | None) -> dict:
@@ -117,10 +89,10 @@ class EngineConfigService:
 
         Returns:
             The parsed config dict on success; ``{}`` **only** when the config file is
-            missing or empty on the device — including the provider 404 arca/baas
-            raise for an absent file, which :func:`_read_config_bytes` reconciles.
-            Every other failure is surfaced (raised), never collapsed into an empty
-            result.
+            missing or empty on the device — a bot whose config has never been
+            written reads as empty, which every ``DeviceFileSystem`` reports as
+            ``None``. Every other failure is surfaced (raised), never collapsed into
+            an empty result.
 
         Raises:
             DeviceNotBoundError: there is no resolvable active-stage device binding —
@@ -130,8 +102,10 @@ class EngineConfigService:
                 error (not masked as an empty config).
             json.JSONDecodeError: the config file exists but is not valid JSON
                 (the caller maps this to a malformed-config error response).
-            httpx.HTTPStatusError: the device answered with a failing status other
-                than 404 — a proxy 401, a sandbox 5xx. Only 404 means "no config".
+
+        A device that is unreachable or refuses the read raises out of ``read_file``
+        rather than reading as an absent config — absence and unavailability must
+        stay distinguishable, or a caller would overwrite a config it never read.
         """
         owner_id = record.owner_id
         bot_id = record.source_bot_id
@@ -162,7 +136,7 @@ class EngineConfigService:
             ctx, namespace=CONFIG_NS, entity_type=entity_type, entity_id=entity_id,
             bot_id=bot_id, engine_type=engine_type,
         )
-        content_bytes = await _read_config_bytes(device_fs)
+        content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
         return _decode_config(content_bytes)
 
     # ── bot-level (draft/current binding) read + write ───────────────────────
@@ -199,14 +173,14 @@ class EngineConfigService:
 
         Returns the parsed dict; ``{}`` only when the file is missing/empty — a bot
         that has never had a config written reads as empty on every provider, not as
-        an error (see :func:`_read_config_bytes`). Resolve errors, a non-404 device
-        status, and ``json.JSONDecodeError`` propagate (the caller surfaces them).
+        an error. Resolve errors, a device that refuses the read, and
+        ``json.JSONDecodeError`` propagate (the caller surfaces them).
         """
         device_fs = self._bot_config_device_fs(
             bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
             entity_type=entity_type, engine_type=engine_type,
         )
-        content_bytes = await _read_config_bytes(device_fs)
+        content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
         return _decode_config(content_bytes)
 
     async def write_bot_config(

--- a/src/backend/src/agentclaw/community/core/services/identity.py
+++ b/src/backend/src/agentclaw/community/core/services/identity.py
@@ -284,10 +284,15 @@ class IdentityService:
             owner_id=owner_id,
             engine_type=engine_type,
         )
-        # 容器里没写过这个 identity 文件时,baas/arca 的 device_fs.read_file 会抛
-        # 404(plugin 故意不吞,见 BaasDeviceFileSystem.read_file 注释)。identity
-        # 域的契约是"缺省即空内容",由 service 层在这里收口,避免 router 吃 500、
-        # 前端打不开编辑器。非 404 的 HTTPStatusError(代理 401/沙箱 5xx 等)仍透出。
+        # identity 域的契约是"缺省即空内容"。``DeviceFileSystem.read_file`` 的契约
+        # 同样是"文件不存在 → None",baas/teclaw/local 都已按此实现,所以正常路径
+        # 不再依赖这里的 except。
+        #
+        # 保留它只为 ArcaDeviceFileSystem:该实现是 corp-only(见
+        # ``DeviceFileSystemResolver._resolve_arca``),本仓库看不到也测不到,若它仍
+        # 抛 404,这里兜住,避免 router 吃 500、前端打不开编辑器。等 arca 侧也按契约
+        # 把 404 收敛成 None,这段 except 就该整体删掉——core 不该认识 HTTP 状态码。
+        # 非 404 的 HTTPStatusError(代理 401/沙箱 5xx 等)始终透出。
         try:
             content_bytes = await device_fs.read_file(f"{IDENTITY_NS}/{file_type}")
         except httpx.HTTPStatusError as e:

--- a/src/backend/tests/community/core/services/test_engine_config_service.py
+++ b/src/backend/tests/community/core/services/test_engine_config_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
@@ -28,6 +29,20 @@ def _record(*, status: str = "success", binding: dict | None = None,
     return rec
 
 
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """The error arca/baas ``read_file`` raises — it re-raises every failing status.
+
+    Built from real httpx objects rather than a mock so the ``exc.response.status_code``
+    the service reads is the genuine attribute path, not one a MagicMock would answer
+    for regardless of what the service asked.
+    """
+    request = httpx.Request("POST", "https://device.invalid/api/file/read")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=request, response=response
+    )
+
+
 def _service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca"):
     bot_repo = MagicMock()
     bot_repo.get_by_id_and_owner.return_value = {"entity_id": "100018", "entity_type": "staff"}
@@ -41,7 +56,10 @@ def _service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca"):
         resolver.resolve_for_binding.return_value = ctx
 
     device_fs = MagicMock()
-    device_fs.read_file = AsyncMock(return_value=read_return)
+    if isinstance(read_return, Exception):
+        device_fs.read_file = AsyncMock(side_effect=read_return)
+    else:
+        device_fs.read_file = AsyncMock(return_value=read_return)
     dispatcher = MagicMock()
     dispatcher.dispatch_addressed.return_value = device_fs
 
@@ -142,7 +160,10 @@ def _bot_service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca
         resolver.resolve_for_bot.return_value = ctx
 
     device_fs = MagicMock()
-    device_fs.read_file = AsyncMock(return_value=read_return)
+    if isinstance(read_return, Exception):
+        device_fs.read_file = AsyncMock(side_effect=read_return)
+    else:
+        device_fs.read_file = AsyncMock(return_value=read_return)
     device_fs.write_file = AsyncMock()
     dispatcher = MagicMock()
     dispatcher.dispatch_addressed.return_value = device_fs
@@ -208,3 +229,56 @@ async def test_bot_config_resolve_failure_propagates():
     with pytest.raises(DeviceNotBoundError):
         await svc.read_bot_config(**_BOT_COORDS)
     dispatcher.dispatch_addressed.assert_not_called()
+
+
+# ── an absent config file, however the provider says so ──────────────────────
+#
+# Regression: a bot whose engine config had never been written answered 500 on
+# GET /openapi/v1/bots/{bot_id}/engine-config. arca/baas report an absent file as
+# HTTP 404 and their read_file re-raises it (deliberately — a swallowed 401 once
+# read as "file gone"), nothing between there and the router caught it, and
+# httpx.HTTPStatusError is not in ENVELOPE_ERRORS, so it escaped as an unhandled
+# 500. The domain contract is "absent means empty" for every provider.
+
+
+@pytest.mark.asyncio
+async def test_read_bot_config_absent_file_404_returns_empty_dict():
+    svc, _, _, device_fs = _bot_service(read_return=_http_status_error(404))
+
+    assert await svc.read_bot_config(**_BOT_COORDS) == {}
+    device_fs.read_file.assert_awaited_once_with("config/teclaw.json")
+
+
+@pytest.mark.asyncio
+async def test_read_publish_config_absent_file_404_returns_empty_dict():
+    svc, _, _, _ = _service(read_return=_http_status_error(404))
+
+    data = await svc.read_publish_config(
+        _record(status="success", binding={"online": 7}), "openclaw"
+    )
+
+    assert data == {}
+
+
+@pytest.mark.asyncio
+async def test_read_bot_config_non_404_device_status_propagates():
+    """A proxy 401 / sandbox 5xx is a real failure and must not read as "no config".
+
+    Reporting one as an empty config would invite the caller to overwrite a config
+    they never managed to read — the same swallowed-401 failure mode that made
+    read_file re-raise every status in the first place.
+    """
+    for status in (401, 403, 500, 502):
+        svc, _, _, _ = _bot_service(read_return=_http_status_error(status))
+        with pytest.raises(httpx.HTTPStatusError):
+            await svc.read_bot_config(**_BOT_COORDS)
+
+
+@pytest.mark.asyncio
+async def test_read_publish_config_non_404_device_status_propagates():
+    for status in (401, 500):
+        svc, _, _, _ = _service(read_return=_http_status_error(status))
+        with pytest.raises(httpx.HTTPStatusError):
+            await svc.read_publish_config(
+                _record(status="success", binding={"online": 7}), "openclaw"
+            )

--- a/src/backend/tests/community/core/services/test_engine_config_service.py
+++ b/src/backend/tests/community/core/services/test_engine_config_service.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
@@ -27,20 +26,6 @@ def _record(*, status: str = "success", binding: dict | None = None,
     rec.status = status
     rec.ext = {"binding": binding} if binding is not None else {}
     return rec
-
-
-def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
-    """The error arca/baas ``read_file`` raises — it re-raises every failing status.
-
-    Built from real httpx objects rather than a mock so the ``exc.response.status_code``
-    the service reads is the genuine attribute path, not one a MagicMock would answer
-    for regardless of what the service asked.
-    """
-    request = httpx.Request("POST", "https://device.invalid/api/file/read")
-    response = httpx.Response(status_code, request=request)
-    return httpx.HTTPStatusError(
-        f"HTTP {status_code}", request=request, response=response
-    )
 
 
 def _service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca"):
@@ -231,54 +216,31 @@ async def test_bot_config_resolve_failure_propagates():
     dispatcher.dispatch_addressed.assert_not_called()
 
 
-# ── an absent config file, however the provider says so ──────────────────────
+# ── a device failure is not an absent config ─────────────────────────────────
 #
-# Regression: a bot whose engine config had never been written answered 500 on
-# GET /openapi/v1/bots/{bot_id}/engine-config. arca/baas report an absent file as
-# HTTP 404 and their read_file re-raises it (deliberately — a swallowed 401 once
-# read as "file gone"), nothing between there and the router caught it, and
-# httpx.HTTPStatusError is not in ENVELOPE_ERRORS, so it escaped as an unhandled
-# 500. The domain contract is "absent means empty" for every provider.
+# Regression guard for the fix's shape. An unwritten config now reads as {} because
+# BaasDeviceFileSystem maps a verified 404 to None at the boundary (see
+# tests/community/plugins/prod/test_baas_device_filesystem.py), NOT because this
+# service catches transport errors — core stays transport-agnostic per AGENTS.md.
+# So anything read_file still raises must travel straight through: absence and
+# unavailability have to stay distinguishable, or a caller would overwrite a config
+# it never managed to read. These use a plain exception on purpose; a core test that
+# named an HTTP error would re-import the coupling the fix removed.
 
 
 @pytest.mark.asyncio
-async def test_read_bot_config_absent_file_404_returns_empty_dict():
-    svc, _, _, device_fs = _bot_service(read_return=_http_status_error(404))
+async def test_read_bot_config_device_read_failure_propagates():
+    svc, _, _, _ = _bot_service(read_return=RuntimeError("device unreachable"))
 
-    assert await svc.read_bot_config(**_BOT_COORDS) == {}
-    device_fs.read_file.assert_awaited_once_with("config/teclaw.json")
-
-
-@pytest.mark.asyncio
-async def test_read_publish_config_absent_file_404_returns_empty_dict():
-    svc, _, _, _ = _service(read_return=_http_status_error(404))
-
-    data = await svc.read_publish_config(
-        _record(status="success", binding={"online": 7}), "openclaw"
-    )
-
-    assert data == {}
+    with pytest.raises(RuntimeError, match="device unreachable"):
+        await svc.read_bot_config(**_BOT_COORDS)
 
 
 @pytest.mark.asyncio
-async def test_read_bot_config_non_404_device_status_propagates():
-    """A proxy 401 / sandbox 5xx is a real failure and must not read as "no config".
+async def test_read_publish_config_device_read_failure_propagates():
+    svc, _, _, _ = _service(read_return=RuntimeError("device unreachable"))
 
-    Reporting one as an empty config would invite the caller to overwrite a config
-    they never managed to read — the same swallowed-401 failure mode that made
-    read_file re-raise every status in the first place.
-    """
-    for status in (401, 403, 500, 502):
-        svc, _, _, _ = _bot_service(read_return=_http_status_error(status))
-        with pytest.raises(httpx.HTTPStatusError):
-            await svc.read_bot_config(**_BOT_COORDS)
-
-
-@pytest.mark.asyncio
-async def test_read_publish_config_non_404_device_status_propagates():
-    for status in (401, 500):
-        svc, _, _, _ = _service(read_return=_http_status_error(status))
-        with pytest.raises(httpx.HTTPStatusError):
-            await svc.read_publish_config(
-                _record(status="success", binding={"online": 7}), "openclaw"
-            )
+    with pytest.raises(RuntimeError, match="device unreachable"):
+        await svc.read_publish_config(
+            _record(status="success", binding={"online": 7}), "openclaw"
+        )

--- a/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
@@ -53,9 +53,18 @@ async def test_read_file_calls_transport_post():
 
 
 @pytest.mark.asyncio
-async def test_read_file_raises_on_404():
-    """A failed read must NOT be swallowed — surface every HTTP error (404 included)
-    so a silent 401 can't masquerade as an empty/missing file (the file-loss bug)."""
+async def test_read_file_returns_none_on_404():
+    """An explicit 404 is the container saying "no such file" — the contract's ``None``.
+
+    ``DeviceFileSystem.read_file`` documents "bytes, or None if file does not exist",
+    and the two impls hitting the same read endpoint (TeclawDeviceFileSystem,
+    LocalDeviceFileSystem._baas_read_file) already answer None. Raising here instead
+    forced every core caller to catch httpx and made an unconfigured bot a 500.
+
+    This is narrower than the guard it replaces, not weaker: only a *verified* 404
+    becomes None, so the swallowed-401 file-loss bug stays impossible — see
+    ``test_read_file_raises_on_401`` and ``test_read_file_raises_on_5xx``.
+    """
     from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
     err_resp = httpx.Response(
         status_code=404, content=b"not found",
@@ -63,8 +72,26 @@ async def test_read_file_raises_on_404():
     )
     transport = _make_transport(response=err_resp)
     fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
-    with pytest.raises(httpx.HTTPStatusError):
-        await fs.read_file("/missing")
+    assert await fs.read_file("/missing") is None
+
+
+@pytest.mark.asyncio
+async def test_read_file_raises_on_5xx():
+    """A server failure is unavailability, not absence — it must not read as None.
+
+    Collapsing it would let a caller treat an unreachable runtime as an empty file
+    and overwrite content it never managed to read.
+    """
+    from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
+    for status in (500, 502, 503):
+        err_resp = httpx.Response(
+            status_code=status, content=b"boom",
+            request=httpx.Request("POST", "http://fake/"),
+        )
+        transport = _make_transport(response=err_resp)
+        fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
+        with pytest.raises(httpx.HTTPStatusError):
+            await fs.read_file("/foo")
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_device_filesystem.py
@@ -76,6 +76,47 @@ async def test_read_file_returns_none_on_404():
 
 
 @pytest.mark.asyncio
+async def test_read_file_raises_on_proxy_routing_404():
+    """A proxy 404 means the bot/device is gone — unavailability, not an absent file.
+
+    ``DesktopBaasInvokeTransport`` reaches the device through secbaas'
+    ``invoke-http`` router, which answers 404 with its own error body when it cannot
+    route to a device — before the request reaches the device at all. Mapping that to
+    ``None`` would report a gone bot as "engine config is {}", the exact
+    absence/unavailability conflation the surrounding guard exists to prevent.
+    """
+    from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
+    for marker in ("BOT_NOT_FOUND", "NO_DEVICES_FOUND"):
+        err_resp = httpx.Response(
+            status_code=404,
+            json={"detail": {"error": marker, "message": "gone", "bot_uuid": "b1"}},
+            request=httpx.Request("POST", "http://fake/"),
+        )
+        transport = _make_transport(response=err_resp)
+        fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
+        with pytest.raises(httpx.HTTPStatusError):
+            await fs.read_file("/some/file")
+
+
+@pytest.mark.asyncio
+async def test_read_file_returns_none_on_json_404_that_is_not_a_proxy_error():
+    """Only the proxy's own markers re-raise; a device 404 with a JSON body is absence.
+
+    The proxy emits exactly two 404s of its own, so any other 404 — whatever its body
+    looks like — travelled through it from the device.
+    """
+    from agentclaw.community.core.devices.services.baas_device_filesystem import BaasDeviceFileSystem
+    err_resp = httpx.Response(
+        status_code=404,
+        json={"detail": "file not found"},
+        request=httpx.Request("POST", "http://fake/"),
+    )
+    transport = _make_transport(response=err_resp)
+    fs = BaasDeviceFileSystem(transport=transport, conn_info=_conn_info(), path_mapper=lambda p: p)
+    assert await fs.read_file("/missing") is None
+
+
+@pytest.mark.asyncio
 async def test_read_file_raises_on_5xx():
     """A server failure is unavailability, not absence — it must not read as None.
 


### PR DESCRIPTION
## Problem

A bot whose engine configuration has never been written answers **500** on
`GET /openapi/v1/bots/{bot_id}/engine-config`. Reproduced against Pre:

```
[BaasDeviceFileSystem.read_file] HTTP 404: .../staff_272471/20260812_1k42fup2/claude_code/config.json
openapi_access method=GET route=/openapi/v1/bots/{bot_id}/engine-config status=- error=HTTPStatusError
```

The root cause is a contract violation one layer down. `DeviceFileSystem.read_file`
documents its return as *"File content as bytes, or `None` if file does not exist"*,
and two of the three implementations honor it:

| Implementation | Missing file |
| --- | --- |
| `TeclawDeviceFileSystem.read_file` | → `None` |
| `LocalDeviceFileSystem._baas_read_file` (same `/api/file/read` endpoint) | → `None` |
| `BaasDeviceFileSystem.read_file` | **raises `httpx.HTTPStatusError`** |

`BaasDeviceFileSystem` re-raised every failing status, 404 included. Nothing between
there and the router caught it, and `httpx.HTTPStatusError` is not in
`ENVELOPE_ERRORS`, so it escaped the envelope as an unhandled 500.

Because the boundary broke its contract, the workaround was propagating into core:
`IdentityService._device_read` had already grown its own `httpx` 404 catch for exactly
this reason, and engine-config needed a second copy.

The same defect reaches the internal UI route `GET /api/bots/{bot_id}/engine-config`,
where a blanket `except Exception` masks it as HTTP 200 with
`success: false, error_code: 500` — an error toast instead of a config editor.

## Solution

Fix it at the boundary: `BaasDeviceFileSystem.read_file` now maps a **device-level**
404 to `None`, matching the contract and the two implementations that already comply.
Core's engine-config reads go back to plain `read_file` calls with no `httpx` import,
so the service stays transport-agnostic per `AGENTS.md`.

"Device-level" is doing real work in that sentence. On the desktop path,
`DesktopBaasInvokeTransport` reaches the device through secbaas'
`/api/v1/bots/{tenant}/{bot_uuid}/invoke-http/{port}{path}` router, and
`invoke_http_in_bot` answers **404 for its own routing failures** —
`HTTPException(404, detail={"error": "BOT_NOT_FOUND" | "NO_DEVICES_FOUND", ...})` —
before the request reaches the device at all. So the status code alone cannot
distinguish "no such file" from "no such bot"; only the body can.
`_is_proxy_routing_failure` re-raises those two markers and maps every other 404 to
`None`, which is sound rather than merely convenient: the proxy emits exactly these two
404s of its own, so any other 404 travelled through it from the device. Its
no-active-devices case is a **503** and never reaches the branch. The cloud
`BaasInvokeTransport` doesn't use that router — it resolves the device via
`get_http_info` first and raises `BaasServiceError` — so this only fires on desktop,
but the check is unconditional since a device has no reason to answer in the proxy's
error shape.

**The result is narrower than the guard it replaces, not weaker.** That guard existed
because a swallowed 401 (missing `x-proxypass-token`) once returned empty content that
callers read as "file gone", silently dropping promoted files at draft→verify.
Translating only a verified device 404 keeps that impossible — 401, 5xx, and
proxy-routing 404s all still propagate, so absence stays distinguishable from
unavailability. The case it protected, `teclaw_file_promotion.py:151`, already treats
`None` as a hard failure (`TeclawFilePromotionError: source file unreadable`), so
promotion still fails loudly.

`exists()` no longer needs its own 404 catch on the read path; non-404 still
propagates from it untouched. `DesktopBaasDeviceFileSystem` inherits the fix.

Rejected alternative: **catching `httpx.HTTPStatusError` in `EngineConfigService`.**
That was the first commit here, and it was wrong — it makes a provider-blind core
service depend on HTTP status codes, violates the transport-agnostic rule, and fixes
only the one caller while leaving the next one to rediscover the same workaround.
Caught in review (P1, thread resolved).

### Known remaining gap

`ArcaDeviceFileSystem` is corp-only — `DeviceFileSystemResolver._resolve_arca` raises
in community — so the same fix cannot be applied to it from this repository. The
`httpx` catch in `IdentityService._device_read` is therefore left in place as a guard
for that implementation alone, with its comment rewritten to say so and to state that
it should be deleted once arca honors the contract. That is the only place core still
knows a status code, and it is now marked as debt rather than presented as the design.

## Validation

- Full `tests/community` suite — **11,705 passed**, 3 skipped.
  - The 2 failures in `test_bot_build_service_skill_artifact.py` are environmental
    (`rsync` is not installed in this container) and reproduce identically on a
    stashed clean tree.
- `tests/community/plugins/prod/test_baas_device_filesystem.py`:
  - `test_read_file_raises_on_404` → `test_read_file_returns_none_on_404`.
  - `test_read_file_raises_on_5xx` (500/502/503) added alongside the existing 401 test.
  - `test_read_file_raises_on_proxy_routing_404` covers both proxy markers in the real
    FastAPI-nested body shape.
  - `test_read_file_returns_none_on_json_404_that_is_not_a_proxy_error` pins that a JSON
    404 which isn't a proxy error is still absence.
  - `test_exists_returns_false_on_404` / `test_exists_raises_on_401` pass unchanged.
- `tests/community/core/services/test_engine_config_service.py` — the absent-file case
  is covered by the pre-existing `None`/empty tests; added two propagation guards using
  a plain exception, so a core test never re-imports the HTTP coupling this removes.
- `tests/community/architecture` — 135 passed.
- `ruff check` on all changed files — clean.

Not run: the acceptance E2E suite and the Pre-environment request itself. The original
`curl` should now return `200` with `data: {}`; I have no access to that environment to
confirm.

## Compatibility and risk

Two layers change.

**`BaasDeviceFileSystem.read_file`** — a missing file now returns `None` instead of
raising. This is a shared seam, so the full suite was run rather than a targeted
subset. Callers that treat `None` as failure keep failing (promotion); callers that
treat it as absence now work (engine-config, identity, resources). A gone bot or
device still raises, so the change does not make unavailability look like absence.

**Three endpoints**, all moving the same direction — an unconfigured bot reads as an
empty config instead of failing:

| Endpoint | Before | After |
| --- | --- | --- |
| `GET /openapi/v1/bots/{bot_id}/engine-config` | 500 | 200, `data: {}` |
| `GET /api/bots/{bot_id}/engine-config` | 200, `success: false` | 200, `success: true`, `data: {}` |
| `GET /api/service-bot/publish/{publish_id}/engine-config` | 500 on an unwritten stage config | 200, `data: {}` |

The published OpenAPI docstring now states the empty-object behavior, so the schema
snapshot for that description changes.

Rollback is the revert; nothing is persisted or migrated.

## Related issues

Two follow-ups found while investigating, deliberately **not** in this PR:

1. **Engine-config GET/PUT are draft-only.** Both resolve `resolve_for_bot`
   (`ac_bots.binding_id`), so a service bot's verify/online runtimes are unreachable —
   unlike the connection API, which takes `?stage=`. `core/engine_runtime/stage.py`
   already has the machinery. PUT against a published stage should be refused rather
   than mutating an immutable runtime. Being handled separately, across the other
   OpenAPI endpoints with the same gap.
2. **Two divergent stage-selection rules.** `EngineConfigService.read_publish_config`
   uses `select_stage_bind_id(ext.binding, record.status)` while `stage.py` uses
   `resolve_stage_bind_id(stage → record)`, which additionally handles a verify runtime
   retained after promotion. `stage.py`'s module docstring exists to prevent exactly
   this drift.

Noted in passing, not touched: `TeclawDeviceFileSystem.read_file` returns `None` for
*every* exception including 401/5xx — the same swallowed-auth failure mode the BaaS
guard was written against, and it has no proxy-404 discrimination either. Pre-existing
and out of scope here.