### PR TITLE
fix(gateway): allow optional principals for internal collaboration APIs

### DIFF
--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -240,8 +240,9 @@ user_config:
       app: required
 
     "/api/v1/collaboration/**":
-      user: required
-      app: required
+      user: optional
+      app: optional
+      bot: optional
 
     # Session-file use cases let BCN choose Human or Bot as the effective Actor.
     # Gateway therefore best-effort resolves and signs every relevant identity;

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -134,8 +134,9 @@ def test_shipped_config_routes_internal_collaboration_verbatim_to_bcs() -> None:
         "GET", "/api/v1/collaboration/bots/bot-1/candidates/search"
     )
     assert requirement is not None
-    assert requirement[PrincipalType.USER] is Presence.REQUIRED
-    assert requirement[PrincipalType.APP] is Presence.REQUIRED
+    assert requirement[PrincipalType.USER] is Presence.OPTIONAL
+    assert requirement[PrincipalType.APP] is Presence.OPTIONAL
+    assert requirement[PrincipalType.BOT] is Presence.OPTIONAL
 
     file_requirement = security.resolve(
         "PUT", "/api/v1/collaboration/sessions/session-1/files/file-1/content"


### PR DESCRIPTION
## Summary

This PR updates the Gateway internal collaboration API security contract so `/api/v1/collaboration/**` accepts optional User, App, and Bot principals.

## Changes

- Change the shipped Gateway config for `/api/v1/collaboration/**` from required User + App to optional User + App + Bot.
- Update the domain-map test to assert the new optional-principal behavior for internal collaboration candidate search.
- Keep the existing session-file-specific optional identity behavior unchanged.

## Rationale

BCS internal collaboration APIs need to support callers that may authenticate as a human, an app, a bot, or a combination of those principals. Gateway should best-effort resolve and sign the available identities, while BCS remains responsible for enforcing the effective authorization policy.

## Validation

- `uv run pytest tests/unit/core/forwarding/test_domain_map.py::test_shipped_config_routes_internal_collaboration_verbatim_to_bcs -q`