### PR TITLE
fix(skills): keep uploaded skill locators canonical

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -76,8 +76,13 @@ internal_dependencies:
 
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
 
-Local Skill replacement stages a complete package before switching the existing
-Skill metadata. Its old-package cleanup work is persisted before an Active
+Local Skill replacement stages and verifies a complete package in a hidden
+implementation directory, then publishes it to the stable layout-owned
+``skills-local/<skill-name>`` locator before switching existing Skill metadata.
+For a Skills Pool layout, ``skills-local`` is the Pool local root resolved by
+``SkillServiceFactory``. Hidden ``.replacement-*`` and ``.rollback-*``
+directories are never database authority and are removed or recorded as
+cleanup work after the operation. Its old-package cleanup work is persisted before an Active
 runtime switch can commit; a rollback cancels that old-locator work before the
 old package becomes authoritative again. Failed post-switch obsolete-byte deletion is recorded through
 `LocalSkillCleanupRepository` in the exact deployment-wide Bot scope

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -23,9 +23,13 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
-from agentclaw.community.core.repository.protocols.skill_center import SkillCategoryRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillCategoryRepository,
+)
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
 from agentclaw.community.core.skill_center.path_resolution import (
     build_pool_local_path_adapter,
@@ -107,6 +111,26 @@ class LocalSkillPackageStorage:
         """Read and validate every package file without changing storage."""
         await self._read_package_files()
         return True
+
+    async def copy_to(
+        self, target: "LocalSkillPackageStorage", *, replace: bool = False
+    ) -> None:
+        """Copy and verify this complete package without deleting the source.
+
+        Device backends deliberately do not promise a common directory rename.
+        Replacement therefore stages and verifies bytes first, then publishes
+        them to the stable user-visible package directory through this portable
+        copy seam.  The source remains available for rollback until the caller
+        explicitly cleans it up.
+        """
+        files = await self._read_package_files()
+        if await target._filesystem.exists(target.directory):
+            if not replace:
+                raise OSError("Local Skill copy target already exists")
+            if not await target.cleanup():
+                raise OSError("unable to clear Local Skill copy target")
+        if not await target._restore_contents(files):
+            raise OSError("Local Skill copy verification failed")
 
     async def quarantine_to(self, quarantine: "LocalSkillPackageStorage") -> None:
         """Copy, verify, then remove this authoritative package.
@@ -320,8 +344,9 @@ class SkillServiceFactory:
         """Return a Bot-local package storage port.
 
         ``directory_name`` is intentionally internal.  A replacement writes a
-        complete package to an isolated versioned directory before its metadata
-        points runtime at it; first creation keeps the historical name path.
+        complete package to an isolated versioned directory, then publishes it
+        to the stable ``name`` directory.  Metadata never points at the
+        internal directory.
         """
         service = self.create(
             entity_id=entity_id,
@@ -388,7 +413,9 @@ class SkillServiceFactory:
         try:
             relative_locator = resolved_candidate.relative_to(resolved_base)
         except ValueError as exc:
-            raise ValueError("Local Skill cleanup locator escapes skills-local") from exc
+            raise ValueError(
+                "Local Skill cleanup locator escapes skills-local"
+            ) from exc
         if not relative_locator.parts:
             raise ValueError("Local Skill cleanup locator must name a package")
         # Keep the original path form for the device adapter (notably Teclaw's

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -20,7 +20,9 @@ from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
 )
-from agentclaw.community.core.repository.protocols.bot import BotCollabLogRepositoryProtocol
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLogRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillDuplicateError,
@@ -34,7 +36,9 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillTooLargeError,
     LocalSkillLayoutRollbackError,
 )
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
@@ -42,7 +46,9 @@ from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
     SkillSetServiceFactory,
 )
-from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    LocalSkillCleanupRepository,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
@@ -344,19 +350,39 @@ class LocalSkillUploadService:
         files: list[tuple[str, bytes]],
         is_teclaw: bool,
     ) -> dict[str, Any]:
-        """Stage a complete replacement, then atomically switch its locator authority."""
+        """Publish a replacement at the stable layout-owned package locator.
+
+        The hidden directory is staging only.  Runtime and database authority
+        always converge on ``<resolved-local-root>/<skill-name>``; this keeps
+        normal and Skills Pool layouts consistent and keeps implementation
+        directories out of the public workspace contract.
+        """
         old_locator = str(skill["git_path"])[len("local://") :]
         version_dir = f".{name}.replacement-{uuid4().hex}"
-        new_locator, staged = self._skill_service_factory.local_skill_package_storage(
-            entity_id=str(bot["entity_id"]),
-            owner_id=owner_id,
-            bot_id=bot_id,
-            engine_type=bot.get("active_engine"),
-            entity_type=str(bot.get("entity_type") or "staff"),
-            is_desktop=bot.get("bot_type") == "desktop",
-            is_teclaw=is_teclaw,
-            name=name,
-            directory_name=version_dir,
+        canonical_locator, canonical = (
+            self._skill_service_factory.local_skill_package_storage(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
+                name=name,
+            )
+        )
+        staged_locator, staged = (
+            self._skill_service_factory.local_skill_package_storage(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
+                name=name,
+                directory_name=version_dir,
+            )
         )
         old_storage = (
             self._skill_service_factory.local_skill_package_storage_for_locator(
@@ -370,6 +396,10 @@ class LocalSkillUploadService:
                 locator=old_locator,
             )
         )
+        old_is_canonical = old_locator == canonical_locator
+        obsolete_locator = old_locator
+        obsolete_storage = old_storage
+        backup = None
         old_metadata = {
             "description": skill.get("description"),
             "git_path": skill.get("git_path"),
@@ -378,14 +408,38 @@ class LocalSkillUploadService:
         switched = False
         old_cleanup_work_id: int | None = None
         runtime_sync_attempted = False
+        canonical_published = False
         try:
             await staged.write(files)
+            await staged.verify()
+            if old_is_canonical:
+                backup_dir = f".{name}.rollback-{uuid4().hex}"
+                obsolete_locator, backup = (
+                    self._skill_service_factory.local_skill_package_storage(
+                        entity_id=str(bot["entity_id"]),
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        engine_type=bot.get("active_engine"),
+                        entity_type=str(bot.get("entity_type") or "staff"),
+                        is_desktop=bot.get("bot_type") == "desktop",
+                        is_teclaw=is_teclaw,
+                        name=name,
+                        directory_name=backup_dir,
+                    )
+                )
+                await old_storage.copy_to(backup)
+                obsolete_storage = backup
+            # ``copy_to(..., replace=True)`` can fail after clearing or partly
+            # writing the canonical directory.  Mark the mutation before the
+            # call so every such failure restores the old authority.
+            canonical_published = True
+            await staged.copy_to(canonical, replace=True)
             old_cleanup_work_id = self._cleanup_repo.record_preparing(
                 env=str(bot["env"]),
                 owner_id=owner_id,
                 bot_id=bot_id,
                 skill_id=str(skill["id"]),
-                package_locator=old_locator,
+                package_locator=obsolete_locator,
             )
             if old_cleanup_work_id is None:
                 raise LocalSkillStorageError()
@@ -394,7 +448,7 @@ class LocalSkillUploadService:
                 owner_id=owner_id,
                 bot_id=bot_id,
                 old_locator=old_locator,
-                new_locator=new_locator,
+                new_locator=canonical_locator,
                 description=description,
                 # Replacements always reconcile the runtime before the old
                 # package can be cleaned up, including an inactive skill
@@ -449,14 +503,20 @@ class LocalSkillUploadService:
                 owner_id=owner_id,
                 bot_id=bot_id,
                 staged=staged,
-                staged_locator=new_locator,
+                staged_locator=staged_locator,
+                canonical=canonical,
+                canonical_locator=canonical_locator,
+                old_is_canonical=old_is_canonical,
+                backup=backup,
+                obsolete_locator=obsolete_locator,
+                canonical_published=canonical_published,
                 switched=switched,
                 old_cleanup_work_id=old_cleanup_work_id,
                 runtime_sync_attempted=runtime_sync_attempted,
             )
             raise
         except Exception as exc:
-            if switched:
+            if switched or canonical_published:
                 await self._restore_replacement(
                     skill=skill,
                     old_metadata=old_metadata,
@@ -464,8 +524,14 @@ class LocalSkillUploadService:
                     owner_id=owner_id,
                     bot_id=bot_id,
                     staged=staged,
-                    staged_locator=new_locator,
-                    switched=True,
+                    staged_locator=staged_locator,
+                    canonical=canonical,
+                    canonical_locator=canonical_locator,
+                    old_is_canonical=old_is_canonical,
+                    backup=backup,
+                    obsolete_locator=obsolete_locator,
+                    canonical_published=canonical_published,
+                    switched=switched,
                     old_cleanup_work_id=old_cleanup_work_id,
                     runtime_sync_attempted=runtime_sync_attempted,
                 )
@@ -473,19 +539,28 @@ class LocalSkillUploadService:
                 self._cancel_cleanup_if_registered(
                     old_cleanup_work_id, bot, owner_id, bot_id
                 )
+                if backup is not None:
+                    await self._discard_or_record(
+                        bot=bot,
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        skill_id=str(skill["id"]),
+                        storage=backup,
+                        locator=obsolete_locator,
+                    )
                 await self._discard_or_record(
                     bot=bot,
                     owner_id=owner_id,
                     bot_id=bot_id,
                     skill_id=str(skill["id"]),
                     storage=staged,
-                    locator=new_locator,
+                    locator=staged_locator,
                 )
             raise LocalSkillStorageError() from exc
         # The old locator already has durable work.  Its purge is never a
         # reason to undo a working replacement.
         try:
-            cleaned = await old_storage.cleanup()
+            cleaned = await obsolete_storage.cleanup()
         except Exception:
             cleaned = False
         if cleaned:
@@ -496,12 +571,20 @@ class LocalSkillUploadService:
                 bot_id=bot_id,
             ):
                 raise LocalSkillStorageError()
+        await self._discard_or_record(
+            bot=bot,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            skill_id=str(skill["id"]),
+            storage=staged,
+            locator=staged_locator,
+        )
         return {
             "operation": "updated",
             "skill": {
                 **skill,
                 "description": description,
-                "git_path": f"local://{new_locator}",
+                "git_path": f"local://{canonical_locator}",
                 "user_id": owner_id,
             },
             "actor_id": actor_id,
@@ -517,18 +600,31 @@ class LocalSkillUploadService:
         bot_id: str,
         staged,
         staged_locator: str,
+        canonical,
+        canonical_locator: str,
+        old_is_canonical: bool,
+        backup,
+        obsolete_locator: str,
+        canonical_published: bool,
         switched: bool,
         old_cleanup_work_id: int | None,
         runtime_sync_attempted: bool,
     ) -> None:
+        if canonical_published:
+            try:
+                if old_is_canonical:
+                    if backup is None:
+                        raise LocalSkillStorageError()
+                    await backup.copy_to(canonical, replace=True)
+                elif not await canonical.cleanup():
+                    raise LocalSkillStorageError()
+            except Exception as exc:
+                raise LocalSkillStorageError() from exc
         if switched:
             restored = self._skill_repo.update(skill["id"], old_metadata)
             if restored is None:
                 raise LocalSkillStorageError()
-            if (
-                runtime_sync_attempted
-                and not self._sync_runtime(bot, owner_id, bot_id)
-            ):
+            if runtime_sync_attempted and not self._sync_runtime(bot, owner_id, bot_id):
                 # Runtime may have switched partway before reporting failure.
                 # Keep the complete staged package until a later serialized
                 # mutation can restore the old mapping before deleting it.
@@ -538,7 +634,9 @@ class LocalSkillUploadService:
                         owner_id=owner_id,
                         bot_id=bot_id,
                         skill_id=str(skill["id"]),
-                        locator=staged_locator,
+                        locator=(
+                            staged_locator if old_is_canonical else canonical_locator
+                        ),
                         requires_runtime_restore=True,
                     )
                     is None
@@ -548,8 +646,15 @@ class LocalSkillUploadService:
                     old_cleanup_work_id, bot, owner_id, bot_id
                 )
                 raise LocalSkillRuntimeSyncError()
-            self._cancel_cleanup_if_registered(
-                old_cleanup_work_id, bot, owner_id, bot_id
+        self._cancel_cleanup_if_registered(old_cleanup_work_id, bot, owner_id, bot_id)
+        if backup is not None:
+            await self._discard_or_record(
+                bot=bot,
+                owner_id=owner_id,
+                bot_id=bot_id,
+                skill_id=str(skill["id"]),
+                storage=backup,
+                locator=obsolete_locator,
             )
         await self._discard_or_record(
             bot=bot,
@@ -695,9 +800,12 @@ class LocalSkillUploadService:
             skill = self._skill_repo.get_by_id(str(skill_id))
             if skill and skill.get("git_path") == f"local://{locator}":
                 return True
-        return self._skill_repo.get_bot_local_by_locator(
-            bot_id=bot_id, user_id=owner_id, locator=locator
-        ) is not None
+        return (
+            self._skill_repo.get_bot_local_by_locator(
+                bot_id=bot_id, user_id=owner_id, locator=locator
+            )
+            is not None
+        )
 
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -282,6 +282,61 @@ async def test_package_storage_prepare_accepts_an_absent_first_upload_directory(
     assert filesystem.deleted == []
 
 
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_preserves_source_and_verifies_target():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"skill"
+    source = LocalSkillPackageStorage(filesystem, "/private/source")
+    target = LocalSkillPackageStorage(filesystem, "/private/target")
+
+    await source.copy_to(target)
+
+    assert filesystem.files["/private/source/SKILL.md"] == b"skill"
+    assert filesystem.files["/private/target/SKILL.md"] == b"skill"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_rejects_an_existing_target_without_replace():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    filesystem.files["/private/target/SKILL.md"] = b"old"
+
+    with pytest.raises(OSError, match="copy target already exists"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(
+            LocalSkillPackageStorage(filesystem, "/private/target")
+        )
+
+    assert filesystem.files["/private/target/SKILL.md"] == b"old"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_requires_existing_target_cleanup():
+    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    filesystem.files["/private/target/SKILL.md"] = b"old"
+
+    with pytest.raises(OSError, match="unable to clear Local Skill copy target"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(
+            LocalSkillPackageStorage(filesystem, "/private/target"), replace=True
+        )
+
+    assert filesystem.files["/private/target/SKILL.md"] == b"old"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_rejects_failed_target_verification():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    target = LocalSkillPackageStorage(filesystem, "/private/target")
+
+    async def fail_restore(_files):
+        return False
+
+    target._restore_contents = fail_restore
+    with pytest.raises(OSError, match="Local Skill copy verification failed"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(target)
+
+
 class _Collaborators:
     def check_collaborator_permission(self, *args):
         return {"has_permission": True}
@@ -1021,6 +1076,96 @@ async def test_replacement_migrates_a_legacy_hidden_locator_to_the_canonical_pat
         b"name: upload-skill\ndescription: canonical\n"
     )
     assert not any(".replacement-" in path for path in filesystem.files)
+
+
+@pytest.mark.asyncio
+async def test_replacement_discards_staging_and_backup_when_backup_copy_fails(
+    monkeypatch,
+):
+    filesystem = _Filesystem()
+    canonical = "/private/skills-local/upload-skill"
+    rollback = "/private/skills-local/.upload-skill.rollback-backup"
+    filesystem.files[f"{canonical}/SKILL.md"] = b"old"
+    filesystem.files[f"{rollback}/stale.txt"] = b"stale"
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    ids = iter([SimpleNamespace(hex="staged"), SimpleNamespace(hex="backup")])
+    monkeypatch.setattr(upload_module, "uuid4", lambda: next(ids))
+
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: replacement\n"}
+            ),
+        )
+
+    assert rollback in filesystem.deleted
+    assert "/private/skills-local/.upload-skill.replacement-staged" in (
+        filesystem.deleted
+    )
+    assert repo.atomic_replacements == []
+
+
+@pytest.mark.asyncio
+async def test_restore_replacement_requires_backup_after_canonical_publish():
+    filesystem = _Filesystem()
+    skill = _existing_skill(active=False)
+    service = _replacement_service(
+        filesystem, _ReplacementRepo([skill]), _ReplacementRuntime([True])
+    )
+
+    with pytest.raises(LocalSkillStorageError):
+        await service._restore_replacement(
+            skill=skill,
+            old_metadata={},
+            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
+            owner_id="owner",
+            bot_id="bot",
+            staged=_Storage(filesystem, "/private/staged"),
+            staged_locator="/private/staged",
+            canonical=_Storage(filesystem, "/private/canonical"),
+            canonical_locator="/private/canonical",
+            old_is_canonical=True,
+            backup=None,
+            obsolete_locator="/private/canonical",
+            canonical_published=True,
+            switched=False,
+            old_cleanup_work_id=None,
+            runtime_sync_attempted=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_restore_replacement_requires_noncanonical_publish_cleanup():
+    filesystem = _Filesystem(cleanup_results=[False])
+    skill = _existing_skill(active=False)
+    service = _replacement_service(
+        filesystem, _ReplacementRepo([skill]), _ReplacementRuntime([True])
+    )
+
+    with pytest.raises(LocalSkillStorageError):
+        await service._restore_replacement(
+            skill=skill,
+            old_metadata={},
+            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
+            owner_id="owner",
+            bot_id="bot",
+            staged=_Storage(filesystem, "/private/staged"),
+            staged_locator="/private/staged",
+            canonical=_Storage(filesystem, "/private/canonical"),
+            canonical_locator="/private/canonical",
+            old_is_canonical=False,
+            backup=None,
+            obsolete_locator="/private/legacy",
+            canonical_published=True,
+            switched=False,
+            old_cleanup_work_id=None,
+            runtime_sync_attempted=False,
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -156,6 +156,18 @@ class _Filesystem:
             raise OSError("private path")
         self.files[path] = content
 
+    async def read_file(self, path):
+        return self.files.get(path)
+
+    async def list_dir(self, path, *, recursive=False):
+        prefix = f"{path}/"
+        entries = [
+            {"relative_path": file_path[len(prefix) :], "is_dir": False}
+            for file_path in self.files
+            if file_path.startswith(prefix)
+        ]
+        return entries or None
+
     async def delete_tree(self, path):
         self.deleted.append(path)
         result = next(self.cleanup_results, True)
@@ -237,6 +249,29 @@ class _Storage:
     async def cleanup(self):
         return await self.filesystem.delete_tree(self.directory)
 
+    async def verify(self):
+        entries = await self.filesystem.list_dir(self.directory, recursive=True)
+        if not entries:
+            raise OSError("missing package")
+        return True
+
+    async def copy_to(self, target, *, replace=False):
+        prefix = f"{self.directory}/"
+        files = [
+            (path[len(prefix) :], content)
+            for path, content in self.filesystem.files.items()
+            if path.startswith(prefix)
+        ]
+        if not files:
+            raise OSError("missing package")
+        if await self.filesystem.exists(target.directory):
+            if not replace:
+                raise OSError("target exists")
+            if not await target.cleanup():
+                raise OSError("cleanup failed")
+        await target.write(files)
+        await target.verify()
+
 
 @pytest.mark.asyncio
 async def test_package_storage_prepare_accepts_an_absent_first_upload_directory():
@@ -288,9 +323,7 @@ class _Cleanup:
 
     def commit_preparing(self, work_id, *, requires_runtime_restore):
         row = self.preparing[work_id - 1]
-        self.rows.append(
-            {**row, "requires_runtime_restore": requires_runtime_restore}
-        )
+        self.rows.append({**row, "requires_runtime_restore": requires_runtime_restore})
 
     def record_pending(self, **kwargs):
         self.rows.append(kwargs)
@@ -387,9 +420,7 @@ class _ReplacementRepo(_Repo):
         )
 
     def get_bot_local_skill(self, *, skill_id, **_kwargs):
-        return next(
-            (row for row in self.rows if str(row["id"]) == str(skill_id)), None
-        )
+        return next((row for row in self.rows if str(row["id"]) == str(skill_id)), None)
 
     def update(self, skill_id, values):
         self.updates.append((skill_id, values))
@@ -956,11 +987,40 @@ async def test_same_name_replacement_preserves_id_owner_and_desired_state_after_
     assert result["skill"]["id"] == "9"
     assert result["skill"]["user_id"] == "owner"
     assert result["skill"]["active"] is False
-    assert result["skill"]["git_path"] != "local:///private/skills-local/upload-skill"
+    assert result["skill"]["git_path"] == "local:///private/skills-local/upload-skill"
     assert sets.exclusions == [("owner", "bot", 4, 9)]
     assert runtime.calls == 1
     assert "/private/skills-local/upload-skill" in filesystem.deleted
-    assert any("replacement-" in path for path in filesystem.files)
+    assert not any("replacement-" in path for path in filesystem.files)
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == (
+        b"name: upload-skill\ndescription: new description\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_migrates_a_legacy_hidden_locator_to_the_canonical_path():
+    old_locator = "/private/skills-local/.upload-skill.replacement-old"
+    filesystem = _Filesystem()
+    filesystem.files[f"{old_locator}/SKILL.md"] = b"old"
+    old = {**_existing_skill(active=False), "git_path": f"local://{old_locator}"}
+    repo = _ReplacementRepo([old])
+
+    result = await _replacement_service(
+        filesystem, repo, _ReplacementRuntime([True])
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip({"SKILL.md": b"name: upload-skill\ndescription: canonical\n"}),
+    )
+
+    canonical = "/private/skills-local/upload-skill"
+    assert result["skill"]["git_path"] == f"local://{canonical}"
+    assert old["git_path"] == f"local://{canonical}"
+    assert filesystem.files[f"{canonical}/SKILL.md"] == (
+        b"name: upload-skill\ndescription: canonical\n"
+    )
+    assert not any(".replacement-" in path for path in filesystem.files)
 
 
 @pytest.mark.asyncio
@@ -1094,7 +1154,8 @@ async def test_active_replacement_runtime_failure_restores_old_metadata_and_runt
 
 @pytest.mark.asyncio
 async def test_active_replacement_restore_sync_failure_keeps_original_authority_and_records_staged_cleanup():
-    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem = _Filesystem(cleanup_results=[True, True])
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     old = _existing_skill(active=True)
     cleanup = _Cleanup()
     with pytest.raises(LocalSkillRuntimeSyncError):
@@ -1117,7 +1178,7 @@ async def test_active_replacement_restore_sync_failure_keeps_original_authority_
     )
     assert staged_work["requires_runtime_restore"] is True
     assert cleanup.cancelled == [1]
-    assert filesystem.deleted == []
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == b"old"
 
 
 @pytest.mark.asyncio
@@ -1163,7 +1224,8 @@ async def test_foreign_owner_same_name_is_excluded_from_this_owner_scope():
 
 @pytest.mark.asyncio
 async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_update():
-    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem = _Filesystem(cleanup_results=[True, False])
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     repo = _ReplacementRepo([_existing_skill(active=False)])
     cleanup = _Cleanup()
     result = await _replacement_service(
@@ -1177,16 +1239,9 @@ async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_
         ),
     )
     assert result["operation"] == "updated"
-    assert cleanup.rows == [
-        {
-            "env": "test",
-            "owner_id": "owner",
-            "bot_id": "bot",
-            "skill_id": "9",
-            "package_locator": "/private/skills-local/upload-skill",
-            "requires_runtime_restore": True,
-        }
-    ]
+    assert len(cleanup.rows) == 1
+    assert cleanup.rows[0]["requires_runtime_restore"] is True
+    assert ".upload-skill.rollback-" in cleanup.rows[0]["package_locator"]
 
 
 @pytest.mark.asyncio
@@ -1219,6 +1274,7 @@ async def test_cleanup_registration_failure_restores_old_authority_before_runtim
 async def test_later_serialized_upload_retries_durable_cleanup_work():
     filesystem = _Filesystem()
     filesystem.files["/private/skills-local/obsolete/SKILL.md"] = b"obsolete"
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     cleanup = _PendingCleanup()
     result = await _replacement_service(
         filesystem,
@@ -1297,6 +1353,7 @@ async def test_cleanup_progress_write_failure_blocks_the_next_replacement(
 async def test_runtime_restore_work_keeps_staged_bytes_until_old_mapping_is_restored():
     filesystem = _Filesystem()
     filesystem.files["/private/skills-local/staged/SKILL.md"] = b"staged"
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     cleanup = _RuntimeRestoreCleanup()
     runtime = _ReplacementRuntime([True, True])
     await _replacement_service(
@@ -1385,6 +1442,7 @@ class _YieldingFilesystem(_Filesystem):
 async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
     repo = _ConcurrentRepo()
     filesystem = _YieldingFilesystem()
+
     class _Participation:
         def resolve(self, *, scope):
             return SkillLayoutParticipation(

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -185,6 +185,32 @@ def test_local_skill_package_storage_splits_path_entity_from_device_owner(
     assert device_calls == [("bot-1", "owner-7")]
 
 
+def test_pool_local_skill_package_storage_uses_the_canonical_pool_local_root(
+    test_injector,
+):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: (
+        "/pool/active",
+        "/pool/skills-local",
+        "/pool/skills-repo",
+    )
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+
+    directory, storage = factory.local_skill_package_storage(
+        entity_id="project-42",
+        owner_id="owner-7",
+        bot_id="bot-1",
+        engine_type="hermes",
+        entity_type="project",
+        is_desktop=False,
+        is_teclaw=False,
+        name="reviewer",
+    )
+
+    assert directory == "/pool/skills-local/reviewer"
+    assert storage.directory == "/pool/skills-local/reviewer"
+
+
 def test_teclaw_legacy_local_skill_package_storage_uses_workspace_adapter(
     test_injector,
 ):
@@ -239,9 +265,7 @@ def test_legacy_relative_locator_cleanup_resolves_against_bot_local_dir(
         locator="reviewer",
     )
 
-    assert storage._device_directory == (
-        "/bots/project-42/bot-1/skills-local/reviewer"
-    )
+    assert storage._device_directory == ("/bots/project-42/bot-1/skills-local/reviewer")
 
 
 @pytest.mark.parametrize("locator", ["../skills-repo", "skills-local/.."])
@@ -655,7 +679,8 @@ async def test_bot_skill_set_activation_holds_the_layout_edit_lease(test_injecto
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=ActivateResult(success=True, message="ok"))
     activator._activate_skill_set_unlocked = unlocked
@@ -696,7 +721,8 @@ async def test_bot_skill_set_activation_uses_entity_id_for_the_layout_edit_lease
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=ActivateResult(success=True, message="ok"))
     activator._activate_skill_set_unlocked = unlocked
@@ -734,7 +760,8 @@ async def test_bot_skill_set_deactivation_holds_the_layout_edit_lease(test_injec
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=DeactivateResult(success=True, message="ok"))
     activator._deactivate_skill_set_unlocked = unlocked
@@ -837,11 +864,15 @@ async def test_bot_skill_set_switch_and_sync_use_the_resolved_owner_edit_lease(
     assert (await switcher.sync_skill_set_to_active("8", user_id="owner")).success
 
     assert [event[0] for event in guard.events] == [
-        "acquire", "release", "acquire", "release"
+        "acquire",
+        "release",
+        "acquire",
+        "release",
     ]
     assert owner_lookups == [("bot", "owner"), ("bot", "owner")]
     assert [event[1].entity_id for event in guard.events if event[0] == "acquire"] == [
-        "project-42", "project-42"
+        "project-42",
+        "project-42",
     ]
     switch_unlocked.assert_awaited_once_with("7", user_id="owner", proxy_token=None)
     sync_unlocked.assert_awaited_once_with("8", "owner")


### PR DESCRIPTION
## Summary

- keep OpenAPI Local Skill `git_path` on the stable layout-owned `<skills-local>/<skill-name>` locator
- use hidden replacement and rollback directories only for staging and compensation, then clean them up
- preserve canonical path resolution for legacy and Skills Pool layouts
- migrate a hidden locator back to canonical on the next same-name upload; no bulk data migration is included

## Verification

- 713 focused Skill Center, OpenAPI endpoint, repository, and architecture tests passed
- Ruff check and format check passed
- `git diff --check` passed
