### PR TITLE
fix(bot_runtime): strip agent:main: prefix on create_session for key

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -268,8 +268,9 @@ class BaasBotService(BotService):
                     run_id=run_id,
                     session_id=session_id,
                 )
+            consistency_key = _strip_agent_main_prefix(session_consistency_key) if session_consistency_key else None
             conn_info = await self._resolve_ws_connection(
-                bot_id, tenant, engine_type, session_consistency_key
+                bot_id, tenant, engine_type, consistency_key
             )
         except BotNotFoundError:
             logger.error(
@@ -1130,7 +1131,7 @@ class BaasBotService(BotService):
         device. The persisted/returned session id contract is unchanged.
         """
         if session_id is not None:
-            return _strip_agent_main_prefix(session_id)
+            return session_id
 
         if engine_type == "openclaw":
             # Fixed prefix 'agent:main:'

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -165,8 +165,10 @@ class TestCreateSessionTenantValidation:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(
@@ -193,23 +195,22 @@ class TestCreateSessionTenantValidation:
 class TestSessionRoutingAffinityPrefix:
     """device_affinity 必须对 ``agent:main:`` 前缀不敏感。
 
-    同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递必须哈希到同一实例,
-    因此 ``_create_session_consistency_key`` 对非 None session_id 剥离前导 ``agent:main:``。
+    同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递必须哈希到同一实例。
+    前缀剥离职责在调用点(create_session 271 行 / _resolve_ws_connection_for_binding
+    842 行),_create_session_consistency_key 只负责构造亲和键,不做规范化。
     """
 
-    def test_prefixed_and_raw_collapse_to_same_affinity(self, service):
-        raw = "bcs-sess-123"
-        prefixed = f"agent:main:{raw}"
-        kwargs = dict(
-            engine_type="openclaw",
-            tc_bot_id=BOT_UUID,
-            user_id="u-1",
-            run_id="run-1",
-        )
+    def test_consistency_key_returns_session_id_as_is(self, service):
+        """_create_session_consistency_key 不再剥离前缀,原样返回 session_id。"""
         assert (
-            service._create_session_consistency_key(session_id=raw, **kwargs)
-            == service._create_session_consistency_key(session_id=prefixed, **kwargs)
-            == raw
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="agent:main:bcs-sess-123",
+            )
+            == "agent:main:bcs-sess-123"
         )
 
     def test_non_prefix_id_unchanged(self, service):
@@ -237,31 +238,48 @@ class TestSessionRoutingAffinityPrefix:
             == "agent:main:session:run-1:user:u-1"
         )
 
-    def test_double_prefix_stripped_to_idempotent_form(self, service):
-        """重复 agent:main: 前缀应被完全剥离,亲和键对前缀次数幂等。"""
-        assert (
-            service._create_session_consistency_key(
-                engine_type="openclaw",
-                tc_bot_id=BOT_UUID,
-                user_id="u-1",
-                run_id="run-1",
-                session_id="agent:main:agent:main:X",
-            )
-            == "X"
+    @pytest.mark.asyncio
+    async def test_create_session_path_strips_prefix_before_resolve(
+        self, service, wss_resolver
+    ):
+        """create_session 路径(271 行)对带前缀的 session_id 剥离后再传给 resolver。"""
+        from secbaas.community.api.bot_runtime import BotChatContext
+
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.id = "agent:main:sess-strip"
+        mock_session_client.create_session = AsyncMock(return_value=mock_session)
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        context = BotChatContext(
+            api_key_prefix=INVOKER,
+            tenant=TENANT,
+            app_id="test-app",
+            app_type="test-type",
         )
 
-    def test_empty_after_strip(self, service):
-        """仅含前缀的退化 id 剥离后为空串(不致崩溃,固定哈希到某设备)。"""
-        assert (
-            service._create_session_consistency_key(
-                engine_type="openclaw",
-                tc_bot_id=BOT_UUID,
-                user_id="u-1",
-                run_id="run-1",
-                session_id="agent:main:",
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_persist_session_create", return_value=None),
+        ):
+            await service.create_session(
+                bot_id=BOT_UUID,
+                session_id="agent:main:bcs-sess-456",
+                metadata={},
+                context=context,
+                binding_info=_make_binding_info(),
             )
-            == ""
-        )
+            assert (
+                wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs[
+                    "device_affinity"
+                ]
+                == "bcs-sess-456"
+            )
 
     @pytest.mark.asyncio
     async def test_send_path_routes_raw_and_prefixed_to_same_device(
@@ -1133,8 +1151,10 @@ class TestCreateSessionEngineType:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(
@@ -1252,8 +1272,10 @@ class TestCreateSessionInvokerInjection:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(

--- a/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
@@ -106,7 +106,7 @@ _CASES = [
         "openclaw",
         "sess-oc",
         "/api/openclaw/ws",
-        f"agent:main:session:{_RUN_ID}:user:{_USER_ID}",
+        f"session:{_RUN_ID}:user:{_USER_ID}",
         "agent:main:sess-oc",
     ),
     ("teclaw", "sess-tc", "/api/teclaw/ws", None, "sess-tc"),


### PR DESCRIPTION
## Problem

BaasBotService._resolve_ws_connection routes devices via consistent hashing on an affinity key, which must be insensitive to the agent:main: prefix: openclaw persists session ids with the prefix while DingTalk inbound carries the raw id -- both forms must hash to the same device or the same conversation lands on different instances across channels.

_resolve_ws_connection_for_binding (send/inject API paths) already strips the prefix at line 842, but the create_session path passed the key to _resolve_ws_connection without normalization. For openclaw, _create_session_consistency_key always yields
"agent:main:session:{run_id}:user:{user_id}", so the prefixed form was hashed directly.

Consequence: a session created via create_session (prefixed) and then addressed via send/inject (raw id) hashed to different devices, breaking affinity -- the raw-id request landed on a device lacking the session's WS context, causing state loss / reconnect thrash.

## Solution

Realign normalization responsibility so both entry paths are symmetric:

1. create_session (line 271): strip the prefix from session_consistency_key before passing it to _resolve_ws_connection, matching the existing normalization at line 842 in _resolve_ws_connection_for_binding.

2. _create_session_consistency_key (line 1133): revert to "return session_id" and drop the _strip_agent_main_prefix call. This method's responsibility is to construct the affinity key, not to normalize it. Normalization now lives at both call sites (271 / 842), avoiding double-strip on the same value and keeping the responsibility boundary clean.

Rejected alternative: strip inside _resolve_ws_connection itself. Not adopted -- its parameter is named session_consistency_key (already "the value to use as affinity key"), and silently rewriting it there would make the final device_affinity= opaque to callers, hiding the actual value hashed at line 802. Keeping normalization at the call sites is explicit.

## Validation

- Static check: line 271 strip -> line 272 _resolve_ws_connection ->
  line 802 device_affinity= chain is consistent; the existing line-842
  strip path is unchanged.
- No dynamic regression run: reproducing requires an openclaw engine plus a cross-channel (create_session vs send) same-session scenario, which this local environment cannot provide. Recommend a downstream affinity regression: create_session with a prefixed id, then send with the raw id, and assert both hit the same device.

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
