### PR TITLE
feat(baas): env-scope ARCA TTL renew dist lock

### DIFF
--- a/openspec/changes/env-scoped-arca-dist-lock/.openspec.yaml
+++ b/openspec/changes/env-scoped-arca-dist-lock/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/env-scoped-arca-dist-lock/design.md
+++ b/openspec/changes/env-scoped-arca-dist-lock/design.md
@@ -1,0 +1,148 @@
+## Context
+
+The ARCA device TTL renew scheduler (`DeviceTtlTimerTask`) guards its cron-run
+full-drain scan with a distributed lock named `device_ttl_timer_lock`. This lock
+name is hardcoded as a default in `DeviceTtlTimerTaskConfig` and explicitly
+configured in `configs/application.yaml` and `singlebox-configs/application.yaml`.
+
+PRE and PROD deployments against the same distributed lock store therefore
+compete for the same lock key. When one environment holds the lock, the other
+environment's cron run skips (`Lock not acquired`). Since lock keys are global in
+the shared lock store, this couples the two environments' renewal scheduling.
+
+The codebase already has an environment utility, `get_current_env()` in
+`core/utils/env_utils.py`, which returns `"dev"`, `"pre"`, or `"prod"` by
+inspecting deploy env vars (`SERVER_ENV` / `REAL_SERVER_ENV` / the
+`ConfigPath.DEPLOY_ENV_VAR` variable), mapping `prepub→pre`, `gray→prod`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pre and prod instances use distinct distributed lock names so the ARCA TTL
+  renew cron is scoped per environment.
+- Keep the lock name configurable via config with a safe environment-scoped
+  default; no requirement for operators to change deploy config.
+- Preserve testability of the scheduler task.
+
+**Non-Goals:**
+- Changing the distributed lock service itself.
+- Switching the lock store or lock semantics.
+- Scoping any other lock/task beyond the ARCA device TTL renew lock.
+- Migrating existing in-progress lock leases (they expire naturally via TTL).
+
+## Decisions
+
+### Decision 1: Scope the lock name with the environment obtained from `get_current_env()`
+
+When constructing the effective lock name, derive the environment tag via the
+existing `get_current_env()` helper and compose it into the lock name as
+`device_ttl_timer_lock_<env>` (e.g. `device_ttl_timer_lock_dev`,
+`device_ttl_timer_lock_pre`, `device_ttl_timer_lock_prod`).
+
+- **Why**: `get_current_env()` is the canonical, already-tested env source; it
+  normalizes `prepub`/`gray` correctly. Reusing it avoids a new env-resolution
+  path and keeps behavior consistent with the rest of the codebase.
+- **Alternative considered**: deriving env from raw `SERVER_ENV` directly — rejected
+  because it bypasses the normalization (e.g. `prepub`, `gray`) and duplicates
+  existing logic.
+- **Alternative considered**: requiring operators to set `lock_name` per env in
+  config — rejected because it couples correctness to manual deploy config and is
+  error-prone.
+
+### Decision 2: Default `lock_name` to a sentinel meaning "scope by env"; resolve lazily at runtime
+
+`DeviceTtlTimerTaskConfig.lock_name` keeps an explicit default that signals
+"auto-scope by environment". At lock acquisition time, the effective lock name is
+`<configured_base_or_default><env_suffix>`. If an operator explicitly sets a
+`lock_name`, it is still suffixed with the env to guarantee isolation.
+
+- **Why**: An explicit config value of `device_ttl_timer_lock` set by operators
+  (as today) must not silently disable env isolation. Resolving at runtime and
+  always applying the suffix guarantees pre/prod isolation regardless of whether
+  `lock_name` comes from the default or from config.
+- **Alternative considered**: storing the final suffixed name in config — rejected
+  because config is static per deployment and would require per-env config values,
+  defeating the "safe default" goal.
+
+### Decision 3: Expose the resolved lock name via a helper/property
+
+Add a helper (e.g. `resolved_lock_name()`) on the config or task that returns the
+env-scoped lock name, so tests and callers observe the exact string that is used
+for acquisition.
+
+- **Why**: Keeps the suffix logic in one place, testable, and readable.
+
+### Decision 4: Ensure `lock_expire_seconds < cron_interval_seconds` so another box can acquire the lock
+
+Today both default to `1800`. With equal values (and auto-renew keeping the lease
+alive through a long scan), the same machine that held the lock is typically the
+one to re-acquire it at the next cron tick — the lease has not yet expired by the
+time the next interval fires, so competitors are crowded out. Making the lease
+expire strictly before the next interval lets the lock become free between rounds
+so a different instance can acquire it (improving scheduling balance and avoiding
+single-box monopolization).
+
+- **Why**: `lock_expire_seconds` bounds how long a holder may actually keep the
+  lease (it is the "safe" ceiling even if renew is missed); the cron interval is
+  the earliest a competitor can contend. For fairness the ceiling must be below
+  the contention point.
+- **Concrete change**: set `lock_expire_seconds` default to `1750` (clearly below
+  `cron_interval_seconds` `1800`), and document in config that
+  `lock_expire_seconds < cron_interval_seconds` is required for cross-machine
+  takeover between rounds.
+- **Alternative considered**: leaving values equal so a single fast box always
+  wins — rejected because it contradicts the env-isolation distribution goal and
+  reduces resilience/load balancing.
+
+### Decision 5: Remove the dead `lock_renew_interval_seconds` YAML key
+
+`lock_renew_interval_seconds` under `device_ttl_timer` in the YAML configs is
+**never read by any Python code**. The auto-renew interval is configured at the
+`DistributedLockService` level (wired from `bot_run_queue.session_lock_renew_seconds`)
+and per-task this is not overridable. Keeping the key in `device_ttl_timer`
+suggests per-task renew control that does not exist.
+
+- **Why**: Removing dead/misleading config prevents operators from believing they
+  can tune renew interval per task and avoids silent no-op configuration. Only the
+  `device_ttl_timer` occurrences are removed; the `bot_run_queue` occurrences are
+  left untouched.
+- **Note — related defect (out of scope to fix here unless confirmed):** the renew
+  thread (`distributed_lock/_service.py`) refreshes the lease to
+  `self._default_expire_seconds` (wired to `session_lock_expire_seconds=300`),
+  not to the task's per-acquisition `expire_seconds`. If we keep task-level
+  renew, this must be reconciled; the immediate decision is to drop the unused
+  task-level key.
+- **Alternative considered**: keep the key and wire it through
+  `DeviceTtlTimerTaskConfig` → per-acquisition renew. Rejected for this change to
+  keep scope small; the env-isolation goal does not require per-task renew tuning.
+
+## Risks / Trade-offs
+
+- **Lock store accumulates stale keys** → Old `device_ttl_timer_lock` leases
+  (and dev-scoped variants) linger until their TTL expires after a deploy; this is
+  benign because the scheduler only ever acquires the env-scoped name. No cleanup
+  required.
+- **Gray/pre differentiation** → `get_current_env()` maps `gray→prod`, so gray
+  shares prod's lock. `get_current_env_with_gray()` could be used instead if gray
+  must be separated. Trade-off between sharing (fewer distinct keys) and strict
+  isolation; defaulting to prod-sharing is consistent with existing env semantics.
+- **Behavior change to lock key name** → Cross-check: any runbook that manually
+  inspects or clears `device_ttl_timer_lock` must now look at the env-suffixed
+  key. Addressed by documenting the new name scheme in the design and config
+  comment.
+
+## Migration Plan
+
+- No schema or contract changes. `lock_expire_seconds` default changes from 1800
+  to `1750`; the unused `device_ttl_timer.lock_renew_interval_seconds` key is
+  removed from the YAML configs.
+- Deploy: new builds acquire env-scoped lock keys. Existing older builds still use
+  the shared key until they are decommissioned — brief co-existence can cause the
+  old key to be held while the new key is free, so during rolling upgrade both
+  environments may scan independently; this is the intended new behavior.
+- Rollback: reverting the code restores the shared name; no data migration.
+
+## Open Questions
+
+- Should gray be isolated from prod? Initially no (consistent with existing env
+  semantics); can revisit via `get_current_env_with_gray()` if required.

--- a/openspec/changes/env-scoped-arca-dist-lock/proposal.md
+++ b/openspec/changes/env-scoped-arca-dist-lock/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The ARCA TTL renew scheduler uses a fixed distributed lock name
+`device_ttl_timer_lock` for the cron path. Pre-production and production
+deployments share the same lock store, so when both environments run the
+scheduler the lock is shared across environments. This lets one environment's
+renewal run block the other's, and can cause cross-environment interference and
+misleading lock-acquisition logic. Each environment needs its own lock so the
+lock is isolated by env.
+
+## What Changes
+
+- Scope the distributed lock name by environment so pre and prod use distinct
+  lock names instead of the shared `device_ttl_timer_lock`.
+- Make `lock_expire_seconds` strictly less than `cron_interval_seconds` so the
+  lease frees between rounds and a different machine can acquire the lock,
+  instead of the same box re-acquiring every tick.
+- Remove the unused `lock_renew_interval_seconds` key from the `device_ttl_timer`
+  YAML config: it is never read by any code and misleadingly implies per-task
+  renew control that does not exist.
+- Keep the existing `lock_name` configurable with a sane default, but default it
+  to an env-qualified name derived from the environment identifier.
+- Update the packaged config files (`configs/application.yaml`,
+  `singlebox-configs/application.yaml`) and adjust unit tests that assert the
+  lock name.
+
+## Capabilities
+
+### New Capabilities
+- `env-scoped-dist-lock`: the distributed lock name used by the ARCA TTL renew
+  cron path is namespaced by environment, isolating PRE and PROD lock holders.
+
+### Modified Capabilities
+<!-- None: no existing specs yet. -->
+
+## Impact
+
+- `src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py`
+  — `DeviceTtlTimerTaskConfig` and lock acquisition.
+- `src/baas/configs/application.yaml` and
+  `src/baas/singlebox-configs/application.yaml` — lock name configuration, lock
+  expire default, and removal of the dead device_ttl_timer renew-interval key
+  (`bot_run_queue` occurrences are left intact).
+- `src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py` —
+  lock name assertions.
+- No change to persisted contract/schema; lock keys in the distributed lock store
+  will change on deploy (old `device_ttl_timer_lock` leases may linger until their
+  TTL expires).

--- a/openspec/changes/env-scoped-arca-dist-lock/specs/env-scoped-dist-lock/spec.md
+++ b/openspec/changes/env-scoped-arca-dist-lock/specs/env-scoped-dist-lock/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Env-scoped distributed lock name
+The ARCA device TTL renew scheduler SHALL derive its distributed lock name from the
+deployment environment so that pre-production and production use distinct lock
+names and do not share a lock holder.
+
+The effective lock name is composed of the configured lock name base and an
+environment suffix derived from the current environment identifier. The suffix MUST
+reflect the normalized environment (`dev`, `pre`, or `prod`) so that distinct
+deployments to different environments never acquire the same lock key.
+
+#### Scenario: Production uses a prod-scoped lock name
+- **WHEN** a deployment's current environment resolves to `prod`
+- **THEN** the scheduler acquires a distributed lock whose name carries a `prod`
+  environment suffix and is distinct from the pre scoped name
+
+#### Scenario: Pre-production uses a pre-scoped lock name
+- **WHEN** a deployment's current environment resolves to `pre`
+- **THEN** the scheduler acquires a distributed lock whose name carries a `pre`
+  environment suffix and is distinct from the prod scoped name
+
+#### Scenario: Environment isolation is guaranteed with an explicit lock_name
+- **WHEN** a configuration specifies an explicit `lock_name` value
+- **THEN** the effective lock name still carries the environment suffix so that
+  pre and prod never share the same lock key
+
+#### Scenario: Dev uses a dev-scoped lock name
+- **WHEN** a deployment's current environment resolves to `dev`
+- **THEN** the scheduler acquires a distributed lock whose name carries a `dev`
+  environment suffix
+
+### Requirement: Lock lease shorter than cron interval
+The scheduler's distributed lock lease (`lock_expire_seconds`) SHALL be strictly
+less than the cron interval (`cron_interval_seconds`), so that between cron rounds
+the lock is released and a different instance can acquire it rather than the same
+machine re-acquiring it every tick.
+
+#### Scenario: Another machine acquires after lease expiry
+- **WHEN** a cron interval elapses with the lock no longer held because its lease
+  (less than the interval) has expired
+- **THEN** the lock is acquirable by a different scheduler instance that contends
+  at the tick
+
+#### Scenario: Default values enforce the ordering
+- **WHEN** the task is constructed with default configuration
+- **THEN** `lock_expire_seconds` is strictly less than `cron_interval_seconds`
+
+### Requirement: No dead renew-interval config
+The `device_ttl_timer` configuration SHALL NOT expose a `lock_renew_interval_seconds`
+key, because no code reads it and it misleadingly implies per-task auto-renew control
+that does not exist.

--- a/openspec/changes/env-scoped-arca-dist-lock/tasks.md
+++ b/openspec/changes/env-scoped-arca-dist-lock/tasks.md
@@ -1,0 +1,23 @@
+## 1. Env-scoped lock name resolution
+
+- [x] 1.1 Add a `resolved_lock_name()` helper on `DeviceTtlTimerTaskConfig` (or task) that combines the configured `lock_name` base with an environment suffix from `get_current_env()` (e.g. `device_ttl_timer_lock_<env>`).
+- [x] 1.2 Update `DeviceTtlTimerTask.run()` to use the resolved lock name when acquiring the distributed lock (and when logging acquisition/skip messages).
+
+## 2. Config and comments
+
+- [x] 2.1 Update the `lock_name` comment in `src/baas/configs/application.yaml` and `src/baas/singlebox-configs/application.yaml` to document the env-suffixed key scheme.
+- [x] 2.2 Set `lock_expire_seconds` in the YAML configs and `DeviceTtlTimerTaskConfig` default to `1750` (strictly less than `cron_interval_seconds` `1800`), and add a config comment requiring `lock_expire_seconds < cron_interval_seconds`.
+- [x] 2.3 Remove the unused `lock_renew_interval_seconds` key from the `device_ttl_timer` sections of both YAML configs. (The `bot_run_queue` occurrences are left intact.)
+- [x] 2.4 Verify no other code references the raw `device_ttl_timer_lock` name for acquisition.
+
+## 3. Tests
+
+- [x] 3.1 Add/update unit tests in `test_device_ttl_timer_task.py` asserting the effective lock name carries the correct environment suffix for dev, pre, and prod.
+- [x] 3.2 Add a test that an explicit `lock_name` config value still yields an env-suffixed effective lock name.
+- [x] 3.3 Update `DeviceTtlTimerTaskConfig` default assertions for `lock_expire_seconds == 1750` (strictly less than `cron_interval_seconds` `1800`).
+- [x] 3.4 Run the scheduler unit tests and confirm all pass.
+
+## 4. Architecture and CI gates
+
+- [x] 4.1 Run the module SAST/lint and architecture boundary checks for `src/baas/` and confirm no regressions.
+- [x] 4.2 Document the new lock key naming in the design/migration notes so runbooks referencing `device_ttl_timer_lock` are updated.

--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -124,9 +124,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # 文件传输轮询器配置（定期检测 OSS 上传完成并触发 device 下载）

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -109,9 +109,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # BotRun 队列恢复配置（周期性重置心跳过期的 RUNNING 请求回 PENDING）

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
@@ -27,6 +27,7 @@ from secbaas.community.core.service.health_check.sandbox import (
     SandboxDeviceRouter,
     TableType,
 )
+from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 
 log = get_logger("core-scheduler")
@@ -38,11 +39,9 @@ class DeviceTtlTimerTaskConfig:
 
     enabled: bool = True
     lock_name: str = "device_ttl_timer_lock"
-    # 锁过期时间须 >= cron 间隔：full-drain 一轮可能超过5分钟，锁在持有期间
-    # 会被 DistributedLockService 自动续期，为避免进程卡住时锁永远不释放，
-    # 这里给一个宽松的租约（默认30分钟）。cron 间隔与 lock 到期解耦，避免
-    # “下一轮在上一轮还没跑完时就再次触发、锁又正好过期”导致并发重复扫描。
-    lock_expire_seconds: int = 1800
+    # 锁过期时间须 < cron 间隔：租约在下一轮触发前到期释放，允许其它机器
+    # 在轮次间抢到锁，避免同一实例每轮都重复占锁。
+    lock_expire_seconds: int = 1750
     cron_interval_seconds: int = 1800
     batch_size: int = 100
     dry_run: bool = False
@@ -51,6 +50,15 @@ class DeviceTtlTimerTaskConfig:
     max_page_concurrency: int = 10
     # 单页查询 DB 失败时的重试次数（指数退避），吸收瞬时 DB 抖动。
     query_retries: int = 3
+
+    def resolved_lock_name(self) -> str:
+        """返回按环境作用域的分布式锁名。
+
+        在配置的 ``lock_name`` 基准上追加环境后缀（如 ``_pre``/``_prod``），
+        使 pre 与 prod 使用不同的锁名，避免共享同一把分布式锁。
+        """
+        env = get_current_env()
+        return f"{self.lock_name}_{env}"
 
 
 @dataclass
@@ -181,19 +189,20 @@ class DeviceTtlTimerTask:
             log.info("[DeviceTtlTimer] Another run in progress, skipping cron trigger")
             return None
 
+        lock_name = self._config.resolved_lock_name()
         with self._lock_service.try_lock(
-            lock_name=self._config.lock_name,
+            lock_name=lock_name,
             expire_seconds=self._config.lock_expire_seconds,
             block=False,
         ) as lock:
             if not lock.acquired:
                 log.info(
                     "[DeviceTtlTimer] Lock %s not acquired, skipping",
-                    self._config.lock_name,
+                    lock_name,
                 )
                 return None
 
-            log.info("[DeviceTtlTimer] Lock %s acquired", self._config.lock_name)
+            log.info("[DeviceTtlTimer] Lock %s acquired", lock_name)
             self._running = True
             try:
                 return await self._run_once(run_uuid=run_uuid)

--- a/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
@@ -7,7 +7,7 @@ stall trailing devices. Also covers the per-record digest logging.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -100,7 +100,56 @@ class TestDefaults:
         assert task.interval_seconds == 42
         assert task._config.batch_size == 100
         assert task._config.lock_name == "device_ttl_timer_lock"
-        assert task._config.lock_expire_seconds == 1800
+        assert task._config.lock_expire_seconds == 1750
+
+
+class TestResolvedLockName:
+    def test_dev_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="dev",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_dev"
+
+    def test_pre_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_pre"
+
+    def test_prod_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_prod"
+
+    def test_explicit_lock_name_still_env_suffixed(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig(lock_name="custom_timer_lock")
+            assert cfg.resolved_lock_name() == "custom_timer_lock_pre"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_resolved_lock_name(self):
+        cfg = DeviceTtlTimerTaskConfig(enabled=True)
+        lock_service = MagicMock()
+        lock_service.try_lock.return_value.__enter__.return_value = _not_acquired_lock()
+        task = DeviceTtlTimerTask(cfg, lock_service, MagicMock(), MagicMock())
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            await task.run()
+        lock_service.try_lock.assert_called_once()
+        call_kwargs = lock_service.try_lock.call_args
+        assert call_kwargs.kwargs["lock_name"] == "device_ttl_timer_lock_prod"
 
 
 class TestEarlyReturns:


### PR DESCRIPTION
## Problem

The ARCA device TTL renew scheduler guards its cron run with a fixed distributed
lock name `device_ttl_timer_lock`. PRE and PROD deployments share the same
distributed lock store, so both environments contend for the same lock key. When
one environment holds the lock the other's cron run is skipped, coupling the two
environments' renewal scheduling and causing misleading lock-acquisition behavior.

Additionally, `lock_expire_seconds` and `cron_interval_seconds` both default to
`1800`. With auto-renew keeping the lease alive through a long scan, the same
box that held the lock is typically the one to re-acquire it at the next tick,
crowding out other instances.

## Solution

- Scope the distributed lock name by environment: resolve `resolved_lock_name()`
  against `get_current_env()` (dev/pre/prod) and always append the env suffix,
  even when `lock_name` is set explicitly. PRE and PROD now use distinct lock keys.
- Lower `lock_expire_seconds` to `1750` (strictly below `cron_interval_seconds`
  `1800`) so the lease frees between rounds and a different machine can acquire
  the lock.
- Remove the unused `device_ttl_timer.lock_renew_interval_seconds` config key;
  no code reads it (the service-level renew interval is wired from
  `bot_run_queue.session_lock_renew_seconds`). `bot_run_queue` occurrences are
  left intact.

## Validation

- 116 unit tests pass (`tests/unit/core/service/scheduler/` and
  `tests/unit/core/service/distributed_lock/`), including new tests for the
  env suffix on dev/pre/prod, explicit `lock_name` still being env-suffixed,
  and `run()` acquiring the resolved lock name.
- `ruff check` clean on changed files.
- Pre-push BaaS SAST/lint gate (lint-only mode) passed.

Not run: full BaaS changed-line coverage and singlebox coverage (lint-only
pre-push mode; not exercised locally).

## Compatibility and risk

- No schema or config-schema change. Effective lock keys in the shared lock
  store change on deploy; old `device_ttl_timer_lock` leases linger only until
  their TTL expires and are not acquired anymore. Runbooks that inspect or clear
  `device_ttl_timer_lock` should track the env-suffixed keys
  (`device_ttl_timer_lock_dev/pre/prod`).
- Known latent defect (out of scope): the lock service renew thread refreshes the
  lease to `default_expire_seconds` (wired to `session_lock_expire_seconds`),
  not the task's per-acquisition `expire_seconds`. Not changed here.