### PR TITLE
feat(backend): address published runtimes on the per-bot file endpoints

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -744,6 +744,8 @@ rule as `user_id` (query string, never a body field or a path segment):
 GET /openapi/v1/bots/b-1/sessions?user_id=u-collab&owner_id=u-owner            collaborator, team bot
 GET /openapi/v1/bots/b-1/engine/status?user_id=u-owner&stage=online            owner, live runtime
 GET /openapi/v1/bots/b-1/connection?user_id=u-collab&owner_id=u-owner&stage=verify
+GET /openapi/v1/bots/b-1/engine/config?user_id=u-owner&stage=online            the release's own config
+GET /openapi/v1/bots/b-1/identity/RULES?user_id=u-owner&stage=verify           what verify received
 ```
 
 - **`owner_id`** — the owner of the bot the request addresses. Defaults to
@@ -759,6 +761,63 @@ GET /openapi/v1/bots/b-1/connection?user_id=u-collab&owner_id=u-owner&stage=veri
   published stage named on a personal bot — is `409` `"No live runtime at
   the requested stage"`, never a fallback to another stage's binding.
   (`eval` has no long-lived runtime and is not addressable.)
+
+### `?stage=` beyond the operator console
+
+Five more operations take it — the ones that read or write a file **on** a
+runtime, rather than forwarding a request to it:
+
+```text
+GET, PUT  /openapi/v1/bots/{bot_id}/engine/config
+GET       /openapi/v1/bots/{bot_id}/identity
+GET, PUT  /openapi/v1/bots/{bot_id}/identity/{file_type}
+```
+
+Same vocabulary, same default, same liveness rule. Two differences worth
+knowing:
+
+- **The reads serve all three stages; the writes accept only the draft.** A
+  published runtime is what a release produced and is replaced by publishing
+  again, never edited, so `PUT …?stage=verify` or `?stage=online` is refused
+  with `409` `"The requested stage is read-only"` and **nothing is written** —
+  not to the published runtime, and not to the draft as a substitute. This is
+  deliberately not a `200` carrying a no-op flag: automation that checks the
+  status code would record the write as landed. It is also a different answer
+  from `"No live runtime at the requested stage"`, which would send a caller
+  off to publish something and retry; publishing would not make the write land.
+- **The list reports one runtime.** `GET …/identity?stage=verify` probes every
+  identity file against the verify runtime, so a caller never sees a draft row
+  beside a verify row.
+
+These five carry `user_id`, not `owner_id`: they are owner-scoped, not operator
+console operations, and reaching another owner's bot through them is not
+offered.
+
+**The retiring addresses do not take `stage`.** `…/bots/identity/{bot_id}`,
+`…/bots/{bot_id}/engine-config` and their siblings answer with the contract they
+were frozen with, which is the draft. A caller who sends the parameter at one of
+them gets the draft, because the parameter is not declared there. The
+engine-runtime groups are the exception and not a contradiction: their retiring
+addresses *do* publish `stage`, because they took it before the freeze, so it is
+part of the contract those addresses are frozen with.
+
+### Per-bot device surfaces that are still draft-only
+
+Named so a reader looking for them stops here rather than in the source:
+
+- **Startup script** (`GET`/`PUT`/`DELETE …/{bot_id}/startup-script`) takes no
+  `stage`, and that is not an omission. It is backed by
+  `ac_bot_startup_script`, keyed `(env, entity_id, bot_id)` — one row per bot,
+  not one per runtime — so the parameter would be inert.
+- **MCP** addresses no bot at all; its six operations are keyed by
+  `server_code` and `user_id`. The config write does fan out to every bot's
+  **draft** device, which is correct for the same reason the writes above are
+  draft-only: a release inlines its MCP credentials into the artifact, so a
+  published runtime's config changes by republishing.
+- **Resources, skills and routines** read or write per-bot device state and are
+  still draft-only. Deferred, with reasons, in
+  `specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md`; routines'
+  stage pin is [#908](https://github.com/inclusionAI/Avernet/issues/908).
 
 **What an operator sees is device-wide, by documented contract.** The
 engine's session collection is not scoped per caller — the engine ports drop
@@ -792,8 +851,11 @@ addresses still publish the old name (spec Open Question 1, closed).
 `tests/…/openapi_v1/engine_runtime/test_operator_access.py` sweeps the
 operator matrix across all sixteen operations;
 `…/test_stage_addressing.py` pins the stage behaviour and asserts the two
-parameters sit on exactly the sixteen, optional, in the query;
-`tests/community/core/engine_runtime/test_stage.py` pins the liveness rule.
+parameters sit on exactly the operations listed above — optional, in the query,
+and on no retiring address that did not already have them;
+`tests/community/core/engine_runtime/test_stage.py` pins the liveness rule;
+`…/openapi_v1/test_stage_addressed_bot_files.py` pins the five file operations,
+including that their retiring twins still read the draft.
 
 ---
 

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -793,13 +793,24 @@ These five carry `user_id`, not `owner_id`: they are owner-scoped, not operator
 console operations, and reaching another owner's bot through them is not
 offered.
 
-**The retiring addresses do not take `stage`.** `…/bots/identity/{bot_id}`,
-`…/bots/{bot_id}/engine-config` and their siblings answer with the contract they
-were frozen with, which is the draft. A caller who sends the parameter at one of
-them gets the draft, because the parameter is not declared there. The
-engine-runtime groups are the exception and not a contradiction: their retiring
-addresses *do* publish `stage`, because they took it before the freeze, so it is
-part of the contract those addresses are frozen with.
+**These five retiring addresses do not take `stage`:**
+
+```text
+GET, PUT  /openapi/v1/bots/{bot_id}/engine-config
+GET       /openapi/v1/bots/identity/{bot_id}
+GET, PUT  /openapi/v1/bots/identity/{bot_id}/{file_type}
+```
+
+They answer with the contract they were frozen with, which is the draft. A
+caller who sends the parameter at one of them gets the draft, because the
+parameter is not declared there — including on the two writes, which therefore
+answer `200` and write the draft where their replacements answer `409` and write
+nothing. That divergence is the strongest reason to migrate.
+
+This is **not** a statement about every retiring address. The engine-runtime
+ones — `…/bots/sessions/{bot_id}`, `…/bots/engine/{bot_id}/status` and the rest
+— *do* publish `stage` and honour it, because they took it before the freeze, so
+it is part of the contract they were frozen with.
 
 ### Per-bot device surfaces that are still draft-only
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -206,24 +206,19 @@ adapters/http/openapi_v1/responses.py
   constrains: the deprecated addresses it registers are frozen byte for byte and
   must **not** gain `stage` (spec D7).
 
-  It also rewrites the two suites this feature extends —
-  `test_stage_addressing.py`'s prefix test becomes the `_is_engine_runtime()`
-  segment test, and `_OWNER_ADDRESSED_ELSEWHERE` gains the two skills
-  operations. Task D4 is written against that shape, not today's.
+  It also rewrites the suite Task D4 extends: `test_stage_addressing.py`'s
+  prefix test becomes `_is_engine_runtime()`, backed by an
+  `_engine_runtime_paths()` set read off the mounted routers (current groups
+  plus the deprecated package's). Task D4 is written against that shape, not
+  today's. Its `_OWNER_ADDRESSED_ELSEWHERE` also gains the two skills
+  operations, now that they spell the locator `owner_id`.
 
 - **PR #1073** (`fix(backend): read an unwritten engine config as empty, not
-  500`) is open against `dev` and touches
-  `core/services/engine_config.py` — the same file Task B1 edits, in the same
-  two read methods.
-
-  This branch is based on **`dev`**, not on #1073, so the two changes are
-  independent until B1 lands. Whichever merges second resolves the overlap; if
-  #1073 is still open when implementation starts, rebase onto its head first so
-  B1 is written against the `_read_config_bytes` helper it introduces rather
-  than against the raw `device_fs.read_file` call it replaces. The two edits are
-  compatible in substance — #1073 changes *how a missing file is decoded*, B1
-  changes *which device is read* — so this is a textual conflict, not a design
-  one.
+  500`) — **merged to `dev` as `a5afd54`.** No longer a conflict to manage:
+  Task B1 edits `read_bot_config`/`read_publish_config` as #1073 left them, so
+  the read goes through its `_read_config_bytes` helper rather than a raw
+  `device_fs.read_file`. #1074 carried the same merge and reports one conflict
+  on the relocated handler, resolved in its favour.
 
 ## Risks & Mitigations
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -8,9 +8,9 @@ already publish the parameter, and `EngineConnectionService._stage_binding_id`
 is the worked example. Three things are missing and this plan adds exactly
 those:
 
-1. A core helper that goes one step further than `resolve_stage_bind_id` —
-   stage → **`DeviceContext`** — because a file surface needs to address a
-   filesystem, not forward a request. `EngineConfigService` and
+1. A core helper that goes one step further than `resolve_stage_bind_id` — a
+   published stage → **`DeviceContext`** — because a file surface needs to
+   address a filesystem, not forward a request. `EngineConfigService` and
    `IdentityService` both call it, so the two cannot drift from each other or
    from the relay.
 2. A core refusal for a write addressed to a published runtime, mapped once.
@@ -23,12 +23,16 @@ lookup, no new error — and the published branch is the only new path.
 
 ## The rules
 
-- **Reads** carry a `StageAddress` — stage plus the `(bot_pk, bot_type)` from
-  the read that proved the caller's ownership. Published stages need both; the
-  draft reads neither.
-- **Writes** carry only a stage name. `require_stage_writable` refuses anything
+- **One bot-identity model.** `BotFacts` with `stage: str` beside it — the shape
+  the relay and the Service API Protocol already use (spec D8). No new value
+  object.
+- **Reads** take `stage: str`. The draft branch is the existing
+  `resolve_for_bot(bot_id, owner_id)` call, unchanged. The published branch
+  resolves `BotFacts` from an owner-scoped read *inside the service*, then goes
+  through the shared rule.
+- **Writes** take `stage: str` too. `require_stage_writable` refuses anything
   but the draft as the first statement of the method, then the draft is
-  resolved. There is no code path from a write to a published binding.
+  resolved. A write never reaches the facts-resolving branch at all.
 - **Stage-keyed → `resolve_stage_bind_id`. Record-keyed →
   `select_stage_bind_id`.** Stated in both modules' docstrings and at all four
   call sites (spec D3).
@@ -38,14 +42,16 @@ lookup, no new error — and the published branch is the only new path.
 | Component | Change |
 | --- | --- |
 | `core/engine_runtime/errors.py` | new `EngineStageReadOnlyError` |
-| `core/engine_runtime/stage.py` | `StageAddress`, `DRAFT_ADDRESS`, `require_stage_writable`, `resolve_stage_device_context`; docstring records the second rule |
-| `core/services/engine_config.py` | two new constructor deps; read takes `address`, write takes `stage` |
-| `core/services/identity.py` | one new constructor dep; `address` threaded down the read path; `stage` on the write |
+| `core/engine_runtime/models.py` | `BotFacts.from_record` — one projection of a bot row into facts |
+| `core/engine_runtime/relay.py` | its one `BotFacts(...)` construction moves onto `from_record` |
+| `core/engine_runtime/stage.py` | `require_stage_writable`, `resolve_published_device_context`; docstring records the second rule |
+| `core/services/engine_config.py` | two new constructor deps; `_bot_facts`; read and write each take `stage: str` |
+| `core/services/identity.py` | one new constructor dep; `_bot_facts`; `stage: str` threaded down the read path and on the write |
 | `api/engine_config_service.py` | Protocol mirrors both signatures |
 | `adapters/http/openapi_v1/engine_runtime/params.py` | `WRITE_STAGE_DESCRIPTION`, `WriteStageQuery` |
 | `adapters/http/openapi_v1/responses.py` | `EngineStageReadOnlyError → (409, …)` |
 | the engine-config router #1074 Task 15 creates at `/openapi/v1/bots/{bot_id}/engine` | `stage` on its two handlers |
-| `adapters/http/openapi_v1/identity/router.py` | `stage` on the three handlers; `BotRepository` injected for the published branch |
+| `adapters/http/openapi_v1/identity/router.py` | `stage` on the three handlers — nothing else |
 | `adapters/http/bot_management/router.py` | two internal call sites say `draft` explicitly |
 | `docs/openapi-v1/README.md` | the stage section covers 21 operations, not 16 |
 
@@ -59,112 +65,138 @@ this addresses them.
 ### The core seam
 
 ```python
+# core/engine_runtime/models.py — one projection of a bot row into facts
+@classmethod
+def from_record(cls, record: dict, *, bot_id: str, owner_id: str) -> "BotFacts":
+    """The narrow facts, from an owner-scoped ``(bot_id, owner_id)`` row."""
+
 # core/engine_runtime/stage.py
-
-@dataclass(frozen=True)
-class StageAddress:
-    stage: str
-    bot_pk: int      # from the ownership-proving read; unread on draft
-    bot_type: str    # decides whether a published stage is refused
-
-DRAFT_ADDRESS = StageAddress(stage=STAGE_DRAFT, bot_pk=0, bot_type="")
-
 def require_stage_writable(stage: str) -> None:
     """Refuse a write to a published runtime. Not conditional on bot type or
     liveness — neither changes the answer, and both would need a lookup."""
 
-def resolve_stage_device_context(
-    resolver, publish_repo, binding_repo, *, address, bot_id, owner_id
+def resolve_published_device_context(
+    resolver, publish_repo, binding_repo, *, facts: BotFacts, stage: str
 ) -> DeviceContext:
-    require_stage_addressable(address.bot_type, address.stage)
-    if address.stage == STAGE_DRAFT:
-        return resolver.resolve_for_bot(bot_id, owner_id)          # unchanged path
+    """The device context of the published runtime ``stage`` names."""
+    require_stage_addressable(facts.bot_type, stage)
     bind_id = resolve_stage_bind_id(publish_repo, binding_repo,
-                                    bot_pk=address.bot_pk, bot_id=bot_id,
-                                    stage=address.stage, env=get_current_env())
-    return resolver.resolve_for_binding(bind_id, owner_id, bot_id=bot_id)
+                                    bot_pk=facts.bot_pk, bot_id=facts.bot_id,
+                                    stage=stage, env=get_current_env())
+    return resolver.resolve_for_binding(bind_id, facts.owner_id, bot_id=facts.bot_id)
 ```
 
-`resolve_for_binding`, not the relay's `resolve_for_binding_invoke`: callers
-here address a **filesystem** on the resolved device and need the full
-connection info the invoke variant deliberately omits.
+**Published-only, and the branch stays at the caller** — which is exactly
+`relay._resolve_device`'s structure, where the draft leg is an inline
+`resolve_for_bot` and the published leg is a separate method. Each service reads:
 
-`StageAddress` is one value rather than three parameters because identity
-threads it four levels deep (`get_bot_file` → `read_identity_file` →
-`_device_read` → `_identity_device_fs`); three parameters at each hop is three
-chances to drop one.
+```python
+if stage == STAGE_DRAFT:
+    ctx = self._resolver.resolve_for_bot(bot_id, owner_id)   # unchanged; no row read
+else:
+    facts = self._bot_facts(bot_id, owner_id)                # owner-scoped
+    ctx = resolve_published_device_context(
+        self._resolver, self._publish_repo, self._binding_repo,
+        facts=facts, stage=stage,
+    )
+```
+
+Two notes on why it is shaped this way rather than as one function covering both
+legs: a helper that handled the draft would need `BotFacts` for the draft, which
+is the row read the compatibility requirement forbids; and
+`require_stage_addressable` needs `bot_type`, which only the published branch has
+resolved — so a personal bot naming `verify` costs one row read and is then
+refused, before any device work.
+
+`resolve_for_binding`, not the relay's `resolve_for_binding_invoke`: callers here
+address a **filesystem** on the resolved device and need the full connection info
+the invoke variant deliberately omits. That single differing line is why this is
+a sibling of `relay._resolve_published_device` rather than a shared body; what
+they *do* share is `resolve_stage_bind_id`, which is the rule that must not
+drift.
+
+`BotFacts.from_record` is the one touch outside the feature: the relay's single
+construction site moves onto it, so there is one projection of a bot row into
+facts rather than two. Reversible in isolation if a reviewer disagrees.
 
 ### The service signatures
 
 ```python
 # core/services/engine_config.py  (+ api/engine_config_service.py, identically)
 async def read_bot_config(self, *, bot_id, owner_id, entity_id, entity_type,
-                          engine_type, address: StageAddress) -> dict: ...
+                          engine_type, stage: str) -> dict: ...
 async def write_bot_config(self, *, bot_id, owner_id, entity_id, entity_type,
                            engine_type, config, stage: str) -> None: ...
 ```
 
-**Required, not defaulted, on this pair only.** The conformance test
-(`test_service_api_conformance.py`) compares defaults *by value*, so a default
-would force `api/` to import `core.engine_runtime` at runtime — and that
-package's import graph reaches the DI container and a partially-initialised
-`bot_service`. Verified: it raises `ImportError` when `api/engine_config_service`
-is imported first. Both adapters therefore state the runtime they address, which
-reads better regardless.
+One added parameter, the same `str` the relay carries.
 
-`IdentityService` has no Protocol and many internal callers
-(`bot_profile`, `sync_agents_md`, the legacy `/api/identity` router), so there
-the parameters are **defaulted** to `DRAFT_ADDRESS` / `STAGE_DRAFT` and every
-existing caller is untouched.
+**Required, not defaulted, on this pair** — matching
+`EngineRuntimeRelayProtocol`, which documents `stage` as "required with no
+default, so the stage a handler gated on and the stage it forwards to cannot
+silently diverge." A default would also have to be the same object on both sides
+(`test_service_api_conformance.py` compares defaults by value), which means
+`api/` importing `core.engine_runtime` at runtime — verified to raise
+`ImportError`, because that package's import graph reaches the DI container and
+a partially-initialised `bot_service`. Convention and mechanics agree.
+
+`IdentityService` has no Protocol and many internal callers (`bot_profile`,
+`sync_agents_md`, the legacy `/api/identity` router), so there `stage` is
+**defaulted** to `STAGE_DRAFT` and every existing caller is untouched. That is a
+deliberate departure from the required-no-default convention, taken because the
+alternative is editing ten call sites to say what they already mean.
 
 ### The five handlers
 
 The two engine-config handlers are edited **wherever #1074's Task 15 leaves
 them** — its own router mounted at `/openapi/v1/bots/{bot_id}/engine`, serving
 `GET`/`PUT …/config`. Task 15 moves the handler bodies unchanged, so
-`_engine_config_target` and the `_stage_address` helper below travel with them;
+`_engine_config_target` travels with them;
 if Task 15 has not landed, the same two handlers are still in
 `openapi_v1/bots/router.py` at `/{bot_id}/engine-config` and the edit is
 identical apart from the file.
 
+Every one of the five is the same two-line edit — declare the parameter, pass
+its value. No adapter helper, no repository, no branching:
+
 ```python
-# the engine-config router — GET keeps the record it already fetched
+# the engine-config router
 async def get_bot_engine_config(bot_id, request, owner_id,
                                 stage: StageQuery = RuntimeStage.DRAFT, ...):
-    bot = bot_service.get_bot(bot_id, owner_id)        # ownership/tenant guard
     ...
-    address=_stage_address(bot, stage)                 # pk + type from that record
+    await engine_config_service.read_bot_config(..., stage=stage.value)
 
-# the engine-config router — PUT takes the parameter to refuse it
 async def update_bot_engine_config(..., stage: WriteStageQuery = RuntimeStage.DRAFT, ...):
     ...
     await engine_config_service.write_bot_config(..., stage=stage.value)
 ```
 
-The identity router today resolves no bot at all — the owner-scoping is the
-`(bot_id, owner_id)` binding query inside `resolve_for_bot`. Adding an
-unconditional lookup would change the draft path's failure mode (today a bot
-that is not the caller's fails as `409 Bot has no active device`; a lookup would
-make it `404`). So the lookup happens **only when a published stage is named**:
+The identity router in particular needs **no** change beyond that. It resolves no
+bot today — the owner-scoping is the `(bot_id, owner_id)` binding query inside
+`resolve_for_bot` — and it still resolves none. An earlier draft had it inject
+`BotRepository` and look the bot up when a published stage was named, to avoid
+changing the draft path's failure mode (today a bot that is not the caller's
+fails as `409 Bot has no active device`; an unconditional lookup would make it
+`404`). Moving the facts resolution into the service removes the need for that
+conditional entirely: the draft path never reaches it.
+
+The service-side helper both services gain:
 
 ```python
-# identity/router.py
-def _stage_address(bot_id, owner_id, stage, bot_repo) -> StageAddress:
-    if stage is RuntimeStage.DRAFT:
-        return DRAFT_ADDRESS                            # no query, no change
-    bot = bot_repo.get_by_id_and_owner(bot_id, owner_id)
-    if not bot:
+def _bot_facts(self, bot_id: str, owner_id: str) -> BotFacts:
+    """The addressed bot's facts, from an owner-scoped read.
+
+    ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id`` is not unique
+    across owners, so a wider query can name another owner's row (spec D6).
+    """
+    record = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+    if not record:
         raise BotNotFoundError(f"Bot not found: {bot_id}")
-    return StageAddress(stage=stage.value, bot_pk=int(bot.get("id") or 0),
-                        bot_type=str(bot.get("bot_type") or ""))
+    return BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
 ```
 
-`BotRepository` injected directly in the adapter follows the resources router's
-precedent, and avoids `bot_service.get_bot`, which attaches `device_binding` —
-device topology this surface exists to stop publishing.
-
-The identity **PUT** adds no lookup at all: it passes `stage=stage.value` and
-the service refuses before anything is resolved.
+Both services already hold `BotRepository` (`self._bot_repo`), so this adds no
+constructor dependency.
 
 ## Key Files & Functions
 
@@ -172,22 +204,30 @@ the service refuses before anything is resolved.
 core/engine_runtime/errors.py
     + EngineStageReadOnlyError            # sibling of EngineStageNotLiveError
 
+core/engine_runtime/models.py
+    + BotFacts.from_record(record, *, bot_id, owner_id)
+
+core/engine_runtime/relay.py
+    ~ resolve_bot: its BotFacts(...) construction → BotFacts.from_record
+                   (the one touch outside the feature; one projection, not two)
+
 core/engine_runtime/stage.py
-    + StageAddress, DRAFT_ADDRESS
     + require_stage_writable
-    + resolve_stage_device_context
+    + resolve_published_device_context
     ~ module docstring: names select_stage_bind_id as the *other* question
 
 core/services/engine_config.py
     ~ __init__(+ publish_repo, + binding_repo)
-    ~ _bot_config_device_fs(+ address)  → resolve_stage_device_context
-    ~ read_bot_config(+ address) / write_bot_config(+ stage)
+    + _bot_facts(bot_id, owner_id)
+    ~ _bot_config_device_fs(+ stage)  → draft inline / published via the helper
+    ~ read_bot_config(+ stage) / write_bot_config(+ stage)
     ~ read_publish_config: comment on why it stays record-keyed
 
 core/services/identity.py
     ~ __init__(+ binding_repo)
-    ~ _identity_device_fs / _device_read / read_identity_file (+ address=DRAFT_ADDRESS)
-    ~ get_bot_file / list_bot_files (+ address), update_bot_file (+ stage)
+    + _bot_facts(bot_id, owner_id)
+    ~ _identity_device_fs / _device_read / read_identity_file (+ stage=STAGE_DRAFT)
+    ~ get_bot_file / list_bot_files / update_bot_file (+ stage=STAGE_DRAFT)
     ~ _read_from_publish_device: comment on why it stays record-keyed
 
 adapters/http/openapi_v1/responses.py
@@ -231,7 +271,8 @@ adapters/http/openapi_v1/responses.py
 | #1074's `_is_engine_runtime()` matches the moved `…/{bot_id}/engine/config` and asserts `owner_id` on it, which engine-config does not carry | Not ours to fix and not ours to work around — it breaks #1074's Task 15 before this feature exists (spec **Open Questions**). Task D4 starts by confirming which shape #1074 settled on, and adds the five to `_STAGE_ADDRESSED_ELSEWHERE` on top of it |
 | `stage` leaks onto a deprecated address | The deprecated package re-registers old addresses against their own shim handlers; this feature edits only the new-address handlers. Task D4's exact-set assertion is what catches a leak |
 | A future reader re-merges the two 409s | Both messages, both error docstrings and the `ENVELOPE_ERRORS` comment state the distinction |
-| The write refusal drifts into "write the draft instead" | The write path never receives a `StageAddress`, so there is nothing to resolve a published binding *with* |
+| The write refusal drifts into "write the draft instead" | The write path never resolves `BotFacts`, so there is nothing to resolve a published binding *with* |
+| The in-service facts read duplicates one the adapter already did | Accepted and recorded (spec D8). It is one owner-scoped row read, on published-stage requests only; the draft path — every request that names no stage — reads nothing extra. Task D3 pins that |
 
 ## Alternatives Considered
 
@@ -247,8 +288,14 @@ adapters/http/openapi_v1/responses.py
   changes the draft path's failure mode (409 → 404), which the "byte-for-byte"
   requirement forbids. It would be an improvement to make deliberately, on its
   own.
-- **Give writes a `StageAddress` for symmetry.** Rejected: it would carry facts
-  the write must never use, and weaken D4 from structural to conventional.
+- **A `StageAddress` value object** carrying `(stage, bot_pk, bot_type)`.
+  Rejected on review: those are a subset of `BotFacts` fused with the stage, so
+  it would stand a second bot-identity model beside the one the relay and the
+  Service API Protocol already use (spec D8).
+- **Threading `BotFacts` down from the adapters** instead of resolving it in the
+  service. Rejected with D8: it avoids one row read on the published path, at
+  the cost of an optional at every service boundary (`None` meaning draft) and a
+  conditional bot lookup in the identity router.
 
 ## Rollout
 
@@ -260,11 +307,11 @@ unchanged. No DDL, no migration, no config. Rollback is the revert.
 ```text
 tests/community/core/engine_runtime/test_stage.py            (extend)
     require_stage_writable: draft passes; verify/online raise
-    resolve_stage_device_context: draft → resolve_for_bot with (bot_id, owner_id)
-                                  and NOT resolve_for_binding; published →
-                                  resolve_for_binding with the resolved bind_id;
+    resolve_published_device_context: resolve_for_binding with the resolved
+                                  bind_id, facts.owner_id and facts.bot_id;
                                   personal + published → EngineStageNotLiveError
                                   before any resolver call
+    BotFacts.from_record: same fallbacks the relay applied inline
 
 tests/community/core/services/test_engine_config_service.py  (extend)
     read at verify/online resolves through the publish record's binding
@@ -277,7 +324,7 @@ new: tests/community/core/services/test_identity_stage_addressing.py
 new: tests/…/openapi_v1/test_stage_addressed_bot_files.py
     GET …/{bot_id}/engine/config and …/{bot_id}/identity[/{file_type}] with
       each stage → the address the service saw
-    default (no parameter) → DRAFT_ADDRESS, and no bot lookup on identity
+    default (no parameter) → the draft resolve, and no bot row read at all
     PUT with stage=verify|online → 409 "The requested stage is read-only"
     PUT with no stage → unchanged 200
     stage=eval → 422 from the enum, no handler run

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -92,7 +92,7 @@ def resolve_published_device_context(
 
 ```python
 if stage == STAGE_DRAFT:
-    ctx = self._resolver.resolve_for_bot(bot_id, owner_id)   # unchanged; no row read
+    ctx = self._resolver.resolve_for_bot(bot_id, owner_id)   # unchanged; adds no read
 else:
     facts = self._bot_facts(bot_id, owner_id)                # owner-scoped
     ctx = resolve_published_device_context(
@@ -324,7 +324,7 @@ new: tests/community/core/services/test_identity_stage_addressing.py
 new: tests/…/openapi_v1/test_stage_addressed_bot_files.py
     GET …/{bot_id}/engine/config and …/{bot_id}/identity[/{file_type}] with
       each stage → the address the service saw
-    default (no parameter) → the draft resolve, and no bot row read at all
+    default (no parameter) → the draft resolve, with no read added to it
     PUT with stage=verify|online → 409 "The requested stage is read-only"
     PUT with no stage → unchanged 200
     stage=eval → 422 from the enum, no handler run

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -229,6 +229,7 @@ adapters/http/openapi_v1/responses.py
 
 | Risk | Mitigation |
 | --- | --- |
+| The surface audit missed a group | Re-run over all 31 `resolve_for_bot` call sites, not a truncated listing — that is how MCP was found. The groups reachable from `/openapi/v1` are engine-config, identity, resources, skills, MCP, routines and the engine-runtime relay; the rest are internal-only surfaces |
 | The draft path changes behaviour by accident | The draft branch is literally `resolve_for_bot(bot_id, owner_id)`; a test asserts the resolver call is identical with and without `?stage=draft`, and that no bot lookup is made on the identity draft path |
 | Two new constructor deps break direct service construction in tests | Nine call sites, enumerated in the task list; `injector` supplies them in prod (`DeviceBindingRepository` and `BotPublishRepositoryProtocol` are both already bound) |
 | `test_stage_addressing.py` asserts `stage` is on *exactly* sixteen operations | The document half gains a `_STAGE_ADDRESSED_ELSEWHERE` set, mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE` — so the assertion stays exact rather than being loosened |

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -1,0 +1,266 @@
+# Plan: Public API — Stage-Addressed Per-Bot Files
+
+## Approach
+
+The machinery exists; nothing here is new policy. `core/engine_runtime/stage.py`
+already knows which runtime a stage names, `RuntimeStage` and `StageQuery`
+already publish the parameter, and `EngineConnectionService._stage_binding_id`
+is the worked example. Three things are missing and this plan adds exactly
+those:
+
+1. A core helper that goes one step further than `resolve_stage_bind_id` —
+   stage → **`DeviceContext`** — because a file surface needs to address a
+   filesystem, not forward a request. `EngineConfigService` and
+   `IdentityService` both call it, so the two cannot drift from each other or
+   from the relay.
+2. A core refusal for a write addressed to a published runtime, mapped once.
+3. The parameter on five handlers.
+
+The one design constraint that shapes everything below: **a request that names
+no stage must execute the code it executes today**. So the draft branch is
+`resolve_for_bot(bot_id, owner_id)` exactly as now — no extra query, no new
+lookup, no new error — and the published branch is the only new path.
+
+## The rules
+
+- **Reads** carry a `StageAddress` — stage plus the `(bot_pk, bot_type)` from
+  the read that proved the caller's ownership. Published stages need both; the
+  draft reads neither.
+- **Writes** carry only a stage name. `require_stage_writable` refuses anything
+  but the draft as the first statement of the method, then the draft is
+  resolved. There is no code path from a write to a published binding.
+- **Stage-keyed → `resolve_stage_bind_id`. Record-keyed →
+  `select_stage_bind_id`.** Stated in both modules' docstrings and at all four
+  call sites (spec D3).
+
+## Affected Components
+
+| Component | Change |
+| --- | --- |
+| `core/engine_runtime/errors.py` | new `EngineStageReadOnlyError` |
+| `core/engine_runtime/stage.py` | `StageAddress`, `DRAFT_ADDRESS`, `require_stage_writable`, `resolve_stage_device_context`; docstring records the second rule |
+| `core/services/engine_config.py` | two new constructor deps; read takes `address`, write takes `stage` |
+| `core/services/identity.py` | one new constructor dep; `address` threaded down the read path; `stage` on the write |
+| `api/engine_config_service.py` | Protocol mirrors both signatures |
+| `adapters/http/openapi_v1/engine_runtime/params.py` | `WRITE_STAGE_DESCRIPTION`, `WriteStageQuery` |
+| `adapters/http/openapi_v1/responses.py` | `EngineStageReadOnlyError → (409, …)` |
+| `adapters/http/openapi_v1/bots/router.py` | `stage` on the two engine-config handlers |
+| `adapters/http/openapi_v1/identity/router.py` | `stage` on the three handlers; `BotRepository` injected for the published branch |
+| `adapters/http/bot_management/router.py` | two internal call sites say `draft` explicitly |
+| `docs/openapi-v1/README.md` | the stage section covers 21 operations, not 16 |
+
+## Data Model Changes
+
+None. No table, column, or DDL. The runtimes and their bindings already exist;
+this addresses them.
+
+## API / Interface Changes
+
+### The core seam
+
+```python
+# core/engine_runtime/stage.py
+
+@dataclass(frozen=True)
+class StageAddress:
+    stage: str
+    bot_pk: int      # from the ownership-proving read; unread on draft
+    bot_type: str    # decides whether a published stage is refused
+
+DRAFT_ADDRESS = StageAddress(stage=STAGE_DRAFT, bot_pk=0, bot_type="")
+
+def require_stage_writable(stage: str) -> None:
+    """Refuse a write to a published runtime. Not conditional on bot type or
+    liveness — neither changes the answer, and both would need a lookup."""
+
+def resolve_stage_device_context(
+    resolver, publish_repo, binding_repo, *, address, bot_id, owner_id
+) -> DeviceContext:
+    require_stage_addressable(address.bot_type, address.stage)
+    if address.stage == STAGE_DRAFT:
+        return resolver.resolve_for_bot(bot_id, owner_id)          # unchanged path
+    bind_id = resolve_stage_bind_id(publish_repo, binding_repo,
+                                    bot_pk=address.bot_pk, bot_id=bot_id,
+                                    stage=address.stage, env=get_current_env())
+    return resolver.resolve_for_binding(bind_id, owner_id, bot_id=bot_id)
+```
+
+`resolve_for_binding`, not the relay's `resolve_for_binding_invoke`: callers
+here address a **filesystem** on the resolved device and need the full
+connection info the invoke variant deliberately omits.
+
+`StageAddress` is one value rather than three parameters because identity
+threads it four levels deep (`get_bot_file` → `read_identity_file` →
+`_device_read` → `_identity_device_fs`); three parameters at each hop is three
+chances to drop one.
+
+### The service signatures
+
+```python
+# core/services/engine_config.py  (+ api/engine_config_service.py, identically)
+async def read_bot_config(self, *, bot_id, owner_id, entity_id, entity_type,
+                          engine_type, address: StageAddress) -> dict: ...
+async def write_bot_config(self, *, bot_id, owner_id, entity_id, entity_type,
+                           engine_type, config, stage: str) -> None: ...
+```
+
+**Required, not defaulted, on this pair only.** The conformance test
+(`test_service_api_conformance.py`) compares defaults *by value*, so a default
+would force `api/` to import `core.engine_runtime` at runtime — and that
+package's import graph reaches the DI container and a partially-initialised
+`bot_service`. Verified: it raises `ImportError` when `api/engine_config_service`
+is imported first. Both adapters therefore state the runtime they address, which
+reads better regardless.
+
+`IdentityService` has no Protocol and many internal callers
+(`bot_profile`, `sync_agents_md`, the legacy `/api/identity` router), so there
+the parameters are **defaulted** to `DRAFT_ADDRESS` / `STAGE_DRAFT` and every
+existing caller is untouched.
+
+### The five handlers
+
+```python
+# bots/router.py — GET keeps the record it already fetched
+async def get_bot_engine_config(bot_id, request, owner_id,
+                                stage: StageQuery = RuntimeStage.DRAFT, ...):
+    bot = bot_service.get_bot(bot_id, owner_id)        # ownership/tenant guard
+    ...
+    address=_stage_address(bot, stage)                 # pk + type from that record
+
+# bots/router.py — PUT takes the parameter to refuse it
+async def update_bot_engine_config(..., stage: WriteStageQuery = RuntimeStage.DRAFT, ...):
+    ...
+    await engine_config_service.write_bot_config(..., stage=stage.value)
+```
+
+The identity router today resolves no bot at all — the owner-scoping is the
+`(bot_id, owner_id)` binding query inside `resolve_for_bot`. Adding an
+unconditional lookup would change the draft path's failure mode (today a bot
+that is not the caller's fails as `409 Bot has no active device`; a lookup would
+make it `404`). So the lookup happens **only when a published stage is named**:
+
+```python
+# identity/router.py
+def _stage_address(bot_id, owner_id, stage, bot_repo) -> StageAddress:
+    if stage is RuntimeStage.DRAFT:
+        return DRAFT_ADDRESS                            # no query, no change
+    bot = bot_repo.get_by_id_and_owner(bot_id, owner_id)
+    if not bot:
+        raise BotNotFoundError(f"Bot not found: {bot_id}")
+    return StageAddress(stage=stage.value, bot_pk=int(bot.get("id") or 0),
+                        bot_type=str(bot.get("bot_type") or ""))
+```
+
+`BotRepository` injected directly in the adapter follows the resources router's
+precedent, and avoids `bot_service.get_bot`, which attaches `device_binding` —
+device topology this surface exists to stop publishing.
+
+The identity **PUT** adds no lookup at all: it passes `stage=stage.value` and
+the service refuses before anything is resolved.
+
+## Key Files & Functions
+
+```text
+core/engine_runtime/errors.py
+    + EngineStageReadOnlyError            # sibling of EngineStageNotLiveError
+
+core/engine_runtime/stage.py
+    + StageAddress, DRAFT_ADDRESS
+    + require_stage_writable
+    + resolve_stage_device_context
+    ~ module docstring: names select_stage_bind_id as the *other* question
+
+core/services/engine_config.py
+    ~ __init__(+ publish_repo, + binding_repo)
+    ~ _bot_config_device_fs(+ address)  → resolve_stage_device_context
+    ~ read_bot_config(+ address) / write_bot_config(+ stage)
+    ~ read_publish_config: comment on why it stays record-keyed
+
+core/services/identity.py
+    ~ __init__(+ binding_repo)
+    ~ _identity_device_fs / _device_read / read_identity_file (+ address=DRAFT_ADDRESS)
+    ~ get_bot_file / list_bot_files (+ address), update_bot_file (+ stage)
+    ~ _read_from_publish_device: comment on why it stays record-keyed
+
+adapters/http/openapi_v1/responses.py
+    + EngineStageReadOnlyError: (409, "The requested stage is read-only")
+```
+
+## Dependencies
+
+- **PR #1073** (`fix(backend): read an unwritten engine config as empty, not
+  500`) is open against `dev` and touches
+  `core/services/engine_config.py` — the same file Task B1 edits, in the same
+  two read methods.
+
+  This branch is based on **`dev`**, not on #1073, so the two changes are
+  independent until B1 lands. Whichever merges second resolves the overlap; if
+  #1073 is still open when implementation starts, rebase onto its head first so
+  B1 is written against the `_read_config_bytes` helper it introduces rather
+  than against the raw `device_fs.read_file` call it replaces. The two edits are
+  compatible in substance — #1073 changes *how a missing file is decoded*, B1
+  changes *which device is read* — so this is a textual conflict, not a design
+  one.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| The draft path changes behaviour by accident | The draft branch is literally `resolve_for_bot(bot_id, owner_id)`; a test asserts the resolver call is identical with and without `?stage=draft`, and that no bot lookup is made on the identity draft path |
+| Two new constructor deps break direct service construction in tests | Nine call sites, enumerated in the task list; `injector` supplies them in prod (`DeviceBindingRepository` and `BotPublishRepositoryProtocol` are both already bound) |
+| `test_stage_addressing.py` asserts `stage` is on *exactly* sixteen operations | The document half gains a `_STAGE_ADDRESSED_ELSEWHERE` set, mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE` — so the assertion stays exact rather than being loosened |
+| A future reader re-merges the two 409s | Both messages, both error docstrings and the `ENVELOPE_ERRORS` comment state the distinction |
+| The write refusal drifts into "write the draft instead" | The write path never receives a `StageAddress`, so there is nothing to resolve a published binding *with* |
+
+## Alternatives Considered
+
+- **Collapse `read_publish_config` onto `resolve_stage_bind_id`.** Rejected: it
+  is keyed by `publish_id` and that rule ignores the record named. Spec D3.
+- **`200` with `{"applied": false}` for a published-stage write.** Rejected in
+  the requirement and here: a caller checking status codes reads it as success.
+- **Refuse published-stage writes at the adapter.** Rejected: it is domain
+  policy, and the internal routes would not inherit it.
+- **A separate `stage` enum or parameter for writes.** Rejected: same values,
+  same vocabulary; only the description differs.
+- **Resolve the bot unconditionally in the identity router.** Rejected: it
+  changes the draft path's failure mode (409 → 404), which the "byte-for-byte"
+  requirement forbids. It would be an improvement to make deliberately, on its
+  own.
+- **Give writes a `StageAddress` for symmetry.** Rejected: it would carry facts
+  the write must never use, and weaken D4 from structural to conventional.
+
+## Rollout
+
+Additive and backward compatible. Every existing request omits `stage` and is
+unchanged. No DDL, no migration, no config. Rollback is the revert.
+
+## Test Strategy
+
+```text
+tests/community/core/engine_runtime/test_stage.py            (extend)
+    require_stage_writable: draft passes; verify/online raise
+    resolve_stage_device_context: draft → resolve_for_bot with (bot_id, owner_id)
+                                  and NOT resolve_for_binding; published →
+                                  resolve_for_binding with the resolved bind_id;
+                                  personal + published → EngineStageNotLiveError
+                                  before any resolver call
+
+tests/community/core/services/test_engine_config_service.py  (extend)
+    read at verify/online resolves through the publish record's binding
+    write at verify/online raises EngineStageReadOnlyError and the dispatcher
+      is never touched (assert_not_called — "nothing is written")
+
+new: tests/community/core/services/test_identity_stage_addressing.py
+    the same two pins for identity read/list/write
+
+new: tests/…/openapi_v1/test_stage_addressed_bot_files.py
+    GET engine-config / identity with each stage → the address the service saw
+    default (no parameter) → DRAFT_ADDRESS, and no bot lookup on identity
+    PUT with stage=verify|online → 409 "The requested stage is read-only"
+    PUT with no stage → unchanged 200
+    stage=eval → 422 from the enum, no handler run
+
+tests/…/openapi_v1/engine_runtime/test_stage_addressing.py   (extend)
+    the document half: stage now on 16 + 5, still optional everywhere,
+    still never a body field or path segment
+```

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/plan.md
@@ -44,7 +44,7 @@ lookup, no new error — and the published branch is the only new path.
 | `api/engine_config_service.py` | Protocol mirrors both signatures |
 | `adapters/http/openapi_v1/engine_runtime/params.py` | `WRITE_STAGE_DESCRIPTION`, `WriteStageQuery` |
 | `adapters/http/openapi_v1/responses.py` | `EngineStageReadOnlyError → (409, …)` |
-| `adapters/http/openapi_v1/bots/router.py` | `stage` on the two engine-config handlers |
+| the engine-config router #1074 Task 15 creates at `/openapi/v1/bots/{bot_id}/engine` | `stage` on its two handlers |
 | `adapters/http/openapi_v1/identity/router.py` | `stage` on the three handlers; `BotRepository` injected for the published branch |
 | `adapters/http/bot_management/router.py` | two internal call sites say `draft` explicitly |
 | `docs/openapi-v1/README.md` | the stage section covers 21 operations, not 16 |
@@ -119,15 +119,23 @@ existing caller is untouched.
 
 ### The five handlers
 
+The two engine-config handlers are edited **wherever #1074's Task 15 leaves
+them** — its own router mounted at `/openapi/v1/bots/{bot_id}/engine`, serving
+`GET`/`PUT …/config`. Task 15 moves the handler bodies unchanged, so
+`_engine_config_target` and the `_stage_address` helper below travel with them;
+if Task 15 has not landed, the same two handlers are still in
+`openapi_v1/bots/router.py` at `/{bot_id}/engine-config` and the edit is
+identical apart from the file.
+
 ```python
-# bots/router.py — GET keeps the record it already fetched
+# the engine-config router — GET keeps the record it already fetched
 async def get_bot_engine_config(bot_id, request, owner_id,
                                 stage: StageQuery = RuntimeStage.DRAFT, ...):
     bot = bot_service.get_bot(bot_id, owner_id)        # ownership/tenant guard
     ...
     address=_stage_address(bot, stage)                 # pk + type from that record
 
-# bots/router.py — PUT takes the parameter to refuse it
+# the engine-config router — PUT takes the parameter to refuse it
 async def update_bot_engine_config(..., stage: WriteStageQuery = RuntimeStage.DRAFT, ...):
     ...
     await engine_config_service.write_bot_config(..., stage=stage.value)
@@ -188,6 +196,21 @@ adapters/http/openapi_v1/responses.py
 
 ## Dependencies
 
+- **PR #1074** (`docs(openapi-v1): specify bot-first addressing…`) — a **hard
+  ordering dependency**, confirmed with the owner: it lands first and this is
+  written against the surface it leaves.
+
+  What it gives us: identity already sits at `/openapi/v1/bots/{bot_id}/identity`
+  (its Task 4, done), and its Task 15 moves engine-config to
+  `/openapi/v1/bots/{bot_id}/engine/config` onto its own router. What it
+  constrains: the deprecated addresses it registers are frozen byte for byte and
+  must **not** gain `stage` (spec D7).
+
+  It also rewrites the two suites this feature extends —
+  `test_stage_addressing.py`'s prefix test becomes the `_is_engine_runtime()`
+  segment test, and `_OWNER_ADDRESSED_ELSEWHERE` gains the two skills
+  operations. Task D4 is written against that shape, not today's.
+
 - **PR #1073** (`fix(backend): read an unwritten engine config as empty, not
   500`) is open against `dev` and touches
   `core/services/engine_config.py` — the same file Task B1 edits, in the same
@@ -209,6 +232,8 @@ adapters/http/openapi_v1/responses.py
 | The draft path changes behaviour by accident | The draft branch is literally `resolve_for_bot(bot_id, owner_id)`; a test asserts the resolver call is identical with and without `?stage=draft`, and that no bot lookup is made on the identity draft path |
 | Two new constructor deps break direct service construction in tests | Nine call sites, enumerated in the task list; `injector` supplies them in prod (`DeviceBindingRepository` and `BotPublishRepositoryProtocol` are both already bound) |
 | `test_stage_addressing.py` asserts `stage` is on *exactly* sixteen operations | The document half gains a `_STAGE_ADDRESSED_ELSEWHERE` set, mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE` — so the assertion stays exact rather than being loosened |
+| #1074's `_is_engine_runtime()` matches the moved `…/{bot_id}/engine/config` and asserts `owner_id` on it, which engine-config does not carry | Not ours to fix and not ours to work around — it breaks #1074's Task 15 before this feature exists (spec **Open Questions**). Task D4 starts by confirming which shape #1074 settled on, and adds the five to `_STAGE_ADDRESSED_ELSEWHERE` on top of it |
+| `stage` leaks onto a deprecated address | The deprecated package re-registers old addresses against their own shim handlers; this feature edits only the new-address handlers. Task D4's exact-set assertion is what catches a leak |
 | A future reader re-merges the two 409s | Both messages, both error docstrings and the `ENVELOPE_ERRORS` comment state the distinction |
 | The write refusal drifts into "write the draft instead" | The write path never receives a `StageAddress`, so there is nothing to resolve a published binding *with* |
 
@@ -254,13 +279,18 @@ new: tests/community/core/services/test_identity_stage_addressing.py
     the same two pins for identity read/list/write
 
 new: tests/…/openapi_v1/test_stage_addressed_bot_files.py
-    GET engine-config / identity with each stage → the address the service saw
+    GET …/{bot_id}/engine/config and …/{bot_id}/identity[/{file_type}] with
+      each stage → the address the service saw
     default (no parameter) → DRAFT_ADDRESS, and no bot lookup on identity
     PUT with stage=verify|online → 409 "The requested stage is read-only"
     PUT with no stage → unchanged 200
     stage=eval → 422 from the enum, no handler run
+    the deprecated twins (…/bots/identity/{bot_id}, …/{bot_id}/engine-config)
+      do not declare `stage` in the document, and a request that sends it
+      anyway still reads the draft — FastAPI ignores an undeclared query
+      parameter, which is the freeze behaving as #1074 specified it
 
 tests/…/openapi_v1/engine_runtime/test_stage_addressing.py   (extend)
     the document half: stage now on 16 + 5, still optional everywhere,
-    still never a body field or path segment
+    still never a body field or path segment, and on no deprecated address
 ```

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -159,9 +159,10 @@ one — see **Decisions**.
 
 - `?stage=` on the five operations above.
 - One new core error for the write refusal, mapped once in `ENVELOPE_ERRORS`.
-- One shared core helper that turns a stage into a device context, so the file
-  surfaces and the forwarding surfaces cannot drift on which runtime a stage
-  names.
+- One shared core helper that turns a **published** stage into a device
+  context, so the file surfaces and the forwarding surfaces cannot drift on
+  which runtime a stage names. The draft stays the `resolve_for_bot` call it
+  already is.
 - A recorded decision on the two divergent stage-selection rules, and a comment
   at each call site that keeps them apart.
 - Doc update in `docs/openapi-v1/README.md`.
@@ -266,20 +267,46 @@ longer happens: every stage-keyed caller goes through `resolve_stage_bind_id`,
 every record-keyed caller through `select_stage_bind_id`, and the split is
 stated in both modules and at each call site.
 
-**D4 — Writes never carry the bot facts a published stage would need.** The
+**D4 — A write never resolves the bot facts a published stage would need.** The
 write path takes only the stage name, refuses anything but the draft, and then
-resolves the draft. There is therefore no code path from a write to a published
-runtime's binding — the guarantee is structural, not a promise kept by a guard.
+resolves the draft through the same owner-scoped call it always used. It never
+reaches the branch that reads a bot row or a publish record, so there is no code
+path from a write to a published runtime's binding — the guarantee is
+structural, not a promise kept by a guard.
 
 **D5 — `stage` is imported from `engine_runtime/params.py`, not re-declared.**
 A second spelling of the same parameter is a second thing to keep in step. The
 module keeps the vocabulary; the group does not own the parameter.
 
-**D6 — The bot primary key comes from the ownership check, never a fresh
-lookup.** `resolve_stage_bind_id` is keyed on `ac_bots.id` because `bot_id`
-carries no unique constraint and every user's first bot is called `default`. The
-key passed is the one from the record the request's ownership guard already
-resolved.
+**D6 — The bot primary key always comes from an owner-scoped read.**
+`resolve_stage_bind_id` is keyed on `ac_bots.id` because `bot_id` carries no
+unique constraint and every user's first bot is called `default`, so a lookup by
+`bot_id` alone can select another owner's row and hand back their running
+device. The invariant is therefore about *which query* produced the key, not
+about how few queries ran: it must come from a `(bot_id, owner_id)` read. Under
+**D8** that read happens inside the service, on the published branch only — the
+same ownership check the adapter performs, run again rather than threaded down.
+A `bot_id`-only lookup is never acceptable, here or anywhere.
+
+**D8 — One bot-identity model: `BotFacts`, with `stage` beside it as a `str`.**
+This is the shape every stage-aware path in the codebase already uses — the
+relay's `_resolve_device(bot_id, owner_id, facts, stage)` and
+`_resolve_published_device(facts, owner_id, stage)`, and
+`EngineRuntimeRelayProtocol.call(..., facts, stage)`. These services adopt it
+rather than introducing a second projection of the same concept.
+
+An earlier draft of this spec proposed a `StageAddress` value object carrying
+`(stage, bot_pk, bot_type)`. It was rejected on review: those are a subset of
+`BotFacts` fused with the stage, so it would have put two overlapping
+bot-identity models next to each other for the sake of two services.
+
+The consequence is that a published-stage request does one owner-scoped row read
+inside the service instead of reusing the record the adapter already fetched.
+That is the accepted cost. It buys back more than it spends: the adapters pass a
+single `stage=` string and nothing else, the identity router needs no bot
+repository and no conditional lookup, and no parameter has to be threaded
+through four service layers. The draft path — every request that names no stage
+— reads no extra row at all.
 
 **D7 — This lands after #1074, on the bot-first addresses only.** Two
 consequences, both deliberate:

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -322,6 +322,23 @@ consequences, both deliberate:
   about to be deprecated and then adding it again to its replacement, and the
   deprecation freeze would make the first of those a contract violation.
 
+## Known limitations
+
+**A published stage is addressed with the bot's *current* engine.** Both
+services resolve `engine_type` from the live `ac_bots` row, and that value picks
+the per-engine directory and the provider's config filename. A service bot
+published on `openclaw` whose owner later switches to `claude_code` will have its
+online runtime read at the claude_code paths, where the release never wrote
+anything — so the caller sees "never configured" rather than the config that is
+there.
+
+Not introduced here: `read_publish_config`'s route resolves the engine the same
+way, from the same row, and has shipped that way. What this feature changes is
+that the mismatch is now reachable from the public surface rather than only from
+the internal `publish_id` route. Fixing it needs the engine the release was cut
+with, which no publish record currently stores — so it is recorded rather than
+patched around.
+
 ## Open Questions
 
 None blocking.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -99,12 +99,18 @@ one — see **Decisions**.
 
 ### Legacy addresses
 
-- The deprecated addresses #1074 keeps answering — `…/bots/identity/{bot_id}`,
-  `…/bots/{bot_id}/engine-config`, and the rest — **do not gain `stage`.**
-  Their contract is frozen byte for byte by that feature: same parameters, same
-  locations, same schemas. Adding one there would break the freeze, and it would
-  also be pointless — a caller who wants a published runtime is a caller who can
-  move to the new address.
+- The five retiring twins of the operations above — `…/bots/identity/{bot_id}`,
+  `…/bots/identity/{bot_id}/{file_type}`, `…/bots/{bot_id}/engine-config` —
+  **do not gain `stage`.** #1074 freezes their contract byte for byte: same
+  parameters, same locations, same schemas, until the 2027-08-15 sunset. Adding
+  one there would break the freeze, and it would also be pointless — a caller
+  who wants a published runtime is a caller who can move to the new address.
+- **This is not a claim about every deprecated address.** The retiring
+  engine-runtime addresses *do* carry `stage`, because they always did: they are
+  the same operations at a former address, mounted with the same response table
+  and the same parameters, and #1074's parity promise is exactly that they keep
+  it. The rule is "a retiring address keeps the contract it had", which for
+  those means keeping `stage` and for these five means never acquiring it.
 - A caller on a legacy address therefore keeps reading the draft, which is
   exactly what that address does today. Nothing regresses; the new capability
   simply lives only on the new addresses.
@@ -293,18 +299,16 @@ consequences, both deliberate:
 
 None blocking.
 
-**Noted for #1074, found while writing this spec.** Its Task 15 moves
-engine-config to `/openapi/v1/bots/{bot_id}/engine/config`, and its new
-`_is_engine_runtime(path)` predicate in `test_stage_addressing.py` classifies a
-path by `parts[4] == "{bot_id}" and parts[5] in {sessions, engine, models,
-approvals, connection}`. That predicate matches the moved engine-config path,
-which is **not** an engine-runtime operation — it carries `user_id` rather than
-`owner_id`, and Task 15 gives it the ordinary error table precisely because it
-cannot produce the 501/504 those groups document. The predicate's first
-assertion is `"owner_id" in params`, so Task 15 will fail that test on its own,
-before this feature exists. It belongs to #1074 to narrow the predicate (a
-`("engine", "config")` exclusion, or matching the operation set rather than the
-segment); Task D4 here depends on whichever shape it takes.
+**Resolved — the `_is_engine_runtime` collision.** Raised here while #1074 was
+still specification: its segment predicate would have matched the moved
+`/openapi/v1/bots/{bot_id}/engine/config` and asserted `owner_id` on an
+operation that publishes `user_id`. #1074 settled it by dropping the segment
+test for a **path-set membership** test — `_engine_runtime_paths()` collects the
+routes off `_ENGINE_RUNTIME_GROUPS` and the deprecated package's
+`ENGINE_RUNTIME_GROUPS`, so the classification comes from what is mounted rather
+than from what a path looks like. Task D4 builds on that shape: the five
+operations here are simply not in that set, so they belong in
+`_STAGE_ADDRESSED_ELSEWHERE`.
 
 **Noted for the follow-up work:** when resources is stage-addressed,
 `ResourceFileService`'s `publish_id` parameter and a new `stage` parameter would

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -163,7 +163,9 @@ one — see **Decisions**.
 ## Out of Scope
 
 Each of these was checked against the callers of
-`DeviceContextResolver.resolve_for_bot`, not assumed.
+`DeviceContextResolver.resolve_for_bot`, not assumed. The audit covers all 31
+call sites; an earlier pass of it was truncated and missed MCP, which is why
+that group is enumerated below rather than absent.
 
 - **The startup-script operations** (`GET`/`PUT`/`DELETE
   …/{bot_id}/startup-script`). Named as affected in the original request; they
@@ -190,6 +192,33 @@ Each of these was checked against the callers of
 - **Routines.** `CronRelayService` resolves `resolve_for_bot`, but a routine is
   not a per-bot file and its stage pin is already filed as
   [#908](https://github.com/inclusionAI/Avernet/issues/908).
+- **The MCP group** (6 operations) — out for a different reason from the rest,
+  and the reason is worth stating because the group *does* reach devices.
+
+  **None of the six addresses a bot.** They are keyed by `server_code` and
+  `user_id`: `/openapi/v1/bots/mcp/servers`, `/tenants`,
+  `/servers/{server_code}`, `…/permissions`, and `GET`/`PUT …/config`. #1074
+  keeps all six at their current addresses for exactly that reason — a bot id
+  would have nothing to name.
+
+  **But `PUT …/servers/{server_code}/config` is not bot-free in effect.**
+  `write_unified_config` → `MCPSyncService.sync_mcp_detail_to_all_bots` lists
+  every bot under the identity and calls `resolve_for_bot(bot_id, entity_id)`
+  for each, pushing the config to that bot's device. One account-level write
+  fans out to N bots.
+
+  A `stage` parameter still does not belong there, and not merely because the
+  group is out of scope. The operation names no single bot, so there is no one
+  runtime for a stage to name; and what a published stage would ask for is a
+  fan-out write to published runtimes, which is precisely what this feature's
+  write rule refuses.
+
+  **The fan-out reaches drafts only, and that is correct rather than a gap** —
+  by the same rule, arrived at independently. A release inlines its MCP
+  credentials into the artifact (`sync_service.py`: "凭据已内联进产物，改
+  api_key 即改产物字节"), so a published runtime's MCP config changes by
+  republishing, not by being written. That is this spec's D1 reasoning holding
+  on a surface that never consulted it.
 - **Internal `/api/...` routes.** They stay draft-only, explicitly, at their
   call sites.
 - **Any change to what a published runtime contains.** This surface reads it; the

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -1,0 +1,226 @@
+# Public API — Stage-Addressed Per-Bot Files
+
+## Summary
+
+Five OpenAPI v1 operations read or write a file on a bot's device, and every one
+of them can only reach the bot's **draft** workspace:
+
+```text
+GET  /openapi/v1/bots/{bot_id}/engine-config
+PUT  /openapi/v1/bots/{bot_id}/engine-config
+GET  /openapi/v1/bots/identity/{bot_id}
+GET  /openapi/v1/bots/identity/{bot_id}/{file_type}
+PUT  /openapi/v1/bots/identity/{bot_id}/{file_type}
+```
+
+A service bot has up to three long-lived runtimes — draft, verify, online — and
+the engine-runtime groups have addressed all three with `?stage=` since
+2026-08-09. These five resolve `DeviceContextResolver.resolve_for_bot`, which
+reads `ac_bots.binding_id`, so a published runtime is unreachable through them.
+
+This adds `?stage=` to all five, with the same vocabulary, the same default and
+the same refusals the connection API already publishes. The three reads serve
+all three stages. The two writes take the parameter in order to **refuse** a
+published one: a release is replaced by publishing again, never edited.
+
+## Motivation
+
+An operator who has published a service bot cannot answer the two questions
+this surface exists to answer:
+
+- *What configuration is my online release actually running?* The draft has
+  moved on since the release was cut, so the draft's answer is not the release's.
+- *Which identity files did verify receive?* The publish flow copies them into
+  the released runtime; whether the copy is what the operator intended is only
+  observable by reading the runtime.
+
+Both are answerable today only through internal, `publish_id`-keyed routes that
+the public surface does not expose and that an external tenant has no id for.
+
+The write side has a sharper problem than "not supported". `PUT
+…/engine-config` accepts a request that names no stage and writes the draft —
+which is correct. Once `stage` exists on the read, a caller will send it on the
+write, and the two dishonest answers are exactly the ones a surface must not
+give: writing the published runtime forks it from the record that describes it,
+and quietly writing the draft instead reports success for an edit the addressed
+runtime never received.
+
+There is also a latent correctness problem this change must not spread. Two
+stage-selection rules exist in the codebase, and engine-config is on the weaker
+one — see **Decisions**.
+
+## User Stories
+
+- As an operator debugging a released service bot, I read the engine
+  configuration my **online** runtime is running, without needing a publish id.
+- As an operator validating a release, I read the identity files on the
+  **verify** runtime and compare them with the draft I authored.
+- As an operator, when I try to edit a published runtime I am **refused with an
+  error**, not told the write succeeded.
+- As an owner of a personal bot, every one of these calls behaves exactly as it
+  did before this change, because I never name a stage.
+- As an integrator, the stage parameter means the same thing, takes the same
+  values and fails the same way on these five operations as on the sixteen
+  engine-runtime ones.
+
+## Acceptance Criteria
+
+### Which operations take the parameter
+
+- `stage` is an **optional query parameter** on exactly the five operations
+  listed in the Summary, and on the sixteen engine-runtime operations that
+  already have it. Nowhere else.
+- It is never a body field and never a path segment.
+- Its values are the existing `RuntimeStage` enum — `draft`, `verify`, `online`.
+  A value outside the enum is a `422` from the adapter, before any handler runs.
+
+### Reads
+
+- The default is `draft`. A request that names no stage is byte-for-byte the
+  request that exists today: same device resolution, same query count, same
+  errors.
+- `stage=verify` and `stage=online` on a `service` bot resolve that stage's live
+  runtime and read from it.
+- Liveness is the rule in `core/engine_runtime/stage.py`, unchanged and not
+  re-implemented: `online` while the newest publish record is at `SUCCESS`;
+  `verify` while a record is at `VALIDATING`, or through the promoted record's
+  **retained** verify binding while that binding is still `ACTIVE`.
+- No fallback between stages, and none to the draft. A verify request is never
+  answered by the online runtime, or by the workspace.
+- `GET /openapi/v1/bots/identity/{bot_id}` reports every file from the **one**
+  addressed runtime. A caller never sees a draft row beside a verify row.
+
+### Writes
+
+- `PUT …/engine-config` and `PUT …/identity/{bot_id}/{file_type}` accept
+  `stage`, default `draft`, and write the draft.
+- `stage=verify` or `stage=online` is refused with `409` and the fixed message
+  **"The requested stage is read-only"**.
+- The refusal is unconditional on bot type and on liveness. A published stage
+  named on a personal bot, or a stage with no runtime up, is still this refusal
+  on a write — publishing a runtime there would not make the write land.
+- **Nothing is written anywhere.** The refusal is raised in core before the
+  device is resolved, and the draft is not touched as a substitute.
+- A `200` carrying a "no-op" flag is explicitly rejected as the answer.
+  Automation that checks the status code would record the write as landed.
+
+### Refusals and disclosure
+
+- A published stage named on a `personal` bot, or a stage with no live runtime,
+  is the existing `409` **"No live runtime at the requested stage"**
+  (`EngineStageNotLiveError`). That mapping already exists; no second mapping is
+  added for it.
+- The read-only refusal is a **distinct** error and a distinct message from the
+  not-live one. Merging them would tell a caller to publish a runtime and retry,
+  which would not help.
+- Neither refusal reveals anything a caller could not already learn: both run
+  after the existing ownership guard, which still answers a bot that is not the
+  caller's with the masked `404`.
+
+### Published document
+
+- Both descriptions are published: the read's existing `STAGE_DESCRIPTION`, and
+  a write-specific one that states the draft is the only writable runtime.
+  Publishing the read's text on a write would advertise verify/online as
+  addressable there.
+- `409` is already documented surface-wide; no per-route response table changes.
+
+## In Scope
+
+- `?stage=` on the five operations above.
+- One new core error for the write refusal, mapped once in `ENVELOPE_ERRORS`.
+- One shared core helper that turns a stage into a device context, so the file
+  surfaces and the forwarding surfaces cannot drift on which runtime a stage
+  names.
+- A recorded decision on the two divergent stage-selection rules, and a comment
+  at each call site that keeps them apart.
+- Doc update in `docs/openapi-v1/README.md`.
+
+## Out of Scope
+
+Each of these was checked against the callers of
+`DeviceContextResolver.resolve_for_bot`, not assumed.
+
+- **The startup-script operations** (`GET`/`PUT`/`DELETE
+  …/{bot_id}/startup-script`). Named as affected in the original request; they
+  are **not**. `BotStartupScriptService` is backed by the
+  `ac_bot_startup_script` table keyed `(env, entity_id, bot_id)` and never
+  resolves a device context. There is one row per bot, not one per runtime, so a
+  `stage` parameter there would be inert — three stages returning the same row —
+  and inert parameters are worse than absent ones.
+- **The resources group** (7 handlers). A genuine per-bot device-file surface
+  with the same gap, but it is `definition-only / NOT PUBLIC-READY` (its own
+  router says so; `require_principal` is still a stub) and it has a
+  `publish_id`-shaped stage path in `ResourceFileService` that would have to be
+  reconciled first. Filed as follow-up, not folded in.
+- **The skills group** (6 handlers). Same gap, and release-pending; its
+  `owner_entity_id` locator predates `owner_id` and the openapi-v1 README
+  already records that it must be reconciled to `owner_id` before release.
+  Doing stage addressing on top of an unreconciled locator would have to be
+  redone.
+- **Routines.** `CronRelayService` resolves `resolve_for_bot`, but a routine is
+  not a per-bot file and its stage pin is already filed as
+  [#908](https://github.com/inclusionAI/Avernet/issues/908).
+- **Internal `/api/...` routes.** They stay draft-only, explicitly, at their
+  call sites.
+- **Any change to what a published runtime contains.** This surface reads it; the
+  publish flow writes it.
+
+## Decisions
+
+**D1 — The write refusal is a new error, not a reuse of an existing 409.**
+Three 409s now live side by side and each answers a different question:
+`BotOperationNotAllowedError` ("this bot cannot do this at all"),
+`EngineStageNotLiveError` ("that runtime is not up"), and the new one ("that
+runtime does not take writes"). The second is the tempting reuse and the wrong
+one: it implies a retry after publishing.
+
+**D2 — On a write, the read-only refusal wins over the not-live refusal.**
+`PUT …?stage=online` against a personal bot answers "read-only", not "no live
+runtime". The refusal is a property of the *operation*, true whatever the bot
+and whatever is running; answering "no live runtime" would suggest that
+publishing one would make the write work. It is also what lets the refusal run
+before any lookup at all.
+
+**D3 — `read_publish_config` stays on `select_stage_bind_id`.** This is the
+trap the request flagged, and the answer is that the two rules are not
+duplicates — they answer different questions:
+
+| Question | Rule | Callers |
+| --- | --- | --- |
+| A **stage** was named — which runtime does it have? | `engine_runtime/stage.py::resolve_stage_bind_id` | the relay, the connection socket, and (new) the stage-addressed file reads |
+| A **publish record** was named — which binding is its runtime? | `service_bot/repository/models.py::select_stage_bind_id` | `EngineConfigService.read_publish_config`, `IdentityService._read_from_publish_device`, `ResourceFileService._stage_bind_id` |
+
+`GET /api/service-bot/publish/{publish_id}/engine-config` is keyed by
+`publish_id`. `resolve_stage_bind_id` selects the *newest* record at a status
+and ignores which record the caller named, so collapsing that route onto it
+would answer a question about release 7 from whichever release is currently
+newest — a regression, not a consolidation. The drift `stage.py`'s docstring
+warns about ("two surfaces disagreeing on whether a runtime exists") is between
+two callers answering the *same* question two ways, which after this change no
+longer happens: every stage-keyed caller goes through `resolve_stage_bind_id`,
+every record-keyed caller through `select_stage_bind_id`, and the split is
+stated in both modules and at each call site.
+
+**D4 — Writes never carry the bot facts a published stage would need.** The
+write path takes only the stage name, refuses anything but the draft, and then
+resolves the draft. There is therefore no code path from a write to a published
+runtime's binding — the guarantee is structural, not a promise kept by a guard.
+
+**D5 — `stage` is imported from `engine_runtime/params.py`, not re-declared.**
+A second spelling of the same parameter is a second thing to keep in step. The
+module keeps the vocabulary; the group does not own the parameter.
+
+**D6 — The bot primary key comes from the ownership check, never a fresh
+lookup.** `resolve_stage_bind_id` is keyed on `ac_bots.id` because `bot_id`
+carries no unique constraint and every user's first bot is called `default`. The
+key passed is the one from the record the request's ownership guard already
+resolved.
+
+## Open Questions
+
+None blocking. One noted for the follow-up work: when resources and skills are
+stage-addressed, `ResourceFileService`'s `publish_id` parameter and a new
+`stage` parameter would coexist on the same service, and the precedence between
+them should be settled the same way `IdentityService.get_bot_file` settles it
+here (record-keyed wins, as the more specific address).

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/spec.md
@@ -6,12 +6,19 @@ Five OpenAPI v1 operations read or write a file on a bot's device, and every one
 of them can only reach the bot's **draft** workspace:
 
 ```text
-GET  /openapi/v1/bots/{bot_id}/engine-config
-PUT  /openapi/v1/bots/{bot_id}/engine-config
-GET  /openapi/v1/bots/identity/{bot_id}
-GET  /openapi/v1/bots/identity/{bot_id}/{file_type}
-PUT  /openapi/v1/bots/identity/{bot_id}/{file_type}
+GET  /openapi/v1/bots/{bot_id}/engine/config
+PUT  /openapi/v1/bots/{bot_id}/engine/config
+GET  /openapi/v1/bots/{bot_id}/identity
+GET  /openapi/v1/bots/{bot_id}/identity/{file_type}
+PUT  /openapi/v1/bots/{bot_id}/identity/{file_type}
 ```
+
+Those are the **bot-first** addresses that
+[#1074](https://github.com/inclusionAI/Avernet/pull/1074) establishes — its
+Task 4 has already moved identity, and its Task 15 moves `engine-config` to
+`/{bot_id}/engine/config` onto its own router. This feature lands after it and
+targets those addresses only; the deprecated addresses #1074 leaves behind are
+frozen and do not gain the parameter (see **Legacy addresses** below).
 
 A service bot has up to three long-lived runtimes — draft, verify, online — and
 the engine-runtime groups have addressed all three with `?stage=` since
@@ -38,7 +45,7 @@ Both are answerable today only through internal, `publish_id`-keyed routes that
 the public surface does not expose and that an external tenant has no id for.
 
 The write side has a sharper problem than "not supported". `PUT
-…/engine-config` accepts a request that names no stage and writes the draft —
+…/engine/config` accepts a request that names no stage and writes the draft —
 which is correct. Once `stage` exists on the read, a caller will send it on the
 write, and the two dishonest answers are exactly the ones a surface must not
 give: writing the published runtime forks it from the record that describes it,
@@ -87,12 +94,29 @@ one — see **Decisions**.
   **retained** verify binding while that binding is still `ACTIVE`.
 - No fallback between stages, and none to the draft. A verify request is never
   answered by the online runtime, or by the workspace.
-- `GET /openapi/v1/bots/identity/{bot_id}` reports every file from the **one**
+- `GET /openapi/v1/bots/{bot_id}/identity` reports every file from the **one**
   addressed runtime. A caller never sees a draft row beside a verify row.
+
+### Legacy addresses
+
+- The deprecated addresses #1074 keeps answering — `…/bots/identity/{bot_id}`,
+  `…/bots/{bot_id}/engine-config`, and the rest — **do not gain `stage`.**
+  Their contract is frozen byte for byte by that feature: same parameters, same
+  locations, same schemas. Adding one there would break the freeze, and it would
+  also be pointless — a caller who wants a published runtime is a caller who can
+  move to the new address.
+- A caller on a legacy address therefore keeps reading the draft, which is
+  exactly what that address does today. Nothing regresses; the new capability
+  simply lives only on the new addresses.
+- A caller who sends `?stage=online` to a legacy address anyway reads the draft:
+  FastAPI ignores an undeclared query parameter. That is the freeze behaving as
+  specified rather than a silent substitution of the kind the writes refuse —
+  the address never advertised the parameter, and the document is what a client
+  is generated from.
 
 ### Writes
 
-- `PUT …/engine-config` and `PUT …/identity/{bot_id}/{file_type}` accept
+- `PUT …/engine/config` and `PUT …/{bot_id}/identity/{file_type}` accept
   `stage`, default `draft`, and write the draft.
 - `stage=verify` or `stage=online` is refused with `409` and the fixed message
   **"The requested stage is read-only"**.
@@ -149,15 +173,20 @@ Each of these was checked against the callers of
   `stage` parameter there would be inert — three stages returning the same row —
   and inert parameters are worse than absent ones.
 - **The resources group** (7 handlers). A genuine per-bot device-file surface
-  with the same gap, but it is `definition-only / NOT PUBLIC-READY` (its own
-  router says so; `require_principal` is still a stub) and it has a
-  `publish_id`-shaped stage path in `ResourceFileService` that would have to be
-  reconciled first. Filed as follow-up, not folded in.
-- **The skills group** (6 handlers). Same gap, and release-pending; its
-  `owner_entity_id` locator predates `owner_id` and the openapi-v1 README
-  already records that it must be reconciled to `owner_id` before release.
-  Doing stage addressing on top of an unreconciled locator would have to be
-  redone.
+  with the same gap. It is `definition-only / NOT PUBLIC-READY` (its own router
+  says so; `require_principal` is still a stub), and `ResourceFileService`
+  already carries a `publish_id`-shaped stage path that would have to be
+  reconciled with a `stage` parameter first — the Open Question below. Filed as
+  follow-up, not folded in. (#1074 re-addresses it to
+  `/openapi/v1/bots/{bot_id}/resources`; that is an address change, not a
+  runtime one.)
+- **The skills group** (6 handlers). Same gap, release-pending. Its
+  `owner_entity_id` locator — the reason this group could not be stage-addressed
+  on the same terms as the others — is fixed by #1074's Task 14, which renames it
+  to `owner_id`, so that blocker is gone by the time this lands. What remains is
+  scope: six operations whose device interaction is skill activation and
+  package upload, not a file read, and which are pending their own release
+  runbook. Deferred on those grounds rather than on the locator's.
 - **Routines.** `CronRelayService` resolves `resolve_for_bot`, but a routine is
   not a per-bot file and its stage pin is already filed as
   [#908](https://github.com/inclusionAI/Avernet/issues/908).
@@ -217,10 +246,39 @@ carries no unique constraint and every user's first bot is called `default`. The
 key passed is the one from the record the request's ownership guard already
 resolved.
 
+**D7 — This lands after #1074, on the bot-first addresses only.** Two
+consequences, both deliberate:
+
+- The five addresses in the Summary are the post-#1074 ones. The engine-config
+  pair in particular moves house — #1074's Task 15 takes the two handlers out of
+  `openapi_v1/bots/router.py` onto their own router mounted at
+  `/openapi/v1/bots/{bot_id}/engine`, with the ordinary error table rather than
+  the engine-runtime one. This feature adds the parameter wherever those
+  handlers then live; it does not move them itself.
+- The deprecated addresses do not get the parameter, per **Legacy addresses**
+  above. Sequencing this before #1074 would mean adding `stage` to an address
+  about to be deprecated and then adding it again to its replacement, and the
+  deprecation freeze would make the first of those a contract violation.
+
 ## Open Questions
 
-None blocking. One noted for the follow-up work: when resources and skills are
-stage-addressed, `ResourceFileService`'s `publish_id` parameter and a new
-`stage` parameter would coexist on the same service, and the precedence between
-them should be settled the same way `IdentityService.get_bot_file` settles it
-here (record-keyed wins, as the more specific address).
+None blocking.
+
+**Noted for #1074, found while writing this spec.** Its Task 15 moves
+engine-config to `/openapi/v1/bots/{bot_id}/engine/config`, and its new
+`_is_engine_runtime(path)` predicate in `test_stage_addressing.py` classifies a
+path by `parts[4] == "{bot_id}" and parts[5] in {sessions, engine, models,
+approvals, connection}`. That predicate matches the moved engine-config path,
+which is **not** an engine-runtime operation — it carries `user_id` rather than
+`owner_id`, and Task 15 gives it the ordinary error table precisely because it
+cannot produce the 501/504 those groups document. The predicate's first
+assertion is `"owner_id" in params`, so Task 15 will fail that test on its own,
+before this feature exists. It belongs to #1074 to narrow the predicate (a
+`("engine", "config")` exclusion, or matching the operation set rather than the
+segment); Task D4 here depends on whichever shape it takes.
+
+**Noted for the follow-up work:** when resources is stage-addressed,
+`ResourceFileService`'s `publish_id` parameter and a new `stage` parameter would
+coexist on the same service, and the precedence between them should be settled
+the same way `IdentityService.get_bot_file` settles it here — record-keyed wins,
+as the more specific address.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -176,21 +176,21 @@
 
 ## Group C — Adapters
 
-### Task C1: The write-side parameter  `[ ]`
+### Task C1: The write-side parameter  `[x]`
 
 - **Goal:** One parameter, two published descriptions — the write's must not
   advertise verify/online as addressable.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py`
 - **Done when:**
-  - [ ] `WRITE_STAGE_DESCRIPTION` states that only the draft accepts writes,
+  - [x] `WRITE_STAGE_DESCRIPTION` states that only the draft accepts writes,
         that a published runtime is replaced by publishing again, and that
         naming one is a 409 with nothing written.
-  - [ ] `WriteStageQuery` alongside `StageQuery`; both exported.
-  - [ ] Module docstring records that `stage` is now imported outside this
+  - [x] `WriteStageQuery` alongside `StageQuery`; both exported.
+  - [x] Module docstring records that `stage` is now imported outside this
         group (the per-bot file operations) and why it still lives here.
 - **Depends on:** —
 
-### Task C2: `stage` on the two engine-config operations  `[ ]`
+### Task C2: `stage` on the two engine-config operations  `[x]`
 
 - **Goal:** `GET /openapi/v1/bots/{bot_id}/engine/config` serves three runtimes;
   `PUT` of the same address refuses two.
@@ -201,40 +201,46 @@
   15 shipped after #1074 rather than in it, they are still in `bots/router.py`
   at `/{bot_id}/engine-config` and the edit is the same apart from the file.
 - **Done when:**
-  - [ ] `get_bot_engine_config(..., stage: StageQuery = RuntimeStage.DRAFT)`
+  - [x] `get_bot_engine_config(..., stage: StageQuery = RuntimeStage.DRAFT)`
         passes `stage=stage.value`. No adapter-side helper and no extra
         lookup — the service resolves its own facts (spec D8).
-  - [ ] `update_bot_engine_config(..., stage: WriteStageQuery =
+  - [x] `update_bot_engine_config(..., stage: WriteStageQuery =
         RuntimeStage.DRAFT)` passes `stage=stage.value`.
-  - [ ] Both docstrings are caller-facing prose only (they are published
+  - [x] Both docstrings are caller-facing prose only (they are published
         verbatim); rationale stays in `#` comments.
-  - [ ] The **deprecated** `/{bot_id}/engine-config` shim is left alone: it
-        declares no `stage`, and its handler keeps calling the service with
-        `stage=STAGE_DRAFT` (#1074 froze its contract).
+  - [x] The **deprecated** `/{bot_id}/engine-config` twin declares no `stage`.
+        **Leaving the shim alone was not enough** — `relocate` re-registers the
+        *same endpoint function*, so the parameter would have appeared on both
+        addresses. A new `without_parameter` transform (the mirror of the
+        existing `with_query_parameter`) drops it from the registered signature,
+        and the handler's own default applies.
 - **Depends on:** B1, C1, and #1074
 
-### Task C3: `stage` on the three identity operations  `[ ]`
+### Task C3: `stage` on the three identity operations  `[x]`
 
 - **Goal:** Same contract on `/openapi/v1/bots/{bot_id}/identity` and
   `…/identity/{file_type}`, without changing the draft path.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py`
   (already mounted bot-first by #1074's Task 4)
 - **Done when:**
-  - [ ] `list_bot_identity_files` and `get_bot_identity_file` take
+  - [x] `list_bot_identity_files` and `get_bot_identity_file` take
         `stage: StageQuery = RuntimeStage.DRAFT` and pass `stage=stage.value`.
-  - [ ] `update_bot_identity_file` takes `stage: WriteStageQuery =
+  - [x] `update_bot_identity_file` takes `stage: WriteStageQuery =
         RuntimeStage.DRAFT` and passes `stage=stage.value`.
-  - [ ] **No `BotRepository` injection and no bot lookup anywhere in this
+  - [x] **No `BotRepository` injection and no bot lookup anywhere in this
         router** — the earlier draft had a conditional one; resolving the facts
         in the shared helper removed the need. The draft path adds no row read
         of its own, so its failure mode is unchanged (409, not 404).
-  - [ ] The stale "Reads address the bot's draft runtime." line in
+  - [x] The stale "Reads address the bot's draft runtime." line in
         `get_bot_identity_file`'s published docstring is corrected.
-  - [ ] The direct-invocation tests in
+  - [x] The direct-invocation tests in
         `tests/…/openapi_v1/identity/test_identity_handlers.py` are updated for
         the new handler parameters (their stub gains `address`/`stage`).
-  - [ ] The **deprecated** `…/bots/identity/{bot_id}` shims are left alone —
-        no `stage`, draft only.
+  - [x] The **deprecated** `…/bots/identity/{bot_id}` twins declare no `stage`,
+        via the same `without_parameter` transform. Note the contrast recorded
+        in `deprecated/engine_runtime.py`: the engine-runtime groups keep
+        publishing `stage` at both addresses, because they took it before the
+        freeze — identity gained it after, which makes it a new capability.
 - **Depends on:** B2, C1, and #1074
 
 ### Task C4: The internal routes say `draft` out loud  `[x]`

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -30,7 +30,7 @@
         entry in nothing (this file has no ordering rule; `responses.py` does).
 - **Depends on:** —
 
-### Task A2: `BotFacts.from_record`, `require_stage_writable`, `resolve_published_device_context`  `[ ]`
+### Task A2: `BotFacts.from_record`, `require_stage_writable`, `resolve_published_device_context`  `[x]`
 
 - **Goal:** A published stage → `DeviceContext`, in one place, for the surfaces
   that read a bot's files — so they cannot drift from the surfaces that forward
@@ -40,30 +40,30 @@
   `…/core/engine_runtime/stage.py`,
   `…/core/engine_runtime/relay.py`
 - **Done when:**
-  - [ ] `BotFacts.from_record(record, *, bot_id, owner_id)` classmethod, with the
+  - [x] `BotFacts.from_record(record, *, bot_id, owner_id)` classmethod, with the
         same `or`-fallbacks `relay.resolve_bot` applies today, and a docstring
         saying the record must come from an owner-scoped read (spec D6).
-  - [ ] `relay.resolve_bot`'s inline `BotFacts(...)` construction uses it, so
+  - [x] `relay.resolve_bot`'s inline `BotFacts(...)` construction uses it, so
         there is **one** projection of a bot row into facts. This is the only
         edit outside the feature; it is reversible on its own if a reviewer
         disagrees.
-  - [ ] `require_stage_writable(stage)` raises `EngineStageReadOnlyError` for
+  - [x] `require_stage_writable(stage)` raises `EngineStageReadOnlyError` for
         anything but the draft; docstring says why it is not conditional on bot
         type or liveness.
-  - [ ] `resolve_published_device_context(resolver, publish_repo, binding_repo,
+  - [x] `resolve_published_device_context(resolver, publish_repo, binding_repo,
         *, facts: BotFacts, stage: str)`: `require_stage_addressable(
         facts.bot_type, stage)` first, then `resolve_stage_bind_id(...)` keyed
         on `facts.bot_pk`, then `resolve_for_binding(bind_id, facts.owner_id,
         bot_id=facts.bot_id)`.
-  - [ ] Its docstring says **why published-only** — a draft leg would need facts
+  - [x] Its docstring says **why published-only** — a draft leg would need facts
         the draft path must not read (spec D8) — and why `resolve_for_binding`
         rather than the relay's `…_invoke` (a filesystem needs the full conn
         info). It names `relay._resolve_published_device` as its sibling and
         `resolve_stage_bind_id` as the rule they share.
-  - [ ] Module docstring gains the *other question* paragraph: stage-keyed comes
+  - [x] Module docstring gains the *other question* paragraph: stage-keyed comes
         here, record-keyed goes to `select_stage_bind_id`, and why routing a
         `publish_id` through this rule would answer about the wrong release.
-  - [ ] `__all__` updated. `ruff check` clean.
+  - [x] `__all__` updated. `ruff check` clean.
 - **Depends on:** A1
 
 ### Task A3: Map the refusal to 409  `[ ]`

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -379,12 +379,22 @@
 
 ## Verification
 
-- [ ] `ruff check` clean on every changed file.
-- [ ] `tests/community/architecture` — passes (conformance + boundary gates).
-- [ ] `tests/community/core/engine_runtime`, `tests/community/core/services`,
-      `tests/community/adapters/http/openapi_v1`,
-      `tests/community/api/bot_management` — pass.
-- [ ] `scripts/ci/pre_push.sh` per the AGENTS.md contract (lint-only by
-      default; `OCB_PRE_PUSH_RUN_CI=1` for the full module gates).
-- [ ] PR titled `feat(backend): address published runtimes on the per-bot file
-      endpoints`, body using the Problem / Solution / Validation template.
+- [x] `ruff check` clean on every changed file. (One touched test file carries
+      9 pre-existing errors — identical with the change stashed.)
+- [x] `scripts/ci/python_sast_local.sh src/backend` — flags 100 files
+      repo-wide, none of them this change's.
+- [x] `tests/community/architecture` — 135 passed (conformance + boundary
+      gates). `core.repository.protocols.bot` added to engine_runtime's context
+      boundary, which `stage.py` now imports.
+- [x] Full backend suite — **9,915 passed, 4 skipped, 2 failed**. Both failures
+      shell out to `rsync`, absent from this container; verified pre-existing by
+      re-running with the branch's work stashed (#1073 and #1074 recorded the
+      same pair).
+- [x] The published document asserted directly: `stage` optional, in the query,
+      defaulted `draft`, enum of exactly three, 409 documented — on the five,
+      and on none of their retiring twins.
+- [!] `scripts/ci/pre_push.sh` full-gate mode stops at the two rsync failures
+      above, so the changed-line-coverage and Singlebox E2E stages did **not**
+      run locally. GitHub's runners are the authority for those two.
+- [x] PR #1075, titled `feat(backend): address published runtimes on the per-bot
+      file endpoints`, body using the Problem / Solution / Validation template.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -6,9 +6,8 @@
 > addresses below are its bot-first ones, and the two suites Group D extends are
 > the ones it rewrites. Do not start Group C before it is in.
 >
-> PR #1073 is also open, against the same two read methods in
-> `core/services/engine_config.py` that Task B1 edits — see the plan's
-> **Dependencies**; rebase onto its head before starting B1 if it is still open.
+> PR #1073 has merged (`a5afd54`); Task B1 edits `engine_config.py` as it left
+> it, through its `_read_config_bytes` helper. Nothing to rebase.
 >
 > Groups run in order. Within a group the tasks may be done together.
 
@@ -292,20 +291,20 @@
 
 - **Files:** `tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py`
 - **Done when:**
-  - [ ] **First**, read how #1074 settled the `_is_engine_runtime()` /
-        `…/{bot_id}/engine/config` collision (spec **Open Questions**) — that
-        predicate matches the moved engine-config path, which carries `user_id`
-        rather than `owner_id`. Build on its resolution; do not add a second
-        one.
+  - [ ] Build on #1074's `_engine_runtime_paths()` — membership in the mounted
+        route set, not a segment match (spec **Open Questions**, resolved). The
+        five operations here are not in that set, so they need no change to the
+        predicate; do not add a second classification.
   - [ ] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five bot-first operations,
         mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE`, so
         `test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations`
         stays an **exact** assertion (16 + 5) rather than being loosened.
   - [ ] `stage` is still optional on every operation carrying it, and still
         never a body field or a path segment.
-  - [ ] **No deprecated address carries `stage`** — the exact-set assertion
-        already gives this, since the legacy operations are in neither set;
-        make it a named check rather than a side effect.
+  - [ ] **None of the five retiring twins carries `stage`** — and note the
+        distinction: the retiring *engine-runtime* addresses do carry it and
+        must keep doing so (they always had it, and #1074's parity promise is
+        that they keep their contract). The claim is about these five only.
   - [ ] The module docstring is updated: "sixteen … and nowhere else" is no
         longer true.
 - **Depends on:** C2, C3

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -30,29 +30,39 @@
         entry in nothing (this file has no ordering rule; `responses.py` does).
 - **Depends on:** —
 
-### Task A2: `StageAddress`, `require_stage_writable`, `resolve_stage_device_context`  `[ ]`
+### Task A2: `BotFacts.from_record`, `require_stage_writable`, `resolve_published_device_context`  `[ ]`
 
-- **Goal:** Stage → `DeviceContext`, in one place, for the surfaces that read a
-  bot's files — so they cannot drift from the surfaces that forward to it.
-- **Files:** `src/backend/src/agentclaw/community/core/engine_runtime/stage.py`
+- **Goal:** A published stage → `DeviceContext`, in one place, for the surfaces
+  that read a bot's files — so they cannot drift from the surfaces that forward
+  to it. Carried on the bot-identity model the codebase already has.
+- **Files:**
+  `src/backend/src/agentclaw/community/core/engine_runtime/models.py`,
+  `…/core/engine_runtime/stage.py`,
+  `…/core/engine_runtime/relay.py`
 - **Done when:**
-  - [ ] `StageAddress` frozen dataclass (`stage`, `bot_pk`, `bot_type`) with a
-        docstring stating that `bot_pk`/`bot_type` must come from the read that
-        proved ownership, and that neither is read on the draft.
-  - [ ] `DRAFT_ADDRESS` module constant.
+  - [ ] `BotFacts.from_record(record, *, bot_id, owner_id)` classmethod, with the
+        same `or`-fallbacks `relay.resolve_bot` applies today, and a docstring
+        saying the record must come from an owner-scoped read (spec D6).
+  - [ ] `relay.resolve_bot`'s inline `BotFacts(...)` construction uses it, so
+        there is **one** projection of a bot row into facts. This is the only
+        edit outside the feature; it is reversible on its own if a reviewer
+        disagrees.
   - [ ] `require_stage_writable(stage)` raises `EngineStageReadOnlyError` for
         anything but the draft; docstring says why it is not conditional on bot
         type or liveness.
-  - [ ] `resolve_stage_device_context(resolver, publish_repo, binding_repo, *,
-        address, bot_id, owner_id)`: `require_stage_addressable` first, then
-        draft → `resolve_for_bot(bot_id, owner_id)`, published →
-        `resolve_stage_bind_id(...)` → `resolve_for_binding(bind_id, owner_id,
-        bot_id=bot_id)`. Docstring says why `resolve_for_binding` and not the
-        relay's `…_invoke` (a filesystem needs the full conn info).
-  - [ ] Module docstring gains the *other question* paragraph: stage-keyed
-        comes here, record-keyed goes to `select_stage_bind_id`, and why
-        routing a `publish_id` through this rule would answer about the wrong
-        release.
+  - [ ] `resolve_published_device_context(resolver, publish_repo, binding_repo,
+        *, facts: BotFacts, stage: str)`: `require_stage_addressable(
+        facts.bot_type, stage)` first, then `resolve_stage_bind_id(...)` keyed
+        on `facts.bot_pk`, then `resolve_for_binding(bind_id, facts.owner_id,
+        bot_id=facts.bot_id)`.
+  - [ ] Its docstring says **why published-only** — a draft leg would need facts
+        the draft path must not read (spec D8) — and why `resolve_for_binding`
+        rather than the relay's `…_invoke` (a filesystem needs the full conn
+        info). It names `relay._resolve_published_device` as its sibling and
+        `resolve_stage_bind_id` as the rule they share.
+  - [ ] Module docstring gains the *other question* paragraph: stage-keyed comes
+        here, record-keyed goes to `select_stage_bind_id`, and why routing a
+        `publish_id` through this rule would answer about the wrong release.
   - [ ] `__all__` updated. `ruff check` clean.
 - **Depends on:** A1
 
@@ -83,19 +93,25 @@
   - [ ] Constructor takes `publish_repo: BotPublishRepositoryProtocol` and
         `binding_repo: DeviceBindingRepository`, with a comment that both exist
         only for the stage-addressed read.
-  - [ ] `_bot_config_device_fs(..., address)` calls
-        `resolve_stage_device_context`.
-  - [ ] `read_bot_config(..., address: StageAddress)` — required, not defaulted.
+  - [ ] `_bot_facts(bot_id, owner_id)` builds `BotFacts` from
+        `self._bot_repo.get_by_id_and_owner`, raising `BotNotFoundError` on a
+        miss. No new constructor dependency — the service already holds the
+        repository.
+  - [ ] `_bot_config_device_fs(..., stage)` branches: draft → the existing
+        `resolve_for_bot(bot_id, owner_id)` **unchanged and with no row read**;
+        published → `_bot_facts` then `resolve_published_device_context`.
+  - [ ] `read_bot_config(..., stage: str)` — required, not defaulted.
   - [ ] `write_bot_config(..., stage: str)` calls `require_stage_writable(stage)`
-        as its **first** statement, then resolves `DRAFT_ADDRESS`.
+        as its **first** statement, then takes the draft branch. It must never
+        reach `_bot_facts`.
   - [ ] `read_publish_config` unchanged in behaviour, with a comment at the
         `select_stage_bind_id` call saying why it is deliberately not the stage
         rule (spec D3).
   - [ ] `EngineConfigServiceProtocol` mirrors both signatures exactly; its
-        class docstring records why the two parameters are required rather than
-        defaulted (the conformance test compares defaults by value, and a
-        runtime `api → core.engine_runtime` import hits a partially-initialised
-        `bot_service`).
+        class docstring records why `stage` is required rather than defaulted —
+        `EngineRuntimeRelayProtocol` states the same convention, and a default
+        would also need a runtime `api → core.engine_runtime` import, which hits
+        a partially-initialised `bot_service`.
   - [ ] Module and class docstrings updated to describe three addresses, two of
         them read-only.
   - [ ] `tests/community/architecture/test_service_api_conformance.py` passes.
@@ -108,19 +124,20 @@
 - **Files:** `src/backend/src/agentclaw/community/core/services/identity.py`
 - **Done when:**
   - [ ] Constructor takes `binding_repo: DeviceBindingRepository`.
+  - [ ] `_bot_facts(bot_id, owner_id)` as in B1 — same shape, same reason.
   - [ ] `_identity_device_fs`, `_device_read`, `read_identity_file` take
-        `address: StageAddress = DRAFT_ADDRESS`; `_identity_device_fs` resolves
-        through `resolve_stage_device_context`.
+        `stage: str = STAGE_DRAFT`; `_identity_device_fs` carries the same
+        draft/published branch B1 describes.
   - [ ] `get_bot_file` and `list_bot_files` take keyword-only
-        `address: StageAddress = DRAFT_ADDRESS` and pass it down;
-        `list_bot_files` probes all 16 files against the **one** addressed
-        runtime.
+        `stage: str = STAGE_DRAFT` and pass it down; `list_bot_files` probes all
+        16 files against the **one** addressed runtime, resolving the facts once
+        rather than per file.
   - [ ] `get_bot_file`'s docstring states the precedence: `publish_id` (a
-        record) wins over `address` (a stage), because it names one exact
-        release, and because it is the older internal contract.
+        record) wins over `stage`, because it names one exact release, and
+        because it is the older internal contract.
   - [ ] `update_bot_file` takes keyword-only `stage: str = STAGE_DRAFT` and
         calls `require_stage_writable(stage)` first; the write path below it is
-        unchanged and needs no address.
+        unchanged and never resolves facts.
   - [ ] `_read_from_publish_device` unchanged in behaviour, with the same
         record-keyed-vs-stage-keyed comment as B1.
   - [ ] `write_identity_file` / `sync_agents_md` untouched — draft-only by
@@ -144,8 +161,7 @@
   - [ ] Every direct `IdentityService(...)` passes `binding_repo`; every direct
         `EngineConfigService(...)` passes `publish_repo` and `binding_repo`.
   - [ ] `read_bot_config` / `write_bot_config` call sites in
-        `test_engine_config_service.py` pass `address=DRAFT_ADDRESS` /
-        `stage=STAGE_DRAFT`.
+        `test_engine_config_service.py` pass `stage=STAGE_DRAFT`.
   - [ ] Those suites pass unchanged otherwise.
 - **Depends on:** B1, B2
 
@@ -178,18 +194,16 @@
   15 shipped after #1074 rather than in it, they are still in `bots/router.py`
   at `/{bot_id}/engine-config` and the edit is the same apart from the file.
 - **Done when:**
-  - [ ] `_stage_address(bot, stage)` helper builds the `StageAddress` from the
-        record `bot_service.get_bot(bot_id, owner_id)` already returned —
-        docstring says why a second lookup by `bot_id` would be wrong.
   - [ ] `get_bot_engine_config(..., stage: StageQuery = RuntimeStage.DRAFT)`
-        passes `address=_stage_address(bot, stage)`.
+        passes `stage=stage.value`. No adapter-side helper and no extra
+        lookup — the service resolves its own facts (spec D8).
   - [ ] `update_bot_engine_config(..., stage: WriteStageQuery =
         RuntimeStage.DRAFT)` passes `stage=stage.value`.
   - [ ] Both docstrings are caller-facing prose only (they are published
         verbatim); rationale stays in `#` comments.
   - [ ] The **deprecated** `/{bot_id}/engine-config` shim is left alone: it
         declares no `stage`, and its handler keeps calling the service with
-        `DRAFT_ADDRESS` / `STAGE_DRAFT` (#1074 froze its contract).
+        `stage=STAGE_DRAFT` (#1074 froze its contract).
 - **Depends on:** B1, C1, and #1074
 
 ### Task C3: `stage` on the three identity operations  `[ ]`
@@ -199,17 +213,14 @@
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py`
   (already mounted bot-first by #1074's Task 4)
 - **Done when:**
-  - [ ] A module-level `_stage_address(bot_id, owner_id, stage, bot_repo)`
-        returns `DRAFT_ADDRESS` **without any query** for the draft, and
-        otherwise resolves `bot_repo.get_by_id_and_owner(bot_id, owner_id)`,
-        raising `BotNotFoundError` on a miss. Comment says why the lookup is
-        conditional (an unconditional one would turn today's 409 into a 404 on
-        the default path).
   - [ ] `list_bot_identity_files` and `get_bot_identity_file` take
-        `stage: StageQuery = RuntimeStage.DRAFT` and `bot_repo:
-        BotRepository = Injected(BotRepository)`; both pass `address=`.
+        `stage: StageQuery = RuntimeStage.DRAFT` and pass `stage=stage.value`.
   - [ ] `update_bot_identity_file` takes `stage: WriteStageQuery =
-        RuntimeStage.DRAFT`, passes `stage=stage.value`, and adds **no** lookup.
+        RuntimeStage.DRAFT` and passes `stage=stage.value`.
+  - [ ] **No `BotRepository` injection and no bot lookup anywhere in this
+        router** — the earlier draft had a conditional one; resolving the facts
+        in the service removed the need. The draft path still reads no bot row,
+        so its failure mode is unchanged (409, not 404).
   - [ ] The stale "Reads address the bot's draft runtime." line in
         `get_bot_identity_file`'s published docstring is corrected.
   - [ ] The direct-invocation tests in
@@ -225,7 +236,7 @@
   console's draft-only scope is stated rather than inherited.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/bot_management/router.py`
 - **Done when:**
-  - [ ] `read_bot_config(..., address=DRAFT_ADDRESS)` and
+  - [ ] `read_bot_config(..., stage=STAGE_DRAFT)` and
         `write_bot_config(..., stage=STAGE_DRAFT)`, with a comment that naming a
         runtime is the public surface's parameter, not this route's.
   - [ ] `tests/community/api/bot_management/test_router.py` passes.
@@ -241,11 +252,15 @@
 - **Done when:**
   - [ ] `require_stage_writable`: draft passes; verify and online raise
         `EngineStageReadOnlyError`.
-  - [ ] `resolve_stage_device_context`: draft calls `resolve_for_bot(bot_id,
-        owner_id)` and never `resolve_for_binding`; verify/online resolve the
-        publish record's binding and call `resolve_for_binding`; a published
-        stage on a `personal` bot raises `EngineStageNotLiveError` **before**
-        any resolver call.
+  - [ ] `resolve_published_device_context`: verify/online resolve the publish
+        record's binding and call `resolve_for_binding` with `facts.owner_id`
+        and `facts.bot_id`; a published stage on a `personal` bot raises
+        `EngineStageNotLiveError` **before** any resolver call; a draft stage
+        raises `ValueError` from `resolve_stage_bind_id` (it is not this
+        function's job).
+  - [ ] `BotFacts.from_record` applies the same fallbacks the relay applied
+        inline, and `relay.resolve_bot` still returns identical facts — the
+        existing relay tests are the check.
 - **Depends on:** A2
 
 ### Task D2: Service-level behaviour  `[ ]`
@@ -273,9 +288,9 @@
   - [ ] Each of the three reads — `GET …/{bot_id}/engine/config`,
         `GET …/{bot_id}/identity`, `GET …/{bot_id}/identity/{file_type}` —
         with `stage=draft|verify|online` hands the service the matching
-        `StageAddress`.
-  - [ ] No parameter → `DRAFT_ADDRESS`, and on identity **no bot lookup at
-        all** (the byte-for-byte pin).
+        stage string.
+  - [ ] No parameter → `stage="draft"`, and the draft path reads **no bot
+        row** — assert the repository was not touched (the byte-for-byte pin).
   - [ ] Both writes with `stage=verify|online` → `409` and the body message
         `"The requested stage is read-only"`; with no parameter → unchanged
         `200`.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -66,15 +66,15 @@
   - [x] `__all__` updated. `ruff check` clean.
 - **Depends on:** A1
 
-### Task A3: Map the refusal to 409  `[ ]`
+### Task A3: Map the refusal to 409  `[x]`
 
 - **Goal:** The new error leaves the envelope as a fixed-message 409, not a 500.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py`
 - **Done when:**
-  - [ ] `EngineStageReadOnlyError: (409, "The requested stage is read-only")`,
+  - [x] `EngineStageReadOnlyError: (409, "The requested stage is read-only")`,
         placed inside the engine-runtime block **above** the
         `EngineRuntimeError` base (the block's stated ordering rule).
-  - [ ] Comment says why it is a separate answer from
+  - [x] Comment says why it is a separate answer from
         `EngineStageNotLiveError` and from a `200` with a no-op flag.
 - **Depends on:** A1
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -348,24 +348,24 @@
 
 ## Group E — Documentation
 
-### Task E1: `docs/openapi-v1/README.md`  `[ ]`
+### Task E1: `docs/openapi-v1/README.md`  `[x]`
 
 - **Goal:** The operator-facing description matches the surface.
 - **Files:** `src/backend/docs/openapi-v1/README.md`
 - **Done when:**
-  - [ ] The `?owner_id=`/`?stage=` section says `stage` reaches the five
+  - [x] The `?owner_id=`/`?stage=` section says `stage` reaches the five
         bot-first per-bot file operations too, and that on the two writes only
         the draft is writable. Its example URLs use the bot-first form #1074's
         Task 32 leaves behind (`/openapi/v1/bots/{bot_id}/engine/status?stage=`,
         not `/openapi/v1/bots/engine/{bot_id}/status?stage=`).
-  - [ ] It states that the deprecated addresses do not take `stage`, in the
+  - [x] It states that the deprecated addresses do not take `stage`, in the
         deprecation section #1074's Task 32 adds rather than as a new one.
-  - [ ] The startup-script finding is recorded where a reader looking for it
+  - [x] The startup-script finding is recorded where a reader looking for it
         would land: those operations are storage-keyed, not runtime-keyed, and
         deliberately take no stage.
-  - [ ] Resources / skills / routines are named as the remaining draft-only
+  - [x] Resources / skills / routines are named as the remaining draft-only
         device surfaces, with the reason each is deferred (spec Out of Scope).
-  - [ ] MCP is named too, and correctly: its six operations address no bot, but
+  - [x] MCP is named too, and correctly: its six operations address no bot, but
         its config write fans out to every bot's draft device. Draft-only is
         the right answer there for the same reason the writes here refuse a
         published stage — say so, so a later reader does not file it as a gap.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -96,13 +96,17 @@
   - [x] Constructor takes `publish_repo: BotPublishRepositoryProtocol` and
         `binding_repo: DeviceBindingRepository`, with a comment that both exist
         only for the stage-addressed read.
-  - [x] `_bot_facts(bot_id, owner_id)` builds `BotFacts` from
-        `self._bot_repo.get_by_id_and_owner`, raising `BotNotFoundError` on a
-        miss. No new constructor dependency — the service already holds the
-        repository.
-  - [x] `_bot_config_device_fs(..., stage)` branches: draft → the existing
-        `resolve_for_bot(bot_id, owner_id)` **unchanged and with no row read**;
-        published → `_bot_facts` then `resolve_published_device_context`.
+  - [x] `_bot_config_device_fs(..., stage)` delegates both legs to
+        `resolve_stage_device_context`. **Deviation, recorded:** the plan had a
+        per-service `_bot_facts` raising `BotNotFoundError` on a miss. Review
+        showed that duplicated the branch in two services, so the facts
+        resolution moved into the shared helper — and a missing row yields empty
+        facts, which `require_stage_addressable` refuses as 409 "no live
+        runtime". A 404 would have made a published-stage request the one way to
+        learn whether a bot exists.
+  - [x] The draft leg adds **no row read of its own**. It is not row-free —
+        `resolve_for_bot` reads the bot to fill `ctx.bot_type` — but nothing is
+        added to what it already did.
   - [x] `read_bot_config(..., stage: str)` — required, not defaulted.
   - [x] `write_bot_config(..., stage: str)` calls `require_stage_writable(stage)`
         as its **first** statement, then takes the draft branch. It must never
@@ -222,8 +226,8 @@
         RuntimeStage.DRAFT` and passes `stage=stage.value`.
   - [ ] **No `BotRepository` injection and no bot lookup anywhere in this
         router** — the earlier draft had a conditional one; resolving the facts
-        in the service removed the need. The draft path still reads no bot row,
-        so its failure mode is unchanged (409, not 404).
+        in the shared helper removed the need. The draft path adds no row read
+        of its own, so its failure mode is unchanged (409, not 404).
   - [ ] The stale "Reads address the bot's draft runtime." line in
         `get_bot_identity_file`'s published docstring is corrected.
   - [ ] The direct-invocation tests in

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -2,7 +2,11 @@
 
 > Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
 >
-> Base: `dev`. PR #1073 is open against the same two read methods in
+> Base: `dev`, **after PR #1074 lands** — a hard ordering dependency. The five
+> addresses below are its bot-first ones, and the two suites Group D extends are
+> the ones it rewrites. Do not start Group C before it is in.
+>
+> PR #1073 is also open, against the same two read methods in
 > `core/services/engine_config.py` that Task B1 edits — see the plan's
 > **Dependencies**; rebase onto its head before starting B1 if it is still open.
 >
@@ -166,8 +170,14 @@
 
 ### Task C2: `stage` on the two engine-config operations  `[ ]`
 
-- **Goal:** `GET` serves three runtimes; `PUT` refuses two.
-- **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py`
+- **Goal:** `GET /openapi/v1/bots/{bot_id}/engine/config` serves three runtimes;
+  `PUT` of the same address refuses two.
+- **Files:** the engine-config router #1074's Task 15 mounts at
+  `/openapi/v1/bots/{bot_id}/engine` — it moves the two handlers out of
+  `adapters/http/openapi_v1/bots/router.py` unchanged, so
+  `_engine_config_target` travels with them. **Start by locating them**; if Task
+  15 shipped after #1074 rather than in it, they are still in `bots/router.py`
+  at `/{bot_id}/engine-config` and the edit is the same apart from the file.
 - **Done when:**
   - [ ] `_stage_address(bot, stage)` helper builds the `StageAddress` from the
         record `bot_service.get_bot(bot_id, owner_id)` already returned —
@@ -178,12 +188,17 @@
         RuntimeStage.DRAFT)` passes `stage=stage.value`.
   - [ ] Both docstrings are caller-facing prose only (they are published
         verbatim); rationale stays in `#` comments.
-- **Depends on:** B1, C1
+  - [ ] The **deprecated** `/{bot_id}/engine-config` shim is left alone: it
+        declares no `stage`, and its handler keeps calling the service with
+        `DRAFT_ADDRESS` / `STAGE_DRAFT` (#1074 froze its contract).
+- **Depends on:** B1, C1, and #1074
 
 ### Task C3: `stage` on the three identity operations  `[ ]`
 
-- **Goal:** Same contract on identity, without changing the draft path.
+- **Goal:** Same contract on `/openapi/v1/bots/{bot_id}/identity` and
+  `…/identity/{file_type}`, without changing the draft path.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py`
+  (already mounted bot-first by #1074's Task 4)
 - **Done when:**
   - [ ] A module-level `_stage_address(bot_id, owner_id, stage, bot_repo)`
         returns `DRAFT_ADDRESS` **without any query** for the draft, and
@@ -201,7 +216,9 @@
   - [ ] The direct-invocation tests in
         `tests/…/openapi_v1/identity/test_identity_handlers.py` are updated for
         the new handler parameters (their stub gains `address`/`stage`).
-- **Depends on:** B2, C1
+  - [ ] The **deprecated** `…/bots/identity/{bot_id}` shims are left alone —
+        no `stage`, draft only.
+- **Depends on:** B2, C1, and #1074
 
 ### Task C4: The internal routes say `draft` out loud  `[ ]`
 
@@ -254,8 +271,10 @@
 
 - **Files:** new `tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py`
 - **Done when:**
-  - [ ] Each of the three reads with `stage=draft|verify|online` hands the
-        service the matching `StageAddress`.
+  - [ ] Each of the three reads — `GET …/{bot_id}/engine/config`,
+        `GET …/{bot_id}/identity`, `GET …/{bot_id}/identity/{file_type}` —
+        with `stage=draft|verify|online` hands the service the matching
+        `StageAddress`.
   - [ ] No parameter → `DRAFT_ADDRESS`, and on identity **no bot lookup at
         all** (the byte-for-byte pin).
   - [ ] Both writes with `stage=verify|online` → `409` and the body message
@@ -264,18 +283,29 @@
   - [ ] A published stage on a personal bot read → `409 "No live runtime at the
         requested stage"`.
   - [ ] `stage=eval` → `422`, no handler reached.
+  - [ ] The deprecated twins still read the draft when `?stage=online` is sent
+        at them — FastAPI ignores the undeclared parameter, and this pins that
+        the shim was not wired to the new code path by accident.
 - **Depends on:** C2, C3
 
 ### Task D4: The published document  `[ ]`
 
 - **Files:** `tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py`
 - **Done when:**
-  - [ ] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five operations, mirroring
-        the existing `_OWNER_ADDRESSED_ELSEWHERE`, so
+  - [ ] **First**, read how #1074 settled the `_is_engine_runtime()` /
+        `…/{bot_id}/engine/config` collision (spec **Open Questions**) — that
+        predicate matches the moved engine-config path, which carries `user_id`
+        rather than `owner_id`. Build on its resolution; do not add a second
+        one.
+  - [ ] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five bot-first operations,
+        mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE`, so
         `test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations`
         stays an **exact** assertion (16 + 5) rather than being loosened.
   - [ ] `stage` is still optional on every operation carrying it, and still
         never a body field or a path segment.
+  - [ ] **No deprecated address carries `stage`** — the exact-set assertion
+        already gives this, since the legacy operations are in neither set;
+        make it a named check rather than a side effect.
   - [ ] The module docstring is updated: "sixteen … and nowhere else" is no
         longer true.
 - **Depends on:** C2, C3
@@ -290,8 +320,12 @@
 - **Files:** `src/backend/docs/openapi-v1/README.md`
 - **Done when:**
   - [ ] The `?owner_id=`/`?stage=` section says `stage` reaches the five
-        per-bot file operations too, and that on the two writes only the draft
-        is writable.
+        bot-first per-bot file operations too, and that on the two writes only
+        the draft is writable. Its example URLs use the bot-first form #1074's
+        Task 32 leaves behind (`/openapi/v1/bots/{bot_id}/engine/status?stage=`,
+        not `/openapi/v1/bots/engine/{bot_id}/status?stage=`).
+  - [ ] It states that the deprecated addresses do not take `stage`, in the
+        deprecation section #1074's Task 32 adds rather than as a new one.
   - [ ] The startup-script finding is recorded where a reader looking for it
         would land: those operations are storage-keyed, not runtime-keyed, and
         deliberately take no stage.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -1,0 +1,314 @@
+# Tasks: Public API — Stage-Addressed Per-Bot Files
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+>
+> Base: `dev`. PR #1073 is open against the same two read methods in
+> `core/services/engine_config.py` that Task B1 edits — see the plan's
+> **Dependencies**; rebase onto its head before starting B1 if it is still open.
+>
+> Groups run in order. Within a group the tasks may be done together.
+
+---
+
+## Group A — Core: the stage seam and the refusal
+
+### Task A1: A core error for a write addressed to a published runtime  `[ ]`
+
+- **Goal:** One named domain state for "that runtime does not take writes",
+  distinct from "that runtime is not up".
+- **Files:** `src/backend/src/agentclaw/community/core/engine_runtime/errors.py`
+- **Done when:**
+  - [ ] `EngineStageReadOnlyError(EngineRuntimeError)` exists, docstring says
+        why a published runtime is replaced rather than edited, and states
+        explicitly that it is **not** `EngineStageNotLiveError` — it does not
+        depend on liveness, so publishing a runtime would not make the write
+        land.
+  - [ ] Listed in `__all__`, placed above the `EngineRuntimeError` base's own
+        entry in nothing (this file has no ordering rule; `responses.py` does).
+- **Depends on:** —
+
+### Task A2: `StageAddress`, `require_stage_writable`, `resolve_stage_device_context`  `[ ]`
+
+- **Goal:** Stage → `DeviceContext`, in one place, for the surfaces that read a
+  bot's files — so they cannot drift from the surfaces that forward to it.
+- **Files:** `src/backend/src/agentclaw/community/core/engine_runtime/stage.py`
+- **Done when:**
+  - [ ] `StageAddress` frozen dataclass (`stage`, `bot_pk`, `bot_type`) with a
+        docstring stating that `bot_pk`/`bot_type` must come from the read that
+        proved ownership, and that neither is read on the draft.
+  - [ ] `DRAFT_ADDRESS` module constant.
+  - [ ] `require_stage_writable(stage)` raises `EngineStageReadOnlyError` for
+        anything but the draft; docstring says why it is not conditional on bot
+        type or liveness.
+  - [ ] `resolve_stage_device_context(resolver, publish_repo, binding_repo, *,
+        address, bot_id, owner_id)`: `require_stage_addressable` first, then
+        draft → `resolve_for_bot(bot_id, owner_id)`, published →
+        `resolve_stage_bind_id(...)` → `resolve_for_binding(bind_id, owner_id,
+        bot_id=bot_id)`. Docstring says why `resolve_for_binding` and not the
+        relay's `…_invoke` (a filesystem needs the full conn info).
+  - [ ] Module docstring gains the *other question* paragraph: stage-keyed
+        comes here, record-keyed goes to `select_stage_bind_id`, and why
+        routing a `publish_id` through this rule would answer about the wrong
+        release.
+  - [ ] `__all__` updated. `ruff check` clean.
+- **Depends on:** A1
+
+### Task A3: Map the refusal to 409  `[ ]`
+
+- **Goal:** The new error leaves the envelope as a fixed-message 409, not a 500.
+- **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py`
+- **Done when:**
+  - [ ] `EngineStageReadOnlyError: (409, "The requested stage is read-only")`,
+        placed inside the engine-runtime block **above** the
+        `EngineRuntimeError` base (the block's stated ordering rule).
+  - [ ] Comment says why it is a separate answer from
+        `EngineStageNotLiveError` and from a `200` with a no-op flag.
+- **Depends on:** A1
+
+---
+
+## Group B — Core services
+
+### Task B1: `EngineConfigService` reads a stage, writes only the draft  `[ ]`
+
+- **Goal:** The engine-config read reaches all three runtimes; the write reaches
+  one and refuses the rest before touching a device.
+- **Files:**
+  `src/backend/src/agentclaw/community/core/services/engine_config.py`,
+  `src/backend/src/agentclaw/community/api/engine_config_service.py`
+- **Done when:**
+  - [ ] Constructor takes `publish_repo: BotPublishRepositoryProtocol` and
+        `binding_repo: DeviceBindingRepository`, with a comment that both exist
+        only for the stage-addressed read.
+  - [ ] `_bot_config_device_fs(..., address)` calls
+        `resolve_stage_device_context`.
+  - [ ] `read_bot_config(..., address: StageAddress)` — required, not defaulted.
+  - [ ] `write_bot_config(..., stage: str)` calls `require_stage_writable(stage)`
+        as its **first** statement, then resolves `DRAFT_ADDRESS`.
+  - [ ] `read_publish_config` unchanged in behaviour, with a comment at the
+        `select_stage_bind_id` call saying why it is deliberately not the stage
+        rule (spec D3).
+  - [ ] `EngineConfigServiceProtocol` mirrors both signatures exactly; its
+        class docstring records why the two parameters are required rather than
+        defaulted (the conformance test compares defaults by value, and a
+        runtime `api → core.engine_runtime` import hits a partially-initialised
+        `bot_service`).
+  - [ ] Module and class docstrings updated to describe three addresses, two of
+        them read-only.
+  - [ ] `tests/community/architecture/test_service_api_conformance.py` passes.
+- **Depends on:** A2
+
+### Task B2: `IdentityService` reads a stage, writes only the draft  `[ ]`
+
+- **Goal:** Same contract for the identity files, threaded through the layers
+  that actually reach the device.
+- **Files:** `src/backend/src/agentclaw/community/core/services/identity.py`
+- **Done when:**
+  - [ ] Constructor takes `binding_repo: DeviceBindingRepository`.
+  - [ ] `_identity_device_fs`, `_device_read`, `read_identity_file` take
+        `address: StageAddress = DRAFT_ADDRESS`; `_identity_device_fs` resolves
+        through `resolve_stage_device_context`.
+  - [ ] `get_bot_file` and `list_bot_files` take keyword-only
+        `address: StageAddress = DRAFT_ADDRESS` and pass it down;
+        `list_bot_files` probes all 16 files against the **one** addressed
+        runtime.
+  - [ ] `get_bot_file`'s docstring states the precedence: `publish_id` (a
+        record) wins over `address` (a stage), because it names one exact
+        release, and because it is the older internal contract.
+  - [ ] `update_bot_file` takes keyword-only `stage: str = STAGE_DRAFT` and
+        calls `require_stage_writable(stage)` first; the write path below it is
+        unchanged and needs no address.
+  - [ ] `_read_from_publish_device` unchanged in behaviour, with the same
+        record-keyed-vs-stage-keyed comment as B1.
+  - [ ] `write_identity_file` / `sync_agents_md` untouched — draft-only by
+        construction.
+- **Depends on:** A2
+
+### Task B3: Fix up direct service construction in tests  `[ ]`
+
+- **Goal:** The new constructor dependencies do not silently break unrelated
+  suites.
+- **Files:**
+  `tests/community/unit/harness/test_patch_engine.py`,
+  `tests/community/unit/harness/test_bot_profile.py`,
+  `tests/community/core/services/test_identity_provider_blind.py` (×2),
+  `tests/community/core/services/test_identity_service_coverage.py`,
+  `tests/community/core/services/test_identity_uses_resolver.py`,
+  `tests/community/adapters/http/test_http_adapters_use_resolver.py`,
+  `tests/community/adapters/http/test_identity_tenant_indirect_isolation.py`,
+  `tests/community/core/services/test_engine_config_service.py` (×2)
+- **Done when:**
+  - [ ] Every direct `IdentityService(...)` passes `binding_repo`; every direct
+        `EngineConfigService(...)` passes `publish_repo` and `binding_repo`.
+  - [ ] `read_bot_config` / `write_bot_config` call sites in
+        `test_engine_config_service.py` pass `address=DRAFT_ADDRESS` /
+        `stage=STAGE_DRAFT`.
+  - [ ] Those suites pass unchanged otherwise.
+- **Depends on:** B1, B2
+
+---
+
+## Group C — Adapters
+
+### Task C1: The write-side parameter  `[ ]`
+
+- **Goal:** One parameter, two published descriptions — the write's must not
+  advertise verify/online as addressable.
+- **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py`
+- **Done when:**
+  - [ ] `WRITE_STAGE_DESCRIPTION` states that only the draft accepts writes,
+        that a published runtime is replaced by publishing again, and that
+        naming one is a 409 with nothing written.
+  - [ ] `WriteStageQuery` alongside `StageQuery`; both exported.
+  - [ ] Module docstring records that `stage` is now imported outside this
+        group (the per-bot file operations) and why it still lives here.
+- **Depends on:** —
+
+### Task C2: `stage` on the two engine-config operations  `[ ]`
+
+- **Goal:** `GET` serves three runtimes; `PUT` refuses two.
+- **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py`
+- **Done when:**
+  - [ ] `_stage_address(bot, stage)` helper builds the `StageAddress` from the
+        record `bot_service.get_bot(bot_id, owner_id)` already returned —
+        docstring says why a second lookup by `bot_id` would be wrong.
+  - [ ] `get_bot_engine_config(..., stage: StageQuery = RuntimeStage.DRAFT)`
+        passes `address=_stage_address(bot, stage)`.
+  - [ ] `update_bot_engine_config(..., stage: WriteStageQuery =
+        RuntimeStage.DRAFT)` passes `stage=stage.value`.
+  - [ ] Both docstrings are caller-facing prose only (they are published
+        verbatim); rationale stays in `#` comments.
+- **Depends on:** B1, C1
+
+### Task C3: `stage` on the three identity operations  `[ ]`
+
+- **Goal:** Same contract on identity, without changing the draft path.
+- **Files:** `src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py`
+- **Done when:**
+  - [ ] A module-level `_stage_address(bot_id, owner_id, stage, bot_repo)`
+        returns `DRAFT_ADDRESS` **without any query** for the draft, and
+        otherwise resolves `bot_repo.get_by_id_and_owner(bot_id, owner_id)`,
+        raising `BotNotFoundError` on a miss. Comment says why the lookup is
+        conditional (an unconditional one would turn today's 409 into a 404 on
+        the default path).
+  - [ ] `list_bot_identity_files` and `get_bot_identity_file` take
+        `stage: StageQuery = RuntimeStage.DRAFT` and `bot_repo:
+        BotRepository = Injected(BotRepository)`; both pass `address=`.
+  - [ ] `update_bot_identity_file` takes `stage: WriteStageQuery =
+        RuntimeStage.DRAFT`, passes `stage=stage.value`, and adds **no** lookup.
+  - [ ] The stale "Reads address the bot's draft runtime." line in
+        `get_bot_identity_file`'s published docstring is corrected.
+  - [ ] The direct-invocation tests in
+        `tests/…/openapi_v1/identity/test_identity_handlers.py` are updated for
+        the new handler parameters (their stub gains `address`/`stage`).
+- **Depends on:** B2, C1
+
+### Task C4: The internal routes say `draft` out loud  `[ ]`
+
+- **Goal:** The two now-required arguments are supplied, and the internal
+  console's draft-only scope is stated rather than inherited.
+- **Files:** `src/backend/src/agentclaw/community/adapters/http/bot_management/router.py`
+- **Done when:**
+  - [ ] `read_bot_config(..., address=DRAFT_ADDRESS)` and
+        `write_bot_config(..., stage=STAGE_DRAFT)`, with a comment that naming a
+        runtime is the public surface's parameter, not this route's.
+  - [ ] `tests/community/api/bot_management/test_router.py` passes.
+- **Depends on:** B1
+
+---
+
+## Group D — Tests
+
+### Task D1: Core stage seam  `[ ]`
+
+- **Files:** `tests/community/core/engine_runtime/test_stage.py`
+- **Done when:**
+  - [ ] `require_stage_writable`: draft passes; verify and online raise
+        `EngineStageReadOnlyError`.
+  - [ ] `resolve_stage_device_context`: draft calls `resolve_for_bot(bot_id,
+        owner_id)` and never `resolve_for_binding`; verify/online resolve the
+        publish record's binding and call `resolve_for_binding`; a published
+        stage on a `personal` bot raises `EngineStageNotLiveError` **before**
+        any resolver call.
+- **Depends on:** A2
+
+### Task D2: Service-level behaviour  `[ ]`
+
+- **Files:**
+  `tests/community/core/services/test_engine_config_service.py`,
+  new `tests/community/core/services/test_identity_stage_addressing.py`
+- **Done when:**
+  - [ ] Engine-config: a verify/online read resolves through the publish
+        record's binding and reads the same canonical `config/teclaw.json`
+        path.
+  - [ ] Engine-config: a verify/online write raises
+        `EngineStageReadOnlyError` and the dispatcher is **never** called —
+        the "nothing is written" claim, asserted rather than described.
+  - [ ] Identity: the same two pins for `get_bot_file`, plus `list_bot_files`
+        probing the addressed runtime, plus the write refusal.
+  - [ ] Identity: `get_bot_file` with both `publish_id` and a published
+        `address` takes the record-keyed branch (the documented precedence).
+- **Depends on:** B1, B2
+
+### Task D3: HTTP behaviour  `[ ]`
+
+- **Files:** new `tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py`
+- **Done when:**
+  - [ ] Each of the three reads with `stage=draft|verify|online` hands the
+        service the matching `StageAddress`.
+  - [ ] No parameter → `DRAFT_ADDRESS`, and on identity **no bot lookup at
+        all** (the byte-for-byte pin).
+  - [ ] Both writes with `stage=verify|online` → `409` and the body message
+        `"The requested stage is read-only"`; with no parameter → unchanged
+        `200`.
+  - [ ] A published stage on a personal bot read → `409 "No live runtime at the
+        requested stage"`.
+  - [ ] `stage=eval` → `422`, no handler reached.
+- **Depends on:** C2, C3
+
+### Task D4: The published document  `[ ]`
+
+- **Files:** `tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py`
+- **Done when:**
+  - [ ] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five operations, mirroring
+        the existing `_OWNER_ADDRESSED_ELSEWHERE`, so
+        `test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations`
+        stays an **exact** assertion (16 + 5) rather than being loosened.
+  - [ ] `stage` is still optional on every operation carrying it, and still
+        never a body field or a path segment.
+  - [ ] The module docstring is updated: "sixteen … and nowhere else" is no
+        longer true.
+- **Depends on:** C2, C3
+
+---
+
+## Group E — Documentation
+
+### Task E1: `docs/openapi-v1/README.md`  `[ ]`
+
+- **Goal:** The operator-facing description matches the surface.
+- **Files:** `src/backend/docs/openapi-v1/README.md`
+- **Done when:**
+  - [ ] The `?owner_id=`/`?stage=` section says `stage` reaches the five
+        per-bot file operations too, and that on the two writes only the draft
+        is writable.
+  - [ ] The startup-script finding is recorded where a reader looking for it
+        would land: those operations are storage-keyed, not runtime-keyed, and
+        deliberately take no stage.
+  - [ ] Resources / skills / routines are named as the remaining draft-only
+        device surfaces, with the reason each is deferred (spec Out of Scope).
+- **Depends on:** C2, C3
+
+---
+
+## Verification
+
+- [ ] `ruff check` clean on every changed file.
+- [ ] `tests/community/architecture` — passes (conformance + boundary gates).
+- [ ] `tests/community/core/engine_runtime`, `tests/community/core/services`,
+      `tests/community/adapters/http/openapi_v1`,
+      `tests/community/api/bot_management` — pass.
+- [ ] `scripts/ci/pre_push.sh` per the AGENTS.md contract (lint-only by
+      default; `OCB_PRE_PUSH_RUN_CI=1` for the full module gates).
+- [ ] PR titled `feat(backend): address published runtimes on the per-bot file
+      endpoints`, body using the Problem / Solution / Validation template.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -307,8 +307,12 @@
         `GET …/{bot_id}/identity`, `GET …/{bot_id}/identity/{file_type}` —
         with `stage=draft|verify|online` hands the service the matching
         stage string.
-  - [x] No parameter → `stage="draft"`, and the draft path reads **no bot
-        row** — assert the repository was not touched (the byte-for-byte pin).
+  - [x] No parameter → `stage="draft"` on all five. The "reads no bot row" half
+        of this pin lives at the core level
+        (`test_stage.py::test_the_draft_resolves_the_bots_own_binding_and_reads_no_extra_row`),
+        because it is not true at the HTTP level for engine config: that
+        adapter reads the row unconditionally for its ownership guard, and did
+        before this change.
   - [x] Both writes with `stage=verify|online` → `409` and the body message
         `"The requested stage is read-only"`; with no parameter → unchanged
         `200`.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -256,8 +256,10 @@
         record's binding and call `resolve_for_binding` with `facts.owner_id`
         and `facts.bot_id`; a published stage on a `personal` bot raises
         `EngineStageNotLiveError` **before** any resolver call; a draft stage
-        raises `ValueError` from `resolve_stage_bind_id` (it is not this
-        function's job).
+        raises `ValueError` naming the call to make instead. (Round-1 review:
+        falling through to `resolve_stage_bind_id`'s generic "not a published
+        stage" left the caller without the fix. The guard is local so the
+        message can name `resolve_for_bot`.)
   - [ ] `BotFacts.from_record` applies the same fallbacks the relay applied
         inline, and `relay.resolve_bot` still returns identical facts — the
         existing relay tests are the check.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -15,18 +15,18 @@
 
 ## Group A — Core: the stage seam and the refusal
 
-### Task A1: A core error for a write addressed to a published runtime  `[ ]`
+### Task A1: A core error for a write addressed to a published runtime  `[x]`
 
 - **Goal:** One named domain state for "that runtime does not take writes",
   distinct from "that runtime is not up".
 - **Files:** `src/backend/src/agentclaw/community/core/engine_runtime/errors.py`
 - **Done when:**
-  - [ ] `EngineStageReadOnlyError(EngineRuntimeError)` exists, docstring says
+  - [x] `EngineStageReadOnlyError(EngineRuntimeError)` exists, docstring says
         why a published runtime is replaced rather than edited, and states
         explicitly that it is **not** `EngineStageNotLiveError` — it does not
         depend on liveness, so publishing a runtime would not make the write
         land.
-  - [ ] Listed in `__all__`, placed above the `EngineRuntimeError` base's own
+  - [x] Listed in `__all__`, placed above the `EngineRuntimeError` base's own
         entry in nothing (this file has no ordering rule; `responses.py` does).
 - **Depends on:** —
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -331,6 +331,10 @@
         deliberately take no stage.
   - [ ] Resources / skills / routines are named as the remaining draft-only
         device surfaces, with the reason each is deferred (spec Out of Scope).
+  - [ ] MCP is named too, and correctly: its six operations address no bot, but
+        its config write fans out to every bot's draft device. Draft-only is
+        the right answer there for the same reason the writes here refuse a
+        published stage — say so, so a later reader does not file it as a gap.
 - **Depends on:** C2, C3
 
 ---

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -299,46 +299,48 @@
         `address` takes the record-keyed branch (the documented precedence).
 - **Depends on:** B1, B2
 
-### Task D3: HTTP behaviour  `[ ]`
+### Task D3: HTTP behaviour  `[x]`
 
 - **Files:** new `tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py`
 - **Done when:**
-  - [ ] Each of the three reads — `GET …/{bot_id}/engine/config`,
+  - [x] Each of the three reads — `GET …/{bot_id}/engine/config`,
         `GET …/{bot_id}/identity`, `GET …/{bot_id}/identity/{file_type}` —
         with `stage=draft|verify|online` hands the service the matching
         stage string.
-  - [ ] No parameter → `stage="draft"`, and the draft path reads **no bot
+  - [x] No parameter → `stage="draft"`, and the draft path reads **no bot
         row** — assert the repository was not touched (the byte-for-byte pin).
-  - [ ] Both writes with `stage=verify|online` → `409` and the body message
+  - [x] Both writes with `stage=verify|online` → `409` and the body message
         `"The requested stage is read-only"`; with no parameter → unchanged
         `200`.
-  - [ ] A published stage on a personal bot read → `409 "No live runtime at the
+  - [x] A published stage on a personal bot read → `409 "No live runtime at the
         requested stage"`.
-  - [ ] `stage=eval` → `422`, no handler reached.
-  - [ ] The deprecated twins still read the draft when `?stage=online` is sent
+  - [x] `stage=eval` → `422`, no handler reached.
+  - [x] The deprecated twins still read the draft when `?stage=online` is sent
         at them — FastAPI ignores the undeclared parameter, and this pins that
         the shim was not wired to the new code path by accident.
 - **Depends on:** C2, C3
 
-### Task D4: The published document  `[ ]`
+### Task D4: The published document  `[x]`
 
 - **Files:** `tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py`
 - **Done when:**
-  - [ ] Build on #1074's `_engine_runtime_paths()` — membership in the mounted
+  - [x] Build on #1074's `_engine_runtime_paths()` — membership in the mounted
         route set, not a segment match (spec **Open Questions**, resolved). The
         five operations here are not in that set, so they need no change to the
         predicate; do not add a second classification.
-  - [ ] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five bot-first operations,
+  - [x] A `_STAGE_ADDRESSED_ELSEWHERE` set names the five bot-first operations,
         mirroring the existing `_OWNER_ADDRESSED_ELSEWHERE`, so
         `test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations`
-        stays an **exact** assertion (16 + 5) rather than being loosened.
-  - [ ] `stage` is still optional on every operation carrying it, and still
+        stays an **exact** assertion rather than being loosened. The
+        engine-runtime side is 32 post-#1074 — sixteen current plus sixteen
+        retiring — so the total is 32 + 5.
+  - [x] `stage` is still optional on every operation carrying it, and still
         never a body field or a path segment.
-  - [ ] **None of the five retiring twins carries `stage`** — and note the
+  - [x] **None of the five retiring twins carries `stage`** — and note the
         distinction: the retiring *engine-runtime* addresses do carry it and
         must keep doing so (they always had it, and #1074's parity promise is
         that they keep their contract). The claim is about these five only.
-  - [ ] The module docstring is updated: "sixteen … and nowhere else" is no
+  - [x] The module docstring is updated: "sixteen … and nowhere else" is no
         longer true.
 - **Depends on:** C2, C3
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -38,15 +38,18 @@
 - **Files:**
   `src/backend/src/agentclaw/community/core/engine_runtime/models.py`,
   `…/core/engine_runtime/stage.py`,
-  `…/core/engine_runtime/relay.py`
+  `…/core/engine_runtime/relay.py`,
+  `…/core/engine_runtime/connection.py` (its inline projection, same reason)
 - **Done when:**
   - [x] `BotFacts.from_record(record, *, bot_id, owner_id)` classmethod, with the
         same `or`-fallbacks `relay.resolve_bot` applies today, and a docstring
         saying the record must come from an owner-scoped read (spec D6).
-  - [x] `relay.resolve_bot`'s inline `BotFacts(...)` construction uses it, so
-        there is **one** projection of a bot row into facts. This is the only
-        edit outside the feature; it is reversible on its own if a reviewer
-        disagrees.
+  - [x] `relay.resolve_bot`'s and `EngineConnectionService.build`'s inline
+        `BotFacts(...)` constructions use it, so there is **one** projection of
+        a bot row into engine-runtime facts. These are the only edits outside
+        the feature and are reversible on their own. Nothing else in either
+        file changes — an owner-argument inconsistency noticed in
+        `_stage_binding_id` is left alone as pre-existing and out of scope.
   - [x] `require_stage_writable(stage)` raises `EngineStageReadOnlyError` for
         anything but the draft; docstring says why it is not conditional on bot
         type or liveness.

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -85,7 +85,7 @@
 
 ## Group B — Core services
 
-### Task B1: `EngineConfigService` reads a stage, writes only the draft  `[ ]`
+### Task B1: `EngineConfigService` reads a stage, writes only the draft  `[x]`
 
 - **Goal:** The engine-config read reaches all three runtimes; the write reaches
   one and refuses the rest before touching a device.
@@ -93,31 +93,31 @@
   `src/backend/src/agentclaw/community/core/services/engine_config.py`,
   `src/backend/src/agentclaw/community/api/engine_config_service.py`
 - **Done when:**
-  - [ ] Constructor takes `publish_repo: BotPublishRepositoryProtocol` and
+  - [x] Constructor takes `publish_repo: BotPublishRepositoryProtocol` and
         `binding_repo: DeviceBindingRepository`, with a comment that both exist
         only for the stage-addressed read.
-  - [ ] `_bot_facts(bot_id, owner_id)` builds `BotFacts` from
+  - [x] `_bot_facts(bot_id, owner_id)` builds `BotFacts` from
         `self._bot_repo.get_by_id_and_owner`, raising `BotNotFoundError` on a
         miss. No new constructor dependency — the service already holds the
         repository.
-  - [ ] `_bot_config_device_fs(..., stage)` branches: draft → the existing
+  - [x] `_bot_config_device_fs(..., stage)` branches: draft → the existing
         `resolve_for_bot(bot_id, owner_id)` **unchanged and with no row read**;
         published → `_bot_facts` then `resolve_published_device_context`.
-  - [ ] `read_bot_config(..., stage: str)` — required, not defaulted.
-  - [ ] `write_bot_config(..., stage: str)` calls `require_stage_writable(stage)`
+  - [x] `read_bot_config(..., stage: str)` — required, not defaulted.
+  - [x] `write_bot_config(..., stage: str)` calls `require_stage_writable(stage)`
         as its **first** statement, then takes the draft branch. It must never
         reach `_bot_facts`.
-  - [ ] `read_publish_config` unchanged in behaviour, with a comment at the
+  - [x] `read_publish_config` unchanged in behaviour, with a comment at the
         `select_stage_bind_id` call saying why it is deliberately not the stage
         rule (spec D3).
-  - [ ] `EngineConfigServiceProtocol` mirrors both signatures exactly; its
+  - [x] `EngineConfigServiceProtocol` mirrors both signatures exactly; its
         class docstring records why `stage` is required rather than defaulted —
         `EngineRuntimeRelayProtocol` states the same convention, and a default
         would also need a runtime `api → core.engine_runtime` import, which hits
         a partially-initialised `bot_service`.
-  - [ ] Module and class docstrings updated to describe three addresses, two of
+  - [x] Module and class docstrings updated to describe three addresses, two of
         them read-only.
-  - [ ] `tests/community/architecture/test_service_api_conformance.py` passes.
+  - [x] `tests/community/architecture/test_service_api_conformance.py` passes.
 - **Depends on:** A2
 
 ### Task B2: `IdentityService` reads a stage, writes only the draft  `[ ]`
@@ -233,16 +233,19 @@
         no `stage`, draft only.
 - **Depends on:** B2, C1, and #1074
 
-### Task C4: The internal routes say `draft` out loud  `[ ]`
+### Task C4: The internal routes say `draft` out loud  `[x]`
 
 - **Goal:** The two now-required arguments are supplied, and the internal
   console's draft-only scope is stated rather than inherited.
 - **Files:** `src/backend/src/agentclaw/community/adapters/http/bot_management/router.py`
 - **Done when:**
-  - [ ] `read_bot_config(..., stage=STAGE_DRAFT)` and
+  - [x] `read_bot_config(..., stage=STAGE_DRAFT)` and
         `write_bot_config(..., stage=STAGE_DRAFT)`, with a comment that naming a
         runtime is the public surface's parameter, not this route's.
-  - [ ] `tests/community/api/bot_management/test_router.py` passes.
+  - [x] `tests/community/api/bot_management/test_router.py` passes.
+- **Note:** landed inside B1's commit rather than its own. Making `stage`
+  required breaks these two call sites the moment the service changes, so
+  splitting them would have left one commit that does not run.
 - **Depends on:** B1
 
 ---

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -262,13 +262,13 @@
 
 ## Group D — Tests
 
-### Task D1: Core stage seam  `[ ]`
+### Task D1: Core stage seam  `[x]`
 
 - **Files:** `tests/community/core/engine_runtime/test_stage.py`
 - **Done when:**
-  - [ ] `require_stage_writable`: draft passes; verify and online raise
+  - [x] `require_stage_writable`: draft passes; verify and online raise
         `EngineStageReadOnlyError`.
-  - [ ] `resolve_published_device_context`: verify/online resolve the publish
+  - [x] `resolve_published_device_context`: verify/online resolve the publish
         record's binding and call `resolve_for_binding` with `facts.owner_id`
         and `facts.bot_id`; a published stage on a `personal` bot raises
         `EngineStageNotLiveError` **before** any resolver call; a draft stage
@@ -276,26 +276,26 @@
         falling through to `resolve_stage_bind_id`'s generic "not a published
         stage" left the caller without the fix. The guard is local so the
         message can name `resolve_for_bot`.)
-  - [ ] `BotFacts.from_record` applies the same fallbacks the relay applied
+  - [x] `BotFacts.from_record` applies the same fallbacks the relay applied
         inline, and `relay.resolve_bot` still returns identical facts — the
         existing relay tests are the check.
 - **Depends on:** A2
 
-### Task D2: Service-level behaviour  `[ ]`
+### Task D2: Service-level behaviour  `[x]`
 
 - **Files:**
   `tests/community/core/services/test_engine_config_service.py`,
   new `tests/community/core/services/test_identity_stage_addressing.py`
 - **Done when:**
-  - [ ] Engine-config: a verify/online read resolves through the publish
+  - [x] Engine-config: a verify/online read resolves through the publish
         record's binding and reads the same canonical `config/teclaw.json`
         path.
-  - [ ] Engine-config: a verify/online write raises
+  - [x] Engine-config: a verify/online write raises
         `EngineStageReadOnlyError` and the dispatcher is **never** called —
         the "nothing is written" claim, asserted rather than described.
-  - [ ] Identity: the same two pins for `get_bot_file`, plus `list_bot_files`
+  - [x] Identity: the same two pins for `get_bot_file`, plus `list_bot_files`
         probing the addressed runtime, plus the write refusal.
-  - [ ] Identity: `get_bot_file` with both `publish_id` and a published
+  - [x] Identity: `get_bot_file` with both `publish_id` and a published
         `address` takes the record-keyed branch (the documented precedence).
 - **Depends on:** B1, B2
 

--- a/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
+++ b/src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/tasks.md
@@ -120,34 +120,34 @@
   - [x] `tests/community/architecture/test_service_api_conformance.py` passes.
 - **Depends on:** A2
 
-### Task B2: `IdentityService` reads a stage, writes only the draft  `[ ]`
+### Task B2: `IdentityService` reads a stage, writes only the draft  `[x]`
 
 - **Goal:** Same contract for the identity files, threaded through the layers
   that actually reach the device.
 - **Files:** `src/backend/src/agentclaw/community/core/services/identity.py`
 - **Done when:**
-  - [ ] Constructor takes `binding_repo: DeviceBindingRepository`.
-  - [ ] `_bot_facts(bot_id, owner_id)` as in B1 — same shape, same reason.
-  - [ ] `_identity_device_fs`, `_device_read`, `read_identity_file` take
+  - [x] Constructor takes `binding_repo: DeviceBindingRepository`.
+  - [x] `_bot_facts(bot_id, owner_id)` as in B1 — same shape, same reason.
+  - [x] `_identity_device_fs`, `_device_read`, `read_identity_file` take
         `stage: str = STAGE_DRAFT`; `_identity_device_fs` carries the same
         draft/published branch B1 describes.
-  - [ ] `get_bot_file` and `list_bot_files` take keyword-only
+  - [x] `get_bot_file` and `list_bot_files` take keyword-only
         `stage: str = STAGE_DRAFT` and pass it down; `list_bot_files` probes all
         16 files against the **one** addressed runtime, resolving the facts once
         rather than per file.
-  - [ ] `get_bot_file`'s docstring states the precedence: `publish_id` (a
+  - [x] `get_bot_file`'s docstring states the precedence: `publish_id` (a
         record) wins over `stage`, because it names one exact release, and
         because it is the older internal contract.
-  - [ ] `update_bot_file` takes keyword-only `stage: str = STAGE_DRAFT` and
+  - [x] `update_bot_file` takes keyword-only `stage: str = STAGE_DRAFT` and
         calls `require_stage_writable(stage)` first; the write path below it is
         unchanged and never resolves facts.
-  - [ ] `_read_from_publish_device` unchanged in behaviour, with the same
+  - [x] `_read_from_publish_device` unchanged in behaviour, with the same
         record-keyed-vs-stage-keyed comment as B1.
-  - [ ] `write_identity_file` / `sync_agents_md` untouched — draft-only by
+  - [x] `write_identity_file` / `sync_agents_md` untouched — draft-only by
         construction.
 - **Depends on:** A2
 
-### Task B3: Fix up direct service construction in tests  `[ ]`
+### Task B3: Fix up direct service construction in tests  `[x]`
 
 - **Goal:** The new constructor dependencies do not silently break unrelated
   suites.
@@ -161,11 +161,11 @@
   `tests/community/adapters/http/test_identity_tenant_indirect_isolation.py`,
   `tests/community/core/services/test_engine_config_service.py` (×2)
 - **Done when:**
-  - [ ] Every direct `IdentityService(...)` passes `binding_repo`; every direct
+  - [x] Every direct `IdentityService(...)` passes `binding_repo`; every direct
         `EngineConfigService(...)` passes `publish_repo` and `binding_repo`.
-  - [ ] `read_bot_config` / `write_bot_config` call sites in
+  - [x] `read_bot_config` / `write_bot_config` call sites in
         `test_engine_config_service.py` pass `stage=STAGE_DRAFT`.
-  - [ ] Those suites pass unchanged otherwise.
+  - [x] Those suites pass unchanged otherwise.
 - **Depends on:** B1, B2
 
 ---

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -77,6 +77,7 @@ from agentclaw.community.core.bot_management.create_flow import (  # noqa: F401
 )
 from agentclaw.community.api.engine_config_service import EngineConfigServiceProtocol
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
+from agentclaw.community.core.engine_runtime.stage import STAGE_DRAFT
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE, _get_engine_types
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
@@ -2924,9 +2925,13 @@ async def get_engine_config(
         # Provider-blind read through EngineConfigService (resolve_for_bot +
         # dispatch_addressed(config)). data is {} only when the file is missing/empty;
         # malformed JSON / resolve failures surface via the except blocks below.
+        # ``STAGE_DRAFT``: this internal console edits the bot's own workspace.
+        # Naming a runtime is the public surface's parameter
+        # (``/openapi/v1/bots/{bot_id}/engine/config?stage=``), not this route's.
         data = await engine_config_service.read_bot_config(
             bot_id=bot_id, owner_id=resolved_owner_id,
             entity_id=entity_id, entity_type=entity_type, engine_type=effective_engine,
+            stage=STAGE_DRAFT,
         )
         return ApiResponse(success=True, data=data)
 
@@ -3050,7 +3055,7 @@ async def update_engine_config(
         await engine_config_service.write_bot_config(
             bot_id=bot_id, owner_id=resolved_owner_id,
             entity_id=entity_id, entity_type=entity_type, engine_type=effective_engine,
-            config=config_data,
+            config=config_data, stage=STAGE_DRAFT,
         )
         logger.info(f"[bot_router.update_engine_config] Saved engine config for bot {bot_id}")
         return ApiResponse(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
@@ -48,6 +48,7 @@ from agentclaw.community.api.engine_config_service import EngineConfigServicePro
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
 )
+from agentclaw.community.core.engine_runtime.stage import STAGE_DRAFT
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.di import Injected
 
@@ -100,7 +101,7 @@ async def get_bot_engine_config(
     entity_id, entity_type, engine = _engine_config_target(bot)
     data = await engine_config_service.read_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
-        entity_type=entity_type, engine_type=engine,
+        entity_type=entity_type, engine_type=engine, stage=STAGE_DRAFT,
     )
     return envelope(data, request)
 
@@ -128,5 +129,6 @@ async def update_bot_engine_config(
     await engine_config_service.write_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
         entity_type=entity_type, engine_type=engine, config=body,
+        stage=STAGE_DRAFT,
     )
     return envelope(body, request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
@@ -38,6 +38,13 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Envelope,
     USER_SCOPED_403,
 )
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
+    RuntimeStage,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    StageQuery,
+    WriteStageQuery,
+)
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
@@ -48,7 +55,6 @@ from agentclaw.community.api.engine_config_service import EngineConfigServicePro
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
 )
-from agentclaw.community.core.engine_runtime.stage import STAGE_DRAFT
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.di import Injected
 
@@ -86,12 +92,16 @@ async def get_bot_engine_config(
     bot_id: BotIdPath,
     request: Request,
     owner_id: UserIdDep,
+    stage: StageQuery = RuntimeStage.DRAFT,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     engine_config_service: EngineConfigServiceProtocol = Injected(
         EngineConfigServiceProtocol
     ),
 ) -> Envelope[dict[str, Any]]:
     """Read a bot's engine configuration (free-form JSON).
+
+    Reads the runtime named by the stage parameter — the bot's own workspace
+    unless a published one is asked for.
 
     A bot whose engine configuration has never been written reads as an empty
     object — every engine keeps this configuration in a file its runtime creates
@@ -101,7 +111,7 @@ async def get_bot_engine_config(
     entity_id, entity_type, engine = _engine_config_target(bot)
     data = await engine_config_service.read_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
-        entity_type=entity_type, engine_type=engine, stage=STAGE_DRAFT,
+        entity_type=entity_type, engine_type=engine, stage=stage.value,
     )
     return envelope(data, request)
 
@@ -118,17 +128,23 @@ async def update_bot_engine_config(
     body: dict[str, Any],
     request: Request,
     owner_id: UserIdDep,
+    stage: WriteStageQuery = RuntimeStage.DRAFT,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
     engine_config_service: EngineConfigServiceProtocol = Injected(
         EngineConfigServiceProtocol
     ),
 ) -> Envelope[dict[str, Any]]:
-    """Write a bot's engine configuration (free-form JSON)."""
+    """Write a bot's engine configuration (free-form JSON).
+
+    Writes the bot's own workspace. A published runtime is what a release
+    produced and is replaced by publishing again, never edited, so naming one is
+    refused and nothing is written.
+    """
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
     entity_id, entity_type, engine = _engine_config_target(bot)
     await engine_config_service.write_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
         entity_type=entity_type, engine_type=engine, config=body,
-        stage=STAGE_DRAFT,
+        stage=stage.value,
     )
     return envelope(body, request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
@@ -5,6 +5,9 @@ one way: ``bot_id`` was a required query parameter and is now a path segment.
 Everything else — the other parameters, the body, the response model, the
 service calls — is identical.
 
+A second, smaller need is the mirror image: a parameter the current address
+gained that the retiring one must not publish (see :func:`without_parameter`).
+
 Writing those twenty-one shims by hand means copying twenty-one signatures,
 each one a second declaration of a contract that already exists a few files
 away. The copies would be correct on the day they were written and wrong the
@@ -81,6 +84,50 @@ def with_query_parameter(
     # — so FastAPI would build the route from the *new* signature and the shim
     # would publish a path parameter its address does not have.
     shim.__signature__ = signature.replace(parameters=parameters)  # type: ignore[attr-defined]
+    shim.__name__ = f"{handler.__name__}_{suffix}"
+    shim.__doc__ = doc or handler.__doc__
+    return shim
+
+
+def without_parameter(
+    handler: Callable[..., Any],
+    name: str,
+    *,
+    suffix: str = "legacy",
+    doc: str | None = None,
+) -> Callable[..., Any]:
+    """A shim calling *handler* with *name* dropped from the published signature.
+
+    The mirror of :func:`with_query_parameter`, for a parameter the retiring
+    address must **not** publish at all. The handler's own default supplies the
+    value, so the shim's behaviour is whatever the address did before the
+    parameter existed.
+
+    Why a retiring address would want this: a legacy route registered by
+    ``relocate`` is *the same endpoint function* as its replacement, so a
+    parameter added to the handler appears on both. When the addition is a new
+    capability rather than a rename, publishing it on the retiring address
+    widens a contract that is supposed to be frozen — and hands a caller a
+    reason to stay there.
+    """
+    signature = inspect.signature(handler, eval_str=True)
+    if name not in signature.parameters:
+        raise ValueError(f"{handler.__name__} has no parameter {name!r}")
+    if signature.parameters[name].default is inspect.Parameter.empty:
+        raise ValueError(
+            f"{handler.__name__}.{name} has no default, so dropping it from the "
+            "legacy signature would leave the shim unable to call the handler"
+        )
+
+    async def shim(**kwargs: Any) -> Any:
+        return await handler(**kwargs)
+
+    # Same reason as ``with_query_parameter``: set, not ``functools.wraps``,
+    # or ``inspect.signature`` follows ``__wrapped__`` back to the original and
+    # FastAPI republishes the parameter this exists to remove.
+    shim.__signature__ = signature.replace(  # type: ignore[attr-defined]
+        parameters=[p for k, p in signature.parameters.items() if k != name]
+    )
     shim.__name__ = f"{handler.__name__}_{suffix}"
     shim.__doc__ = doc or handler.__doc__
     return shim

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
@@ -23,6 +23,7 @@ publish an operation with no parameters at all.
 from __future__ import annotations
 
 import inspect
+from collections.abc import Mapping
 from typing import Annotated, Any, Callable
 
 from fastapi import Query, params
@@ -132,7 +133,11 @@ def without_parameter(
         )
 
     async def shim(**kwargs: Any) -> Any:
-        return await handler(**kwargs)
+        # The value is supplied, not left to Python's own default binding. For
+        # the marker form the parameter's real default *is* the ``Query``
+        # object, so omitting it would hand the handler a marker instead of a
+        # value — the unwrapped default above is the one that was validated.
+        return await handler(**kwargs, **{name: default})
 
     # Same reason as ``with_query_parameter``: set, not ``functools.wraps``,
     # or ``inspect.signature`` follows ``__wrapped__`` back to the original and
@@ -147,7 +152,7 @@ def without_parameter(
 
 def drop_parameter(
     name: str,
-    rewords: dict[tuple[str, str], tuple[str, str]] | None = None,
+    rewords: Mapping[tuple[str, str], tuple[str, str]],
 ) -> Callable[..., Any]:
     """A ``relocate`` transform that keeps *name* off the retiring address.
 
@@ -162,20 +167,51 @@ def drop_parameter(
     handler describes the parameter in its own words, and ``deprecated_doc``
     matches the stale text literally — so editing a handler's docstring without
     revisiting the map fails at import instead of shipping the contradiction.
-    """
 
-    def transform(endpoint, method, new_path):
+    Both halves of that promise are enforced. The stale-text half is
+    ``deprecated_doc``'s. The **key** half is
+    :meth:`~_DropParameter.verify_all_applied`, which the caller runs after
+    ``relocate``: an entry whose ``(method, path)`` no longer matches any route
+    would otherwise be skipped in silence, republishing the very contradiction
+    the entry was written to remove.
+
+    Required, not defaulted: every caller has one, and an empty map means "this
+    handler never mentions the parameter", which is a claim worth writing out.
+    """
+    return _DropParameter(name, rewords)
+
+
+class _DropParameter:
+    """The transform :func:`drop_parameter` returns; see it for the contract."""
+
+    def __init__(
+        self, name: str, rewords: Mapping[tuple[str, str], tuple[str, str]]
+    ) -> None:
+        self._name = name
+        self._rewords = rewords
+        self._applied: set[tuple[str, str]] = set()
+
+    def __call__(self, endpoint, method, new_path):
+        key = (method, new_path)
+        reword = self._rewords.get(key)
+        if reword is not None:
+            self._applied.add(key)
         return without_parameter(
             endpoint,
-            name,
-            doc=deprecated_doc(
-                endpoint,
-                f"{method} {new_path}",
-                reword=(rewords or {}).get((method, new_path)),
-            ),
+            self._name,
+            doc=deprecated_doc(endpoint, f"{method} {new_path}", reword=reword),
         )
 
-    return transform
+    def verify_all_applied(self) -> None:
+        """Raise if any reword was written for a route that does not exist."""
+        unused = sorted(set(self._rewords) - self._applied)
+        if unused:
+            raise ValueError(
+                f"reword entries for {self._name!r} matched no route: {unused}. "
+                "The address moved or the key is mistyped — either way the "
+                "retiring address would publish a description naming a "
+                "parameter it does not have."
+            )
 
 
 def deprecated_doc(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/_requery.py
@@ -113,10 +113,22 @@ def without_parameter(
     signature = inspect.signature(handler, eval_str=True)
     if name not in signature.parameters:
         raise ValueError(f"{handler.__name__} has no parameter {name!r}")
-    if signature.parameters[name].default is inspect.Parameter.empty:
+
+    # A handler may declare the parameter either way — ``Annotated[...] = value``
+    # or a plain type with a FastAPI marker *as* the default — and only the first
+    # leaves a usable value behind when the parameter is dropped. The second
+    # would bind the ``Query`` object itself, so it is refused rather than
+    # shipped. ``with_query_parameter`` unwraps the same two shapes.
+    default = signature.parameters[name].default
+    if isinstance(default, params.Param):
+        default = (
+            inspect.Parameter.empty if default.default is Ellipsis else default.default
+        )
+    if default is inspect.Parameter.empty:
         raise ValueError(
-            f"{handler.__name__}.{name} has no default, so dropping it from the "
-            "legacy signature would leave the shim unable to call the handler"
+            f"{handler.__name__}.{name} has no usable default, so dropping it "
+            "from the legacy signature would leave the shim unable to call the "
+            "handler"
         )
 
     async def shim(**kwargs: Any) -> Any:
@@ -131,6 +143,39 @@ def without_parameter(
     shim.__name__ = f"{handler.__name__}_{suffix}"
     shim.__doc__ = doc or handler.__doc__
     return shim
+
+
+def drop_parameter(
+    name: str,
+    rewords: dict[tuple[str, str], tuple[str, str]] | None = None,
+) -> Callable[..., Any]:
+    """A ``relocate`` transform that keeps *name* off the retiring address.
+
+    Wraps :func:`without_parameter` with the description handling every legacy
+    registration needs, so it is written once rather than once per group.
+
+    ``rewords`` maps ``(method, current_path)`` to the ``(stale, correct)`` pair
+    :func:`deprecated_doc` should apply. Dropping a parameter almost always
+    needs one: a handler docstring that mentions the parameter is republished at
+    an address whose parameter table does not list it, which is precisely the
+    contradiction ``reword`` exists to prevent. Per-operation because each
+    handler describes the parameter in its own words, and ``deprecated_doc``
+    matches the stale text literally — so editing a handler's docstring without
+    revisiting the map fails at import instead of shipping the contradiction.
+    """
+
+    def transform(endpoint, method, new_path):
+        return without_parameter(
+            endpoint,
+            name,
+            doc=deprecated_doc(
+                endpoint,
+                f"{method} {new_path}",
+                reword=(rewords or {}).get((method, new_path)),
+            ),
+        )
+
+    return transform
 
 
 def deprecated_doc(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
@@ -21,16 +21,17 @@ from agentclaw.community.adapters.http.openapi_v1.bots.engine_config import (
 from fastapi import APIRouter
 
 from ._relocate import relocate
-from ._requery import deprecated_doc, without_parameter
+from ._requery import drop_parameter
 from ._shim import legacy_router
 
+_CONFIG = "/openapi/v1/bots/{bot_id}/engine/config"
 
-def _drop_stage(endpoint, method, new_path):
-    return without_parameter(
-        endpoint,
-        "stage",
-        doc=deprecated_doc(endpoint, f"{method} {new_path}"),
-    )
+#: The handler descriptions name the stage parameter; this address does not have
+#: one, so they are reworded rather than republished as written.
+_REWORDS = {
+    ("GET", _CONFIG): ("Reads the runtime named by the stage parameter — the bot's own workspace\nunless a published one is asked for.", "Reads the bot's own workspace. Reaching a published runtime is offered at\nthe address that replaces this one."),
+    ("PUT", _CONFIG): ("Writes the bot's own workspace. A published runtime is what a release\nproduced and is replaced by publishing again, never edited, so naming one is\nrefused and nothing is written.", "Writes the bot's own workspace."),
+}
 
 
 def _to_hyphenated(path: str) -> str | None:
@@ -45,7 +46,7 @@ router: APIRouter = relocate(
     engine_config_router,
     legacy_router("/openapi/v1/bots", "bots"),
     _to_hyphenated,
-    transform=_drop_stage,
+    transform=drop_parameter("stage", _REWORDS),
 )
 
 __all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
@@ -2,8 +2,14 @@
 
 ``/openapi/v1/bots/{bot_id}/engine-config`` became
 ``/openapi/v1/bots/{bot_id}/engine/config``. The bot was a path segment before
-and after, so these are the same handlers registered at the old address — the
-one group in this package where nothing at all changed but the spelling.
+and after, so these are the same handlers registered at the old address.
+
+One thing does change: the current address gained a ``stage`` query parameter,
+and this one must not publish it. A published runtime is reachable only through
+the address that is not going away — the retiring contract is frozen, and a new
+capability here would be a reason to stay on it. ``without_parameter`` drops it
+from the registered signature, so the handler's own default (the draft) applies
+and the old address answers exactly as it always did.
 """
 
 from __future__ import annotations
@@ -15,7 +21,16 @@ from agentclaw.community.adapters.http.openapi_v1.bots.engine_config import (
 from fastapi import APIRouter
 
 from ._relocate import relocate
+from ._requery import deprecated_doc, without_parameter
 from ._shim import legacy_router
+
+
+def _drop_stage(endpoint, method, new_path):
+    return without_parameter(
+        endpoint,
+        "stage",
+        doc=deprecated_doc(endpoint, f"{method} {new_path}"),
+    )
 
 
 def _to_hyphenated(path: str) -> str | None:
@@ -30,6 +45,7 @@ router: APIRouter = relocate(
     engine_config_router,
     legacy_router("/openapi/v1/bots", "bots"),
     _to_hyphenated,
+    transform=_drop_stage,
 )
 
 __all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/bots.py
@@ -28,10 +28,10 @@ _CONFIG = "/openapi/v1/bots/{bot_id}/engine/config"
 
 #: The handler descriptions name the stage parameter; this address does not have
 #: one, so they are reworded rather than republished as written.
-_REWORDS = {
+_DROP_STAGE = drop_parameter("stage", {
     ("GET", _CONFIG): ("Reads the runtime named by the stage parameter — the bot's own workspace\nunless a published one is asked for.", "Reads the bot's own workspace. Reaching a published runtime is offered at\nthe address that replaces this one."),
     ("PUT", _CONFIG): ("Writes the bot's own workspace. A published runtime is what a release\nproduced and is replaced by publishing again, never edited, so naming one is\nrefused and nothing is written.", "Writes the bot's own workspace."),
-}
+})
 
 
 def _to_hyphenated(path: str) -> str | None:
@@ -46,7 +46,11 @@ router: APIRouter = relocate(
     engine_config_router,
     legacy_router("/openapi/v1/bots", "bots"),
     _to_hyphenated,
-    transform=drop_parameter("stage", _REWORDS),
+    transform=_DROP_STAGE,
 )
+
+# A reword written for a route that no longer exists would be skipped in
+# silence, republishing the description it was written to remove.
+_DROP_STAGE.verify_all_applied()
 
 __all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
@@ -40,7 +40,24 @@ from agentclaw.community.adapters.http.openapi_v1.identity import (
 from fastapi import APIRouter
 
 from ._relocate import bot_first_to_component_first, relocate
+from ._requery import deprecated_doc, without_parameter
 from ._shim import legacy_router
+
+
+def _drop_stage(endpoint, method, new_path):
+    """Keep ``stage`` off identity's retiring addresses.
+
+    The engine-runtime groups above publish ``stage`` at both addresses, and
+    should: they have taken it since before this package existed, so it is part
+    of the contract those addresses are frozen with. Identity gained it after,
+    which makes it a new capability — and a retiring address that grows one is a
+    reason not to migrate.
+    """
+    return without_parameter(
+        endpoint,
+        "stage",
+        doc=deprecated_doc(endpoint, f"{method} {new_path}"),
+    )
 
 connection: APIRouter = relocate(
     connection_router,
@@ -79,6 +96,7 @@ identity: APIRouter = relocate(
     identity_router,
     legacy_router("/openapi/v1/bots/identity", "identity"),
     bot_first_to_component_first("identity"),
+    transform=_drop_stage,
 )
 
 #: Mounted with ``ENGINE_RUNTIME_ERROR_RESPONSES``, like their replacements.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
@@ -2,9 +2,13 @@
 
 connection, engine, models, sessions, identity and the approvals *read* moved
 from ``/openapi/v1/bots/<component>/{bot_id}/…`` to
-``/openapi/v1/bots/{bot_id}/<component>/…``. Nothing else about them changed —
-same handler, same parameters, same schemas — so the old address is the same
-endpoint function registered a second time.
+``/openapi/v1/bots/{bot_id}/<component>/…``. For all but identity nothing else
+changed — same handler, same parameters, same schemas — so the old address is
+the same endpoint function registered a second time.
+
+**Identity is the exception.** Its handlers later gained a ``stage`` parameter,
+which the retiring address must not publish (see ``_REWORDS`` below), so it is
+registered through a transform rather than as-is.
 
 The approvals *write* is not here. Its body lost ``session_key``, so the old
 address needs a body the new handler no longer accepts; it is shimmed by hand
@@ -40,24 +44,24 @@ from agentclaw.community.adapters.http.openapi_v1.identity import (
 from fastapi import APIRouter
 
 from ._relocate import bot_first_to_component_first, relocate
-from ._requery import deprecated_doc, without_parameter
+from ._requery import drop_parameter
 from ._shim import legacy_router
 
+#: Keep ``stage`` off identity's retiring addresses.
+#:
+#: The engine-runtime groups in this module publish ``stage`` at both addresses,
+#: and should: they have taken it since before this package existed, so it is
+#: part of the contract those addresses are frozen with. Identity gained it
+#: after, which makes it a new capability — and a retiring address that grows
+#: one is a reason not to migrate.
+_IDENTITY = "/openapi/v1/bots/{bot_id}/identity"
+_IDENTITY_FILE = f"{_IDENTITY}/{{file_type}}"
 
-def _drop_stage(endpoint, method, new_path):
-    """Keep ``stage`` off identity's retiring addresses.
-
-    The engine-runtime groups above publish ``stage`` at both addresses, and
-    should: they have taken it since before this package existed, so it is part
-    of the contract those addresses are frozen with. Identity gained it after,
-    which makes it a new capability — and a retiring address that grows one is a
-    reason not to migrate.
-    """
-    return without_parameter(
-        endpoint,
-        "stage",
-        doc=deprecated_doc(endpoint, f"{method} {new_path}"),
-    )
+_REWORDS = {
+    ("GET", _IDENTITY): ("Every entry comes from the one runtime the stage parameter names, so a\nfile's presence is always reported for the runtime asked about.", "Every entry comes from the bot's own workspace."),
+    ("GET", _IDENTITY_FILE): ("Reads the runtime named by the stage parameter — the bot's own workspace\nunless a published one is asked for.", "Reads the bot's own workspace. Reaching a published runtime is offered at\nthe address that replaces this one."),
+    ("PUT", _IDENTITY_FILE): ("Writes the bot's own workspace. A published runtime is what a release\nproduced and is replaced by publishing again, never edited, so naming one is\nrefused and nothing is written.", "Writes the bot's own workspace."),
+}
 
 connection: APIRouter = relocate(
     connection_router,
@@ -96,7 +100,7 @@ identity: APIRouter = relocate(
     identity_router,
     legacy_router("/openapi/v1/bots/identity", "identity"),
     bot_first_to_component_first("identity"),
-    transform=_drop_stage,
+    transform=drop_parameter("stage", _REWORDS),
 )
 
 #: Mounted with ``ENGINE_RUNTIME_ERROR_RESPONSES``, like their replacements.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/engine_runtime.py
@@ -57,11 +57,11 @@ from ._shim import legacy_router
 _IDENTITY = "/openapi/v1/bots/{bot_id}/identity"
 _IDENTITY_FILE = f"{_IDENTITY}/{{file_type}}"
 
-_REWORDS = {
+_DROP_STAGE = drop_parameter("stage", {
     ("GET", _IDENTITY): ("Every entry comes from the one runtime the stage parameter names, so a\nfile's presence is always reported for the runtime asked about.", "Every entry comes from the bot's own workspace."),
     ("GET", _IDENTITY_FILE): ("Reads the runtime named by the stage parameter — the bot's own workspace\nunless a published one is asked for.", "Reads the bot's own workspace. Reaching a published runtime is offered at\nthe address that replaces this one."),
     ("PUT", _IDENTITY_FILE): ("Writes the bot's own workspace. A published runtime is what a release\nproduced and is replaced by publishing again, never edited, so naming one is\nrefused and nothing is written.", "Writes the bot's own workspace."),
-}
+})
 
 connection: APIRouter = relocate(
     connection_router,
@@ -100,7 +100,7 @@ identity: APIRouter = relocate(
     identity_router,
     legacy_router("/openapi/v1/bots/identity", "identity"),
     bot_first_to_component_first("identity"),
-    transform=drop_parameter("stage", _REWORDS),
+    transform=_DROP_STAGE,
 )
 
 #: Mounted with ``ENGINE_RUNTIME_ERROR_RESPONSES``, like their replacements.
@@ -119,3 +119,8 @@ __all__ = [
     "models",
     "sessions",
 ]
+
+# A reword written for a route that no longer exists would be skipped in
+# silence, republishing the description it was written to remove.
+_DROP_STAGE.verify_all_applied()
+

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
@@ -165,8 +165,6 @@ WriteStageQuery = Annotated[RuntimeStage, Query(description=WRITE_STAGE_DESCRIPT
 
 __all__ = [
     "OWNER_ID_QUERY",
-    "STAGE_DESCRIPTION",
-    "WRITE_STAGE_DESCRIPTION",
     "OwnerIdDep",
     "StageQuery",
     "WriteStageQuery",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
@@ -16,6 +16,12 @@ call is *for*, not an attribute of any resource.
 Defined once and imported by every engine-runtime router, like ``UserIdDep``:
 a second spelling would be a second thing to keep in step.
 
+``stage`` has since outgrown this group — the per-bot file operations (engine
+config, identity) address the same three runtimes and import it from here for
+that reason. It stays in this package because this is where the vocabulary and
+its enum are defined, not because the group owns the parameter; ``owner_id``,
+whose adjudication *is* engine-runtime's, has not moved either.
+
 ``owner_id`` is also the one parameter on this surface whose *source* depends on
 the caller. For a human it is the request's, defaulting to themselves; for an
 application it comes from the grant record, and a request that names a different
@@ -60,6 +66,20 @@ STAGE_DESCRIPTION = (
     "draft — the bot's own workspace, the only runtime a personal bot has. "
     "A service bot's verify/online runtimes are addressable while live; a "
     "stage with no live runtime is refused (409)."
+)
+
+#: What an operation that **writes** to a bot's runtime publishes for ``stage``.
+#:
+#: A separate description, not a separate parameter: the write takes the same
+#: values from the same enum, and what differs is the answer it gives for two of
+#: them. Publishing the read's text on a write would advertise verify and online
+#: as addressable there.
+WRITE_STAGE_DESCRIPTION = (
+    "Which of the bot's runtimes this request addresses. Only the draft — the "
+    "bot's own workspace — accepts writes, and it is the default. A published "
+    "runtime is what a release produced and is replaced by publishing again, "
+    "never edited: naming verify or online is refused (409) and nothing is "
+    "written anywhere."
 )
 
 
@@ -140,9 +160,15 @@ OwnerIdDep = Annotated[str, Depends(resolve_owner_id)]
 #: default and the handler signature states it in one place.
 StageQuery = Annotated[RuntimeStage, Query(description=STAGE_DESCRIPTION)]
 
+#: The same, for a handler that writes to the addressed runtime.
+WriteStageQuery = Annotated[RuntimeStage, Query(description=WRITE_STAGE_DESCRIPTION)]
+
 __all__ = [
     "OWNER_ID_QUERY",
+    "STAGE_DESCRIPTION",
+    "WRITE_STAGE_DESCRIPTION",
     "OwnerIdDep",
     "StageQuery",
+    "WriteStageQuery",
     "resolve_owner_id",
 ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
@@ -17,6 +17,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Path, Request
 
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
+    RuntimeStage,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    StageQuery,
+    WriteStageQuery,
+)
 from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.contracts import BotIdPath, Envelope
 from agentclaw.community.adapters.http.openapi_v1.responses import (
@@ -60,9 +67,13 @@ async def list_bot_identity_files(
     bot_id: BotIdPath,
     owner_id: UserIdDep,
     request: Request,
+    stage: StageQuery = RuntimeStage.DRAFT,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileList]:
     """List every identity file type a bot can carry and whether each exists.
+
+    Every entry comes from the one runtime the stage parameter names, so a
+    file's presence is always reported for the runtime asked about.
 
     A file reports exists false both when it is absent and when it exists
     with empty content. Entry order is not guaranteed — key off type.
@@ -76,6 +87,7 @@ async def list_bot_identity_files(
         entity_id,
         bot_id,
         owner_id,
+        stage=stage.value,
     )
     files = [
         IdentityFileInfo(
@@ -98,16 +110,20 @@ async def get_bot_identity_file(
     file_type: FileTypePath,
     owner_id: UserIdDep,
     request: Request,
+    stage: StageQuery = RuntimeStage.DRAFT,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFile]:
     """Read one identity file of a bot.
 
+    Reads the runtime named by the stage parameter — the bot's own workspace
+    unless a published one is asked for.
+
     A file that has never been written reads as an empty content string, not
-    an error. Reads address the bot's draft runtime.
+    an error.
     """
     # I2: entity params come from the authenticated principal via UserIdDep
     # (personal bot owner = the named user). I3: publish_id is not exposed —
-    # only draft-device reads (get_bot_file default branch). The service's
+    # the runtime is named by ``stage`` instead. The service's
     # validate_file_type requires the physical <type>.md form
     # (VALID_IDENTITY_FILES carries the suffix), so the enum value is
     # re-suffixed before forwarding.
@@ -120,6 +136,7 @@ async def get_bot_identity_file(
         bot_id,
         file_type_md,
         owner_id,
+        stage=stage.value,
     )
     # BotIdentityFileResponse → openapi IdentityFile. content/file_path are
     # guaranteed by the legacy response model; getattr is a defensive belt.
@@ -145,12 +162,17 @@ async def update_bot_identity_file(
     body: IdentityFileWrite,
     owner_id: UserIdDep,
     request: Request,
+    stage: WriteStageQuery = RuntimeStage.DRAFT,
     identity_service: IdentityService = Injected(IdentityService),
 ) -> Envelope[IdentityFileRef]:
     """Create or overwrite one identity file of a bot.
 
     A full replacement — the body's content becomes the whole file. The
     response is a reference only; the content is not echoed back.
+
+    Writes the bot's own workspace. A published runtime is what a release
+    produced and is replaced by publishing again, never edited, so naming one is
+    refused and nothing is written.
     """
     # I2: entity params come from the authenticated principal via UserIdDep
     # as above; validate_file_type requires the <type>.md form.
@@ -164,6 +186,7 @@ async def update_bot_identity_file(
         file_type_md,
         body.content,
         owner_id,
+        stage=stage.value,
     )
     return envelope(
         IdentityFileRef(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -300,8 +300,9 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # ── Engine-runtime (Track C) ──────────────────────────────────────────
     # Ordering inside this block is load-bearing: ``EngineRuntimeError`` is the
     # base of every ``Engine*`` error below it and is listed AFTER them.
-    # ``test_engine_runtime_base_does_not_swallow_its_leaves`` reads the leaves
-    # off ``errors.__all__``, so a new one is covered without editing a list.
+    # ``test_engine_runtime_base_does_not_swallow_its_leaves`` finds the leaves
+    # by scanning the errors module and its ``__all__``, so a new one is covered
+    # here without editing any list — but it must still be given an entry below.
     # Lookup returns on the first isinstance match in insertion order, so a base
     # placed first would swallow every leaf under it — the trap recorded in the
     # Track B gotchas.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -89,6 +89,7 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineResourceNotFoundError,
     EngineRuntimeError,
     EngineStageNotLiveError,
+    EngineStageReadOnlyError,
     EngineUpstreamError,
 )
 from agentclaw.community.core.gateway_principal import PrincipalVerificationError
@@ -332,6 +333,13 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # publishing — and from "device not ready", which promises a retry will
     # eventually succeed.
     EngineStageNotLiveError: (409, "No live runtime at the requested stage"),
+    # A write addressed to a published runtime. 409 like the two above, and a
+    # *separate* answer from both: "no live runtime" would send the caller off to
+    # publish one and retry, which would not help, and the caller is entitled to
+    # the operation — it is the addressed runtime that does not take writes.
+    # Deliberately not a 200 with a no-op flag either: automation that checks the
+    # status code would record the write as landed.
+    EngineStageReadOnlyError: (409, "The requested stage is read-only"),
     # An out-of-range page argument, so it joins the 422 FastAPI already returns
     # for page_size > 100 rather than inventing a status. Needs a mapped entry
     # rather than a bare HTTPException: app-level handlers replace an unmapped

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -299,7 +299,9 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     InvalidIdentityFileTypeError: (400, "Invalid file type"),
     # ── Engine-runtime (Track C) ──────────────────────────────────────────
     # Ordering inside this block is load-bearing: ``EngineRuntimeError`` is the
-    # base of the four ``Engine*`` errors below it and is listed AFTER them.
+    # base of every ``Engine*`` error below it and is listed AFTER them.
+    # ``test_engine_runtime_base_does_not_swallow_its_leaves`` reads the leaves
+    # off ``errors.__all__``, so a new one is covered without editing a list.
     # Lookup returns on the first isinstance match in insertion order, so a base
     # placed first would swallow every leaf under it — the trap recorded in the
     # Track B gotchas.

--- a/src/backend/src/agentclaw/community/api/engine_config_service.py
+++ b/src/backend/src/agentclaw/community/api/engine_config_service.py
@@ -25,6 +25,15 @@ class EngineConfigServiceProtocol(Protocol):
     request failed at runtime with ``TypeError``, and the adapters' mocks would
     not catch the drift either. The keyword-only markers mirror the
     implementation, so a positional call is a type error here too.
+
+    ``stage`` is **required, with no default**, matching
+    ``EngineRuntimeRelayProtocol``: "the stage a handler gated on and the stage
+    it forwards to cannot silently diverge." A default would also have to be the
+    same object on both sides — ``test_service_api_conformance.py`` compares
+    defaults by value — which means this package importing
+    ``core.engine_runtime`` at runtime, and that package's import graph reaches
+    the DI container and a partially-initialised ``bot_service``. Convention and
+    mechanics agree.
     """
 
     async def read_bot_config(
@@ -35,8 +44,13 @@ class EngineConfigServiceProtocol(Protocol):
         entity_id: str,
         entity_type: str,
         engine_type: str,
+        stage: str,
     ) -> dict[str, Any]:
-        """Read a bot's engine config from its own device, provider-blind."""
+        """Read a bot's engine config from the runtime ``stage`` names.
+
+        ``draft`` is the bot's own workspace — what every caller read before
+        stages were addressable.
+        """
         ...
 
     async def write_bot_config(
@@ -48,8 +62,13 @@ class EngineConfigServiceProtocol(Protocol):
         entity_type: str,
         engine_type: str,
         config: dict[str, Any],
+        stage: str,
     ) -> None:
-        """Write a bot's engine config to its own device, provider-blind."""
+        """Write a bot's engine config to its own device, provider-blind.
+
+        Only the draft accepts a write; naming a published stage is refused
+        rather than applied to the draft.
+        """
         ...
 
     async def read_publish_config(

--- a/src/backend/src/agentclaw/community/core/engine_runtime/README.md
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/README.md
@@ -22,6 +22,7 @@ consumes:
   - "DeviceBindingRepository — the active binding id, without building conn info"
   - "BotPublishRepository — a service bot's published stage bindings (ext.binding.{verify,online})"
 internal_dependencies:
+  - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.devices    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.publishing    # repository contracts consumed by this module
   - agentclaw.community.core.bot_collaborator.models

--- a/src/backend/src/agentclaw/community/core/engine_runtime/__init__.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/__init__.py
@@ -8,6 +8,7 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineResourceNotFoundError,
     EngineRuntimeError,
     EngineStageNotLiveError,
+    EngineStageReadOnlyError,
     EngineUpstreamError,
 )
 from agentclaw.community.core.engine_runtime.connection import EngineConnectionService
@@ -30,6 +31,7 @@ __all__ = [
     "EngineResult",
     "EngineRuntimeError",
     "EngineStageNotLiveError",
+    "EngineStageReadOnlyError",
     "EngineUpstreamError",
     "SocketInfo",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -39,7 +39,11 @@ from agentclaw.community.core.engine_runtime.gate import (
     require_bot_operator,
     require_operable_bot,
 )
-from agentclaw.community.core.engine_runtime.models import ConnectionResult, SocketInfo
+from agentclaw.community.core.engine_runtime.models import (
+    BotFacts,
+    ConnectionResult,
+    SocketInfo,
+)
 from agentclaw.community.core.engine_runtime.stage import (
     STAGE_DRAFT,
     resolve_stage_bind_id,
@@ -182,9 +186,10 @@ class EngineConnectionService:
         widen this surface.
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
-        resolved_id = str(bot.get("bot_id") or bot_id)
-        resolved_owner = str(bot.get("owner_id") or owner_id)
-        bot_pk = int(bot.get("id") or 0)
+        facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
+        resolved_id = facts.bot_id
+        resolved_owner = facts.owner_id
+        bot_pk = facts.bot_pk
         # The socket this endpoint publishes is **not** chat-scoped, however it
         # is labelled: the engine's ``hello`` advertises the ``sessions.*`` and
         # ``exec.approvals`` methods and grants ``operator.admin``, so the
@@ -200,10 +205,8 @@ class EngineConnectionService:
             caller_id=caller_id,
             owner_id=resolved_owner,
         )
-        require_operable_bot(
-            str(bot.get("bot_type") or ""), stage=stage, surface="connections"
-        )
-        engine = str(bot.get("active_engine") or "")
+        require_operable_bot(facts.bot_type, stage=stage, surface="connections")
+        engine = facts.active_engine
 
         binding_id = self._stage_binding_id(
             bot_pk=bot_pk, bot_id=resolved_id, owner_id=owner_id, stage=stage

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -209,7 +209,7 @@ class EngineConnectionService:
         engine = facts.active_engine
 
         binding_id = self._stage_binding_id(
-            bot_pk=bot_pk, bot_id=resolved_id, owner_id=resolved_owner, stage=stage
+            bot_pk=bot_pk, bot_id=resolved_id, owner_id=owner_id, stage=stage
         )
 
         # Composed as the **resolved owner**, deliberately, even when the

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -209,7 +209,7 @@ class EngineConnectionService:
         engine = facts.active_engine
 
         binding_id = self._stage_binding_id(
-            bot_pk=bot_pk, bot_id=resolved_id, owner_id=owner_id, stage=stage
+            bot_pk=bot_pk, bot_id=resolved_id, owner_id=resolved_owner, stage=stage
         )
 
         # Composed as the **resolved owner**, deliberately, even when the

--- a/src/backend/src/agentclaw/community/core/engine_runtime/errors.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/errors.py
@@ -56,6 +56,22 @@ class EngineStageNotLiveError(EngineRuntimeError):
     """
 
 
+class EngineStageReadOnlyError(EngineRuntimeError):
+    """The requested stage is a published runtime, and writes do not reach it.
+
+    A ``verify`` or ``online`` runtime is the artefact a release produced. It is
+    replaced by publishing again, never edited in place, so a write addressed to
+    one has no correct effect: applying it would fork the runtime from the record
+    that describes it, and quietly writing the draft instead would report success
+    for an edit the addressed runtime never received.
+
+    Distinct from :class:`EngineStageNotLiveError`, which the same operation
+    raises for a stage that *could* accept the request but has no runtime up.
+    This one does not depend on liveness — publishing a runtime at the named
+    stage would not make the write land — so the two must not be merged.
+    """
+
+
 class EngineHistoryDepthExceededError(EngineRuntimeError):
     """The requested message page reaches past the history depth served.
 
@@ -99,5 +115,6 @@ __all__ = [
     "EngineHistoryDepthExceededError",
     "EngineResourceNotFoundError",
     "EngineStageNotLiveError",
+    "EngineStageReadOnlyError",
     "EngineUpstreamError",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/models.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/models.py
@@ -72,11 +72,18 @@ class BotFacts:
     ) -> "BotFacts":
         """Project an ``ac_bots`` row onto the narrow facts.
 
-        The one place a bot record becomes facts, so two callers cannot disagree
-        about which columns matter or how a missing one reads. ``bot_id`` and
-        ``owner_id`` are the *requested* values, used only as the fallback when
-        the row does not carry its own — the same fallback this projection has
-        always applied.
+        The one place an ``ac_bots`` row becomes **engine-runtime** facts — the
+        relay, the connection socket and the stage-addressed file reads all come
+        through here, so they cannot disagree about which columns matter or how a
+        missing one reads. ``bot_id`` and ``owner_id`` are the *requested*
+        values, used only as the fallback when the row does not carry its own —
+        the same fallback this projection has always applied.
+
+        Not every projection on the surface: ``authorized_apps.gating`` reads the
+        same row and deliberately **refuses** an empty ``owner_id`` rather than
+        substituting the requested one, because that value is written into a
+        grant record where it must name a real owner. Its rule is stricter on
+        purpose and is not folded in here.
 
         ``record`` must come from an **owner-scoped** ``(bot_id, owner_id)``
         read. ``bot_id`` carries no unique constraint and every user's first bot

--- a/src/backend/src/agentclaw/community/core/engine_runtime/models.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/models.py
@@ -66,6 +66,32 @@ class BotFacts:
     #: caller actually addressed.
     bot_pk: int = 0
 
+    @classmethod
+    def from_record(
+        cls, record: dict[str, Any], *, bot_id: str, owner_id: str
+    ) -> "BotFacts":
+        """Project an ``ac_bots`` row onto the narrow facts.
+
+        The one place a bot record becomes facts, so two callers cannot disagree
+        about which columns matter or how a missing one reads. ``bot_id`` and
+        ``owner_id`` are the *requested* values, used only as the fallback when
+        the row does not carry its own — the same fallback this projection has
+        always applied.
+
+        ``record`` must come from an **owner-scoped** ``(bot_id, owner_id)``
+        read. ``bot_id`` carries no unique constraint and every user's first bot
+        is called ``default``, so a row fetched by ``bot_id`` alone can belong to
+        another owner — and ``bot_pk`` is exactly the value later lookups trust
+        to stay on the addressed bot.
+        """
+        return cls(
+            bot_id=str(record.get("bot_id") or bot_id),
+            bot_type=str(record.get("bot_type") or ""),
+            active_engine=str(record.get("active_engine") or ""),
+            owner_id=str(record.get("owner_id") or owner_id),
+            bot_pk=int(record.get("id") or 0),
+        )
+
 
 @dataclass(frozen=True)
 class SocketInfo:

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -130,22 +130,15 @@ class EngineRuntimeRelay:
         impossible rather than merely discouraged.
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
-        resolved_id = str(bot.get("bot_id") or bot_id)
-        resolved_owner = str(bot.get("owner_id") or owner_id)
+        facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         require_bot_operator(
             self._collaborators,
-            bot_pk=int(bot.get("id") or 0),
-            bot_id=resolved_id,
+            bot_pk=facts.bot_pk,
+            bot_id=facts.bot_id,
             caller_id=caller_id,
-            owner_id=resolved_owner,
+            owner_id=facts.owner_id,
         )
-        return BotFacts(
-            bot_id=resolved_id,
-            bot_type=str(bot.get("bot_type") or ""),
-            active_engine=str(bot.get("active_engine") or ""),
-            owner_id=resolved_owner,
-            bot_pk=int(bot.get("id") or 0),
-        )
+        return facts
 
     async def resolve_bot_off_loop(
         self, bot_id: str, owner_id: str, caller_id: str

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -28,24 +28,19 @@ keyed by publish record, go there.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
 )
 from agentclaw.community.core.devices.services.device_context import (
-    DeviceContext,
     DeviceNotBoundError,
-)
-from agentclaw.community.core.devices.services.device_context_resolver import (
-    DeviceContextResolver,
 )
 from agentclaw.community.core.engine_runtime.errors import (
     EngineStageNotLiveError,
     EngineStageReadOnlyError,
 )
-from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.core.repository.protocols.publishing import (
     BotPublishRepositoryProtocol,
 )
@@ -53,6 +48,18 @@ from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
+
+# Annotations only, and deliberately deferred. ``gate.py`` imports this module
+# and every openapi_v1 router imports the gate, so naming the concrete resolver
+# at module scope would pull all four conn-info builders — and ``BaasService``
+# behind them — into the import graph of every process that touches the gate.
+# ``from __future__ import annotations`` above is what lets these stay here.
+if TYPE_CHECKING:
+    from agentclaw.community.core.devices.services.device_context import DeviceContext
+    from agentclaw.community.core.devices.services.device_context_resolver import (
+        DeviceContextResolver,
+    )
+    from agentclaw.community.core.engine_runtime.models import BotFacts
 
 logger = get_logger()
 
@@ -82,6 +89,18 @@ STAGE_ONLINE = PublishStage.ONLINE.value
 RUNTIME_STAGES = frozenset({STAGE_DRAFT, STAGE_VERIFY, STAGE_ONLINE})
 
 
+def _require_known_stage(stage: str) -> None:
+    """Refuse a stage name outside :data:`RUNTIME_STAGES`.
+
+    Unreachable from HTTP, where the adapter's enum answers 422 first, but a
+    programmatic caller's typo must not sail through — and must not be *mistaken
+    for something else*, which is why this runs ahead of both the addressable
+    and the writable checks rather than being folded into either.
+    """
+    if stage not in RUNTIME_STAGES:
+        raise EngineStageNotLiveError(f"unknown stage {stage!r}")
+
+
 def require_stage_writable(stage: str) -> None:
     """Refuse a write addressed to a published runtime, before anything else.
 
@@ -98,6 +117,7 @@ def require_stage_writable(stage: str) -> None:
     otherwise, accepts a write through this surface. Running first is what makes
     "nothing is written" structural rather than a promise.
     """
+    _require_known_stage(stage)
     if stage != STAGE_DRAFT:
         raise EngineStageReadOnlyError(
             f"the {stage} runtime is published and does not accept writes"
@@ -108,16 +128,13 @@ def require_stage_addressable(bot_type: str, stage: str) -> None:
     """Refuse a stage this bot cannot have, before any device work.
 
     Two refusals, one answer (:class:`EngineStageNotLiveError`): a stage name
-    outside :data:`RUNTIME_STAGES` — unreachable from HTTP, where the
-    adapter's enum answers 422 first, but a programmatic caller's typo must
-    not sail through to an unmapped 500 at device resolution — and a
-    published stage named on anything but a ``service`` bot, which has no
-    such runtime to be live. Run by the gate (before device work, for the
-    public surface) and by the relay's device resolution (for callers that
-    bypass the gate); one implementation so the two cannot drift.
+    outside :data:`RUNTIME_STAGES` (see :func:`_require_known_stage`), and a
+    published stage named on anything but a ``service`` bot, which has no such
+    runtime to be live. Run by the gate (before device work, for the public
+    surface) and by the relay's device resolution (for callers that bypass the
+    gate); one implementation so the two cannot drift.
     """
-    if stage not in RUNTIME_STAGES:
-        raise EngineStageNotLiveError(f"unknown stage {stage!r}")
+    _require_known_stage(stage)
     if stage != STAGE_DRAFT and bot_type != SERVICE_BOT_TYPE:
         raise EngineStageNotLiveError(
             f"a {bot_type} bot has no {stage} runtime; only its workspace"
@@ -299,7 +316,30 @@ def resolve_published_device_context(
     ``relay._resolve_published_device`` rather than a shared body; what the two
     share is :func:`resolve_stage_bind_id`, which is the rule that must not
     drift.
+
+    One consequence of that choice, shared with every other publish-addressed
+    file read (``ResourceFileService``, ``IdentityService._read_from_publish_
+    device``, ``EngineConfigService.read_publish_config``): ``resolve_for_binding``
+    derives ``ctx.bot_type`` from ``get_by_binding_id``, which finds nothing for
+    a published service binding — those ids are not on ``ac_bots.binding_id`` —
+    so the returned context carries an empty ``bot_type``. Harmless today, since
+    the filesystem resolver branches only on provider, and identical to what the
+    three existing callers already get. A future ``(provider, bot_type)`` branch
+    must not rely on it.
+
+    **Resolver errors are not translated**, deliberately. ``DeviceNotBoundError``
+    and ``ConnInfoBuildError`` propagate as themselves, exactly as they do from
+    the ``resolve_for_bot`` call on the draft leg of the same endpoints. The
+    relay folds them into ``EngineDeviceNotReadyError`` because it presents a
+    device-forwarding contract; doing that here would make ``?stage=online``
+    answer differently from ``?stage=draft`` on one endpoint, which is a worse
+    inconsistency than the one it would fix.
     """
+    if stage == STAGE_DRAFT:
+        raise ValueError(
+            "resolve_published_device_context does not answer the draft; "
+            "resolve the bot's own binding with resolve_for_bot instead"
+        )
     require_stage_addressable(facts.bot_type, stage)
     bind_id = resolve_stage_bind_id(
         publish_repo,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -27,6 +27,7 @@ keyed by publish record, go there.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, TYPE_CHECKING
 
@@ -117,8 +118,13 @@ def require_stage_writable(stage: str) -> None:
     Deliberately **not** conditional on the bot's type or on the stage being
     live. Both would need a row read to answer, and neither changes the answer:
     no runtime at ``verify`` or ``online``, live or not, on a service bot or
-    otherwise, accepts a write through this surface. Running first is what makes
-    "nothing is written" structural rather than a promise.
+    otherwise, accepts a write through this surface. It is also what lets this
+    run as a method's *first* statement, before anything is resolved.
+
+    What that buys is narrower than "structural", and worth stating exactly: in
+    the two write paths that call it, nothing downstream can reach a published
+    binding, because neither resolves :class:`BotFacts` at all. A write surface
+    added later inherits none of that and must call this itself.
     """
     _require_known_stage(stage)
     if stage != STAGE_DRAFT:
@@ -286,6 +292,32 @@ def _binding_is_active(binding_repo: DeviceBindingRepository, bind_id: int) -> b
     return binding is not None and str(binding.status) == DeviceBindingStatus.ACTIVE
 
 
+async def resolve_published_device_context_off_loop(
+    resolver: "DeviceContextResolver",
+    publish_repo: BotPublishRepositoryProtocol,
+    binding_repo: DeviceBindingRepository,
+    *,
+    facts: BotFacts,
+    stage: str,
+) -> DeviceContext:
+    """:func:`resolve_published_device_context`, run in a worker thread.
+
+    The safe call for anything on an event loop, and the reason it exists rather
+    than a warning in prose: the work below is blocking I/O with a 30-second
+    provider timeout, and every caller of this seam is an ``async`` service
+    method. ``relay.resolve_bot_off_loop`` is the same pattern for the same
+    reason.
+    """
+    return await asyncio.to_thread(
+        resolve_published_device_context,
+        resolver,
+        publish_repo,
+        binding_repo,
+        facts=facts,
+        stage=stage,
+    )
+
+
 def resolve_published_device_context(
     resolver: DeviceContextResolver,
     publish_repo: BotPublishRepositoryProtocol,
@@ -327,16 +359,21 @@ def resolve_published_device_context(
     a published service binding — those ids are not on ``ac_bots.binding_id`` —
     so the returned context carries an **empty** ``bot_type``.
 
-    Two consumers already read it, so this is a live hazard rather than a
-    hypothetical one: ``DefaultDeviceFileSystemResolver`` forks
-    ``bot_type == "desktop"`` inside its baas branch, and
-    ``_validate_bot_device_combination`` skips its legality check entirely on an
-    empty value (logging a warning). Neither misbehaves for the bots this
-    function serves — a published *service* bot is not ``desktop`` whether the
-    field is filled or empty, so it lands on the cloud filesystem either way,
-    and it is exactly what the three existing publish-addressed reads already
-    get. But a second arm added beside that ``desktop`` fork would receive an
-    empty string here and mis-dispatch silently.
+    One consumer reads it in production: ``DefaultDeviceFileSystemResolver``
+    forks ``bot_type == "desktop"`` inside its baas branch. A published
+    *service* bot is not ``desktop`` whether the field is filled or empty, so it
+    lands on the cloud filesystem either way — and this is exactly what the three
+    existing publish-addressed reads already get. A second arm added beside that
+    fork would receive an empty string here and mis-dispatch silently.
+
+    **Do not "fix" the empty value by filling it in.** The other reader,
+    ``_validate_bot_device_combination``, lists ``("service", "baas")`` in
+    ``_ILLEGAL_BOT_DEVICE_COMBINATIONS`` — the combination is not yet supported
+    — and raises ``DeviceServiceError`` for it. It skips the check entirely when
+    ``bot_type`` is empty, and it is reached only from the dispatcher's legacy
+    direct-construction path, so nothing breaks today; but a correctly-filled
+    ``bot_type`` would turn every published service-bot read on that path into a
+    refusal. The emptiness is load-bearing, not merely tolerated.
 
     **Synchronous, and blocking.** The publish scan, the binding read and the
     provider resolve are all blocking I/O — on the BaaS path
@@ -380,5 +417,6 @@ __all__ = [
     "require_stage_addressable",
     "require_stage_writable",
     "resolve_published_device_context",
+    "resolve_published_device_context_off_loop",
     "resolve_stage_bind_id",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -27,7 +27,6 @@ keyed by publish record, go there.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any, TYPE_CHECKING
 
@@ -292,32 +291,6 @@ def _binding_is_active(binding_repo: DeviceBindingRepository, bind_id: int) -> b
     return binding is not None and str(binding.status) == DeviceBindingStatus.ACTIVE
 
 
-async def resolve_published_device_context_off_loop(
-    resolver: "DeviceContextResolver",
-    publish_repo: BotPublishRepositoryProtocol,
-    binding_repo: DeviceBindingRepository,
-    *,
-    facts: BotFacts,
-    stage: str,
-) -> DeviceContext:
-    """:func:`resolve_published_device_context`, run in a worker thread.
-
-    The safe call for anything on an event loop, and the reason it exists rather
-    than a warning in prose: the work below is blocking I/O with a 30-second
-    provider timeout, and every caller of this seam is an ``async`` service
-    method. ``relay.resolve_bot_off_loop`` is the same pattern for the same
-    reason.
-    """
-    return await asyncio.to_thread(
-        resolve_published_device_context,
-        resolver,
-        publish_repo,
-        binding_repo,
-        facts=facts,
-        stage=stage,
-    )
-
-
 def resolve_published_device_context(
     resolver: DeviceContextResolver,
     publish_repo: BotPublishRepositoryProtocol,
@@ -359,29 +332,29 @@ def resolve_published_device_context(
     a published service binding — those ids are not on ``ac_bots.binding_id`` —
     so the returned context carries an **empty** ``bot_type``.
 
-    One consumer reads it in production: ``DefaultDeviceFileSystemResolver``
-    forks ``bot_type == "desktop"`` inside its baas branch. A published
-    *service* bot is not ``desktop`` whether the field is filled or empty, so it
-    lands on the cloud filesystem either way — and this is exactly what the three
-    existing publish-addressed reads already get. A second arm added beside that
-    fork would receive an empty string here and mis-dispatch silently.
-
-    **Do not "fix" the empty value by filling it in.** The other reader,
-    ``_validate_bot_device_combination``, lists ``("service", "baas")`` in
-    ``_ILLEGAL_BOT_DEVICE_COMBINATIONS`` — the combination is not yet supported
-    — and raises ``DeviceServiceError`` for it. It skips the check entirely when
-    ``bot_type`` is empty, and it is reached only from the dispatcher's legacy
-    direct-construction path, so nothing breaks today; but a correctly-filled
-    ``bot_type`` would turn every published service-bot read on that path into a
-    refusal. The emptiness is load-bearing, not merely tolerated.
+    ``DefaultDeviceFileSystemResolver`` reads it: inside its baas branch it
+    forks on ``bot_type == "desktop"``. A published *service* bot is not
+    ``desktop`` whether the field is filled or empty, so it lands on the cloud
+    filesystem either way — and this is exactly what the three existing
+    publish-addressed reads already get. A second arm added beside that fork
+    would receive an empty string here and mis-dispatch silently, so check this
+    before adding one.
 
     **Synchronous, and blocking.** The publish scan, the binding read and the
     provider resolve are all blocking I/O — on the BaaS path
     ``resolve_for_binding`` reaches ``get_ws_info`` over a sync ``httpx`` client
     with a 30-second timeout. ``relay._resolve_device`` carries the same warning
-    and its caller offloads to a worker thread; an ``async`` caller here must do
-    the same rather than calling this inline, or one slow stage read parks the
-    event loop for every unrelated request on the worker.
+    and ``relay.call`` offloads it, with the bot resolution, in **one** worker
+    thread hop.
+
+    The file surfaces do not offload today: their draft leg already calls
+    ``resolve_for_bot`` inline from an ``async`` method, so this branch is no
+    worse than the path beside it — but it is not better either, and both belong
+    in one hop rather than two. Offloading is a change to those services' shape,
+    not to this function, which is why there is no ``…_off_loop`` sibling here:
+    it could not be awaited from the synchronous ``_device_fs`` helpers that
+    call it, and adding a second hop around only half the blocking work would
+    buy nothing.
 
     **Resolver errors are not translated**, deliberately. ``DeviceNotBoundError``
     and ``ConnInfoBuildError`` propagate as themselves, exactly as they do from
@@ -417,6 +390,5 @@ __all__ = [
     "require_stage_addressable",
     "require_stage_writable",
     "resolve_published_device_context",
-    "resolve_published_device_context_off_loop",
     "resolve_stage_bind_id",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -8,12 +8,21 @@ publish records (which share the bot's own ``publish_bot_id``; no ``…pub…``
 id is ever written). A ``personal`` bot has only its own workspace runtime —
 the ``draft`` stage.
 
-Two callers translate a stage into a published binding — the relay's device
-resolution and ``EngineConnectionService``'s socket composition — and they
-must agree on which runtime a stage names: a socket composed against one
-binding while the sessions group forwards to another would let the two
-surfaces describe different devices for the same request. So the lookup lives
-here, once, like the gate.
+Several callers translate a stage into a published binding — the relay's device
+resolution, ``EngineConnectionService``'s socket composition, and the per-bot
+file surfaces (engine config, identity) — and they must agree on which runtime
+a stage names: a socket composed against one binding while the sessions group
+forwards to another would let the two surfaces describe different devices for
+the same request. So the lookup lives here, once, like the gate.
+
+**A stage is not the only way to name a runtime, and the other way is not this
+one.** ``select_stage_bind_id`` (``core/service_bot/repository/models.py``)
+answers a different question — *one publish record* was named, which of its
+bindings is that record's runtime — for the ``publish_id``-addressed internal
+reads. It cannot answer this module's question, and this module must not answer
+its: :func:`resolve_stage_bind_id` picks the newest record at a status and would
+ignore the record the caller actually addressed. Keyed by stage, come here;
+keyed by publish record, go there.
 """
 
 from __future__ import annotations
@@ -26,15 +35,24 @@ from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
 )
 from agentclaw.community.core.devices.services.device_context import (
+    DeviceContext,
     DeviceNotBoundError,
 )
-from agentclaw.community.core.engine_runtime.errors import EngineStageNotLiveError
+from agentclaw.community.core.devices.services.device_context_resolver import (
+    DeviceContextResolver,
+)
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineStageNotLiveError,
+    EngineStageReadOnlyError,
+)
+from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.core.repository.protocols.publishing import (
     BotPublishRepositoryProtocol,
 )
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
 
@@ -62,6 +80,28 @@ STAGE_ONLINE = PublishStage.ONLINE.value
 
 #: Every stage the surface can address.
 RUNTIME_STAGES = frozenset({STAGE_DRAFT, STAGE_VERIFY, STAGE_ONLINE})
+
+
+def require_stage_writable(stage: str) -> None:
+    """Refuse a write addressed to a published runtime, before anything else.
+
+    A published runtime is what a release produced; it is replaced by publishing
+    again, never edited. Neither thing a write could do here is honest — editing
+    the published runtime forks it from the record that describes it, and
+    writing the draft instead reports success for an edit the addressed runtime
+    never received — so the request is refused outright with
+    :class:`EngineStageReadOnlyError`.
+
+    Deliberately **not** conditional on the bot's type or on the stage being
+    live. Both would need a row read to answer, and neither changes the answer:
+    no runtime at ``verify`` or ``online``, live or not, on a service bot or
+    otherwise, accepts a write through this surface. Running first is what makes
+    "nothing is written" structural rather than a promise.
+    """
+    if stage != STAGE_DRAFT:
+        raise EngineStageReadOnlyError(
+            f"the {stage} runtime is published and does not accept writes"
+        )
 
 
 def require_stage_addressable(bot_type: str, stage: str) -> None:
@@ -226,6 +266,52 @@ def _binding_is_active(binding_repo: DeviceBindingRepository, bind_id: int) -> b
     return binding is not None and str(binding.status) == DeviceBindingStatus.ACTIVE
 
 
+def resolve_published_device_context(
+    resolver: DeviceContextResolver,
+    publish_repo: BotPublishRepositoryProtocol,
+    binding_repo: DeviceBindingRepository,
+    *,
+    facts: BotFacts,
+    stage: str,
+) -> DeviceContext:
+    """The device context of the published runtime ``stage`` names.
+
+    The one entry point for a *read* that addresses a published stage, so the
+    surfaces that read a bot's files cannot drift from the surfaces that forward
+    to it: which runtime a stage names is :func:`resolve_stage_bind_id`'s rule,
+    shared with cron, the relay and the connection socket.
+
+    **Published stages only** — the draft is deliberately absent. Its runtime is
+    the bot's own binding, reachable through the owner-scoped
+    ``resolve_for_bot(bot_id, owner_id)`` its callers already use, and answering
+    it here would oblige every caller to resolve :class:`BotFacts` first: a row
+    read on the path that must stay exactly as cheap as it was before stages
+    were addressable. So the caller keeps the branch, which is also how
+    ``relay._resolve_device`` is shaped.
+
+    :func:`require_stage_addressable` runs first, so a published stage named on
+    a bot that has no such runtime is refused before any device work.
+
+    ``resolve_for_binding`` rather than the relay's
+    ``resolve_for_binding_invoke``: callers here address a **filesystem** on the
+    resolved device and need the full connection info the invoke variant omits.
+    That one line is why this is a sibling of
+    ``relay._resolve_published_device`` rather than a shared body; what the two
+    share is :func:`resolve_stage_bind_id`, which is the rule that must not
+    drift.
+    """
+    require_stage_addressable(facts.bot_type, stage)
+    bind_id = resolve_stage_bind_id(
+        publish_repo,
+        binding_repo,
+        bot_pk=facts.bot_pk,
+        bot_id=facts.bot_id,
+        stage=stage,
+        env=get_current_env(),
+    )
+    return resolver.resolve_for_binding(bind_id, facts.owner_id, bot_id=facts.bot_id)
+
+
 __all__ = [
     "RUNTIME_STAGES",
     "SERVICE_BOT_TYPE",
@@ -233,5 +319,7 @@ __all__ = [
     "STAGE_ONLINE",
     "STAGE_VERIFY",
     "require_stage_addressable",
+    "require_stage_writable",
+    "resolve_published_device_context",
     "resolve_stage_bind_id",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -35,8 +35,10 @@ from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
 )
 from agentclaw.community.core.devices.services.device_context import (
+    DeviceContext,
     DeviceNotBoundError,
 )
+from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.core.engine_runtime.errors import (
     EngineStageNotLiveError,
     EngineStageReadOnlyError,
@@ -49,17 +51,18 @@ from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
 
-# Annotations only, and deliberately deferred. ``gate.py`` imports this module
-# and every openapi_v1 router imports the gate, so naming the concrete resolver
-# at module scope would pull all four conn-info builders — and ``BaasService``
-# behind them — into the import graph of every process that touches the gate.
-# ``from __future__ import annotations`` above is what lets these stay here.
+# Deferred because it is *heavy*, not merely because it is an annotation:
+# ``device_context_resolver`` pulls all four conn-info builders and
+# ``BaasService`` behind them. ``gate.py`` imports this module and every
+# openapi_v1 router imports the gate, so naming the concrete resolver at module
+# scope would put that graph in every process that touches the gate. The other
+# annotations above are imported normally — their modules are already loaded
+# here, and splitting one module's names across two import styles for no saving
+# is how ``DeviceNotBoundError`` ends up in the guarded block by accident.
 if TYPE_CHECKING:
-    from agentclaw.community.core.devices.services.device_context import DeviceContext
     from agentclaw.community.core.devices.services.device_context_resolver import (
         DeviceContextResolver,
     )
-    from agentclaw.community.core.engine_runtime.models import BotFacts
 
 logger = get_logger()
 
@@ -322,10 +325,26 @@ def resolve_published_device_context(
     device``, ``EngineConfigService.read_publish_config``): ``resolve_for_binding``
     derives ``ctx.bot_type`` from ``get_by_binding_id``, which finds nothing for
     a published service binding — those ids are not on ``ac_bots.binding_id`` —
-    so the returned context carries an empty ``bot_type``. Harmless today, since
-    the filesystem resolver branches only on provider, and identical to what the
-    three existing callers already get. A future ``(provider, bot_type)`` branch
-    must not rely on it.
+    so the returned context carries an **empty** ``bot_type``.
+
+    Two consumers already read it, so this is a live hazard rather than a
+    hypothetical one: ``DefaultDeviceFileSystemResolver`` forks
+    ``bot_type == "desktop"`` inside its baas branch, and
+    ``_validate_bot_device_combination`` skips its legality check entirely on an
+    empty value (logging a warning). Neither misbehaves for the bots this
+    function serves — a published *service* bot is not ``desktop`` whether the
+    field is filled or empty, so it lands on the cloud filesystem either way,
+    and it is exactly what the three existing publish-addressed reads already
+    get. But a second arm added beside that ``desktop`` fork would receive an
+    empty string here and mis-dispatch silently.
+
+    **Synchronous, and blocking.** The publish scan, the binding read and the
+    provider resolve are all blocking I/O — on the BaaS path
+    ``resolve_for_binding`` reaches ``get_ws_info`` over a sync ``httpx`` client
+    with a 30-second timeout. ``relay._resolve_device`` carries the same warning
+    and its caller offloads to a worker thread; an ``async`` caller here must do
+    the same rather than calling this inline, or one slow stage read parks the
+    event loop for every unrelated request on the worker.
 
     **Resolver errors are not translated**, deliberately. ``DeviceNotBoundError``
     and ``ConnInfoBuildError`` propagate as themselves, exactly as they do from

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -316,8 +316,11 @@ def resolve_stage_device_context(
     itself, to fill ``ctx.bot_type``; the point is that this function adds
     nothing.)
 
-    **A published stage costs one owner-scoped row read**, for the primary key
-    and the bot type. ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id``
+    **A published stage costs one owner-scoped row read here**, for the primary
+    key and the bot type. An adapter that already fetched the row for its own
+    ownership guard — engine config does — pays for it twice on that request;
+    that is the accepted cost of resolving the facts in one place instead of
+    threading them through every caller (spec D8). ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id``
     carries no unique constraint and every user's first bot is called
     ``default``, so a wider query can return another owner's row — and
     ``bot_pk`` is what the publish lookup trusts to stay on the addressed bot.

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -31,6 +31,7 @@ import json
 from typing import Any, TYPE_CHECKING
 
 from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
 )
@@ -92,7 +93,7 @@ STAGE_ONLINE = PublishStage.ONLINE.value
 RUNTIME_STAGES = frozenset({STAGE_DRAFT, STAGE_VERIFY, STAGE_ONLINE})
 
 
-def _require_known_stage(stage: str) -> None:
+def require_known_stage(stage: str) -> None:
     """Refuse a stage name outside :data:`RUNTIME_STAGES`.
 
     Unreachable from HTTP, where the adapter's enum answers 422 first, but a
@@ -125,7 +126,7 @@ def require_stage_writable(stage: str) -> None:
     binding, because neither resolves :class:`BotFacts` at all. A write surface
     added later inherits none of that and must call this itself.
     """
-    _require_known_stage(stage)
+    require_known_stage(stage)
     if stage != STAGE_DRAFT:
         raise EngineStageReadOnlyError(
             f"the {stage} runtime is published and does not accept writes"
@@ -136,13 +137,13 @@ def require_stage_addressable(bot_type: str, stage: str) -> None:
     """Refuse a stage this bot cannot have, before any device work.
 
     Two refusals, one answer (:class:`EngineStageNotLiveError`): a stage name
-    outside :data:`RUNTIME_STAGES` (see :func:`_require_known_stage`), and a
+    outside :data:`RUNTIME_STAGES` (see :func:`require_known_stage`), and a
     published stage named on anything but a ``service`` bot, which has no such
     runtime to be live. Run by the gate (before device work, for the public
     surface) and by the relay's device resolution (for callers that bypass the
     gate); one implementation so the two cannot drift.
     """
-    _require_known_stage(stage)
+    require_known_stage(stage)
     if stage != STAGE_DRAFT and bot_type != SERVICE_BOT_TYPE:
         raise EngineStageNotLiveError(
             f"a {bot_type} bot has no {stage} runtime; only its workspace"
@@ -291,70 +292,67 @@ def _binding_is_active(binding_repo: DeviceBindingRepository, bind_id: int) -> b
     return binding is not None and str(binding.status) == DeviceBindingStatus.ACTIVE
 
 
-def resolve_published_device_context(
-    resolver: DeviceContextResolver,
+def resolve_stage_device_context(
+    resolver: "DeviceContextResolver",
     publish_repo: BotPublishRepositoryProtocol,
     binding_repo: DeviceBindingRepository,
+    bot_repo: BotRepository,
     *,
-    facts: BotFacts,
+    bot_id: str,
+    owner_id: str,
     stage: str,
 ) -> DeviceContext:
-    """The device context of the published runtime ``stage`` names.
+    """The device context of the runtime ``stage`` names.
 
-    The one entry point for a *read* that addresses a published stage, so the
-    surfaces that read a bot's files cannot drift from the surfaces that forward
-    to it: which runtime a stage names is :func:`resolve_stage_bind_id`'s rule,
-    shared with cron, the relay and the connection socket.
+    The one entry point for a read that addresses a stage, so the surfaces that
+    read a bot's files cannot drift from each other or from the surfaces that
+    forward to it: which runtime a stage names is :func:`resolve_stage_bind_id`'s
+    rule, shared with cron, the relay and the connection socket.
 
-    **Published stages only** — the draft is deliberately absent. Its runtime is
-    the bot's own binding, reachable through the owner-scoped
-    ``resolve_for_bot(bot_id, owner_id)`` its callers already use, and answering
-    it here would oblige every caller to resolve :class:`BotFacts` first: a row
-    read on the path that must stay exactly as cheap as it was before stages
-    were addressable. So the caller keeps the branch, which is also how
-    ``relay._resolve_device`` is shaped.
+    **The draft costs nothing extra.** It resolves the bot's own binding through
+    the same owner-scoped ``resolve_for_bot`` its callers always used — no bot
+    row is read here that was not read before, which is what keeps a request
+    naming no stage byte-for-byte what it was. (``resolve_for_bot`` reads the row
+    itself, to fill ``ctx.bot_type``; the point is that this function adds
+    nothing.)
 
-    :func:`require_stage_addressable` runs first, so a published stage named on
-    a bot that has no such runtime is refused before any device work.
+    **A published stage costs one owner-scoped row read**, for the primary key
+    and the bot type. ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id``
+    carries no unique constraint and every user's first bot is called
+    ``default``, so a wider query can return another owner's row — and
+    ``bot_pk`` is what the publish lookup trusts to stay on the addressed bot.
+
+    A row that is not there yields empty facts rather than an exception, and
+    :func:`require_stage_addressable` then refuses the published stage as having
+    no live runtime. That is a 409, the same class of answer the draft leg gives
+    for a bot that is not the caller's; a 404 here would make a published-stage
+    request the one way to learn whether a bot exists.
 
     ``resolve_for_binding`` rather than the relay's
     ``resolve_for_binding_invoke``: callers here address a **filesystem** on the
     resolved device and need the full connection info the invoke variant omits.
     That one line is why this is a sibling of
     ``relay._resolve_published_device`` rather than a shared body; what the two
-    share is :func:`resolve_stage_bind_id`, which is the rule that must not
-    drift.
+    share is :func:`resolve_stage_bind_id`, the rule that must not drift.
 
-    One consequence of that choice, shared with every other publish-addressed
-    file read (``ResourceFileService``, ``IdentityService._read_from_publish_
-    device``, ``EngineConfigService.read_publish_config``): ``resolve_for_binding``
-    derives ``ctx.bot_type`` from ``get_by_binding_id``, which finds nothing for
-    a published service binding — those ids are not on ``ac_bots.binding_id`` —
-    so the returned context carries an **empty** ``bot_type``.
-
-    ``DefaultDeviceFileSystemResolver`` reads it: inside its baas branch it
-    forks on ``bot_type == "desktop"``. A published *service* bot is not
-    ``desktop`` whether the field is filled or empty, so it lands on the cloud
-    filesystem either way — and this is exactly what the three existing
-    publish-addressed reads already get. A second arm added beside that fork
-    would receive an empty string here and mis-dispatch silently, so check this
-    before adding one.
+    ``DefaultDeviceFileSystemResolver`` reads ``ctx.bot_type``: inside its baas
+    branch it forks on ``bot_type == "desktop"``. ``resolve_for_binding`` derives
+    that from ``get_by_binding_id``, which finds nothing for a published service
+    binding — those ids are not on ``ac_bots.binding_id`` — so the context comes
+    back with an empty ``bot_type``. A published *service* bot is not
+    ``desktop`` either way, so it lands on the cloud filesystem, and this is
+    exactly what the three existing publish-addressed reads already get; but a
+    second arm added beside that fork would receive an empty string here and
+    mis-dispatch silently.
 
     **Synchronous, and blocking.** The publish scan, the binding read and the
     provider resolve are all blocking I/O — on the BaaS path
     ``resolve_for_binding`` reaches ``get_ws_info`` over a sync ``httpx`` client
     with a 30-second timeout. ``relay._resolve_device`` carries the same warning
-    and ``relay.call`` offloads it, with the bot resolution, in **one** worker
-    thread hop.
-
-    The file surfaces do not offload today: their draft leg already calls
-    ``resolve_for_bot`` inline from an ``async`` method, so this branch is no
-    worse than the path beside it — but it is not better either, and both belong
-    in one hop rather than two. Offloading is a change to those services' shape,
-    not to this function, which is why there is no ``…_off_loop`` sibling here:
-    it could not be awaited from the synchronous ``_device_fs`` helpers that
-    call it, and adding a second hop around only half the blocking work would
-    buy nothing.
+    and ``relay.call`` offloads it in one worker-thread hop. The file surfaces do
+    not offload today: their draft leg already calls ``resolve_for_bot`` inline
+    from an ``async`` method, so this is no worse than the path beside it — but
+    it is not better either. Resolve **once per request**, not once per file.
 
     **Resolver errors are not translated**, deliberately. ``DeviceNotBoundError``
     and ``ConnInfoBuildError`` propagate as themselves, exactly as they do from
@@ -364,11 +362,12 @@ def resolve_published_device_context(
     answer differently from ``?stage=draft`` on one endpoint, which is a worse
     inconsistency than the one it would fix.
     """
+    require_known_stage(stage)
     if stage == STAGE_DRAFT:
-        raise ValueError(
-            "resolve_published_device_context does not answer the draft; "
-            "resolve the bot's own binding with resolve_for_bot instead"
-        )
+        return resolver.resolve_for_bot(bot_id, owner_id)
+
+    record = bot_repo.get_by_id_and_owner(bot_id, owner_id) or {}
+    facts = BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
     require_stage_addressable(facts.bot_type, stage)
     bind_id = resolve_stage_bind_id(
         publish_repo,
@@ -387,8 +386,9 @@ __all__ = [
     "STAGE_DRAFT",
     "STAGE_ONLINE",
     "STAGE_VERIFY",
+    "require_known_stage",
     "require_stage_addressable",
     "require_stage_writable",
-    "resolve_published_device_context",
     "resolve_stage_bind_id",
+    "resolve_stage_device_context",
 ]

--- a/src/backend/src/agentclaw/community/core/services/engine_config.py
+++ b/src/backend/src/agentclaw/community/core/services/engine_config.py
@@ -16,6 +16,11 @@ The config file is addressed by the canonical logical path
 
 The router resolves and passes ``engine_type`` (this service does no engine guessing),
 and passes the already-fetched ``BotPublishRecord`` (no second lookup).
+
+The bot-level read/write below address a bot rather than a publish record. The
+read takes a ``stage``: the draft is the bot's own binding, and a service bot's
+verify/online runtimes resolve through the shared rule in
+``core/engine_runtime/stage.py``. Only the draft accepts a write.
 """
 from __future__ import annotations
 
@@ -31,6 +36,18 @@ from agentclaw.community.core.config_compose.teclaw_paths import (
 from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
+)
+from agentclaw.community.core.engine_runtime.models import BotFacts
+from agentclaw.community.core.engine_runtime.stage import (
+    STAGE_DRAFT,
+    require_stage_writable,
+    resolve_published_device_context,
+)
+from agentclaw.community.core.repository.protocols.devices import (
+    DeviceBindingRepository,
+)
+from agentclaw.community.core.repository.protocols.publishing import (
+    BotPublishRepositoryProtocol,
 )
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
@@ -64,7 +81,11 @@ def _decode_config(content_bytes: bytes | None) -> dict:
 
 
 class EngineConfigService:
-    """Reads a service bot's deployed engine config for a publish record, provider-blind."""
+    """Reads and writes a bot's engine config, provider-blind.
+
+    Three addresses, two of them read-only: a publish record (``publish_id``), a
+    bot at a named runtime stage, and a bot's draft for the one write.
+    """
 
     @inject
     def __init__(
@@ -72,10 +93,18 @@ class EngineConfigService:
         bot_repo: BotRepository,
         resolver: DeviceContextResolver,
         device_fs_dispatcher: DeviceFilesystemDispatcher,
+        publish_repo: BotPublishRepositoryProtocol,
+        binding_repo: DeviceBindingRepository,
     ):
         self._bot_repo = bot_repo
         self._resolver = resolver
         self._device_fs_dispatcher = device_fs_dispatcher
+        # Both only for a read that names a published stage: finding that
+        # stage's live runtime among this bot's publish records, and confirming
+        # a retained verify binding is still ACTIVE. The draft read and every
+        # write touch neither.
+        self._publish_repo = publish_repo
+        self._binding_repo = binding_repo
 
     async def read_publish_config(
         self, record: BotPublishRecord, engine_type: str
@@ -120,6 +149,13 @@ class EngineConfigService:
         # Select by record.status; a missing/0 bind_id means there is no resolvable
         # active-stage binding (binding PKs are ≥1, so 0 is never a real binding).
         # This is a real failure, not an empty config — surface it (don't swallow).
+        # Deliberately NOT ``engine_runtime.stage.resolve_stage_bind_id``, which
+        # the stage-addressed read above uses. The two answer different
+        # questions and this one is keyed by *record*: the caller named a
+        # ``publish_id``, and that rule picks the newest record at a status — so
+        # routing this path through it would answer a question about release 7
+        # from whichever release happens to be newest. The stage module's own
+        # docstring draws the same line.
         bind_id = select_stage_bind_id(ext.get("binding", {}), record.status)
         if not bind_id:
             raise DeviceNotBoundError(
@@ -139,7 +175,26 @@ class EngineConfigService:
         content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
         return _decode_config(content_bytes)
 
-    # ── bot-level (draft/current binding) read + write ───────────────────────
+    # ── bot-level (stage-addressed read, draft-only write) ───────────────────
+
+    def _bot_facts(self, bot_id: str, owner_id: str) -> BotFacts:
+        """The addressed bot's facts, from an **owner-scoped** read.
+
+        ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id`` carries no
+        unique constraint and every user's first bot is called ``default``, so a
+        wider query can return another owner's row — and ``bot_pk`` is what the
+        publish lookup trusts to stay on the addressed bot.
+
+        A row that is not there yields empty facts rather than an exception, and
+        the guards downstream answer it: ``require_stage_addressable`` sees a
+        ``bot_type`` that is not ``service`` and refuses the published stage as
+        having no live runtime. That is a 409, which is the same class of answer
+        this endpoint's draft leg gives for a bot that is not the caller's —
+        raising a 404 here instead would make a published-stage request the one
+        way to learn whether a bot exists.
+        """
+        record = self._bot_repo.get_by_id_and_owner(bot_id, owner_id) or {}
+        return BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
 
     def _bot_config_device_fs(
         self,
@@ -149,12 +204,28 @@ class EngineConfigService:
         entity_id: str,
         entity_type: str,
         engine_type: str,
+        stage: str,
     ):
-        """Resolve the bot's own (draft/current) binding and build its config-addressing
+        """Resolve the runtime ``stage`` names and build its config-addressing
         DeviceFileSystem via the dispatcher (mirrors
-        ``IdentityService._identity_device_fs``). Raises ``DeviceNotBoundError`` if the
-        bot has no active binding — same as the legacy ``for_bot`` path."""
-        ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
+        ``IdentityService._identity_device_fs``).
+
+        The draft is the bot's own binding, resolved exactly as it always was —
+        no bot row is read — and raises ``DeviceNotBoundError`` if the bot has
+        no active binding, same as the legacy ``for_bot`` path. A published
+        stage resolves that stage's live runtime and raises
+        ``EngineStageNotLiveError`` when there is none.
+        """
+        if stage == STAGE_DRAFT:
+            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
+        else:
+            ctx = resolve_published_device_context(
+                self._resolver,
+                self._publish_repo,
+                self._binding_repo,
+                facts=self._bot_facts(bot_id, owner_id),
+                stage=stage,
+            )
         return self._device_fs_dispatcher.dispatch_addressed(
             ctx, namespace=CONFIG_NS, entity_type=entity_type, entity_id=entity_id,
             bot_id=bot_id, engine_type=engine_type,
@@ -168,17 +239,23 @@ class EngineConfigService:
         entity_id: str,
         entity_type: str,
         engine_type: str,
+        stage: str,
     ) -> dict:
-        """Read a bot's engine config from its own device, provider-blind.
+        """Read a bot's engine config from the runtime ``stage`` names, provider-blind.
+
+        ``stage`` is required rather than defaulted — see the Service API
+        contract for why. ``STAGE_DRAFT`` is the bot's own workspace, what every
+        caller read before stages were addressable.
 
         Returns the parsed dict; ``{}`` only when the file is missing/empty — a bot
         that has never had a config written reads as empty on every provider, not as
         an error. Resolve errors, a device that refuses the read, and
-        ``json.JSONDecodeError`` propagate (the caller surfaces them).
+        ``json.JSONDecodeError`` propagate (the caller surfaces them), as does
+        ``EngineStageNotLiveError`` for a published stage with no live runtime.
         """
         device_fs = self._bot_config_device_fs(
             bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
-            entity_type=entity_type, engine_type=engine_type,
+            entity_type=entity_type, engine_type=engine_type, stage=stage,
         )
         content_bytes = await device_fs.read_file(_CONFIG_LOGICAL_PATH)
         return _decode_config(content_bytes)
@@ -192,16 +269,25 @@ class EngineConfigService:
         entity_type: str,
         engine_type: str,
         config: dict,
+        stage: str,
     ) -> None:
         """Write a bot's engine config to its own device, provider-blind.
+
+        Only the draft accepts a write. ``stage`` is taken so that a caller
+        naming a published runtime is *refused* (``EngineStageReadOnlyError``)
+        rather than having their edit quietly applied to the draft — a write
+        that would report success for a runtime it never touched. The refusal is
+        the first thing that happens, before any row or device is resolved, so
+        nothing is written anywhere.
 
         Bytes are ``json.dumps(config, ensure_ascii=False, indent=2)`` — byte-identical
         to the legacy ``update_engine_config`` serialization. Resolve/write errors
         propagate (the caller surfaces them).
         """
+        require_stage_writable(stage)
         device_fs = self._bot_config_device_fs(
             bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
-            entity_type=entity_type, engine_type=engine_type,
+            entity_type=entity_type, engine_type=engine_type, stage=STAGE_DRAFT,
         )
         payload = json.dumps(config, ensure_ascii=False, indent=2).encode("utf-8")
         await device_fs.write_file(_CONFIG_LOGICAL_PATH, payload)

--- a/src/backend/src/agentclaw/community/core/services/engine_config.py
+++ b/src/backend/src/agentclaw/community/core/services/engine_config.py
@@ -37,11 +37,9 @@ from agentclaw.community.core.devices.services.device_context import DeviceNotBo
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
-from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.core.engine_runtime.stage import (
-    STAGE_DRAFT,
     require_stage_writable,
-    resolve_published_device_context,
+    resolve_stage_device_context,
 )
 from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
@@ -150,7 +148,7 @@ class EngineConfigService:
         # active-stage binding (binding PKs are ≥1, so 0 is never a real binding).
         # This is a real failure, not an empty config — surface it (don't swallow).
         # Deliberately NOT ``engine_runtime.stage.resolve_stage_bind_id``, which
-        # the stage-addressed read above uses. The two answer different
+        # the bot-level stage-addressed read below uses. The two answer different
         # questions and this one is keyed by *record*: the caller named a
         # ``publish_id``, and that rule picks the newest record at a status — so
         # routing this path through it would answer a question about release 7
@@ -177,25 +175,6 @@ class EngineConfigService:
 
     # ── bot-level (stage-addressed read, draft-only write) ───────────────────
 
-    def _bot_facts(self, bot_id: str, owner_id: str) -> BotFacts:
-        """The addressed bot's facts, from an **owner-scoped** read.
-
-        ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id`` carries no
-        unique constraint and every user's first bot is called ``default``, so a
-        wider query can return another owner's row — and ``bot_pk`` is what the
-        publish lookup trusts to stay on the addressed bot.
-
-        A row that is not there yields empty facts rather than an exception, and
-        the guards downstream answer it: ``require_stage_addressable`` sees a
-        ``bot_type`` that is not ``service`` and refuses the published stage as
-        having no live runtime. That is a 409, which is the same class of answer
-        this endpoint's draft leg gives for a bot that is not the caller's —
-        raising a 404 here instead would make a published-stage request the one
-        way to learn whether a bot exists.
-        """
-        record = self._bot_repo.get_by_id_and_owner(bot_id, owner_id) or {}
-        return BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
-
     def _bot_config_device_fs(
         self,
         *,
@@ -210,22 +189,21 @@ class EngineConfigService:
         DeviceFileSystem via the dispatcher (mirrors
         ``IdentityService._identity_device_fs``).
 
-        The draft is the bot's own binding, resolved exactly as it always was —
-        no bot row is read — and raises ``DeviceNotBoundError`` if the bot has
-        no active binding, same as the legacy ``for_bot`` path. A published
-        stage resolves that stage's live runtime and raises
-        ``EngineStageNotLiveError`` when there is none.
+        The draft raises ``DeviceNotBoundError`` if the bot has no active
+        binding, same as the legacy ``for_bot`` path; a published stage raises
+        ``EngineStageNotLiveError`` when that stage has no live runtime. Both
+        legs, and the reasons behind them, live in
+        :func:`resolve_stage_device_context`.
         """
-        if stage == STAGE_DRAFT:
-            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
-        else:
-            ctx = resolve_published_device_context(
-                self._resolver,
-                self._publish_repo,
-                self._binding_repo,
-                facts=self._bot_facts(bot_id, owner_id),
-                stage=stage,
-            )
+        ctx = resolve_stage_device_context(
+            self._resolver,
+            self._publish_repo,
+            self._binding_repo,
+            self._bot_repo,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            stage=stage,
+        )
         return self._device_fs_dispatcher.dispatch_addressed(
             ctx, namespace=CONFIG_NS, entity_type=entity_type, entity_id=entity_id,
             bot_id=bot_id, engine_type=engine_type,
@@ -287,7 +265,7 @@ class EngineConfigService:
         require_stage_writable(stage)
         device_fs = self._bot_config_device_fs(
             bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
-            entity_type=entity_type, engine_type=engine_type, stage=STAGE_DRAFT,
+            entity_type=entity_type, engine_type=engine_type, stage=stage,
         )
         payload = json.dumps(config, ensure_ascii=False, indent=2).encode("utf-8")
         await device_fs.write_file(_CONFIG_LOGICAL_PATH, payload)

--- a/src/backend/src/agentclaw/community/core/services/identity.py
+++ b/src/backend/src/agentclaw/community/core/services/identity.py
@@ -31,6 +31,15 @@ from agentclaw.community.core.devices.services.device_context import (
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
+from agentclaw.community.core.engine_runtime.models import BotFacts
+from agentclaw.community.core.engine_runtime.stage import (
+    STAGE_DRAFT,
+    require_stage_writable,
+    resolve_published_device_context,
+)
+from agentclaw.community.core.repository.protocols.devices import (
+    DeviceBindingRepository,
+)
 from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
 from agentclaw.community.core.devices.services import device_info as device_info_lookup
 from agentclaw.community.di.modules.skill_center_module import (
@@ -181,12 +190,16 @@ class IdentityService:
         bot_repo: BotRepository,
         resolver: DeviceContextResolver,
         device_fs_dispatcher: DeviceFilesystemDispatcher,
+        binding_repo: DeviceBindingRepository,
     ):
         self.path_factory = path_factory
         self._publish_repo = publish_repo
         self._resolver = resolver
         self._device_fs_dispatcher = device_fs_dispatcher
         self._bot_repo = bot_repo
+        # Only for a read that names a published stage: confirming that a verify
+        # runtime retained after promotion still has an ACTIVE binding.
+        self._binding_repo = binding_repo
 
     # ==================== Validation ====================
 
@@ -246,6 +259,24 @@ class IdentityService:
     # a bot with no resolvable device context is a bug and surfaces as the
     # resolver's error (fail early, never silently touch a dead local path).
 
+    def _bot_facts(self, bot_id: str, owner_id: str) -> BotFacts:
+        """The addressed bot's facts, from an **owner-scoped** read.
+
+        ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id`` carries no
+        unique constraint, so a wider query can return another owner's row — and
+        ``bot_pk`` is what the publish lookup trusts to stay on the addressed
+        bot.
+
+        A row that is not there yields empty facts rather than an exception, and
+        ``require_stage_addressable`` downstream refuses the published stage as
+        having no live runtime. That is a 409, the same class of answer this
+        service's draft leg already gives for a bot that is not the caller's; a
+        404 here would make a published-stage request the one way to learn
+        whether a bot exists.
+        """
+        record = self._bot_repo.get_by_id_and_owner(bot_id, owner_id) or {}
+        return BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
+
     def _identity_device_fs(
         self,
         *,
@@ -254,10 +285,26 @@ class IdentityService:
         bot_id: str,
         owner_id: str,
         engine_type: str,
+        stage: str = STAGE_DRAFT,
     ):
-        """Resolve the bot's device context (raises if unbound) and build its
-        identity-addressing DeviceFileSystem via the dispatcher."""
-        ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
+        """Resolve the runtime ``stage`` names and build its identity-addressing
+        DeviceFileSystem via the dispatcher.
+
+        The default is the bot's own workspace, resolved exactly as it always
+        was (raises if unbound) and reading no bot row. A service bot's
+        published runtimes resolve through the shared stage rule, which raises
+        ``EngineStageNotLiveError`` when the named stage has none up.
+        """
+        if stage == STAGE_DRAFT:
+            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
+        else:
+            ctx = resolve_published_device_context(
+                self._resolver,
+                self._publish_repo,
+                self._binding_repo,
+                facts=self._bot_facts(bot_id, owner_id),
+                stage=stage,
+            )
         return self._device_fs_dispatcher.dispatch_addressed(
             ctx,
             namespace=IDENTITY_NS,
@@ -276,6 +323,7 @@ class IdentityService:
         file_type: str,
         owner_id: str,
         engine_type: str,
+        stage: str = STAGE_DRAFT,
     ) -> str:
         device_fs = self._identity_device_fs(
             entity_type=entity_type,
@@ -283,6 +331,7 @@ class IdentityService:
             bot_id=bot_id,
             owner_id=owner_id,
             engine_type=engine_type,
+            stage=stage,
         )
         # identity 域的契约是"缺省即空内容"。``DeviceFileSystem.read_file`` 的契约
         # 同样是"文件不存在 → None",baas/teclaw/local 都已按此实现,所以正常路径
@@ -332,12 +381,16 @@ class IdentityService:
         owner_id: str,
         *,
         engine_type: str | None = None,
+        stage: str = STAGE_DRAFT,
     ) -> str:
         """Read a bot-level **identity** file (provider-blind, coordinate-based).
 
-        ``engine_type`` is resolved per-bot when not given. The high-level identity
-        methods + ``bot_profile`` use this; it addresses the file as
-        ``identity/<file_type>`` and lets the factory compose the device address.
+        ``engine_type`` is resolved per-bot when not given. ``stage`` names which
+        of the bot's runtimes to read and defaults to its own workspace, so every
+        caller that does not address a stage reads what it always did. The
+        high-level identity methods + ``bot_profile`` use this; it addresses the
+        file as ``identity/<file_type>`` and lets the factory compose the device
+        address.
         """
         eng = resolve_engine_for_bot(
             bot_id, entity_id, override=engine_type, bot_repo=self._bot_repo
@@ -349,6 +402,7 @@ class IdentityService:
             file_type=file_type,
             owner_id=owner_id,
             engine_type=eng,
+            stage=stage,
         )
 
     async def write_identity_file(
@@ -611,7 +665,19 @@ class IdentityService:
         operator_id: str,
         publish_id: str | None = None,
         engine_type: str | None = None,
+        *,
+        stage: str = STAGE_DRAFT,
     ) -> BotIdentityFileResponse:
+        """Read one identity file of a bot.
+
+        Two ways to name a runtime other than the draft, and they are not
+        interchangeable. ``stage`` names a **stage** and resolves whichever
+        runtime that stage currently has; ``publish_id`` names a **release
+        record** and reads the binding that record holds. The record-keyed
+        branch wins when both are given — it names one exact release, which is
+        the more specific address — and it is the older internal contract, so
+        nothing about it changes here.
+        """
         self.validate_entity_type(entity_type)
         self.validate_file_type(file_type)
         eng = resolve_engine_for_bot(
@@ -652,6 +718,7 @@ class IdentityService:
             file_type,
             owner_id,
             engine_type=eng,
+            stage=stage,
         )
         return BotIdentityFileResponse(
             success=True,
@@ -671,6 +738,7 @@ class IdentityService:
         owner_id: str,
         *,
         engine_type: str | None = None,
+        stage: str = STAGE_DRAFT,
     ) -> list[tuple[str, bool]]:
         """Probe each whitelisted identity file_type's presence for a bot.
 
@@ -679,6 +747,9 @@ class IdentityService:
         returned non-empty content. Provider-blind: ``read_identity_file``
         addresses each file as ``identity/<file_type>`` and turns a device
         404 into an empty string (absent → ``exists=False``).
+
+        ``stage`` names which runtime is probed, and the whole list comes from
+        that one runtime — a caller never sees a draft row beside a verify row.
         """
         self.validate_entity_type(entity_type)
         # Probe all 16 identity files concurrently: each read is a device
@@ -703,6 +774,7 @@ class IdentityService:
                     ft,
                     owner_id,
                     engine_type=engine_type,
+                    stage=stage,
                 )
                 for ft in ordered
             )
@@ -727,6 +799,13 @@ class IdentityService:
         device_fs.read_file("identity/<file>")`` — covering arca / baas / teclaw
         uniformly (replaces the old ``ARCA_`` target string-sniff). Returns ``None``
         when the publish record / stage binding can't be resolved.
+
+        Deliberately **not** ``engine_runtime.stage.resolve_stage_bind_id``,
+        which the stage-addressed read uses. The caller here named one publish
+        record, and that rule picks the newest record at a status — routing this
+        path through it would answer a question about release 7 from whichever
+        release is currently newest. Keyed by record, stay here; keyed by stage,
+        go there.
         """
         from agentclaw.community.core.service_bot.repository.models import (
             select_stage_bind_id,
@@ -787,7 +866,19 @@ class IdentityService:
         content: str,
         operator_id: str,
         engine_type: str | None = None,
+        *,
+        stage: str = STAGE_DRAFT,
     ) -> BotIdentityFileUpdateResponse:
+        """Create or overwrite one identity file of a bot.
+
+        Only the draft accepts a write, and it is the default. ``stage`` is taken
+        so that a caller naming a published runtime is *refused*
+        (``EngineStageReadOnlyError``) rather than having their edit quietly
+        applied to the draft. The refusal is the first thing that happens, before
+        anything is resolved — which is also why the write path below needs no
+        stage of its own: there is only one runtime it can reach.
+        """
+        require_stage_writable(stage)
         self.validate_entity_type(entity_type)
         self.validate_file_type(file_type)
         eng = resolve_engine_for_bot(

--- a/src/backend/src/agentclaw/community/core/services/identity.py
+++ b/src/backend/src/agentclaw/community/core/services/identity.py
@@ -31,11 +31,11 @@ from agentclaw.community.core.devices.services.device_context import (
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
-from agentclaw.community.core.engine_runtime.models import BotFacts
 from agentclaw.community.core.engine_runtime.stage import (
     STAGE_DRAFT,
+    require_known_stage,
     require_stage_writable,
-    resolve_published_device_context,
+    resolve_stage_device_context,
 )
 from agentclaw.community.core.repository.protocols.devices import (
     DeviceBindingRepository,
@@ -259,24 +259,6 @@ class IdentityService:
     # a bot with no resolvable device context is a bug and surfaces as the
     # resolver's error (fail early, never silently touch a dead local path).
 
-    def _bot_facts(self, bot_id: str, owner_id: str) -> BotFacts:
-        """The addressed bot's facts, from an **owner-scoped** read.
-
-        ``get_by_id_and_owner`` and not ``get_by_id``: ``bot_id`` carries no
-        unique constraint, so a wider query can return another owner's row — and
-        ``bot_pk`` is what the publish lookup trusts to stay on the addressed
-        bot.
-
-        A row that is not there yields empty facts rather than an exception, and
-        ``require_stage_addressable`` downstream refuses the published stage as
-        having no live runtime. That is a 409, the same class of answer this
-        service's draft leg already gives for a bot that is not the caller's; a
-        404 here would make a published-stage request the one way to learn
-        whether a bot exists.
-        """
-        record = self._bot_repo.get_by_id_and_owner(bot_id, owner_id) or {}
-        return BotFacts.from_record(record, bot_id=bot_id, owner_id=owner_id)
-
     def _identity_device_fs(
         self,
         *,
@@ -291,20 +273,20 @@ class IdentityService:
         DeviceFileSystem via the dispatcher.
 
         The default is the bot's own workspace, resolved exactly as it always
-        was (raises if unbound) and reading no bot row. A service bot's
-        published runtimes resolve through the shared stage rule, which raises
-        ``EngineStageNotLiveError`` when the named stage has none up.
+        was (raises if unbound). A service bot's published runtimes resolve
+        through the shared stage rule, which raises ``EngineStageNotLiveError``
+        when the named stage has none up. Both legs, and the reasons behind
+        them, live in :func:`resolve_stage_device_context`.
         """
-        if stage == STAGE_DRAFT:
-            ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
-        else:
-            ctx = resolve_published_device_context(
-                self._resolver,
-                self._publish_repo,
-                self._binding_repo,
-                facts=self._bot_facts(bot_id, owner_id),
-                stage=stage,
-            )
+        ctx = resolve_stage_device_context(
+            self._resolver,
+            self._publish_repo,
+            self._binding_repo,
+            self._bot_repo,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            stage=stage,
+        )
         return self._device_fs_dispatcher.dispatch_addressed(
             ctx,
             namespace=IDENTITY_NS,
@@ -342,6 +324,16 @@ class IdentityService:
         # 抛 404,这里兜住,避免 router 吃 500、前端打不开编辑器。等 arca 侧也按契约
         # 把 404 收敛成 None,这段 except 就该整体删掉——core 不该认识 HTTP 状态码。
         # 非 404 的 HTTPStatusError(代理 401/沙箱 5xx 等)始终透出。
+        return await self._read_through(device_fs, file_type)
+
+    @staticmethod
+    async def _read_through(device_fs, file_type: str) -> str:
+        """One identity file, through an **already-resolved** ``device_fs``.
+
+        Split out of :meth:`_device_read` so a caller reading many files for one
+        runtime resolves that runtime once — see :meth:`list_bot_files`. The 404
+        contract is the one described there and is not repeated.
+        """
         try:
             content_bytes = await device_fs.read_file(f"{IDENTITY_NS}/{file_type}")
         except httpx.HTTPStatusError as e:
@@ -680,6 +672,10 @@ class IdentityService:
         """
         self.validate_entity_type(entity_type)
         self.validate_file_type(file_type)
+        # Checked even though the ``publish_id`` branch below ignores ``stage``:
+        # a caller who passed a stage name that is not one should hear about it
+        # rather than have the argument silently discarded.
+        require_known_stage(stage)
         eng = resolve_engine_for_bot(
             bot_id, entity_id, override=engine_type, bot_repo=self._bot_repo
         )
@@ -752,6 +748,26 @@ class IdentityService:
         that one runtime — a caller never sees a draft row beside a verify row.
         """
         self.validate_entity_type(entity_type)
+
+        # The runtime is resolved **once**, not once per file. Every resolution
+        # step is synchronous — the engine lookup, and on a published stage a
+        # bot-row read, a publish-record scan, a binding read and a provider
+        # call with a 30-second timeout — and synchronous work in a coroutine
+        # runs before its first ``await``, so ``gather`` would execute sixteen
+        # of them back to back on the event loop rather than concurrently. One
+        # resolution, sixteen reads through it.
+        eng = resolve_engine_for_bot(
+            bot_id, entity_id, override=engine_type, bot_repo=self._bot_repo
+        )
+        device_fs = self._identity_device_fs(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            engine_type=eng,
+            stage=stage,
+        )
+
         # Probe all 16 identity files concurrently: each read is a device
         # round-trip (baas/arca = a network hop), so gathering instead of a
         # serial loop cuts this list endpoint's tail latency from 16× to ~1×.
@@ -766,18 +782,7 @@ class IdentityService:
         # cap is needed, wrap the gather in asyncio.Semaphore.
         ordered = list(VALID_IDENTITY_FILES)
         contents = await asyncio.gather(
-            *(
-                self.read_identity_file(
-                    entity_type,
-                    entity_id,
-                    bot_id,
-                    ft,
-                    owner_id,
-                    engine_type=engine_type,
-                    stage=stage,
-                )
-                for ft in ordered
-            )
+            *(self._read_through(device_fs, ft) for ft in ordered)
         )
         return list(zip(ordered, [bool(c) for c in contents]))
 
@@ -878,9 +883,13 @@ class IdentityService:
         anything is resolved — which is also why the write path below needs no
         stage of its own: there is only one runtime it can reach.
         """
-        require_stage_writable(stage)
+        # The two static validators run first: they resolve nothing, so the
+        # stage guard keeps its "before anything is resolved" property, and a
+        # request that is *also* malformed still hears which part is wrong
+        # rather than being answered only about its stage.
         self.validate_entity_type(entity_type)
         self.validate_file_type(file_type)
+        require_stage_writable(stage)
         eng = resolve_engine_for_bot(
             bot_id, entity_id, override=engine_type, bot_repo=self._bot_repo
         )

--- a/src/backend/src/agentclaw/community/di/modules/engine_config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/engine_config_module.py
@@ -1,8 +1,10 @@
 """EngineConfigModule — production singleton for the engine-config service.
 
 ``EngineConfigService.__init__`` uses ``@inject`` to receive ``BotRepository``,
-``DeviceContextResolver`` and ``DeviceFilesystemDispatcher``; a ``configure``
-self-binding is enough for the injector to construct it.
+``DeviceContextResolver``, ``DeviceFilesystemDispatcher``,
+``BotPublishRepositoryProtocol`` and ``DeviceBindingRepository`` (the last two
+for stage-addressed reads); a ``configure`` self-binding is enough for the
+injector to construct it.
 
 The ``EngineConfigService`` import is deferred to ``configure`` time so that loading
 this module file does not eagerly pull ``service_bot``/``skill_center`` into the early

--- a/src/backend/src/agentclaw/community/di/modules/identity_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/identity_module.py
@@ -1,9 +1,11 @@
 """IdentityModule — production singleton for the identity service.
 
 ``IdentityService.__init__`` uses ``@inject`` to receive
-``WorkspacePathFactory``, ``BotPublishRepositoryProtocol`` and
-``BaasService``; a ``configure`` self-binding is enough for the
-injector to construct it.
+``WorkspacePathFactory``, ``BotPublishRepositoryProtocol``,
+``BotRepository``, ``DeviceContextResolver``,
+``DeviceFilesystemDispatcher`` and ``DeviceBindingRepository`` (the
+last for stage-addressed reads); a ``configure`` self-binding is
+enough for the injector to construct it.
 
 The ``IdentityService`` import is deferred to ``configure`` time so
 that loading this module file does not eagerly pull

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -84,6 +84,11 @@ _STAGE_ADDRESSED_ELSEWHERE = {
 }
 
 #: The other operations that address a bot by ``(owner, bot_id)``.
+#:
+#: They take ``owner_id`` for the same reason and with the same default — the
+#: caller's own bot — because ``bot_id`` alone does not identify one. They do
+#: **not** take ``stage``: there is no runtime in question when you are
+#: recording who may reach a bot, or listing a bot's stored skills.
 _OWNER_ADDRESSED_ELSEWHERE = {
     ("get", "/openapi/v1/bots/{bot_id}/authorized-apps"),
     ("post", "/openapi/v1/bots/{bot_id}/authorized-apps"),

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -4,10 +4,11 @@ The behavioural half: the default is the draft byte-for-byte, a named stage
 travels to the forward unchanged, a stage a bot cannot have is the one fixed
 409, and a value outside the enum never reaches a handler. The document half,
 in the shape of ``test_explicit_user_id.py``: ``stage`` is an optional query
-parameter on exactly the sixteen engine-runtime operations and nowhere else,
-and ``owner_id`` on those plus the three bot-scoped authorization operations —
-asserted against the generated description so a later operation is covered
-without editing this file.
+parameter on exactly the engine-runtime operations (current and retiring) plus
+the five per-bot file operations that address a runtime, and ``owner_id`` on the
+engine-runtime ones plus the bot-scoped authorization and skills operations — asserted against the
+generated description so a later operation is covered without editing this
+file.
 """
 
 from __future__ import annotations
@@ -65,6 +66,24 @@ def _is_engine_runtime(path: str) -> bool:
 #: caller's own bot — because ``bot_id`` alone does not identify one. They do
 #: **not** take ``stage``: there is no runtime in question when you are
 #: recording who may reach a bot, or listing a bot's stored skills.
+#: The per-bot file operations. They read or write a file **on** the addressed
+#: runtime, so they name one the same way the forwarding groups do — but they
+#: are not engine-runtime operations: they carry ``user_id`` rather than
+#: ``owner_id``, and engine-config publishes the ordinary error table because it
+#: cannot produce the 501 or 504 those groups document.
+#:
+#: The retiring twins of these five are deliberately absent. Their contract is
+#: frozen, so they must not have grown the parameter — which the exclusivity
+#: assertion below is what proves.
+_STAGE_ADDRESSED_ELSEWHERE = {
+    ("get", "/openapi/v1/bots/{bot_id}/engine/config"),
+    ("put", "/openapi/v1/bots/{bot_id}/engine/config"),
+    ("get", "/openapi/v1/bots/{bot_id}/identity"),
+    ("get", "/openapi/v1/bots/{bot_id}/identity/{file_type}"),
+    ("put", "/openapi/v1/bots/{bot_id}/identity/{file_type}"),
+}
+
+#: The other operations that address a bot by ``(owner, bot_id)``.
 _OWNER_ADDRESSED_ELSEWHERE = {
     ("get", "/openapi/v1/bots/{bot_id}/authorized-apps"),
     ("post", "/openapi/v1/bots/{bot_id}/authorized-apps"),
@@ -257,7 +276,13 @@ def test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations():
     # addresses while callers migrate. The number halves again when the
     # deprecated package is deleted.
     assert len(engine_runtime) == 32
-    assert sorted(carrying_stage) == sorted(engine_runtime), "stage is theirs alone"
+    assert sorted(carrying_stage) == sorted(
+        set(engine_runtime) | _STAGE_ADDRESSED_ELSEWHERE
+    ), (
+        "stage belongs to the engine-runtime operations and the five per-bot "
+        "file operations, and to nothing else by accident — in particular to "
+        "no retiring address of those five, whose contract is frozen"
+    )
     assert sorted(carrying_owner) == sorted(
         set(engine_runtime) | _OWNER_ADDRESSED_ELSEWHERE
     ), (

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -60,12 +60,6 @@ def _is_engine_runtime(path: str) -> bool:
     return path in _engine_runtime_paths()
 
 
-#: The other operations that address a bot by ``(owner, bot_id)``.
-#:
-#: They take ``owner_id`` for the same reason and with the same default — the
-#: caller's own bot — because ``bot_id`` alone does not identify one. They do
-#: **not** take ``stage``: there is no runtime in question when you are
-#: recording who may reach a bot, or listing a bot's stored skills.
 #: The per-bot file operations. They read or write a file **on** the addressed
 #: runtime, so they name one the same way the forwarding groups do — but they
 #: are not engine-runtime operations: they carry ``user_id`` rather than

--- a/src/backend/tests/community/adapters/http/openapi_v1/identity/test_identity_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/identity/test_identity_handlers.py
@@ -104,6 +104,7 @@ class _StubIdentityService:
         owner_id,
         *,
         engine_type=None,
+        stage="draft",
     ):
         self.last_call_kwargs = {
             "entity_type": entity_type,
@@ -111,6 +112,7 @@ class _StubIdentityService:
             "bot_id": bot_id,
             "owner_id": owner_id,
             "engine_type": engine_type,
+            "stage": stage,
         }
         return self._presence
 
@@ -192,7 +194,8 @@ async def test_list_bot_identity_files_400_when_entity_type_invalid():
 
     class _RaisingService:
         async def list_bot_files(
-            self, entity_type, entity_id, bot_id, owner_id, *, engine_type=None
+            self, entity_type, entity_id, bot_id, owner_id, *, engine_type=None,
+            stage="draft",
         ):
             raise InvalidIdentityEntityTypeError(f"Invalid entity_type: {entity_type}")
 
@@ -266,6 +269,8 @@ class _StubGetUpdateService:
         operator_id,
         publish_id=None,
         engine_type=None,
+        *,
+        stage="draft",
     ):
         self.last_get_call = {
             "entity_type": entity_type,
@@ -275,6 +280,7 @@ class _StubGetUpdateService:
             "operator_id": operator_id,
             "publish_id": publish_id,
             "engine_type": engine_type,
+            "stage": stage,
         }
         if self._raise_on_get:
             raise self._raise_on_get
@@ -294,6 +300,8 @@ class _StubGetUpdateService:
         content,
         operator_id,
         engine_type=None,
+        *,
+        stage="draft",
     ):
         self.last_update_call = {
             "entity_type": entity_type,
@@ -303,6 +311,7 @@ class _StubGetUpdateService:
             "content": content,
             "operator_id": operator_id,
             "engine_type": engine_type,
+            "stage": stage,
         }
         if self._raise_on_update:
             raise self._raise_on_update

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -354,6 +354,7 @@ def test_local_skill_edit_errors_have_distinct_public_responses(error, expected)
         ("EngineBotTypeNotSupportedError", 501),
         ("EngineCapabilityUnsupportedError", 501),
         ("EngineDeviceNotReadyError", 409),
+        ("EngineStageReadOnlyError", 409),
         ("EngineResourceNotFoundError", 404),
         ("EngineUpstreamError", 502),
     ],
@@ -367,29 +368,33 @@ def test_engine_runtime_errors_map_to_their_own_status(exc_name, expected_status
 
 
 def test_engine_runtime_base_does_not_swallow_its_leaves():
-    """``EngineRuntimeError`` is the base of all four; it must be listed last.
+    """``EngineRuntimeError`` is the base of every ``Engine*``; it is listed last.
 
     This is the "map the base class last" trap from the Track B gotchas, and
-    Track C introduces two base/leaf pairs at once — so it is asserted, not
+    Track C introduced two base/leaf pairs at once — so it is asserted, not
     trusted.
+
+    The leaves are read off the errors module rather than listed here. A
+    hand-written list is a second inventory that a new error joins only if
+    someone remembers, and the cost of forgetting is silent: a leaf placed after
+    its base still resolves, just to the base's 502, with a green suite.
     """
+    import agentclaw.community.core.engine_runtime.errors as errs
     from agentclaw.community.adapters.http.openapi_v1.responses import ENVELOPE_ERRORS
-    from agentclaw.community.core.engine_runtime.errors import (
-        EngineCapabilityUnsupportedError,
-        EngineDeviceNotReadyError,
-        EngineResourceNotFoundError,
-        EngineRuntimeError,
-        EngineUpstreamError,
-    )
+    from agentclaw.community.core.engine_runtime.errors import EngineRuntimeError
+
+    leaves = [
+        getattr(errs, name)
+        for name in errs.__all__
+        if name != "EngineRuntimeError"
+        and issubclass(getattr(errs, name), EngineRuntimeError)
+    ]
+    assert len(leaves) >= 7, "the errors module stopped exporting its leaves"
 
     order = list(ENVELOPE_ERRORS)
     base = order.index(EngineRuntimeError)
-    for leaf in (
-        EngineCapabilityUnsupportedError,
-        EngineDeviceNotReadyError,
-        EngineResourceNotFoundError,
-        EngineUpstreamError,
-    ):
+    for leaf in leaves:
+        assert leaf in ENVELOPE_ERRORS, f"{leaf.__name__} has no mapped status"
         assert order.index(leaf) < base, f"{leaf.__name__} listed after its base"
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -367,6 +367,35 @@ def test_engine_runtime_errors_map_to_their_own_status(exc_name, expected_status
     assert status == expected_status
 
 
+def test_the_three_409s_do_not_share_a_message():
+    """Status alone cannot tell them apart, so the message has to.
+
+    ``EngineDeviceNotReadyError``, ``EngineStageNotLiveError`` and
+    ``EngineStageReadOnlyError`` all answer 409 and mean three different things:
+    retry, publish something, and stop. Asserting only the status lets a
+    copy-pasted message — the entries are adjacent in ``responses.py`` — pass
+    while the caller loses the distinction the errors exist for.
+    """
+    from agentclaw.community.core.engine_runtime.errors import (
+        EngineDeviceNotReadyError,
+        EngineStageNotLiveError,
+        EngineStageReadOnlyError,
+    )
+
+    answers = {
+        exc: _lookup(exc("boom"))
+        for exc in (
+            EngineDeviceNotReadyError,
+            EngineStageNotLiveError,
+            EngineStageReadOnlyError,
+        )
+    }
+    assert all(status == 409 for status, _ in answers.values())
+    assert answers[EngineStageReadOnlyError][1] == "The requested stage is read-only"
+    messages = [message for _, message in answers.values()]
+    assert len(set(messages)) == 3, f"two 409s share a message: {messages}"
+
+
 def test_engine_runtime_base_does_not_swallow_its_leaves():
     """``EngineRuntimeError`` is the base of every ``Engine*``; it is listed last.
 
@@ -383,13 +412,21 @@ def test_engine_runtime_base_does_not_swallow_its_leaves():
     from agentclaw.community.adapters.http.openapi_v1.responses import ENVELOPE_ERRORS
     from agentclaw.community.core.engine_runtime.errors import EngineRuntimeError
 
+    exported = [getattr(errs, name) for name in errs.__all__]
     leaves = [
-        getattr(errs, name)
-        for name in errs.__all__
-        if name != "EngineRuntimeError"
-        and issubclass(getattr(errs, name), EngineRuntimeError)
+        obj
+        for obj in exported
+        if isinstance(obj, type)
+        and obj is not EngineRuntimeError
+        and issubclass(obj, EngineRuntimeError)
     ]
-    assert len(leaves) >= 7, "the errors module stopped exporting its leaves"
+    # Every export is a leaf but the base itself. A floor (">= 7") would have
+    # tolerated exactly the regression this test exists to catch: drop a name
+    # from ``__all__`` and the loop below simply never sees it.
+    assert len(leaves) == len(exported) - 1, (
+        "the errors module exports something that is not an EngineRuntimeError "
+        "leaf; this test's inventory assumption no longer holds"
+    )
 
     order = list(ENVELOPE_ERRORS)
     base = order.index(EngineRuntimeError)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -367,33 +367,38 @@ def test_engine_runtime_errors_map_to_their_own_status(exc_name, expected_status
     assert status == expected_status
 
 
-def test_the_three_409s_do_not_share_a_message():
+def test_engine_runtime_409s_do_not_share_a_message():
     """Status alone cannot tell them apart, so the message has to.
 
-    ``EngineDeviceNotReadyError``, ``EngineStageNotLiveError`` and
-    ``EngineStageReadOnlyError`` all answer 409 and mean three different things:
-    retry, publish something, and stop. Asserting only the status lets a
-    copy-pasted message — the entries are adjacent in ``responses.py`` — pass
-    while the caller loses the distinction the errors exist for.
+    Several engine-runtime errors answer 409 and mean different things: retry
+    (device not ready), publish something (stage not live), stop (stage
+    read-only). Asserting only the status lets a copy-pasted message — the
+    entries are adjacent in ``responses.py`` — pass while the caller loses the
+    distinction the errors exist for.
+
+    The set is derived from the mapping rather than listed, so a 409 added later
+    is covered without editing this test. Scoped to engine-runtime: the surface
+    has other 409s (startup script, local skills) whose messages are not this
+    block's business.
     """
+    from agentclaw.community.adapters.http.openapi_v1.responses import ENVELOPE_ERRORS
     from agentclaw.community.core.engine_runtime.errors import (
-        EngineDeviceNotReadyError,
-        EngineStageNotLiveError,
+        EngineRuntimeError,
         EngineStageReadOnlyError,
     )
 
-    answers = {
-        exc: _lookup(exc("boom"))
-        for exc in (
-            EngineDeviceNotReadyError,
-            EngineStageNotLiveError,
-            EngineStageReadOnlyError,
-        )
+    conflicting = {
+        exc: message
+        for exc, (status, message) in ENVELOPE_ERRORS.items()
+        if status == 409
+        and isinstance(exc, type)
+        and issubclass(exc, EngineRuntimeError)
     }
-    assert all(status == 409 for status, _ in answers.values())
-    assert answers[EngineStageReadOnlyError][1] == "The requested stage is read-only"
-    messages = [message for _, message in answers.values()]
-    assert len(set(messages)) == 3, f"two 409s share a message: {messages}"
+    assert len(conflicting) >= 3, "the engine-runtime 409s went missing"
+    assert conflicting[EngineStageReadOnlyError] == "The requested stage is read-only"
+    assert len(set(conflicting.values())) == len(conflicting), (
+        f"two engine-runtime 409s share a message: {sorted(conflicting.values())}"
+    )
 
 
 def test_engine_runtime_base_does_not_swallow_its_leaves():
@@ -412,27 +417,35 @@ def test_engine_runtime_base_does_not_swallow_its_leaves():
     from agentclaw.community.adapters.http.openapi_v1.responses import ENVELOPE_ERRORS
     from agentclaw.community.core.engine_runtime.errors import EngineRuntimeError
 
-    exported = [getattr(errs, name) for name in errs.__all__]
+    # Read off the classes the module *defines*, not off ``__all__``. Deriving
+    # from ``__all__`` looks self-maintaining and is not: a class added to the
+    # module but forgotten in ``__all__`` disappears from the inventory and from
+    # the loop, which is one of the two ways this regression actually happens.
     leaves = [
         obj
-        for obj in exported
+        for obj in vars(errs).values()
         if isinstance(obj, type)
         and obj is not EngineRuntimeError
         and issubclass(obj, EngineRuntimeError)
+        and obj.__module__ == errs.__name__
     ]
-    # Every export is a leaf but the base itself. A floor (">= 7") would have
-    # tolerated exactly the regression this test exists to catch: drop a name
-    # from ``__all__`` and the loop below simply never sees it.
-    assert len(leaves) == len(exported) - 1, (
-        "the errors module exports something that is not an EngineRuntimeError "
-        "leaf; this test's inventory assumption no longer holds"
-    )
+    assert len(leaves) >= 8, "the errors module stopped defining its leaves"
 
     order = list(ENVELOPE_ERRORS)
-    base = order.index(EngineRuntimeError)
     for leaf in leaves:
         assert leaf in ENVELOPE_ERRORS, f"{leaf.__name__} has no mapped status"
-        assert order.index(leaf) < base, f"{leaf.__name__} listed after its base"
+
+    # Every mapped ancestor, not just the root: an intermediate base (say an
+    # ``EngineStageError`` grouping the two stage errors) listed above its own
+    # subclasses would swallow them exactly as the root would, and a
+    # root-only check passes while the distinction is lost.
+    for leaf in leaves:
+        for ancestor in leaf.__mro__[1:]:
+            if ancestor in ENVELOPE_ERRORS:
+                assert order.index(leaf) < order.index(ancestor), (
+                    f"{leaf.__name__} is listed after its ancestor "
+                    f"{ancestor.__name__}, which will swallow it"
+                )
 
 
 def test_transport_errors_are_siblings_and_map_independently():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -387,17 +387,26 @@ def test_engine_runtime_409s_do_not_share_a_message():
         EngineStageReadOnlyError,
     )
 
-    conflicting = {
-        exc: message
-        for exc, (status, message) in ENVELOPE_ERRORS.items()
-        if status == 409
-        and isinstance(exc, type)
-        and issubclass(exc, EngineRuntimeError)
-    }
-    assert len(conflicting) >= 3, "the engine-runtime 409s went missing"
-    assert conflicting[EngineStageReadOnlyError] == "The requested stage is read-only"
-    assert len(set(conflicting.values())) == len(conflicting), (
-        f"two engine-runtime 409s share a message: {sorted(conflicting.values())}"
+    # Resolved through ``_lookup``, not read out of the dict. ``envelope_errors``
+    # returns on the first isinstance match in insertion order, so the entry a
+    # key *holds* and the answer a caller *gets* are different questions — and
+    # the second is the one this test is about.
+    candidates = [
+        exc
+        for exc, (status, _) in ENVELOPE_ERRORS.items()
+        if status == 409 and issubclass(exc, EngineRuntimeError)
+    ]
+    assert len(candidates) >= 3, "the engine-runtime 409s went missing"
+
+    answers = {exc: _lookup(exc("boom")) for exc in candidates}
+    assert answers[EngineStageReadOnlyError] == (
+        409,
+        "The requested stage is read-only",
+    ), "the read-only refusal no longer resolves to its own answer"
+
+    messages = [message for _, message in answers.values()]
+    assert len(set(messages)) == len(messages), (
+        f"two engine-runtime 409s resolve to one message: {sorted(messages)}"
     )
 
 
@@ -417,35 +426,42 @@ def test_engine_runtime_base_does_not_swallow_its_leaves():
     from agentclaw.community.adapters.http.openapi_v1.responses import ENVELOPE_ERRORS
     from agentclaw.community.core.engine_runtime.errors import EngineRuntimeError
 
-    # Read off the classes the module *defines*, not off ``__all__``. Deriving
-    # from ``__all__`` looks self-maintaining and is not: a class added to the
-    # module but forgotten in ``__all__`` disappears from the inventory and from
-    # the loop, which is one of the two ways this regression actually happens.
-    leaves = [
+    # The union of what the module *defines* and what it *exports*. Either alone
+    # has a hole: reading only ``__all__`` misses a class defined here and left
+    # out of it, and reading only ``vars`` misses one defined in a sibling module
+    # and re-exported through it. Both are ways this regression actually happens.
+    candidates = list(vars(errs).values()) + [
+        getattr(errs, name) for name in errs.__all__
+    ]
+    leaves = {
         obj
-        for obj in vars(errs).values()
+        for obj in candidates
         if isinstance(obj, type)
         and obj is not EngineRuntimeError
         and issubclass(obj, EngineRuntimeError)
-        and obj.__module__ == errs.__name__
-    ]
-    assert len(leaves) >= 8, "the errors module stopped defining its leaves"
+    }
+    assert len(leaves) >= 8, "the errors module stopped carrying its leaves"
 
     order = list(ENVELOPE_ERRORS)
     for leaf in leaves:
-        assert leaf in ENVELOPE_ERRORS, f"{leaf.__name__} has no mapped status"
+        # An intermediate grouping base needs no entry of its own — its
+        # subclasses carry the answers and ``EngineRuntimeError`` is the
+        # fallback — so only classes with no mapped subclass must be mapped.
+        if not any(
+            other is not leaf and issubclass(other, leaf) and other in ENVELOPE_ERRORS
+            for other in leaves
+        ):
+            assert leaf in ENVELOPE_ERRORS, f"{leaf.__name__} has no mapped status"
 
-    # Every mapped ancestor, not just the root: an intermediate base (say an
-    # ``EngineStageError`` grouping the two stage errors) listed above its own
-    # subclasses would swallow them exactly as the root would, and a
-    # root-only check passes while the distinction is lost.
-    for leaf in leaves:
-        for ancestor in leaf.__mro__[1:]:
-            if ancestor in ENVELOPE_ERRORS:
-                assert order.index(leaf) < order.index(ancestor), (
-                    f"{leaf.__name__} is listed after its ancestor "
-                    f"{ancestor.__name__}, which will swallow it"
-                )
+        # Every mapped ancestor, not just the root: an intermediate base listed
+        # above its own subclasses would swallow them exactly as the root would.
+        if leaf in ENVELOPE_ERRORS:
+            for ancestor in leaf.__mro__[1:]:
+                if ancestor in ENVELOPE_ERRORS:
+                    assert order.index(leaf) < order.index(ancestor), (
+                        f"{leaf.__name__} is listed after its ancestor "
+                        f"{ancestor.__name__}, which will swallow it"
+                    )
 
 
 def test_transport_errors_are_siblings_and_map_independently():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
@@ -9,7 +9,7 @@ never gained the parameter.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from fastapi import FastAPI
@@ -69,7 +69,11 @@ def bot_service():
 
 @pytest.fixture
 def engine_config():
-    m = AsyncMock()
+    # ``create_autospec`` rather than a bare AsyncMock: it binds the real
+    # signatures, so an adapter forwarding a keyword the service does not accept
+    # fails here instead of at the first production request. A ``spec=`` alone
+    # would only restrict attribute *names*.
+    m = create_autospec(EngineConfigServiceProtocol, instance=True)
     m.read_bot_config.return_value = {"k": "v"}
     m.write_bot_config.return_value = None
     return m
@@ -77,14 +81,15 @@ def engine_config():
 
 @pytest.fixture
 def identity():
-    m = MagicMock(spec=IdentityService)
-    m.list_bot_files = AsyncMock(return_value=[("RULES.md", True)])
-    m.get_bot_file = AsyncMock(
-        return_value=MagicMock(content="body", file_path="identity/RULES.md")
+    # Autospecced for the reason above. The return values are set on the
+    # autospecced children rather than replacing them, which would discard the
+    # bound signature and the check with it.
+    m = create_autospec(IdentityService, instance=True)
+    m.list_bot_files.return_value = [("RULES.md", True)]
+    m.get_bot_file.return_value = MagicMock(
+        content="body", file_path="identity/RULES.md"
     )
-    m.update_bot_file = AsyncMock(
-        return_value=MagicMock(file_path="identity/RULES.md")
-    )
+    m.update_bot_file.return_value = MagicMock(file_path="identity/RULES.md")
     return m
 
 
@@ -202,3 +207,32 @@ def test_the_retiring_addresses_still_read_the_draft(
         if m.call_args is not None
     ]
     assert forwarded and set(forwarded) == {"draft"}
+
+
+@pytest.mark.parametrize(
+    ("url", "body"),
+    [
+        (_LEGACY_ENGINE_CONFIG, {"a": 1}),
+        (_LEGACY_IDENTITY_FILE, {"content": "x"}),
+    ],
+)
+def test_a_retiring_write_naming_a_published_stage_still_writes_the_draft(
+    client, engine_config, identity, url, body
+):
+    """Pinned because it is the one place "nothing is written" does not hold.
+
+    The current addresses refuse a published write with a 409. These do not:
+    they never declared the parameter, so it is ignored and the draft is
+    written — the contract they were frozen with. That is a deliberate
+    consequence of freezing them rather than an oversight, and it is the
+    strongest reason to migrate, so it is asserted rather than left to be
+    discovered.
+    """
+    assert client.put(url, params={"stage": "online"}, json=body).status_code == 200
+
+    written = [
+        m.call_args.kwargs.get("stage")
+        for m in (engine_config.write_bot_config, identity.update_bot_file)
+        if m.call_args is not None
+    ]
+    assert written == ["draft"]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
@@ -145,10 +145,39 @@ def test_naming_no_stage_addresses_the_draft(client, engine_config, identity):
     assert identity.update_bot_file.call_args.kwargs["stage"] == "draft"
 
 
-def test_a_stage_outside_the_enum_never_reaches_a_handler(client, engine_config):
-    resp = client.get(_ENGINE_CONFIG, params={"stage": "eval"})
-    assert resp.status_code == 422
-    engine_config.read_bot_config.assert_not_called()
+@pytest.mark.parametrize(
+    ("method", "url", "body"),
+    [
+        ("get", _ENGINE_CONFIG, None),
+        ("put", _ENGINE_CONFIG, {"a": 1}),
+        ("get", _IDENTITY_LIST, None),
+        ("get", _IDENTITY_FILE, None),
+        ("put", _IDENTITY_FILE, {"content": "x"}),
+    ],
+)
+def test_a_stage_outside_the_enum_never_reaches_a_handler(
+    client, engine_config, identity, method, url, body
+):
+    """All five, and the writes especially.
+
+    ``eval`` is a real publish stage with no long-lived runtime, so it is the
+    value a caller is most likely to try. If the enum were ever loosened to a
+    bare string the writes would answer a typo as "no live runtime" instead of
+    422 — a different contract, pinned separately at the core level.
+    """
+    kwargs = {"params": {"stage": "eval"}}
+    if body is not None:
+        kwargs["json"] = body
+    assert getattr(client, method)(url, **kwargs).status_code == 422
+
+    for m in (
+        engine_config.read_bot_config,
+        engine_config.write_bot_config,
+        identity.list_bot_files,
+        identity.get_bot_file,
+        identity.update_bot_file,
+    ):
+        m.assert_not_called()
 
 
 # ── refusals ─────────────────────────────────────────────────────────────────

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_stage_addressed_bot_files.py
@@ -1,0 +1,204 @@
+"""``?stage=`` on the five per-bot file operations, at the HTTP boundary.
+
+What the services do with a stage is pinned in
+``tests/community/core/services/``; this is about the wire — that the parameter
+reaches the service unchanged, that the default is the draft, that a write to a
+published runtime is refused with the fixed 409, and that the retiring twins
+never gained the parameter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+
+from agentclaw.community.adapters.http.openapi_v1.bots.engine_config import (
+    router as engine_config_router,
+)
+from agentclaw.community.adapters.http.openapi_v1.deprecated import (
+    ENGINE_RUNTIME_GROUPS as _LEGACY_ENGINE_RUNTIME,
+    GRANT_CHECKED_GROUPS as _LEGACY_GRANT_CHECKED,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.identity import (
+    router as identity_router,
+)
+from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.engine_config_service import EngineConfigServiceProtocol
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineStageNotLiveError,
+    EngineStageReadOnlyError,
+)
+from agentclaw.community.core.services.identity import IdentityService
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    user_scoped_client,
+)
+
+BOT = "b1"
+USER = "u1"
+
+_ENGINE_CONFIG = f"/openapi/v1/bots/{BOT}/engine/config"
+_IDENTITY_LIST = f"/openapi/v1/bots/{BOT}/identity"
+_IDENTITY_FILE = f"/openapi/v1/bots/{BOT}/identity/RULES"
+
+#: The addresses #1074 retired. Frozen: they must not have grown ``stage``.
+_LEGACY_ENGINE_CONFIG = f"/openapi/v1/bots/{BOT}/engine-config"
+_LEGACY_IDENTITY_LIST = f"/openapi/v1/bots/identity/{BOT}"
+_LEGACY_IDENTITY_FILE = f"/openapi/v1/bots/identity/{BOT}/RULES"
+
+
+@pytest.fixture
+def bot_service():
+    m = MagicMock()
+    m.get_bot.return_value = {
+        "id": 100,
+        "bot_id": BOT,
+        "owner_id": USER,
+        "entity_id": USER,
+        "entity_type": "staff",
+        "bot_type": "service",
+        "active_engine": "openclaw",
+    }
+    return m
+
+
+@pytest.fixture
+def engine_config():
+    m = AsyncMock()
+    m.read_bot_config.return_value = {"k": "v"}
+    m.write_bot_config.return_value = None
+    return m
+
+
+@pytest.fixture
+def identity():
+    m = MagicMock(spec=IdentityService)
+    m.list_bot_files = AsyncMock(return_value=[("RULES.md", True)])
+    m.get_bot_file = AsyncMock(
+        return_value=MagicMock(content="body", file_path="identity/RULES.md")
+    )
+    m.update_bot_file = AsyncMock(
+        return_value=MagicMock(file_path="identity/RULES.md")
+    )
+    return m
+
+
+@pytest.fixture
+def client(bot_service, engine_config, identity):
+    class _M(Module):
+        def configure(self, binder):
+            binder.bind(BotServiceProtocol, to=bot_service)
+            binder.bind(EngineConfigServiceProtocol, to=engine_config)
+            binder.bind(IdentityService, to=identity)
+
+    app = FastAPI()
+    app.include_router(engine_config_router)
+    app.include_router(identity_router)
+    for legacy in (*_LEGACY_ENGINE_RUNTIME, *_LEGACY_GRANT_CHECKED):
+        app.include_router(legacy)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": USER}
+    attach_injector(app, Injector([_M()]))
+    mount_public_error_handlers(app)
+    return user_scoped_client(app, USER)
+
+
+# ── the parameter reaches the service ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stage", ["draft", "verify", "online"])
+def test_each_read_forwards_the_named_stage(client, engine_config, identity, stage):
+    assert client.get(_ENGINE_CONFIG, params={"stage": stage}).status_code == 200
+    assert engine_config.read_bot_config.call_args.kwargs["stage"] == stage
+
+    assert client.get(_IDENTITY_LIST, params={"stage": stage}).status_code == 200
+    assert identity.list_bot_files.call_args.kwargs["stage"] == stage
+
+    assert client.get(_IDENTITY_FILE, params={"stage": stage}).status_code == 200
+    assert identity.get_bot_file.call_args.kwargs["stage"] == stage
+
+
+def test_naming_no_stage_addresses_the_draft(client, engine_config, identity):
+    """The compatibility pin: an unchanged request behaves as it always did."""
+    client.get(_ENGINE_CONFIG)
+    assert engine_config.read_bot_config.call_args.kwargs["stage"] == "draft"
+
+    client.get(_IDENTITY_LIST)
+    assert identity.list_bot_files.call_args.kwargs["stage"] == "draft"
+
+    client.get(_IDENTITY_FILE)
+    assert identity.get_bot_file.call_args.kwargs["stage"] == "draft"
+
+    client.put(_ENGINE_CONFIG, json={"a": 1})
+    assert engine_config.write_bot_config.call_args.kwargs["stage"] == "draft"
+
+    client.put(_IDENTITY_FILE, json={"content": "x"})
+    assert identity.update_bot_file.call_args.kwargs["stage"] == "draft"
+
+
+def test_a_stage_outside_the_enum_never_reaches_a_handler(client, engine_config):
+    resp = client.get(_ENGINE_CONFIG, params={"stage": "eval"})
+    assert resp.status_code == 422
+    engine_config.read_bot_config.assert_not_called()
+
+
+# ── refusals ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stage", ["verify", "online"])
+def test_a_published_write_is_refused_with_the_read_only_409(
+    client, engine_config, identity, stage
+):
+    engine_config.write_bot_config.side_effect = EngineStageReadOnlyError("no")
+    identity.update_bot_file.side_effect = EngineStageReadOnlyError("no")
+
+    for url, body in (
+        (_ENGINE_CONFIG, {"a": 1}),
+        (_IDENTITY_FILE, {"content": "x"}),
+    ):
+        resp = client.put(url, params={"stage": stage}, json=body)
+        assert resp.status_code == 409, url
+        assert resp.json()["message"] == "The requested stage is read-only"
+
+
+def test_a_stage_with_no_live_runtime_keeps_its_own_409(client, engine_config):
+    engine_config.read_bot_config.side_effect = EngineStageNotLiveError("no")
+
+    resp = client.get(_ENGINE_CONFIG, params={"stage": "online"})
+    assert resp.status_code == 409
+    assert resp.json()["message"] == "No live runtime at the requested stage"
+
+
+# ── the retiring twins ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url", [_LEGACY_ENGINE_CONFIG, _LEGACY_IDENTITY_LIST, _LEGACY_IDENTITY_FILE]
+)
+def test_the_retiring_addresses_still_read_the_draft(
+    client, engine_config, identity, url
+):
+    """Frozen, and not merely undocumented.
+
+    A caller who sends ``?stage=online`` at a retiring address gets the draft:
+    the parameter is not declared there, so FastAPI ignores it. Registering the
+    legacy route re-uses the *same endpoint function*, so without the
+    ``without_parameter`` transform this would forward ``online`` instead.
+    """
+    resp = client.get(url, params={"stage": "online"})
+    assert resp.status_code == 200
+
+    forwarded = [
+        m.call_args.kwargs.get("stage")
+        for m in (
+            engine_config.read_bot_config,
+            identity.list_bot_files,
+            identity.get_bot_file,
+        )
+        if m.call_args is not None
+    ]
+    assert forwarded and set(forwarded) == {"draft"}

--- a/src/backend/tests/community/adapters/http/test_http_adapters_use_resolver.py
+++ b/src/backend/tests/community/adapters/http/test_http_adapters_use_resolver.py
@@ -367,6 +367,7 @@ def _identity_router_app(mock_ctx, tmp_path, monkeypatch):
         bot_repo=bot_repo,
         resolver=resolver,
         device_fs_dispatcher=dispatcher,
+        binding_repo=MagicMock(),
     )
 
     class _TestModule(Module):

--- a/src/backend/tests/community/adapters/http/test_identity_tenant_indirect_isolation.py
+++ b/src/backend/tests/community/adapters/http/test_identity_tenant_indirect_isolation.py
@@ -187,6 +187,7 @@ def _make_identity_service(*, bot_repo, device_repo) -> IdentityService:
         bot_repo=bot_repo,
         resolver=_make_real_resolver(device_repo, bot_repo),
         device_fs_dispatcher=MagicMock(),
+        binding_repo=MagicMock(),
     )
 
 

--- a/src/backend/tests/community/core/engine_runtime/test_package_exports.py
+++ b/src/backend/tests/community/core/engine_runtime/test_package_exports.py
@@ -1,0 +1,32 @@
+"""The package's re-exports stay in step with the errors module.
+
+``core/engine_runtime/__init__.py`` restates every error name twice — once to
+import it, once in ``__all__`` — and callers reach them by the package path.
+That is a second inventory beside ``errors.__all__``, and nothing else notices
+when the two disagree: adding an error and forgetting the package leaves ruff
+clean, the ordering pin in ``test_responses.py`` green (it reads the *errors*
+module), and the first ``from …core.engine_runtime import NewError`` failing at
+import time.
+"""
+
+from __future__ import annotations
+
+import agentclaw.community.core.engine_runtime as package
+import agentclaw.community.core.engine_runtime.errors as errors
+
+
+def test_every_error_is_reachable_from_the_package():
+    missing = [
+        name
+        for name in errors.__all__
+        if getattr(package, name, None) is not getattr(errors, name)
+    ]
+    assert not missing, (
+        f"{missing} are exported by errors.py but not re-exported by the "
+        "package; import them in __init__.py and list them in its __all__"
+    )
+
+
+def test_the_package_all_lists_what_it_re_exports():
+    missing = [name for name in errors.__all__ if name not in package.__all__]
+    assert not missing, f"{missing} are importable from the package but absent from __all__"

--- a/src/backend/tests/community/core/engine_runtime/test_stage.py
+++ b/src/backend/tests/community/core/engine_runtime/test_stage.py
@@ -14,16 +14,22 @@ from agentclaw.community.core.devices.models import DeviceBindingStatus
 from agentclaw.community.core.devices.services.device_context import (
     DeviceNotBoundError,
 )
-from agentclaw.community.core.engine_runtime.errors import EngineStageNotLiveError
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineStageNotLiveError,
+    EngineStageReadOnlyError,
+)
 from agentclaw.community.core.engine_runtime.stage import (
     STAGE_DRAFT,
     STAGE_ONLINE,
     STAGE_VERIFY,
     require_stage_addressable,
+    require_stage_writable,
     resolve_stage_bind_id,
+    resolve_stage_device_context,
 )
 
 BOT = "bot-1"
+OWNER = "u-1"
 PK = 100
 ENV = "test"
 
@@ -227,3 +233,166 @@ def test_the_socket_and_the_relay_address_the_same_binding():
 
     assert "resolve_stage_bind_id" in inspect.getsource(connection_resolver)
     assert "resolve_stage_bind_id" in inspect.getsource(relay_resolver)
+
+
+# ── writes ───────────────────────────────────────────────────────────────────
+
+
+def test_the_draft_is_the_only_writable_stage():
+    require_stage_writable(STAGE_DRAFT)
+    for stage in (STAGE_VERIFY, STAGE_ONLINE):
+        with pytest.raises(EngineStageReadOnlyError):
+            require_stage_writable(stage)
+
+
+def test_a_write_to_an_unknown_stage_is_not_reported_as_read_only():
+    """A typo is a typo, not a published runtime.
+
+    ``require_stage_writable`` refuses everything that is not the draft, so
+    without the known-stage check first it would answer "that runtime is
+    published and frozen" about a string that names no runtime at all.
+    """
+    with pytest.raises(EngineStageNotLiveError):
+        require_stage_writable("onlien")
+
+
+# ── stage → device context ───────────────────────────────────────────────────
+
+
+class _Resolver:
+    """Records which resolution path a stage took."""
+
+    def __init__(self):
+        self.for_bot = []
+        self.for_binding = []
+
+    def resolve_for_bot(self, bot_id, owner_id, **kwargs):
+        self.for_bot.append((bot_id, owner_id))
+        return f"ctx-draft:{bot_id}"
+
+    def resolve_for_binding(self, binding_id, operator_id, *, bot_id, **kwargs):
+        self.for_binding.append((binding_id, operator_id, bot_id))
+        return f"ctx-bound:{binding_id}"
+
+
+class _BotRepo:
+    def __init__(self, record=None):
+        self._record = record
+        self.calls = []
+
+    def get_by_id_and_owner(self, bot_id, owner_id):
+        self.calls.append((bot_id, owner_id))
+        return self._record
+
+
+def _service_row(bot_type="service"):
+    return {"id": PK, "bot_id": BOT, "bot_type": bot_type, "owner_id": OWNER}
+
+
+def _context(stage, *, records=(), bot_repo=None, bindings=None):
+    resolver = _Resolver()
+    repo = bot_repo if bot_repo is not None else _BotRepo(_service_row())
+    ctx = resolve_stage_device_context(
+        resolver,
+        _PublishRepo(records),
+        bindings or _BindingRepo(),
+        repo,
+        bot_id=BOT,
+        owner_id=OWNER,
+        stage=stage,
+    )
+    return ctx, resolver, repo
+
+
+def test_the_draft_resolves_the_bots_own_binding_and_reads_no_extra_row():
+    """The byte-for-byte pin: a request naming no stage does what it always did.
+
+    One ``resolve_for_bot(bot_id, owner_id)`` — the call this path has always
+    made — and **no** bot-row read added on top of it.
+    """
+    ctx, resolver, repo = _context(STAGE_DRAFT)
+
+    assert ctx == f"ctx-draft:{BOT}"
+    assert resolver.for_bot == [(BOT, OWNER)]
+    assert resolver.for_binding == []
+    assert repo.calls == [], "the draft leg must not add a bot-row read"
+
+
+@pytest.mark.parametrize(
+    ("stage", "binding"),
+    [(STAGE_ONLINE, 41), (STAGE_VERIFY, 42)],
+)
+def test_a_published_stage_resolves_that_stages_binding(stage, binding):
+    records = [
+        _Record(
+            {"binding": {"online": 41, "verify": 42}},
+            "validating" if stage == STAGE_VERIFY else "success",
+        )
+    ]
+    ctx, resolver, _ = _context(stage, records=records)
+
+    assert ctx == f"ctx-bound:{binding}"
+    assert resolver.for_binding == [(binding, OWNER, BOT)]
+    assert resolver.for_bot == [], "a published stage never falls back to the draft"
+
+
+def test_a_published_stage_on_a_personal_bot_refuses_before_any_resolution():
+    bot_repo = _BotRepo(_service_row(bot_type="personal"))
+    resolver = _Resolver()
+
+    with pytest.raises(EngineStageNotLiveError):
+        resolve_stage_device_context(
+            resolver,
+            _PublishRepo([]),
+            _BindingRepo(),
+            bot_repo,
+            bot_id=BOT,
+            owner_id=OWNER,
+            stage=STAGE_ONLINE,
+        )
+
+    assert resolver.for_bot == [] and resolver.for_binding == []
+
+
+def test_a_bot_that_is_not_the_callers_is_refused_as_a_stage_with_no_runtime():
+    """Not a 404. A published-stage request must not become the one way to
+    learn whether a bot exists, so a missing row answers exactly as a personal
+    bot does — the same 409 the draft leg gives."""
+    with pytest.raises(EngineStageNotLiveError):
+        _context(STAGE_ONLINE, bot_repo=_BotRepo(None))
+
+
+def test_an_unknown_stage_never_reaches_the_published_branch():
+    """``stage=""`` is a typo, not a published runtime: it must not cost a bot
+    read and must not be answered as "no live runtime at online"."""
+    bot_repo = _BotRepo(_service_row())
+    with pytest.raises(EngineStageNotLiveError):
+        _context("", bot_repo=bot_repo)
+    assert bot_repo.calls == []
+
+
+def test_the_published_lookup_is_keyed_on_the_primary_key_not_the_bot_id():
+    """``bot_id`` is not unique across owners; ``bot_pk`` is the discriminator."""
+    records = [_Record({"binding": {"online": 41}}, "success")]
+    publish_repo = _PublishRepo(records)
+    resolve_stage_device_context(
+        _Resolver(),
+        publish_repo,
+        _BindingRepo(),
+        _BotRepo(_service_row()),
+        bot_id=BOT,
+        owner_id=OWNER,
+        stage=STAGE_ONLINE,
+    )
+    # The env comes from ``get_current_env()`` inside the function; the pk is
+    # what this pins.
+    assert [pk for pk, _env in publish_repo.calls] == [PK]
+
+
+def test_the_owner_scoped_read_is_the_one_used_for_the_primary_key():
+    bot_repo = _BotRepo(_service_row())
+    _context(STAGE_ONLINE, records=[_Record({"binding": {"online": 41}}, "success")],
+             bot_repo=bot_repo)
+    assert bot_repo.calls == [(BOT, OWNER)], (
+        "the pk must come from a (bot_id, owner_id) read, never a wider one"
+    )

--- a/src/backend/tests/community/core/services/test_engine_config_service.py
+++ b/src/backend/tests/community/core/services/test_engine_config_service.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
+from agentclaw.community.core.engine_runtime.stage import STAGE_DRAFT
 from agentclaw.community.core.services.engine_config import EngineConfigService
 
 
@@ -50,6 +51,7 @@ def _service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca"):
 
     svc = EngineConfigService(
         bot_repo=bot_repo, resolver=resolver, device_fs_dispatcher=dispatcher,
+        publish_repo=MagicMock(), binding_repo=MagicMock(),
     )
     return svc, resolver, dispatcher, device_fs
 
@@ -155,6 +157,7 @@ def _bot_service(*, read_return=b'{"a": 1}', resolve_raises=None, provider="arca
 
     svc = EngineConfigService(
         bot_repo=MagicMock(), resolver=resolver, device_fs_dispatcher=dispatcher,
+        publish_repo=MagicMock(), binding_repo=MagicMock(),
     )
     return svc, resolver, dispatcher, device_fs
 
@@ -169,7 +172,7 @@ _BOT_COORDS = dict(
 async def test_read_bot_config_parses_via_resolve_for_bot():
     svc, resolver, dispatcher, device_fs = _bot_service(read_return=b'{"k": "v"}')
 
-    data = await svc.read_bot_config(**_BOT_COORDS)
+    data = await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT)
 
     assert data == {"k": "v"}
     resolver.resolve_for_bot.assert_called_once_with("default", "100018")
@@ -183,21 +186,21 @@ async def test_read_bot_config_parses_via_resolve_for_bot():
 async def test_read_bot_config_empty_file_returns_empty_dict():
     for ret in (None, b"", b"  \n"):
         svc, _, _, _ = _bot_service(read_return=ret)
-        assert await svc.read_bot_config(**_BOT_COORDS) == {}
+        assert await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT) == {}
 
 
 @pytest.mark.asyncio
 async def test_read_bot_config_malformed_propagates():
     svc, _, _, _ = _bot_service(read_return=b"{bad")
     with pytest.raises(json.JSONDecodeError):
-        await svc.read_bot_config(**_BOT_COORDS)
+        await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT)
 
 
 @pytest.mark.asyncio
 async def test_write_bot_config_serializes_and_targets_canonical_path():
     svc, resolver, dispatcher, device_fs = _bot_service()
 
-    await svc.write_bot_config(**_BOT_COORDS, config={"x": 1, "y": "z"})
+    await svc.write_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT, config={"x": 1, "y": "z"})
 
     resolver.resolve_for_bot.assert_called_once_with("default", "100018")
     _, kwargs = dispatcher.dispatch_addressed.call_args
@@ -212,7 +215,7 @@ async def test_write_bot_config_serializes_and_targets_canonical_path():
 async def test_bot_config_resolve_failure_propagates():
     svc, _, dispatcher, _ = _bot_service(resolve_raises=DeviceNotBoundError("unbound"))
     with pytest.raises(DeviceNotBoundError):
-        await svc.read_bot_config(**_BOT_COORDS)
+        await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT)
     dispatcher.dispatch_addressed.assert_not_called()
 
 
@@ -233,7 +236,7 @@ async def test_read_bot_config_device_read_failure_propagates():
     svc, _, _, _ = _bot_service(read_return=RuntimeError("device unreachable"))
 
     with pytest.raises(RuntimeError, match="device unreachable"):
-        await svc.read_bot_config(**_BOT_COORDS)
+        await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT)
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/services/test_engine_config_service.py
+++ b/src/backend/tests/community/core/services/test_engine_config_service.py
@@ -11,10 +11,20 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+from types import SimpleNamespace
+
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
-from agentclaw.community.core.engine_runtime.stage import STAGE_DRAFT
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineStageNotLiveError,
+    EngineStageReadOnlyError,
+)
+from agentclaw.community.core.engine_runtime.stage import (
+    STAGE_DRAFT,
+    STAGE_ONLINE,
+    STAGE_VERIFY,
+)
 from agentclaw.community.core.services.engine_config import EngineConfigService
 
 
@@ -247,3 +257,92 @@ async def test_read_publish_config_device_read_failure_propagates():
         await svc.read_publish_config(
             _record(status="success", binding={"online": 7}), "openclaw"
         )
+
+
+# ── stage addressing ─────────────────────────────────────────────────────────
+
+
+def _staged_service(*, bot_type="service", online_binding=41, read_return=b"{}"):
+    """A bot-level service wired so a published stage can actually resolve."""
+    resolver = MagicMock()
+    resolver.resolve_for_binding.return_value = MagicMock(provider="baas")
+
+    device_fs = MagicMock()
+    device_fs.read_file = AsyncMock(return_value=read_return)
+    device_fs.write_file = AsyncMock()
+    dispatcher = MagicMock()
+    dispatcher.dispatch_addressed.return_value = device_fs
+
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = {
+        "id": 100, "bot_id": "default", "bot_type": bot_type, "owner_id": "100018",
+    }
+    publish_repo = MagicMock()
+    publish_repo.list_by_source_bot.return_value = [
+        SimpleNamespace(
+            id=7, status="success", ext={"binding": {"online": online_binding}}
+        )
+    ]
+    svc = EngineConfigService(
+        bot_repo=bot_repo, resolver=resolver, device_fs_dispatcher=dispatcher,
+        publish_repo=publish_repo, binding_repo=MagicMock(),
+    )
+    return svc, resolver, dispatcher, device_fs
+
+
+@pytest.mark.asyncio
+async def test_reading_online_resolves_the_published_binding_not_the_draft():
+    svc, resolver, dispatcher, device_fs = _staged_service(
+        read_return=b'{"model": "published"}'
+    )
+
+    data = await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_ONLINE)
+
+    assert data == {"model": "published"}
+    resolver.resolve_for_bot.assert_not_called()
+    resolver.resolve_for_binding.assert_called_once_with(
+        41, "100018", bot_id="default"
+    )
+    # Same canonical logical path on every runtime — the stage picks the device,
+    # not the filename.
+    device_fs.read_file.assert_awaited_once_with("config/teclaw.json")
+
+
+@pytest.mark.asyncio
+async def test_reading_a_published_stage_on_a_personal_bot_is_not_live():
+    svc, resolver, _, _ = _staged_service(bot_type="personal")
+
+    with pytest.raises(EngineStageNotLiveError):
+        await svc.read_bot_config(**_BOT_COORDS, stage=STAGE_ONLINE)
+
+    resolver.resolve_for_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", [STAGE_VERIFY, STAGE_ONLINE])
+async def test_writing_a_published_stage_is_refused_and_writes_nothing(stage):
+    """The safety-critical half: refused, and nothing reached a device.
+
+    ``assert_not_called`` on the dispatcher is the claim that matters — a
+    refusal that had already resolved a device would mean the draft was one
+    line away from being written instead.
+    """
+    svc, resolver, dispatcher, device_fs = _staged_service()
+
+    with pytest.raises(EngineStageReadOnlyError):
+        await svc.write_bot_config(**_BOT_COORDS, stage=stage, config={"x": 1})
+
+    dispatcher.dispatch_addressed.assert_not_called()
+    device_fs.write_file.assert_not_awaited()
+    resolver.resolve_for_bot.assert_not_called()
+    resolver.resolve_for_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_the_draft_write_still_lands():
+    svc, resolver, _, device_fs = _staged_service()
+
+    await svc.write_bot_config(**_BOT_COORDS, stage=STAGE_DRAFT, config={"x": 1})
+
+    resolver.resolve_for_bot.assert_called_once_with("default", "100018")
+    device_fs.write_file.assert_awaited_once()

--- a/src/backend/tests/community/core/services/test_identity_provider_blind.py
+++ b/src/backend/tests/community/core/services/test_identity_provider_blind.py
@@ -37,6 +37,7 @@ def _service(*, provider: str, engine: str):
         bot_repo=bot_repo,
         resolver=resolver,
         device_fs_dispatcher=dispatcher,
+        binding_repo=MagicMock(),
     )
     return svc, dispatcher, device_fs
 
@@ -110,6 +111,7 @@ def _publish_service(*, provider: str, engine: str, ext: dict):
     svc = IdentityService(
         path_factory=MagicMock(), publish_repo=publish_repo,
         bot_repo=bot_repo, resolver=resolver, device_fs_dispatcher=dispatcher,
+        binding_repo=MagicMock(),
     )
     return svc, resolver, device_fs
 

--- a/src/backend/tests/community/core/services/test_identity_service_coverage.py
+++ b/src/backend/tests/community/core/services/test_identity_service_coverage.py
@@ -23,6 +23,7 @@ def _svc(*, resolver=None, dispatcher=None, bot_repo=None, publish_repo=None, pa
         bot_repo=bot_repo or MagicMock(),
         resolver=resolver or MagicMock(),
         device_fs_dispatcher=dispatcher or MagicMock(),
+        binding_repo=MagicMock(),
     )
 
 

--- a/src/backend/tests/community/core/services/test_identity_stage_addressing.py
+++ b/src/backend/tests/community/core/services/test_identity_stage_addressing.py
@@ -124,13 +124,30 @@ async def test_listing_resolves_the_runtime_once_for_all_sixteen_files():
 
 @pytest.mark.asyncio
 async def test_listing_reports_every_file_from_the_one_addressed_runtime():
-    svc, _, _, _ = _service(read_return=b"")
+    """Every read goes through the *same* filesystem object.
+
+    A single shared stub could not show this — it is returned for any context —
+    so the dispatcher hands back a distinct filesystem per resolved binding and
+    the test asserts all sixteen reads landed on one of them.
+    """
+    svc, resolver, dispatcher, _ = _service()
+
+    per_binding = {}
+
+    def _dispatch(ctx, **kwargs):
+        fs = per_binding.setdefault(id(ctx), MagicMock())
+        fs.read_file = AsyncMock(return_value=b"")
+        return fs
+
+    dispatcher.dispatch_addressed.side_effect = _dispatch
+    resolver.resolve_for_binding.side_effect = lambda *a, **k: MagicMock()
 
     presence = await svc.list_bot_files(
         "staff", OWNER, BOT, OWNER, stage=STAGE_ONLINE
     )
 
     assert {exists for _ft, exists in presence} == {False}
+    assert len(per_binding) == 1, "the sixteen reads spanned more than one runtime"
 
 
 @pytest.mark.asyncio
@@ -178,9 +195,13 @@ async def test_the_draft_write_still_lands():
     # published one. Not an exact call count: RULES.md is a reference file and
     # the engine is openclaw, so the write is followed by the AGENTS.md sync,
     # which reads and writes more files through the same draft runtime.
-    assert resolver.resolve_for_bot.call_args_list == [
-        (((BOT, OWNER)), {})
-    ] * resolver.resolve_for_bot.call_count
+    assert resolver.resolve_for_bot.call_count >= 1, (
+        "a comparison against N copies of the expected call is vacuously true "
+        "when N is zero, so the floor is what makes this assert anything"
+    )
+    assert all(
+        call.args == (BOT, OWNER) for call in resolver.resolve_for_bot.call_args_list
+    )
     resolver.resolve_for_binding.assert_not_called()
     device_fs.write_file.assert_awaited()
 

--- a/src/backend/tests/community/core/services/test_identity_stage_addressing.py
+++ b/src/backend/tests/community/core/services/test_identity_stage_addressing.py
@@ -1,0 +1,201 @@
+"""Stage addressing on ``IdentityService`` — which runtime a read reaches.
+
+The draft half is a byte-for-byte pin: a call that names no stage must resolve
+exactly what it always resolved. The published half pins that the runtime comes
+from the publish record rather than the bot's own binding, and that the write
+refuses a published stage without touching a device.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineStageNotLiveError,
+    EngineStageReadOnlyError,
+)
+from agentclaw.community.core.engine_runtime.stage import (
+    STAGE_DRAFT,
+    STAGE_ONLINE,
+    STAGE_VERIFY,
+)
+from agentclaw.community.core.services.identity import IdentityService
+
+BOT = "bot-1"
+OWNER = "u-1"
+ONLINE_BINDING = 41
+
+
+def _service(*, bot_type="service", read_return=b"hello"):
+    resolver = MagicMock()
+    resolver.resolve_for_bot.return_value = MagicMock(provider="baas")
+    resolver.resolve_for_binding.return_value = MagicMock(provider="baas")
+
+    device_fs = MagicMock()
+    device_fs.read_file = AsyncMock(return_value=read_return)
+    device_fs.write_file = AsyncMock()
+    dispatcher = MagicMock()
+    dispatcher.dispatch_addressed.return_value = device_fs
+
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = {
+        "id": 100,
+        "bot_id": BOT,
+        "bot_type": bot_type,
+        "owner_id": OWNER,
+        "active_engine": "openclaw",
+    }
+    publish_repo = MagicMock()
+    publish_repo.list_by_source_bot.return_value = [
+        SimpleNamespace(
+            id=7, status="success", ext={"binding": {"online": ONLINE_BINDING}}
+        )
+    ]
+    svc = IdentityService(
+        path_factory=MagicMock(),
+        publish_repo=publish_repo,
+        bot_repo=bot_repo,
+        resolver=resolver,
+        device_fs_dispatcher=dispatcher,
+        binding_repo=MagicMock(),
+    )
+    return svc, resolver, dispatcher, device_fs
+
+
+@pytest.mark.asyncio
+async def test_a_read_naming_no_stage_resolves_the_bots_own_binding():
+    svc, resolver, _, _ = _service()
+
+    await svc.get_bot_file("staff", OWNER, BOT, "RULES.md", OWNER)
+
+    resolver.resolve_for_bot.assert_called_once_with(BOT, OWNER)
+    resolver.resolve_for_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reading_online_resolves_the_published_binding():
+    svc, resolver, _, _ = _service()
+
+    resp = await svc.get_bot_file(
+        "staff", OWNER, BOT, "RULES.md", OWNER, stage=STAGE_ONLINE
+    )
+
+    assert resp.content == "hello"
+    resolver.resolve_for_binding.assert_called_once_with(
+        ONLINE_BINDING, OWNER, bot_id=BOT
+    )
+    resolver.resolve_for_bot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_published_stage_on_a_personal_bot_is_not_live():
+    svc, resolver, _, _ = _service(bot_type="personal")
+
+    with pytest.raises(EngineStageNotLiveError):
+        await svc.get_bot_file(
+            "staff", OWNER, BOT, "RULES.md", OWNER, stage=STAGE_ONLINE
+        )
+
+    resolver.resolve_for_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listing_resolves_the_runtime_once_for_all_sixteen_files():
+    """Not once per file.
+
+    Resolution is synchronous, and synchronous work in a coroutine runs before
+    its first await — so a per-file resolve would execute sixteen publish scans
+    and sixteen provider calls back to back on the event loop, not concurrently.
+    """
+    svc, resolver, dispatcher, device_fs = _service()
+
+    presence = await svc.list_bot_files(
+        "staff", OWNER, BOT, OWNER, stage=STAGE_ONLINE
+    )
+
+    assert len(presence) == 16
+    assert resolver.resolve_for_binding.call_count == 1
+    assert dispatcher.dispatch_addressed.call_count == 1
+    assert device_fs.read_file.await_count == 16
+
+
+@pytest.mark.asyncio
+async def test_listing_reports_every_file_from_the_one_addressed_runtime():
+    svc, _, _, _ = _service(read_return=b"")
+
+    presence = await svc.list_bot_files(
+        "staff", OWNER, BOT, OWNER, stage=STAGE_ONLINE
+    )
+
+    assert {exists for _ft, exists in presence} == {False}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", [STAGE_VERIFY, STAGE_ONLINE])
+async def test_writing_a_published_stage_is_refused_and_writes_nothing(stage):
+    svc, resolver, dispatcher, device_fs = _service()
+
+    with pytest.raises(EngineStageReadOnlyError):
+        await svc.update_bot_file(
+            "staff", OWNER, BOT, "RULES.md", "new", OWNER, stage=stage
+        )
+
+    dispatcher.dispatch_addressed.assert_not_called()
+    device_fs.write_file.assert_not_awaited()
+    resolver.resolve_for_bot.assert_not_called()
+    resolver.resolve_for_binding.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_write_still_hears_which_part_is_wrong():
+    """The stage guard runs before anything is *resolved*, but after the two
+    static validators — so a request that is both malformed and stage-addressed
+    is told about the malformed part, which it can fix."""
+    from agentclaw.community.core.services.identity import (
+        InvalidIdentityEntityTypeError,
+    )
+
+    svc, _, _, _ = _service()
+
+    with pytest.raises(InvalidIdentityEntityTypeError):
+        await svc.update_bot_file(
+            "bogus", OWNER, BOT, "RULES.md", "new", OWNER, stage=STAGE_ONLINE
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_draft_write_still_lands():
+    svc, resolver, _, device_fs = _service()
+
+    await svc.update_bot_file(
+        "staff", OWNER, BOT, "RULES.md", "new", OWNER, stage=STAGE_DRAFT
+    )
+
+    # Every resolution went through the bot's own binding and none through a
+    # published one. Not an exact call count: RULES.md is a reference file and
+    # the engine is openclaw, so the write is followed by the AGENTS.md sync,
+    # which reads and writes more files through the same draft runtime.
+    assert resolver.resolve_for_bot.call_args_list == [
+        (((BOT, OWNER)), {})
+    ] * resolver.resolve_for_bot.call_count
+    resolver.resolve_for_binding.assert_not_called()
+    device_fs.write_file.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_publish_id_wins_over_a_stage_and_a_bogus_stage_is_still_refused():
+    """The documented precedence, and its limit.
+
+    ``publish_id`` names one exact release and is the more specific address, so
+    it wins. A stage name that is not a stage is still refused, rather than
+    silently discarded because the other branch was taken.
+    """
+    svc, _, _, _ = _service()
+
+    with pytest.raises(EngineStageNotLiveError):
+        await svc.get_bot_file(
+            "staff", OWNER, BOT, "RULES.md", OWNER, publish_id="7", stage="onlien"
+        )

--- a/src/backend/tests/community/core/services/test_identity_stage_addressing.py
+++ b/src/backend/tests/community/core/services/test_identity_stage_addressing.py
@@ -186,16 +186,40 @@ async def test_the_draft_write_still_lands():
 
 
 @pytest.mark.asyncio
-async def test_a_publish_id_wins_over_a_stage_and_a_bogus_stage_is_still_refused():
-    """The documented precedence, and its limit.
+async def test_a_publish_id_wins_over_a_named_stage():
+    """The documented precedence: a release record is the more specific address.
 
-    ``publish_id`` names one exact release and is the more specific address, so
-    it wins. A stage name that is not a stage is still refused, rather than
-    silently discarded because the other branch was taken.
+    Both are given, and both are *valid* — so this actually exercises the
+    branch. The record-keyed read is taken, which means the stage rule is never
+    consulted and the resolver is reached by binding rather than by stage.
+    """
+    svc, resolver, _, _ = _service()
+    svc._read_from_publish_device = AsyncMock(return_value="from-the-record")
+
+    resp = await svc.get_bot_file(
+        "staff", OWNER, BOT, "RULES.md", OWNER, publish_id="7", stage=STAGE_ONLINE
+    )
+
+    assert resp.content == "from-the-record"
+    svc._read_from_publish_device.assert_awaited_once()
+    resolver.resolve_for_binding.assert_not_called()
+    resolver.resolve_for_bot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_bogus_stage_is_refused_even_when_publish_id_would_win():
+    """The limit of that precedence.
+
+    The record-keyed branch ignores ``stage``, so without an explicit check a
+    caller who misspelled it would get a 200 and never learn the argument was
+    discarded.
     """
     svc, _, _, _ = _service()
+    svc._read_from_publish_device = AsyncMock(return_value="from-the-record")
 
     with pytest.raises(EngineStageNotLiveError):
         await svc.get_bot_file(
             "staff", OWNER, BOT, "RULES.md", OWNER, publish_id="7", stage="onlien"
         )
+
+    svc._read_from_publish_device.assert_not_awaited()

--- a/src/backend/tests/community/core/services/test_identity_uses_resolver.py
+++ b/src/backend/tests/community/core/services/test_identity_uses_resolver.py
@@ -50,6 +50,7 @@ def _make_identity(
         bot_repo=bot_repo or MagicMock(),
         resolver=resolver or MagicMock(),
         device_fs_dispatcher=dispatcher or MagicMock(),
+        binding_repo=MagicMock(),
     )
 
 

--- a/src/backend/tests/community/unit/harness/test_bot_profile.py
+++ b/src/backend/tests/community/unit/harness/test_bot_profile.py
@@ -47,6 +47,7 @@ def bot_profile(tmp_path: Path):
             bot_repo=bot_repo,
             resolver=resolver,
             device_fs_dispatcher=_LocalIdentityDispatcher(),
+            binding_repo=MagicMock(),
         )
         yield BotProfile(
             identity_service=identity,

--- a/src/backend/tests/community/unit/harness/test_patch_engine.py
+++ b/src/backend/tests/community/unit/harness/test_patch_engine.py
@@ -53,6 +53,7 @@ def bot_profile(tmp_path: Path):
             bot_repo=bot_repo,
             resolver=resolver,
             device_fs_dispatcher=_LocalIdentityDispatcher(),
+            binding_repo=MagicMock(),
         )
         yield BotProfile(
             identity_service=identity,


### PR DESCRIPTION
## Problem

Five OpenAPI v1 operations read or write a file on a bot's device, and every one
of them could only reach the bot's **draft** workspace:

```text
GET, PUT  /openapi/v1/bots/{bot_id}/engine/config
GET       /openapi/v1/bots/{bot_id}/identity
GET, PUT  /openapi/v1/bots/{bot_id}/identity/{file_type}
```

They resolve `DeviceContextResolver.resolve_for_bot`, which reads
`ac_bots.binding_id`. A service bot's verify and online runtimes bind only in
`ac_bot_publish.ext.binding.{verify,online}`, so they were unreachable — unlike
the engine-runtime groups, which have addressed all three with `?stage=` since
2026-08-09.

So an operator who had published a service bot could not ask what configuration
their online release was running, or which identity files verify received. Both
were answerable only through internal `publish_id`-keyed routes the public
surface does not expose and an external tenant has no id for.

The write side had a sharper problem than "unsupported". Once `stage` exists on
the read, callers send it on the write, and both plausible behaviours are
dishonest: editing a published runtime forks it from the record that describes
it, and quietly writing the draft instead reports success for an edit the
addressed runtime never received.

## Solution

`?stage=` on all five, reusing the existing mechanism rather than a second one:
the `RuntimeStage` enum, `StageQuery`, `require_stage_addressable`, and
`resolve_stage_bind_id`'s liveness rule — the same rule cron's runtime
targeting and the connection socket already share.

- **Reads serve all three stages.** The default stays `draft`, and the draft
  branch is the `resolve_for_bot(bot_id, owner_id)` call it always was, adding
  no query of its own.
- **Writes take the parameter in order to refuse a published one:** a new
  `EngineStageReadOnlyError`, mapped once to `409 "The requested stage is
  read-only"`, raised in core before anything is resolved. Nothing is written —
  not to the published runtime, and not to the draft as a substitute. Not a
  `200` with a no-op flag: automation checking the status code would record the
  write as landed.
- **One bot-identity model.** `BotFacts` with `stage: str` beside it, which is
  what the relay and `EngineRuntimeRelayProtocol` already carry.
  `resolve_stage_device_context` owns both legs, so the two services cannot
  drift from each other or from the forwarding surfaces.

**The retiring addresses do not get the parameter**, and leaving them alone
would not have achieved that: `relocate` re-registers the *same endpoint
function*, so adding `stage` to a handler publishes it at both addresses. A new
`without_parameter` / `drop_parameter` transform — the mirror of the existing
`with_query_parameter` — drops it from the registered signature. The
engine-runtime retiring addresses keep publishing `stage`, correctly: they took
it before the freeze, so it is part of the contract they were frozen with.

**The surface list in the original request was wrong in one direction and short
in another.** Audited against all 31 `resolve_for_bot` call sites:

- **startup-script is not affected.** It is backed by `ac_bot_startup_script`
  keyed `(env, entity_id, bot_id)` and never resolves a device context — one row
  per bot, not one per runtime, so the parameter would be inert.
- **MCP was missing from the audit** (a truncated grep on the first pass). None
  of its six operations addresses a bot, but its config write fans out to every
  bot's **draft** device — correct for the same reason the writes here are
  draft-only: a release inlines its MCP credentials into the artifact.
- **resources, skills and routines** share the gap and are deferred with
  reasons; routines' stage pin is #908.

**The two divergent stage-selection rules are kept separate deliberately**,
because they answer different questions: `resolve_stage_bind_id` answers "a
stage was named", `select_stage_bind_id` answers "a publish record was named".
`GET /api/service-bot/publish/{publish_id}/engine-config` is keyed by
`publish_id`, and the stage rule picks the newest record at a status — routing
it through there would answer about release 7 from whichever release is newest.
The split is stated in both modules and at all four call sites.

## Validation

**Full backend suite: 9,915 passed, 4 skipped, 2 failed.** Both failures are
`test_bot_build_service_skill_artifact::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs`,
which shells out to `rsync` — absent from this container. Verified pre-existing
by re-running with this branch's work stashed; #1073 and #1074 both recorded the
same pair.

- `ruff check` on all 34 changed Python files — clean. (One touched test file
  carries 9 pre-existing errors, identical with the change stashed.)
- `scripts/ci/python_sast_local.sh src/backend` flags 100 files repo-wide and
  **none** of mine.
- Architecture gates pass, including Service API conformance and the context
  boundary — `core.repository.protocols.bot` is declared in engine_runtime's
  boundary, which `stage.py` now imports.
- The published document was generated and asserted directly: `stage` is
  optional, in the query, defaulted `draft`, enum of exactly three, and 409
  documented on all five — and absent from all five retiring twins.

New tests: `test_stage.py` (extended), `test_identity_stage_addressing.py`,
`test_stage_addressed_bot_files.py`, `test_package_exports.py`. Two pins were
verified by breaking the thing they guard and watching them fail.

**Not run:** the Singlebox E2E and changed-line coverage stages (the local
pre-push gate stops at the rsync failures above). GitHub's runners are the
authority for those and their results are on this PR.

## Review history

Six automated review rounds across the groups, 48 findings. The ones worth
naming, because they were mine and the pattern matters more than the individual
bugs:

| Round | Finding |
| --- | --- |
| A/2 | Claimed the filesystem resolver "branches only on provider". It forks `bot_type == "desktop"` — the hazard I called hypothetical was live |
| A/4 | Then claimed filling that `bot_type` in would cause refusals. Also wrong: `_validate_bot_device_combination` reads a different source entirely. I was wrong about this file twice; the docstring now claims only what is verifiable |
| A/4 | The `off_loop` helper I added in round 3 could not be awaited from its own intended call sites. Removed |
| B/1 | **`list_bot_files` resolved the runtime once per file.** Resolution is synchronous, so `gather` ran sixteen publish scans and sixteen provider calls back to back on the event loop. Task B2 asked for one resolution and I had ticked it without doing it |
| C/2 | `without_parameter`'s guard did not refuse what its own comment said it refused — it validated a default and then discarded it |
| C/2 | A reword written for a route that no longer matches was skipped in silence, shipping the contradiction it existed to remove |

Two themes: **docstrings asserting things I had not verified**, which cost three
rounds on one paragraph; and **ticking a checklist item the code did not
satisfy**, which is what the `list_bot_files` defect was.

Three findings were rejected with reasons recorded in the code: resolver errors
stay untranslated (folding them would make `?stage=online` answer differently
from `?stage=draft` on one endpoint), the personal-bot write answers "read-only"
rather than "not live" (spec D2), and the retiring writes keep their frozen
behaviour (out of scope by instruction — now pinned by test instead of left
undiscovered).

## Compatibility and risk

Additive. Every request that exists today omits `stage` and is unchanged — an
explicit acceptance criterion, pinned at the core level by asserting the draft
leg touches no bot repository.

No DDL, no migration, no configuration. Rollback is the revert.

**Known limitation, recorded in the spec:** a published stage is addressed with
the bot's *current* `active_engine`, so an engine switch after publishing reads
the release at the wrong per-engine paths and answers `{}`. Not introduced here
— `read_publish_config`'s route resolves the engine the same way — but this
change makes it reachable from the public surface. Fixing it needs the engine
the release was cut with, which no publish record stores.

**Two costs accepted, both recorded:** a published-stage request resolves its
own facts inside the service, so engine-config (whose adapter already fetched
the row for its ownership guard) reads it twice; and a write to a retiring
address still writes the draft with a `200`, where its replacement answers `409`.

## Spec

`src/backend/specs/2026-08-15-openapi-v1-stage-addressed-bot-files/` —
`spec.md`, `plan.md`, `tasks.md` (13 tasks in 5 groups, all complete).

## Related issues

- Implements the follow-up #1073 named: engine-config being draft-only, and the
  two divergent stage-selection rules.
- Sequenced after #1074 (bot-first addressing), now merged.
- Deferred, unchanged: routines' stage pin (#908).
