### PR TITLE
feat(baas): env-scope ARCA TTL renew dist lock

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -124,9 +124,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # 文件传输轮询器配置（定期检测 OSS 上传完成并触发 device 下载）

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -109,9 +109,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # BotRun 队列恢复配置（周期性重置心跳过期的 RUNNING 请求回 PENDING）

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
@@ -27,6 +27,7 @@ from secbaas.community.core.service.health_check.sandbox import (
     SandboxDeviceRouter,
     TableType,
 )
+from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 
 log = get_logger("core-scheduler")
@@ -38,11 +39,9 @@ class DeviceTtlTimerTaskConfig:
 
     enabled: bool = True
     lock_name: str = "device_ttl_timer_lock"
-    # 锁过期时间须 >= cron 间隔：full-drain 一轮可能超过5分钟，锁在持有期间
-    # 会被 DistributedLockService 自动续期，为避免进程卡住时锁永远不释放，
-    # 这里给一个宽松的租约（默认30分钟）。cron 间隔与 lock 到期解耦，避免
-    # “下一轮在上一轮还没跑完时就再次触发、锁又正好过期”导致并发重复扫描。
-    lock_expire_seconds: int = 1800
+    # 锁过期时间须 < cron 间隔：租约在下一轮触发前到期释放，允许其它机器
+    # 在轮次间抢到锁，避免同一实例每轮都重复占锁。
+    lock_expire_seconds: int = 1750
     cron_interval_seconds: int = 1800
     batch_size: int = 100
     dry_run: bool = False
@@ -51,6 +50,15 @@ class DeviceTtlTimerTaskConfig:
     max_page_concurrency: int = 10
     # 单页查询 DB 失败时的重试次数（指数退避），吸收瞬时 DB 抖动。
     query_retries: int = 3
+
+    def resolved_lock_name(self) -> str:
+        """返回按环境作用域的分布式锁名。
+
+        在配置的 ``lock_name`` 基准上追加环境后缀（如 ``_pre``/``_prod``），
+        使 pre 与 prod 使用不同的锁名，避免共享同一把分布式锁。
+        """
+        env = get_current_env()
+        return f"{self.lock_name}_{env}"
 
 
 @dataclass
@@ -181,19 +189,20 @@ class DeviceTtlTimerTask:
             log.info("[DeviceTtlTimer] Another run in progress, skipping cron trigger")
             return None
 
+        lock_name = self._config.resolved_lock_name()
         with self._lock_service.try_lock(
-            lock_name=self._config.lock_name,
+            lock_name=lock_name,
             expire_seconds=self._config.lock_expire_seconds,
             block=False,
         ) as lock:
             if not lock.acquired:
                 log.info(
                     "[DeviceTtlTimer] Lock %s not acquired, skipping",
-                    self._config.lock_name,
+                    lock_name,
                 )
                 return None
 
-            log.info("[DeviceTtlTimer] Lock %s acquired", self._config.lock_name)
+            log.info("[DeviceTtlTimer] Lock %s acquired", lock_name)
             self._running = True
             try:
                 return await self._run_once(run_uuid=run_uuid)

--- a/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
@@ -7,7 +7,7 @@ stall trailing devices. Also covers the per-record digest logging.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -100,7 +100,56 @@ class TestDefaults:
         assert task.interval_seconds == 42
         assert task._config.batch_size == 100
         assert task._config.lock_name == "device_ttl_timer_lock"
-        assert task._config.lock_expire_seconds == 1800
+        assert task._config.lock_expire_seconds == 1750
+
+
+class TestResolvedLockName:
+    def test_dev_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="dev",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_dev"
+
+    def test_pre_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_pre"
+
+    def test_prod_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_prod"
+
+    def test_explicit_lock_name_still_env_suffixed(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig(lock_name="custom_timer_lock")
+            assert cfg.resolved_lock_name() == "custom_timer_lock_pre"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_resolved_lock_name(self):
+        cfg = DeviceTtlTimerTaskConfig(enabled=True)
+        lock_service = MagicMock()
+        lock_service.try_lock.return_value.__enter__.return_value = _not_acquired_lock()
+        task = DeviceTtlTimerTask(cfg, lock_service, MagicMock(), MagicMock())
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            await task.run()
+        lock_service.try_lock.assert_called_once()
+        call_kwargs = lock_service.try_lock.call_args
+        assert call_kwargs.kwargs["lock_name"] == "device_ttl_timer_lock_prod"
 
 
 class TestEarlyReturns:


### PR DESCRIPTION
## Problem

The ARCA device TTL renew scheduler guards its cron run with a fixed distributed
lock name `device_ttl_timer_lock`. PRE and PROD deployments share the same
distributed lock store, so both environments contend for the same lock key. When
one environment holds the lock the other's cron run is skipped, coupling the two
environments' renewal scheduling and causing misleading lock-acquisition behavior.

Additionally, `lock_expire_seconds` and `cron_interval_seconds` both default to
`1800`. With auto-renew keeping the lease alive through a long scan, the same
box that held the lock is typically the one to re-acquire it at the next tick,
crowding out other instances.

## Solution

- Scope the distributed lock name by environment: resolve `resolved_lock_name()`
  against `get_current_env()` (dev/pre/prod) and always append the env suffix,
  even when `lock_name` is set explicitly. PRE and PROD now use distinct lock keys.
- Lower `lock_expire_seconds` to `1750` (strictly below `cron_interval_seconds`
  `1800`) so the lease frees between rounds and a different machine can acquire
  the lock.
- Remove the unused `device_ttl_timer.lock_renew_interval_seconds` config key;
  no code reads it (the service-level renew interval is wired from
  `bot_run_queue.session_lock_renew_seconds`). `bot_run_queue` occurrences are
  left intact.

## Validation

- 116 unit tests pass (`tests/unit/core/service/scheduler/` and
  `tests/unit/core/service/distributed_lock/`), including new tests for the
  env suffix on dev/pre/prod, explicit `lock_name` still being env-suffixed,
  and `run()` acquiring the resolved lock name.
- `ruff check` clean on changed files.
- Pre-push BaaS SAST/lint gate (lint-only mode) passed.

Not run: full BaaS changed-line coverage and singlebox coverage (lint-only
pre-push mode; not exercised locally).

## Compatibility and risk

- No schema or config-schema change. Effective lock keys in the shared lock
  store change on deploy; old `device_ttl_timer_lock` leases linger only until
  their TTL expires and are not acquired anymore. Runbooks that inspect or clear
  `device_ttl_timer_lock` should track the env-suffixed keys
  (`device_ttl_timer_lock_dev/pre/prod`).
- Known latent defect (out of scope): the lock service renew thread refreshes the
  lease to its `default_expire_seconds` (wired to `session_lock_expire_seconds`),
  not the task's per-acquisition `expire_seconds`. Not changed here.