### PR TITLE
feat(config-compose): carry stdio MCP servers in the bot-config artifact

### DIFF
--- a/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
+++ b/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
@@ -4,11 +4,25 @@
 # the production MCP Center plugin as fallback metadata for LOCAL/stdio MCPs.
 # The key is used as serverCode. ``args`` is normalized to stdio
 # ``arguments`` before sync.
+#
+# A server whose launch differs per engine declares ``stdioConfigs`` explicitly,
+# one entry per variant, with ``engineType`` naming the engine an entry is for.
+# An entry with no ``engineType`` is the default for every other engine. The
+# flat ``command``/``args``/``env`` form below is shorthand for a single
+# engine-agnostic entry, so a server that launches the same way everywhere needs
+# no ``stdioConfigs`` at all.
 servers:
   hitl:
-    command: "python3"
-    args:
-      - "/home/admin/hitl/hitl_mcp_server.py"
+    stdioConfigs:
+      # teclaw ships the server at a different path than the other engines, so
+      # the same server_code needs a per-engine launch instruction.
+      - engineType: "teclaw"
+        command: "python3"
+        arguments:
+          - "/usr/local/bin/teclaw_hitl_mcp_server.py"
+      - command: "python3"
+        arguments:
+          - "/home/admin/hitl/hitl_mcp_server.py"
   clawmind:
     command: "node"
     args:

--- a/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
+++ b/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
@@ -2,15 +2,20 @@
 #
 # These servers are not fetched from MCP Center, but they are still used by
 # the production MCP Center plugin as fallback metadata for LOCAL/stdio MCPs.
-# The key is used as serverCode. ``args`` is normalized to stdio
-# ``arguments`` before sync.
+# The key is used as serverCode.
 #
-# A server whose launch differs per engine declares ``stdioConfigs`` explicitly,
-# one entry per variant, with ``engineType`` naming the engine an entry is for.
-# An entry with no ``engineType`` is the default for every other engine. The
-# flat ``command``/``args``/``env`` form below is shorthand for a single
-# engine-agnostic entry, so a server that launches the same way everywhere needs
-# no ``stdioConfigs`` at all.
+# Every server declares ``stdioConfigs``: a list of launch instructions, one per
+# engine layout, each naming the engine it is for in ``engineType``. An entry
+# with no ``engineType`` is the default for every other engine, so a server that
+# launches the same way everywhere is just a one-entry list.
+#
+# ``LocalMCPRegistry`` also accepts a flat ``command``/``args``/``env`` shorthand
+# on the server itself and expands it into a single entry (translating ``args`` ->
+# ``arguments`` and ``env`` -> ``envVariables`` on the way). That form is kept
+# working for any deployment whose own catalog uses it, but is deliberately not
+# used here: two shapes in one file means two sets of key names, and the next
+# entry added by copying the wrong neighbour would write ``args`` inside a
+# ``stdioConfigs`` entry, where nothing translates it.
 #
 # ORDER MATTERS: the engine-agnostic entry MUST come first. The teclaw compose
 # path selects by ``engineType`` and is order-blind, but the arca/baas device
@@ -33,9 +38,10 @@ servers:
         arguments:
           - "/usr/local/bin/teclaw_hitl_mcp_server.py"
   clawmind:
-    command: "node"
-    args:
-      - "/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js"
-    env:
-      MCP_TRANSPORT: "stdio"
-      CCT_SOP_MCP_SERVER_MODE: "prod"
+    stdioConfigs:
+      - command: "node"
+        arguments:
+          - "/home/admin/clawmind-mcp/dist/esm/platform/mcp-entry.js"
+        envVariables:
+          MCP_TRANSPORT: "stdio"
+          CCT_SOP_MCP_SERVER_MODE: "prod"

--- a/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
+++ b/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
@@ -11,18 +11,27 @@
 # flat ``command``/``args``/``env`` form below is shorthand for a single
 # engine-agnostic entry, so a server that launches the same way everywhere needs
 # no ``stdioConfigs`` at all.
+#
+# ORDER MATTERS: the engine-agnostic entry MUST come first. The teclaw compose
+# path selects by ``engineType`` and is order-blind, but the arca/baas device
+# path (``plugins/prod/mcp_device_payload.convert_to_device_format``, corp-side)
+# takes ``stdioConfigs[0]`` with no ``engineType`` awareness — so whatever sits
+# first is what every non-teclaw container is told to run. Putting a
+# teclaw-specific entry first hands those containers a path their image does not
+# have. Guarded by ``test_local_mcp_registry.py``, since the consumer that makes
+# this matter is not in this repo.
 servers:
   hitl:
     stdioConfigs:
+      - command: "python3"
+        arguments:
+          - "/home/admin/hitl/hitl_mcp_server.py"
       # teclaw ships the server at a different path than the other engines, so
       # the same server_code needs a per-engine launch instruction.
       - engineType: "teclaw"
         command: "python3"
         arguments:
           - "/usr/local/bin/teclaw_hitl_mcp_server.py"
-      - command: "python3"
-        arguments:
-          - "/home/admin/hitl/hitl_mcp_server.py"
   clawmind:
     command: "node"
     args:

--- a/src/backend/src/agentclaw/community/core/config_compose/models.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/models.py
@@ -12,10 +12,27 @@ from typing import Any
 
 __all__ = [
     "McpComposeInput",
+    "StdioLaunch",
     "ComposeRequest",
     "CollectedSkill",
     "CollectedFile",
 ]
+
+
+@dataclass(frozen=True)
+class StdioLaunch:
+    """A local MCP server's launch instruction, as the collector resolved it.
+
+    Deliberately resolved **before** the composer runs: the launch instruction
+    comes from :class:`LocalMCPRegistry` (a local YAML read), not from the
+    best-effort MCP Center enrichment. So a Center outage cannot turn a local
+    server into a mis-classified remote one — see
+    ``ConfigComposerInputCollector._stdio_launch_for``.
+    """
+
+    command: str
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -84,3 +101,9 @@ class McpComposeInput:
     ``("OFFICE", "INTERNET", "INTRANET")``). When set, the composer picks the
     endpoint deterministically by ``(network rank, transport rank)``; when None,
     it uses the legacy filter + ``transport_protocol`` preference."""
+    stdio: StdioLaunch | None = None
+    """Set for a LOCAL/stdio server, ``None`` for a remote one — this **is** the
+    composer's discriminator, so the local-vs-remote decision is made once, by the
+    collector, from a source that does not depend on MCP Center being reachable.
+    When set, the remote fields above are ignored (a stdio server has no endpoint
+    and needs no credential)."""

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -32,12 +32,14 @@ from agentclaw.community.core.config_compose.models import (
     CollectedSkill,
     ComposeRequest,
     McpComposeInput,
+    StdioLaunch,
 )
 from agentclaw.community.core.config_compose.protocols import ComposeInputCollector
 from agentclaw.community.core.config_compose.services.mcporter_composer import (
     mcp_network_priority_for,
 )
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
+from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
 from agentclaw.community.core.repository.protocols.platform import ResourceRepositoryProtocol
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
 from agentclaw.community.core.workspace.path_factory import (
@@ -90,6 +92,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         path_factory: WorkspacePathFactory,
         identity_service: "IdentityService",
         overrides_reader: ChannelEngineOverridesReader,
+        local_mcp_registry: LocalMCPRegistry | None = None,
     ) -> None:
         self._skill_set_service_factory = skill_set_service_factory
         self._mcp_config_service = mcp_config_service
@@ -98,6 +101,13 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         self._path_factory = path_factory
         self._identity_service = identity_service
         self._overrides_reader = overrides_reader
+        # Defaulting to the bare registry (its own default config path) matches
+        # what ``passport_scope`` already does for every caller, so "is this
+        # server local?" has one answer across the codebase. A divergent source
+        # here would let passport treat a server as local while compose treated
+        # it as remote — and the remote path would then fail looking for an
+        # endpoint that never existed. Injectable for tests.
+        self._local_mcp_registry = local_mcp_registry or LocalMCPRegistry()
 
     # ── skills ──────────────────────────────────────────────────────────
     def skills(self, req: ComposeRequest) -> list[CollectedSkill]:
@@ -191,6 +201,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         inputs: list[McpComposeInput] = []
         for md in raw:
             md = self._enrich_mcp_detail(svc, md)
+            server_code = md.get("server_code") or md.get("serverCode") or ""
             api_key, headers, endpoint_env, transport = (
                 self._mcp_config_service.build_mcp_sync_payload(
                     user_id=req.user_id,
@@ -206,9 +217,45 @@ class ConfigComposerInputCollector(ComposeInputCollector):
                     endpoint_env=endpoint_env,
                     transport_protocol=transport,
                     network_priority=network_priority,
+                    stdio=self._stdio_launch_for(server_code, md),
                 )
             )
         return inputs
+
+    def _stdio_launch_for(
+        self, server_code: str, md: dict[str, Any]
+    ) -> StdioLaunch | None:
+        """Resolve a LOCAL server's launch instruction; ``None`` if it is remote.
+
+        Reads :class:`LocalMCPRegistry` (a local YAML file) **first**, falling back
+        to ``md`` only if the registry has no entry. That order is the point: the
+        enrichment above is best-effort, so on an MCP Center failure ``md`` carries
+        neither ``runMode`` nor ``stdioConfigs`` — and a local server, having no
+        endpoint to find, would then fail the remote path outright. The registry
+        needs no network, so a local server stays recognizable regardless.
+
+        The registry normalizes the YAML's flat ``command``/``args``/``env`` into
+        ``stdioConfigs: [{command, arguments, envVariables}]``; today that list is
+        always single-entry (a multi-variant form would need a per-variant
+        discriminator the shape does not yet carry), so the first entry is taken.
+        """
+        if not server_code:
+            return None
+        detail = self._local_mcp_registry.get_mcp_detail(server_code) or md
+        configs = detail.get("stdioConfigs") or detail.get("stdio_configs") or []
+        if not configs or not isinstance(configs, list):
+            return None
+        cfg = configs[0]
+        if not isinstance(cfg, dict) or not cfg.get("command"):
+            return None
+        return StdioLaunch(
+            command=str(cfg["command"]),
+            args=[str(a) for a in (cfg.get("arguments") or cfg.get("args") or [])],
+            env={
+                str(k): str(v)
+                for k, v in (cfg.get("envVariables") or cfg.get("env") or {}).items()
+            },
+        )
 
     def _enrich_mcp_detail(self, svc: Any, md: dict[str, Any]) -> dict[str, Any]:
         """Merge MCP Center detail (endpoints/runMode/…) over a bare association.

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -277,10 +277,11 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         outright. Reading a local YAML needs no network, so a local server stays
         recognizable exactly when Center cannot vouch for it.
 
-        The registry normalizes the YAML's flat ``command``/``args``/``env`` into
-        ``stdioConfigs: [{command, arguments, envVariables}]``; today that list is
-        always single-entry (a multi-variant form would need a per-variant
-        discriminator the shape does not yet carry), so the first entry is taken.
+        Either source speaks ``stdioConfigs: [{command, arguments, envVariables}]``
+        — the registry normalizes the YAML's flat ``command``/``args``/``env`` into
+        exactly that. The list holds one entry per engine layout, discriminated by
+        ``engineType``; :meth:`_stdio_config_for_engine` picks the one for this
+        engine.
         """
         if not server_code:
             return None

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -214,7 +214,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         for md in raw:
             md, detail_failure = self._enrich_mcp_detail(svc, md)
             server_code = md.get("server_code") or md.get("serverCode") or ""
-            stdio = self._stdio_launch_for(server_code, md)
+            stdio = self._stdio_launch_for(server_code, md, req.engine_type)
             if stdio is None and detail_failure is not None:
                 # Remote server we could not resolve. Fail here, at the point the
                 # lookup actually failed, with the cause chained — rather than
@@ -250,7 +250,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         return inputs
 
     def _stdio_launch_for(
-        self, server_code: str, md: dict[str, Any]
+        self, server_code: str, md: dict[str, Any], engine_type: str
     ) -> StdioLaunch | None:
         """Resolve a LOCAL server's launch instruction; ``None`` if it is remote.
 
@@ -288,10 +288,10 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         if isinstance(run_mode, str) and run_mode.strip().upper() == "REMOTE":
             return None
 
-        cfg = self._first_stdio_config(md)
+        cfg = self._stdio_config_for_engine(md, engine_type)
         if cfg is None:
             registry_detail = self._local_mcp_registry.get_mcp_detail(server_code)
-            cfg = self._first_stdio_config(registry_detail or {})
+            cfg = self._stdio_config_for_engine(registry_detail or {}, engine_type)
         if cfg is None:
             return None
         return StdioLaunch(
@@ -304,20 +304,36 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         )
 
     @staticmethod
-    def _first_stdio_config(detail: dict[str, Any]) -> dict[str, Any] | None:
-        """First launchable ``stdioConfigs`` entry, or ``None``.
+    def _stdio_config_for_engine(
+        detail: dict[str, Any], engine_type: str
+    ) -> dict[str, Any] | None:
+        """The launchable ``stdioConfigs`` entry for ``engine_type``, or ``None``.
+
+        A launch instruction is a path into a specific image, so the same
+        ``server_code`` can need a different one per engine — ``hitl`` ships at
+        ``/usr/local/bin`` on teclaw and under ``/home/admin`` elsewhere. An entry
+        naming this engine in ``engineType`` wins; an entry naming no engine is
+        the default for the rest. An entry for a *different* engine is never a
+        fallback: launching another image's binary is worse than not launching.
 
         An entry without a ``command`` is not a launch instruction, so it does not
         count as a hit — the caller then falls through to its next source rather
         than emitting a stdio server the engine cannot start.
         """
         configs = detail.get("stdioConfigs") or detail.get("stdio_configs") or []
-        if not isinstance(configs, list) or not configs:
+        if not isinstance(configs, list):
             return None
-        cfg = configs[0]
-        if not isinstance(cfg, dict) or not cfg.get("command"):
-            return None
-        return cfg
+
+        default: dict[str, Any] | None = None
+        for cfg in configs:
+            if not isinstance(cfg, dict) or not cfg.get("command"):
+                continue
+            declared = cfg.get("engineType") or cfg.get("engine_type")
+            if declared is None:
+                default = default if default is not None else cfg
+            elif str(declared).strip().lower() == engine_type.strip().lower():
+                return cfg
+        return default
 
     def _enrich_mcp_detail(
         self, svc: Any, md: dict[str, Any]

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -263,12 +263,19 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         keeps a community deployment, where the MCP Center plugin deliberately
         ignores that bundled file, from inheriting its company-only launch paths.
 
-        Otherwise :class:`LocalMCPRegistry` (a local YAML read) is consulted before
-        ``md``. That order is the point: the enrichment above is best-effort, so on
-        an MCP Center failure ``md`` carries neither ``runMode`` nor
-        ``stdioConfigs`` — and a local server, having no endpoint to find, would
-        then fail the remote path outright. The registry needs no network, so a
-        local server stays recognizable exactly when Center cannot vouch for it.
+        Otherwise the launch instruction is taken from the **resolved detail
+        first**, and only then from :class:`LocalMCPRegistry`. A deployment that
+        registers its own local server — including under a name the bundled
+        catalog also ships (``hitl``, ``clawmind``) — must keep its own command
+        rather than have it replaced by the bundled ``/home/admin/...`` path,
+        which that deployment's image need not even contain.
+
+        The registry is what makes the fallback work when there is nothing to
+        prefer: enrichment is best-effort, so on an MCP Center failure ``md``
+        carries neither ``runMode`` nor ``stdioConfigs``, and a local server —
+        having no endpoint to find — would otherwise fail the remote path
+        outright. Reading a local YAML needs no network, so a local server stays
+        recognizable exactly when Center cannot vouch for it.
 
         The registry normalizes the YAML's flat ``command``/``args``/``env`` into
         ``stdioConfigs: [{command, arguments, envVariables}]``; today that list is
@@ -280,12 +287,12 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         run_mode = md.get("run_mode") or md.get("runMode")
         if isinstance(run_mode, str) and run_mode.strip().upper() == "REMOTE":
             return None
-        detail = self._local_mcp_registry.get_mcp_detail(server_code) or md
-        configs = detail.get("stdioConfigs") or detail.get("stdio_configs") or []
-        if not configs or not isinstance(configs, list):
-            return None
-        cfg = configs[0]
-        if not isinstance(cfg, dict) or not cfg.get("command"):
+
+        cfg = self._first_stdio_config(md)
+        if cfg is None:
+            registry_detail = self._local_mcp_registry.get_mcp_detail(server_code)
+            cfg = self._first_stdio_config(registry_detail or {})
+        if cfg is None:
             return None
         return StdioLaunch(
             command=str(cfg["command"]),
@@ -295,6 +302,22 @@ class ConfigComposerInputCollector(ComposeInputCollector):
                 for k, v in (cfg.get("envVariables") or cfg.get("env") or {}).items()
             },
         )
+
+    @staticmethod
+    def _first_stdio_config(detail: dict[str, Any]) -> dict[str, Any] | None:
+        """First launchable ``stdioConfigs`` entry, or ``None``.
+
+        An entry without a ``command`` is not a launch instruction, so it does not
+        count as a hit — the caller then falls through to its next source rather
+        than emitting a stdio server the engine cannot start.
+        """
+        configs = detail.get("stdioConfigs") or detail.get("stdio_configs") or []
+        if not isinstance(configs, list) or not configs:
+            return None
+        cfg = configs[0]
+        if not isinstance(cfg, dict) or not cfg.get("command"):
+            return None
+        return cfg
 
     def _enrich_mcp_detail(
         self, svc: Any, md: dict[str, Any]

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -227,12 +227,21 @@ class ConfigComposerInputCollector(ComposeInputCollector):
     ) -> StdioLaunch | None:
         """Resolve a LOCAL server's launch instruction; ``None`` if it is remote.
 
-        Reads :class:`LocalMCPRegistry` (a local YAML file) **first**, falling back
-        to ``md`` only if the registry has no entry. That order is the point: the
-        enrichment above is best-effort, so on an MCP Center failure ``md`` carries
-        neither ``runMode`` nor ``stdioConfigs`` — and a local server, having no
-        endpoint to find, would then fail the remote path outright. The registry
-        needs no network, so a local server stays recognizable regardless.
+        A ``run_mode`` of REMOTE on the collected entry settles it. That value only
+        appears when the MCP Center lookup **succeeded**, and Center is
+        authoritative for the servers it knows, so a caller's own remote server is
+        never reclassified just because its ``server_code`` collides with a name in
+        the bundled registry (``hitl`` / ``clawmind``). The registry is a fallback
+        catalog for servers Center does not carry, not an override — which also
+        keeps a community deployment, where the MCP Center plugin deliberately
+        ignores that bundled file, from inheriting its company-only launch paths.
+
+        Otherwise :class:`LocalMCPRegistry` (a local YAML read) is consulted before
+        ``md``. That order is the point: the enrichment above is best-effort, so on
+        an MCP Center failure ``md`` carries neither ``runMode`` nor
+        ``stdioConfigs`` — and a local server, having no endpoint to find, would
+        then fail the remote path outright. The registry needs no network, so a
+        local server stays recognizable exactly when Center cannot vouch for it.
 
         The registry normalizes the YAML's flat ``command``/``args``/``env`` into
         ``stdioConfigs: [{command, arguments, envVariables}]``; today that list is
@@ -240,6 +249,9 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         discriminator the shape does not yet carry), so the first entry is taken.
         """
         if not server_code:
+            return None
+        run_mode = md.get("run_mode") or md.get("runMode")
+        if isinstance(run_mode, str) and run_mode.strip().upper() == "REMOTE":
             return None
         detail = self._local_mcp_registry.get_mcp_detail(server_code) or md
         configs = detail.get("stdioConfigs") or detail.get("stdio_configs") or []

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -36,6 +36,7 @@ from agentclaw.community.core.config_compose.models import (
 )
 from agentclaw.community.core.config_compose.protocols import ComposeInputCollector
 from agentclaw.community.core.config_compose.services.mcporter_composer import (
+    McporterComposeError,
     mcp_network_priority_for,
 )
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
@@ -56,6 +57,17 @@ if TYPE_CHECKING:
     from agentclaw.community.core.services.identity import IdentityService
 
 logger = get_logger()
+
+
+class McpDetailUnavailableError(LookupError):
+    """MCP Center returned no record for a server code.
+
+    Distinct from a transport error out of the Center client: this one says the
+    lookup *worked* and came back empty, which for a remote server means the code
+    is unknown to Center — a bad entry in the bot's MCP set or in the per-engine
+    default list. Raised as the chained cause so that distinction survives into
+    the traceback.
+    """
 
 
 def bot_data_relpath(host_path: str) -> str:
@@ -200,8 +212,23 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         network_priority = mcp_network_priority_for(req.engine_type)
         inputs: list[McpComposeInput] = []
         for md in raw:
-            md = self._enrich_mcp_detail(svc, md)
+            md, detail_failure = self._enrich_mcp_detail(svc, md)
             server_code = md.get("server_code") or md.get("serverCode") or ""
+            stdio = self._stdio_launch_for(server_code, md)
+            if stdio is None and detail_failure is not None:
+                # Remote server we could not resolve. Fail here, at the point the
+                # lookup actually failed, with the cause chained — rather than
+                # composing an entry with no endpoints and letting the composer
+                # report "no usable endpoint", which reads as a misconfigured
+                # server and sends the reader hunting in MCP Center for a record
+                # the lookup never retrieved. A local server takes the branch
+                # above instead: Center having no record of it is expected.
+                raise McporterComposeError(
+                    f"MCP {server_code or '<no server_code>'}: could not resolve "
+                    "server detail, and it is not a local server either (the "
+                    "local-MCP registry has no entry for it). MCP Center is "
+                    "unreachable or holds no record for this code."
+                ) from detail_failure
             api_key, headers, endpoint_env, transport = (
                 self._mcp_config_service.build_mcp_sync_payload(
                     user_id=req.user_id,
@@ -217,7 +244,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
                     endpoint_env=endpoint_env,
                     transport_protocol=transport,
                     network_priority=network_priority,
-                    stdio=self._stdio_launch_for(server_code, md),
+                    stdio=stdio,
                 )
             )
         return inputs
@@ -269,7 +296,9 @@ class ConfigComposerInputCollector(ComposeInputCollector):
             },
         )
 
-    def _enrich_mcp_detail(self, svc: Any, md: dict[str, Any]) -> dict[str, Any]:
+    def _enrich_mcp_detail(
+        self, svc: Any, md: dict[str, Any]
+    ) -> tuple[dict[str, Any], Exception | None]:
         """Merge MCP Center detail (endpoints/runMode/…) over a bare association.
 
         ``collect_bot_active_mcps`` returns only the skill-set association fields;
@@ -277,28 +306,28 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         detail per server (same source ``add_mcp_to_skill_set`` validates against)
         and merge it over the bare dict — Center is authoritative for endpoints,
         while locally-set fields absent from Center (e.g. default-MCP ``headers``)
-        are preserved. Best-effort: a missing detail or a Center error leaves the
-        bare dict unchanged (the composer then surfaces the "no usable endpoint"
-        error, same as before).
+        are preserved.
+
+        Returns ``(merged, failure)``. A lookup that raised or returned nothing
+        yields the bare dict plus the **cause**, which is deliberately *carried*
+        rather than logged and dropped: only the caller knows whether the server
+        is local — Center legitimately has no record of a stdio server — so only
+        the caller can decide whether the failure is fatal. It raises with this
+        exception chained, so the root cause survives into the traceback instead
+        of resurfacing three layers down as a misleading "no usable endpoint".
         """
         server_code = md.get("server_code") or md.get("serverCode")
         if not server_code:
-            return md
+            return md, None
         try:
             detail = svc.mcp_center.get_mcp_detail(server_code)
-        except Exception as e:
-            logger.warning(
-                "[ConfigComposerInputCollector] MCP Center detail fetch failed "
-                "for %s: %s", server_code, e,
-            )
-            return md
+        except Exception as e:  # noqa: BLE001 — returned to the caller, not swallowed
+            return md, e
         if not detail:
-            logger.warning(
-                "[ConfigComposerInputCollector] MCP Center has no detail for %s; "
-                "composing without endpoints", server_code,
+            return md, McpDetailUnavailableError(
+                f"MCP Center returned no detail for {server_code}"
             )
-            return md
-        return {**md, **detail}
+        return {**md, **detail}, None
 
     # ── resources ───────────────────────────────────────────────────────
     def resources(self, req: ComposeRequest) -> list[CollectedFile]:

--- a/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
@@ -285,18 +285,19 @@ class McporterComposer:
             if ep.get("env") == endpoint_env and ep.get("networkType") in net_rank
         ]
         if not candidates:
-            # Two different faults used to share one message. "Server declares no
-            # endpoints at all" points at the lookup that produced this dict;
-            # "declares some, none usable" points at the server's own config. The
-            # collector now fails the first case before we get here, so this is a
-            # backstop — but it still has to name the right suspect, or it sends
-            # the reader auditing network coverage for a record that was never
-            # fetched.
+            # Two different faults, and this layer can only tell them apart by
+            # how many endpoints arrived — so it reports exactly that and no
+            # more. In particular it must NOT claim the detail was never
+            # resolved: a record Center does hold but has published no endpoints
+            # for (``{"runMode": "REMOTE"}``) reaches here with an empty list and
+            # a perfectly successful lookup behind it. Asserting a cause this
+            # frame cannot observe is the same misdirection the collector-level
+            # raise exists to remove, just narrowed to a rarer input.
             if not endpoints:
                 raise McporterComposeError(
-                    f"MCP {server_code}: server declares no endpoints at all — its "
-                    "detail was never resolved (MCP Center unreachable, or no "
-                    "record for this code)."
+                    f"MCP {server_code}: the server record carries no endpoints at "
+                    f"all, so there is nothing to select a {endpoint_env} URL from. "
+                    "Check the endpoints published for this server in MCP Center."
                 )
             raise McporterComposeError(
                 f"MCP {server_code}: no usable {endpoint_env} endpoint "

--- a/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
@@ -153,9 +153,31 @@ class McporterComposer:
             headers=headers,
         )
 
+    def _endpoint_tuple(
+        self, server_code: str, ep: dict[str, Any]
+    ) -> tuple[str, str]:
+        """Turn the selected endpoint record into ``(url, transport)``.
+
+        A record that carries no ``url`` cannot produce a usable remote entry —
+        the engine would get a server with nothing to connect to — so it fails
+        here rather than composing ``endpoint: null`` and deferring the discovery
+        to whoever tries to call it. Selection already passed, so the fault is the
+        record itself, and the message says so.
+        """
+        url = ep.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise McporterComposeError(
+                f"MCP {server_code}: the selected "
+                f"{ep.get('networkType', '?')}/{ep.get('env', '?')} endpoint record "
+                "carries no url."
+            )
+        protocol = ep.get("transportProtocol", "SSE")
+        transport = "http" if protocol == "STREAMABLE_HTTP" else "sse"
+        return url, transport
+
     def _inline_secrets(
-        self, endpoint: str | None, api_key: str | None, headers: dict[str, str]
-    ) -> tuple[str | None, dict[str, str]]:
+        self, endpoint: str, api_key: str | None, headers: dict[str, str]
+    ) -> tuple[str, dict[str, str]]:
         """Inline the resolved credential, mirroring ``convert_to_device_format``.
 
         ``api_key`` is ``"name=value"``. ``authorization`` is appended to the
@@ -186,7 +208,7 @@ class McporterComposer:
         endpoint_env: str,
         transport_protocol: str | None,
         network_priority: tuple[str, ...] | None = None,
-    ) -> tuple[str | None, str]:
+    ) -> tuple[str, str]:
         """Pick the (url, transport) for a REMOTE MCP, mirroring device rules.
 
         When ``network_priority`` is set (teclaw), select deterministically by
@@ -257,10 +279,7 @@ class McporterComposer:
         if ep is None:
             ep = valid[0]
 
-        url = ep.get("url")
-        protocol = ep.get("transportProtocol", "SSE")
-        transport = "http" if protocol == "STREAMABLE_HTTP" else "sse"
-        return url, transport
+        return self._endpoint_tuple(server_code, ep)
 
     def _select_by_priority(
         self,
@@ -268,7 +287,7 @@ class McporterComposer:
         endpoints: list[dict[str, Any]],
         endpoint_env: str,
         network_priority: tuple[str, ...],
-    ) -> tuple[str | None, str]:
+    ) -> tuple[str, str]:
         """Pick the (url, transport) deterministically for a priority engine.
 
         Among the ``endpoint_env`` endpoints whose ``networkType`` is in
@@ -314,7 +333,4 @@ class McporterComposer:
             )
 
         ep = min(candidates, key=_key)
-        url = ep.get("url")
-        protocol = ep.get("transportProtocol", "SSE")
-        transport = "http" if protocol == "STREAMABLE_HTTP" else "sse"
-        return url, transport
+        return self._endpoint_tuple(server_code, ep)

--- a/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
@@ -285,9 +285,24 @@ class McporterComposer:
             if ep.get("env") == endpoint_env and ep.get("networkType") in net_rank
         ]
         if not candidates:
+            # Two different faults used to share one message. "Server declares no
+            # endpoints at all" points at the lookup that produced this dict;
+            # "declares some, none usable" points at the server's own config. The
+            # collector now fails the first case before we get here, so this is a
+            # backstop — but it still has to name the right suspect, or it sends
+            # the reader auditing network coverage for a record that was never
+            # fetched.
+            if not endpoints:
+                raise McporterComposeError(
+                    f"MCP {server_code}: server declares no endpoints at all — its "
+                    "detail was never resolved (MCP Center unreachable, or no "
+                    "record for this code)."
+                )
             raise McporterComposeError(
                 f"MCP {server_code}: no usable {endpoint_env} endpoint "
-                f"(networks {'/'.join(network_priority)})."
+                f"(networks {'/'.join(network_priority)}); the server declares "
+                f"{len(endpoints)} endpoint(s), none on a reachable network for "
+                "this env."
             )
 
         def _key(ep: dict[str, Any]) -> tuple[int, int]:

--- a/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
@@ -18,9 +18,12 @@ produces (see ``plugins/prod/mcp_device_payload.convert_to_device_format``):
    ``McpServerRef`` contract, field-aligned with the device format so a foreign
    engine can reconstruct its own mcporter.json.
 
-Scope: REMOTE (URL-based) MCP servers. ``LOCAL``/stdio servers carry
-command/args/env which the current ``McpServerRef`` contract does not model;
-they raise :class:`McporterComposeError` rather than being silently dropped.
+Scope: both MCP forms. A REMOTE (URL-based) server gets an endpoint selected and
+its credential inlined; a LOCAL/stdio server is emitted as a ``stdio`` entry
+carrying its launch instruction. Which form an entry takes is **not decided
+here** — the collector resolves it into ``McpComposeInput.stdio``, so this stays
+a pure function of its inputs (and cannot be fooled by a failed MCP Center
+enrichment; see that field's docstring).
 
 The inlining rule is replicated from ``convert_to_device_format`` (a plugins-layer
 function this core module must not import); a parity test
@@ -31,16 +34,25 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable
 
-from agentclaw.community.core.config_compose.models import McpComposeInput
-from agentclaw.community.kernel.bot_config import McpManifest, McpServerRef
+from agentclaw.community.core.config_compose.models import McpComposeInput, StdioLaunch
+from agentclaw.community.kernel.bot_config import McpManifest, McpServerRef, StdioSpec
 
 
 __all__ = [
     "McporterComposer",
     "McporterComposeError",
+    "STDIO_TRANSPORT",
     "TECLAW_MCP_NETWORK_PRIORITY",
     "mcp_network_priority_for",
 ]
+
+# ``transport`` value marking the local form of an ``McpServerRef``. The engine
+# reads this to decide "spawn a child process" vs "make an HTTP request", so it
+# is part of the published contract — see ``McpServerRef``. Lowercase to sit in
+# the same vocabulary as the remote values this composer already emits
+# ("http" / "sse", the device-format spelling), and it matches what the MCP spec
+# itself calls this transport.
+STDIO_TRANSPORT = "stdio"
 
 # Engine types whose MCP endpoint selection follows the deterministic
 # network-priority rule below. Kept local to avoid coupling config_compose to
@@ -79,25 +91,51 @@ class McporterComposer:
     def compose(self, inputs: Iterable[McpComposeInput]) -> McpManifest:
         """Build a full ``McpManifest`` from per-MCP merged config.
 
-        The published artifact contract is still remote-MCP-only. Runtime device
-        sync handles LOCAL/stdio MCPs separately, so artifact composition skips
-        them instead of failing the whole bot config.
+        Every input yields an entry; LOCAL/stdio servers are no longer dropped.
         """
-        servers = [
-            self.compose_server(item)
-            for item in inputs
-            if not self._is_local_stdio(item.mcp_data)
-        ]
-        return McpManifest(servers=servers)
+        return McpManifest(servers=[self.compose_server(item) for item in inputs])
 
     def compose_server(self, item: McpComposeInput) -> McpServerRef:
-        """Build one ``McpServerRef`` — REMOTE only, resolved secrets inlined."""
+        """Build one ``McpServerRef``, in whichever form ``item`` calls for."""
         md = item.mcp_data
         server_code = md.get("server_code") or md.get("serverCode") or ""
         if not server_code:
             raise McporterComposeError("MCP entry missing server_code")
 
         name = md.get("name") or md.get("description")
+        if item.stdio is not None:
+            return self._compose_stdio(server_code, name, item.stdio)
+        return self._compose_remote(server_code, name, item, md)
+
+    def _compose_stdio(
+        self, server_code: str, name: str | None, launch: StdioLaunch
+    ) -> McpServerRef:
+        """Emit the local form: a launch instruction, no endpoint, no credential.
+
+        A stdio server is a child of the engine process on the same host, so there
+        is nothing to authenticate against — the input's ``api_key`` / ``headers``
+        are deliberately not passed here rather than being inlined into a
+        non-existent endpoint.
+        """
+        return McpServerRef(
+            server_code=server_code,
+            name=name,
+            transport=STDIO_TRANSPORT,
+            stdio=StdioSpec(
+                command=launch.command,
+                args=list(launch.args),
+                env=dict(launch.env),
+            ),
+        )
+
+    def _compose_remote(
+        self,
+        server_code: str,
+        name: str | None,
+        item: McpComposeInput,
+        md: dict[str, Any],
+    ) -> McpServerRef:
+        """Emit the remote form: selected endpoint with the credential inlined."""
         endpoint, transport = self._select_endpoint(
             server_code,
             md,
@@ -114,10 +152,6 @@ class McporterComposer:
             transport=transport,
             headers=headers,
         )
-
-    def _is_local_stdio(self, md: dict[str, Any]) -> bool:
-        run_mode = md.get("run_mode") or md.get("runMode", "REMOTE")
-        return run_mode == "LOCAL"
 
     def _inline_secrets(
         self, endpoint: str | None, api_key: str | None, headers: dict[str, str]
@@ -164,9 +198,17 @@ class McporterComposer:
         """
         run_mode = md.get("run_mode") or md.get("runMode", "REMOTE")
         if run_mode == "LOCAL":
+            # Reachable only when an entry reads as LOCAL but arrived with no
+            # resolved launch instruction — i.e. the collector could not find it
+            # in the local-MCP registry. Fail with *that* cause rather than
+            # falling through to a misleading "no usable endpoint": a local
+            # server has no endpoint to find, so the endpoint error would send
+            # the reader hunting in MCP Center for something that was never
+            # there.
             raise McporterComposeError(
-                f"MCP {server_code}: stdio/LOCAL servers are not modeled in the "
-                "BotConfigArtifact contract yet (command/args/env)."
+                f"MCP {server_code}: LOCAL server reached the remote path with no "
+                "stdio launch instruction — the local-MCP registry has no entry "
+                "for it (check that local-mcp-servers.yaml is readable)."
             )
 
         endpoints = md.get("endpoints", [])

--- a/src/backend/src/agentclaw/community/kernel/bot_config/__init__.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/__init__.py
@@ -19,6 +19,7 @@ from .artifact import (  # noqa: F401  (relative intra-kernel import — no cros
     McpServerRef,
     ResourceRef,
     SkillRef,
+    StdioSpec,
     StoreRef,
 )
 
@@ -31,5 +32,6 @@ __all__ = [
     "McpServerRef",
     "ResourceRef",
     "SkillRef",
+    "StdioSpec",
     "StoreRef",
 ]

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
@@ -194,8 +194,21 @@ class BotConfigArtifact:
     version: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to the published JSON shape (matches ``artifact.schema.json``)."""
-        return asdict(self)
+        """Serialize to the published JSON shape (matches ``artifact.schema.json``).
+
+        A remote MCP entry omits ``stdio`` entirely rather than emitting it as
+        ``null``. ``asdict`` would include the key on every entry, which changes
+        the wire shape of artifacts that contain no local server at all — and a
+        consumer validating them against the pre-``stdio`` definition (which is
+        ``additionalProperties: false``) would reject them. Omitting it keeps
+        those bytes exactly what they were, so only artifacts that genuinely
+        carry the new form differ.
+        """
+        data = asdict(self)
+        for server in data.get("mcp", {}).get("servers", []):
+            if server.get("stdio") is None:
+                server.pop("stdio", None)
+        return data
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "BotConfigArtifact":

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
@@ -25,6 +25,10 @@ Module rules (kernel is the lowest layer):
   contrast, are **inlined** into the server entry (the resolved key rides in
   the endpoint query or in ``headers``) — the backend holds the plaintext at
   compose time and the engine consumes it directly, with no secret broker.
+* An MCP server entry comes in two mutually exclusive forms, discriminated by
+  ``transport``: a **remote** one (``http`` / ``sse``) carrying ``endpoint`` +
+  ``headers``, and a **local** one (``stdio``) carrying a ``stdio`` launch
+  instruction. See :class:`McpServerRef`.
 """
 from __future__ import annotations
 
@@ -98,21 +102,54 @@ class FileRef:
 
 
 @dataclass(frozen=True)
-class McpServerRef:
-    """One MCP server entry.
+class StdioSpec:
+    """How to launch a local (stdio) MCP server.
 
-    Resolved credentials are **inlined**: an ``authorization`` key rides in the
-    ``endpoint`` query string and any secret header (e.g. ``x-ling-auth``) rides
-    in ``headers`` — exactly the shape the device ``/api/mcp`` path produces. The
-    backend holds the plaintext at compose time and the engine uses it directly;
-    there is no secret broker / by-reference indirection.
+    Present only on entries whose ``transport`` is ``"STDIO"``. Unlike a remote
+    entry — which is pure data (a URL plus headers) — this is an **instruction to
+    execute**, so it is only meaningful in an engine whose image actually carries
+    ``command`` at that path. Placement/lifecycle of the child process is the
+    engine owner's decision; the backend only names what to run.
+
+    Carries no credentials: a stdio server is a child of the engine process on the
+    same host, so there is no endpoint to authenticate against.
     """
 
+    command: str
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class McpServerRef:
+    """One MCP server entry, in one of two mutually exclusive forms.
+
+    ``transport`` is the discriminator:
+
+    * ``"stdio"`` — a local server. Read :attr:`stdio` for the launch
+      instruction; ``endpoint`` / ``headers`` are unset.
+    * ``"http"`` / ``"sse"`` — a remote server. Read ``endpoint`` and
+      ``headers``; ``stdio`` is ``None``.
+
+    For the remote form, resolved credentials are **inlined**: an
+    ``authorization`` key rides in the ``endpoint`` query string and any secret
+    header (e.g. ``x-ling-auth``) rides in ``headers`` — exactly the shape the
+    device ``/api/mcp`` path produces. The backend holds the plaintext at compose
+    time and the engine uses it directly; there is no secret broker /
+    by-reference indirection.
+    """
+
+    # Field order is append-only: existing fields keep their positions so
+    # positional construction and the ``asdict`` key order (which feeds the
+    # published bytes and their content digest) stay unchanged.
     server_code: str
     name: str | None = None
-    endpoint: str | None = None
-    transport: str | None = None
-    headers: dict[str, str] = field(default_factory=dict)
+    endpoint: str | None = None  # remote form
+    transport: str | None = None  # discriminator, see above
+    headers: dict[str, str] = field(default_factory=dict)  # remote form
+    # Local form. ``None`` is a meaningful contract state, not an "unset"
+    # placeholder: a remote server genuinely has no launch instruction.
+    stdio: StdioSpec | None = None
 
 
 @dataclass(frozen=True)
@@ -120,6 +157,20 @@ class McpManifest:
     """The bot's resolved MCP servers."""
 
     servers: list[McpServerRef] = field(default_factory=list)
+
+
+def _mcp_server_from_dict(data: dict[str, Any]) -> McpServerRef:
+    """Rebuild one server entry, re-nesting ``stdio`` into its dataclass.
+
+    A remote entry (no ``stdio`` key, or an explicit ``null``) yields
+    ``stdio=None`` — so artifacts published before the local form existed
+    deserialize unchanged.
+    """
+    stdio = data.get("stdio")
+    return McpServerRef(
+        **{k: v for k, v in data.items() if k != "stdio"},
+        stdio=StdioSpec(**stdio) if stdio else None,
+    )
 
 
 @dataclass(frozen=True)
@@ -151,7 +202,7 @@ class BotConfigArtifact:
         """Reconstruct from the published JSON shape."""
         mcp_data = data.get("mcp") or {}
         mcp = McpManifest(
-            servers=[McpServerRef(**s) for s in mcp_data.get("servers", [])],
+            servers=[_mcp_server_from_dict(s) for s in mcp_data.get("servers", [])],
         )
         return cls(
             schema_version=data["schema_version"],
@@ -203,6 +254,7 @@ EXAMPLE_ARTIFACT = BotConfigArtifact(
     ],
     mcp=McpManifest(
         servers=[
+            # remote form — reachable over HTTP, so it carries endpoint + headers
             McpServerRef(
                 server_code="github",
                 name="GitHub",
@@ -212,6 +264,18 @@ EXAMPLE_ARTIFACT = BotConfigArtifact(
                 # shape); an ``authorization`` key would instead ride in the
                 # endpoint query (``?authorization=<token>``).
                 headers={"x-ling-auth": "<resolved-token>"},
+            ),
+            # local form — the engine spawns it as a child process and speaks
+            # JSON-RPC over its stdin/stdout. No endpoint, and no credential:
+            # it runs inside the engine's own container as the same user.
+            McpServerRef(
+                server_code="hitl",
+                name="hitl",
+                transport="stdio",
+                stdio=StdioSpec(
+                    command="python3",
+                    args=["/home/admin/hitl/hitl_mcp_server.py"],
+                ),
             ),
         ],
     ),

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
@@ -105,7 +105,7 @@ class FileRef:
 class StdioSpec:
     """How to launch a local (stdio) MCP server.
 
-    Present only on entries whose ``transport`` is ``"STDIO"``. Unlike a remote
+    Present only on entries whose ``transport`` is ``"stdio"``. Unlike a remote
     entry — which is pure data (a URL plus headers) — this is an **instruction to
     execute**, so it is only meaningful in an engine whose image actually carries
     ``command`` at that path. Placement/lifecycle of the child process is the

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
@@ -110,16 +110,32 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["server_code"],
+      "description": "One MCP server, in one of two mutually exclusive forms discriminated by 'transport': 'stdio' reads the 'stdio' object; 'http'/'sse' read 'endpoint' + 'headers'.",
       "properties": {
         "server_code": { "type": "string" },
         "name": { "type": ["string", "null"] },
-        "endpoint": { "type": ["string", "null"], "description": "May carry an inlined ?authorization=<token> query." },
-        "transport": { "type": ["string", "null"] },
+        "endpoint": { "type": ["string", "null"], "description": "Remote form. May carry an inlined ?authorization=<token> query." },
+        "transport": { "type": ["string", "null"], "description": "Discriminator: 'stdio' (local) | 'http' | 'sse' (remote)." },
         "headers": {
           "type": "object",
-          "description": "May carry inlined secret headers (e.g. x-ling-auth).",
+          "description": "Remote form. May carry inlined secret headers (e.g. x-ling-auth).",
           "additionalProperties": { "type": "string" }
+        },
+        "stdio": {
+          "$ref": "#/definitions/stdioSpec",
+          "description": "Local form (transport == 'stdio'). Null/absent for a remote server."
         }
+      }
+    },
+    "stdioSpec": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["command"],
+      "description": "How to launch a local MCP server: the engine spawns 'command' as a child process and speaks JSON-RPC over its stdin/stdout. Carries no credentials — the child runs inside the engine's own container.",
+      "properties": {
+        "command": { "type": "string", "description": "Executable, e.g. 'python3'." },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "env": { "type": "object", "additionalProperties": { "type": "string" } }
       }
     }
   }

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
@@ -140,10 +140,11 @@
         },
         {
           "title": "remote (http/sse)",
-          "description": "transport 'http'/'sse' ⇒ no launch instruction.",
-          "required": ["transport"],
+          "description": "transport 'http'/'sse' ⇒ a URL to connect to, and no launch instruction. 'endpoint' is required here even though it is nullable at the top level: an entry with neither a URL nor a launch instruction gives the engine nothing to act on.",
+          "required": ["transport", "endpoint"],
           "properties": {
             "transport": { "enum": ["http", "sse"] },
+            "endpoint": { "type": "string", "minLength": 1 },
             "stdio": { "type": "null" }
           }
         }

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
@@ -110,7 +110,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["server_code"],
-      "description": "One MCP server, in one of two mutually exclusive forms discriminated by 'transport': 'stdio' reads the 'stdio' object; 'http'/'sse' read 'endpoint' + 'headers'.",
+      "description": "One MCP server, in one of two mutually exclusive forms discriminated by 'transport'. The 'oneOf' below is the authority: a local entry ('stdio') must carry the 'stdio' launch object and no endpoint/headers; a remote entry ('http'/'sse') must carry no 'stdio'. Validating against this schema is enough to reject a half-formed entry — no engine-side launch attempt required.",
       "properties": {
         "server_code": { "type": "string" },
         "name": { "type": ["string", "null"] },
@@ -122,18 +122,40 @@
           "additionalProperties": { "type": "string" }
         },
         "stdio": {
-          "$ref": "#/definitions/stdioSpec",
+          "oneOf": [{ "$ref": "#/definitions/stdioSpec" }, { "type": "null" }],
           "description": "Local form (transport == 'stdio'). Null/absent for a remote server."
         }
-      }
+      },
+      "oneOf": [
+        {
+          "title": "local (stdio)",
+          "description": "transport 'stdio' ⇒ a launch instruction, and none of the remote fields.",
+          "required": ["transport", "stdio"],
+          "properties": {
+            "transport": { "const": "stdio" },
+            "stdio": { "$ref": "#/definitions/stdioSpec" },
+            "endpoint": { "type": "null" },
+            "headers": { "type": "object", "maxProperties": 0 }
+          }
+        },
+        {
+          "title": "remote (http/sse)",
+          "description": "transport 'http'/'sse' ⇒ no launch instruction.",
+          "required": ["transport"],
+          "properties": {
+            "transport": { "enum": ["http", "sse"] },
+            "stdio": { "type": "null" }
+          }
+        }
+      ]
     },
     "stdioSpec": {
-      "type": ["object", "null"],
+      "type": "object",
       "additionalProperties": false,
       "required": ["command"],
       "description": "How to launch a local MCP server: the engine spawns 'command' as a child process and speaks JSON-RPC over its stdin/stdout. Carries no credentials — the child runs inside the engine's own container.",
       "properties": {
-        "command": { "type": "string", "description": "Executable, e.g. 'python3'." },
+        "command": { "type": "string", "minLength": 1, "description": "Executable, e.g. 'python3'." },
         "args": { "type": "array", "items": { "type": "string" } },
         "env": { "type": "object", "additionalProperties": { "type": "string" } }
       }

--- a/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
+++ b/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+from dataclasses import asdict
 from typing import Any
 
 import jsonschema
@@ -27,9 +28,13 @@ from agentclaw.community.core.config_compose.models import (
     CollectedSkill,
     ComposeRequest,
     McpComposeInput,
+    StdioLaunch,
 )
 from agentclaw.community.core.config_compose.services.config_composer import ConfigComposer
-from agentclaw.community.core.config_compose.services.mcporter_composer import McporterComposer
+from agentclaw.community.core.config_compose.services.mcporter_composer import (
+    STDIO_TRANSPORT,
+    McporterComposer,
+)
 from agentclaw.community.core.service_bot.services.deploy.external_compose_producer import (
     ExternalComposeProducer,
 )
@@ -140,20 +145,77 @@ def _full_collector() -> _FakeCollector:
 # ── composer output conforms across the bot-state matrix ─────────────────────
 
 
+def _mixed_mcp_collector() -> _FakeCollector:
+    """A bot carrying both MCP forms — the shape a teclaw bot with ``hitl`` has."""
+    return _FakeCollector(
+        mcps=[
+            McpComposeInput(
+                mcp_data={
+                    "server_code": "github",
+                    "run_mode": "REMOTE",
+                    "endpoints": [
+                        {
+                            "networkType": "INTERNET", "env": "PROD",
+                            "transportProtocol": "STREAMABLE_HTTP",
+                            "url": "https://mcp/github",
+                        }
+                    ],
+                },
+                api_key=f"x-ling-auth={_SECRET}",
+                endpoint_env="PROD",
+            ),
+            McpComposeInput(
+                mcp_data={"server_code": "hitl", "run_mode": "LOCAL"},
+                stdio=StdioLaunch(
+                    command="python3",
+                    args=["/home/admin/hitl/hitl_mcp_server.py"],
+                    env={"MCP_TRANSPORT": "stdio"},
+                ),
+            ),
+        ],
+    )
+
+
 @pytest.mark.parametrize(
     "name,collector,version",
     [
         ("empty_live_bot", _FakeCollector(), None),
         ("full_published_bot", _full_collector(), 7),
+        ("mixed_remote_and_stdio_mcp", _mixed_mcp_collector(), 7),
     ],
 )
 def test_composed_artifact_conforms_to_schema(name, collector, version) -> None:
     """The artifact the real ``ConfigComposer`` assembles from inputs validates
-    against the schema oracle — for both a bare live bot and a fully-populated
-    published snapshot (skills + mcp-by-reference + resources + url + identity +
-    embedded stores + overrides)."""
+    against the schema oracle — for a bare live bot, a fully-populated published
+    snapshot (skills + mcp-by-reference + resources + url + identity + embedded
+    stores + overrides), and a bot mixing remote and stdio MCP servers."""
     artifact = _composer(collector).compose(_req(version=version))
     _validate(artifact)
+
+
+def test_composed_stdio_mcp_carries_launch_and_no_credential() -> None:
+    """Beyond raw schema shape: the stdio entry is the *local* form end-to-end.
+
+    The schema permits both forms on every entry, so it cannot express that a
+    stdio server must carry a launch instruction and must not carry endpoint or
+    credentials. Assert that here, against the real composer's output.
+    """
+    artifact = _composer(_mixed_mcp_collector()).compose(_req(version=7))
+    by_code = {s.server_code: s for s in artifact.mcp.servers}
+
+    assert set(by_code) == {"github", "hitl"}
+
+    local = by_code["hitl"]
+    assert local.transport == STDIO_TRANSPORT
+    assert local.stdio is not None
+    assert local.stdio.command == "python3"
+    assert local.stdio.args == ["/home/admin/hitl/hitl_mcp_server.py"]
+    assert local.endpoint is None and local.headers == {}
+
+    # The remote entry is unaffected: it still inlines its secret.
+    remote = by_code["github"]
+    assert remote.stdio is None
+    assert _SECRET in json.dumps(asdict(remote), ensure_ascii=False)
 
 
 def test_composed_artifact_carries_channels_engine_override() -> None:

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -213,6 +213,31 @@ def test_mcps_resolve_stdio_launch_when_center_lookup_fails():
 
 
 @pytest.mark.unit
+def test_mcps_resolved_local_definition_wins_over_bundled_catalog():
+    """A deployment's own local server keeps its own command.
+
+    The bundled catalog ships ``hitl``; an operator may register a local server
+    under that same code with a different binary. Preferring the catalog would
+    swap in a ``/home/admin/...`` path their image need not contain.
+    """
+    inputs = _mcps_with(
+        [{"server_code": "hitl"}],
+        center_detail={
+            "serverCode": "hitl",
+            "runMode": "LOCAL",
+            "stdioConfigs": [
+                {"command": "/opt/acme/bin/hitl", "arguments": ["--serve"]}
+            ],
+        },
+        registry_catalog=_HITL_CATALOG,
+    )
+
+    assert inputs[0].stdio == StdioLaunch(
+        command="/opt/acme/bin/hitl", args=["--serve"], env={}
+    )
+
+
+@pytest.mark.unit
 def test_mcps_center_remote_wins_over_colliding_registry_name():
     """A caller's own REMOTE server is not hijacked by a same-named local entry.
 

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -25,9 +25,9 @@ from agentclaw.community.core.config_compose.services.mcporter_composer import (
 from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
 
 
-def _req() -> ComposeRequest:
+def _req(engine_type: str = "openclaw") -> ComposeRequest:
     return ComposeRequest(
-        entity_id="staff_u1", bot_id="bot1", user_id="u1", engine_type="openclaw"
+        entity_id="staff_u1", bot_id="bot1", user_id="u1", engine_type=engine_type
     )
 
 
@@ -210,6 +210,79 @@ def test_mcps_resolve_stdio_launch_when_center_lookup_fails():
 
     assert inputs[0].stdio is not None
     assert inputs[0].stdio.command == "python3"
+
+
+_PER_ENGINE_HITL_CATALOG = {
+    "hitl": {
+        "stdioConfigs": [
+            {"engineType": "teclaw", "command": "python3",
+             "arguments": ["/usr/local/bin/teclaw_hitl_mcp_server.py"]},
+            {"command": "python3",
+             "arguments": ["/home/admin/hitl/hitl_mcp_server.py"]},
+        ]
+    }
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "engine_type,expected_arg",
+    [
+        ("teclaw", "/usr/local/bin/teclaw_hitl_mcp_server.py"),
+        ("openclaw", "/home/admin/hitl/hitl_mcp_server.py"),
+        ("claude_code", "/home/admin/hitl/hitl_mcp_server.py"),
+    ],
+)
+def test_mcps_pick_the_launch_instruction_for_this_engine(engine_type, expected_arg):
+    """A launch instruction is a path into a specific image, so the same
+    ``server_code`` resolves differently per engine — ``hitl`` ships under
+    ``/usr/local/bin`` on teclaw and under ``/home/admin`` everywhere else. An
+    entry naming no engine is the default for the rest."""
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": "hitl"}]
+    svc.mcp_center.get_mcp_detail.return_value = None
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+
+    inputs = _collector(
+        skill_set_service=svc,
+        mcp_config_service=mcp_cfg,
+        local_mcp_registry=_registry_over(_PER_ENGINE_HITL_CATALOG),
+    ).mcps(_req(engine_type=engine_type))
+
+    assert inputs[0].stdio == StdioLaunch(command="python3", args=[expected_arg], env={})
+
+
+@pytest.mark.unit
+def test_mcps_never_borrow_another_engines_launch_instruction():
+    """With only a teclaw-specific entry and no engine-agnostic default, a
+    different engine gets nothing rather than teclaw's binary — launching another
+    image's path is worse than not launching."""
+    catalog = {
+        "hitl": {
+            "stdioConfigs": [
+                {"engineType": "teclaw", "command": "python3",
+                 "arguments": ["/usr/local/bin/teclaw_hitl_mcp_server.py"]},
+            ]
+        }
+    }
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": "hitl"}]
+    svc.mcp_center.get_mcp_detail.return_value = None
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+
+    collector = _collector(
+        skill_set_service=svc,
+        mcp_config_service=mcp_cfg,
+        local_mcp_registry=_registry_over(catalog),
+    )
+
+    # teclaw resolves it…
+    assert collector.mcps(_req(engine_type="teclaw"))[0].stdio is not None
+    # …openclaw does not, and since Center has no record either, it fails loudly.
+    with pytest.raises(McporterComposeError, match="not a local server"):
+        collector.mcps(_req(engine_type="openclaw"))
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -17,6 +17,10 @@ from agentclaw.community.core.channel.services.engine_overrides_reader import (
 from agentclaw.community.core.config_compose.models import ComposeRequest, StdioLaunch
 from agentclaw.community.core.config_compose.services.collector import (
     ConfigComposerInputCollector,
+    McpDetailUnavailableError,
+)
+from agentclaw.community.core.config_compose.services.mcporter_composer import (
+    McporterComposeError,
 )
 from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
 
@@ -128,8 +132,9 @@ def test_mcps_run_collect_then_per_server_merge():
     svc.collect_bot_active_mcps.return_value = [
         {"server_code": "a"}, {"server_code": "b"}
     ]
-    # Center has no extra detail for these — leaves the bare dicts unchanged.
-    svc.mcp_center.get_mcp_detail.return_value = None
+    # Center carries both codes. A resolvable record is now a precondition for a
+    # remote server: an empty lookup fails the compose (see the raise cases below).
+    svc.mcp_center.get_mcp_detail.return_value = {"runMode": "REMOTE", "endpoints": []}
     mcp_cfg = MagicMock()
     mcp_cfg.build_mcp_sync_payload.return_value = ("kee", {"h": "v"}, "PROD", "http")
     inputs = _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(_req())
@@ -232,7 +237,9 @@ def test_mcps_center_remote_wins_over_colliding_registry_name():
 @pytest.mark.unit
 def test_mcps_remote_server_absent_from_registry_has_no_stdio():
     inputs = _mcps_with(
-        [{"server_code": "dima"}], center_detail=None, registry_catalog=_HITL_CATALOG
+        [{"server_code": "dima"}],
+        center_detail={"serverCode": "dima", "runMode": "REMOTE", "endpoints": []},
+        registry_catalog=_HITL_CATALOG,
     )
 
     assert inputs[0].stdio is None
@@ -242,12 +249,25 @@ def test_mcps_remote_server_absent_from_registry_has_no_stdio():
 def test_mcps_registry_entry_without_command_yields_no_launch():
     """An unlaunchable catalog entry must not produce a half-formed local entry.
 
-    Better to fall through to the remote path — which raises naming the registry —
-    than to publish a stdio entry the engine cannot act on.
+    With Center also holding no record, the server resolves as neither form and
+    the compose fails — the correct outcome, and better than publishing a stdio
+    entry the engine cannot act on.
     """
+    with pytest.raises(McporterComposeError, match="not a local server"):
+        _mcps_with(
+            [{"server_code": "broken"}],
+            center_detail=None,
+            registry_catalog={"broken": {"args": ["--x"]}},
+        )
+
+
+@pytest.mark.unit
+def test_mcps_registry_entry_without_command_defers_to_center_when_it_has_one():
+    """Same unlaunchable catalog entry, but Center knows the code: it composes as
+    a remote server. The broken catalog row is simply not a launch instruction."""
     inputs = _mcps_with(
         [{"server_code": "broken"}],
-        center_detail=None,
+        center_detail={"serverCode": "broken", "runMode": "REMOTE", "endpoints": []},
         registry_catalog={"broken": {"args": ["--x"]}},
     )
 
@@ -311,16 +331,56 @@ def test_mcps_skip_center_lookup_when_no_server_code():
 
 
 @pytest.mark.unit
-def test_mcps_center_error_leaves_bare_dict_unchanged():
-    # A Center fetch failure is best-effort: the bare dict flows through unchanged
-    # (the composer surfaces the "no usable endpoint" error, same as before).
+def test_mcps_center_error_raises_here_with_the_cause_chained():
+    """A Center failure on a remote server fails the compose, keeping the cause.
+
+    Swallowing it produced an entry with no endpoints, and the composer three
+    layers down then reported "no usable endpoint" — which reads as a
+    misconfigured server and sends the reader auditing network coverage for a
+    record that was never fetched. The original error must survive as
+    ``__cause__`` so the traceback names what actually broke.
+    """
     svc = MagicMock()
     svc.collect_bot_active_mcps.return_value = [{"server_code": "boom"}]
     svc.mcp_center.get_mcp_detail.side_effect = RuntimeError("center down")
     mcp_cfg = MagicMock()
     mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
-    inputs = _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(_req())
-    assert inputs[0].mcp_data == {"server_code": "boom"}
+
+    with pytest.raises(McporterComposeError, match="could not resolve") as excinfo:
+        _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(_req())
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert str(excinfo.value.__cause__) == "center down"
+
+
+@pytest.mark.unit
+def test_mcps_center_empty_record_raises_here_too():
+    """A lookup that succeeds but returns nothing is equally fatal for a remote
+    server — the code is simply unknown to Center — and is reported as its own
+    cause rather than as a transport error."""
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": "ghost"}]
+    svc.mcp_center.get_mcp_detail.return_value = None
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+
+    with pytest.raises(McporterComposeError, match="could not resolve") as excinfo:
+        _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(_req())
+
+    assert isinstance(excinfo.value.__cause__, McpDetailUnavailableError)
+
+
+@pytest.mark.unit
+def test_mcps_local_server_survives_center_having_no_record():
+    """The converse, and the reason the failure is decided by the caller: Center
+    legitimately has no record of a stdio server, so an empty lookup must NOT be
+    fatal once the registry has supplied a launch instruction."""
+    inputs = _mcps_with(
+        [{"server_code": "hitl"}], center_detail=None, registry_catalog=_HITL_CATALOG
+    )
+
+    assert inputs[0].stdio is not None
+    assert inputs[0].stdio.command == "python3"
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -4,18 +4,21 @@ Verifies the concrete collector adapts each source service into the composer's
 container-view inputs: skill scope/name derivation, the MCP collect+merge loop,
 resource/identity mapping, and the engine_overrides default.
 """
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 
 from agentclaw.community.core.channel.services.engine_overrides_reader import (
     ChannelEngineOverridesReader,
 )
-from agentclaw.community.core.config_compose.models import ComposeRequest
+from agentclaw.community.core.config_compose.models import ComposeRequest, StdioLaunch
 from agentclaw.community.core.config_compose.services.collector import (
     ConfigComposerInputCollector,
 )
+from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
 
 
 def _req() -> ComposeRequest:
@@ -36,7 +39,8 @@ def _reader_over(channel_repo) -> ChannelEngineOverridesReader:
 
 def _collector(*, skill_set_service=None, mcp_config_service=None,
                resource_repository=None,
-               identity_service=None, channel_repo=None):
+               identity_service=None, channel_repo=None,
+               local_mcp_registry=None):
     return ConfigComposerInputCollector(
         skill_set_service_factory=_factory_returning(skill_set_service or MagicMock()),
         mcp_config_service=mcp_config_service or MagicMock(),
@@ -45,7 +49,20 @@ def _collector(*, skill_set_service=None, mcp_config_service=None,
         path_factory=MagicMock(),
         identity_service=identity_service or MagicMock(),
         overrides_reader=_reader_over(channel_repo),
+        # Default to an EMPTY registry rather than the production default, which
+        # would read the repo's bundled local-mcp-servers.yaml off disk and make
+        # every test here depend on that file's contents.
+        local_mcp_registry=local_mcp_registry or _registry_over({}),
     )
+
+
+def _registry_over(servers: dict) -> LocalMCPRegistry:
+    """A REAL registry over a temp catalog, so these tests exercise its actual
+    normalization (flat ``command``/``args``/``env`` → ``stdioConfigs`` with
+    ``arguments``/``envVariables``) rather than a mock's idea of it."""
+    path = Path(tempfile.mkdtemp()) / "local-mcp-servers.yaml"
+    path.write_text(yaml.safe_dump({"servers": servers}), encoding="utf-8")
+    return LocalMCPRegistry(path)
 
 
 def _factory_returning(svc):
@@ -122,6 +139,133 @@ def test_mcps_run_collect_then_per_server_merge():
     assert inputs[0].endpoint_env == "PROD"
     assert inputs[0].transport_protocol == "http"
     assert mcp_cfg.build_mcp_sync_payload.call_count == 2
+
+
+_HITL_CATALOG = {
+    "hitl": {
+        "command": "python3",
+        "args": ["/home/admin/hitl/hitl_mcp_server.py"],
+        "env": {"MCP_TRANSPORT": "stdio"},
+    }
+}
+
+
+def _mcps_with(servers, *, center_detail, registry_catalog):
+    """Run ``mcps()`` over one collected server code, with the given Center reply."""
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = servers
+    svc.mcp_center.get_mcp_detail.return_value = center_detail
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+    return _collector(
+        skill_set_service=svc,
+        mcp_config_service=mcp_cfg,
+        local_mcp_registry=_registry_over(registry_catalog),
+    ).mcps(_req())
+
+
+@pytest.mark.unit
+def test_mcps_resolve_stdio_launch_from_registry():
+    """A server in the local registry arrives at the composer as the local form.
+
+    Also pins the key-name translation: the registry normalizes to
+    ``arguments``/``envVariables``, the compose input speaks ``args``/``env``.
+    """
+    inputs = _mcps_with(
+        [{"server_code": "hitl"}], center_detail=None, registry_catalog=_HITL_CATALOG
+    )
+
+    assert inputs[0].stdio == StdioLaunch(
+        command="python3",
+        args=["/home/admin/hitl/hitl_mcp_server.py"],
+        env={"MCP_TRANSPORT": "stdio"},
+    )
+
+
+@pytest.mark.unit
+def test_mcps_resolve_stdio_launch_when_center_lookup_fails():
+    """The registry is consulted even when enrichment gives us nothing.
+
+    This is the whole reason classification lives here rather than reading
+    ``run_mode`` downstream: MCP Center is best-effort, and a local server has no
+    endpoint, so a Center outage must not turn it into a remote entry that then
+    fails compose outright.
+    """
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": "hitl"}]
+    svc.mcp_center.get_mcp_detail.side_effect = RuntimeError("center down")
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+
+    inputs = _collector(
+        skill_set_service=svc,
+        mcp_config_service=mcp_cfg,
+        local_mcp_registry=_registry_over(_HITL_CATALOG),
+    ).mcps(_req())
+
+    assert inputs[0].stdio is not None
+    assert inputs[0].stdio.command == "python3"
+
+
+@pytest.mark.unit
+def test_mcps_center_remote_wins_over_colliding_registry_name():
+    """A caller's own REMOTE server is not hijacked by a same-named local entry.
+
+    The bundled catalog ships ``hitl``/``clawmind``; a deployment may legitimately
+    register a remote server under one of those codes. Center positively reporting
+    REMOTE settles it — otherwise the entry would be rewritten into a launch
+    command for a binary that deployment's image need not even contain.
+    """
+    inputs = _mcps_with(
+        [{"server_code": "hitl"}],
+        center_detail={"serverCode": "hitl", "runMode": "REMOTE",
+                       "endpoints": [{"env": "PROD", "networkType": "INTERNET",
+                                      "transportProtocol": "STREAMABLE_HTTP",
+                                      "url": "https://byo.example/hitl"}]},
+        registry_catalog=_HITL_CATALOG,
+    )
+
+    assert inputs[0].stdio is None
+    assert inputs[0].mcp_data["endpoints"][0]["url"] == "https://byo.example/hitl"
+
+
+@pytest.mark.unit
+def test_mcps_remote_server_absent_from_registry_has_no_stdio():
+    inputs = _mcps_with(
+        [{"server_code": "dima"}], center_detail=None, registry_catalog=_HITL_CATALOG
+    )
+
+    assert inputs[0].stdio is None
+
+
+@pytest.mark.unit
+def test_mcps_registry_entry_without_command_yields_no_launch():
+    """An unlaunchable catalog entry must not produce a half-formed local entry.
+
+    Better to fall through to the remote path — which raises naming the registry —
+    than to publish a stdio entry the engine cannot act on.
+    """
+    inputs = _mcps_with(
+        [{"server_code": "broken"}],
+        center_detail=None,
+        registry_catalog={"broken": {"args": ["--x"]}},
+    )
+
+    assert inputs[0].stdio is None
+
+
+@pytest.mark.unit
+def test_mcps_fall_back_to_collected_stdio_configs_when_registry_empty():
+    """With no registry entry, a ``stdioConfigs`` carried on the collected dict
+    still resolves — the registry is the preferred source, not the only one."""
+    inputs = _mcps_with(
+        [{"server_code": "fs"}],
+        center_detail={"serverCode": "fs", "runMode": "LOCAL",
+                       "stdioConfigs": [{"command": "node", "arguments": ["/srv.js"]}]},
+        registry_catalog={},
+    )
+
+    assert inputs[0].stdio == StdioLaunch(command="node", args=["/srv.js"], env={})
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
+++ b/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
@@ -6,13 +6,15 @@ from dataclasses import asdict
 
 import pytest
 
-from agentclaw.community.core.config_compose.models import McpComposeInput
+from agentclaw.community.core.config_compose.models import McpComposeInput, StdioLaunch
 from agentclaw.community.core.config_compose.services.mcporter_composer import (
+    STDIO_TRANSPORT,
     TECLAW_MCP_NETWORK_PRIORITY,
     McporterComposeError,
     McporterComposer,
     mcp_network_priority_for,
 )
+from agentclaw.community.kernel.bot_config import StdioSpec
 
 
 SECRET_TOKEN = "supersecrettoken-inlined-123"
@@ -159,34 +161,73 @@ def test_no_matching_env_endpoint_raises() -> None:
         composer.compose_server(McpComposeInput(mcp_data=md, endpoint_env="PROD"))
 
 
-def test_local_stdio_raises_as_unmodeled() -> None:
+def test_local_without_resolved_launch_raises_naming_the_registry() -> None:
+    """A LOCAL entry that arrives with no ``stdio`` cannot be composed either way.
+
+    It has no endpoint to select (local servers have none), so the failure must
+    name the real cause — the local-MCP registry had no entry — rather than the
+    endpoint error that would send a reader hunting in MCP Center.
+    """
     composer = McporterComposer()
     md = {"server_code": "fs", "run_mode": "LOCAL", "stdio_configs": [{"command": "node"}]}
-    with pytest.raises(McporterComposeError):
+
+    with pytest.raises(McporterComposeError, match="local-MCP registry"):
         composer.compose_server(McpComposeInput(mcp_data=md))
 
 
-def test_compose_skips_local_stdio_servers() -> None:
+def test_compose_emits_local_stdio_servers() -> None:
+    """LOCAL servers ride the artifact as ``stdio`` entries, no longer dropped."""
     composer = McporterComposer()
     manifest = composer.compose(
         [
             McpComposeInput(mcp_data=_remote_mcp("remote"), endpoint_env="PROD"),
             McpComposeInput(
-                mcp_data={
-                    "server_code": "hitl",
-                    "runMode": "LOCAL",
-                    "stdioConfigs": [
-                        {
-                            "command": "python3",
-                            "arguments": ["/home/admin/hitl/hitl_mcp_server.py"],
-                        }
-                    ],
-                }
+                mcp_data={"server_code": "hitl", "runMode": "LOCAL"},
+                stdio=StdioLaunch(
+                    command="python3",
+                    args=["/home/admin/hitl/hitl_mcp_server.py"],
+                    env={"MCP_TRANSPORT": "stdio"},
+                ),
             ),
         ]
     )
 
-    assert [s.server_code for s in manifest.servers] == ["remote"]
+    assert [s.server_code for s in manifest.servers] == ["remote", "hitl"]
+
+    local = manifest.servers[1]
+    assert local.transport == STDIO_TRANSPORT
+    assert local.stdio == StdioSpec(
+        command="python3",
+        args=["/home/admin/hitl/hitl_mcp_server.py"],
+        env={"MCP_TRANSPORT": "stdio"},
+    )
+    # The local form carries no remote fields — a stdio child needs no endpoint
+    # and has nothing to authenticate against.
+    assert local.endpoint is None
+    assert local.headers == {}
+
+
+def test_local_stdio_ignores_credentials_rather_than_inlining_them() -> None:
+    """Credentials on a LOCAL input are dropped, not smuggled into the entry.
+
+    ``build_mcp_sync_payload`` merges a user's stored config for every server
+    regardless of run mode, so a local entry can arrive carrying an api_key. There
+    is no endpoint to append it to and no request to sign, so it must not survive
+    into the published artifact.
+    """
+    composer = McporterComposer()
+    manifest = composer.compose(
+        [
+            McpComposeInput(
+                mcp_data={"server_code": "hitl", "runMode": "LOCAL"},
+                api_key=f"authorization={SECRET_TOKEN}",
+                headers={"x-ling-auth": SECRET_TOKEN},
+                stdio=StdioLaunch(command="python3"),
+            )
+        ]
+    )
+
+    assert SECRET_TOKEN not in _manifest_json(manifest)
 
 
 def test_missing_server_code_raises() -> None:

--- a/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
+++ b/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
@@ -236,17 +236,19 @@ def test_missing_server_code_raises() -> None:
         composer.compose_server(McpComposeInput(mcp_data={"name": "x"}))
 
 
-def test_no_endpoints_at_all_blames_the_lookup_not_the_networks() -> None:
-    """An entry with zero endpoints means its detail was never resolved.
+def test_no_endpoints_reports_only_what_this_layer_can_observe() -> None:
+    """Zero endpoints must not be reported as "the detail was never resolved".
 
-    Blaming network coverage here would send the reader auditing MCP Center for a
-    record that was never fetched. The collector fails this case earlier now, so
-    this is a backstop — but it still has to name the right suspect.
+    Both a failed lookup and a record Center genuinely holds but has published no
+    endpoints for arrive here as an empty list, and this frame cannot tell them
+    apart. Naming either cause would misdirect for the other, so the message
+    stays with the fact — no endpoints — and points at the server's published
+    endpoints rather than at the lookup.
     """
     composer = McporterComposer()
-    md = {"server_code": "unresolved", "run_mode": "REMOTE", "endpoints": []}
+    md = {"server_code": "no-endpoints", "run_mode": "REMOTE", "endpoints": []}
 
-    with pytest.raises(McporterComposeError, match="declares no endpoints at all"):
+    with pytest.raises(McporterComposeError) as excinfo:
         composer.compose_server(
             McpComposeInput(
                 mcp_data=md,
@@ -254,6 +256,9 @@ def test_no_endpoints_at_all_blames_the_lookup_not_the_networks() -> None:
                 network_priority=TECLAW_MCP_NETWORK_PRIORITY,
             )
         )
+
+    assert "carries no endpoints at all" in str(excinfo.value)
+    assert "never resolved" not in str(excinfo.value)
 
 
 def test_endpoints_present_but_unreachable_blames_the_networks() -> None:

--- a/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
+++ b/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
@@ -236,6 +236,52 @@ def test_missing_server_code_raises() -> None:
         composer.compose_server(McpComposeInput(mcp_data={"name": "x"}))
 
 
+def test_selected_endpoint_without_a_url_raises() -> None:
+    """A remote entry with no URL gives the engine nothing to connect to.
+
+    Selection can pick a record that matched on network/env but carries no
+    ``url``; composing it produced ``endpoint: null``, deferring the discovery to
+    whoever tried to call the server. It fails at compose instead, naming the
+    record that was chosen.
+    """
+    composer = McporterComposer()
+    md = {
+        "server_code": "urlless",
+        "run_mode": "REMOTE",
+        "endpoints": [
+            {"networkType": "OFFICE", "env": "PROD",
+             "transportProtocol": "STREAMABLE_HTTP"},  # no url
+        ],
+    }
+
+    with pytest.raises(McporterComposeError, match="carries no url"):
+        composer.compose_server(
+            McpComposeInput(
+                mcp_data=md,
+                endpoint_env="PROD",
+                network_priority=TECLAW_MCP_NETWORK_PRIORITY,
+            )
+        )
+
+
+def test_selected_endpoint_without_a_url_raises_on_the_legacy_path() -> None:
+    """Same guard on the non-priority selector other engines still use."""
+    composer = McporterComposer()
+    md = {
+        "server_code": "urlless",
+        "run_mode": "REMOTE",
+        "endpoints": [
+            {"networkType": "INTERNET", "env": "PROD",
+             "transportProtocol": "STREAMABLE_HTTP"},  # no url
+        ],
+    }
+
+    with pytest.raises(McporterComposeError, match="carries no url"):
+        composer.compose_server(
+            McpComposeInput(mcp_data=md, endpoint_env="PROD")
+        )
+
+
 def test_no_endpoints_reports_only_what_this_layer_can_observe() -> None:
     """Zero endpoints must not be reported as "the detail was never resolved".
 

--- a/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
+++ b/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
@@ -236,6 +236,49 @@ def test_missing_server_code_raises() -> None:
         composer.compose_server(McpComposeInput(mcp_data={"name": "x"}))
 
 
+def test_no_endpoints_at_all_blames_the_lookup_not_the_networks() -> None:
+    """An entry with zero endpoints means its detail was never resolved.
+
+    Blaming network coverage here would send the reader auditing MCP Center for a
+    record that was never fetched. The collector fails this case earlier now, so
+    this is a backstop — but it still has to name the right suspect.
+    """
+    composer = McporterComposer()
+    md = {"server_code": "unresolved", "run_mode": "REMOTE", "endpoints": []}
+
+    with pytest.raises(McporterComposeError, match="declares no endpoints at all"):
+        composer.compose_server(
+            McpComposeInput(
+                mcp_data=md,
+                endpoint_env="PROD",
+                network_priority=TECLAW_MCP_NETWORK_PRIORITY,
+            )
+        )
+
+
+def test_endpoints_present_but_unreachable_blames_the_networks() -> None:
+    """The genuinely misconfigured case keeps pointing at network coverage, and
+    reports how many endpoints were rejected so the gap is diagnosable."""
+    composer = McporterComposer()
+    md = {
+        "server_code": "wrong-net",
+        "run_mode": "REMOTE",
+        "endpoints": [
+            {"networkType": "DEVNET", "env": "PROD",
+             "transportProtocol": "STREAMABLE_HTTP", "url": "https://dev/x"},
+        ],
+    }
+
+    with pytest.raises(McporterComposeError, match="declares 1 endpoint"):
+        composer.compose_server(
+            McpComposeInput(
+                mcp_data=md,
+                endpoint_env="PROD",
+                network_priority=TECLAW_MCP_NETWORK_PRIORITY,
+            )
+        )
+
+
 def test_compose_builds_manifest_for_multiple_servers() -> None:
     composer = McporterComposer()
     manifest = composer.compose(

--- a/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
+++ b/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
@@ -147,6 +147,34 @@ def test_default_config_path_loads_repo_hitl_config():
     assert by_engine[None]["arguments"] == ["/home/admin/hitl/hitl_mcp_server.py"]
 
 
+def test_shipped_multi_variant_servers_put_the_engine_agnostic_entry_first():
+    """Every shipped ``stdioConfigs`` list must lead with its engine-agnostic entry.
+
+    The teclaw compose path selects by ``engineType`` and does not care about
+    order, but the arca/baas device path — ``convert_to_device_format`` in the
+    corp-side ``plugins/prod/mcp_device_payload`` — does
+    ``stdio_configs[0]`` with no ``engineType`` awareness. Whatever sits first is
+    therefore what every non-teclaw container is told to launch, and a
+    teclaw-specific entry in that slot hands them a path their image does not
+    carry.
+
+    That consumer is not in this repo, so nothing else here would catch a
+    reorder. This test is the guard.
+    """
+    registry = LocalMCPRegistry()
+
+    for detail in registry.list_mcp_details():
+        configs = detail.get("stdioConfigs") or []
+        if len(configs) < 2:
+            continue  # single-entry lists cannot pick the wrong default
+        first = configs[0]
+        assert not (first.get("engineType") or first.get("engine_type")), (
+            f"{detail['serverCode']}: stdioConfigs[0] is engine-specific "
+            f"({first.get('engineType')!r}). The arca/baas device path takes "
+            "index 0 blindly — the engine-agnostic entry must come first."
+        )
+
+
 def test_default_config_path_loads_repo_clawmind_config():
     detail = LocalMCPRegistry().get_mcp_detail("clawmind")
 

--- a/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
+++ b/src/backend/tests/community/core/mcp/services/test_local_mcp_registry.py
@@ -125,11 +125,26 @@ def test_environment_variable_is_ignored(monkeypatch, tmp_path):
 
 
 def test_default_config_path_loads_repo_hitl_config():
+    """``hitl`` carries one launch instruction per engine layout.
+
+    Asserted by ``engineType`` rather than by position: the entries are a set of
+    variants that a consumer selects from, so nothing may depend on their order.
+    """
     detail = LocalMCPRegistry().get_mcp_detail("hitl")
 
     assert detail is not None
-    assert detail["stdioConfigs"][0]["command"] == "python3"
-    assert detail["stdioConfigs"][0]["arguments"] == ["/home/admin/hitl/hitl_mcp_server.py"]
+    by_engine = {
+        cfg.get("engineType"): cfg for cfg in detail["stdioConfigs"]
+    }
+
+    # teclaw ships the server under /usr/local/bin …
+    assert by_engine["teclaw"]["command"] == "python3"
+    assert by_engine["teclaw"]["arguments"] == [
+        "/usr/local/bin/teclaw_hitl_mcp_server.py"
+    ]
+    # … and the engine-agnostic entry (no engineType) covers everyone else.
+    assert by_engine[None]["command"] == "python3"
+    assert by_engine[None]["arguments"] == ["/home/admin/hitl/hitl_mcp_server.py"]
 
 
 def test_default_config_path_loads_repo_clawmind_config():

--- a/src/backend/tests/community/kernel/test_bot_config_artifact.py
+++ b/src/backend/tests/community/kernel/test_bot_config_artifact.py
@@ -20,6 +20,7 @@ from agentclaw.community.kernel.bot_config import (
     McpServerRef,
     ResourceRef,
     SkillRef,
+    StdioSpec,
     StoreRef,
 )
 
@@ -32,6 +33,41 @@ _SCHEMA_PATH = (
     / "bot_config"
     / "artifact.schema.json"
 )
+
+
+def test_remote_entry_omits_the_stdio_key_entirely() -> None:
+    """An artifact with no local server keeps its pre-``stdio`` wire shape.
+
+    ``asdict`` would emit ``"stdio": null`` on every remote entry, changing the
+    bytes of artifacts that never use the new form — and a consumer validating
+    those against the pre-``stdio`` definition (``additionalProperties: false``)
+    would reject them. Only artifacts that genuinely carry a local server may
+    differ.
+    """
+    artifact = _sample_artifact()
+    entry = artifact.to_dict()["mcp"]["servers"][0]
+
+    assert "stdio" not in entry
+    assert set(entry) == {"server_code", "name", "endpoint", "transport", "headers"}
+
+
+def test_local_entry_keeps_its_stdio_key() -> None:
+    artifact = BotConfigArtifact(
+        schema_version=SCHEMA_VERSION,
+        engine_type="teclaw",
+        mcp=McpManifest(
+            servers=[
+                McpServerRef(
+                    server_code="hitl",
+                    transport="stdio",
+                    stdio=StdioSpec(command="python3", args=["/a.py"]),
+                )
+            ]
+        ),
+    )
+    entry = artifact.to_dict()["mcp"]["servers"][0]
+
+    assert entry["stdio"] == {"command": "python3", "args": ["/a.py"], "env": {}}
 
 
 def _sample_artifact() -> BotConfigArtifact:

--- a/src/backend/tests/community/kernel/test_bot_config_artifact.py
+++ b/src/backend/tests/community/kernel/test_bot_config_artifact.py
@@ -41,10 +41,14 @@ def _sample_artifact() -> BotConfigArtifact:
         version=7,
         mcp=McpManifest(
             servers=[
+                # "http" — not "STREAMABLE_HTTP". That is MCP Center's endpoint
+                # vocabulary; ``McporterComposer._select_endpoint`` maps it onto
+                # the artifact's own transport values ("http" / "sse"), which are
+                # what the discriminator in the schema enumerates.
                 McpServerRef(
                     server_code="mcp.ant.faas.xxx",
                     endpoint="https://example/mcp",
-                    transport="STREAMABLE_HTTP",
+                    transport="http",
                     headers={"x-ling-auth": "ak-antchat-inlined"},
                 )
             ]


### PR DESCRIPTION
## Problem

LOCAL/stdio MCP servers could not reach an engine that boots from the whole composed artifact. `McpServerRef` modelled only the remote form (endpoint + headers), so `McporterComposer.compose` skipped every LOCAL entry outright. arca/baas were unaffected — they deliver MCP incrementally over `/api/mcp` — but teclaw is artifact-only, so `hitl` and `clawmind` were structurally unreachable there.

The local-vs-remote decision also sat in the wrong place. `_is_local_stdio` read `run_mode` off the enriched dict and **defaulted to REMOTE**, while the enrichment that supplies `run_mode` (`_enrich_mcp_detail` → MCP Center) swallowed every failure. On a Center failure a local server was classified remote, sent down the endpoint path, and — having no endpoint, as local servers never do — failed the whole compose with a message blaming network coverage. A local MCP is not a probabilistic risk here: it has no endpoint by construction, so a broken classification always ends in a failed build, reported against the wrong suspect.

## Solution

`McpServerRef` gains a `stdio` launch instruction alongside the remote fields, with `transport` as the discriminator — `"stdio"` for the local form, the existing `"http"` / `"sse"` for the remote one.

```jsonc
// local
{ "server_code": "hitl", "transport": "stdio",
  "stdio": { "command": "python3", "args": ["/home/admin/hitl/hitl_mcp_server.py"], "env": {} } }

// remote — unchanged, and the "stdio" key is omitted entirely
{ "server_code": "...", "transport": "http",
  "endpoint": "https://...?authorization=<tok>", "headers": { "x-ling-auth": "<tok>" } }
```

The schema encodes that exclusivity rather than merely describing it: `mcpServerRef` carries a two-branch `oneOf` — the local branch requires `transport: "stdio"` plus a `stdio` object and forbids endpoint/headers; the remote branch enumerates `http`/`sse` and requires `stdio` to be absent or null. Since this schema is the language-neutral artifact a foreign engine validates and generates against, a half-formed entry is now rejected by validation instead of at launch time.

Classification moves up to the collector, which resolves it into `McpComposeInput.stdio`; the composer branches on that field and stays a pure function of its inputs. Rejected alternative: injecting the registry into the composer, which would have made it stateful and left the "is this local?" question answerable in two places.

The resolution order in `_stdio_launch_for` is deliberate and layered:

1. A `run_mode` of REMOTE settles it immediately. That value only appears when the Center lookup **succeeded**, and Center is authoritative for the servers it carries — so a deployment's own remote server is never hijacked because its `server_code` collides with a bundled name (`hitl`, `clawmind`).
2. Otherwise the launch instruction comes from the **resolved detail first**, and only then from `LocalMCPRegistry`. A deployment that registers its own *local* server under a bundled name likewise keeps its own command instead of the bundled `/home/admin/...` path its image need not contain.
3. The registry is what makes the fallback work when there is nothing to prefer: on a Center failure the dict carries no `stdioConfigs` at all, and a local YAML read needs no network — so a local server stays recognizable exactly when Center cannot vouch for it.

Failures now surface where they happen. `_enrich_mcp_detail` returns the cause instead of logging and dropping it, and the collector raises with it chained once the entry has also failed to resolve as local:

```
RuntimeError: HTTPSConnectionPool: connection refused

The above exception was the direct cause of the following exception:

McporterComposeError: MCP <code>: could not resolve server detail, and it is not a
local server either (the local-MCP registry has no entry for it). MCP Center is
unreachable or holds no record for this code.
```

Deciding this in the collector rather than at the fetch is what makes it correct: Center legitimately has no record of a stdio server, so an empty lookup is only fatal once the registry has also failed. A lookup that succeeds but returns nothing gets its own `McpDetailUnavailableError` cause, keeping "Center is down" and "Center does not know this code" distinguishable. Skipping unresolvable entries was considered and rejected — a silently dropped MCP means the bot boots without a capability its owner configured, which is worse than a loud failure.

Credentials are not inlined into a stdio entry: the child runs inside the engine's own container with no endpoint to authenticate against, so `api_key` / `headers` are dropped rather than smuggled in.

## Validation

- **Full community suite: 11847 passed, 4 skipped.** The 2 deselected `test_bot_build_service_skill_artifact` cases fail identically on a clean tree (no `rsync` binary in this container) and are unrelated to this change.
- Rewrote the cases that encoded superseded behavior (LOCAL raises; LOCAL is skipped; a Center error flows through unchanged) into their replacements.
- Collector coverage drives `_stdio_launch_for` through `mcps()` against a **real** `LocalMCPRegistry` over a temp catalog, so its own flat→`stdioConfigs` normalization is exercised: registry resolution, resolution when Center errors, REMOTE winning over a colliding registry name, a resolved local definition winning over a colliding bundled one, a catalog entry with no command, the `md` fallback, cause-chaining, and `McpDetailUnavailableError` on an empty record.
- Schema-oracle contract suite extended with a bot mixing both MCP forms, plus assertions for the invariants the schema cannot express.
- Discriminator checked against 9 hand-built entries: both valid forms accepted; stdio-without-command, stdio-as-null, remote-with-stdio, stdio-with-endpoint, stdio-with-headers, an unknown transport and an empty command all rejected.
- Architecture guards: 120 passed. `ruff check`: 26 findings, byte-identical before and after — no new ones.

Tightening the schema surfaced a fixture asserting `transport="STREAMABLE_HTTP"` — MCP Center's *endpoint* vocabulary, which `_select_endpoint` maps onto the artifact's own `http`/`sse`. Production never emitted that value; the fixture is corrected.

## Compatibility and risk

**`SCHEMA_VERSION` stays at 4 in this PR, deliberately** — see [the discussion on that thread](https://github.com/inclusionAI/Avernet/pull/1083#discussion_r3791998869). Nothing in this backend reads it, so the bump is purely an outbound signal, and publishing 5 before the engine's parser knows it would break *every* artifact, including the overwhelming majority that carry no stdio entry. The bump lands as its own commit, with compatibility coverage, once the engine owner confirms.

That position depends on remote-only artifacts being genuinely unchanged, which took a fix to make true: `to_dict` goes through `asdict`, so the new field was serializing as `"stdio": null` on *every* entry — enough for a consumer validating the pre-`stdio` definition (`additionalProperties: false`) to reject ordinary remote artifacts. `to_dict` now omits the key when it is `None`, verified by validating a remote-only artifact against a reconstructed pre-`stdio` schema.

- New fields are **appended**, so positional construction and the `asdict` key order feeding the published bytes and their content digest are unchanged.
- A remote-only artifact keeps exactly its five prior keys per entry; only artifacts carrying a local server differ from v4 output, and today none do (`get_default_mcp_servers("teclaw")` returns `[]`).
- Artifacts written before this change deserialize unchanged — absent or null `stdio` reads as `None`, covered by a round-trip assertion.

Rollback is a plain revert: with no stdio entries in play the composer's output is byte-identical to before.

## Related work

This is the backend half of stdio MCP support. The runtime half — the engine image carrying the interpreters and the engine spawning/supervising the child processes — is owned by the teclaw team, and the two halves are interlocked: neither is useful alone.

Independently of stdio, this also unblocks landing a teclaw entry in `_DEFAULT_MCP_SERVERS_BY_ENGINE`: every server in that list is composed on every teclaw publish, so a transient Center failure previously surfaced as a confusing endpoint error against an arbitrary server.

Still open, tracked separately: whether `local-mcp-servers.yaml` needs a per-engine dimension. Its `command`/`args` are a single hardcoded value, so if teclaw's image lays these binaries out differently from openclaw's, the same `server_code` cannot yet express two launch instructions. `_first_stdio_config` takes the first `stdioConfigs` entry and says so.