### PR TITLE
feat(baas): add Aliyun ACK-backed Arca sandbox plugin and sync deploy config

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -44,6 +44,29 @@ user_config:
     api_key: "@dummy_api_key"
     default_ttl_minutes: 1440 # 分钟 => 1 天
 
+  # Aliyun ACK 沙箱模板配置（第二类模板，用于 plugins.sandbox.arca = "aliyun_ack"）
+  # 默认使用 dummy 值，启用该后端时才需填充 cluster 与 pod 真实值，无需新增配置键。
+  aliyun_ack_template:
+    template_id: "ALIYUN-ACK-TEMPLATE-000000"
+    cluster:
+      endpoint: "https://k8s.example.com"
+      region: "cn-hangzhou"
+      cluster_name: "ack-sandbox"
+      kubeconfig: ""
+      context: "ack-sandbox"
+      access_key_id: "@dummy_access_key_id"
+      access_key_secret: "@dummy_access_key_secret"
+    pod:
+      image: "ubuntu:22.04"
+      namespace: "default"
+      service_account: ""
+      cpu_request: ""
+      cpu_limit: ""
+      memory_request: ""
+      memory_limit: ""
+      storage_class: ""
+      envs: {}
+
   bot_service:
     proxy_base_url: "https://bot_service.example.com"
     proxy_ws_base_url: "wss://bot_service.example.com"

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -44,6 +44,29 @@ user_config:
     api_key: "@dummy_api_key"
     default_ttl_minutes: 1440 # 分钟 => 1 天
 
+  # Aliyun ACK 沙箱模板配置（第二类模板，用于 plugins.sandbox.arca = "aliyun_ack"）
+  # 默认使用 dummy 值，启用该后端时才需填充 cluster 与 pod 真实值，无需新增配置键。
+  aliyun_ack_template:
+    template_id: "ALIYUN-ACK-TEMPLATE-000000"
+    cluster:
+      endpoint: "https://k8s.example.com"
+      region: "cn-hangzhou"
+      cluster_name: "ack-sandbox"
+      kubeconfig: ""
+      context: "ack-sandbox"
+      access_key_id: "@dummy_access_key_id"
+      access_key_secret: "@dummy_access_key_secret"
+    pod:
+      image: "ubuntu:22.04"
+      namespace: "default"
+      service_account: ""
+      cpu_request: ""
+      cpu_limit: ""
+      memory_request: ""
+      memory_limit: ""
+      storage_class: ""
+      envs: {}
+
   bot_service:
     proxy_base_url: "https://proxy.example.com"
     proxy_ws_base_url: "wss://proxy.example.com"


### PR DESCRIPTION
## Problem

The community baas core needs an Aliyun ACK-backed Arca sandbox backend, but the
deploy configs did not declare the new `aliyun_ack_template` config block, so the
plugin's DI config lookup could silently fall back or fail in production.

## Solution
- Unify the Arca sandbox info model in the community SPI.
- Add an Aliyun ACK-backed Arca sandbox plugin, selected via
  `plugins.sandbox.arca: aliyun_ack`.
- Declare the inert `user_config.aliyun_ack_template` block (dummy values) in both
  the base and singlebox deploy configs so the config surface is always present;
  the backend stays opt-in.

## Validation
- `pytest tests/architecture/` passes (config consistency + new community→enterprise
  config-sync test).
- `ruff check` / `ruff format` clean.
- OCB pre-push gate passed (lint-only).

## Compatibility and risk
Backward compatible; new block is inert until `plugins.sandbox.arca` is set to
`aliyun_ack`. Rollback is a config/selector change.

## Related issues
Closes the Aliyun ACK sandbox enablement work on `baas/aliyun_ack_sandbox`.