### PR TITLE
fix(skills): gate edit locks by layout state

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
@@ -408,6 +408,12 @@ class UploadSkillResponse(BaseModel):
     message: str
 
 
+class UploadSkillErrorResponse(BaseModel):
+    """HTTP error body returned when an upload cannot start safely."""
+
+    detail: str = Field(description="Human-readable reason for the failed upload.")
+
+
 class SkillParametersResponse(BaseModel):
     success: bool
     data: dict

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -76,6 +76,7 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     UpdateRiskTagsRequest,
     UpdateSkillMemberRoleRequest,
     UpdateSkillRequest,
+    UploadSkillErrorResponse,
     UploadSkillResponse,
     VersionListResponse,
 )
@@ -90,6 +91,7 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
     SkillsPoolEditPausedError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
@@ -375,7 +377,20 @@ def _require_pool_runtime_sync_success(
 
 # ==================== Core CRUD APIs ====================
 
-@router.post("/upload", response_model=UploadSkillResponse)
+@router.post(
+    "/upload",
+    response_model=UploadSkillResponse,
+    responses={
+        409: {
+            "model": UploadSkillErrorResponse,
+            "description": "A Local Skill edit or layout rollback is in progress.",
+        },
+        503: {
+            "model": UploadSkillErrorResponse,
+            "description": "The edit-lock backend is temporarily unavailable.",
+        },
+    },
+)
 @with_interceptors(CollaboratorPermissionInterceptor(
     bot_id="$bot_id",
     owner_id="$user_id",
@@ -555,6 +570,8 @@ async def upload_skill(
             ),
             message="Skill uploaded successfully"
         )
+    except SkillsPoolEditLockUnavailableError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
     except SkillsPoolEditPausedError as e:
         # A held edit/rollback lock is an ordinary request conflict, not a
         # successful response carrying a failed business envelope.  Clients

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -556,7 +556,12 @@ async def upload_skill(
             message="Skill uploaded successfully"
         )
     except SkillsPoolEditPausedError as e:
-        return UploadSkillResponse(success=False, message=str(e))
+        # A held edit/rollback lock is an ordinary request conflict, not a
+        # successful response carrying a failed business envelope.  Clients
+        # must be able to distinguish it from a completed upload.
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except HTTPException:
+        raise
     except ValueError as e:
         error_msg = str(e)
         logger.error(f"[skills.upload_skill] Validation error: {error_msg}")

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import hashlib
 import time
 
 from injector import inject
@@ -47,6 +48,7 @@ class SkillsPoolEditLockUnavailableError(SkillsPoolEditPausedError):
 class SkillsPoolEditLease:
     key: str
     token: str | None
+    ttl_seconds: int | None = None
 
 
 class SkillsPoolEditGuard:
@@ -157,24 +159,87 @@ class SkillsPoolEditGuard:
         # Rollback has historically treated cache unavailability as a
         # retryable ``EDIT_BUSY`` outcome.  Preserve that operator contract;
         # only product-side edits need the more precise user-facing outcome.
-        token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
+        started_at = time.perf_counter()
+        try:
+            token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="acquire",
+                key=key,
+                token=None,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+            )
+            raise
+        self._log_lock_event(
+            event="acquire",
+            key=key,
+            token=token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="acquired" if token is not None else "busy",
+        )
         if token is None:
             return None
-        return SkillsPoolEditLease(key=key, token=token)
+        return SkillsPoolEditLease(
+            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+        )
 
     def _acquire_for_edit(
         self, *, scope: BotSkillLayoutScope
     ) -> SkillsPoolEditLease | None:
         key = self._key(scope=scope)
-        token = self._cache.acquire_lock_strict(key, ttl=self._LOCK_TTL_SECONDS)
+        started_at = time.perf_counter()
+        try:
+            token = self._cache.acquire_lock_strict(
+                key, ttl=self._LOCK_TTL_SECONDS
+            )
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="acquire",
+                key=key,
+                token=None,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+            )
+            raise
+        self._log_lock_event(
+            event="acquire",
+            key=key,
+            token=token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="acquired" if token is not None else "busy",
+        )
         if token is None:
             return None
-        return SkillsPoolEditLease(key=key, token=token)
+        return SkillsPoolEditLease(
+            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+        )
 
     def release(self, lease: SkillsPoolEditLease) -> bool:
         if lease.token is None:
             return True
-        return self._cache.release_lock(lease.key, lease.token)
+        started_at = time.perf_counter()
+        try:
+            released = self._cache.release_lock(lease.key, lease.token)
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="release",
+                key=lease.key,
+                token=lease.token,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+                ttl_seconds=lease.ttl_seconds,
+            )
+            raise
+        self._log_lock_event(
+            event="release",
+            key=lease.key,
+            token=lease.token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="released" if released else "token_mismatch",
+            ttl_seconds=lease.ttl_seconds,
+        )
+        return released
 
     def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
         return self._layouts.get(scope).phase in self._ROLLBACK_PHASES
@@ -195,6 +260,37 @@ class SkillsPoolEditGuard:
             participation.label,
             reason,
         )
+
+    @staticmethod
+    def _duration_ms(started_at: float) -> float:
+        return (time.perf_counter() - started_at) * 1000
+
+    def _log_lock_event(
+        self,
+        *,
+        event: str,
+        key: str,
+        token: str | None,
+        duration_ms: float,
+        outcome: str,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        logger.info(
+            "[skills_pool.edit_guard] lock_%s key=%s ttl_seconds=%s "
+            "token_fingerprint=%s duration_ms=%.3f outcome=%s",
+            event,
+            key,
+            ttl_seconds if ttl_seconds is not None else self._LOCK_TTL_SECONDS,
+            self._token_fingerprint(token),
+            duration_ms,
+            outcome,
+        )
+
+    @staticmethod
+    def _token_fingerprint(token: str | None) -> str:
+        if token is None:
+            return "none"
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import time
+from threading import Lock
 
 from injector import inject
 
@@ -44,11 +45,22 @@ class SkillsPoolEditLockUnavailableError(SkillsPoolEditPausedError):
     """The distributed lock service is unavailable; fail closed."""
 
 
+class _OrdinaryEditLockEntry:
+    """One in-process Local Skill mutation lock and its active users."""
+
+    def __init__(self) -> None:
+        self.lock = Lock()
+        self.users = 0
+
+
 @dataclass(frozen=True, slots=True)
 class SkillsPoolEditLease:
     key: str
     token: str | None
     ttl_seconds: int | None = None
+    ordinary_lock_entry: _OrdinaryEditLockEntry | None = field(
+        default=None, repr=False, compare=False
+    )
 
 
 class SkillsPoolEditGuard:
@@ -71,6 +83,8 @@ class SkillsPoolEditGuard:
         self._cache = cache
         self._layouts = layout_repository
         self._participation_resolver = participation_resolver
+        self._ordinary_locks_guard = Lock()
+        self._ordinary_locks: dict[str, _OrdinaryEditLockEntry] = {}
 
     @staticmethod
     def _key(*, scope: BotSkillLayoutScope) -> str:
@@ -82,9 +96,6 @@ class SkillsPoolEditGuard:
         scope: BotSkillLayoutScope,
     ) -> SkillsPoolEditLease:
         participation = self._participation_resolver.resolve(scope=scope)
-        if not participation.participates_in_pool_layout:
-            return SkillsPoolEditLease(key="", token=None)
-
         if self._is_rollback_phase(scope):
             self._log_rejection(
                 scope=scope, participation=participation, reason="rollback_phase"
@@ -93,9 +104,27 @@ class SkillsPoolEditGuard:
                 "Skills are temporarily read-only during layout rollback"
             )
 
+        ordinary_lock_entry = self._acquire_ordinary_lock(scope=scope)
+        if ordinary_lock_entry is None:
+            self._log_rejection(
+                scope=scope, participation=participation, reason="ordinary_lock_busy"
+            )
+            raise SkillsPoolEditBusyError(
+                "Another skill update is already in progress; please retry shortly"
+            )
+
+        # Legacy Bots have no Pool rollback to serialize against, but still
+        # need this ordinary mutex so concurrent same-name uploads cannot both
+        # observe an absent Skill and create competing records/packages.
+        if not participation.participates_in_pool_layout:
+            return SkillsPoolEditLease(
+                key="", token=None, ordinary_lock_entry=ordinary_lock_entry
+            )
+
         try:
             lease = self._acquire_for_edit(scope=scope)
         except CacheLockInfrastructureError as exc:
+            self._release_ordinary_lock(ordinary_lock_entry)
             self._log_rejection(
                 scope=scope, participation=participation, reason="cache_unavailable"
             )
@@ -103,6 +132,7 @@ class SkillsPoolEditGuard:
                 "Skill updates are temporarily unavailable because the lock service is unavailable"
             ) from exc
         if lease is None:
+            self._release_ordinary_lock(ordinary_lock_entry)
             if self._is_rollback_phase(scope):
                 self._log_rejection(
                     scope=scope, participation=participation, reason="rollback_phase"
@@ -117,14 +147,26 @@ class SkillsPoolEditGuard:
                 "Another skill update is already in progress; please retry shortly"
             )
         if self._is_rollback_phase(scope):
-            self.release(lease)
+            self.release(
+                SkillsPoolEditLease(
+                    key=lease.key,
+                    token=lease.token,
+                    ttl_seconds=lease.ttl_seconds,
+                    ordinary_lock_entry=ordinary_lock_entry,
+                )
+            )
             self._log_rejection(
                 scope=scope, participation=participation, reason="rollback_phase"
             )
             raise SkillsPoolEditRollbackError(
                 "Skills are temporarily read-only during layout rollback"
             )
-        return lease
+        return SkillsPoolEditLease(
+            key=lease.key,
+            token=lease.token,
+            ttl_seconds=lease.ttl_seconds,
+            ordinary_lock_entry=ordinary_lock_entry,
+        )
 
     async def acquire_for_edit_wait(
         self, *, scope: BotSkillLayoutScope, timeout_seconds: float = 30.0
@@ -159,10 +201,14 @@ class SkillsPoolEditGuard:
         # Rollback has historically treated cache unavailability as a
         # retryable ``EDIT_BUSY`` outcome.  Preserve that operator contract;
         # only product-side edits need the more precise user-facing outcome.
+        ordinary_lock_entry = self._acquire_ordinary_lock(scope=scope)
+        if ordinary_lock_entry is None:
+            return None
         started_at = time.perf_counter()
         try:
             token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
         except CacheLockInfrastructureError:
+            self._release_ordinary_lock(ordinary_lock_entry)
             self._log_lock_event(
                 event="acquire",
                 key=key,
@@ -179,9 +225,13 @@ class SkillsPoolEditGuard:
             outcome="acquired" if token is not None else "busy",
         )
         if token is None:
+            self._release_ordinary_lock(ordinary_lock_entry)
             return None
         return SkillsPoolEditLease(
-            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+            key=key,
+            token=token,
+            ttl_seconds=self._LOCK_TTL_SECONDS,
+            ordinary_lock_entry=ordinary_lock_entry,
         )
 
     def _acquire_for_edit(
@@ -217,6 +267,7 @@ class SkillsPoolEditGuard:
 
     def release(self, lease: SkillsPoolEditLease) -> bool:
         if lease.token is None:
+            self._release_ordinary_lock(lease.ordinary_lock_entry)
             return True
         started_at = time.perf_counter()
         try:
@@ -231,6 +282,8 @@ class SkillsPoolEditGuard:
                 ttl_seconds=lease.ttl_seconds,
             )
             raise
+        finally:
+            self._release_ordinary_lock(lease.ordinary_lock_entry)
         self._log_lock_event(
             event="release",
             key=lease.key,
@@ -240,6 +293,38 @@ class SkillsPoolEditGuard:
             ttl_seconds=lease.ttl_seconds,
         )
         return released
+
+    def _acquire_ordinary_lock(
+        self, *, scope: BotSkillLayoutScope
+    ) -> _OrdinaryEditLockEntry | None:
+        key = self._key(scope=scope)
+        with self._ordinary_locks_guard:
+            entry = self._ordinary_locks.get(key)
+            if entry is None:
+                entry = _OrdinaryEditLockEntry()
+                self._ordinary_locks[key] = entry
+            entry.users += 1
+        if entry.lock.acquire(blocking=False):
+            return entry
+        self._discard_ordinary_lock_user(entry)
+        return None
+
+    def _release_ordinary_lock(self, entry: _OrdinaryEditLockEntry | None) -> None:
+        if entry is None:
+            return
+        entry.lock.release()
+        self._discard_ordinary_lock_user(entry)
+
+    def _discard_ordinary_lock_user(self, entry: _OrdinaryEditLockEntry) -> None:
+        with self._ordinary_locks_guard:
+            entry.users -= 1
+            if entry.users == 0:
+                stale_keys = [
+                    key for key, candidate in self._ordinary_locks.items()
+                    if candidate is entry
+                ]
+                for key in stale_keys:
+                    self._ordinary_locks.pop(key, None)
 
     def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
         return self._layouts.get(scope).phase in self._ROLLBACK_PHASES

--- a/src/backend/src/agentclaw/community/core/skills_pool/participation.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/participation.py
@@ -1,17 +1,21 @@
 """Resolve whether a Bot participates in the Skills Pool filesystem contract.
 
-The shared edit guard must not contain engine-specific policy.  This resolver
-keeps the conservative default in the domain layer and receives any explicit
-engine opt-out from the composition root.
+Pool edit serialization is a property of the Bot's persisted layout state, not
+of its engine.  An engine can support Pool while a particular Bot still uses
+the Legacy layout, so applying the lock from an engine-level default would
+block unrelated Legacy edits.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
-from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.types import SkillLayout
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,37 +33,34 @@ class SkillLayoutParticipationResolver(Protocol):
     def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation: ...
 
 
-class BotEngineSkillLayoutParticipationResolver:
-    """Repository-backed, engine-agnostic implementation of the policy port.
-
-    Unknown, missing, or cross-environment Bot records intentionally resolve to
-    the supplied default policy.  Production wiring supplies a participating
-    default, so new engines cannot bypass the edit lock accidentally.
-    """
+class BotSkillLayoutStateParticipationResolver:
+    """Use the persisted Bot layout as the sole edit-lock participation fact."""
 
     def __init__(
         self,
         *,
-        bot_repository: BotRepository,
-        default: SkillLayoutParticipation,
-        by_engine: Mapping[str, SkillLayoutParticipation],
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
     ) -> None:
-        self._bots = bot_repository
-        self._default = default
-        self._by_engine = dict(by_engine)
+        self._layouts = layout_repository
 
     def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation:
-        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
-        if not bot or bot.get("env") != scope.env:
-            return self._default
-        engine = bot.get("active_engine")
-        if not isinstance(engine, str):
-            return self._default
-        return self._by_engine.get(engine, self._default)
+        state = self._layouts.get(scope)
+        if (
+            state.active_layout is SkillLayout.POOL
+            or state.target_layout is SkillLayout.POOL
+        ):
+            return SkillLayoutParticipation(
+                participates_in_pool_layout=True,
+                label="pool_layout_state",
+            )
+        return SkillLayoutParticipation(
+            participates_in_pool_layout=False,
+            label="legacy_layout_state",
+        )
 
 
 __all__ = [
-    "BotEngineSkillLayoutParticipationResolver",
+    "BotSkillLayoutStateParticipationResolver",
     "SkillLayoutParticipation",
     "SkillLayoutParticipationResolver",
 ]

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -24,8 +24,7 @@ from agentclaw.community.core.skills_pool.claim_service import (
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.participation import (
-    BotEngineSkillLayoutParticipationResolver,
-    SkillLayoutParticipation,
+    BotSkillLayoutStateParticipationResolver,
     SkillLayoutParticipationResolver,
 )
 from agentclaw.community.core.skills_pool.operational_query import (
@@ -147,23 +146,10 @@ class SkillsPoolModule(Module):
     @inject
     def skill_layout_participation_resolver(
         self,
-        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
     ) -> SkillLayoutParticipationResolver:
-        return BotEngineSkillLayoutParticipationResolver(
-            bot_repository=bot_repository,
-            default=SkillLayoutParticipation(
-                participates_in_pool_layout=True,
-                label="default_pool_layout",
-            ),
-            # Teclaw owns an artifact-style filesystem and never enters the
-            # Pool migration or rollback state machine.  Keep that engine
-            # policy in composition, rather than the shared edit guard.
-            by_engine={
-                "teclaw": SkillLayoutParticipation(
-                    participates_in_pool_layout=False,
-                    label="teclaw_no_pool_layout",
-                )
-            },
+        return BotSkillLayoutStateParticipationResolver(
+            layout_repository=layout_repository,
         )
 
     @singleton

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -37,6 +37,7 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
+from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditBusyError
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -469,9 +470,7 @@ def _upload_skill_di_app(
                 DeviceContextResolver,
             )
             from agentclaw.community.core.skill_center.factories import SkillServiceFactory
-            from agentclaw.community.core.skills_pool.edit_guard import (
-                SkillsPoolEditGuard,
-            )
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
             from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 
             from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
@@ -577,6 +576,39 @@ class TestUploadSkillValidation:
             body = response.json()
             assert body["success"] is True
             assert mock_svc.upload_skill.await_count == 1
+
+    def test_upload_edit_lock_conflict_returns_http_409(self, mock_ctx):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (
+            client,
+            mock_svc,
+            _,
+            _,
+        ):
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+
+            # The fixture's injected guard is resolved through the app injector;
+            # reach it via the dependency's configured instance.
+            # Rebuilding this narrow response assertion through a side effect
+            # prevents a failed mutation from masquerading as HTTP 200.
+            app = client.app
+            injector = app.state.injector
+            guard = injector.get(SkillsPoolEditGuard)
+            guard.acquire_for_edit.side_effect = SkillsPoolEditBusyError("busy")
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.status_code == 409
+            assert response.json()["detail"] == "busy"
+            mock_svc.upload_skill.assert_not_called()
 
     def test_upload_persists_bot_owner_for_collaborator_upload(self):
         collaborator_ctx = RequestContext(

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -37,7 +37,10 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
-from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditBusyError
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
+    SkillsPoolEditLockUnavailableError,
+)
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -609,6 +612,46 @@ class TestUploadSkillValidation:
             assert response.status_code == 409
             assert response.json()["detail"] == "busy"
             mock_svc.upload_skill.assert_not_called()
+
+    def test_upload_lock_backend_outage_returns_http_503(self, mock_ctx):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (
+            client,
+            mock_svc,
+            _,
+            _,
+        ):
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+
+            guard = client.app.state.injector.get(SkillsPoolEditGuard)
+            guard.acquire_for_edit.side_effect = SkillsPoolEditLockUnavailableError(
+                "lock service unavailable"
+            )
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.status_code == 503
+            assert response.json()["detail"] == "lock service unavailable"
+            mock_svc.upload_skill.assert_not_called()
+
+
+def test_upload_openapi_documents_edit_lock_conflict_and_outage():
+    app = FastAPI()
+    app.include_router(skills_router)
+
+    responses = app.openapi()["paths"]["/api/skills/upload"]["post"]["responses"]
+    for status in ("409", "503"):
+        assert responses[status]["content"]["application/json"]["schema"]["$ref"].endswith(
+            "UploadSkillErrorResponse"
+        )
 
     def test_upload_persists_bot_owner_for_collaborator_upload(self):
         collaborator_ctx = RequestContext(

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -225,6 +225,37 @@ def test_legacy_bot_bypasses_an_abandoned_pool_edit_lock() -> None:
     assert cache.held
 
 
+@pytest.mark.asyncio
+async def test_legacy_bot_still_serializes_ordinary_edits() -> None:
+    layouts = _Layouts()
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=None,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE,
+        persisted=False,
+    )
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=layouts,
+        participation_resolver=_Participation(
+            participates=False, label="legacy_layout_state"
+        ),
+    )
+
+    first = guard.acquire_for_edit(scope=SCOPE)
+    waiting = asyncio.create_task(
+        guard.acquire_for_edit_wait(scope=SCOPE, timeout_seconds=0.2)
+    )
+    await asyncio.sleep(0.02)
+    assert not waiting.done()
+
+    assert guard.release(first)
+    second = await waiting
+    assert second.token is None
+    assert guard.release(second)
+
+
 def test_cache_outage_is_not_reported_as_lock_contention() -> None:
     guard = SkillsPoolEditGuard(
         cache=_UnavailableCache(),

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
+import logging
 
 import pytest
 
@@ -195,18 +196,25 @@ def test_rollback_starting_after_lock_acquisition_releases_edit_lease() -> None:
     assert cache.held == {}
 
 
-def test_teclaw_bypasses_an_abandoned_pool_edit_lock() -> None:
+def test_legacy_bot_bypasses_an_abandoned_pool_edit_lock() -> None:
     cache = _Cache()
+    layouts = _Layouts()
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=None,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE,
+        persisted=False,
+    )
     guard = SkillsPoolEditGuard(
         cache=cache,
-        layout_repository=_Layouts(),
+        layout_repository=layouts,
         participation_resolver=_Participation(
-            participates=False, label="teclaw_no_pool_layout"
+            participates=False, label="legacy_layout_state"
         ),
     )
-    # Simulates a previous worker acquiring the legacy generic lock and then
-    # exiting before its finally block.  Teclaw never owns Pool rollback, so a
-    # current Teclaw write must not wait for that lock's TTL.
+    # A Legacy Bot never owns Pool rollback, so it must not wait for a generic
+    # lock left by an earlier, wrongly-participating worker.
     abandoned = cache.acquire_lock(guard._key(scope=SCOPE))
     assert abandoned is not None
 
@@ -226,6 +234,30 @@ def test_cache_outage_is_not_reported_as_lock_contention() -> None:
 
     with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
         guard.acquire_for_edit(scope=SCOPE)
+
+
+def test_lock_lifecycle_logs_key_ttl_token_fingerprint_and_duration(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=_Layouts(),
+        participation_resolver=_Participation(),
+    )
+
+    lease = guard.acquire_for_edit(scope=SCOPE)
+    assert guard.release(lease)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "lock_acquire" in message
+        and lease.key in message
+        and "ttl_seconds=600" in message
+        and "token_fingerprint=" in message
+        and "duration_ms=" in message
+        and "outcome=acquired" in message
+        for message in messages
+    )
+    assert any("lock_release" in message and "outcome=released" in message for message in messages)
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_participation.py
+++ b/src/backend/tests/community/core/skills_pool/test_participation.py
@@ -3,73 +3,83 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.skills_pool.participation import (
-    BotEngineSkillLayoutParticipationResolver,
+    BotSkillLayoutStateParticipationResolver,
     SkillLayoutParticipation,
 )
-from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
 from agentclaw.community.di.modules.skills_pool_module import SkillsPoolModule
 
 
 SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
-DEFAULT = SkillLayoutParticipation(
-    participates_in_pool_layout=True,
-    label="default_pool_layout",
-)
-NO_POOL = SkillLayoutParticipation(
-    participates_in_pool_layout=False,
-    label="artifact_layout",
-)
 
 
-class _Bots:
-    def __init__(self, bot: dict | None) -> None:
-        self._bot = bot
+class _Layouts:
+    def __init__(
+        self,
+        *,
+        active_layout: SkillLayout = SkillLayout.LEGACY,
+        target_layout: SkillLayout | None = None,
+    ) -> None:
+        self.state = BotSkillLayoutState(
+            scope=SCOPE,
+            active_layout=active_layout,
+            target_layout=target_layout,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            migration_generation=None,
+            persisted=active_layout is SkillLayout.POOL or target_layout is not None,
+        )
 
-    def get_by_id_and_entity(self, bot_id: str, entity_id: str) -> dict | None:
-        assert (bot_id, entity_id) == (SCOPE.bot_id, SCOPE.entity_id)
-        return self._bot
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
 
 
-def _resolver(bot: dict | None) -> BotEngineSkillLayoutParticipationResolver:
-    return BotEngineSkillLayoutParticipationResolver(
-        bot_repository=_Bots(bot),
-        default=DEFAULT,
-        by_engine={"artifact_engine": NO_POOL},
-    )
-
-
-def test_explicit_engine_policy_controls_layout_participation() -> None:
-    result = _resolver({"env": "pre", "active_engine": "artifact_engine"}).resolve(
-        scope=SCOPE
-    )
-
-    assert result is NO_POOL
+def _resolver(layouts: _Layouts) -> BotSkillLayoutStateParticipationResolver:
+    return BotSkillLayoutStateParticipationResolver(layout_repository=layouts)
 
 
 @pytest.mark.parametrize(
-    "bot",
+    ("active_layout", "target_layout"),
     [
-        None,
-        {"env": "prod", "active_engine": "artifact_engine"},
-        {"env": "pre"},
-        {"env": "pre", "active_engine": 123},
-        {"env": "pre", "active_engine": "unknown_engine"},
+        (SkillLayout.POOL, None),
+        (SkillLayout.LEGACY, SkillLayout.POOL),
     ],
 )
-def test_unknown_or_incomplete_bot_keeps_conservative_default(bot: dict | None) -> None:
-    result = _resolver(bot).resolve(scope=SCOPE)
+def test_pool_or_transitioning_bot_participates_in_edit_lock(
+    active_layout: SkillLayout, target_layout: SkillLayout | None
+) -> None:
+    result = _resolver(
+        _Layouts(active_layout=active_layout, target_layout=target_layout)
+    ).resolve(scope=SCOPE)
 
-    assert result is DEFAULT
+    assert result == SkillLayoutParticipation(
+        participates_in_pool_layout=True,
+        label="pool_layout_state",
+    )
 
 
-def test_module_wires_artifact_engine_policy_outside_shared_guard() -> None:
+def test_legacy_bot_does_not_participate_in_pool_edit_lock() -> None:
+    result = _resolver(_Layouts()).resolve(scope=SCOPE)
+
+    assert result == SkillLayoutParticipation(
+        participates_in_pool_layout=False,
+        label="legacy_layout_state",
+    )
+
+
+def test_module_wires_layout_state_as_the_participation_source() -> None:
     resolver = SkillsPoolModule().skill_layout_participation_resolver(
-        _Bots({"env": "pre", "active_engine": "teclaw"})
+        _Layouts(target_layout=SkillLayout.POOL)
     )
 
     result = resolver.resolve(scope=SCOPE)
 
     assert result == SkillLayoutParticipation(
-        participates_in_pool_layout=False,
-        label="teclaw_no_pool_layout",
+        participates_in_pool_layout=True,
+        label="pool_layout_state",
     )


### PR DESCRIPTION
## 变更
- 仅当 `ac_bot_skill_layout_state` 的 `active_layout` 或 `target_layout` 为 `POOL` 时参与 Skills Pool 编辑锁。
- 为锁 acquire/release 记录 key、配置 TTL、token 指纹、耗时和结果。
- 旧 `/api/skills/upload` 在编辑锁冲突时返回 HTTP 409，不再返回 HTTP 200 的失败业务包。

## 根因
此前以运行时引擎做默认参与判断，未迁移的 Legacy Bot 也进入 editGuard；该路径上的缓存绑定异常会被表象化为 lock_busy。

## 影响
已进入或正在进入 Pool 的 Bot 继续受互斥保护；Legacy Bot（包括未灰度的 Bot）不再因 Pool 锁阻塞本地 Skill 上传。

## 验证
- `uv run pytest tests/community/core/skills_pool/test_participation.py tests/community/core/skills_pool/test_edit_guard.py tests/community/core/skill_center/test_local_skill_upload_service.py tests/community/core/skill_center/test_local_skill_delete_service.py tests/community/core/skill_center/test_local_skill_state_service.py tests/community/adapters/http/openapi_v1/test_responses.py tests/community/api/skill_center/test_skills_api_async_correctness.py -q`
- `uv run ruff check ...`