### PR TITLE
feat(baas): add Aliyun ACK-backed Arca sandbox plugin

### DIFF
--- a/src/baas/src/secbaas/community/bootstrap/_configs.py
+++ b/src/baas/src/secbaas/community/bootstrap/_configs.py
@@ -183,7 +183,9 @@ class SandboxPluginConfig(BaseSettings):
     """
 
     model_config = _CFG
-    arca: str = Field(default="stub", pattern=r"^(arca_sdk|stub)$")
+    arca: str = Field(
+        default="stub", pattern=r"^(arca_sdk|stub|local_proc|aliyun_ack)$"
+    )
     desktop: str = Field(default="stub", pattern=r"^(real|stub)$")
     teclaw: str = Field(default="stub", pattern=r"^(real|stub)$")
     k8s: str = Field(default="stub", pattern=r"^(real|stub)$")

--- a/src/baas/src/secbaas/community/bootstrap/plugins/_plugin_core.py
+++ b/src/baas/src/secbaas/community/bootstrap/plugins/_plugin_core.py
@@ -29,7 +29,14 @@ from secbaas.community.plugins.cache.stub import StubCachePlugin
 from secbaas.community.plugins.database.mariadb.mariadb_orm import MariaDbOrmPlugin
 from secbaas.community.plugins.database.sqlite.sqlite_orm import SqliteOrmPlugin
 from secbaas.community.plugins.file_transfer import NoopFileTransferBackend
-from secbaas.community.plugins.sandbox.arca import StubArcaSandboxPlugin
+from secbaas.community.plugins.sandbox.arca import (
+    AliyunAckSandboxPlugin,
+    StubArcaSandboxPlugin,
+)
+from secbaas.community.plugins.sandbox.arca.aliyun_ack import (
+    AliyunAckTemplateConfig,
+    build_aliyun_ack_template,
+)
 from secbaas.community.plugins.sandbox.arca.local_proc import (
     LocalProcessArcaSandboxPlugin,
 )
@@ -51,6 +58,17 @@ from secbaas.community.plugins.sandbox.teclaw import StubTeClawBotPlugin
 from secbaas.community.plugins.sandbox.utils.arca_utils import ArcaUtils
 from secbaas.community.plugins.secret import AliyunKmsSecretStorePlugin
 from secbaas.community.plugins.secret.stub import StubSecretStorePlugin
+
+
+def _build_aliyun_ack_templates(
+    raw_templates: dict | None,
+) -> dict[str, AliyunAckTemplateConfig]:
+    """Build the typed AliyunAckTemplateConfig map from the DI config dict."""
+    out = {}
+    for ack_id, raw in (raw_templates or {}).items():
+        if isinstance(raw, dict):
+            out[ack_id] = build_aliyun_ack_template(ack_id, raw)
+    return out
 
 
 class PluginContainer(containers.DeclarativeContainer):
@@ -89,10 +107,20 @@ class PluginContainer(containers.DeclarativeContainer):
         stub=providers.Singleton(StubAuthPlugin),
     )
 
+    arca_ack_templates_map = providers.Callable(
+        _build_aliyun_ack_templates,
+        raw_templates=config.aliyun_ack_template,
+    )
+
     arca_sandbox_plugin_factory = providers.Selector(
         config.plugins.sandbox.arca,
         stub=providers.Object(StubArcaSandboxPlugin),
         local_proc=providers.Object(LocalProcessArcaSandboxPlugin),
+        aliyun_ack=providers.Factory(
+            AliyunAckSandboxPlugin,
+            ack_templates=arca_ack_templates_map,
+            arca_utils=arca_utils,
+        ),
     )
 
     desktop_sandbox_plugin = providers.Selector(

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/__init__.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/__init__.py
@@ -1,12 +1,20 @@
-"""Arca sandbox plugin — stub and local implementations.
+"""Arca sandbox plugin — stub, local, and Aliyun ACK implementations.
 
 ArcaSdkSandbox and ArcaSdkSandboxPlugin are in secbaas.enterprise.
 """
 
 from ._stub import StubArcaSandbox, StubArcaSandboxPlugin
+from .aliyun_ack import (
+    AliyunAckClientManager,
+    AliyunAckSandbox,
+    AliyunAckSandboxPlugin,
+)
 from .local_proc import LocalProcessArcaSandbox, LocalProcessArcaSandboxPlugin
 
 __all__ = [
+    "AliyunAckClientManager",
+    "AliyunAckSandbox",
+    "AliyunAckSandboxPlugin",
     "LocalProcessArcaSandbox",
     "LocalProcessArcaSandboxPlugin",
     "StubArcaSandbox",

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/_stub.py
@@ -20,7 +20,11 @@ from secbaas.community.api.device_manage import (
     Storage,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
+from secbaas.community.spi.sandbox.arca import (
+    ArcaSandbox,
+    ArcaSandboxInfo,
+    ArcaSandboxPlugin,
+)
 
 if TYPE_CHECKING:
     from secbaas.community.api.device_manage import ArcaCredentials
@@ -28,20 +32,26 @@ if TYPE_CHECKING:
 logger = get_logger("plugin-sandbox")
 
 
-class StubSandboxInfo:
-    """Mimics the Arca SDK SandboxInfo object returned by SyncSandbox.get_info()."""
+class StubSandboxInfo(ArcaSandboxInfo):
+    """Backward-compatible alias of :class:`~secbaas.community.spi.sandbox.arca.ArcaSandboxInfo`.
+
+    Retained so existing imports and ``isinstance`` checks keep working. Offers the same
+    attribute surface as the unified model.
+    """
 
     def __init__(self, sandbox_id: str, template_id: str) -> None:
-        self.sandbox_id = sandbox_id
-        self.status = "RUNNING"
-        self.template_id = template_id
-        self.resources = None
-        self.ttl_in_minutes = None
-        self.ttl_timestamp = None
-        self.envs = None
-        self.snapshot_id = None
-        self.metadata = None
-        self.outbound_operation_rule = None
+        super().__init__(
+            sandbox_id=sandbox_id,
+            status="RUNNING",
+            template_id=template_id,
+            resources=None,
+            ttl_in_minutes=None,
+            ttl_timestamp=None,
+            envs=None,
+            snapshot_id=None,
+            metadata=None,
+            outbound_operation_rule=None,
+        )
 
 
 class StubArcaSandbox(ArcaSandbox):
@@ -59,7 +69,7 @@ class StubArcaSandbox(ArcaSandbox):
     def sandbox_id(self) -> str:
         return self._sandbox_id
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         return StubSandboxInfo(self._sandbox_id, self._template_id)
 
     def destroy(self) -> Any:

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/__init__.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/__init__.py
@@ -1,0 +1,14 @@
+"""Aliyun ACK Arca sandbox plugin — Aliyun ACK managed Kubernetes backend."""
+
+from ._client_manager import AliyunAckClientManager
+from ._config_type import AliyunAckTemplateConfig, build_aliyun_ack_template
+from ._sandbox import AliyunAckSandbox
+from ._sandbox_plugin import AliyunAckSandboxPlugin
+
+__all__ = [
+    "AliyunAckClientManager",
+    "AliyunAckSandbox",
+    "AliyunAckSandboxPlugin",
+    "AliyunAckTemplateConfig",
+    "build_aliyun_ack_template",
+]

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_client_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_client_manager.py
@@ -21,7 +21,7 @@ from secbaas.community.logger import get_logger
 if TYPE_CHECKING:
     from kubernetes.client import ApiClient
 
-logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+logger = get_logger("plugin-sandbox")
 
 
 class AliyunAckClusterConfigLike(Protocol):

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_client_manager.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_client_manager.py
@@ -1,0 +1,118 @@
+"""Aliyun ACK ApiClient lifecycle manager.
+
+Provides thread-safe lazy-init of a Kubernetes ApiClient for an Aliyun ACK
+managed cluster, built from the resolved ``AliyunAckTemplateConfig.cluster``
+connection. All Kubernetes SDK calls are isolated behind this factory so unit
+tests can inject a mock client.
+
+An ACK cluster exposes a standard Kubernetes API server and ships an inline
+``kubeconfig`` (downloadable from the Aliyun console/CLI) for authentication, so
+the existing ``kubernetes`` SDK is reused. Construction fails fast when no
+kubeconfig is configured.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Protocol
+
+from secbaas.community.logger import get_logger
+
+if TYPE_CHECKING:
+    from kubernetes.client import ApiClient
+
+logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+
+
+class AliyunAckClusterConfigLike(Protocol):
+    """Cluster connection surface required to build an ACK ApiClient."""
+
+    endpoint: str
+    region: str
+    cluster_name: str
+    kubeconfig: str
+    context: str
+    access_key_id: str
+    access_key_secret: str
+
+
+class AliyunAckClientManager:
+    """Thread-safe Aliyun ACK ApiClient lifecycle manager.
+
+    Lazily initializes one ApiClient from an inline ACK ``kubeconfig`` and reuses
+    it across operations. Construction fails fast when the required kubeconfig
+    is missing.
+    """
+
+    def __init__(self, cluster: AliyunAckClusterConfigLike | None = None) -> None:
+        """Initialize the manager with the given Aliyun ACK cluster config.
+
+        Args:
+            cluster: The resolved Aliyun ACK cluster connection.
+
+        Raises:
+            ValueError: If the ACK configuration is missing the kubeconfig.
+        """
+        self._cluster = cluster
+        self._lock = threading.Lock()
+        self._client: ApiClient | None = None
+
+    def _validate_config(self) -> None:
+        """Fail fast on invalid or incomplete ACK configuration.
+
+        Requires an inline ``kubeconfig`` for the ACK cluster.
+
+        Raises:
+            ValueError: If no kubeconfig is configured.
+        """
+        if self._cluster is None or not getattr(self._cluster, "kubeconfig", None):
+            raise ValueError(
+                "AliyunAckClientManager requires a cluster config with an inline "
+                "kubeconfig to connect to the Aliyun ACK cluster"
+            )
+
+    def validate(self) -> None:
+        """Public validation of the ACK configuration (fail fast)."""
+        self._validate_config()
+
+    def build_client(self) -> ApiClient:
+        """Build a Kubernetes ApiClient from the ACK inline kubeconfig.
+
+        Mirror of the repo's existing K8s plugin consumption pattern:
+        kubeconfig string -> yaml.safe_load ->
+        ``new_client_from_config_dict(config_dict, context=..., persist_config=False)``.
+        """
+        self._validate_config()
+        import yaml
+        from kubernetes import config as k8s_config
+
+        kubeconfig_dict = yaml.safe_load(self._cluster.kubeconfig)
+        return k8s_config.new_client_from_config_dict(
+            config_dict=kubeconfig_dict,
+            context=self._cluster.context or None,
+            persist_config=False,
+        )
+
+    def get_client(self) -> ApiClient:
+        """Return a lazily-initialized, thread-safe ApiClient (cached)."""
+        with self._lock:
+            if self._client is None:
+                self._client = self.build_client()
+                logger.info(
+                    "Created new Aliyun ACK ApiClient (cluster=%s)",
+                    self._cluster.cluster_name
+                    or getattr(self._cluster, "endpoint", None)
+                    or "default",
+                )
+            return self._client
+
+    def close(self) -> None:
+        """Close the cached ApiClient connection pool, if any."""
+        with self._lock:
+            if self._client is not None:
+                try:
+                    self._client.close()
+                except Exception:
+                    logger.warning("Error closing Aliyun ACK ApiClient", exc_info=True)
+                self._client = None
+                logger.info("AliyunAckClientManager closed its ApiClient")

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_config_type.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_config_type.py
@@ -1,0 +1,84 @@
+"""Aliyun ACK template (second template kind) configuration.
+
+The Aliyun ACK backend uses a **two-template model**:
+- the ARCA **device template** (`baas_device_template`, ``ArcaTemplateConfig``)
+  carries exactly the ``ArcaCredentials`` surface (including ``arca_template_id``);
+- the **Aliyun ACK template** holds all the Aliyun ACK / Pod runtime config,
+  keyed by an ``ALIYUN_ACK_TEMPLATE_xxx`` id.
+
+The ACK template id (``ALIYUN_ACK_TEMPLATE_ID``) is carried in the device
+template's ``arca_template_id`` field. When the arca selector is ``aliyun_ack``,
+the plugin resolves the ``AliyunAckTemplateConfig`` for that id from
+``application.yaml`` (loaded by the DI ``ConfigLoader``) and uses it to build
+the Kubernetes client and the Pod spec.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AliyunAckClusterConfig(BaseModel):
+    """Aliyun ACK cluster connection. Secret values come from env references,
+    never hard-coded."""
+
+    model_config = ConfigDict(extra="allow")
+
+    endpoint: str = Field(default="", description="ACK API server endpoint")
+    region: str = Field(default="", description="Aliyun region")
+    cluster_name: str = Field(default="", description="ACK cluster name")
+    kubeconfig: str = Field(
+        default="", description="Inline kubeconfig YAML for cluster authentication"
+    )
+    context: str = Field(default="", description="kubeconfig context name")
+    access_key_id: str = Field(default="", description="RAM access key id (secret ref)")
+    access_key_secret: str = Field(
+        default="", description="RAM access key secret (secret ref)"
+    )
+
+
+class AliyunAckPodConfig(BaseModel):
+    """Per-template Pod runtime configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    image: str = Field(default="ubuntu:22.04", description="Container image")
+    namespace: str = Field(default="default", description="Target namespace")
+    service_account: str = Field(default="", description="Pod ServiceAccount")
+    cpu_request: str = Field(default="", description="CPU request (e.g. 500m)")
+    cpu_limit: str = Field(default="", description="CPU limit (e.g. 1)")
+    memory_request: str = Field(default="", description="Memory request (e.g. 512Mi)")
+    memory_limit: str = Field(default="", description="Memory limit (e.g. 1Gi)")
+    storage_class: str = Field(default="", description="PVC storage class")
+    envs: dict[str, str] = Field(
+        default_factory=dict, description="Environment variables for the Pod"
+    )
+
+
+class AliyunAckTemplateConfig(BaseModel):
+    """One Aliyun ACK template entry, keyed by ``ALIYUN_ACK_TEMPLATE_xxx``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    template_id: str = Field(
+        ...,
+        description="Aliyun ACK template id (value of the device's arca_template_id)",
+    )
+    cluster: AliyunAckClusterConfig = Field(
+        default_factory=AliyunAckClusterConfig, description="Cluster connection"
+    )
+    pod: AliyunAckPodConfig = Field(
+        default_factory=AliyunAckPodConfig, description="Pod runtime spec"
+    )
+
+
+def build_aliyun_ack_template(template_id: str, raw: dict) -> AliyunAckTemplateConfig:
+    """Build an ``AliyunAckTemplateConfig`` from a raw DI config dict.
+
+    The DI ``Configuration`` yields plain dicts for the
+    ``aliyun_ack_templates`` block; this helper validates/coerces them into the
+    typed model for the plugin.
+    """
+    body = dict(raw or {})
+    body.pop("template_id", None)
+    return AliyunAckTemplateConfig(template_id=template_id, **body)

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from kubernetes.client import ApiClient, CoreV1Api
     from kubernetes.client.rest import ApiException
 
-logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+logger = get_logger("plugin-sandbox")
 
 
 def _import_k8s() -> None:

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
@@ -1,0 +1,234 @@
+"""Aliyun ACK-backed ArcaSandbox implementation.
+
+Wraps an ACK (Aliyun managed Kubernetes) Pod behind the ``ArcaSandbox``
+protocol. All Kubernetes API calls go through the injected ApiClient.
+
+Kubernetes SDK classes are lazily bound to this module so unit tests can patch
+``_sandbox.CoreV1Api`` / ``_sandbox.ApiException`` via ``unittest.mock``.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+from secbaas.community.api.device_manage import (
+    OutBoundOperationRule,
+    OutBoundOperationRuleUpdatedMode,
+)
+from secbaas.community.logger import get_logger
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxInfo
+
+if TYPE_CHECKING:
+    from kubernetes.client import ApiClient, CoreV1Api
+    from kubernetes.client.rest import ApiException
+
+logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+
+
+def _import_k8s() -> None:
+    """Lazily bind Kubernetes SDK classes into this module namespace."""
+    _mod = sys.modules[__name__]
+    if getattr(_mod, "_k8s_loaded", False):
+        return
+    from kubernetes.client import CoreV1Api as _CoreV1Api
+    from kubernetes.client.rest import ApiException as _ApiException
+
+    _mod.CoreV1Api = _CoreV1Api
+    _mod.ApiException = _ApiException
+    _mod._k8s_loaded = True
+
+
+class _ExecResult:
+    """Simple CommandResult-like namespace object."""
+
+    exit_code = 0
+    stdout = ""
+    stderr = ""
+    elapsed_time = 0.0
+
+
+class AliyunAckSandbox(ArcaSandbox):
+    """An Arca-compatible sandbox backed by an ACK Pod.
+
+    Implements the ``ArcaSandbox`` Protocol for ACK-managed Kubernetes sandbox
+    devices. ``get_info()`` returns the unified :class:`ArcaSandboxInfo`.
+    The stable ``sandbox_id`` is the Pod name (not the ephemeral Pod IP).
+    """
+
+    def __init__(
+        self,
+        sandbox_id: str,
+        namespace: str,
+        template_id: str,
+        client: ApiClient,
+        *,
+        pod_name: str | None = None,
+        container_name: str = "sandbox",
+        image: str = "ubuntu:22.04",
+    ) -> None:
+        self._sandbox_id = sandbox_id
+        self._namespace = namespace
+        self._template_id = template_id
+        self._client = client
+        self._pod_name = pod_name or sandbox_id
+        self._container_name = container_name
+        self._image = image
+
+    @property
+    def is_ready(self) -> bool:
+        """Check whether the backing Pod is in the Running phase."""
+        try:
+            info = self.get_info()
+        except Exception:
+            return False
+        return info.status == "Running"
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox_id
+
+    def get_info(self) -> ArcaSandboxInfo:
+        """Extract Pod status into the unified ArcaSandboxInfo."""
+        _import_k8s()
+        try:
+            core_api = CoreV1Api(self._client)
+            pod = core_api.read_namespaced_pod(
+                name=self._pod_name, namespace=self._namespace
+            )
+            status = getattr(pod, "status", None)
+            return ArcaSandboxInfo(
+                sandbox_id=self._sandbox_id,
+                status=getattr(status, "phase", None) or "UNKNOWN",
+                template_id=self._template_id,
+                metadata={
+                    "pod_name": self._pod_name,
+                    "namespace": self._namespace,
+                },
+            )
+        except ApiException as e:
+            raise RuntimeError(
+                f"get_info failed for sandbox {self._sandbox_id} ({e.status})"
+            ) from e
+
+    def destroy(self) -> bool:
+        """Delete the backing Pod. Idempotent on 404."""
+        _import_k8s()
+        logger.info(
+            "[aliyun_ack] destroy sandbox_id=%s pod=%s",
+            self._sandbox_id,
+            self._pod_name,
+        )
+        try:
+            core_api = CoreV1Api(self._client)
+            core_api.delete_namespaced_pod(
+                name=self._pod_name, namespace=self._namespace
+            )
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                logger.info(
+                    "[aliyun_ack] destroy: pod %s already gone (404), idempotent",
+                    self._pod_name,
+                )
+                return True
+            raise RuntimeError(f"destroy failed ({e.status})") from e
+
+    def exec_command(
+        self,
+        cmd: str,
+        timeout_in_millis: int = 30000,
+        envs: dict[str, str] | None = None,
+    ) -> Any:
+        """Execute a command inside the backing ACK Pod via exec."""
+        _import_k8s()
+        logger.info(
+            "[aliyun_ack] exec_command sandbox_id=%s timeout=%d cmd=%s",
+            self._sandbox_id,
+            timeout_in_millis,
+            cmd[:200],
+        )
+        started = time.monotonic()
+        try:
+            core_api = CoreV1Api(self._client)
+            resp = core_api.connect_get_namespaced_pod_exec(
+                name=self._pod_name,
+                namespace=self._namespace,
+                container=self._container_name,
+                command=["/bin/sh", "-c", cmd],
+                stderr=True,
+                stdout=True,
+                stdin=False,
+                tty=False,
+                _preload_content=False,
+            )
+            resp.run_forever(timeout=timeout_in_millis / 1000.0)
+        except ApiException as e:
+            raise RuntimeError(f"exec_command failed ({e.status})") from e
+
+        elapsed = time.monotonic() - started
+        result = _ExecResult()
+        result.exit_code = resp.returncode if resp.returncode is not None else 0
+        result.stdout = resp.read_stdout() or ""
+        result.stderr = resp.read_stderr() or ""
+        result.elapsed_time = elapsed
+        return result
+
+    def update_outbound_rule(
+        self,
+        rule: OutBoundOperationRule,
+        updated_mode: OutBoundOperationRuleUpdatedMode,
+    ) -> Any:
+        """Apply an outbound rule to the backing Pod. Only REPLACE is supported."""
+        if updated_mode != OutBoundOperationRuleUpdatedMode.REPLACE:
+            raise NotImplementedError(
+                "ACK sandbox only supports REPLACE outbound rule updates, "
+                f"got {updated_mode}"
+            )
+        _import_k8s()
+        import json
+
+        annotations = {
+            "avernet.arcasandbox/outbound-rule": json.dumps(
+                rule.model_dump(exclude_none=True)
+                if hasattr(rule, "model_dump")
+                else {}
+            )
+        }
+        try:
+            core_api = CoreV1Api(self._client)
+            core_api.patch_namespaced_pod(
+                name=self._pod_name,
+                namespace=self._namespace,
+                body={
+                    "metadata": {"annotations": annotations},
+                },
+            )
+            return True
+        except ApiException as e:
+            raise RuntimeError(f"update_outbound_rule failed ({e.status})") from e
+
+    def extend_ttl(self, ttl_minutes: int) -> Any:
+        """Extend the Pod TTL annotation by ``ttl_minutes``."""
+        _import_k8s()
+        logger.info(
+            "[aliyun_ack] extend_ttl sandbox_id=%s ttl_minutes=%d",
+            self._sandbox_id,
+            ttl_minutes,
+        )
+        annotations = {
+            "avernet.arcasandbox/ttl-minutes": str(ttl_minutes),
+        }
+        try:
+            core_api = CoreV1Api(self._client)
+            core_api.patch_namespaced_pod(
+                name=self._pod_name,
+                namespace=self._namespace,
+                body={
+                    "metadata": {"annotations": annotations},
+                },
+            )
+            return True
+        except ApiException as e:
+            raise RuntimeError(f"extend_ttl failed ({e.status})") from e

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from kubernetes.client import CoreV1Api
     from kubernetes.client.rest import ApiException
 
-logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+logger = get_logger("plugin-sandbox")
 
 _BOLT_PORT = 20003
 

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -1,0 +1,362 @@
+"""Aliyun ACK-backed Arca sandbox plugin factory."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from secbaas.community.api.bot_runtime import HttpConnectionInfo, WsConnectionInfo
+from secbaas.community.api.device_manage import (
+    ArcaCredentials,
+    MountPoint,
+    OutBoundOperationRule,
+    ResourceSpecification,
+    Storage,
+)
+from secbaas.community.logger import get_logger
+from secbaas.community.plugins.sandbox.utils.arca_utils import ArcaUtils
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
+
+from ._client_manager import AliyunAckClientManager
+from ._config_type import AliyunAckPodConfig, AliyunAckTemplateConfig
+from ._sandbox import AliyunAckSandbox
+
+if TYPE_CHECKING:
+    from kubernetes.client import CoreV1Api
+    from kubernetes.client.rest import ApiException
+
+logger = get_logger("plugin-sandbox-arca-aliyun-ack")
+
+_BOLT_PORT = 20003
+
+
+def _import_k8s() -> None:
+    """Lazily bind Kubernetes SDK classes into this module namespace."""
+    import sys
+
+    _mod = sys.modules[__name__]
+    if getattr(_mod, "_k8s_loaded", False):
+        return
+    from kubernetes.client import CoreV1Api as _CoreV1Api
+    from kubernetes.client.rest import ApiException as _ApiException
+
+    _mod.CoreV1Api = _CoreV1Api
+    _mod.ApiException = _ApiException
+    _mod._k8s_loaded = True
+
+
+def _sanitize_pod_name(name: str) -> str:
+    sanitized = "".join(c if c.isalnum() or c in "-." else "-" for c in name.lower())
+    while "--" in sanitized:
+        sanitized = sanitized.replace("--", "-")
+    return sanitized.strip("-.") or "aliyun-ack-sandbox"
+
+
+def _wait_for_ready(
+    core_api: Any, pod_name: str, namespace: str, ready_timeout_in_seconds: int
+) -> None:
+    deadline = time.monotonic() + ready_timeout_in_seconds
+    while time.monotonic() < deadline:
+        try:
+            pod = core_api.read_namespaced_pod(name=pod_name, namespace=namespace)
+        except Exception as e:  # noqa: BLE001
+            raise RuntimeError(f"failed to read pod {pod_name}: {e}") from e
+        if pod.status and pod.status.phase == "Running":
+            return
+        time.sleep(1.0)
+    raise RuntimeError(
+        f"ACK pod {pod_name} did not become ready within {ready_timeout_in_seconds}s"
+    )
+
+
+def _resource_manifest(pod: AliyunAckPodConfig) -> dict[str, Any] | None:
+    requests = {
+        k: v for k, v in (("cpu", pod.cpu_request), ("memory", pod.memory_request)) if v
+    }
+    limits = {
+        k: v for k, v in (("cpu", pod.cpu_limit), ("memory", pod.memory_limit)) if v
+    }
+    if not requests and not limits:
+        return None
+    manifest: dict[str, Any] = {}
+    if requests:
+        manifest["requests"] = requests
+    if limits:
+        manifest["limits"] = limits
+    return manifest
+
+
+class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
+    """Arca sandbox plugin backed by Aliyun ACK managed Kubernetes."""
+
+    def __init__(
+        self,
+        config: ArcaCredentials | None = None,
+        *,
+        ack_templates: dict[str, AliyunAckTemplateConfig] | None = None,
+        arca_utils: ArcaUtils | None = None,
+    ) -> None:
+        self._config = config
+        self._ack_templates = ack_templates or {}
+        self._arca_utils = arca_utils
+
+    def _resolve_template(self, template_id: str | None) -> AliyunAckTemplateConfig:
+        ack_id = template_id or (
+            self._config.arca_template_id if self._config else None
+        )
+        if not ack_id:
+            raise ValueError(
+                "AliyunAckSandboxPlugin requires an arca_template_id "
+                "(ALIYUN_ACK_TEMPLATE_xxx) to resolve the AliyunAckTemplate"
+            )
+        template = self._ack_templates.get(ack_id)
+        if template is None:
+            raise ValueError(
+                f"No AliyunAckTemplate found for arca_template_id={ack_id!r}"
+            )
+        return template
+
+    def _resolve_default_template(self) -> AliyunAckTemplateConfig:
+        ack_id = self._config.arca_template_id if self._config else None
+        if not ack_id:
+            raise ValueError(
+                "connect_sync_sandbox/delete_storage require an arca_template_id "
+                "(ALIYUN_ACK_TEMPLATE_xxx) to resolve the AliyunAckTemplate"
+            )
+        template = self._ack_templates.get(ack_id)
+        if template is None:
+            raise ValueError(
+                f"No AliyunAckTemplate found for arca_template_id={ack_id!r}"
+            )
+        return template
+
+    def _client_for(self, template: AliyunAckTemplateConfig) -> Any:
+        manager = AliyunAckClientManager(template.cluster)
+        manager.validate()
+        return manager.get_client()
+
+    def _create_pod_and_service(
+        self,
+        pod_name: str,
+        template: AliyunAckTemplateConfig,
+        envs: dict[str, str] | None,
+        metadata: dict[str, str] | None,
+        ttl_in_minutes: int | None,
+    ) -> None:
+        _import_k8s()
+        core_api = CoreV1Api(self._client_for(template))
+        namespace = template.pod.namespace or "default"
+        effective_envs = dict(template.pod.envs or {})
+        if envs:
+            effective_envs.update(envs)
+
+        container: dict[str, Any] = {
+            "name": "sandbox",
+            "image": template.pod.image,
+            "ports": [{"container_port": _BOLT_PORT}],
+        }
+        resources = _resource_manifest(template.pod)
+        if resources:
+            container["resources"] = resources
+        if effective_envs:
+            container["env"] = [
+                {"name": k, "value": v} for k, v in effective_envs.items()
+            ]
+
+        labels = {
+            "app": "avernet-arca-sandbox",
+            "avernet.arcasandbox/template": template.template_id,
+        }
+        if metadata:
+            labels.update(metadata)
+
+        annotations: dict[str, str] = {
+            "avernet.arcasandbox/image": template.pod.image,
+        }
+        if ttl_in_minutes is not None:
+            annotations["avernet.arcasandbox/ttl-minutes"] = str(ttl_in_minutes)
+
+        pod_spec: dict[str, Any] = {
+            "containers": [container],
+            "restart_policy": "Never",
+        }
+        if template.pod.service_account:
+            pod_spec["service_account_name"] = template.pod.service_account
+
+        pod = {
+            "api_version": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": pod_name,
+                "namespace": namespace,
+                "labels": labels,
+                "annotations": annotations,
+            },
+            "spec": pod_spec,
+        }
+        core_api.create_namespaced_pod(body=pod, namespace=namespace)
+
+        service = {
+            "api_version": "v1",
+            "kind": "Service",
+            "metadata": {"name": pod_name, "namespace": namespace, "labels": labels},
+            "spec": {
+                "selector": {"app": "avernet-arca-sandbox", "aliyun.ack.pod": pod_name},
+                "ports": [{"port": _BOLT_PORT, "targetPort": _BOLT_PORT}],
+            },
+        }
+        core_api.create_namespaced_service(body=service, namespace=namespace)
+
+    def create_sync_sandbox(
+        self,
+        template_id: str,
+        ttl_in_minutes: int | None = None,
+        envs: dict[str, str] | None = None,
+        mount_points: list[MountPoint] | None = None,
+        resource_spec: ResourceSpecification | None = None,
+        metadata: dict[str, str] | None = None,
+        outbound_operation_rule: OutBoundOperationRule | None = None,
+        storage: Storage | None = None,
+        image: str | None = None,
+        timeout_in_millis: int = 60000,
+        ready_timeout_in_seconds: int = 60,
+    ) -> ArcaSandbox:
+        _import_k8s()
+        template = self._resolve_template(template_id)
+        namespace = template.pod.namespace or "default"
+        sandbox_id = f"aliyun-ack-{uuid.uuid4().hex[:12]}"
+        pod_name = _sanitize_pod_name(sandbox_id)
+        self._create_pod_and_service(
+            pod_name=pod_name,
+            template=template,
+            envs=envs,
+            metadata=metadata,
+            ttl_in_minutes=ttl_in_minutes,
+        )
+        try:
+            core_api = CoreV1Api(self._client_for(template))
+            _wait_for_ready(core_api, pod_name, namespace, ready_timeout_in_seconds)
+        except Exception:
+            try:
+                core_api = CoreV1Api(self._client_for(template))
+                core_api.delete_namespaced_pod(name=pod_name, namespace=namespace)
+            except Exception:
+                pass
+            raise
+
+        device = AliyunAckSandbox(
+            sandbox_id=sandbox_id,
+            namespace=namespace,
+            template_id=template.template_id,
+            client=self._client_for(template),
+            pod_name=pod_name,
+            image=image or template.pod.image,
+        )
+        logger.info(
+            "[aliyun_ack] sandbox created template=%s sandbox_id=%s pod=%s",
+            template.template_id,
+            sandbox_id,
+            pod_name,
+        )
+        return device
+
+    def connect_sync_sandbox(self, sandbox_id: str) -> ArcaSandbox:
+        _import_k8s()
+        pod_name = _sanitize_pod_name(sandbox_id)
+        template = self._resolve_default_template()
+        namespace = template.pod.namespace or "default"
+        client = self._client_for(template)
+        try:
+            core_api = CoreV1Api(client)
+            pod = core_api.read_namespaced_pod(name=pod_name, namespace=namespace)
+        except ApiException as e:
+            raise RuntimeError(
+                f"Sandbox {sandbox_id} not found (pod {pod_name}) ({e.status})"
+            ) from e
+
+        template_id = "aliyun_ack"
+        if pod.metadata and pod.metadata.labels:
+            template_id = pod.metadata.labels.get(
+                "avernet.arcasandbox/template", "aliyun_ack"
+            )
+
+        logger.info("[aliyun_ack] sandbox connected sandbox_id=%s", sandbox_id)
+        return AliyunAckSandbox(
+            sandbox_id=sandbox_id,
+            namespace=namespace,
+            template_id=template_id,
+            client=client,
+            pod_name=pod_name,
+            image=template.pod.image,
+        )
+
+    def resolve_ws_conn_info(
+        self,
+        paas_device_id: str,
+        port: int,
+        path: str,
+        template_id: int | None = None,
+    ) -> WsConnectionInfo:
+        norm_path = path if path.startswith("/") else f"/{path}"
+        target = self._arca_utils._get_arca_target(
+            paas_device_id, port=port, template_id=template_id
+        )
+        token = self._arca_utils._get_proxypass_token(
+            paas_device_id, port=port, template_id=template_id, ttl=120
+        )
+        url = self._arca_utils.build_proxypass_url(target, norm_path, scheme="wss")
+        return WsConnectionInfo(
+            ws_url=url,
+            token=token,
+            target=target,
+            expires_at=datetime.now(UTC) + timedelta(seconds=120),
+        )
+
+    def resolve_http_connection_info(
+        self,
+        paas_device_id: str,
+        port: int,
+        path: str = "/",
+        template_id: int | None = None,
+    ) -> HttpConnectionInfo:
+        norm_path = path if path.startswith("/") else f"/{path}"
+        target = self._arca_utils._get_arca_target(
+            paas_device_id, port=port, template_id=template_id
+        )
+        token = self._arca_utils._get_proxypass_token(
+            paas_device_id, port=port, template_id=template_id
+        )
+        url = self._arca_utils.build_proxypass_url(target, norm_path, scheme="https")
+        return HttpConnectionInfo(http_url=url, token=token, target=target)
+
+    def close(self) -> None:
+        """Release any ACK clients."""
+
+    def delete_storage(self, storage_id: str, tenant_name: str) -> bool:
+        _import_k8s()
+        template = self._resolve_default_template()
+        namespace = template.pod.namespace or "default"
+        pvc_name = _sanitize_pod_name(storage_id)
+        logger.info(
+            "[aliyun_ack] delete_storage storage_id=%s tenant_name=%s pvc=%s",
+            storage_id,
+            tenant_name,
+            pvc_name,
+        )
+        try:
+            core_api = CoreV1Api(self._client_for(template))
+            core_api.delete_namespaced_persistent_volume_claim(
+                name=pvc_name, namespace=namespace
+            )
+            return True
+        except ApiException as e:
+            if e.status == 404:
+                logger.info(
+                    "[aliyun_ack] delete_storage: pvc %s not found (404), idempotent",
+                    pvc_name,
+                )
+                return True
+            logger.warning("[aliyun_ack] delete_storage failed (%s)", e.status)
+            return False

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_docker/_sandbox.py
@@ -9,7 +9,7 @@ from secbaas.community.api.device_manage import (
     OutBoundOperationRuleUpdatedMode,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxInfo
 
 logger = get_logger("plugin-sandbox")
 
@@ -47,20 +47,20 @@ class LocalDockerArcaSandbox(ArcaSandbox):
         """沙箱唯一标识符。"""
         return self._sandbox_id
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         """获取沙箱信息。
 
         Returns:
-            包含沙箱信息的字典，包括 sandbox_id, status, template_id 等。
+            返回统一 :class:`ArcaSandboxInfo`，包含 sandbox_id, status, template_id；
+            local-docker 专属字段（container_id, is_ready）附加为额外属性。
         """
-        # TODO: 从 Docker 容器获取实际状态
-        return {
-            "sandbox_id": self._sandbox_id,
-            "status": self._status,
-            "template_id": self._template_id,
-            "container_id": self._container_id,
-            "is_ready": self._is_ready,
-        }
+        return ArcaSandboxInfo(
+            sandbox_id=self._sandbox_id,
+            status=self._status,
+            template_id=self._template_id,
+            container_id=self._container_id,
+            is_ready=self._is_ready,
+        )
 
     def destroy(self) -> Any:
         """销毁沙箱（停止并删除 Docker 容器）。

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/local_proc/_sandbox.py
@@ -10,7 +10,7 @@ from secbaas.community.api.device_manage import (
     OutBoundOperationRuleUpdatedMode,
 )
 from secbaas.community.logger import get_logger
-from secbaas.community.spi.sandbox.arca import ArcaSandbox
+from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxInfo
 
 if TYPE_CHECKING:
     from ._process_manager import ProcessEntry
@@ -18,13 +18,13 @@ if TYPE_CHECKING:
 logger = get_logger("plugin-sandbox")
 
 
-class LocalProcessSandboxInfo:
-    """本地进程沙箱信息对象。
+class LocalProcessSandboxInfo(ArcaSandboxInfo):
+    """Backward-compatible subclass of the unified :class:`ArcaSandboxInfo`.
 
-    支持属性访问（info.status），与 Arca SDK 的 SandboxInfo 接口对齐。
-    ArcaPaasService 通过属性访问以下字段：
-    status, template_id, sandbox_id, resources, ttl_in_minutes, envs,
-    snapshot_id, metadata, outbound_operation_rule, ttl_timestamp。
+    Retained so existing imports, ``isinstance`` checks, and the extra local-process
+    fields keep working. The SDK-common fields align to the unified model; the local-only
+    fields (``bot_id``, ports, pids, config/workspace dirs, ``is_ready``) are carried as
+    attributes.
     """
 
     def __init__(
@@ -48,24 +48,27 @@ class LocalProcessSandboxInfo:
         metadata: dict[str, str] | None = None,
         outbound_operation_rule: Any = None,
     ) -> None:
-        self.sandbox_id = sandbox_id
-        self.status = status
-        self.template_id = template_id
-        self.is_ready = is_ready
-        self.ttl_in_minutes = ttl_in_minutes
-        self.ttl_timestamp = ttl_timestamp
-        self.bot_id = bot_id
-        self.adapter_port = adapter_port
-        self.adapter_pid = adapter_pid
-        self.engine_port = engine_port
-        self.engine_pid = engine_pid
-        self.config_dir = config_dir
-        self.workspace_dir = workspace_dir
-        self.resources = resources
-        self.envs = envs
-        self.snapshot_id = snapshot_id
-        self.metadata = metadata
-        self.outbound_operation_rule = outbound_operation_rule
+        super().__init__(
+            sandbox_id=sandbox_id,
+            status=status,
+            template_id=template_id,
+            resources=resources,
+            ttl_in_minutes=ttl_in_minutes,
+            ttl_timestamp=ttl_timestamp,
+            envs=envs,
+            snapshot_id=snapshot_id,
+            metadata=metadata,
+            outbound_operation_rule=outbound_operation_rule,
+            storage=None,
+            is_ready=is_ready,
+            bot_id=bot_id,
+            adapter_port=adapter_port,
+            adapter_pid=adapter_pid,
+            engine_port=engine_port,
+            engine_pid=engine_pid,
+            config_dir=config_dir,
+            workspace_dir=workspace_dir,
+        )
 
     def __repr__(self) -> str:
         """返回结构化、日志友好的字符串表示。
@@ -135,12 +138,13 @@ class LocalProcessArcaSandbox(ArcaSandbox):
     def _ttl_minutes(self, value: int | None) -> None:
         self.__ttl_minutes = value
 
-    def get_info(self) -> LocalProcessSandboxInfo:
+    def get_info(self) -> ArcaSandboxInfo:
         """获取沙箱信息。
 
         Returns:
-            LocalProcSandboxInfo 对象，包含 sandbox_id, status, template_id 等属性。
+            ArcaSandboxInfo 对象，包含 sandbox_id, status, template_id 等属性。
             返回对象支持属性访问（info.status），与 Arca SDK 的 SandboxInfo 接口对齐。
+            本地进程模式额外字段（bot_id/端口/pid/目录）也会附加到返回对象上。
         """
         entry = self._process_entry
         return LocalProcessSandboxInfo(

--- a/src/baas/src/secbaas/community/spi/sandbox/__init__.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/__init__.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from secbaas.community.spi.sandbox.arca import ArcaSandbox, ArcaSandboxPlugin
+from secbaas.community.spi.sandbox.arca import (
+    ArcaSandbox,
+    ArcaSandboxInfo,
+    ArcaSandboxPlugin,
+)
 from secbaas.community.spi.sandbox.desktop import DesktopSandbox, DesktopSandboxPlugin
 from secbaas.community.spi.sandbox.docker import DockerSandbox, DockerSandboxPlugin
 from secbaas.community.spi.sandbox.k8s import K8sSandbox, K8sSandboxPlugin
@@ -53,6 +57,7 @@ class PaasSandboxPlugins:
 __all__ = [
     "ArcaSandboxPlugin",
     "ArcaSandbox",
+    "ArcaSandboxInfo",
     "DesktopSandboxPlugin",
     "DesktopSandbox",
     "DockerSandbox",

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/__init__.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/__init__.py
@@ -1,5 +1,6 @@
 """Arca device SPI — Protocol for Arca sandbox lifecycle."""
 
+from ._arca_sandbox_info import ArcaSandboxInfo
 from ._errors import (
     ArcaSandboxError,
     ArcaSandboxNotFoundError,
@@ -10,6 +11,7 @@ from ._protocols import ArcaSandbox, ArcaSandboxPlugin
 __all__ = [
     "ArcaSandbox",
     "ArcaSandboxError",
+    "ArcaSandboxInfo",
     "ArcaSandboxNotFoundError",
     "ArcaSandboxPlugin",
     "ArcaSandboxTimeoutError",

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/_arca_sandbox_info.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/_arca_sandbox_info.py
@@ -1,0 +1,143 @@
+"""Unified Arca sandbox info model.
+
+Single, community-owned model for ``ArcaSandbox.get_info()`` return values,
+derived from the Arca SDK ``SandboxInfo`` surface. All Arca sandbox
+implementations (enterprise SDK-backed, community stub, community
+local-process, community local-docker) return this model so the SPI has one
+source of truth for the sandbox info shape.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from secbaas.community.api.device_manage import (
+        OutBoundOperationRule,
+        ResourceSpecification,
+        Storage,
+    )
+
+
+class ArcaSandboxInfo:
+    """Unified Arca sandbox information container.
+
+    ``status`` may be an enum-like value exposing ``.value`` or a plain string;
+    consumers normalize via
+    ``str(status.value) if hasattr(status, "value") else str(status)``.
+
+    Field ownership / optionality:
+
+    ``sandbox_id`` (always set; owned by all backends)
+        ``str``. Arca sandbox ID.
+
+    ``status`` (always set; owned by all backends)
+        ``Any`` enum-like (``.value``) or plain ``str``. Current sandbox status.
+
+    ``template_id`` (optional; owned by all backends)
+        ``str | None``. Platform template ID; ``None`` when the backend does not
+        report a template.
+
+    ``resources`` (optional; owned by all backends)
+        ``ResourceSpecification | None``. CPU/memory/disk; ``None`` when unset.
+
+    ``ttl_in_minutes`` (optional; owned by all backends)
+        ``float | int | None``. Remaining/set TTL in minutes; ``None`` when unset.
+
+    ``ttl_timestamp`` (optional; owned by all backends)
+        ``int | None``. Expiry timestamp (ms); ``None`` when unavailable.
+
+    ``envs`` (optional; owned by all backends)
+        ``dict[str, Any] | None``. Environment variables; ``None`` when unset.
+
+    ``snapshot_id`` (optional; owned by all backends)
+        ``str | None``. Snapshot ID; ``None`` when unset.
+
+    ``metadata`` (optional; owned by all backends)
+        ``dict[str, Any] | None``. Arbitrary metadata; ``None`` when unset.
+
+    ``outbound_operation_rule`` (optional; owned by all backends)
+        ``OutBoundOperationRule | None``. Outbound rule; ``None`` when unset.
+
+    ``storage`` (optional; owned by all backends)
+        ``Storage | None``. NAS storage binding; ``None`` when unset.
+
+    ``is_ready`` (optional; owned by local-process + local-docker)
+        ``bool``. Ready flag; ``False`` on backends that do not model it.
+
+    ``container_id`` (optional; owned by local-docker)
+        ``str | None``. Docker container ID; ``None`` elsewhere.
+
+    ``bot_id`` (optional; owned by local-process)
+        ``str``. Bot ID; ``""`` on backends that do not model it.
+
+    ``adapter_port`` (optional; owned by local-process)
+        ``int``. Adapter port; ``0`` on backends that do not model it.
+
+    ``adapter_pid`` (optional; owned by local-process)
+        ``int | None``. Adapter PID; ``None`` when no adapter process.
+
+    ``engine_port`` (optional; owned by local-process)
+        ``int``. Engine port; ``0`` on backends that do not model it.
+
+    ``engine_pid`` (optional; owned by local-process)
+        ``int | None``. Engine PID; ``None`` when no engine process.
+
+    ``config_dir`` (optional; owned by local-process)
+        ``str``. Config directory; ``""`` on backends that do not model it.
+
+    ``workspace_dir`` (optional; owned by local-process)
+        ``str``. Workspace directory; ``""`` on backends that do not model it.
+
+    NOTE: Core logic that consumes an optional field MUST treat it as
+    ``None`` (or its unset default) — only the owning backend guarantees a
+    value. Do not assume presence without checking.
+    """
+
+    def __init__(
+        self,
+        sandbox_id: str,
+        status: Any = None,
+        template_id: str | None = None,
+        resources: ResourceSpecification | None = None,
+        ttl_in_minutes: float | int | None = None,
+        ttl_timestamp: int | None = None,
+        envs: dict[str, Any] | None = None,
+        snapshot_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        outbound_operation_rule: OutBoundOperationRule | None = None,
+        storage: Storage | None = None,
+        is_ready: bool = False,
+        container_id: str | None = None,
+        bot_id: str = "",
+        adapter_port: int = 0,
+        adapter_pid: int | None = None,
+        engine_port: int = 0,
+        engine_pid: int | None = None,
+        config_dir: str = "",
+        workspace_dir: str = "",
+        **extra: Any,
+    ) -> None:
+        self.sandbox_id = sandbox_id
+        self.status = status
+        self.template_id = template_id
+        self.resources = resources
+        self.ttl_in_minutes = ttl_in_minutes
+        self.ttl_timestamp = ttl_timestamp
+        self.envs = envs
+        self.snapshot_id = snapshot_id
+        self.metadata = metadata
+        self.outbound_operation_rule = outbound_operation_rule
+        self.storage = storage
+        self.is_ready = is_ready
+        self.container_id = container_id
+        self.bot_id = bot_id
+        self.adapter_port = adapter_port
+        self.adapter_pid = adapter_pid
+        self.engine_port = engine_port
+        self.engine_pid = engine_pid
+        self.config_dir = config_dir
+        self.workspace_dir = workspace_dir
+        # Unknown/forward-compatible extras remain available as dynamic attributes.
+        for name, value in extra.items():
+            setattr(self, name, value)

--- a/src/baas/src/secbaas/community/spi/sandbox/arca/_protocols.py
+++ b/src/baas/src/secbaas/community/spi/sandbox/arca/_protocols.py
@@ -12,6 +12,8 @@ from secbaas.community.api.device_manage import (
     Storage,
 )
 
+from ._arca_sandbox_info import ArcaSandboxInfo
+
 if TYPE_CHECKING:
     from secbaas.community.api.bot_runtime import HttpConnectionInfo, WsConnectionInfo
 
@@ -26,12 +28,12 @@ class ArcaSandbox(Protocol):
     is_ready: bool
     sandbox_id: str
 
-    def get_info(self) -> Any:
+    def get_info(self) -> ArcaSandboxInfo:
         """Get sandbox info including status, template_id, resources, ttl, etc.
 
         Returns:
-            An info object with at minimum: sandbox_id, status, template_id.
-            Optional fields depend on the implementation.
+            An ``ArcaSandboxInfo`` with at minimum: sandbox_id, status, template_id.
+            Backends may attach backend-specific optional attributes.
         """
         ...
 

--- a/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
+++ b/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
@@ -1,0 +1,97 @@
+"""Integration smoke test for the Aliyun ACK Arca sandbox backend.
+
+Wires the Arca provider via ``plugins.sandbox.arca: aliyun_ack``, reads the
+ARCA device template from the SQLite database (seeded ``TEMPLATE_ARCA``),
+resolves its ``arca_template_id`` against ``user_config.aliyun_ack_template``,
+and creates an ACK Pod via ``AliyunAckSandboxPlugin`` -- all through the real
+``ApplicationContainer``. ``CoreV1Api`` is stubbed so no live cluster is needed.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from secbaas.community.bootstrap import ApplicationContainer
+from secbaas.community.core.service.paas import ArcaPaasService, PaasServiceFactory
+from secbaas.community.plugins.sandbox.arca.aliyun_ack import AliyunAckSandboxPlugin
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._client_manager import (
+    AliyunAckClientManager,
+)
+
+# Seeded by _seed.py (it-sqlite overlay) under tenant "team_claw"
+TEMPLATE_ARCA = "TEMPLATE-4d0e2849d7004111836333de782b95d8"
+TEMPLATE_ID = "ALIYUN_ACK_TEMPLATE_default"
+TEST_TENANT = "team_claw"
+
+_SANDBOX = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox"
+_PLUGIN = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox_plugin"
+
+
+class _FakePod:
+    def __init__(self, phase: str = "Running") -> None:
+        self.status = MagicMock()
+        self.status.phase = phase
+        self.metadata = MagicMock()
+        self.metadata.labels = {"avernet.arcasandbox/template": TEMPLATE_ID}
+
+
+def _select_aliyun_ack(bootstrap_init: ApplicationContainer) -> PaasServiceFactory:
+    """Point the arca selector at aliyun_ack and supply the ACK template map."""
+    from secbaas.community.config import ConfigLoader
+
+    loader_cfg = ConfigLoader.load()
+    ack_template = loader_cfg.user_config.get("aliyun_ack_template", {})
+    bootstrap_init.config.from_dict(
+        {
+            "plugins": {"sandbox": {"arca": "aliyun_ack"}},
+            "aliyun_ack_template": ack_template,
+        }
+    )
+    return bootstrap_init.services.paas_service_factory()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_aliyun_ack_plugin_created_from_db_template(
+    bootstrap_init: ApplicationContainer,
+) -> None:
+    """A device create on the ARCA device template dispatches to AliyunAckSandboxPlugin."""
+    # Ensure lazy k8s bindings exist so we can patch CoreV1Api.
+    import importlib
+
+    for mod_name in (_SANDBOX, _PLUGIN):
+        importlib.import_module(mod_name)._import_k8s()
+
+    factory = _select_aliyun_ack(bootstrap_init)
+
+    # Resolve the ARCA device template from the DB and build the PaaS service.
+    service = factory.create(tenant_name=TEST_TENANT, template_uuid=TEMPLATE_ARCA)
+    assert isinstance(service, ArcaPaasService)
+    plugin = service._arca_sandbox_plugin
+    assert isinstance(plugin, AliyunAckSandboxPlugin)
+
+    # Stub k8s so create_sync_sandbox does not hit a real cluster.
+    core = MagicMock()
+    core.read_namespaced_pod.return_value = _FakePod()
+    with ExitStack() as stack:
+        stack.enter_context(patch(f"{_PLUGIN}.CoreV1Api", MagicMock(return_value=core)))
+        stack.enter_context(
+            patch(f"{_SANDBOX}.CoreV1Api", MagicMock(return_value=core))
+        )
+        stack.enter_context(
+            patch.object(AliyunAckClientManager, "get_client", return_value=MagicMock())
+        )
+        sandbox = plugin.create_sync_sandbox(
+            template_id=TEMPLATE_ID, image="test:latest"
+        )
+
+    assert core.create_namespaced_pod.called
+    assert core.create_namespaced_service.called
+    from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+    info = sandbox.get_info()
+    assert isinstance(info, ArcaSandboxInfo)
+    assert info.sandbox_id == sandbox.sandbox_id

--- a/src/baas/tests/unit/bootstrap/test_plugins.py
+++ b/src/baas/tests/unit/bootstrap/test_plugins.py
@@ -53,3 +53,58 @@ class TestPluginContainerStandalone:
         assert sandbox["k8s"] == "stub"
         assert sandbox["docker"] == "stub"
         assert sandbox["poolab"] == "stub"
+
+
+class TestAliyunAckSelector:
+    """The aliyun_ack option resolves to AliyunAckSandboxPlugin."""
+
+    def _container(self, with_templates: bool = True):
+        from secbaas.community.bootstrap.plugins import PluginContainer
+
+        container = PluginContainer()
+        cfg = {
+            "plugins": {
+                "secret": "stub",
+                "sandbox": {"arca": "aliyun_ack"},
+            }
+        }
+        if with_templates:
+            cfg["aliyun_ack_template"] = {
+                "ALIYUN_ACK_TEMPLATE_default": {
+                    "cluster": {
+                        "endpoint": "https://ack.example.com",
+                        "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                        "region": "cn-hangzhou",
+                    },
+                    "pod": {"image": "test:latest"},
+                }
+            }
+        container.config.from_dict(cfg)
+        return container
+
+    def test_aliyun_ack_selector_wired(self):
+        from secbaas.community.api.device_manage import ArcaCredentials
+        from secbaas.community.plugins.sandbox.arca.aliyun_ack import (
+            AliyunAckSandboxPlugin,
+        )
+
+        creds = ArcaCredentials(
+            template_id=1,
+            template_uuid="u",
+            base_url="http://x",
+            api_key="k",
+            arca_template_id="ALIYUN_ACK_TEMPLATE_default",
+        )
+        plugin = self._container().arca_sandbox_plugin_factory(creds)
+        assert isinstance(plugin, AliyunAckSandboxPlugin)
+        assert "ALIYUN_ACK_TEMPLATE_default" in plugin._ack_templates
+
+    def test_aliyun_ack_default_selector(self):
+        from secbaas.community.plugins.sandbox.arca import StubArcaSandboxPlugin
+
+        container = self._container()
+        container.config.from_dict(
+            {"plugins": {"secret": "stub", "sandbox": {"arca": "stub"}}}
+        )
+        plugin = container.arca_sandbox_plugin_factory()
+        assert plugin is StubArcaSandboxPlugin

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_config.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_config.py
@@ -1,0 +1,29 @@
+"""Tests for the AliyunAckTemplateConfig model and DI wiring."""
+
+from __future__ import annotations
+
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._config_type import (
+    AliyunAckTemplateConfig,
+    build_aliyun_ack_template,
+)
+
+
+def test_build_template_merges_id():
+    raw = {
+        "cluster": {"kubeconfig": "kc", "endpoint": "e", "region": "r"},
+        "pod": {"image": "img", "envs": {"A": "b"}, "service_account": "sa"},
+    }
+    t = build_aliyun_ack_template("ALIYUN_ACK_TEMPLATE_default", raw)
+    assert isinstance(t, AliyunAckTemplateConfig)
+    assert t.template_id == "ALIYUN_ACK_TEMPLATE_default"
+    assert t.cluster.kubeconfig == "kc"
+    assert t.pod.image == "img"
+    assert t.pod.envs == {"A": "b"}
+    assert t.pod.service_account == "sa"
+
+
+def test_build_template_defaults():
+    t = AliyunAckTemplateConfig(template_id="ALIYUN_ACK_TEMPLATE_default")
+    assert t.cluster.endpoint == ""
+    assert t.pod.image == "ubuntu:22.04"
+    assert t.pod.namespace == "default"

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
@@ -1,0 +1,268 @@
+"""Unit tests for AliyunAckSandboxPlugin / AliyunAckSandbox / AliyunAckClientManager."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from secbaas.community.api.device_manage import ArcaCredentials
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._client_manager import (
+    AliyunAckClientManager,
+)
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._config_type import (
+    AliyunAckTemplateConfig,
+    build_aliyun_ack_template,
+)
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox import AliyunAckSandbox
+from secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox_plugin import (
+    AliyunAckSandboxPlugin,
+    _sanitize_pod_name,
+)
+from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+_SANDBOX = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox"
+_PLUGIN = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox_plugin"
+_MGR = "secbaas.community.plugins.sandbox.arca.aliyun_ack._client_manager"
+
+TEMPLATE_ID = "ALIYUN_ACK_TEMPLATE_default"
+
+
+@pytest.fixture(autouse=True)
+def _k8s_loaded() -> None:
+    import importlib
+
+    for mod_name in (_SANDBOX, _PLUGIN):
+        importlib.import_module(mod_name)._import_k8s()
+
+
+def _template() -> AliyunAckTemplateConfig:
+    return build_aliyun_ack_template(
+        TEMPLATE_ID,
+        {
+            "cluster": {
+                "endpoint": "https://ack.example.com",
+                "region": "cn-hangzhou",
+                "cluster_name": "ack-test",
+                "kubeconfig": "apiVersion: v1\nkind: Config\n",
+                "context": "dummy-context",
+                "access_key_id": "dummy-ak",
+                "access_key_secret": "dummy-sk",
+            },
+            "pod": {
+                "image": "test:latest",
+                "namespace": "sandbox-ns",
+                "service_account": "dummy-sa",
+                "cpu_request": "500m",
+                "cpu_limit": "1",
+                "memory_request": "512Mi",
+                "memory_limit": "1Gi",
+                "storage_class": "dummy-sc",
+                "envs": {"FOO": "bar"},
+            },
+        },
+    )
+
+
+def _creds(arca_template_id: str = TEMPLATE_ID) -> ArcaCredentials:
+    return ArcaCredentials(
+        template_id=1,
+        template_uuid="u",
+        base_url="http://x",
+        api_key="k",
+        arca_template_id=arca_template_id,
+    )
+
+
+def _plugin(**kw) -> AliyunAckSandboxPlugin:
+    kw.setdefault("config", _creds())
+    kw.setdefault("ack_templates", {TEMPLATE_ID: _template()})
+    kw.setdefault("arca_utils", MagicMock())
+    return AliyunAckSandboxPlugin(**kw)
+
+
+class _FakePod:
+    def __init__(self, phase: str = "Running") -> None:
+        self.status = MagicMock()
+        self.status.phase = phase
+        self.metadata = MagicMock()
+        self.metadata.labels = {"avernet.arcasandbox/template": TEMPLATE_ID}
+
+
+class _CoreHarness:
+    """Stack the k8s CoreV1Api + client-manager patches; expose ``core``."""
+
+    def __init__(self) -> None:
+        self.core = MagicMock()
+        self.core.read_namespaced_pod.return_value = _FakePod()
+        self.client = MagicMock()
+        self._stack: ExitStack | None = None
+
+    def __enter__(self) -> _CoreHarness:
+        self._stack = ExitStack()
+        self._stack.enter_context(
+            patch(f"{_PLUGIN}.CoreV1Api", MagicMock(return_value=self.core))
+        )
+        self._stack.enter_context(
+            patch(f"{_SANDBOX}.CoreV1Api", MagicMock(return_value=self.core))
+        )
+        self._stack.enter_context(
+            patch.object(AliyunAckClientManager, "get_client", return_value=self.client)
+        )
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        assert self._stack is not None
+        self._stack.__exit__(exc_type, exc, tb)
+        return False
+
+
+class TestTemplateResolution:
+    def test_resolve_by_template_id(self) -> None:
+        assert _plugin()._resolve_template(TEMPLATE_ID).template_id == TEMPLATE_ID
+
+    def test_resolve_missing_raises(self) -> None:
+        with pytest.raises(ValueError, match="No AliyunAckTemplate"):
+            _plugin()._resolve_template("ALIYUN_ACK_TEMPLATE_missing")
+
+    def test_resolve_requires_id(self) -> None:
+        with pytest.raises(ValueError, match="arca_template_id"):
+            AliyunAckSandboxPlugin(config=None)._resolve_template(None)
+
+
+class TestCreateSyncSandbox:
+    def test_create_success(self) -> None:
+        with _CoreHarness() as h:
+            sb = _plugin().create_sync_sandbox(
+                template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+            )
+        assert isinstance(sb, AliyunAckSandbox)
+        assert h.core.create_namespaced_pod.called
+        assert h.core.create_namespaced_service.called
+
+    def test_create_timeout_cleans_up(self) -> None:
+        with _CoreHarness() as h:
+            h.core.read_namespaced_pod.side_effect = lambda *a, **k: _FakePod("Pending")
+            with patch(f"{_PLUGIN}.time.sleep"):
+                with pytest.raises(RuntimeError, match="did not become ready"):
+                    _plugin().create_sync_sandbox(
+                        template_id=TEMPLATE_ID, ready_timeout_in_seconds=1
+                    )
+            h.core.delete_namespaced_pod.assert_called()
+
+
+class TestConnect:
+    def test_connect_success(self) -> None:
+        with _CoreHarness() as h:
+            sb = _plugin().connect_sync_sandbox("aliyun-ack-abc123")
+        assert isinstance(sb, AliyunAckSandbox)
+        assert sb.sandbox_id == "aliyun-ack-abc123"
+
+    def test_connect_not_found(self) -> None:
+        class _ApiClientException(Exception):
+            status = 404
+
+        with _CoreHarness() as h:
+            h.core.read_namespaced_pod.side_effect = _ApiClientException()
+            with patch(f"{_PLUGIN}.ApiException", _ApiClientException):
+                with pytest.raises(RuntimeError, match="not found"):
+                    _plugin().connect_sync_sandbox("aliyun-ack-missing")
+
+
+class TestConnectionInfo:
+    def _utils(self):
+        u = MagicMock()
+        u._get_arca_target.return_value = "ARCA_ack:20003"
+        u._get_proxypass_token.return_value = "token"
+        u.build_proxypass_url.return_value = "wss://proxy/x"
+        return u
+
+    def test_resolve_ws_conn_info(self) -> None:
+        info = _plugin(arca_utils=self._utils()).resolve_ws_conn_info(
+            "ack-1", 20003, "/api/openclaw/ws"
+        )
+        assert info.ws_url.startswith("wss://")
+        assert info.token == "token"
+
+    def test_resolve_http_conn_info(self) -> None:
+        u = self._utils()
+        u.build_proxypass_url.return_value = "https://proxy/x"
+        info = _plugin(arca_utils=u).resolve_http_connection_info("ack-1", 20003, "/")
+        assert info.http_url.startswith("https://")
+        assert info.token == "token"
+
+
+class TestDeleteStorage:
+    def test_delete_success(self) -> None:
+        with _CoreHarness() as h:
+            assert _plugin().delete_storage("pv-1", "tenant") is True
+        h.core.delete_namespaced_persistent_volume_claim.assert_called()
+
+    def test_delete_not_found_idempotent(self) -> None:
+        class _ApiClientException(Exception):
+            status = 404
+
+        with _CoreHarness() as h:
+            h.core.delete_namespaced_persistent_volume_claim.side_effect = (
+                _ApiClientException()
+            )
+            with patch(f"{_PLUGIN}.ApiException", _ApiClientException):
+                assert _plugin().delete_storage("pv-1", "tenant") is True
+
+    def test_delete_error_false(self) -> None:
+        class _ApiClientException(Exception):
+            status = 500
+
+        with _CoreHarness() as h:
+            h.core.delete_namespaced_persistent_volume_claim.side_effect = (
+                _ApiClientException()
+            )
+            with patch(f"{_PLUGIN}.ApiException", _ApiClientException):
+                assert _plugin().delete_storage("pv-1", "tenant") is False
+
+
+class TestSandbox:
+    def test_get_info_returns_unified_model(self) -> None:
+        with _CoreHarness() as h:
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        assert isinstance(info, ArcaSandboxInfo)
+        assert info.sandbox_id == "aliyun-ack-1"
+        assert info.status == "Running"
+
+    def test_destroy_idempotent(self) -> None:
+        class _ApiClientException(Exception):
+            status = 404
+
+        with _CoreHarness() as h:
+            h.core.delete_namespaced_pod.side_effect = _ApiClientException()
+            with patch(f"{_SANDBOX}.ApiException", _ApiClientException):
+                sb = AliyunAckSandbox(
+                    "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="p"
+                )
+                assert sb.destroy() is True
+
+
+class TestClientManager:
+    def test_validate_missing_kubeconfig(self) -> None:
+        with pytest.raises(ValueError, match="kubeconfig"):
+            AliyunAckClientManager(cluster=None).validate()
+
+    def test_get_client_lazy_builds(self) -> None:
+        mgr = AliyunAckClientManager(_template().cluster)
+        fake = MagicMock()
+        mgr.build_client = MagicMock(return_value=fake)
+        assert mgr.get_client() is fake
+        mgr.build_client.assert_called_once()
+
+    def test_close_noop(self) -> None:
+        AliyunAckClientManager(_template().cluster).close()
+
+
+class TestSanitizePodName:
+    def test_sanitizes(self) -> None:
+        assert _sanitize_pod_name("ALIYUN_ACK_abc-123") == "aliyun-ack-abc-123"
+        assert _sanitize_pod_name("!!!") == "aliyun-ack-sandbox"

--- a/src/baas/tests/unit/plugins/sandbox/arca/local_docker/test_docker_sandbox_get_info.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/local_docker/test_docker_sandbox_get_info.py
@@ -1,0 +1,60 @@
+"""Coverage tests for LocalDockerArcaSandbox.get_info().
+
+Verifies the local-docker Arca sandbox returns the unified ArcaSandboxInfo model
+with its backend-specific extras (container_id, is_ready).
+"""
+
+from __future__ import annotations
+
+from secbaas.community.plugins.sandbox.arca.local_docker._sandbox import (
+    LocalDockerArcaSandbox,
+)
+from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+
+class TestLocalDockerSandboxGetInfo:
+    def test_returns_unified_sandbox_info_with_extras(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-1", "tpl-1", container_id="cid-1")
+        info = sandbox.get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert info.sandbox_id == "sb-docker-1"
+        assert info.template_id == "tpl-1"
+        assert info.status == "PENDING"
+        assert info.container_id == "cid-1"
+        assert info.is_ready is False
+
+    def test_after_mark_ready_status_is_running(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-2", "tpl-1")
+        sandbox.mark_ready("cid-2")
+
+        info = sandbox.get_info()
+
+        assert info.container_id == "cid-2"
+        assert info.is_ready is True
+        assert info.status == "RUNNING"
+
+    def test_unified_attribute_surface(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-3", "tpl-1")
+        info = sandbox.get_info()
+
+        for attr in (
+            "sandbox_id",
+            "status",
+            "template_id",
+            "resources",
+            "ttl_in_minutes",
+            "ttl_timestamp",
+            "envs",
+            "snapshot_id",
+            "metadata",
+            "outbound_operation_rule",
+            "storage",
+        ):
+            assert hasattr(info, attr), f"missing attribute: {attr}"
+
+    def test_destroy_marks_status(self) -> None:
+        sandbox = LocalDockerArcaSandbox("sb-docker-4", "tpl-1")
+        assert sandbox.destroy() is True
+        assert sandbox.get_info().status == "DESTROYED"
+        assert sandbox.get_info().is_ready is False

--- a/src/baas/tests/unit/plugins/sandbox/arca/local_proc/test_sandbox_get_info.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/local_proc/test_sandbox_get_info.py
@@ -1,0 +1,123 @@
+"""Coverage tests for LocalProcessArcaSandbox.get_info().
+
+Verifies that the local-process sandbox returns the unified ArcaSandboxInfo model
+while preserving the backend-specific extra fields, covering both
+process-present and process-absent branches for adapter and engine processes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from secbaas.community.plugins.sandbox.arca.local_proc._process_manager import (
+    ProcessEntry,
+)
+from secbaas.community.plugins.sandbox.arca.local_proc._sandbox import (
+    LocalProcessArcaSandbox,
+    LocalProcessSandboxInfo,
+)
+from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+
+def _fake_process() -> MagicMock:
+    proc = MagicMock()
+    proc.pid = 12345
+    return proc
+
+
+def _entry(
+    *,
+    adapter_process=None,
+    openclaw_process=None,
+    hermes_process=None,
+    openclaw_port: int = 0,
+    hermes_port: int = 0,
+) -> ProcessEntry:
+    return ProcessEntry(
+        sandbox_id="sb-local-1",
+        device_id="dev-1",
+        bot_id="bot-1",
+        adapter_process=adapter_process,
+        adapter_port=9001,
+        openclaw_process=openclaw_process,
+        openclaw_port=openclaw_port,
+        hermes_process=hermes_process,
+        hermes_port=hermes_port,
+        config_dir=Path("/tmp/sb-local-1/config"),
+        workspace_dir=Path("/tmp/sb-local-1/workspace"),
+    )
+
+
+def _sandbox(entry: ProcessEntry) -> LocalProcessArcaSandbox:
+    return LocalProcessArcaSandbox(
+        sandbox_id="sb-local-1", template_id="openclaw", process_entry=entry
+    )
+
+
+class TestLocalProcessSandboxGetInfo:
+    def test_returns_unified_sandbox_info_with_extras(self) -> None:
+        info = _sandbox(_entry(adapter_process=_fake_process())).get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert isinstance(info, LocalProcessSandboxInfo)
+        assert info.sandbox_id == "sb-local-1"
+        assert info.status == "RUNNING"
+        assert info.template_id == "openclaw"
+        assert info.is_ready is True
+        assert info.bot_id == "bot-1"
+        assert info.adapter_port == 9001
+        assert info.adapter_pid == 12345
+        assert info.engine_port == 0
+        assert info.engine_pid is None
+        assert info.config_dir == "/tmp/sb-local-1/config"
+        assert info.workspace_dir == "/tmp/sb-local-1/workspace"
+        assert info.resources is None
+        assert info.envs is None
+        assert info.snapshot_id is None
+        assert info.metadata is None
+        assert info.outbound_operation_rule is None
+        assert info.storage is None
+        assert info.ttl_in_minutes is None
+        assert info.ttl_timestamp is None
+
+    def test_engine_port_from_openclaw(self) -> None:
+        entry = _entry(
+            adapter_process=_fake_process(),
+            openclaw_process=_fake_process(),
+            openclaw_port=9200,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.engine_port == 9200
+        assert info.engine_pid == 12345
+
+    def test_engine_port_from_hermes(self) -> None:
+        entry = _entry(
+            adapter_process=_fake_process(),
+            hermes_process=_fake_process(),
+            hermes_port=9300,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.engine_port == 9300
+        assert info.engine_pid == 12345
+
+    def test_missing_adapter_process_pid_none(self) -> None:
+        entry = _entry(
+            adapter_process=None,
+            openclaw_process=None,
+            hermes_process=None,
+        )
+        info = _sandbox(entry).get_info()
+
+        assert info.adapter_pid is None
+        assert info.engine_pid is None
+
+    def test_repr_includes_local_fields(self) -> None:
+        info = _sandbox(_entry(adapter_process=_fake_process())).get_info()
+        text = repr(info)
+
+        assert "LocalProcessSandboxInfo(" in text
+        assert "sb-local-1" in text
+        assert "9001" in text

--- a/src/baas/tests/unit/plugins/sandbox/arca/test_stub.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/test_stub.py
@@ -77,6 +77,50 @@ class TestStubArcaSandboxGetInfo:
         info = device.get_info()
         assert info.template_id == "mock-template"
 
+    def test_returns_unified_sandbox_info(self) -> None:
+        from secbaas.community.plugins.sandbox.arca._stub import StubSandboxInfo
+        from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+        device = StubArcaSandbox("sb-unified", template_id="tpl-unified")
+        info = device.get_info()
+
+        assert isinstance(info, ArcaSandboxInfo)
+        assert isinstance(info, StubSandboxInfo)
+        # Full SDK-aligned surface with optional fields defaulted
+        for attr in (
+            "sandbox_id",
+            "status",
+            "template_id",
+            "resources",
+            "ttl_in_minutes",
+            "ttl_timestamp",
+            "envs",
+            "snapshot_id",
+            "metadata",
+            "outbound_operation_rule",
+            "storage",
+        ):
+            assert hasattr(info, attr)
+        assert info.resources is None
+        assert info.storage is None
+        assert info.outbound_operation_rule is None
+        # status is a plain string; consumer normalize convention works
+        assert (
+            str(info.status.value)
+            if hasattr(info.status, "value")
+            else str(info.status) == "RUNNING"
+        )
+
+    def test_stub_sandbox_info_is_backward_compatible_alias(self) -> None:
+        from secbaas.community.plugins.sandbox.arca._stub import StubSandboxInfo
+        from secbaas.community.spi.sandbox.arca import ArcaSandboxInfo
+
+        info = StubSandboxInfo("sb-alias", "tpl-alias")
+        assert isinstance(info, ArcaSandboxInfo)
+        assert info.sandbox_id == "sb-alias"
+        assert info.template_id == "tpl-alias"
+        assert info.status == "RUNNING"
+
 
 class TestStubArcaSandboxDestroy:
     """Test StubArcaSandbox.destroy()."""


### PR DESCRIPTION
## Problem

The Arca sandbox currently lacks an Aliyun ACK-backed execution backend. The community SPI models the Arca sandbox info in a way that cannot describe Aliyun ACK clusters, and there is no sandbox plugin that provisions and runs sandboxes against ACK.

## Solution

- `feat(baas): unify Arca sandbox info model in community SPI` — redefine the community Arca sandbox info model so it can represent multiple backends.
- `feat(baas): add Aliyun ACK-backed Arca sandbox plugin` — add an ACK-backed sandbox plugin exposing runtime configuration, an ACK client manager, and a sandbox implementation, wired up through the community plugin bootstrap.

## Validation

- Added unit tests for the new config type and sandbox plugin (`src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/`).
- Added bootstrap wiring test (`src/baas/tests/unit/bootstrap/test_plugins.py`) and an ACK integration test.
- Pre-push lint/SAST gate passed for `src/baas`.

## Compatibility and risk

Introduces a new backend plugin and extends the community sandbox info model. No existing backend behavior is removed; existing sandbox paths remain intact.

## Related issues

Migrates Aliyun ACK support to the new Arca sandbox API.