### PR TITLE
refactor(backend): key engine-runtime lookups off the bot row, not BotFacts

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -1988,6 +1988,38 @@ class BotService:
 
         return bot
 
+    def get_bot_pk(self, bot_id: str, user_id: str) -> int:
+        """Return ``ac_bots.id`` for the owner-scoped bot, or raise.
+
+        The narrow sibling of :meth:`get_bot`, for callers that need only the
+        primary key downstream tables are keyed on (``ac_bot_collaborator``,
+        ``ac_bot_publish.source_bot_pk``). ``get_bot`` also fetches the device
+        binding and the template — a provider call and a second query — and a
+        caller that wants an int should not pay for either.
+
+        Resolved through the same ``get_by_id_and_owner`` :meth:`get_bot` uses,
+        so it returns the primary key of the row that method would have
+        returned. It states no new identity: a caller re-reading the key of a
+        bot it already resolved gets the same row back, not a wider match.
+
+        Returns the key the row carries, which is ``0`` only if the projection
+        lost it — ``ac_bots.id`` is a non-nullable autoincrement column, so a
+        live row always has one. The refusal for a keyless row belongs to the
+        caller, whose own answer for "no safe key" is already established:
+        ``engine_runtime.stage.resolve_stage_bind_id`` raises
+        ``DeviceNotBoundError`` before it queries anything. Raising a different
+        error here would change that caller-visible answer.
+
+        Raises:
+            BotNotFoundError: no live bot with this ``(bot_id, user_id)`` —
+                the bot is gone, which is not the same as a row whose key did
+                not survive projection.
+        """
+        bot = self._repository.get_by_id_and_owner(bot_id, user_id)
+        if not bot:
+            raise BotNotFoundError(f"Bot not found: {bot_id}")
+        return int(bot.get("id") or 0)
+
     def list_coding_bots_by_architect(self, architect_bot_id: str) -> List[Dict[str, Any]]:
         """List application coding bots associated with a domain architect bot.
 

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -189,7 +189,11 @@ class EngineConnectionService:
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         resolved_id = facts.bot_id
         resolved_owner = facts.owner_id
-        bot_pk = facts.bot_pk
+        # From the row read just above, not from the facts: both the
+        # collaborator adjudication and the publish lookup are keyed on
+        # ``ac_bots.id``, and that internal join key stays off the narrow
+        # projection — this method holds the record, so it costs nothing here.
+        bot_pk = int(bot.get("id") or 0)
         # The socket this endpoint publishes is **not** chat-scoped, however it
         # is labelled: the engine's ``hello`` advertises the ``sessions.*`` and
         # ``exec.approvals`` methods and grants ``operator.admin``, so the

--- a/src/backend/src/agentclaw/community/core/engine_runtime/models.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/models.py
@@ -56,15 +56,6 @@ class BotFacts:
     #: were once "the caller's id" now need the owner the bot was actually
     #: resolved against.
     owner_id: str
-    #: ``ac_bots`` primary key of the row ownership was just proven against.
-    #: Internal, never published — it exists because ``bot_id`` is **not**
-    #: unique across owners (no unique constraint on the column, and
-    #: ``create_bot_for_others`` gives every user a bot called ``default``), so
-    #: any second query keyed on ``bot_id`` alone could select a different
-    #: owner's row. This is the discriminator that keeps the service-bot
-    #: publish lookup — and the collaborator adjudication — on the bot the
-    #: caller actually addressed.
-    bot_pk: int = 0
 
     @classmethod
     def from_record(
@@ -88,15 +79,21 @@ class BotFacts:
         ``record`` must come from an **owner-scoped** ``(bot_id, owner_id)``
         read. ``bot_id`` carries no unique constraint and every user's first bot
         is called ``default``, so a row fetched by ``bot_id`` alone can belong to
-        another owner — and ``bot_pk`` is exactly the value later lookups trust
-        to stay on the addressed bot.
+        another owner.
+
+        Deliberately **without** ``ac_bots.id``. The collaborator adjudication
+        and the publish lookup are keyed on that primary key, but they take it
+        from the row their caller read rather than from these facts — see
+        ``gate.require_bot_operator`` and ``stage.resolve_stage_bind_id``.
+        Carrying it here would put an internal join key on the value object
+        three of its four consumers already hold the row for, and give it a
+        default no caller could satisfy.
         """
         return cls(
             bot_id=str(record.get("bot_id") or bot_id),
             bot_type=str(record.get("bot_type") or ""),
             active_engine=str(record.get("active_engine") or ""),
             owner_id=str(record.get("owner_id") or owner_id),
-            bot_pk=int(record.get("id") or 0),
         )
 
 

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -128,12 +128,18 @@ class EngineRuntimeRelay:
         — and this is a public-surface entry point whose entire purpose is to
         stop publishing device topology. A narrow value object makes leaking it
         impossible rather than merely discouraged.
+
+        The adjudication's ``bot_pk`` comes from the row read just above, not
+        from :class:`BotFacts`. ``ac_bot_collaborator`` is keyed on
+        ``ac_bots.id`` (``uk_bot_pk_user_env``), and that key is an internal
+        join value with no business on a projection built to be narrow — the
+        row is right here, so there is nothing to carry and nothing to re-read.
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         require_bot_operator(
             self._collaborators,
-            bot_pk=facts.bot_pk,
+            bot_pk=int(bot.get("id") or 0),
             bot_id=facts.bot_id,
             caller_id=caller_id,
             owner_id=facts.owner_id,
@@ -222,11 +228,35 @@ stage.resolve_stage_bind_id`'s rule, shared with the connection service so a
         different devices. A stage with no live record raises
         ``EngineStageNotLiveError`` there; no fallback to the draft binding,
         and none between stages.
+
+        **One owner-scoped row read for the primary key.** ``ac_bot_publish``
+        is keyed on ``source_bot_pk``, and this is the only one of the four
+        places needing that key that does not already hold the bot row — it
+        runs downstream of :meth:`resolve_bot`, with the facts but not the
+        record. Re-reading here rather than widening :class:`BotFacts` is the
+        trade ``stage.resolve_stage_device_context`` already makes for the same key
+        (spec D8). ``get_bot_pk`` and not ``get_bot``: the latter also fetches
+        the device binding and the template, which is a provider call and a
+        second query to buy an int.
+
+        It states no new identity. ``get_bot_pk`` resolves through the same
+        ``get_by_id_and_owner`` :meth:`resolve_bot` used, so it returns the key
+        of the row that call already adjudicated, not a wider match.
+
+        The re-read adds exactly one failure the single-read path could not
+        have: the bot is soft-deleted between the adjudication and here. That
+        raises ``BotNotFoundError`` — the same masked answer the resolution
+        itself gives for a bot that is not there — rather than being folded
+        into "device not ready", which would invite a retry of a bot that no
+        longer exists. A row that is present but carries no key is *not* that
+        case and keeps its old answer: ``resolve_stage_bind_id`` refuses it
+        with ``DeviceNotBoundError`` before querying, exactly as it did when
+        the key rode along on the facts.
         """
         bind_id = resolve_stage_bind_id(
             self._publish_repo,
             self._binding_repo,
-            bot_pk=facts.bot_pk,
+            bot_pk=self._bot_service.get_bot_pk(facts.bot_id, facts.owner_id),
             bot_id=facts.bot_id,
             stage=stage,
             env=get_current_env(),

--- a/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/stage.py
@@ -202,7 +202,7 @@ def resolve_stage_bind_id(
     stages: a verify request is never answered by the online runtime, or the
     reverse. A stage with no live runtime raises
     :class:`EngineStageNotLiveError`, the caller-facing "not live" answer.
-    Malformed data on our side (a facts object with no primary key, an
+    Malformed data on our side (a row that carried no primary key, an
     unreadable ``ext``) stays :class:`DeviceNotBoundError`, exactly as it was
     before stages were addressable.
 
@@ -375,7 +375,12 @@ def resolve_stage_device_context(
     bind_id = resolve_stage_bind_id(
         publish_repo,
         binding_repo,
-        bot_pk=facts.bot_pk,
+        # Straight off the row this function just read — the publish lookup's
+        # key is ``ac_bots.id`` and does not travel on :class:`BotFacts`. An
+        # absent row is already refused by ``require_stage_addressable`` above
+        # (empty ``bot_type`` is not ``service``), so this cannot reach
+        # ``resolve_stage_bind_id`` as ``0`` on that path.
+        bot_pk=int(record.get("id") or 0),
         bot_id=facts.bot_id,
         stage=stage,
         env=get_current_env(),

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_get_bot_pk.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_get_bot_pk.py
@@ -1,0 +1,118 @@
+"""Unit tests for ``BotService.get_bot_pk``.
+
+The narrow key read the engine-runtime relay makes on its published-stage
+path, where it holds the resolved facts but no longer holds the bot row.
+Covers the three outcomes its contract distinguishes:
+
+- happy path: the row's ``ac_bots.id``, read owner-scoped.
+- no live row -> ``BotNotFoundError`` (the bot is gone).
+- a row whose key did not survive projection -> ``0``, deliberately *not* an
+  exception, because ``resolve_stage_bind_id`` already owns that refusal.
+
+Also pins that it stays narrow: unlike ``get_bot`` it must not reach for the
+device binding or the template.
+
+Constructed with MagicMock collaborators, matching the construction contract
+in ``test_bot_service_list_bot_members``; only the ``repository`` seam is
+driven.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+    BotService,
+)
+
+
+def _make_bot_service(repository, device_service_provider, template_service) -> BotService:
+    return BotService(
+        drm_reader=MagicMock(),
+        repository=repository,
+        allocation_config=MagicMock(),
+        device_binding_repo=MagicMock(),
+        skill_set_factory=MagicMock(),
+        cleanup_service=MagicMock(),
+        bcn_service=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        passport_plugin=MagicMock(),
+        oss_record_repo=MagicMock(),
+        bot_publish_service_provider=lambda: MagicMock(),
+        device_service_provider=device_service_provider,
+        bot_app_grant_service_provider=lambda: MagicMock(),
+        path_factory=MagicMock(),
+        template_service=template_service,
+        workspace_hosting_service=MagicMock(),
+        collaborator_repo=MagicMock(),
+        restart_lock_repo=MagicMock(),
+        teclaw_provision_service_provider=lambda: MagicMock(),
+        device_status_client=MagicMock(),
+        cron_auto_setup_service_provider=lambda: MagicMock(),
+    )
+
+
+def _service(row):
+    """A service whose owner-scoped lookup answers ``row``."""
+    repository = MagicMock()
+    repository.get_by_id_and_owner.return_value = row
+    device_service_provider = MagicMock()
+    template_service = MagicMock()
+    service = _make_bot_service(repository, device_service_provider, template_service)
+    return service, repository, device_service_provider, template_service
+
+
+def test_returns_the_primary_key_of_the_owner_scoped_row():
+    """The key comes from ``get_by_id_and_owner``, never a bare id lookup.
+
+    ``ac_bots`` has no unique key on ``bot_id`` and every user's first bot is
+    called ``default``, so a wider query could answer with another owner's row.
+    """
+    service, repository, _, _ = _service(
+        {"bot_id": "default", "owner_id": "owner-1", "id": 100, "binding_id": 7}
+    )
+
+    assert service.get_bot_pk("default", "owner-1") == 100
+    repository.get_by_id_and_owner.assert_called_once_with("default", "owner-1")
+
+
+def test_stays_narrow_and_skips_the_binding_and_template_fetches():
+    """The reason this is not ``get_bot``.
+
+    ``get_bot`` also resolves the device binding (a provider call) and the
+    template. A caller that wants an int should pay for neither — the relay
+    makes this read on every published-stage forward.
+    """
+    service, _, device_service_provider, template_service = _service(
+        {"bot_id": "default", "owner_id": "owner-1", "id": 100, "binding_id": 7}
+    )
+
+    service.get_bot_pk("default", "owner-1")
+
+    device_service_provider.assert_not_called()
+    template_service.get_template.assert_not_called()
+
+
+def test_missing_row_raises_rather_than_answering_zero():
+    """A bot that is gone is not a bot with an unreadable key.
+
+    This is the one failure the relay's re-read adds over carrying the key on
+    the facts, and it must stay distinguishable: folding it into "device not
+    ready" would invite a retry of a bot that no longer exists.
+    """
+    service, _, _, _ = _service(None)
+
+    with pytest.raises(BotNotFoundError):
+        service.get_bot_pk("default", "owner-1")
+
+
+def test_row_without_a_key_answers_zero_and_leaves_the_refusal_to_the_caller():
+    """Deliberately not an exception.
+
+    ``resolve_stage_bind_id`` already refuses a falsy key with
+    ``DeviceNotBoundError`` before it queries anything, and that answer is
+    caller-visible. Raising something else here would move it.
+    """
+    service, _, _, _ = _service({"bot_id": "default", "owner_id": "owner-1"})
+
+    assert service.get_bot_pk("default", "owner-1") == 0

--- a/src/backend/tests/community/core/engine_runtime/test_relay.py
+++ b/src/backend/tests/community/core/engine_runtime/test_relay.py
@@ -44,11 +44,14 @@ BOT = "bot-1"
 
 
 class _BotService:
-    """Stands in for BotService.get_bot's owner-scoped lookup."""
+    """Stands in for BotService's owner-scoped lookups."""
 
     def __init__(self, bots: dict[tuple[str, str], dict] | None = None) -> None:
         self._bots = bots if bots is not None else {(BOT, OWNER): {"bot_id": BOT}}
         self.calls: list[tuple[str, str]] = []
+        #: ``get_bot_pk`` calls, counted separately from ``get_bot`` so a test
+        #: can assert the published-stage path re-reads the key exactly once.
+        self.pk_calls: list[tuple[str, str]] = []
 
     def get_bot(self, bot_id: str, user_id: str) -> dict:
         self.calls.append((bot_id, user_id))
@@ -56,6 +59,19 @@ class _BotService:
         if bot is None:
             raise BotNotFoundError(f"Bot not found: {bot_id}")
         return bot
+
+    def get_bot_pk(self, bot_id: str, user_id: str) -> int:
+        """The narrow key read the published-stage path makes.
+
+        Mirrors the real method: same owner-scoped lookup as ``get_bot``. A row
+        that is gone raises; one that carries no key answers 0, leaving the
+        refusal to ``resolve_stage_bind_id`` as it was before the re-read.
+        """
+        self.pk_calls.append((bot_id, user_id))
+        bot = self._bots.get((bot_id, user_id))
+        if bot is None:
+            raise BotNotFoundError(f"Bot not found: {bot_id}")
+        return int(bot.get("id") or 0)
 
 
 class _Resolver:
@@ -722,6 +738,54 @@ async def test_service_bot_without_a_primary_key_is_not_ready():
             publish_repo=repo,
         ).call(bot_id=BOT, owner_id=OWNER, stage="online", method="GET", path="/api/models")
 
+    assert repo.calls == []
+
+
+@pytest.mark.asyncio
+async def test_published_stage_rereads_the_primary_key_once():
+    """The key is re-read here, not carried on the facts.
+
+    ``BotFacts`` is the caller-facing projection and deliberately does not
+    carry ``ac_bots.id``; the published-stage path is the one consumer that no
+    longer holds the row, so it pays a single narrow read. ``get_bot_pk`` and
+    not ``get_bot``: the latter also fetches the device binding and template.
+    """
+    bot_service = _service_bot_service(100)
+    repo = _PublishRepo({100: [_PublishRecord({"binding": {"online": 42}})]})
+    resolver = _Resolver()
+
+    await _relay(
+        bot_service=bot_service, resolver=resolver, publish_repo=repo
+    ).call(bot_id=BOT, owner_id=OWNER, stage="online", method="GET", path="/api/models")
+
+    assert bot_service.pk_calls == [(BOT, OWNER)]
+    # Keyed on the re-read pk, so the record scan still lands on this bot's row.
+    assert resolver.binding_calls == [(42, OWNER, BOT)]
+
+
+@pytest.mark.asyncio
+async def test_bot_deleted_between_adjudication_and_key_reread_is_not_found():
+    """The one failure the re-read adds, and it must not read as "retry later".
+
+    A bot that disappears after the operator adjudication is gone, not a device
+    that is warming up. Folding it into ``EngineDeviceNotReadyError`` would
+    invite a caller to retry a bot that no longer exists.
+    """
+
+    class _VanishingBotService(_BotService):
+        def get_bot_pk(self, bot_id, user_id):
+            raise BotNotFoundError(f"Bot not found: {bot_id}")
+
+    repo = _PublishRepo({100: [_PublishRecord({"binding": {"online": 42}})]})
+    with pytest.raises(BotNotFoundError):
+        await _relay(
+            bot_service=_VanishingBotService(
+                {(BOT, OWNER): {"bot_id": BOT, "bot_type": "service", "id": 100}}
+            ),
+            publish_repo=repo,
+        ).call(bot_id=BOT, owner_id=OWNER, stage="online", method="GET", path="/api/models")
+
+    # Refused before the publish scan, like every other "no safe key" answer.
     assert repo.calls == []
 
 


### PR DESCRIPTION
## Problem

`BotFacts` carried `bot_pk`, the `ac_bots` primary key that `ac_bot_collaborator` (`uk_bot_pk_user_env`) and `ac_bot_publish.source_bot_pk` are keyed on.

`BotFacts` exists to be the narrow, caller-facing projection of a bot row — its docstring says so, and the reason is concrete: `BotService.get_bot` attaches `device_binding` / `device_id` / `device_provider` / `device_props`, and this projection is what keeps device topology off a public surface. An internal join key does not belong on that object.

It also forced a `= 0` default that no caller could meaningfully satisfy, which left the field reading as optional when it never was, and split its handling: `stage.resolve_stage_bind_id` guarded the zero case, `gate.require_bot_operator` did not.

## Solution

Drop `bot_pk` from `BotFacts` and take the key from the bot row instead.

Three of the four consumers already hold that row at the point they need the key, so they read it directly and pay nothing:

| Site | Source of the key |
| --- | --- |
| `relay.resolve_bot` → gate | `bot` record read one line above |
| `connection.build` → gate + stage | `bot` record read at the top of the method |
| `stage.resolve_stage_device_context` → stage | `record` read in the same function |

The fourth, `relay._resolve_published_device`, runs downstream of `resolve_bot` with the facts but not the record. It pays one narrow owner-scoped read through a new `BotService.get_bot_pk`. That is the same trade `stage.resolve_stage_device_context` already makes for the same key (spec D8), so this applies a rule the module had already chosen rather than inventing one.

`get_bot_pk` and not `get_bot`: the latter also fetches the device binding (a provider call) and the template, which is an expensive way to buy an int.

**No new identity claim.** `get_bot_pk` resolves through the same `get_by_id_and_owner` that `resolve_bot` used, so it returns the key of the row already adjudicated — not a wider or differently-keyed match.

**Rejected alternative:** re-keying the child tables on `(bot_id, owner_id, env)`. That is a migration across three tables, and the resulting tuple is not unique — `default_bot_passport_repair_service` raises a 409 for exactly the multi-row case, and `ac_bots` constrains `(bot_id, entity_id, env)`, on `entity_id` rather than `owner_id`.

### Error semantics

Deliberately split, to keep this a true refactor:

- **Row present, key did not survive projection** — unchanged. `resolve_stage_bind_id` refuses with `DeviceNotBoundError` before querying anything, exactly as when the key rode on the facts. `get_bot_pk` returns the key the row carries rather than raising, so this caller-visible answer does not move.
- **Bot soft-deleted between the adjudication and the re-read** — new, and the only failure the single-read path could not have. Raises `BotNotFoundError`, the same masked answer the resolution itself gives for an absent bot. Folding it into `EngineDeviceNotReadyError` would invite a caller to retry a bot that no longer exists.

The prose explaining why this key must not degrade to a `bot_id` lookup was rewritten rather than deleted, and now sits where the key is actually read.

## Validation

Run from `src/backend` with `uv run python -m pytest`:

- `tests/community/core/engine_runtime/` — **169 passed**. The 167 pre-existing tests pass **unmodified**, including `test_service_bot_without_a_primary_key_is_not_ready`, which pins the keyless-row answer — that is the evidence external behavior did not move.
- `tests/community/core/bot_management/` + `tests/community/core/engine_runtime/` — **1035 passed**.
- `tests/community/adapters/http/openapi_v1/`, `tests/community/core/bot_management/`, `tests/community/services/` — **1826 passed, 1 skipped**.
- `tests/community/core/service_bot/`, `tests/community/repository/` — 1532 passed, **2 failed**. Both failures are `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]` and are **pre-existing**: confirmed reproducing on the merge base `d8315ca` with this branch's changes stashed. Unrelated to this diff (filesystem snapshot / NFS behavior).
- `scripts/ci/python_sast_local.sh src/backend 1 --base <merge-base> --head HEAD` — exit 0.

Tests added:

- Two in `test_relay.py`: the published-stage path re-reads the key exactly once via `get_bot_pk`, and the deleted-between-reads case raises before the publish scan.
- `test_bot_service_get_bot_pk.py`, covering all three outcomes `get_bot_pk` distinguishes plus the narrowness that is its reason to exist (no device-binding fetch, no template fetch).

The second commit exists because CI's changed-line coverage gate correctly caught that the first one tested `get_bot_pk` only through a fake in the relay tests, leaving the production method itself uncovered (33.33%, 2/6 changed lines).

**Not run locally:** the Singlebox coverage / acceptance E2E gate, which needs a standalone product stack this environment cannot start. Covered by CI.

## Compatibility and risk

No schema, contract, or config change — `ac_bots.id` remains the key of `ac_bot_collaborator` and `ac_bot_publish.source_bot_pk`, and no persisted data moves. `BotFacts` is internal to `engine_runtime` and is not serialized to any caller, so no response body changes.

The one runtime cost is a single extra owner-scoped row read on the relay's published-stage path (service bots addressing `verify`/`online`; the draft path and all personal-bot traffic are untouched).

Worth flagging separately, not addressed here: `ac_bot_publish` has **no index on `source_bot_pk`** (`sql/ac_bot_publish.sql` carries the PK, `uk_oi_p_b_v`, `idx_l_p_i`, `idx_owner_name`, `idx_name`, `idx_pb_owner_s`). `list_by_source_bot` is on the request path for every staged relay call and socket open. That predates this change and needs a prod DDL decision.

Rollback is a straight revert; nothing external depends on the removed field.