### PR TITLE
fix(bot-public): require super_admin for public bot ext update

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_public/public_noauth_router.py
@@ -1,16 +1,25 @@
 """Bot Public Router.
 
 提供 Bot 相关接口：
-- GET /api/public/bots/{bot_id}/appcoding-bots - 获取架构师 bot 关联的 coding bots
-- PATCH /api/public/bots/{bot_id}/ext - 更新 bot ext 字段（限制字段）
+- GET /api/public/bots/{bot_id}/appcoding-bots - 获取架构师 bot 关联的 coding bots（免登录只读，已脱敏）
+- PATCH /api/public/bots/{bot_id}/ext - 更新 bot ext 字段（限制字段，仅超管）
+
+注意：本文件历史上是一个完全免登录的 router。写接口 ``PATCH /ext`` 会跨 owner
+修改任意 Bot 的 ext，免登录暴露等价于任意人可篡改任意 Bot 的架构域分类字段，
+因此该写接口现在要求登录并落在 ``super_admin`` 名单内（与
+``POST /api/bots/update-bot-ext-for-others`` 同一权限域：跨 owner 的 Bot 管理操作）。
+读接口保持免登录：它只返回已 ``_scrub_sensitive`` 脱敏的公开数据。
 """
 import json
 from typing import Any, Optional
 
-from fastapi import APIRouter, Path, Request
+from fastapi import APIRouter, Depends, Path, Request
 from pydantic import BaseModel
 
+from agentclaw.community.adapters.http.auth.dependencies import get_current_user
+from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.core.access.admin_scopes import super_admin
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotServiceError,
 )
@@ -145,12 +154,17 @@ async def list_coding_bots_by_architect_public(
 async def update_bot_ext_public(
     bot_id: str = Path(..., description="Bot ID"),
     request: Request = None,
+    user: AuthenticatedUser = Depends(get_current_user),
     bot_repo: BotRepository = Injected(BotRepository),
 ) -> ApiResponse:
-    """局部更新 bot ext 字段（限制白名单）。
+    """局部更新 bot ext 字段（限制白名单，仅超管）。
 
     PATCH /api/public/bots/{bot_id}/ext
     Body: { "key1": "value1", ... }  # 只允许白名单字段
+
+    该接口按 bot_id 定位 Bot 并以其自身 owner_id 落库，调用方无需是 owner，
+    因此必须限制为管理员：未登录返回 401，登录但不在 ``super_admin`` 名单内
+    返回 403 信封。
 
     只允许更新白名单字段，非白名单字段会被自动过滤；
     敏感字段（如 iam_token 等）会被过滤去除。
@@ -161,10 +175,23 @@ async def update_bot_ext_public(
     Args:
         bot_id: Bot ID
         request: FastAPI request object containing JSON body with fields to update
+        user: 已登录用户（由 ``get_current_user`` 解析，未登录直接 401）
 
     Returns:
         更新结果
     """
+    if user.staffId not in super_admin():
+        logger.warning(
+            f"[public_noauth.update_bot_ext] Permission denied for "
+            f"user={user.staffId} bot_id={bot_id}"
+        )
+        return ApiResponse(
+            success=False,
+            message="权限不足：此接口仅允许管理员调用",
+            error_code=403,
+            data=None,
+        )
+
     try:
         ext_update = await request.json()
         if not isinstance(ext_update, dict):
@@ -229,8 +256,8 @@ async def update_bot_ext_public(
         bot_repo.update_by_owner(bot_id, owner_id, {"ext": ext})
 
         logger.info(
-            f"[public_noauth.update_bot_ext] Updated bot_id={bot_id} "
-            f"fields={list(filtered_update.keys())}"
+            f"[public_noauth.update_bot_ext] operator={user.staffId} "
+            f"Updated bot_id={bot_id} fields={list(filtered_update.keys())}"
         )
 
         return ApiResponse(

--- a/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
+++ b/src/backend/tests/community/api/bot_public/test_public_noauth_router.py
@@ -1,9 +1,14 @@
 """Tests for bot_public_noauth router.
 
-Tests for the public endpoints:
-- GET /api/public/bots/{bot_id}/appcoding-bots
-- PATCH /api/public/bots/{bot_id}/ext
+Tests for the endpoints:
+- GET /api/public/bots/{bot_id}/appcoding-bots (no auth, scrubbed read)
+- PATCH /api/public/bots/{bot_id}/ext (login + ``super_admin`` required)
 
+The PATCH gate is exercised with ``get_current_user`` overridden, so these
+cases pin the *authorization* decision (admin vs non-admin) rather than the
+identity resolution, which belongs to the auth dependency's own tests. The
+anonymous → 401 leg needs the real dependency and is covered by the endpoint
+test ``tests/community/endpoints/test_public_bots_ext.py``.
 """
 import json
 from unittest.mock import MagicMock
@@ -14,6 +19,9 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
+from agentclaw.community.adapters.http.bot_public import public_noauth_router
+from agentclaw.community.adapters.http.auth.dependencies import get_current_user
+from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.adapters.http.bot_public.public_noauth_router import (
     _scrub_sensitive,
     router,
@@ -23,6 +31,28 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 
 
 # --- Helpers ---
+
+ADMIN_STAFF_ID = "100000"
+NON_ADMIN_STAFF_ID = "999999"
+
+
+def _fake_user(staff_id: str) -> AuthenticatedUser:
+    """Build the identity ``get_current_user`` would have resolved."""
+    return AuthenticatedUser(
+        id=staff_id,
+        staffId=staff_id,
+        operatorName=staff_id,
+        nickName=staff_id,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _admin_allowlist(monkeypatch):
+    """Pin the super_admin allow-list — config is not loaded in this unit test."""
+    monkeypatch.setattr(
+        public_noauth_router, "super_admin", lambda: frozenset({ADMIN_STAFF_ID})
+    )
+
 
 def _bind_services(mock_bot_service=None, mock_bot_repo=None):
     """Bind mock services via injector Module."""
@@ -105,13 +135,25 @@ def mock_bot_repo():
     return repo
 
 
-@pytest.fixture
-def client(mock_bot_service, mock_bot_repo):
-    """TestClient with mocked services."""
+def _make_client(mock_bot_service, mock_bot_repo, staff_id):
+    """TestClient with mocked services, authenticated as ``staff_id``."""
     app = FastAPI()
     app.include_router(router)
     attach_injector(app, Injector([_bind_services(mock_bot_service, mock_bot_repo)]))
+    app.dependency_overrides[get_current_user] = lambda: _fake_user(staff_id)
     return TestClient(app)
+
+
+@pytest.fixture
+def client(mock_bot_service, mock_bot_repo):
+    """TestClient authenticated as a super_admin (the PATCH gate's happy path)."""
+    return _make_client(mock_bot_service, mock_bot_repo, ADMIN_STAFF_ID)
+
+
+@pytest.fixture
+def non_admin_client(mock_bot_service, mock_bot_repo):
+    """TestClient authenticated as an ordinary logged-in user."""
+    return _make_client(mock_bot_service, mock_bot_repo, NON_ADMIN_STAFF_ID)
 
 
 # --- Tests for GET /api/public/bots/{bot_id}/appcoding-bots ---
@@ -270,8 +312,8 @@ class TestScrubSensitiveUnit:
 class TestUpdateBotExtPublic:
     """PATCH /api/public/bots/{bot_id}/ext — whitelist enforced."""
 
-    def test_no_auth_required(self, client):
-        """Should respond successfully on a basic PATCH."""
+    def test_admin_can_update(self, client):
+        """A caller in the super_admin allow-list passes the gate."""
         resp = client.patch(
             "/api/public/bots/default/ext",
             json={"is_domain_bot": True, "arch_domain": "新架构域"},
@@ -279,6 +321,20 @@ class TestUpdateBotExtPublic:
         assert resp.status_code == 200
         data = resp.json()
         assert data["success"] is True
+
+    def test_non_admin_forbidden(self, non_admin_client, mock_bot_repo):
+        """A logged-in non-admin is rejected before the bot is touched."""
+        resp = non_admin_client.patch(
+            "/api/public/bots/default/ext",
+            json={"is_domain_bot": True, "arch_domain": "新架构域"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is False
+        assert data["error_code"] == 403
+        # The gate runs before any repository access — nothing was read or written.
+        mock_bot_repo.list_by_conditions.assert_not_called()
+        mock_bot_repo.update_by_owner.assert_not_called()
 
     def test_whitelist_fields_accepted(self, client, mock_bot_repo):
         """Should accept whitelisted fields."""

--- a/src/backend/tests/community/endpoints/test_public_bots_ext.py
+++ b/src/backend/tests/community/endpoints/test_public_bots_ext.py
@@ -5,10 +5,16 @@ same SQLAlchemy code paths the production handler does — no mocking of
 injected components. The happy path verifies the whitelisted-field
 update round-trips through the DB; the error path drives the
 not-found branch by simply not seeding.
+
+The route writes another owner's bot, so it is admin-gated: cases carry
+``x-user-id`` for the seeded ``super_admin``. Two authorization legs are
+pinned here because they need the real auth dependency — an anonymous
+request (401) and a logged-in non-admin (403 envelope).
 """
 from __future__ import annotations
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from tests.community.factories.access import make_staff_user
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -16,6 +22,9 @@ from tests.community.framework import (
     endpoint_test,
 )
 from tests.community.framework.world import World
+
+ADMIN_STAFF_ID = "100000"  # seeded super_admin in application-test.yaml
+NON_ADMIN_STAFF_ID = "999999"
 
 
 def _seed_bot(world: World) -> None:
@@ -32,6 +41,12 @@ def _seed_bot(world: World) -> None:
             "ext": {"existing_key": "existing_value"},
         }
     )
+
+
+def _seed_bot_and_non_admin(world: World) -> None:
+    """Seed the target bot plus an ordinary (non-admin) caller."""
+    _seed_bot(world)
+    make_staff_user(world, user_id=NON_ADMIN_STAFF_ID)
 
 
 def _assert_ext_persisted(response, world: World) -> None:
@@ -53,6 +68,7 @@ def _assert_ext_persisted(response, world: World) -> None:
     input=CaseInput(
         path_params={"bot_id": "test_bot"},
         json_body={"is_domain_bot": True, "arch_domain": "新架构域"},
+        headers={"x-user-id": ADMIN_STAFF_ID},
     ),
     seed=_seed_bot,
     expect=ExpectSuccess(
@@ -75,6 +91,7 @@ def update_bot_ext_public_ok():
     input=CaseInput(
         path_params={"bot_id": "missing_bot"},
         json_body={"is_domain_bot": True},
+        headers={"x-user-id": ADMIN_STAFF_ID},
     ),
     expect=ExpectError(
         status=200,
@@ -86,3 +103,50 @@ def update_bot_ext_public_ok():
 )
 def update_bot_ext_public_not_found():
     """Error path: no seeded bot → repo returns empty → 404 envelope."""
+
+
+def _assert_ext_untouched(response, world: World) -> None:
+    """A rejected caller must not have changed the seeded bot's ext."""
+    repo = world.get(BotRepository)
+    _, items = repo.list_by_conditions(bot_id="test_bot", page=1, page_size=1)
+    assert items, "seeded bot should still exist after a rejected PATCH"
+    ext = items[0].get("ext") or {}
+    assert "is_domain_bot" not in ext
+    assert "arch_domain" not in ext
+    assert ext.get("existing_key") == "existing_value"
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/public/bots/{bot_id}/ext",
+    scenario="anonymous",
+    input=CaseInput(
+        path_params={"bot_id": "test_bot"},
+        json_body={"is_domain_bot": True, "arch_domain": "越权写入"},
+    ),
+    seed=_seed_bot,
+    expect=ExpectError(status=401),
+    extra_assertions=(_assert_ext_untouched,),
+)
+def update_bot_ext_public_anonymous():
+    """No identity → the auth dependency rejects before the handler runs."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/public/bots/{bot_id}/ext",
+    scenario="non_admin_forbidden",
+    input=CaseInput(
+        path_params={"bot_id": "test_bot"},
+        json_body={"is_domain_bot": True, "arch_domain": "越权写入"},
+        headers={"x-user-id": NON_ADMIN_STAFF_ID},
+    ),
+    seed=_seed_bot_and_non_admin,
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 403},
+    ),
+    extra_assertions=(_assert_ext_untouched,),
+)
+def update_bot_ext_public_non_admin():
+    """A logged-in non-admin cannot reclassify someone else's bot."""


### PR DESCRIPTION
## Problem

`PATCH /api/public/bots/{bot_id}/ext` lived on `public_noauth_router.py`, a router with no authentication dependency at all, and `UserContextMiddleware` deliberately does not block unauthenticated requests — routes decide for themselves.

The handler is a cross-owner write: it resolves the bot by `bot_id`, reads that row's own `owner_id`, and calls `bot_repo.update_by_owner(bot_id, owner_id, {"ext": ext})`. The caller never had to be the owner, and never had to be logged in. Anyone who could reach the port could set `arch_domain` / `is_domain_bot` on any bot in the deployment.

The whitelist and `_scrub_sensitive` limited the blast radius to those two fields, but the architecture-domain classification drives which bots are treated as domain architects, so being able to flip it on arbitrary bots is a real integrity problem — worse than the reported "any logged-in user", since no login was required.

## Solution

Gate the write with `Depends(get_current_user)` plus the `super_admin()` allow-list:

- Anonymous callers are rejected by the auth dependency itself (`Unauthorized` → 401), before the handler body runs.
- A logged-in non-admin gets `{"success": false, "error_code": 403}` before any repository access — the check sits ahead of the `try` block, so neither `list_by_conditions` nor `update_by_owner` is reached.
- The caller's staff id is added to the success log line so the admin write is auditable.

`super_admin` is the right scope rather than a new one: it is documented as "staff IDs allowed to perform cross-user bot management operations", and `POST /api/bots/update-bot-ext-for-others` — which does the same cross-owner ext merge — already gates on it. Enforcement follows the existing convention in this codebase (an inline `not in <scope>()` check on `user.staffId`), and the 403 is returned as an `ApiResponse` envelope with HTTP 200 to match the rest of this router, whose `not_found` branch does the same.

Rejected alternatives:

- **Owner-or-admin.** Would keep the endpoint usable by ordinary users on their own bots, but the handler has no notion of a caller-owned bot; adding one is a behavior change beyond closing the hole.
- **Delete the endpoint.** No caller for it exists anywhere in this repo — not the frontend, not `engine`/`gateway`/`bcs`/`scripts` — only backend tests. Removing it was tempting, but an out-of-repo caller is plausible for a route deliberately built as no-auth, so the route and its path are preserved.

The `GET /{bot_id}/appcoding-bots` read on the same router is intentionally left no-auth: it returns only `_scrub_sensitive` output.

## Validation

Run with `.venv/bin/python -m pytest` (backend deps installed via `uv sync`):

- `tests/community/api/bot_public/test_public_noauth_router.py` — **24 passed**. Rewrote the client fixture to authenticate via a `get_current_user` override and pin the allow-list with monkeypatch; replaced `test_no_auth_required` with `test_admin_can_update`, and added `test_non_admin_forbidden` asserting the 403 envelope *and* that `list_by_conditions` / `update_by_owner` were never called.
- `tests/community/endpoints/test_public_bots_ext.py` — the two existing cases now carry `x-user-id` for the seeded `super_admin` (`100000`), plus two new cases that need the real auth dependency: `anonymous` (401) and `non_admin_forbidden` (403 envelope). Both assert via `_assert_ext_untouched` that the seeded bot's ext is unchanged after rejection.
- `tests/community/endpoints/ tests/community/framework/ tests/community/api/bot_public/` — **937 passed, 1 failed**. The single failure is `PATCH /api/bots/{bot_id}/mcps/{server_code}/call-type :: happy` (`CALLER_IDENTITY_INTERNAL_ERROR`), which is pre-existing and unrelated: it reproduces identically on a stashed (clean) tree.
- `ruff check` on all three changed files — clean.
- CI on this PR: all 7 checks green (Backend / BCS / BaaS / Engine / Gateway unit tests, Singlebox coverage, BCS e2e).

Not run locally: the acceptance/E2E suites (excluded by `pytest.ini`; they need baas/mosn/sofa-registry spawned in the CI container).

## Compatibility and risk

Breaking for any caller of `PATCH /api/public/bots/{bot_id}/ext` that is not an authenticated `super_admin`. There is no such caller in this repo, but the route was built no-auth on purpose, so an external automation may exist — if one does, it needs an admin session, or a follow-up that gives it a service identity. The path, request body, and success envelope are unchanged.

`super_admin()` is config-driven and fail-closed: a deployment whose `admin.super_admin` block is empty (the community default) now rejects every call to this endpoint. That is the intended posture, but it is worth flagging for any deployment that was relying on the endpoint being open.

Rollback is the revert of this commit.