### PR TITLE
fix(devices): make concurrent bot deletion idempotent

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -124,9 +124,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # 文件传输轮询器配置（定期检测 OSS 上传完成并触发 device 下载）

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -109,9 +109,8 @@ user_config:
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数
     query_retries: 3  # 单页查询 DB 失败时的重试次数
-    lock_name: "device_ttl_timer_lock"  # 分布式锁名称
-    lock_expire_seconds: 1800  # 分布式锁租约（秒），须 >= cron 间隔，默认: 1800
-    lock_renew_interval_seconds: 60  # 分布式锁自动续期间隔（秒），默认: 60
+    lock_name: "device_ttl_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀（如 _pre/_prod）以实现环境隔离
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
   # BotRun 队列恢复配置（周期性重置心跳过期的 RUNNING 请求回 PENDING）

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -268,8 +268,9 @@ class BaasBotService(BotService):
                     run_id=run_id,
                     session_id=session_id,
                 )
+            consistency_key = _strip_agent_main_prefix(session_consistency_key) if session_consistency_key else None
             conn_info = await self._resolve_ws_connection(
-                bot_id, tenant, engine_type, session_consistency_key
+                bot_id, tenant, engine_type, consistency_key
             )
         except BotNotFoundError:
             logger.error(
@@ -1130,7 +1131,7 @@ class BaasBotService(BotService):
         device. The persisted/returned session id contract is unchanged.
         """
         if session_id is not None:
-            return _strip_agent_main_prefix(session_id)
+            return session_id
 
         if engine_type == "openclaw":
             # Fixed prefix 'agent:main:'

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_device_ttl_timer_task.py
@@ -27,6 +27,7 @@ from secbaas.community.core.service.health_check.sandbox import (
     SandboxDeviceRouter,
     TableType,
 )
+from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 
 log = get_logger("core-scheduler")
@@ -38,11 +39,9 @@ class DeviceTtlTimerTaskConfig:
 
     enabled: bool = True
     lock_name: str = "device_ttl_timer_lock"
-    # 锁过期时间须 >= cron 间隔：full-drain 一轮可能超过5分钟，锁在持有期间
-    # 会被 DistributedLockService 自动续期，为避免进程卡住时锁永远不释放，
-    # 这里给一个宽松的租约（默认30分钟）。cron 间隔与 lock 到期解耦，避免
-    # “下一轮在上一轮还没跑完时就再次触发、锁又正好过期”导致并发重复扫描。
-    lock_expire_seconds: int = 1800
+    # 锁过期时间须 < cron 间隔：租约在下一轮触发前到期释放，允许其它机器
+    # 在轮次间抢到锁，避免同一实例每轮都重复占锁。
+    lock_expire_seconds: int = 1750
     cron_interval_seconds: int = 1800
     batch_size: int = 100
     dry_run: bool = False
@@ -51,6 +50,15 @@ class DeviceTtlTimerTaskConfig:
     max_page_concurrency: int = 10
     # 单页查询 DB 失败时的重试次数（指数退避），吸收瞬时 DB 抖动。
     query_retries: int = 3
+
+    def resolved_lock_name(self) -> str:
+        """返回按环境作用域的分布式锁名。
+
+        在配置的 ``lock_name`` 基准上追加环境后缀（如 ``_pre``/``_prod``），
+        使 pre 与 prod 使用不同的锁名，避免共享同一把分布式锁。
+        """
+        env = get_current_env()
+        return f"{self.lock_name}_{env}"
 
 
 @dataclass
@@ -181,19 +189,20 @@ class DeviceTtlTimerTask:
             log.info("[DeviceTtlTimer] Another run in progress, skipping cron trigger")
             return None
 
+        lock_name = self._config.resolved_lock_name()
         with self._lock_service.try_lock(
-            lock_name=self._config.lock_name,
+            lock_name=lock_name,
             expire_seconds=self._config.lock_expire_seconds,
             block=False,
         ) as lock:
             if not lock.acquired:
                 log.info(
                     "[DeviceTtlTimer] Lock %s not acquired, skipping",
-                    self._config.lock_name,
+                    lock_name,
                 )
                 return None
 
-            log.info("[DeviceTtlTimer] Lock %s acquired", self._config.lock_name)
+            log.info("[DeviceTtlTimer] Lock %s acquired", lock_name)
             self._running = True
             try:
                 return await self._run_once(run_uuid=run_uuid)

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -165,8 +165,10 @@ class TestCreateSessionTenantValidation:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(
@@ -193,23 +195,22 @@ class TestCreateSessionTenantValidation:
 class TestSessionRoutingAffinityPrefix:
     """device_affinity 必须对 ``agent:main:`` 前缀不敏感。
 
-    同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递必须哈希到同一实例,
-    因此 ``_create_session_consistency_key`` 对非 None session_id 剥离前导 ``agent:main:``。
+    同一会话经 DingTalk(裸 id)与 Open API(带前缀 id)两次投递必须哈希到同一实例。
+    前缀剥离职责在调用点(create_session 271 行 / _resolve_ws_connection_for_binding
+    842 行),_create_session_consistency_key 只负责构造亲和键,不做规范化。
     """
 
-    def test_prefixed_and_raw_collapse_to_same_affinity(self, service):
-        raw = "bcs-sess-123"
-        prefixed = f"agent:main:{raw}"
-        kwargs = dict(
-            engine_type="openclaw",
-            tc_bot_id=BOT_UUID,
-            user_id="u-1",
-            run_id="run-1",
-        )
+    def test_consistency_key_returns_session_id_as_is(self, service):
+        """_create_session_consistency_key 不再剥离前缀,原样返回 session_id。"""
         assert (
-            service._create_session_consistency_key(session_id=raw, **kwargs)
-            == service._create_session_consistency_key(session_id=prefixed, **kwargs)
-            == raw
+            service._create_session_consistency_key(
+                engine_type="openclaw",
+                tc_bot_id=BOT_UUID,
+                user_id="u-1",
+                run_id="run-1",
+                session_id="agent:main:bcs-sess-123",
+            )
+            == "agent:main:bcs-sess-123"
         )
 
     def test_non_prefix_id_unchanged(self, service):
@@ -237,31 +238,48 @@ class TestSessionRoutingAffinityPrefix:
             == "agent:main:session:run-1:user:u-1"
         )
 
-    def test_double_prefix_stripped_to_idempotent_form(self, service):
-        """重复 agent:main: 前缀应被完全剥离,亲和键对前缀次数幂等。"""
-        assert (
-            service._create_session_consistency_key(
-                engine_type="openclaw",
-                tc_bot_id=BOT_UUID,
-                user_id="u-1",
-                run_id="run-1",
-                session_id="agent:main:agent:main:X",
-            )
-            == "X"
+    @pytest.mark.asyncio
+    async def test_create_session_path_strips_prefix_before_resolve(
+        self, service, wss_resolver
+    ):
+        """create_session 路径(271 行)对带前缀的 session_id 剥离后再传给 resolver。"""
+        from secbaas.community.api.bot_runtime import BotChatContext
+
+        wss_resolver.dispatch_bot_ws_conn_info.return_value = _make_conn_info()
+
+        mock_session_client = AsyncMock()
+        mock_session = MagicMock()
+        mock_session.id = "agent:main:sess-strip"
+        mock_session_client.create_session = AsyncMock(return_value=mock_session)
+        mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
+        mock_session_client.__aexit__ = AsyncMock(return_value=False)
+
+        context = BotChatContext(
+            api_key_prefix=INVOKER,
+            tenant=TENANT,
+            app_id="test-app",
+            app_type="test-type",
         )
 
-    def test_empty_after_strip(self, service):
-        """仅含前缀的退化 id 剥离后为空串(不致崩溃,固定哈希到某设备)。"""
-        assert (
-            service._create_session_consistency_key(
-                engine_type="openclaw",
-                tc_bot_id=BOT_UUID,
-                user_id="u-1",
-                run_id="run-1",
-                session_id="agent:main:",
+        with (
+            patch.object(
+                service, "_create_session_client", return_value=mock_session_client
+            ),
+            patch.object(service, "_persist_session_create", return_value=None),
+        ):
+            await service.create_session(
+                bot_id=BOT_UUID,
+                session_id="agent:main:bcs-sess-456",
+                metadata={},
+                context=context,
+                binding_info=_make_binding_info(),
             )
-            == ""
-        )
+            assert (
+                wss_resolver.dispatch_bot_ws_conn_info.call_args.kwargs[
+                    "device_affinity"
+                ]
+                == "bcs-sess-456"
+            )
 
     @pytest.mark.asyncio
     async def test_send_path_routes_raw_and_prefixed_to_same_device(
@@ -1133,8 +1151,10 @@ class TestCreateSessionEngineType:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(
@@ -1252,8 +1272,10 @@ class TestCreateSessionInvokerInjection:
         mock_session_client.__aexit__ = AsyncMock(return_value=False)
 
         binding = _make_binding_info()
-        # resolve_user_id falls back to bot_id for service bot_type without context
-        consistency_key = f"agent:main:session:None:user:{BOT_UUID}"
+        # resolve_user_id falls back to bot_id for service bot_type without context;
+        # create_session strips the agent:main: prefix (line 271) before passing
+        # the consistency key to _resolve_ws_connection.
+        consistency_key = f"session:None:user:{BOT_UUID}"
 
         with (
             patch.object(

--- a/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py
@@ -106,7 +106,7 @@ _CASES = [
         "openclaw",
         "sess-oc",
         "/api/openclaw/ws",
-        f"agent:main:session:{_RUN_ID}:user:{_USER_ID}",
+        f"session:{_RUN_ID}:user:{_USER_ID}",
         "agent:main:sess-oc",
     ),
     ("teclaw", "sess-tc", "/api/teclaw/ws", None, "sess-tc"),

--- a/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_device_ttl_timer_task.py
@@ -7,7 +7,7 @@ stall trailing devices. Also covers the per-record digest logging.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -100,7 +100,56 @@ class TestDefaults:
         assert task.interval_seconds == 42
         assert task._config.batch_size == 100
         assert task._config.lock_name == "device_ttl_timer_lock"
-        assert task._config.lock_expire_seconds == 1800
+        assert task._config.lock_expire_seconds == 1750
+
+
+class TestResolvedLockName:
+    def test_dev_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="dev",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_dev"
+
+    def test_pre_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_pre"
+
+    def test_prod_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            cfg = DeviceTtlTimerTaskConfig()
+            assert cfg.resolved_lock_name() == "device_ttl_timer_lock_prod"
+
+    def test_explicit_lock_name_still_env_suffixed(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="pre",
+        ):
+            cfg = DeviceTtlTimerTaskConfig(lock_name="custom_timer_lock")
+            assert cfg.resolved_lock_name() == "custom_timer_lock_pre"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_resolved_lock_name(self):
+        cfg = DeviceTtlTimerTaskConfig(enabled=True)
+        lock_service = MagicMock()
+        lock_service.try_lock.return_value.__enter__.return_value = _not_acquired_lock()
+        task = DeviceTtlTimerTask(cfg, lock_service, MagicMock(), MagicMock())
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._device_ttl_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            await task.run()
+        lock_service.try_lock.assert_called_once()
+        call_kwargs = lock_service.try_lock.call_args
+        assert call_kwargs.kwargs["lock_name"] == "device_ttl_timer_lock_prod"
 
 
 class TestEarlyReturns:

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -16,6 +16,7 @@ from typing import Any, List, Literal, Optional
 
 from fastapi import APIRouter, Query, Request, Response, Depends, Path
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
+from starlette.concurrency import run_in_threadpool
 
 from agentclaw.community.adapters.http.auth.dependencies import require_operator, get_current_user
 from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
@@ -2293,7 +2294,12 @@ async def delete_bot(
 
         resolved_owner_id = owner_id or operator_id
 
-        bot_service.delete_bot(bot_id=bot_id, user_id=resolved_owner_id)
+        # ``BotService.delete_bot`` is synchronous and may wait for a
+        # concurrent deletion result.  Do not block this async route's event
+        # loop while the service performs provider calls or that join.
+        await run_in_threadpool(
+            bot_service.delete_bot, bot_id=bot_id, user_id=resolved_owner_id
+        )
 
         return ApiResponse(
             success=True,

--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -2297,7 +2297,7 @@ async def delete_bot(
         # ``BotService.delete_bot`` is synchronous and may wait for a
         # concurrent deletion result.  Do not block this async route's event
         # loop while the service performs provider calls or that join.
-        await run_in_threadpool(
+        await run_in_threadpool(  # allow-run-in-threadpool: BotService API is synchronous.
             bot_service.delete_bot, bot_id=bot_id, user_id=resolved_owner_id
         )
 

--- a/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/devices/schemas.py
@@ -56,6 +56,7 @@ class DeviceBindingStatus(StrEnum):
     ACTIVE = "ACTIVE"
     STOPPED = "STOPPED"
     FAILED = "FAILED"
+    RELEASING = "RELEASING"
     RELEASED = "RELEASED"
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -17,6 +17,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     EXAMPLE_TRACE_ID,
@@ -583,7 +584,10 @@ async def delete_bot(
     their publish lifecycle.
     """
     _reject_unowned_lifecycle(bot_service.get_bot(bot_id, owner_id), deleting=True)
-    bot_service.delete_bot(bot_id, owner_id)
+    # Bot deletion calls providers and may join an in-flight deletion.  The
+    # service API is synchronous, so keep that blocking work off this async
+    # request worker's event loop.
+    await run_in_threadpool(bot_service.delete_bot, bot_id, owner_id)
     return deleted_envelope(request)
 
 
@@ -923,5 +927,4 @@ async def delete_bot_startup_script(
         raise BotNotFoundError("bot has no associated entity")
     startup_script_service.delete(entity_id=entity_id, bot_id=bot_id)
     return deleted_envelope(request)
-
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -587,7 +587,9 @@ async def delete_bot(
     # Bot deletion calls providers and may join an in-flight deletion.  The
     # service API is synchronous, so keep that blocking work off this async
     # request worker's event loop.
-    await run_in_threadpool(bot_service.delete_bot, bot_id, owner_id)
+    await run_in_threadpool(  # allow-run-in-threadpool: BotService API is synchronous.
+        bot_service.delete_bot, bot_id, owner_id
+    )
     return deleted_envelope(request)
 
 
@@ -927,4 +929,3 @@ async def delete_bot_startup_script(
         raise BotNotFoundError("bot has no associated entity")
     startup_script_service.delete(entity_id=entity_id, bot_id=bot_id)
     return deleted_envelope(request)
-

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -202,6 +202,34 @@ def _file_coords(
     return ("staff", owner_id, engine_type)
 
 
+def _is_baas_bot_not_found(exc: Exception) -> bool:
+    """Recognize the BaaS deletion response across direct and proxy calls."""
+    if "BOT_NOT_FOUND" in str(exc):
+        return True
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return False
+    response = exc.response
+    if response.status_code != 404:
+        return False
+    try:
+        return "BOT_NOT_FOUND" in response.text
+    except httpx.ResponseNotRead:
+        return False
+
+
+def _raise_upload_lifecycle_error(
+    *, exc: Exception, bot_id: str, owner_id: str, bot_repo: BotRepository
+) -> None:
+    """Map a concurrent BaaS deletion to the public upload lifecycle errors."""
+    if not _is_baas_bot_not_found(exc):
+        return
+    if bot_repo.get_by_id_and_owner(bot_id, owner_id) is None:
+        raise HTTPException(status_code=404, detail="Bot not found") from exc
+    raise HTTPException(
+        status_code=409, detail="Bot is being deleted; retry is not available"
+    ) from exc
+
+
 def _to_file_entry(entry: dict[str, Any]) -> FileEntry:
     """Map a ``ResourceFileService.list_dir`` entry to the public schema.
 
@@ -416,13 +444,27 @@ async def upload_resource(
     # changed. Closing it needs an exclusive-create on the engine's write API,
     # since ``DeviceFileSystem`` has no conditional-create to make the check and
     # the write one operation; see the spec's known-limitation section.
-    occupied = await file_svc.exists(
-        entity_type=entity_type,
-        entity_id=entity_id,
-        bot_id=bot_id,
-        engine_type=engine_type,
-        path=safe,
-    )
+    try:
+        occupied = await file_svc.exists(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            bot_id=bot_id,
+            engine_type=engine_type,
+            path=safe,
+        )
+    except (BaasServiceError, httpx.HTTPStatusError) as exc:
+        _raise_upload_lifecycle_error(
+            exc=exc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo
+        )
+        logger.exception("[upload_resource] BaaS duplicate probe failed")
+        raise HTTPException(
+            status_code=502, detail="Upload storage failed"
+        ) from exc
+    except Exception as exc:
+        logger.exception("[upload_resource] duplicate probe failed")
+        raise HTTPException(
+            status_code=502, detail="Upload storage failed"
+        ) from exc
     if occupied and not overwrite:
         raise DuplicateResourceError(f"Resource already exists: {safe}")
     try:
@@ -447,16 +489,14 @@ async def upload_resource(
         # logged here so it is still diagnosable.
         logger.warning("[upload_resource] rejected upload: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc))
-    except BaasServiceError as exc:
+    except (BaasServiceError, httpx.HTTPStatusError) as exc:
         # A delete may win after this request resolved its workspace but before
-        # the engine write.  Do not turn that expected lifecycle race into an
-        # unhandled 500.
-        if "BOT_NOT_FOUND" in str(exc):
-            if bot_repo.get_by_id_and_owner(bot_id, owner_id) is None:
-                raise HTTPException(status_code=404, detail="Bot not found") from exc
-            raise HTTPException(
-                status_code=409, detail="Bot is being deleted; retry is not available"
-            ) from exc
+        # the engine write, including when a desktop proxy reports the 404
+        # directly as an HTTPStatusError. Do not turn that expected lifecycle
+        # race into an unhandled 500.
+        _raise_upload_lifecycle_error(
+            exc=exc, bot_id=bot_id, owner_id=owner_id, bot_repo=bot_repo
+        )
         logger.exception("[upload_resource] BaaS storage failed")
         raise HTTPException(status_code=502, detail="Upload storage failed") from exc
     except Exception:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -70,6 +70,7 @@ from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 from agentclaw.community.core.resources.service import (
     DuplicateResourceError,
     FileTooLargeError,
@@ -446,6 +447,18 @@ async def upload_resource(
         # logged here so it is still diagnosable.
         logger.warning("[upload_resource] rejected upload: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc))
+    except BaasServiceError as exc:
+        # A delete may win after this request resolved its workspace but before
+        # the engine write.  Do not turn that expected lifecycle race into an
+        # unhandled 500.
+        if "BOT_NOT_FOUND" in str(exc):
+            if bot_repo.get_by_id_and_owner(bot_id, owner_id) is None:
+                raise HTTPException(status_code=404, detail="Bot not found") from exc
+            raise HTTPException(
+                status_code=409, detail="Bot is being deleted; retry is not available"
+            ) from exc
+        logger.exception("[upload_resource] BaaS storage failed")
+        raise HTTPException(status_code=502, detail="Upload storage failed") from exc
     except Exception:
         # Device write failure → 502. No record is written below, so a failed
         # upload leaves neither bytes nor a row.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -502,6 +502,12 @@ async def upload_resource(
         )
         logger.exception("[upload_resource] BaaS storage failed")
         raise HTTPException(status_code=502, detail="Upload storage failed") from exc
+    except DeviceNotBoundError:
+        # The workspace disappeared after the duplicate probe, typically because
+        # a concurrent delete released its device binding.  Preserve the domain
+        # error so ``@envelope_errors`` returns the public lifecycle-conflict
+        # response instead of collapsing it into a storage 502.
+        raise
     except Exception:
         # Device write failure → 502. No record is written below, so a failed
         # upload leaves neither bytes nor a row.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -69,6 +69,7 @@ from agentclaw.community.core.bot_management.services.engine_resolver import (
 from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
+from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 from agentclaw.community.core.resources.service import (
@@ -204,7 +205,7 @@ def _file_coords(
 
 def _is_baas_bot_not_found(exc: Exception) -> bool:
     """Recognize the BaaS deletion response across direct and proxy calls."""
-    if "BOT_NOT_FOUND" in str(exc):
+    if "BOT_NOT_FOUND" in str(exc) or "NO_DEVICES_FOUND" in str(exc):
         return True
     if not isinstance(exc, httpx.HTTPStatusError):
         return False
@@ -212,7 +213,7 @@ def _is_baas_bot_not_found(exc: Exception) -> bool:
     if response.status_code != 404:
         return False
     try:
-        return "BOT_NOT_FOUND" in response.text
+        return any(marker in response.text for marker in ("BOT_NOT_FOUND", "NO_DEVICES_FOUND"))
     except httpx.ResponseNotRead:
         return False
 
@@ -460,6 +461,8 @@ async def upload_resource(
         raise HTTPException(
             status_code=502, detail="Upload storage failed"
         ) from exc
+    except DeviceNotBoundError:
+        raise
     except Exception as exc:
         logger.exception("[upload_resource] duplicate probe failed")
         raise HTTPException(

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
@@ -408,6 +408,12 @@ class UploadSkillResponse(BaseModel):
     message: str
 
 
+class UploadSkillErrorResponse(BaseModel):
+    """HTTP error body returned when an upload cannot start safely."""
+
+    detail: str = Field(description="Human-readable reason for the failed upload.")
+
+
 class SkillParametersResponse(BaseModel):
     success: bool
     data: dict

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -76,6 +76,7 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     UpdateRiskTagsRequest,
     UpdateSkillMemberRoleRequest,
     UpdateSkillRequest,
+    UploadSkillErrorResponse,
     UploadSkillResponse,
     VersionListResponse,
 )
@@ -90,6 +91,7 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditGuard,
+    SkillsPoolEditLockUnavailableError,
     SkillsPoolEditPausedError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
@@ -375,7 +377,20 @@ def _require_pool_runtime_sync_success(
 
 # ==================== Core CRUD APIs ====================
 
-@router.post("/upload", response_model=UploadSkillResponse)
+@router.post(
+    "/upload",
+    response_model=UploadSkillResponse,
+    responses={
+        409: {
+            "model": UploadSkillErrorResponse,
+            "description": "A Local Skill edit or layout rollback is in progress.",
+        },
+        503: {
+            "model": UploadSkillErrorResponse,
+            "description": "The edit-lock backend is temporarily unavailable.",
+        },
+    },
+)
 @with_interceptors(CollaboratorPermissionInterceptor(
     bot_id="$bot_id",
     owner_id="$user_id",
@@ -555,6 +570,8 @@ async def upload_skill(
             ),
             message="Skill uploaded successfully"
         )
+    except SkillsPoolEditLockUnavailableError as e:
+        raise HTTPException(status_code=503, detail=str(e)) from e
     except SkillsPoolEditPausedError as e:
         # A held edit/rollback lock is an ordinary request conflict, not a
         # successful response carrying a failed business envelope.  Clients

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -556,7 +556,12 @@ async def upload_skill(
             message="Skill uploaded successfully"
         )
     except SkillsPoolEditPausedError as e:
-        return UploadSkillResponse(success=False, message=str(e))
+        # A held edit/rollback lock is an ordinary request conflict, not a
+        # successful response carrying a failed business envelope.  Clients
+        # must be able to distinguish it from a completed upload.
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except HTTPException:
+        raise
     except ValueError as e:
         error_msg = str(e)
         logger.error(f"[skills.upload_skill] Validation error: {error_msg}")

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -118,6 +118,13 @@ logger = get_logger()
 # blocked from restarting.
 RESTART_LOCK_TTL_SECONDS = 120
 
+# A delete can legitimately spend longer than a restart in provider teardown.
+# It keeps its lease alive, while an abandoned worker becomes recoverable after
+# this DB-clock interval.
+DELETE_LOCK_TTL_SECONDS = 120
+DELETE_LOCK_HEARTBEAT_SECONDS = 10
+DELETE_LOCK_JOIN_TIMEOUT_SECONDS = 300
+
 # Deletion shares the durable, fenced lock implementation used by restart, but
 # uses a separate key namespace.  A restart must not accidentally join a
 # deletion (or vice versa), while duplicate deletes must coalesce before either
@@ -898,12 +905,71 @@ class BotService:
         release: Passport destruction and the terminal soft-delete CAS are
         otherwise still reachable by two concurrent requests.
         """
-        return self._try_acquire_restart_lock(
-            env,
-            entity_id,
-            f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}",
-            holder_user_id,
+        lock_key = f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}"
+        lock = self._restart_lock_repo.acquire(env, entity_id, lock_key, holder_user_id)
+        if lock is not None:
+            return lock
+
+        stale = self._restart_lock_repo.get_if_stale(
+            env, entity_id, lock_key, DELETE_LOCK_TTL_SECONDS
         )
+        if stale is not None:
+            self._restart_lock_repo.release(
+                env, entity_id, lock_key, stale.lock_token
+            )
+        return self._restart_lock_repo.acquire(env, entity_id, lock_key, holder_user_id)
+
+    def _start_delete_lock_heartbeat(
+        self, env: str, entity_id: str, bot_id: str, lock_token: str
+    ) -> tuple[threading.Event, threading.Event, threading.Thread]:
+        """Keep a deletion lease live while its blocking provider calls run."""
+        lock_key = f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}"
+        if not self._restart_lock_repo.refresh(env, entity_id, lock_key, lock_token):
+            raise BotServiceError("Failed to establish bot deletion lock lease")
+
+        stop = threading.Event()
+        lease_lost = threading.Event()
+
+        def _heartbeat() -> None:
+            while not stop.wait(DELETE_LOCK_HEARTBEAT_SECONDS):
+                if not self._restart_lock_repo.refresh(
+                    env, entity_id, lock_key, lock_token
+                ):
+                    lease_lost.set()
+                    logger.error(
+                        "[bot_service.delete_bot] Lost deletion lock lease for bot %s",
+                        bot_id,
+                    )
+                    return
+
+        thread = threading.Thread(
+            target=_heartbeat,
+            name=f"bot-delete-lease-{bot_id}",
+            daemon=True,
+        )
+        thread.start()
+        return stop, lease_lost, thread
+
+    def _join_delete_result(
+        self, env: str, entity_id: str, bot_id: str, user_id: str
+    ) -> bool:
+        """Wait for the current holder's durable deletion result.
+
+        A duplicate reports success only after the bot row is gone. If the
+        holder releases its lock while the row is still live, it failed before
+        the terminal write, so the duplicate fails visibly instead of claiming
+        a deletion that did not happen.
+        """
+        lock_key = f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}"
+        deadline = time.monotonic() + DELETE_LOCK_JOIN_TIMEOUT_SECONDS
+        while True:
+            if self._repository.get_by_id_and_owner(bot_id, user_id) is None:
+                return True
+            if self._restart_lock_repo.get(env, entity_id, lock_key) is None:
+                raise BotServiceError("Concurrent bot deletion did not complete")
+            if time.monotonic() >= deadline:
+                raise BotServiceError("Timed out waiting for concurrent bot deletion")
+            time.sleep(0.1)
 
     async def get_bot_by_ip_and_user(self, ip: str, user_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -3424,6 +3490,9 @@ class BotService:
         delete_lock: BotRestartLockRecord | None = None
         delete_lock_env: str | None = None
         delete_lock_entity_id: str | None = None
+        delete_lock_heartbeat_stop: threading.Event | None = None
+        delete_lock_lease_lost: threading.Event | None = None
+        delete_lock_heartbeat_thread: threading.Thread | None = None
         try:
             # Get bot by bot_id and owner_id (user_id)
             bot = self._repository.get_by_id_and_owner(bot_id, user_id)
@@ -3471,7 +3540,21 @@ class BotService:
                     delete_lock_env,
                     delete_lock_entity_id,
                 )
-                return True
+                return self._join_delete_result(
+                    delete_lock_env, delete_lock_entity_id, bot_id, user_id
+                )
+            (
+                delete_lock_heartbeat_stop,
+                delete_lock_lease_lost,
+                delete_lock_heartbeat_thread,
+            ) = (
+                self._start_delete_lock_heartbeat(
+                    delete_lock_env,
+                    delete_lock_entity_id,
+                    bot_id,
+                    delete_lock.lock_token,
+                )
+            )
 
             # Withdraw every application authorization standing against this
             # bot — whoever delegated it — before anything destructive happens.
@@ -3552,6 +3635,9 @@ class BotService:
                         logger.error(f"[bot_service.delete_bot] Failed to release device for binding {binding_id}: {e}")
                         raise BotServiceError(f"设备释放失败，无法删除 Bot: {e}")
 
+            if delete_lock_lease_lost is not None and delete_lock_lease_lost.is_set():
+                raise BotServiceError("Lost bot deletion lock lease before Passport destruction")
+
             # Step 2: 通知 Passport 服务销毁 Passport（阻塞流程）
             try:
                 self._passport_plugin.destroy_passport(bot_id, user_id)
@@ -3559,6 +3645,9 @@ class BotService:
             except PassportError as e:
                 logger.error(f"[bot_service.delete_bot] destroyPassport failed: bot_id={bot_id}, owner_workno={user_id}, error={e}")
                 raise BotServiceError(f"销毁 Passport 失败: {e}")
+
+            if delete_lock_lease_lost is not None and delete_lock_lease_lost.is_set():
+                raise BotServiceError("Lost bot deletion lock lease before soft delete")
 
             # Soft delete the bot (use soft_delete_by_owner to ensure we only delete the owner's bot)
             result = self._repository.soft_delete_by_owner(bot_id, user_id)
@@ -3596,6 +3685,10 @@ class BotService:
             logger.error(f"[bot_service.delete_bot] Failed to delete bot {bot_id}: {e}")
             raise BotServiceError(f"Failed to delete bot: {e}")
         finally:
+            if delete_lock_heartbeat_stop is not None:
+                delete_lock_heartbeat_stop.set()
+            if delete_lock_heartbeat_thread is not None:
+                delete_lock_heartbeat_thread.join(timeout=1)
             if delete_lock is not None:
                 self._restart_lock_repo.release(
                     delete_lock_env,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -888,10 +888,16 @@ class BotService:
                 env, entity_id, bot_id, stale.gmt_create,
             )
             # Compare-and-delete on the stale row's token: if another worker
-            # already reaped+reacquired, the token won't match and this is a
-            # no-op — the acquire below then fails and we suppress, instead of
-            # stealing their fresh lock.
-            self._restart_lock_repo.release(env, entity_id, bot_id, stale.lock_token)
+            # already reaped+reacquired, or the same holder refreshed its
+            # heartbeat, this is a no-op. The acquire below then fails and we
+            # suppress instead of stealing their fresh lock.
+            self._restart_lock_repo.release(
+                env,
+                entity_id,
+                bot_id,
+                stale.lock_token,
+                expected_gmt_modified=stale.gmt_modified,
+            )
 
         return self._restart_lock_repo.acquire(env, entity_id, bot_id, holder_user_id)
 
@@ -915,7 +921,11 @@ class BotService:
         )
         if stale is not None:
             self._restart_lock_repo.release(
-                env, entity_id, lock_key, stale.lock_token
+                env,
+                entity_id,
+                lock_key,
+                stale.lock_token,
+                expected_gmt_modified=stale.gmt_modified,
             )
         return self._restart_lock_repo.acquire(env, entity_id, lock_key, holder_user_id)
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -967,25 +967,44 @@ class BotService:
         return stop, lease_lost, thread
 
     def _join_delete_result(
-        self, env: str, entity_id: str, bot_id: str, user_id: str
+        self, env: str, entity_id: str, bot_id: str, user_id: str, bot: Dict[str, Any]
     ) -> bool:
         """Wait for the current holder's durable deletion result.
 
-        A duplicate reports success only after the bot row is gone. If the
-        holder releases its lock while the row is still live, it failed before
-        the terminal write, so the duplicate fails visibly instead of claiming
-        a deletion that did not happen.
+        The lock must disappear before a missing bot row means success: the
+        holder still has two failure-propagating persistence sweeps to run
+        after its soft delete. Once the holder has released the fence, this
+        duplicate reruns those idempotent sweeps against the original bot
+        context before reporting the durable completed result. That both waits
+        for an in-flight holder and repairs a holder that failed after the row
+        became invisible, without repeating Passport or device destruction.
         """
         lock_key = f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}"
         deadline = time.monotonic() + DELETE_LOCK_JOIN_TIMEOUT_SECONDS
         while True:
+            if self._restart_lock_repo.get(env, entity_id, lock_key) is not None:
+                if time.monotonic() >= deadline:
+                    raise BotServiceError("Timed out waiting for concurrent bot deletion")
+                time.sleep(0.1)
+                continue
             if self._repository.get_by_id_and_owner(bot_id, user_id) is None:
+                self._finish_post_delete_sweeps(bot_id, user_id, bot)
                 return True
-            if self._restart_lock_repo.get(env, entity_id, lock_key) is None:
-                raise BotServiceError("Concurrent bot deletion did not complete")
-            if time.monotonic() >= deadline:
-                raise BotServiceError("Timed out waiting for concurrent bot deletion")
-            time.sleep(0.1)
+            raise BotServiceError("Concurrent bot deletion did not complete")
+
+    def _finish_post_delete_sweeps(
+        self, bot_id: str, user_id: str, bot: Dict[str, Any]
+    ) -> None:
+        """Run the failure-propagating cleanup that completes a soft delete.
+
+        Both operations are idempotent. A joining request may therefore safely
+        rerun them after the lock holder releases its fence; any persistence
+        error remains visible instead of converting a partially cleaned delete
+        into a successful duplicate response.
+        """
+        self._sweep_grants_that_raced_the_deletion(bot_id, user_id)
+        if bot_id != "default":
+            self._sweep_startup_script_that_raced_the_deletion(bot_id, bot)
 
     async def get_bot_by_ip_and_user(self, ip: str, user_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -3557,7 +3576,7 @@ class BotService:
                     delete_lock_entity_id,
                 )
                 return self._join_delete_result(
-                    delete_lock_env, delete_lock_entity_id, bot_id, user_id
+                    delete_lock_env, delete_lock_entity_id, bot_id, user_id, bot
                 )
 
             # A duplicate may acquire only after the first holder has already
@@ -3572,6 +3591,7 @@ class BotService:
                     "reacquired deletion lock could proceed.",
                     bot_id,
                 )
+                self._finish_post_delete_sweeps(bot_id, user_id, bot)
                 return True
             bot = locked_bot
             (
@@ -3685,10 +3705,7 @@ class BotService:
             if not result:
                 raise BotNotFoundError(f"Bot not found: {bot_id}")
 
-            self._sweep_grants_that_raced_the_deletion(bot_id, user_id)
-
-            if bot_id != "default":
-                self._sweep_startup_script_that_raced_the_deletion(bot_id, bot)
+            self._finish_post_delete_sweeps(bot_id, user_id, bot)
 
             self._sync_provider_bot_delete_to_bcn(bot_id, user_id)
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -118,6 +118,12 @@ logger = get_logger()
 # blocked from restarting.
 RESTART_LOCK_TTL_SECONDS = 120
 
+# Deletion shares the durable, fenced lock implementation used by restart, but
+# uses a separate key namespace.  A restart must not accidentally join a
+# deletion (or vice versa), while duplicate deletes must coalesce before either
+# request reaches Passport or the final soft-delete CAS.
+_DELETE_LOCK_KEY_PREFIX = "delete:"
+
 # Passport refresh is callback-driven and retryable. Keep caller-instance
 # fan-out bounded while still attempting every instance before reporting an
 # aggregate failure.
@@ -881,6 +887,23 @@ class BotService:
             self._restart_lock_repo.release(env, entity_id, bot_id, stale.lock_token)
 
         return self._restart_lock_repo.acquire(env, entity_id, bot_id, holder_user_id)
+
+    def _try_acquire_delete_lock(
+        self, env: str, entity_id: str, bot_id: str, holder_user_id: str
+    ) -> Optional[BotRestartLockRecord]:
+        """Acquire the durable operation lock for a complete bot deletion.
+
+        The underlying lock is intentionally namespaced so a delete joins only
+        another delete.  This guards every destructive step, not just device
+        release: Passport destruction and the terminal soft-delete CAS are
+        otherwise still reachable by two concurrent requests.
+        """
+        return self._try_acquire_restart_lock(
+            env,
+            entity_id,
+            f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}",
+            holder_user_id,
+        )
 
     async def get_bot_by_ip_and_user(self, ip: str, user_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -3398,6 +3421,9 @@ class BotService:
         if not user_id:
             raise BotServiceError("User ID is required for deleting bot")
 
+        delete_lock: BotRestartLockRecord | None = None
+        delete_lock_env: str | None = None
+        delete_lock_entity_id: str | None = None
         try:
             # Get bot by bot_id and owner_id (user_id)
             bot = self._repository.get_by_id_and_owner(bot_id, user_id)
@@ -3423,6 +3449,29 @@ class BotService:
                 earliest_bot_id = earliest.get("bot_id")
                 if earliest_bot_id and bot_id == earliest_bot_id:
                     raise BotOperationNotAllowedError("不能删除首个创建的 Bot，该 Bot 受保护")
+
+            # A device-release claim alone only prevents duplicate provider
+            # destruction.  Keep the rest of deletion (Passport + bot row)
+            # under the same durable operation fence as well.  The losing
+            # request joins the in-flight deletion without repeating any
+            # destructive operation; the winning request reports any failure.
+            delete_lock_env = get_current_env()
+            delete_lock_entity_id = bot.get("entity_id") or user_id
+            delete_lock = self._try_acquire_delete_lock(
+                delete_lock_env,
+                delete_lock_entity_id,
+                bot_id,
+                user_id,
+            )
+            if delete_lock is None:
+                logger.info(
+                    "[bot_service.delete_bot] Deletion already in progress for bot %s "
+                    "(env=%s, entity_id=%s); joining duplicate request.",
+                    bot_id,
+                    delete_lock_env,
+                    delete_lock_entity_id,
+                )
+                return True
 
             # Withdraw every application authorization standing against this
             # bot — whoever delegated it — before anything destructive happens.
@@ -3546,6 +3595,14 @@ class BotService:
         except Exception as e:
             logger.error(f"[bot_service.delete_bot] Failed to delete bot {bot_id}: {e}")
             raise BotServiceError(f"Failed to delete bot: {e}")
+        finally:
+            if delete_lock is not None:
+                self._restart_lock_repo.release(
+                    delete_lock_env,
+                    delete_lock_entity_id,
+                    f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}",
+                    delete_lock.lock_token,
+                )
 
     def _sweep_grants_that_raced_the_deletion(
         self, bot_id: str, user_id: str

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -924,7 +924,13 @@ class BotService:
     ) -> tuple[threading.Event, threading.Event, threading.Thread]:
         """Keep a deletion lease live while its blocking provider calls run."""
         lock_key = f"{_DELETE_LOCK_KEY_PREFIX}{bot_id}"
-        if not self._restart_lock_repo.refresh(env, entity_id, lock_key, lock_token):
+        try:
+            lease_established = self._restart_lock_repo.refresh(
+                env, entity_id, lock_key, lock_token
+            )
+        except Exception as exc:
+            raise BotServiceError("Failed to establish bot deletion lock lease") from exc
+        if not lease_established:
             raise BotServiceError("Failed to establish bot deletion lock lease")
 
         stop = threading.Event()
@@ -932,9 +938,19 @@ class BotService:
 
         def _heartbeat() -> None:
             while not stop.wait(DELETE_LOCK_HEARTBEAT_SECONDS):
-                if not self._restart_lock_repo.refresh(
-                    env, entity_id, lock_key, lock_token
-                ):
+                try:
+                    refreshed = self._restart_lock_repo.refresh(
+                        env, entity_id, lock_key, lock_token
+                    )
+                except Exception:
+                    lease_lost.set()
+                    logger.exception(
+                        "[bot_service.delete_bot] Failed to refresh deletion lock lease "
+                        "for bot %s",
+                        bot_id,
+                    )
+                    return
+                if not refreshed:
                     lease_lost.set()
                     logger.error(
                         "[bot_service.delete_bot] Lost deletion lock lease for bot %s",
@@ -3543,6 +3559,21 @@ class BotService:
                 return self._join_delete_result(
                     delete_lock_env, delete_lock_entity_id, bot_id, user_id
                 )
+
+            # A duplicate may acquire only after the first holder has already
+            # soft-deleted the row and released its lock. Re-read while owning
+            # the new fence so that pre-lock state cannot trigger destructive
+            # cleanup a second time. A missing row is the durable success
+            # result of the holder we just raced.
+            locked_bot = self._repository.get_by_id_and_owner(bot_id, user_id)
+            if locked_bot is None:
+                logger.info(
+                    "[bot_service.delete_bot] Bot %s was deleted before the "
+                    "reacquired deletion lock could proceed.",
+                    bot_id,
+                )
+                return True
+            bot = locked_bot
             (
                 delete_lock_heartbeat_stop,
                 delete_lock_lease_lost,

--- a/src/backend/src/agentclaw/community/core/devices/models.py
+++ b/src/backend/src/agentclaw/community/core/devices/models.py
@@ -51,6 +51,7 @@ class DeviceBindingStatus(StrEnum):
     ACTIVE = "ACTIVE"
     STOPPED = "STOPPED"
     FAILED = "FAILED"
+    RELEASING = "RELEASING"
     RELEASED = "RELEASED"
 
 

--- a/src/backend/src/agentclaw/community/core/devices/models.py
+++ b/src/backend/src/agentclaw/community/core/devices/models.py
@@ -46,7 +46,13 @@ class Env(StrEnum):
 
 
 class DeviceBindingStatus(StrEnum):
-    """Device binding status enumeration."""
+    """Device binding lifecycle states.
+
+    ``RELEASING`` is the durable, exclusive claim between a releasable state
+    and ``RELEASED``.  Only the claim winner may run provider destruction; a
+    caller that observes ``RELEASING`` must not start another release.  A
+    returned binding is fully released only when its status is ``RELEASED``.
+    """
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
     STOPPED = "STOPPED"

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -774,6 +774,12 @@ class DeviceService:
         if current is None:
             raise DeviceNotFoundError(f"binding {binding_id} not found")
 
+        # Deletion retries are idempotent.  More importantly, a concurrent
+        # caller that lost the database claim must never invoke the provider's
+        # destructive operation a second time.
+        if current.status == DeviceBindingStatus.RELEASED.value:
+            return current
+
         if current.status not in [
             DeviceBindingStatus.ACTIVE.value,
             DeviceBindingStatus.PENDING.value,
@@ -783,6 +789,12 @@ class DeviceService:
             raise InvalidDeviceStatusError(
                 "only ACTIVE/PENDING/FAILED/STOPPED devices can be released"
             )
+
+        if not self._repo.claim_binding_release(binding_id=binding_id):
+            claimed = self._repo.get_by_id(binding_id)
+            if claimed is not None and claimed.status == DeviceBindingStatus.RELEASED.value:
+                return claimed
+            raise InvalidDeviceStatusError("device release is already in progress")
 
         entity_id = current.entity_id
         entity_type = current.entity_type

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -790,7 +790,11 @@ class DeviceService:
                 "only ACTIVE/PENDING/FAILED/STOPPED devices can be released"
             )
 
-        if not self._repo.claim_binding_release(binding_id=binding_id):
+        if not self._repo.claim_binding_release(
+            binding_id=binding_id,
+            release_reason=release_reason,
+            released_by=operator.staff,
+        ):
             claimed = self._repo.get_by_id(binding_id)
             if claimed is not None and claimed.status == DeviceBindingStatus.RELEASED.value:
                 return claimed

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -761,6 +761,10 @@ class DeviceService:
     ) -> DeviceBindingRecord | None:
         """Release a device.
 
+        The operation first claims a binding as ``RELEASING``.  A concurrent
+        caller returns that current record without invoking the provider again;
+        only ``RELEASED`` represents completed physical-release handling.
+
         Args:
             binding_id: Binding ID to release
             release_reason: Reason for release

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -780,6 +780,9 @@ class DeviceService:
         if current.status == DeviceBindingStatus.RELEASED.value:
             return current
 
+        if current.status == DeviceBindingStatus.RELEASING.value:
+            raise InvalidDeviceStatusError("device release is already in progress")
+
         if current.status not in [
             DeviceBindingStatus.ACTIVE.value,
             DeviceBindingStatus.PENDING.value,

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -781,7 +781,10 @@ class DeviceService:
             return current
 
         if current.status == DeviceBindingStatus.RELEASING.value:
-            raise InvalidDeviceStatusError("device release is already in progress")
+            # A concurrent caller owns the physical release.  Joining that
+            # claim is idempotent: it must not invoke the provider again, nor
+            # turn a second bot-delete request into a failure.
+            return current
 
         if current.status not in [
             DeviceBindingStatus.ACTIVE.value,
@@ -799,7 +802,10 @@ class DeviceService:
             released_by=operator.staff,
         ):
             claimed = self._repo.get_by_id(binding_id)
-            if claimed is not None and claimed.status == DeviceBindingStatus.RELEASED.value:
+            if claimed is not None and claimed.status in {
+                DeviceBindingStatus.RELEASING.value,
+                DeviceBindingStatus.RELEASED.value,
+            }:
                 return claimed
             raise InvalidDeviceStatusError("device release is already in progress")
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/restart_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/restart_lock.py
@@ -11,8 +11,8 @@ Behavior:
   INSERT wins, the rest hit ``IntegrityError`` and are treated as "lock held".
 - ``release`` hard-deletes the row (no soft delete).
 - Staleness (``get_if_stale``) is judged on the DB clock only: both the row's
-  ``gmt_create`` and "now" are sourced from the database, so app/DB clock skew
-  cannot mis-judge the TTL.
+  ``gmt_modified`` heartbeat and "now" are sourced from the database, so app/DB
+  clock skew cannot mis-judge the TTL.
 """
 from __future__ import annotations
 
@@ -133,6 +133,26 @@ class BotRestartLockRepository(
                 )
             return result > 0
 
+    def refresh(
+        self, env: str, entity_id: str, bot_id: str, lock_token: str
+    ) -> bool:
+        """Renew a fenced lock without extending another holder's lease."""
+        with self._db.orm_session() as db:
+            result = (
+                db.query(self._Lock)
+                .filter(
+                    self._Lock.env == env,
+                    self._Lock.entity_id == entity_id,
+                    self._Lock.bot_id == bot_id,
+                    self._Lock.lock_token == lock_token,
+                )
+                .update(
+                    {self._Lock.gmt_modified: func.now()},
+                    synchronize_session=False,
+                )
+            )
+            return result > 0
+
     # ========================================================================
     # Query
     # ========================================================================
@@ -158,7 +178,7 @@ class BotRestartLockRepository(
     ) -> Optional[BotRestartLockRecord]:
         """仅当锁存在且已超过 ttl_seconds 时返回记录，否则返回 None。
 
-        过期判定完全基于数据库时钟：``gmt_create`` 与 "now" 都取自 DB，
+        过期判定完全基于数据库时钟：``gmt_modified`` 与 "now" 都取自 DB，
         因此不受应用与数据库之间的时钟漂移影响。
         """
         with self._db.orm_session() as db:
@@ -171,7 +191,7 @@ class BotRestartLockRepository(
                 )
                 .first()
             )
-            if row is None or row.gmt_create is None:
+            if row is None or row.gmt_modified is None:
                 return None
 
             # type_coerce ensures both SQLite and MySQL/OceanBase yield a
@@ -187,7 +207,7 @@ class BotRestartLockRepository(
             # while ``func.now()`` coerces tz-naive. Normalize both to naive so
             # the subtraction can't raise "can't subtract offset-naive and
             # offset-aware datetimes" on any driver.
-            elapsed = (_as_naive(db_now) - _as_naive(row.gmt_create)).total_seconds()
+            elapsed = (_as_naive(db_now) - _as_naive(row.gmt_modified)).total_seconds()
             if elapsed >= ttl_seconds:
                 logger.info(
                     "[restart_lock.get_if_stale] stale lock, env=%s, entity_id=%s, bot_id=%s, elapsed=%.1fs, ttl=%ss",

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/restart_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/restart_lock.py
@@ -102,15 +102,23 @@ class BotRestartLockRepository(
                 return None
 
     def release(
-        self, env: str, entity_id: str, bot_id: str, lock_token: str
+        self,
+        env: str,
+        entity_id: str,
+        bot_id: str,
+        lock_token: str,
+        *,
+        expected_gmt_modified: datetime | None = None,
     ) -> bool:
         """释放重启锁（比对令牌后硬删除）。
 
         仅当行的 ``lock_token`` 与传入令牌一致时才删除，避免误删他人在本锁
         被回收后重新获取的新锁（stale-reaper 与超时后异步释放两种竞态）。
+        Stale reapers additionally provide the observed heartbeat timestamp so
+        a same-token renewal between observation and deletion wins the race.
         """
         with self._db.orm_session() as db:
-            result = (
+            query = (
                 db.query(self._Lock)
                 .filter(
                     self._Lock.env == env,
@@ -118,8 +126,12 @@ class BotRestartLockRepository(
                     self._Lock.bot_id == bot_id,
                     self._Lock.lock_token == lock_token,
                 )
-                .delete(synchronize_session=False)
             )
+            if expected_gmt_modified is not None:
+                query = query.filter(
+                    self._Lock.gmt_modified == expected_gmt_modified
+                )
+            result = query.delete(synchronize_session=False)
             if result > 0:
                 logger.info(
                     "[restart_lock.release] released, env=%s, entity_id=%s, bot_id=%s, token=%s",

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -97,6 +97,7 @@ class _DeviceBindingStatus:
 
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
+    STOPPED = "STOPPED"
     FAILED = "FAILED"
     RELEASED = "RELEASED"
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -424,7 +424,13 @@ class DeviceRepository(
                 synchronize_session=False,
             )
 
-    def claim_binding_release(self, *, binding_id: int) -> bool:
+    def claim_binding_release(
+        self,
+        *,
+        binding_id: int,
+        release_reason: str | None,
+        released_by: str,
+    ) -> bool:
         """Claim exactly one physical release by atomically making it terminal.
 
         The release flow already treats a physical-release failure as terminal
@@ -448,6 +454,9 @@ class DeviceRepository(
                 .update(
                     {
                         EntityDeviceBinding.status: _DeviceBindingStatus.RELEASED,
+                        EntityDeviceBinding.release_reason: release_reason,
+                        EntityDeviceBinding.released_by: released_by,
+                        EntityDeviceBinding.released_at: func.now(),
                         EntityDeviceBinding.gmt_modified: func.now(),
                     },
                     synchronize_session=False,
@@ -460,7 +469,8 @@ class DeviceRepository(
     ) -> None:
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
-                EntityDeviceBinding.id == binding_id
+                EntityDeviceBinding.id == binding_id,
+                EntityDeviceBinding.status != _DeviceBindingStatus.RELEASED,
             ).update(
                 {
                     EntityDeviceBinding.status: status,
@@ -474,7 +484,8 @@ class DeviceRepository(
     ) -> None:
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
-                EntityDeviceBinding.id == binding_id
+                EntityDeviceBinding.id == binding_id,
+                EntityDeviceBinding.status != _DeviceBindingStatus.RELEASED,
             ).update(
                 {
                     EntityDeviceBinding.status: status,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -413,7 +413,10 @@ class DeviceRepository(
         # conditional bulk UPDATE matches prod's raw UPDATE SQL.
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
-                EntityDeviceBinding.id == binding_id
+                EntityDeviceBinding.id == binding_id,
+                EntityDeviceBinding.status.notin_(
+                    (_DeviceBindingStatus.RELEASING, _DeviceBindingStatus.RELEASED)
+                ),
             ).update(
                 {
                     EntityDeviceBinding.status: _DeviceBindingStatus.RELEASED,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -423,6 +423,37 @@ class DeviceRepository(
                 synchronize_session=False,
             )
 
+    def claim_binding_release(self, *, binding_id: int) -> bool:
+        """Claim exactly one physical release by atomically making it terminal.
+
+        The release flow already treats a physical-release failure as terminal
+        to avoid orphaned active bindings.  Publishing RELEASED before the
+        external call extends that policy to concurrent callers: only the
+        conditional-update winner may invoke the provider destroy operation.
+        """
+        releasable = (
+            _DeviceBindingStatus.ACTIVE,
+            _DeviceBindingStatus.PENDING,
+            _DeviceBindingStatus.FAILED,
+            _DeviceBindingStatus.STOPPED,
+        )
+        with self._db.orm_session() as db:
+            updated = (
+                db.query(EntityDeviceBinding)
+                .filter(
+                    EntityDeviceBinding.id == binding_id,
+                    EntityDeviceBinding.status.in_(releasable),
+                )
+                .update(
+                    {
+                        EntityDeviceBinding.status: _DeviceBindingStatus.RELEASED,
+                        EntityDeviceBinding.gmt_modified: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return updated == 1
+
     def update_status(
         self, *, binding_id: int, status: str
     ) -> None:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -78,7 +78,7 @@ import json
 from typing import Any
 
 from injector import inject
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
@@ -501,6 +501,41 @@ class DeviceRepository(
                 },
                 synchronize_session=False,
             )
+
+    def activate_publish_binding(self, *, binding_id: int) -> bool:
+        """Reactivate a publish binding only when no device release owns it.
+
+        Rollback may restore a binding that the publish flow itself marked
+        RELEASED while superseding an earlier version. Device-service deletion
+        records ``release_reason`` and ``released_by`` while it claims the
+        binding; that claim is deliberately never reopened here.
+        """
+        with self._db.orm_session() as db:
+            updated = (
+                db.query(EntityDeviceBinding)
+                .filter(
+                    EntityDeviceBinding.id == binding_id,
+                    or_(
+                        EntityDeviceBinding.status.notin_(
+                            (_DeviceBindingStatus.RELEASING, _DeviceBindingStatus.RELEASED)
+                        ),
+                        and_(
+                            EntityDeviceBinding.status == _DeviceBindingStatus.RELEASED,
+                            EntityDeviceBinding.release_reason.is_(None),
+                            EntityDeviceBinding.released_by.is_(None),
+                        ),
+                    ),
+                )
+                .update(
+                    {
+                        EntityDeviceBinding.status: _DeviceBindingStatus.ACTIVE,
+                        EntityDeviceBinding.last_alive_at: func.now(),
+                        EntityDeviceBinding.gmt_modified: func.now(),
+                    },
+                    synchronize_session=False,
+                )
+            )
+        return updated == 1
 
     def update_device_props(
         self, *, binding_id: int, props: dict[str, Any]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -98,6 +98,7 @@ class _DeviceBindingStatus:
     PENDING = "PENDING"
     ACTIVE = "ACTIVE"
     STOPPED = "STOPPED"
+    RELEASING = "RELEASING"
     FAILED = "FAILED"
     RELEASED = "RELEASED"
 
@@ -431,12 +432,11 @@ class DeviceRepository(
         release_reason: str | None,
         released_by: str,
     ) -> bool:
-        """Claim exactly one physical release by atomically making it terminal.
+        """Claim exactly one physical release with a durable intermediate state.
 
-        The release flow already treats a physical-release failure as terminal
-        to avoid orphaned active bindings.  Publishing RELEASED before the
-        external call extends that policy to concurrent callers: only the
-        conditional-update winner may invoke the provider destroy operation.
+        Only the conditional-update winner may invoke provider destruction.
+        RELEASED is written only after that operation returns, so a process
+        crash cannot make an undispatched destroy look complete.
         """
         releasable = (
             _DeviceBindingStatus.ACTIVE,
@@ -453,7 +453,7 @@ class DeviceRepository(
                 )
                 .update(
                     {
-                        EntityDeviceBinding.status: _DeviceBindingStatus.RELEASED,
+                        EntityDeviceBinding.status: _DeviceBindingStatus.RELEASING,
                         EntityDeviceBinding.release_reason: release_reason,
                         EntityDeviceBinding.released_by: released_by,
                         EntityDeviceBinding.released_at: func.now(),
@@ -470,7 +470,10 @@ class DeviceRepository(
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
                 EntityDeviceBinding.id == binding_id,
-                EntityDeviceBinding.status != _DeviceBindingStatus.RELEASED,
+                EntityDeviceBinding.status.notin_((
+                    _DeviceBindingStatus.RELEASING,
+                    _DeviceBindingStatus.RELEASED,
+                )),
             ).update(
                 {
                     EntityDeviceBinding.status: status,
@@ -485,7 +488,10 @@ class DeviceRepository(
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
                 EntityDeviceBinding.id == binding_id,
-                EntityDeviceBinding.status != _DeviceBindingStatus.RELEASED,
+                EntityDeviceBinding.status.notin_((
+                    _DeviceBindingStatus.RELEASING,
+                    _DeviceBindingStatus.RELEASED,
+                )),
             ).update(
                 {
                     EntityDeviceBinding.status: status,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/devices/device.py
@@ -414,9 +414,7 @@ class DeviceRepository(
         with self._db.orm_session() as db:
             db.query(EntityDeviceBinding).filter(
                 EntityDeviceBinding.id == binding_id,
-                EntityDeviceBinding.status.notin_(
-                    (_DeviceBindingStatus.RELEASING, _DeviceBindingStatus.RELEASED)
-                ),
+                EntityDeviceBinding.status != _DeviceBindingStatus.RELEASED,
             ).update(
                 {
                     EntityDeviceBinding.status: _DeviceBindingStatus.RELEASED,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -399,9 +399,21 @@ class BotRestartLockRepositoryProtocol(Protocol):
     ) -> Optional[BotRestartLockRecord]:
         """Return the lock row only if it is older than ``ttl_seconds``.
 
-        Staleness is evaluated DB-side (comparing ``gmt_create`` against the
+        Staleness is evaluated DB-side (comparing ``gmt_modified`` against the
         database clock) to avoid app/DB clock-skew. Returns ``None`` when no
         row exists or the existing row is still fresh.
+        """
+        ...
+
+    @abstractmethod
+    def refresh(
+        self, env: str, entity_id: str, bot_id: str, lock_token: str
+    ) -> bool:
+        """Renew an owned lock's DB-side heartbeat timestamp.
+
+        The token guard means a stale holder cannot extend a lock reaped and
+        acquired by another operation. Returns ``False`` when ownership was
+        lost, allowing the caller to fail rather than continue unfenced.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -9,6 +9,7 @@ site. Domain imports are ``TYPE_CHECKING``-only — see the module docstring in
 from __future__ import annotations
 
 from abc import abstractmethod
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
@@ -419,14 +420,21 @@ class BotRestartLockRepositoryProtocol(Protocol):
 
     @abstractmethod
     def release(
-        self, env: str, entity_id: str, bot_id: str, lock_token: str
+        self,
+        env: str,
+        entity_id: str,
+        bot_id: str,
+        lock_token: str,
+        *,
+        expected_gmt_modified: datetime | None = None,
     ) -> bool:
         """Release the lock by hard-deleting the row — only if it's still ours.
 
         Compare-and-delete: ``DELETE WHERE (env, entity_id, bot_id) matches AND
         lock_token = :lock_token``. The token guard prevents deleting a row that
-        a different holder acquired after ours was reaped (the stale-reaper and
-        late-async-release races). Returns ``True`` if a row was deleted.
+        a different holder acquired after ours was reaped. When supplied,
+        ``expected_gmt_modified`` also fences stale reaping against a heartbeat
+        renewal by the same holder. Returns ``True`` if a row was deleted.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
@@ -92,6 +92,11 @@ class DeviceBindingRepository(Protocol):
         ...
 
     @abstractmethod
+    def claim_binding_release(self, *, binding_id: int) -> bool:
+        """Atomically claim a releasable binding for one physical release."""
+        ...
+
+    @abstractmethod
     def update_status(self, *, binding_id: int, status: str) -> None:
         """更新设备绑定状态."""
         ...

--- a/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
@@ -113,6 +113,16 @@ class DeviceBindingRepository(Protocol):
         ...
 
     @abstractmethod
+    def activate_publish_binding(self, *, binding_id: int) -> bool:
+        """Activate a publish-flow binding without overriding a claimed release.
+
+        A normal publish-flow release has no device-service release audit data and
+        may be restored by a rollback. A binding claimed by device deletion keeps
+        its release audit fields and must remain unavailable.
+        """
+        ...
+
+    @abstractmethod
     def update_device_props(self, *, binding_id: int, props: dict[str, Any]) -> None:
         """合并 ``props`` 到绑定的 device_props（保留其它键）。
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
@@ -88,7 +88,12 @@ class DeviceBindingRepository(Protocol):
         release_reason: str | None,
         released_by: str,
     ) -> None:
-        """释放设备，标记绑定记录为 RELEASED 状态."""
+        """Finalize a claimed release by transitioning it to ``RELEASED``.
+
+        This is idempotent for an already released binding.  Callers must first
+        win :meth:`claim_binding_release`; it is not an authorization to begin
+        another provider release for an arbitrary binding.
+        """
         ...
 
     @abstractmethod
@@ -99,7 +104,13 @@ class DeviceBindingRepository(Protocol):
         release_reason: str | None,
         released_by: str,
     ) -> bool:
-        """Atomically claim a releasable binding and persist its audit data."""
+        """Atomically claim a releasable binding as ``RELEASING``.
+
+        The successful caller exclusively owns provider destruction and must
+        later call :meth:`release_binding`.  A ``False`` result means another
+        lifecycle transition won; it must never be followed by another
+        destructive provider call.
+        """
         ...
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/devices.py
@@ -92,8 +92,14 @@ class DeviceBindingRepository(Protocol):
         ...
 
     @abstractmethod
-    def claim_binding_release(self, *, binding_id: int) -> bool:
-        """Atomically claim a releasable binding for one physical release."""
+    def claim_binding_release(
+        self,
+        *,
+        binding_id: int,
+        release_reason: str | None,
+        released_by: str,
+    ) -> bool:
+        """Atomically claim a releasable binding and persist its audit data."""
         ...
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -184,6 +184,25 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         )
         logger.info(f"[update_device_binding_with_props] binding_id={binding_id}, status={status}, device_props updated")
 
+    def activate_publish_binding_with_props(
+        self,
+        binding_id: int,
+        device_props: Dict[str, Any],
+    ) -> None:
+        """Activate a successful publish binding without reopening device deletion."""
+        device_binding_repo = self._device_binding_repo
+        if not device_binding_repo.activate_publish_binding(binding_id=binding_id):
+            raise BotPublishServiceError(
+                f"Binding {binding_id} has an active release claim and cannot be activated"
+            )
+        device_binding_repo.update_device_props(
+            binding_id=binding_id, props=device_props
+        )
+        logger.info(
+            "[activate_publish_binding_with_props] binding_id=%s, device_props updated",
+            binding_id,
+        )
+
     def create_publish(
         self,
         source_bot_pk: int,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -176,13 +176,11 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         device_binding_repo = self._device_binding_repo
         # 先更新状态
         device_binding_repo.update_status_and_alive_at(binding_id=binding_id, status=status)
-        # 再更新 device_props（需要通过 reuse_binding 方法）
-        device_binding_repo.reuse_binding(
-            binding_id=binding_id,
-            device_props=device_props,
-            apply_reason=None,
-            applied_by="system",
-            status=status,
+        # Reuse is allocation-only: it clears release metadata and may move a
+        # RELEASED binding back to PENDING. Publish callbacks only merge their
+        # result fields and must not reopen a concurrent release claim.
+        device_binding_repo.update_device_props(
+            binding_id=binding_id, props=device_props
         )
         logger.info(f"[update_device_binding_with_props] binding_id={binding_id}, status={status}, device_props updated")
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/device_binding_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/device_binding_mixin.py
@@ -87,9 +87,8 @@ class DeviceBindingMixin:
             "overall_progress": progress.get("overall_progress", {}),
         }
 
-        self._publish_service.update_device_binding_with_props(
+        self._publish_service.activate_publish_binding_with_props(
             binding_id=binding_id,
-            status=DeviceBindingStatus.ACTIVE,
             device_props=device_props,
         )
 

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -76,8 +76,13 @@ internal_dependencies:
 
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
 
-Local Skill replacement stages a complete package before switching the existing
-Skill metadata. Its old-package cleanup work is persisted before an Active
+Local Skill replacement stages and verifies a complete package in a hidden
+implementation directory, then publishes it to the stable layout-owned
+``skills-local/<skill-name>`` locator before switching existing Skill metadata.
+For a Skills Pool layout, ``skills-local`` is the Pool local root resolved by
+``SkillServiceFactory``. Hidden ``.replacement-*`` and ``.rollback-*``
+directories are never database authority and are removed or recorded as
+cleanup work after the operation. Its old-package cleanup work is persisted before an Active
 runtime switch can commit; a rollback cancels that old-locator work before the
 old package becomes authoritative again. Failed post-switch obsolete-byte deletion is recorded through
 `LocalSkillCleanupRepository` in the exact deployment-wide Bot scope

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -23,9 +23,13 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
-from agentclaw.community.core.repository.protocols.skill_center import SkillCategoryRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillCategoryRepository,
+)
 from agentclaw.community.core.skill_center.services.skill_cache import MarketCache
 from agentclaw.community.core.skill_center.path_resolution import (
     build_pool_local_path_adapter,
@@ -107,6 +111,26 @@ class LocalSkillPackageStorage:
         """Read and validate every package file without changing storage."""
         await self._read_package_files()
         return True
+
+    async def copy_to(
+        self, target: "LocalSkillPackageStorage", *, replace: bool = False
+    ) -> None:
+        """Copy and verify this complete package without deleting the source.
+
+        Device backends deliberately do not promise a common directory rename.
+        Replacement therefore stages and verifies bytes first, then publishes
+        them to the stable user-visible package directory through this portable
+        copy seam.  The source remains available for rollback until the caller
+        explicitly cleans it up.
+        """
+        files = await self._read_package_files()
+        if await target._filesystem.exists(target.directory):
+            if not replace:
+                raise OSError("Local Skill copy target already exists")
+            if not await target.cleanup():
+                raise OSError("unable to clear Local Skill copy target")
+        if not await target._restore_contents(files):
+            raise OSError("Local Skill copy verification failed")
 
     async def quarantine_to(self, quarantine: "LocalSkillPackageStorage") -> None:
         """Copy, verify, then remove this authoritative package.
@@ -320,8 +344,9 @@ class SkillServiceFactory:
         """Return a Bot-local package storage port.
 
         ``directory_name`` is intentionally internal.  A replacement writes a
-        complete package to an isolated versioned directory before its metadata
-        points runtime at it; first creation keeps the historical name path.
+        complete package to an isolated versioned directory, then publishes it
+        to the stable ``name`` directory.  Metadata never points at the
+        internal directory.
         """
         service = self.create(
             entity_id=entity_id,
@@ -388,7 +413,9 @@ class SkillServiceFactory:
         try:
             relative_locator = resolved_candidate.relative_to(resolved_base)
         except ValueError as exc:
-            raise ValueError("Local Skill cleanup locator escapes skills-local") from exc
+            raise ValueError(
+                "Local Skill cleanup locator escapes skills-local"
+            ) from exc
         if not relative_locator.parts:
             raise ValueError("Local Skill cleanup locator must name a package")
         # Keep the original path form for the device adapter (notably Teclaw's

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -20,7 +20,9 @@ from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
 )
-from agentclaw.community.core.repository.protocols.bot import BotCollabLogRepositoryProtocol
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLogRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillDuplicateError,
@@ -34,7 +36,9 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillTooLargeError,
     LocalSkillLayoutRollbackError,
 )
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
@@ -42,7 +46,9 @@ from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
     SkillSetServiceFactory,
 )
-from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    LocalSkillCleanupRepository,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
@@ -344,19 +350,39 @@ class LocalSkillUploadService:
         files: list[tuple[str, bytes]],
         is_teclaw: bool,
     ) -> dict[str, Any]:
-        """Stage a complete replacement, then atomically switch its locator authority."""
+        """Publish a replacement at the stable layout-owned package locator.
+
+        The hidden directory is staging only.  Runtime and database authority
+        always converge on ``<resolved-local-root>/<skill-name>``; this keeps
+        normal and Skills Pool layouts consistent and keeps implementation
+        directories out of the public workspace contract.
+        """
         old_locator = str(skill["git_path"])[len("local://") :]
         version_dir = f".{name}.replacement-{uuid4().hex}"
-        new_locator, staged = self._skill_service_factory.local_skill_package_storage(
-            entity_id=str(bot["entity_id"]),
-            owner_id=owner_id,
-            bot_id=bot_id,
-            engine_type=bot.get("active_engine"),
-            entity_type=str(bot.get("entity_type") or "staff"),
-            is_desktop=bot.get("bot_type") == "desktop",
-            is_teclaw=is_teclaw,
-            name=name,
-            directory_name=version_dir,
+        canonical_locator, canonical = (
+            self._skill_service_factory.local_skill_package_storage(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
+                name=name,
+            )
+        )
+        staged_locator, staged = (
+            self._skill_service_factory.local_skill_package_storage(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
+                name=name,
+                directory_name=version_dir,
+            )
         )
         old_storage = (
             self._skill_service_factory.local_skill_package_storage_for_locator(
@@ -370,6 +396,10 @@ class LocalSkillUploadService:
                 locator=old_locator,
             )
         )
+        old_is_canonical = old_locator == canonical_locator
+        obsolete_locator = old_locator
+        obsolete_storage = old_storage
+        backup = None
         old_metadata = {
             "description": skill.get("description"),
             "git_path": skill.get("git_path"),
@@ -378,14 +408,38 @@ class LocalSkillUploadService:
         switched = False
         old_cleanup_work_id: int | None = None
         runtime_sync_attempted = False
+        canonical_published = False
         try:
             await staged.write(files)
+            await staged.verify()
+            if old_is_canonical:
+                backup_dir = f".{name}.rollback-{uuid4().hex}"
+                obsolete_locator, backup = (
+                    self._skill_service_factory.local_skill_package_storage(
+                        entity_id=str(bot["entity_id"]),
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        engine_type=bot.get("active_engine"),
+                        entity_type=str(bot.get("entity_type") or "staff"),
+                        is_desktop=bot.get("bot_type") == "desktop",
+                        is_teclaw=is_teclaw,
+                        name=name,
+                        directory_name=backup_dir,
+                    )
+                )
+                await old_storage.copy_to(backup)
+                obsolete_storage = backup
+            # ``copy_to(..., replace=True)`` can fail after clearing or partly
+            # writing the canonical directory.  Mark the mutation before the
+            # call so every such failure restores the old authority.
+            canonical_published = True
+            await staged.copy_to(canonical, replace=True)
             old_cleanup_work_id = self._cleanup_repo.record_preparing(
                 env=str(bot["env"]),
                 owner_id=owner_id,
                 bot_id=bot_id,
                 skill_id=str(skill["id"]),
-                package_locator=old_locator,
+                package_locator=obsolete_locator,
             )
             if old_cleanup_work_id is None:
                 raise LocalSkillStorageError()
@@ -394,7 +448,7 @@ class LocalSkillUploadService:
                 owner_id=owner_id,
                 bot_id=bot_id,
                 old_locator=old_locator,
-                new_locator=new_locator,
+                new_locator=canonical_locator,
                 description=description,
                 # Replacements always reconcile the runtime before the old
                 # package can be cleaned up, including an inactive skill
@@ -449,14 +503,20 @@ class LocalSkillUploadService:
                 owner_id=owner_id,
                 bot_id=bot_id,
                 staged=staged,
-                staged_locator=new_locator,
+                staged_locator=staged_locator,
+                canonical=canonical,
+                canonical_locator=canonical_locator,
+                old_is_canonical=old_is_canonical,
+                backup=backup,
+                obsolete_locator=obsolete_locator,
+                canonical_published=canonical_published,
                 switched=switched,
                 old_cleanup_work_id=old_cleanup_work_id,
                 runtime_sync_attempted=runtime_sync_attempted,
             )
             raise
         except Exception as exc:
-            if switched:
+            if switched or canonical_published:
                 await self._restore_replacement(
                     skill=skill,
                     old_metadata=old_metadata,
@@ -464,8 +524,14 @@ class LocalSkillUploadService:
                     owner_id=owner_id,
                     bot_id=bot_id,
                     staged=staged,
-                    staged_locator=new_locator,
-                    switched=True,
+                    staged_locator=staged_locator,
+                    canonical=canonical,
+                    canonical_locator=canonical_locator,
+                    old_is_canonical=old_is_canonical,
+                    backup=backup,
+                    obsolete_locator=obsolete_locator,
+                    canonical_published=canonical_published,
+                    switched=switched,
                     old_cleanup_work_id=old_cleanup_work_id,
                     runtime_sync_attempted=runtime_sync_attempted,
                 )
@@ -473,19 +539,28 @@ class LocalSkillUploadService:
                 self._cancel_cleanup_if_registered(
                     old_cleanup_work_id, bot, owner_id, bot_id
                 )
+                if backup is not None:
+                    await self._discard_or_record(
+                        bot=bot,
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        skill_id=str(skill["id"]),
+                        storage=backup,
+                        locator=obsolete_locator,
+                    )
                 await self._discard_or_record(
                     bot=bot,
                     owner_id=owner_id,
                     bot_id=bot_id,
                     skill_id=str(skill["id"]),
                     storage=staged,
-                    locator=new_locator,
+                    locator=staged_locator,
                 )
             raise LocalSkillStorageError() from exc
         # The old locator already has durable work.  Its purge is never a
         # reason to undo a working replacement.
         try:
-            cleaned = await old_storage.cleanup()
+            cleaned = await obsolete_storage.cleanup()
         except Exception:
             cleaned = False
         if cleaned:
@@ -496,12 +571,20 @@ class LocalSkillUploadService:
                 bot_id=bot_id,
             ):
                 raise LocalSkillStorageError()
+        await self._discard_or_record(
+            bot=bot,
+            owner_id=owner_id,
+            bot_id=bot_id,
+            skill_id=str(skill["id"]),
+            storage=staged,
+            locator=staged_locator,
+        )
         return {
             "operation": "updated",
             "skill": {
                 **skill,
                 "description": description,
-                "git_path": f"local://{new_locator}",
+                "git_path": f"local://{canonical_locator}",
                 "user_id": owner_id,
             },
             "actor_id": actor_id,
@@ -517,18 +600,31 @@ class LocalSkillUploadService:
         bot_id: str,
         staged,
         staged_locator: str,
+        canonical,
+        canonical_locator: str,
+        old_is_canonical: bool,
+        backup,
+        obsolete_locator: str,
+        canonical_published: bool,
         switched: bool,
         old_cleanup_work_id: int | None,
         runtime_sync_attempted: bool,
     ) -> None:
+        if canonical_published:
+            try:
+                if old_is_canonical:
+                    if backup is None:
+                        raise LocalSkillStorageError()
+                    await backup.copy_to(canonical, replace=True)
+                elif not await canonical.cleanup():
+                    raise LocalSkillStorageError()
+            except Exception as exc:
+                raise LocalSkillStorageError() from exc
         if switched:
             restored = self._skill_repo.update(skill["id"], old_metadata)
             if restored is None:
                 raise LocalSkillStorageError()
-            if (
-                runtime_sync_attempted
-                and not self._sync_runtime(bot, owner_id, bot_id)
-            ):
+            if runtime_sync_attempted and not self._sync_runtime(bot, owner_id, bot_id):
                 # Runtime may have switched partway before reporting failure.
                 # Keep the complete staged package until a later serialized
                 # mutation can restore the old mapping before deleting it.
@@ -538,7 +634,9 @@ class LocalSkillUploadService:
                         owner_id=owner_id,
                         bot_id=bot_id,
                         skill_id=str(skill["id"]),
-                        locator=staged_locator,
+                        locator=(
+                            staged_locator if old_is_canonical else canonical_locator
+                        ),
                         requires_runtime_restore=True,
                     )
                     is None
@@ -548,8 +646,15 @@ class LocalSkillUploadService:
                     old_cleanup_work_id, bot, owner_id, bot_id
                 )
                 raise LocalSkillRuntimeSyncError()
-            self._cancel_cleanup_if_registered(
-                old_cleanup_work_id, bot, owner_id, bot_id
+        self._cancel_cleanup_if_registered(old_cleanup_work_id, bot, owner_id, bot_id)
+        if backup is not None:
+            await self._discard_or_record(
+                bot=bot,
+                owner_id=owner_id,
+                bot_id=bot_id,
+                skill_id=str(skill["id"]),
+                storage=backup,
+                locator=obsolete_locator,
             )
         await self._discard_or_record(
             bot=bot,
@@ -695,9 +800,12 @@ class LocalSkillUploadService:
             skill = self._skill_repo.get_by_id(str(skill_id))
             if skill and skill.get("git_path") == f"local://{locator}":
                 return True
-        return self._skill_repo.get_bot_local_by_locator(
-            bot_id=bot_id, user_id=owner_id, locator=locator
-        ) is not None
+        return (
+            self._skill_repo.get_bot_local_by_locator(
+                bot_id=bot_id, user_id=owner_id, locator=locator
+            )
+            is not None
+        )
 
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import hashlib
 import time
 
 from injector import inject
@@ -47,6 +48,7 @@ class SkillsPoolEditLockUnavailableError(SkillsPoolEditPausedError):
 class SkillsPoolEditLease:
     key: str
     token: str | None
+    ttl_seconds: int | None = None
 
 
 class SkillsPoolEditGuard:
@@ -157,24 +159,87 @@ class SkillsPoolEditGuard:
         # Rollback has historically treated cache unavailability as a
         # retryable ``EDIT_BUSY`` outcome.  Preserve that operator contract;
         # only product-side edits need the more precise user-facing outcome.
-        token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
+        started_at = time.perf_counter()
+        try:
+            token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="acquire",
+                key=key,
+                token=None,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+            )
+            raise
+        self._log_lock_event(
+            event="acquire",
+            key=key,
+            token=token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="acquired" if token is not None else "busy",
+        )
         if token is None:
             return None
-        return SkillsPoolEditLease(key=key, token=token)
+        return SkillsPoolEditLease(
+            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+        )
 
     def _acquire_for_edit(
         self, *, scope: BotSkillLayoutScope
     ) -> SkillsPoolEditLease | None:
         key = self._key(scope=scope)
-        token = self._cache.acquire_lock_strict(key, ttl=self._LOCK_TTL_SECONDS)
+        started_at = time.perf_counter()
+        try:
+            token = self._cache.acquire_lock_strict(
+                key, ttl=self._LOCK_TTL_SECONDS
+            )
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="acquire",
+                key=key,
+                token=None,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+            )
+            raise
+        self._log_lock_event(
+            event="acquire",
+            key=key,
+            token=token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="acquired" if token is not None else "busy",
+        )
         if token is None:
             return None
-        return SkillsPoolEditLease(key=key, token=token)
+        return SkillsPoolEditLease(
+            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+        )
 
     def release(self, lease: SkillsPoolEditLease) -> bool:
         if lease.token is None:
             return True
-        return self._cache.release_lock(lease.key, lease.token)
+        started_at = time.perf_counter()
+        try:
+            released = self._cache.release_lock(lease.key, lease.token)
+        except CacheLockInfrastructureError:
+            self._log_lock_event(
+                event="release",
+                key=lease.key,
+                token=lease.token,
+                duration_ms=self._duration_ms(started_at),
+                outcome="unavailable",
+                ttl_seconds=lease.ttl_seconds,
+            )
+            raise
+        self._log_lock_event(
+            event="release",
+            key=lease.key,
+            token=lease.token,
+            duration_ms=self._duration_ms(started_at),
+            outcome="released" if released else "token_mismatch",
+            ttl_seconds=lease.ttl_seconds,
+        )
+        return released
 
     def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
         return self._layouts.get(scope).phase in self._ROLLBACK_PHASES
@@ -195,6 +260,37 @@ class SkillsPoolEditGuard:
             participation.label,
             reason,
         )
+
+    @staticmethod
+    def _duration_ms(started_at: float) -> float:
+        return (time.perf_counter() - started_at) * 1000
+
+    def _log_lock_event(
+        self,
+        *,
+        event: str,
+        key: str,
+        token: str | None,
+        duration_ms: float,
+        outcome: str,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        logger.info(
+            "[skills_pool.edit_guard] lock_%s key=%s ttl_seconds=%s "
+            "token_fingerprint=%s duration_ms=%.3f outcome=%s",
+            event,
+            key,
+            ttl_seconds if ttl_seconds is not None else self._LOCK_TTL_SECONDS,
+            self._token_fingerprint(token),
+            duration_ms,
+            outcome,
+        )
+
+    @staticmethod
+    def _token_fingerprint(token: str | None) -> str:
+        if token is None:
+            return "none"
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/edit_guard.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import time
+from threading import Lock
 
 from injector import inject
 
@@ -44,11 +45,22 @@ class SkillsPoolEditLockUnavailableError(SkillsPoolEditPausedError):
     """The distributed lock service is unavailable; fail closed."""
 
 
+class _OrdinaryEditLockEntry:
+    """One in-process Local Skill mutation lock and its active users."""
+
+    def __init__(self) -> None:
+        self.lock = Lock()
+        self.users = 0
+
+
 @dataclass(frozen=True, slots=True)
 class SkillsPoolEditLease:
     key: str
     token: str | None
     ttl_seconds: int | None = None
+    ordinary_lock_entry: _OrdinaryEditLockEntry | None = field(
+        default=None, repr=False, compare=False
+    )
 
 
 class SkillsPoolEditGuard:
@@ -71,6 +83,8 @@ class SkillsPoolEditGuard:
         self._cache = cache
         self._layouts = layout_repository
         self._participation_resolver = participation_resolver
+        self._ordinary_locks_guard = Lock()
+        self._ordinary_locks: dict[str, _OrdinaryEditLockEntry] = {}
 
     @staticmethod
     def _key(*, scope: BotSkillLayoutScope) -> str:
@@ -82,9 +96,6 @@ class SkillsPoolEditGuard:
         scope: BotSkillLayoutScope,
     ) -> SkillsPoolEditLease:
         participation = self._participation_resolver.resolve(scope=scope)
-        if not participation.participates_in_pool_layout:
-            return SkillsPoolEditLease(key="", token=None)
-
         if self._is_rollback_phase(scope):
             self._log_rejection(
                 scope=scope, participation=participation, reason="rollback_phase"
@@ -93,9 +104,27 @@ class SkillsPoolEditGuard:
                 "Skills are temporarily read-only during layout rollback"
             )
 
+        ordinary_lock_entry = self._acquire_ordinary_lock(scope=scope)
+        if ordinary_lock_entry is None:
+            self._log_rejection(
+                scope=scope, participation=participation, reason="ordinary_lock_busy"
+            )
+            raise SkillsPoolEditBusyError(
+                "Another skill update is already in progress; please retry shortly"
+            )
+
+        # Legacy Bots have no Pool rollback to serialize against, but still
+        # need this ordinary mutex so concurrent same-name uploads cannot both
+        # observe an absent Skill and create competing records/packages.
+        if not participation.participates_in_pool_layout:
+            return SkillsPoolEditLease(
+                key="", token=None, ordinary_lock_entry=ordinary_lock_entry
+            )
+
         try:
             lease = self._acquire_for_edit(scope=scope)
         except CacheLockInfrastructureError as exc:
+            self._release_ordinary_lock(ordinary_lock_entry)
             self._log_rejection(
                 scope=scope, participation=participation, reason="cache_unavailable"
             )
@@ -103,6 +132,7 @@ class SkillsPoolEditGuard:
                 "Skill updates are temporarily unavailable because the lock service is unavailable"
             ) from exc
         if lease is None:
+            self._release_ordinary_lock(ordinary_lock_entry)
             if self._is_rollback_phase(scope):
                 self._log_rejection(
                     scope=scope, participation=participation, reason="rollback_phase"
@@ -117,14 +147,26 @@ class SkillsPoolEditGuard:
                 "Another skill update is already in progress; please retry shortly"
             )
         if self._is_rollback_phase(scope):
-            self.release(lease)
+            self.release(
+                SkillsPoolEditLease(
+                    key=lease.key,
+                    token=lease.token,
+                    ttl_seconds=lease.ttl_seconds,
+                    ordinary_lock_entry=ordinary_lock_entry,
+                )
+            )
             self._log_rejection(
                 scope=scope, participation=participation, reason="rollback_phase"
             )
             raise SkillsPoolEditRollbackError(
                 "Skills are temporarily read-only during layout rollback"
             )
-        return lease
+        return SkillsPoolEditLease(
+            key=lease.key,
+            token=lease.token,
+            ttl_seconds=lease.ttl_seconds,
+            ordinary_lock_entry=ordinary_lock_entry,
+        )
 
     async def acquire_for_edit_wait(
         self, *, scope: BotSkillLayoutScope, timeout_seconds: float = 30.0
@@ -159,10 +201,14 @@ class SkillsPoolEditGuard:
         # Rollback has historically treated cache unavailability as a
         # retryable ``EDIT_BUSY`` outcome.  Preserve that operator contract;
         # only product-side edits need the more precise user-facing outcome.
+        ordinary_lock_entry = self._acquire_ordinary_lock(scope=scope)
+        if ordinary_lock_entry is None:
+            return None
         started_at = time.perf_counter()
         try:
             token = self._cache.acquire_lock(key, ttl=self._LOCK_TTL_SECONDS)
         except CacheLockInfrastructureError:
+            self._release_ordinary_lock(ordinary_lock_entry)
             self._log_lock_event(
                 event="acquire",
                 key=key,
@@ -179,9 +225,13 @@ class SkillsPoolEditGuard:
             outcome="acquired" if token is not None else "busy",
         )
         if token is None:
+            self._release_ordinary_lock(ordinary_lock_entry)
             return None
         return SkillsPoolEditLease(
-            key=key, token=token, ttl_seconds=self._LOCK_TTL_SECONDS
+            key=key,
+            token=token,
+            ttl_seconds=self._LOCK_TTL_SECONDS,
+            ordinary_lock_entry=ordinary_lock_entry,
         )
 
     def _acquire_for_edit(
@@ -217,6 +267,7 @@ class SkillsPoolEditGuard:
 
     def release(self, lease: SkillsPoolEditLease) -> bool:
         if lease.token is None:
+            self._release_ordinary_lock(lease.ordinary_lock_entry)
             return True
         started_at = time.perf_counter()
         try:
@@ -231,6 +282,8 @@ class SkillsPoolEditGuard:
                 ttl_seconds=lease.ttl_seconds,
             )
             raise
+        finally:
+            self._release_ordinary_lock(lease.ordinary_lock_entry)
         self._log_lock_event(
             event="release",
             key=lease.key,
@@ -240,6 +293,38 @@ class SkillsPoolEditGuard:
             ttl_seconds=lease.ttl_seconds,
         )
         return released
+
+    def _acquire_ordinary_lock(
+        self, *, scope: BotSkillLayoutScope
+    ) -> _OrdinaryEditLockEntry | None:
+        key = self._key(scope=scope)
+        with self._ordinary_locks_guard:
+            entry = self._ordinary_locks.get(key)
+            if entry is None:
+                entry = _OrdinaryEditLockEntry()
+                self._ordinary_locks[key] = entry
+            entry.users += 1
+        if entry.lock.acquire(blocking=False):
+            return entry
+        self._discard_ordinary_lock_user(entry)
+        return None
+
+    def _release_ordinary_lock(self, entry: _OrdinaryEditLockEntry | None) -> None:
+        if entry is None:
+            return
+        entry.lock.release()
+        self._discard_ordinary_lock_user(entry)
+
+    def _discard_ordinary_lock_user(self, entry: _OrdinaryEditLockEntry) -> None:
+        with self._ordinary_locks_guard:
+            entry.users -= 1
+            if entry.users == 0:
+                stale_keys = [
+                    key for key, candidate in self._ordinary_locks.items()
+                    if candidate is entry
+                ]
+                for key in stale_keys:
+                    self._ordinary_locks.pop(key, None)
 
     def _is_rollback_phase(self, scope: BotSkillLayoutScope) -> bool:
         return self._layouts.get(scope).phase in self._ROLLBACK_PHASES

--- a/src/backend/src/agentclaw/community/core/skills_pool/participation.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/participation.py
@@ -1,17 +1,21 @@
 """Resolve whether a Bot participates in the Skills Pool filesystem contract.
 
-The shared edit guard must not contain engine-specific policy.  This resolver
-keeps the conservative default in the domain layer and receives any explicit
-engine opt-out from the composition root.
+Pool edit serialization is a property of the Bot's persisted layout state, not
+of its engine.  An engine can support Pool while a particular Bot still uses
+the Legacy layout, so applying the lock from an engine-level default would
+block unrelated Legacy edits.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
-from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.types import SkillLayout
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,37 +33,34 @@ class SkillLayoutParticipationResolver(Protocol):
     def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation: ...
 
 
-class BotEngineSkillLayoutParticipationResolver:
-    """Repository-backed, engine-agnostic implementation of the policy port.
-
-    Unknown, missing, or cross-environment Bot records intentionally resolve to
-    the supplied default policy.  Production wiring supplies a participating
-    default, so new engines cannot bypass the edit lock accidentally.
-    """
+class BotSkillLayoutStateParticipationResolver:
+    """Use the persisted Bot layout as the sole edit-lock participation fact."""
 
     def __init__(
         self,
         *,
-        bot_repository: BotRepository,
-        default: SkillLayoutParticipation,
-        by_engine: Mapping[str, SkillLayoutParticipation],
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
     ) -> None:
-        self._bots = bot_repository
-        self._default = default
-        self._by_engine = dict(by_engine)
+        self._layouts = layout_repository
 
     def resolve(self, *, scope: BotSkillLayoutScope) -> SkillLayoutParticipation:
-        bot = self._bots.get_by_id_and_entity(scope.bot_id, scope.entity_id)
-        if not bot or bot.get("env") != scope.env:
-            return self._default
-        engine = bot.get("active_engine")
-        if not isinstance(engine, str):
-            return self._default
-        return self._by_engine.get(engine, self._default)
+        state = self._layouts.get(scope)
+        if (
+            state.active_layout is SkillLayout.POOL
+            or state.target_layout is SkillLayout.POOL
+        ):
+            return SkillLayoutParticipation(
+                participates_in_pool_layout=True,
+                label="pool_layout_state",
+            )
+        return SkillLayoutParticipation(
+            participates_in_pool_layout=False,
+            label="legacy_layout_state",
+        )
 
 
 __all__ = [
-    "BotEngineSkillLayoutParticipationResolver",
+    "BotSkillLayoutStateParticipationResolver",
     "SkillLayoutParticipation",
     "SkillLayoutParticipationResolver",
 ]

--- a/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skills_pool_module.py
@@ -24,8 +24,7 @@ from agentclaw.community.core.skills_pool.claim_service import (
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.participation import (
-    BotEngineSkillLayoutParticipationResolver,
-    SkillLayoutParticipation,
+    BotSkillLayoutStateParticipationResolver,
     SkillLayoutParticipationResolver,
 )
 from agentclaw.community.core.skills_pool.operational_query import (
@@ -147,23 +146,10 @@ class SkillsPoolModule(Module):
     @inject
     def skill_layout_participation_resolver(
         self,
-        bot_repository: BotRepository,
+        layout_repository: SkillsPoolLayoutRepositoryProtocol,
     ) -> SkillLayoutParticipationResolver:
-        return BotEngineSkillLayoutParticipationResolver(
-            bot_repository=bot_repository,
-            default=SkillLayoutParticipation(
-                participates_in_pool_layout=True,
-                label="default_pool_layout",
-            ),
-            # Teclaw owns an artifact-style filesystem and never enters the
-            # Pool migration or rollback state machine.  Keep that engine
-            # policy in composition, rather than the shared edit guard.
-            by_engine={
-                "teclaw": SkillLayoutParticipation(
-                    participates_in_pool_layout=False,
-                    label="teclaw_no_pool_layout",
-                )
-            },
+        return BotSkillLayoutStateParticipationResolver(
+            layout_repository=layout_repository,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -1072,6 +1072,21 @@ async def test_upload_502_when_the_device_write_fails():
 
 
 @pytest.mark.asyncio
+async def test_upload_returns_409_when_baas_bot_disappears_during_delete():
+    from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
+
+    file_svc = _StubFileService(raises=BaasServiceError("404 BOT_NOT_FOUND"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
 async def test_upload_reads_x_trace_id_from_request():
     env = await upload_resource(
         path="hello.txt",

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -159,10 +159,12 @@ class _StubFileService:
         *,
         existing: set[str] | None = None,
         raises: Exception | None = None,
+        exists_raises: Exception | None = None,
         delete_raises: Exception | None = None,
     ):
         self.existing: set[str] = set(existing or ())
         self.raises = raises
+        self.exists_raises = exists_raises
         self.delete_raises = delete_raises
         self.upload_calls: List[dict] = []
         self.exists_calls: List[str] = []
@@ -170,6 +172,8 @@ class _StubFileService:
 
     async def exists(self, *, path, **_kw) -> bool:
         self.exists_calls.append(path)
+        if self.exists_raises is not None:
+            raise self.exists_raises
         return path in self.existing
 
     async def upload_file(self, **kwargs) -> dict:
@@ -1076,6 +1080,44 @@ async def test_upload_returns_409_when_baas_bot_disappears_during_delete():
     from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 
     file_svc = _StubFileService(raises=BaasServiceError("404 BOT_NOT_FOUND"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_upload_returns_409_when_baas_bot_disappears_during_duplicate_probe():
+    from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
+
+    file_svc = _StubFileService(
+        exists_raises=BaasServiceError("404 BOT_NOT_FOUND")
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_upload_returns_409_for_desktop_proxy_bot_not_found():
+    request = httpx.Request("PUT", "http://desktop-proxy/upload")
+    response = httpx.Response(
+        404, json={"detail": {"error_code": "BOT_NOT_FOUND"}}, request=request
+    )
+    file_svc = _StubFileService(
+        raises=httpx.HTTPStatusError(
+            "Client error '404 Not Found'", request=request, response=response
+        )
+    )
 
     with pytest.raises(HTTPException) as excinfo:
         await upload_resource(

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -26,6 +26,8 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     PageParams,
 )
 from agentclaw.community.adapters.http.openapi_v1.resources.router import (
+    _is_baas_bot_not_found,
+    _raise_upload_lifecycle_error,
     create_directory,
     delete_file,
     download_file,
@@ -1146,6 +1148,93 @@ async def test_upload_returns_409_for_desktop_proxy_bot_not_found():
         )
 
     assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_upload_maps_duplicate_probe_storage_failures_to_502():
+    from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
+
+    file_svc = _StubFileService(exists_raises=BaasServiceError("upstream unavailable"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_upload_preserves_device_not_bound_from_duplicate_probe():
+    file_svc = _StubFileService(exists_raises=DeviceNotBoundError("binding released"))
+
+    resp = await upload_resource(
+        path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+        bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+    )
+
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_upload_maps_generic_duplicate_probe_failures_to_502():
+    file_svc = _StubFileService(exists_raises=RuntimeError("device unavailable"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_upload_maps_write_storage_failures_to_502():
+    from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
+
+    file_svc = _StubFileService(raises=BaasServiceError("upstream unavailable"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await upload_resource(
+            path="a.txt", content=b"x", owner_id="u1", bot_id="bot-a",
+            bot_repo=_StubBotRepo(), file_svc=file_svc, request=_request_without_trace(),
+        )
+
+    assert excinfo.value.status_code == 502
+
+
+def test_baas_bot_not_found_rejects_non_matching_proxy_status():
+    request = httpx.Request("POST", "http://desktop-proxy/upload")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("upstream unavailable", request=request, response=response)
+
+    assert _is_baas_bot_not_found(exc) is False
+
+
+def test_baas_bot_not_found_handles_unread_proxy_body():
+    request = httpx.Request("POST", "http://desktop-proxy/upload")
+    response = httpx.Response(404, stream=httpx.ByteStream(b"BOT_NOT_FOUND"), request=request)
+    exc = httpx.HTTPStatusError("not found", request=request, response=response)
+
+    assert _is_baas_bot_not_found(exc) is False
+
+
+def test_upload_lifecycle_error_maps_missing_bot_to_404():
+    from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
+
+    bot_repo = SimpleNamespace(get_by_id_and_owner=lambda *_args: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        _raise_upload_lifecycle_error(
+            exc=BaasServiceError("404 BOT_NOT_FOUND"),
+            bot_id="bot-a",
+            owner_id="u1",
+            bot_repo=bot_repo,
+        )
+
+    assert excinfo.value.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -42,6 +42,7 @@ from agentclaw.community.core.resources.factory import ResourceServiceFactory
 from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
+from agentclaw.community.core.devices.services.device_context import DeviceNotBoundError
 
 
 def _request_scope() -> dict:
@@ -1073,6 +1074,25 @@ async def test_upload_502_when_the_device_write_fails():
         )
 
     assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_upload_preserves_device_not_bound_from_the_write():
+    """A deletion can release the binding after the duplicate probe succeeds."""
+    file_svc = _StubFileService(raises=DeviceNotBoundError("binding released"))
+
+    resp = await upload_resource(
+        path="a.txt",
+        content=b"x",
+        owner_id="u1",
+        bot_id="bot-a",
+        bot_repo=_StubBotRepo(),
+        file_svc=file_svc,
+        request=_request_without_trace(),
+    )
+
+    assert resp.status_code == 409
+    assert json.loads(resp.body)["message"] == "Bot has no active device"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -251,6 +251,16 @@ def test_delete_bot(client, svc):
     svc.delete_bot.assert_called_once_with("b1", "u1")
 
 
+def test_delete_bot_runs_sync_service_in_threadpool(client, svc):
+    with patch.object(
+        bots_router, "run_in_threadpool", new_callable=AsyncMock, return_value=True
+    ) as run:
+        data = _ok(client.delete("/openapi/v1/bots/b1"))
+
+    assert data == {"deleted": True}
+    run.assert_awaited_once_with(svc.delete_bot, "b1", "u1")
+
+
 def test_restart_bot(client):
     data = _ok(client.post("/openapi/v1/bots/b1/restart"))
     assert data["status"] == "PENDING"

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -780,6 +780,20 @@ class TestDeleteBot:
         assert resp.status_code == 200
         assert resp.json()["success"] is True
 
+    def test_runs_sync_service_in_threadpool(self, client):
+        tc, svc, _ = client
+        import agentclaw.community.adapters.http.bot_management.router as router_module
+
+        with patch.object(
+            router_module, "run_in_threadpool", new_callable=AsyncMock, return_value=None
+        ) as run:
+            resp = tc.delete("/api/bots/default")
+
+        assert resp.status_code == 200
+        run.assert_awaited_once_with(
+            svc.delete_bot, bot_id="default", user_id="test_user"
+        )
+
     def test_bot_not_found(self, client):
         tc, svc, _ = client
         svc.delete_bot.side_effect = BotNotFoundError("nope")

--- a/src/backend/tests/community/api/devices/test_converter.py
+++ b/src/backend/tests/community/api/devices/test_converter.py
@@ -1,5 +1,10 @@
 """Tests for device API converter."""
-from agentclaw.community.adapters.http.devices.converter import connection_info_to_response
+from types import SimpleNamespace
+
+from agentclaw.community.adapters.http.devices.converter import (
+    connection_info_to_response,
+    record_to_response,
+)
 from agentclaw.community.core.devices.models import DeviceConnectionInfo
 
 
@@ -33,3 +38,19 @@ class TestConnectionInfoToResponse:
         resp = connection_info_to_response(info)
         assert resp.available is False
         assert resp.message == "本地引擎未连接"
+
+
+def test_record_to_response_supports_releasing_status():
+    record = SimpleNamespace(
+        id=1,
+        entity_id="staff-1",
+        entity_type="staff",
+        device_id="device-1",
+        device_provider="baas",
+        env="dev",
+        device_props={},
+        status="RELEASING",
+        last_alive_at=None,
+    )
+
+    assert record_to_response(record).status == "RELEASING"

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -37,6 +37,7 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
+from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditBusyError
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -469,9 +470,7 @@ def _upload_skill_di_app(
                 DeviceContextResolver,
             )
             from agentclaw.community.core.skill_center.factories import SkillServiceFactory
-            from agentclaw.community.core.skills_pool.edit_guard import (
-                SkillsPoolEditGuard,
-            )
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
             from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 
             from agentclaw.community.api.skill_service_factory import SkillServiceFactoryProtocol
@@ -577,6 +576,39 @@ class TestUploadSkillValidation:
             body = response.json()
             assert body["success"] is True
             assert mock_svc.upload_skill.await_count == 1
+
+    def test_upload_edit_lock_conflict_returns_http_409(self, mock_ctx):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (
+            client,
+            mock_svc,
+            _,
+            _,
+        ):
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+
+            # The fixture's injected guard is resolved through the app injector;
+            # reach it via the dependency's configured instance.
+            # Rebuilding this narrow response assertion through a side effect
+            # prevents a failed mutation from masquerading as HTTP 200.
+            app = client.app
+            injector = app.state.injector
+            guard = injector.get(SkillsPoolEditGuard)
+            guard.acquire_for_edit.side_effect = SkillsPoolEditBusyError("busy")
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.status_code == 409
+            assert response.json()["detail"] == "busy"
+            mock_svc.upload_skill.assert_not_called()
 
     def test_upload_persists_bot_owner_for_collaborator_upload(self):
         collaborator_ctx = RequestContext(

--- a/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_api_async_correctness.py
@@ -37,7 +37,10 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
     RuntimeLayoutProbeStatus,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillInfo
-from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditBusyError
+from agentclaw.community.core.skills_pool.edit_guard import (
+    SkillsPoolEditBusyError,
+    SkillsPoolEditLockUnavailableError,
+)
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -609,6 +612,46 @@ class TestUploadSkillValidation:
             assert response.status_code == 409
             assert response.json()["detail"] == "busy"
             mock_svc.upload_skill.assert_not_called()
+
+    def test_upload_lock_backend_outage_returns_http_503(self, mock_ctx):
+        with _upload_skill_di_app(mock_ctx, bot_status="ACTIVE") as (
+            client,
+            mock_svc,
+            _,
+            _,
+        ):
+            from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
+
+            guard = client.app.state.injector.get(SkillsPoolEditGuard)
+            guard.acquire_for_edit.side_effect = SkillsPoolEditLockUnavailableError(
+                "lock service unavailable"
+            )
+
+            response = client.post(
+                "/api/skills/upload",
+                files=[
+                    (
+                        "files",
+                        ("SKILL.md", b"---\nname: a\ndescription: a\n---", "text/markdown"),
+                    )
+                ],
+                data={"file_paths": json.dumps(["SKILL.md"])},
+            )
+
+            assert response.status_code == 503
+            assert response.json()["detail"] == "lock service unavailable"
+            mock_svc.upload_skill.assert_not_called()
+
+
+def test_upload_openapi_documents_edit_lock_conflict_and_outage():
+    app = FastAPI()
+    app.include_router(skills_router)
+
+    responses = app.openapi()["paths"]["/api/skills/upload"]["post"]["responses"]
+    for status in ("409", "503"):
+        assert responses[status]["content"]["application/json"]["schema"]["$ref"].endswith(
+            "UploadSkillErrorResponse"
+        )
 
     def test_upload_persists_bot_owner_for_collaborator_upload(self):
         collaborator_ctx = RequestContext(

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -6,6 +6,7 @@ check_bot_name_exists, generate_bot_id.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call as mock_call, patch
 
@@ -621,6 +622,24 @@ class TestDeleteBot:
             "staff_user001",
             "delete:bot001",
             "reacquired-delete-lock",
+        )
+
+    def test_delete_stale_reaper_fences_a_renewed_lock(self):
+        svc = _make_service()
+        stale = SimpleNamespace(
+            lock_token="delete-lock", gmt_modified=datetime(2000, 1, 1)
+        )
+        svc._restart_lock_repo.acquire.return_value = None
+        svc._restart_lock_repo.get_if_stale.return_value = stale
+
+        assert svc._try_acquire_delete_lock("dev", "staff_user001", "bot001", "user001") is None
+
+        svc._restart_lock_repo.release.assert_called_once_with(
+            "dev",
+            "staff_user001",
+            "delete:bot001",
+            "delete-lock",
+            expected_gmt_modified=stale.gmt_modified,
         )
 
     def test_delete_lock_heartbeat_marks_refresh_exception_as_lease_loss(self):

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -6,6 +6,7 @@ check_bot_name_exists, generate_bot_id.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call as mock_call, patch
 
 import pytest
@@ -552,6 +553,32 @@ class TestDeleteBot:
         result = svc.delete_bot("bot001", "user001")
         assert result is True
         svc._repository.soft_delete_by_owner.assert_called_once_with("bot001", "user001")
+
+    def test_concurrent_delete_joins_before_passport_or_soft_delete(self):
+        """The durable delete lock covers all destructive stages, not only devices."""
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(binding_id=None)
+        svc._restart_lock_repo.acquire.return_value = None
+        svc._restart_lock_repo.get_if_stale.return_value = None
+
+        assert svc.delete_bot("bot001", "user001") is True
+
+        svc._passport_plugin.destroy_passport.assert_not_called()
+        svc._repository.soft_delete_by_owner.assert_not_called()
+        svc._restart_lock_repo.release.assert_not_called()
+
+    def test_delete_releases_its_operation_lock_after_completion(self):
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_bot(binding_id=None)
+        svc._repository.soft_delete_by_owner.return_value = True
+        svc._restart_lock_repo.acquire.return_value = SimpleNamespace(lock_token="delete-lock")
+
+        with patch.object(bot_service_module, "get_current_env", return_value="dev"):
+            assert svc.delete_bot("bot001", "user001") is True
+
+        svc._restart_lock_repo.release.assert_called_once_with(
+            "dev", "staff_user001", "delete:bot001", "delete-lock"
+        )
 
     def test_syncs_bcn_provider_delete_after_soft_delete(self):
         svc = _make_service()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -555,17 +555,35 @@ class TestDeleteBot:
         svc._repository.soft_delete_by_owner.assert_called_once_with("bot001", "user001")
 
     def test_concurrent_delete_waits_for_durable_completion(self):
-        """A joined request succeeds only after the winner's soft delete is visible."""
+        """A joined request waits for the holder's post-delete sweeps."""
         svc = _make_service()
         svc._repository.get_by_id_and_owner.side_effect = [_make_bot(binding_id=None), None]
         svc._restart_lock_repo.acquire.return_value = None
         svc._restart_lock_repo.get_if_stale.return_value = None
+        svc._restart_lock_repo.get.side_effect = [SimpleNamespace(), None]
 
         assert svc.delete_bot("bot001", "user001") is True
 
         svc._passport_plugin.destroy_passport.assert_not_called()
         svc._repository.soft_delete_by_owner.assert_not_called()
         svc._restart_lock_repo.release.assert_not_called()
+
+    def test_joined_delete_propagates_post_delete_sweep_failure(self):
+        """A missing row alone never turns an incomplete cleanup into success."""
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.side_effect = [_make_bot(binding_id=None), None]
+        svc._restart_lock_repo.acquire.return_value = None
+        svc._restart_lock_repo.get_if_stale.return_value = None
+        svc._restart_lock_repo.get.return_value = None
+        grants = MagicMock()
+        grants.revoke_all_for_bot.side_effect = RuntimeError("grant store unavailable")
+        svc._bot_app_grant_provider = lambda: grants
+
+        with pytest.raises(BotServiceError, match="grant store unavailable"):
+            svc.delete_bot("bot001", "user001")
+
+        svc._passport_plugin.destroy_passport.assert_not_called()
+        svc._repository.soft_delete_by_owner.assert_not_called()
 
     def test_concurrent_delete_surfaces_a_winner_that_released_without_deleting(self):
         svc = _make_service()

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -581,6 +581,46 @@ class TestDeleteBot:
         svc._passport_plugin.destroy_passport.assert_not_called()
         svc._repository.soft_delete_by_owner.assert_not_called()
 
+    def test_reacquired_delete_lock_rechecks_that_the_bot_is_still_live(self):
+        """A lock acquired after the winner completes must join its success."""
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.side_effect = [
+            _make_bot(binding_id=None),
+            None,
+        ]
+        svc._restart_lock_repo.acquire.side_effect = [
+            None,
+            SimpleNamespace(lock_token="reacquired-delete-lock"),
+        ]
+        svc._restart_lock_repo.get_if_stale.return_value = None
+
+        assert svc.delete_bot("bot001", "user001") is True
+
+        svc._passport_plugin.destroy_passport.assert_not_called()
+        svc._repository.soft_delete_by_owner.assert_not_called()
+        svc._restart_lock_repo.release.assert_called_once_with(
+            "dev",
+            "staff_user001",
+            "delete:bot001",
+            "reacquired-delete-lock",
+        )
+
+    def test_delete_lock_heartbeat_marks_refresh_exception_as_lease_loss(self):
+        svc = _make_service()
+        svc._restart_lock_repo.refresh.side_effect = [True, RuntimeError("db unavailable")]
+
+        with patch.object(
+            bot_service_module, "DELETE_LOCK_HEARTBEAT_SECONDS", 0.01
+        ):
+            stop, lease_lost, thread = svc._start_delete_lock_heartbeat(
+                "dev", "staff_user001", "bot001", "delete-lock"
+            )
+            assert lease_lost.wait(timeout=1)
+            stop.set()
+            thread.join(timeout=1)
+
+        assert not thread.is_alive()
+
     def test_delete_releases_its_operation_lock_after_completion(self):
         svc = _make_service()
         svc._repository.get_by_id_and_owner.return_value = _make_bot(binding_id=None)

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -554,10 +554,10 @@ class TestDeleteBot:
         assert result is True
         svc._repository.soft_delete_by_owner.assert_called_once_with("bot001", "user001")
 
-    def test_concurrent_delete_joins_before_passport_or_soft_delete(self):
-        """The durable delete lock covers all destructive stages, not only devices."""
+    def test_concurrent_delete_waits_for_durable_completion(self):
+        """A joined request succeeds only after the winner's soft delete is visible."""
         svc = _make_service()
-        svc._repository.get_by_id_and_owner.return_value = _make_bot(binding_id=None)
+        svc._repository.get_by_id_and_owner.side_effect = [_make_bot(binding_id=None), None]
         svc._restart_lock_repo.acquire.return_value = None
         svc._restart_lock_repo.get_if_stale.return_value = None
 
@@ -566,6 +566,20 @@ class TestDeleteBot:
         svc._passport_plugin.destroy_passport.assert_not_called()
         svc._repository.soft_delete_by_owner.assert_not_called()
         svc._restart_lock_repo.release.assert_not_called()
+
+    def test_concurrent_delete_surfaces_a_winner_that_released_without_deleting(self):
+        svc = _make_service()
+        bot = _make_bot(binding_id=None)
+        svc._repository.get_by_id_and_owner.side_effect = [bot, bot]
+        svc._restart_lock_repo.acquire.return_value = None
+        svc._restart_lock_repo.get_if_stale.return_value = None
+        svc._restart_lock_repo.get.return_value = None
+
+        with pytest.raises(BotServiceError, match="did not complete"):
+            svc.delete_bot("bot001", "user001")
+
+        svc._passport_plugin.destroy_passport.assert_not_called()
+        svc._repository.soft_delete_by_owner.assert_not_called()
 
     def test_delete_releases_its_operation_lock_after_completion(self):
         svc = _make_service()
@@ -577,6 +591,9 @@ class TestDeleteBot:
             assert svc.delete_bot("bot001", "user001") is True
 
         svc._restart_lock_repo.release.assert_called_once_with(
+            "dev", "staff_user001", "delete:bot001", "delete-lock"
+        )
+        svc._restart_lock_repo.refresh.assert_called_once_with(
             "dev", "staff_user001", "delete:bot001", "delete-lock"
         )
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -72,6 +72,7 @@ class FakeRestartLockRepo:
             holder_user_id=holder_user_id,
             lock_token=uuid.uuid4().hex,
             gmt_create=self.now,
+            gmt_modified=self.now,
         )
         self.rows[key] = rec
         return rec
@@ -87,12 +88,21 @@ class FakeRestartLockRepo:
             return rec
         return None
 
-    def release(self, env, entity_id, bot_id, lock_token):
+    def release(
+        self, env, entity_id, bot_id, lock_token, *, expected_gmt_modified=None
+    ):
         self.release_calls += 1
         key = (env, entity_id, bot_id)
         rec = self.rows.get(key)
         # Compare-and-delete: only remove the row if the token still matches.
-        if rec is not None and rec.lock_token == lock_token:
+        if (
+            rec is not None
+            and rec.lock_token == lock_token
+            and (
+                expected_gmt_modified is None
+                or rec.gmt_modified == expected_gmt_modified
+            )
+        ):
             del self.rows[key]
             return True
         return False
@@ -1588,7 +1598,9 @@ class TestStaleReaper:
         # fails because the *other* worker holds the freshly-reacquired lock.
         repo.acquire.side_effect = [None, None]
         stale = SimpleNamespace(
-            lock_token="A", gmt_create=datetime(2026, 5, 28, 12, 0, 0)
+            lock_token="A",
+            gmt_create=datetime(2026, 5, 28, 12, 0, 0),
+            gmt_modified=datetime(2026, 5, 28, 12, 0, 0),
         )
         repo.get_if_stale.return_value = stale
         repo.release.return_value = False  # token "A" no longer matches → no-op
@@ -1599,7 +1611,13 @@ class TestStaleReaper:
         assert result is None  # suppressed — did not steal the newer lock
         # The reap released using the STALE row's token (fencing), not a blind
         # delete of whatever currently occupies the key.
-        repo.release.assert_called_once_with("dev", "ent", "bot001", "A")
+        repo.release.assert_called_once_with(
+            "dev",
+            "ent",
+            "bot001",
+            "A",
+            expected_gmt_modified=stale.gmt_modified,
+        )
         assert repo.acquire.call_count == 2
 
 

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -460,18 +460,38 @@ class TestReleaseDevice:
         assert result is released_record
         repo.release_binding.assert_called_once()
 
-    def test_release_released_device_raises(self):
+    def test_release_released_device_is_idempotent(self):
         record = _make_record(status=DeviceBindingStatus.RELEASED.value)
         repo = MagicMock()
         repo.get_by_id.return_value = record
         svc = _make_service(repo=repo)
 
-        with pytest.raises(InvalidDeviceStatusError):
-            svc.release_device(
-                binding_id=1,
-                release_reason=None,
-                operator=_make_operator(),
-            )
+        result = svc.release_device(
+            binding_id=1,
+            release_reason=None,
+            operator=_make_operator(),
+        )
+
+        assert result is record
+        repo.claim_binding_release.assert_not_called()
+
+    def test_release_losing_database_claim_skips_physical_release(self):
+        active = _make_record(status=DeviceBindingStatus.ACTIVE.value)
+        released = _make_record(status=DeviceBindingStatus.RELEASED.value)
+        repo = MagicMock()
+        repo.get_by_id.side_effect = [active, released]
+        repo.claim_binding_release.return_value = False
+        svc = _make_service(repo=repo)
+        svc._do_release = MagicMock()
+
+        result = svc.release_device(
+            binding_id=1,
+            release_reason=None,
+            operator=_make_operator(),
+        )
+
+        assert result is released
+        svc._do_release.assert_not_called()
 
     def test_release_not_found_raises(self):
         repo = MagicMock()

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -498,6 +498,24 @@ class TestReleaseDevice:
         assert result is releasing
         svc._do_release.assert_not_called()
 
+    def test_release_losing_database_claim_returns_finalized_release(self):
+        active = _make_record(status=DeviceBindingStatus.ACTIVE.value)
+        released = _make_record(status=DeviceBindingStatus.RELEASED.value)
+        repo = MagicMock()
+        repo.get_by_id.side_effect = [active, released]
+        repo.claim_binding_release.return_value = False
+        svc = _make_service(repo=repo)
+        svc._do_release = MagicMock()
+
+        result = svc.release_device(
+            binding_id=1,
+            release_reason="duplicate request",
+            operator=_make_operator(),
+        )
+
+        assert result is released
+        svc._do_release.assert_not_called()
+
     def test_release_in_progress_is_idempotent(self):
         releasing = _make_record(status=DeviceBindingStatus.RELEASING.value)
         repo = MagicMock()

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -459,6 +459,11 @@ class TestReleaseDevice:
 
         assert result is released_record
         repo.release_binding.assert_called_once()
+        repo.claim_binding_release.assert_called_once_with(
+            binding_id=1,
+            release_reason="finalize stopped binding",
+            released_by="u001",
+        )
 
     def test_release_released_device_is_idempotent(self):
         record = _make_record(status=DeviceBindingStatus.RELEASED.value)

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -482,9 +482,9 @@ class TestReleaseDevice:
 
     def test_release_losing_database_claim_skips_physical_release(self):
         active = _make_record(status=DeviceBindingStatus.ACTIVE.value)
-        released = _make_record(status=DeviceBindingStatus.RELEASED.value)
+        releasing = _make_record(status=DeviceBindingStatus.RELEASING.value)
         repo = MagicMock()
-        repo.get_by_id.side_effect = [active, released]
+        repo.get_by_id.side_effect = [active, releasing]
         repo.claim_binding_release.return_value = False
         svc = _make_service(repo=repo)
         svc._do_release = MagicMock()
@@ -495,7 +495,24 @@ class TestReleaseDevice:
             operator=_make_operator(),
         )
 
-        assert result is released
+        assert result is releasing
+        svc._do_release.assert_not_called()
+
+    def test_release_in_progress_is_idempotent(self):
+        releasing = _make_record(status=DeviceBindingStatus.RELEASING.value)
+        repo = MagicMock()
+        repo.get_by_id.return_value = releasing
+        svc = _make_service(repo=repo)
+        svc._do_release = MagicMock()
+
+        result = svc.release_device(
+            binding_id=1,
+            release_reason="duplicate request",
+            operator=_make_operator(),
+        )
+
+        assert result is releasing
+        repo.claim_binding_release.assert_not_called()
         svc._do_release.assert_not_called()
 
     def test_release_not_found_raises(self):

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -100,6 +100,26 @@ def _create_mock_record(
     )
 
 
+class TestDeviceBindingUpdates:
+    def test_publish_callback_merges_props_without_reusing_binding(self):
+        binding_repo = MagicMock()
+        service = _make_service(Mock(), device_binding_repo=binding_repo)
+
+        service.update_device_binding_with_props(
+            binding_id=42,
+            status="ACTIVE",
+            device_props={"publish_id": "p-1"},
+        )
+
+        binding_repo.update_status_and_alive_at.assert_called_once_with(
+            binding_id=42, status="ACTIVE"
+        )
+        binding_repo.update_device_props.assert_called_once_with(
+            binding_id=42, props={"publish_id": "p-1"}
+        )
+        binding_repo.reuse_binding.assert_not_called()
+
+
 class TestCreatePublishImagePolicy:
     def _create(self, *, source_bot, common_config_value=None, is_teclaw=False):
         publish_repo = Mock()

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -119,6 +119,36 @@ class TestDeviceBindingUpdates:
         )
         binding_repo.reuse_binding.assert_not_called()
 
+    def test_publish_success_reactivates_only_an_unclaimed_binding(self):
+        binding_repo = MagicMock()
+        binding_repo.activate_publish_binding.return_value = True
+        service = _make_service(Mock(), device_binding_repo=binding_repo)
+
+        service.activate_publish_binding_with_props(
+            binding_id=42,
+            device_props={"publish_id": "p-1"},
+        )
+
+        binding_repo.activate_publish_binding.assert_called_once_with(binding_id=42)
+        binding_repo.update_device_props.assert_called_once_with(
+            binding_id=42, props={"publish_id": "p-1"}
+        )
+        binding_repo.update_status_and_alive_at.assert_not_called()
+        binding_repo.reuse_binding.assert_not_called()
+
+    def test_publish_success_refuses_claimed_release(self):
+        binding_repo = MagicMock()
+        binding_repo.activate_publish_binding.return_value = False
+        service = _make_service(Mock(), device_binding_repo=binding_repo)
+
+        with pytest.raises(BotPublishServiceError, match="active release claim"):
+            service.activate_publish_binding_with_props(
+                binding_id=42,
+                device_props={"publish_id": "p-1"},
+            )
+
+        binding_repo.update_device_props.assert_not_called()
+
 
 class TestCreatePublishImagePolicy:
     def _create(self, *, source_bot, common_config_value=None, is_teclaw=False):

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -282,6 +282,61 @@ async def test_package_storage_prepare_accepts_an_absent_first_upload_directory(
     assert filesystem.deleted == []
 
 
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_preserves_source_and_verifies_target():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"skill"
+    source = LocalSkillPackageStorage(filesystem, "/private/source")
+    target = LocalSkillPackageStorage(filesystem, "/private/target")
+
+    await source.copy_to(target)
+
+    assert filesystem.files["/private/source/SKILL.md"] == b"skill"
+    assert filesystem.files["/private/target/SKILL.md"] == b"skill"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_rejects_an_existing_target_without_replace():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    filesystem.files["/private/target/SKILL.md"] = b"old"
+
+    with pytest.raises(OSError, match="copy target already exists"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(
+            LocalSkillPackageStorage(filesystem, "/private/target")
+        )
+
+    assert filesystem.files["/private/target/SKILL.md"] == b"old"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_requires_existing_target_cleanup():
+    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    filesystem.files["/private/target/SKILL.md"] = b"old"
+
+    with pytest.raises(OSError, match="unable to clear Local Skill copy target"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(
+            LocalSkillPackageStorage(filesystem, "/private/target"), replace=True
+        )
+
+    assert filesystem.files["/private/target/SKILL.md"] == b"old"
+
+
+@pytest.mark.asyncio
+async def test_package_storage_copy_to_rejects_failed_target_verification():
+    filesystem = _Filesystem()
+    filesystem.files["/private/source/SKILL.md"] = b"new"
+    target = LocalSkillPackageStorage(filesystem, "/private/target")
+
+    async def fail_restore(_files):
+        return False
+
+    target._restore_contents = fail_restore
+    with pytest.raises(OSError, match="Local Skill copy verification failed"):
+        await LocalSkillPackageStorage(filesystem, "/private/source").copy_to(target)
+
+
 class _Collaborators:
     def check_collaborator_permission(self, *args):
         return {"has_permission": True}
@@ -1021,6 +1076,96 @@ async def test_replacement_migrates_a_legacy_hidden_locator_to_the_canonical_pat
         b"name: upload-skill\ndescription: canonical\n"
     )
     assert not any(".replacement-" in path for path in filesystem.files)
+
+
+@pytest.mark.asyncio
+async def test_replacement_discards_staging_and_backup_when_backup_copy_fails(
+    monkeypatch,
+):
+    filesystem = _Filesystem()
+    canonical = "/private/skills-local/upload-skill"
+    rollback = "/private/skills-local/.upload-skill.rollback-backup"
+    filesystem.files[f"{canonical}/SKILL.md"] = b"old"
+    filesystem.files[f"{rollback}/stale.txt"] = b"stale"
+    repo = _ReplacementRepo([_existing_skill(active=False)])
+    ids = iter([SimpleNamespace(hex="staged"), SimpleNamespace(hex="backup")])
+    monkeypatch.setattr(upload_module, "uuid4", lambda: next(ids))
+
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip(
+                {"SKILL.md": b"name: upload-skill\ndescription: replacement\n"}
+            ),
+        )
+
+    assert rollback in filesystem.deleted
+    assert "/private/skills-local/.upload-skill.replacement-staged" in (
+        filesystem.deleted
+    )
+    assert repo.atomic_replacements == []
+
+
+@pytest.mark.asyncio
+async def test_restore_replacement_requires_backup_after_canonical_publish():
+    filesystem = _Filesystem()
+    skill = _existing_skill(active=False)
+    service = _replacement_service(
+        filesystem, _ReplacementRepo([skill]), _ReplacementRuntime([True])
+    )
+
+    with pytest.raises(LocalSkillStorageError):
+        await service._restore_replacement(
+            skill=skill,
+            old_metadata={},
+            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
+            owner_id="owner",
+            bot_id="bot",
+            staged=_Storage(filesystem, "/private/staged"),
+            staged_locator="/private/staged",
+            canonical=_Storage(filesystem, "/private/canonical"),
+            canonical_locator="/private/canonical",
+            old_is_canonical=True,
+            backup=None,
+            obsolete_locator="/private/canonical",
+            canonical_published=True,
+            switched=False,
+            old_cleanup_work_id=None,
+            runtime_sync_attempted=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_restore_replacement_requires_noncanonical_publish_cleanup():
+    filesystem = _Filesystem(cleanup_results=[False])
+    skill = _existing_skill(active=False)
+    service = _replacement_service(
+        filesystem, _ReplacementRepo([skill]), _ReplacementRuntime([True])
+    )
+
+    with pytest.raises(LocalSkillStorageError):
+        await service._restore_replacement(
+            skill=skill,
+            old_metadata={},
+            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
+            owner_id="owner",
+            bot_id="bot",
+            staged=_Storage(filesystem, "/private/staged"),
+            staged_locator="/private/staged",
+            canonical=_Storage(filesystem, "/private/canonical"),
+            canonical_locator="/private/canonical",
+            old_is_canonical=False,
+            backup=None,
+            obsolete_locator="/private/legacy",
+            canonical_published=True,
+            switched=False,
+            old_cleanup_work_id=None,
+            runtime_sync_attempted=False,
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -156,6 +156,18 @@ class _Filesystem:
             raise OSError("private path")
         self.files[path] = content
 
+    async def read_file(self, path):
+        return self.files.get(path)
+
+    async def list_dir(self, path, *, recursive=False):
+        prefix = f"{path}/"
+        entries = [
+            {"relative_path": file_path[len(prefix) :], "is_dir": False}
+            for file_path in self.files
+            if file_path.startswith(prefix)
+        ]
+        return entries or None
+
     async def delete_tree(self, path):
         self.deleted.append(path)
         result = next(self.cleanup_results, True)
@@ -237,6 +249,29 @@ class _Storage:
     async def cleanup(self):
         return await self.filesystem.delete_tree(self.directory)
 
+    async def verify(self):
+        entries = await self.filesystem.list_dir(self.directory, recursive=True)
+        if not entries:
+            raise OSError("missing package")
+        return True
+
+    async def copy_to(self, target, *, replace=False):
+        prefix = f"{self.directory}/"
+        files = [
+            (path[len(prefix) :], content)
+            for path, content in self.filesystem.files.items()
+            if path.startswith(prefix)
+        ]
+        if not files:
+            raise OSError("missing package")
+        if await self.filesystem.exists(target.directory):
+            if not replace:
+                raise OSError("target exists")
+            if not await target.cleanup():
+                raise OSError("cleanup failed")
+        await target.write(files)
+        await target.verify()
+
 
 @pytest.mark.asyncio
 async def test_package_storage_prepare_accepts_an_absent_first_upload_directory():
@@ -288,9 +323,7 @@ class _Cleanup:
 
     def commit_preparing(self, work_id, *, requires_runtime_restore):
         row = self.preparing[work_id - 1]
-        self.rows.append(
-            {**row, "requires_runtime_restore": requires_runtime_restore}
-        )
+        self.rows.append({**row, "requires_runtime_restore": requires_runtime_restore})
 
     def record_pending(self, **kwargs):
         self.rows.append(kwargs)
@@ -387,9 +420,7 @@ class _ReplacementRepo(_Repo):
         )
 
     def get_bot_local_skill(self, *, skill_id, **_kwargs):
-        return next(
-            (row for row in self.rows if str(row["id"]) == str(skill_id)), None
-        )
+        return next((row for row in self.rows if str(row["id"]) == str(skill_id)), None)
 
     def update(self, skill_id, values):
         self.updates.append((skill_id, values))
@@ -956,11 +987,40 @@ async def test_same_name_replacement_preserves_id_owner_and_desired_state_after_
     assert result["skill"]["id"] == "9"
     assert result["skill"]["user_id"] == "owner"
     assert result["skill"]["active"] is False
-    assert result["skill"]["git_path"] != "local:///private/skills-local/upload-skill"
+    assert result["skill"]["git_path"] == "local:///private/skills-local/upload-skill"
     assert sets.exclusions == [("owner", "bot", 4, 9)]
     assert runtime.calls == 1
     assert "/private/skills-local/upload-skill" in filesystem.deleted
-    assert any("replacement-" in path for path in filesystem.files)
+    assert not any("replacement-" in path for path in filesystem.files)
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == (
+        b"name: upload-skill\ndescription: new description\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_migrates_a_legacy_hidden_locator_to_the_canonical_path():
+    old_locator = "/private/skills-local/.upload-skill.replacement-old"
+    filesystem = _Filesystem()
+    filesystem.files[f"{old_locator}/SKILL.md"] = b"old"
+    old = {**_existing_skill(active=False), "git_path": f"local://{old_locator}"}
+    repo = _ReplacementRepo([old])
+
+    result = await _replacement_service(
+        filesystem, repo, _ReplacementRuntime([True])
+    ).upload_local_skill(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        package=_zip({"SKILL.md": b"name: upload-skill\ndescription: canonical\n"}),
+    )
+
+    canonical = "/private/skills-local/upload-skill"
+    assert result["skill"]["git_path"] == f"local://{canonical}"
+    assert old["git_path"] == f"local://{canonical}"
+    assert filesystem.files[f"{canonical}/SKILL.md"] == (
+        b"name: upload-skill\ndescription: canonical\n"
+    )
+    assert not any(".replacement-" in path for path in filesystem.files)
 
 
 @pytest.mark.asyncio
@@ -1094,7 +1154,8 @@ async def test_active_replacement_runtime_failure_restores_old_metadata_and_runt
 
 @pytest.mark.asyncio
 async def test_active_replacement_restore_sync_failure_keeps_original_authority_and_records_staged_cleanup():
-    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem = _Filesystem(cleanup_results=[True, True])
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     old = _existing_skill(active=True)
     cleanup = _Cleanup()
     with pytest.raises(LocalSkillRuntimeSyncError):
@@ -1117,7 +1178,7 @@ async def test_active_replacement_restore_sync_failure_keeps_original_authority_
     )
     assert staged_work["requires_runtime_restore"] is True
     assert cleanup.cancelled == [1]
-    assert filesystem.deleted == []
+    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == b"old"
 
 
 @pytest.mark.asyncio
@@ -1163,7 +1224,8 @@ async def test_foreign_owner_same_name_is_excluded_from_this_owner_scope():
 
 @pytest.mark.asyncio
 async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_update():
-    filesystem = _Filesystem(cleanup_results=[False])
+    filesystem = _Filesystem(cleanup_results=[True, False])
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     repo = _ReplacementRepo([_existing_skill(active=False)])
     cleanup = _Cleanup()
     result = await _replacement_service(
@@ -1177,16 +1239,9 @@ async def test_post_switch_obsolete_cleanup_failure_is_recorded_without_undoing_
         ),
     )
     assert result["operation"] == "updated"
-    assert cleanup.rows == [
-        {
-            "env": "test",
-            "owner_id": "owner",
-            "bot_id": "bot",
-            "skill_id": "9",
-            "package_locator": "/private/skills-local/upload-skill",
-            "requires_runtime_restore": True,
-        }
-    ]
+    assert len(cleanup.rows) == 1
+    assert cleanup.rows[0]["requires_runtime_restore"] is True
+    assert ".upload-skill.rollback-" in cleanup.rows[0]["package_locator"]
 
 
 @pytest.mark.asyncio
@@ -1219,6 +1274,7 @@ async def test_cleanup_registration_failure_restores_old_authority_before_runtim
 async def test_later_serialized_upload_retries_durable_cleanup_work():
     filesystem = _Filesystem()
     filesystem.files["/private/skills-local/obsolete/SKILL.md"] = b"obsolete"
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     cleanup = _PendingCleanup()
     result = await _replacement_service(
         filesystem,
@@ -1297,6 +1353,7 @@ async def test_cleanup_progress_write_failure_blocks_the_next_replacement(
 async def test_runtime_restore_work_keeps_staged_bytes_until_old_mapping_is_restored():
     filesystem = _Filesystem()
     filesystem.files["/private/skills-local/staged/SKILL.md"] = b"staged"
+    filesystem.files["/private/skills-local/upload-skill/SKILL.md"] = b"old"
     cleanup = _RuntimeRestoreCleanup()
     runtime = _ReplacementRuntime([True, True])
     await _replacement_service(
@@ -1385,6 +1442,7 @@ class _YieldingFilesystem(_Filesystem):
 async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill():
     repo = _ConcurrentRepo()
     filesystem = _YieldingFilesystem()
+
     class _Participation:
         def resolve(self, *, scope):
             return SkillLayoutParticipation(

--- a/src/backend/tests/community/core/skill_center/test_skill_factories.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_factories.py
@@ -185,6 +185,32 @@ def test_local_skill_package_storage_splits_path_entity_from_device_owner(
     assert device_calls == [("bot-1", "owner-7")]
 
 
+def test_pool_local_skill_package_storage_uses_the_canonical_pool_local_root(
+    test_injector,
+):
+    factory = test_injector.get(SkillServiceFactory)
+    factory._pool_layout_paths = lambda *_: (
+        "/pool/active",
+        "/pool/skills-local",
+        "/pool/skills-repo",
+    )
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+
+    directory, storage = factory.local_skill_package_storage(
+        entity_id="project-42",
+        owner_id="owner-7",
+        bot_id="bot-1",
+        engine_type="hermes",
+        entity_type="project",
+        is_desktop=False,
+        is_teclaw=False,
+        name="reviewer",
+    )
+
+    assert directory == "/pool/skills-local/reviewer"
+    assert storage.directory == "/pool/skills-local/reviewer"
+
+
 def test_teclaw_legacy_local_skill_package_storage_uses_workspace_adapter(
     test_injector,
 ):
@@ -239,9 +265,7 @@ def test_legacy_relative_locator_cleanup_resolves_against_bot_local_dir(
         locator="reviewer",
     )
 
-    assert storage._device_directory == (
-        "/bots/project-42/bot-1/skills-local/reviewer"
-    )
+    assert storage._device_directory == ("/bots/project-42/bot-1/skills-local/reviewer")
 
 
 @pytest.mark.parametrize("locator", ["../skills-repo", "skills-local/.."])
@@ -655,7 +679,8 @@ async def test_bot_skill_set_activation_holds_the_layout_edit_lease(test_injecto
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=ActivateResult(success=True, message="ok"))
     activator._activate_skill_set_unlocked = unlocked
@@ -696,7 +721,8 @@ async def test_bot_skill_set_activation_uses_entity_id_for_the_layout_edit_lease
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=ActivateResult(success=True, message="ok"))
     activator._activate_skill_set_unlocked = unlocked
@@ -734,7 +760,8 @@ async def test_bot_skill_set_deactivation_holds_the_layout_edit_lease(test_injec
     guard = _Guard()
     activator._edit_guard = guard
     activator.skill_set_service._bot_repo.get_by_id_and_owner = lambda *_: {
-        "env": "dev", "entity_id": "owner",
+        "env": "dev",
+        "entity_id": "owner",
     }
     unlocked = AsyncMock(return_value=DeactivateResult(success=True, message="ok"))
     activator._deactivate_skill_set_unlocked = unlocked
@@ -837,11 +864,15 @@ async def test_bot_skill_set_switch_and_sync_use_the_resolved_owner_edit_lease(
     assert (await switcher.sync_skill_set_to_active("8", user_id="owner")).success
 
     assert [event[0] for event in guard.events] == [
-        "acquire", "release", "acquire", "release"
+        "acquire",
+        "release",
+        "acquire",
+        "release",
     ]
     assert owner_lookups == [("bot", "owner"), ("bot", "owner")]
     assert [event[1].entity_id for event in guard.events if event[0] == "acquire"] == [
-        "project-42", "project-42"
+        "project-42",
+        "project-42",
     ]
     switch_unlocked.assert_awaited_once_with("7", user_id="owner", proxy_token=None)
     sync_unlocked.assert_awaited_once_with("8", "owner")

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -225,6 +225,37 @@ def test_legacy_bot_bypasses_an_abandoned_pool_edit_lock() -> None:
     assert cache.held
 
 
+@pytest.mark.asyncio
+async def test_legacy_bot_still_serializes_ordinary_edits() -> None:
+    layouts = _Layouts()
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=None,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE,
+        persisted=False,
+    )
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=layouts,
+        participation_resolver=_Participation(
+            participates=False, label="legacy_layout_state"
+        ),
+    )
+
+    first = guard.acquire_for_edit(scope=SCOPE)
+    waiting = asyncio.create_task(
+        guard.acquire_for_edit_wait(scope=SCOPE, timeout_seconds=0.2)
+    )
+    await asyncio.sleep(0.02)
+    assert not waiting.done()
+
+    assert guard.release(first)
+    second = await waiting
+    assert second.token is None
+    assert guard.release(second)
+
+
 def test_cache_outage_is_not_reported_as_lock_contention() -> None:
     guard = SkillsPoolEditGuard(
         cache=_UnavailableCache(),

--- a/src/backend/tests/community/core/skills_pool/test_edit_guard.py
+++ b/src/backend/tests/community/core/skills_pool/test_edit_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
+import logging
 
 import pytest
 
@@ -195,18 +196,25 @@ def test_rollback_starting_after_lock_acquisition_releases_edit_lease() -> None:
     assert cache.held == {}
 
 
-def test_teclaw_bypasses_an_abandoned_pool_edit_lock() -> None:
+def test_legacy_bot_bypasses_an_abandoned_pool_edit_lock() -> None:
     cache = _Cache()
+    layouts = _Layouts()
+    layouts.state = replace(
+        layouts.state,
+        active_layout=SkillLayout.LEGACY,
+        target_layout=None,
+        phase=SkillLayoutPhase.LEGACY_ACTIVE,
+        persisted=False,
+    )
     guard = SkillsPoolEditGuard(
         cache=cache,
-        layout_repository=_Layouts(),
+        layout_repository=layouts,
         participation_resolver=_Participation(
-            participates=False, label="teclaw_no_pool_layout"
+            participates=False, label="legacy_layout_state"
         ),
     )
-    # Simulates a previous worker acquiring the legacy generic lock and then
-    # exiting before its finally block.  Teclaw never owns Pool rollback, so a
-    # current Teclaw write must not wait for that lock's TTL.
+    # A Legacy Bot never owns Pool rollback, so it must not wait for a generic
+    # lock left by an earlier, wrongly-participating worker.
     abandoned = cache.acquire_lock(guard._key(scope=SCOPE))
     assert abandoned is not None
 
@@ -226,6 +234,30 @@ def test_cache_outage_is_not_reported_as_lock_contention() -> None:
 
     with pytest.raises(SkillsPoolEditLockUnavailableError, match="lock service"):
         guard.acquire_for_edit(scope=SCOPE)
+
+
+def test_lock_lifecycle_logs_key_ttl_token_fingerprint_and_duration(caplog) -> None:
+    caplog.set_level(logging.INFO)
+    guard = SkillsPoolEditGuard(
+        cache=_Cache(),
+        layout_repository=_Layouts(),
+        participation_resolver=_Participation(),
+    )
+
+    lease = guard.acquire_for_edit(scope=SCOPE)
+    assert guard.release(lease)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "lock_acquire" in message
+        and lease.key in message
+        and "ttl_seconds=600" in message
+        and "token_fingerprint=" in message
+        and "duration_ms=" in message
+        and "outcome=acquired" in message
+        for message in messages
+    )
+    assert any("lock_release" in message and "outcome=released" in message for message in messages)
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_participation.py
+++ b/src/backend/tests/community/core/skills_pool/test_participation.py
@@ -3,73 +3,83 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.skills_pool.participation import (
-    BotEngineSkillLayoutParticipationResolver,
+    BotSkillLayoutStateParticipationResolver,
     SkillLayoutParticipation,
 )
-from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
 from agentclaw.community.di.modules.skills_pool_module import SkillsPoolModule
 
 
 SCOPE = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
-DEFAULT = SkillLayoutParticipation(
-    participates_in_pool_layout=True,
-    label="default_pool_layout",
-)
-NO_POOL = SkillLayoutParticipation(
-    participates_in_pool_layout=False,
-    label="artifact_layout",
-)
 
 
-class _Bots:
-    def __init__(self, bot: dict | None) -> None:
-        self._bot = bot
+class _Layouts:
+    def __init__(
+        self,
+        *,
+        active_layout: SkillLayout = SkillLayout.LEGACY,
+        target_layout: SkillLayout | None = None,
+    ) -> None:
+        self.state = BotSkillLayoutState(
+            scope=SCOPE,
+            active_layout=active_layout,
+            target_layout=target_layout,
+            phase=SkillLayoutPhase.LEGACY_ACTIVE,
+            migration_generation=None,
+            persisted=active_layout is SkillLayout.POOL or target_layout is not None,
+        )
 
-    def get_by_id_and_entity(self, bot_id: str, entity_id: str) -> dict | None:
-        assert (bot_id, entity_id) == (SCOPE.bot_id, SCOPE.entity_id)
-        return self._bot
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        assert scope == SCOPE
+        return self.state
 
 
-def _resolver(bot: dict | None) -> BotEngineSkillLayoutParticipationResolver:
-    return BotEngineSkillLayoutParticipationResolver(
-        bot_repository=_Bots(bot),
-        default=DEFAULT,
-        by_engine={"artifact_engine": NO_POOL},
-    )
-
-
-def test_explicit_engine_policy_controls_layout_participation() -> None:
-    result = _resolver({"env": "pre", "active_engine": "artifact_engine"}).resolve(
-        scope=SCOPE
-    )
-
-    assert result is NO_POOL
+def _resolver(layouts: _Layouts) -> BotSkillLayoutStateParticipationResolver:
+    return BotSkillLayoutStateParticipationResolver(layout_repository=layouts)
 
 
 @pytest.mark.parametrize(
-    "bot",
+    ("active_layout", "target_layout"),
     [
-        None,
-        {"env": "prod", "active_engine": "artifact_engine"},
-        {"env": "pre"},
-        {"env": "pre", "active_engine": 123},
-        {"env": "pre", "active_engine": "unknown_engine"},
+        (SkillLayout.POOL, None),
+        (SkillLayout.LEGACY, SkillLayout.POOL),
     ],
 )
-def test_unknown_or_incomplete_bot_keeps_conservative_default(bot: dict | None) -> None:
-    result = _resolver(bot).resolve(scope=SCOPE)
+def test_pool_or_transitioning_bot_participates_in_edit_lock(
+    active_layout: SkillLayout, target_layout: SkillLayout | None
+) -> None:
+    result = _resolver(
+        _Layouts(active_layout=active_layout, target_layout=target_layout)
+    ).resolve(scope=SCOPE)
 
-    assert result is DEFAULT
+    assert result == SkillLayoutParticipation(
+        participates_in_pool_layout=True,
+        label="pool_layout_state",
+    )
 
 
-def test_module_wires_artifact_engine_policy_outside_shared_guard() -> None:
+def test_legacy_bot_does_not_participate_in_pool_edit_lock() -> None:
+    result = _resolver(_Layouts()).resolve(scope=SCOPE)
+
+    assert result == SkillLayoutParticipation(
+        participates_in_pool_layout=False,
+        label="legacy_layout_state",
+    )
+
+
+def test_module_wires_layout_state_as_the_participation_source() -> None:
     resolver = SkillsPoolModule().skill_layout_participation_resolver(
-        _Bots({"env": "pre", "active_engine": "teclaw"})
+        _Layouts(target_layout=SkillLayout.POOL)
     )
 
     result = resolver.resolve(scope=SCOPE)
 
     assert result == SkillLayoutParticipation(
-        participates_in_pool_layout=False,
-        label="teclaw_no_pool_layout",
+        participates_in_pool_layout=True,
+        label="pool_layout_state",
     )

--- a/src/backend/tests/community/repository/bot/test_bot_restart_lock_repository.py
+++ b/src/backend/tests/community/repository/bot/test_bot_restart_lock_repository.py
@@ -129,3 +129,11 @@ def test_get_if_stale_judges_db_side(repo):
     assert repo.get_if_stale("dev", "ent_c", "bot_c3", 0) is not None
     # Absent row → None regardless of TTL.
     assert repo.get_if_stale("dev", "ent_c", "missing", 0) is None
+
+
+def test_refresh_renews_only_the_owned_lock(repo):
+    lock = repo.acquire("dev", "ent_refresh", "bot_refresh", "owner")
+    assert lock is not None
+
+    assert repo.refresh("dev", "ent_refresh", "bot_refresh", lock.lock_token) is True
+    assert repo.refresh("dev", "ent_refresh", "bot_refresh", "wrong-token") is False

--- a/src/backend/tests/community/repository/bot/test_bot_restart_lock_repository.py
+++ b/src/backend/tests/community/repository/bot/test_bot_restart_lock_repository.py
@@ -4,8 +4,10 @@ Tests the repository behavior with in-memory SQLite — the same single ORM
 body that runs on prod OceanBase, so the UNIQUE guard, token-fenced release,
 and DB-side staleness are exercised against a real database.
 """
-import pytest
 from contextlib import contextmanager
+from datetime import datetime
+
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -137,3 +139,25 @@ def test_refresh_renews_only_the_owned_lock(repo):
 
     assert repo.refresh("dev", "ent_refresh", "bot_refresh", lock.lock_token) is True
     assert repo.refresh("dev", "ent_refresh", "bot_refresh", "wrong-token") is False
+
+
+def test_stale_reap_does_not_delete_a_lock_renewed_after_observation(repo):
+    lock = repo.acquire("dev", "ent_reap", "bot_reap", "owner")
+    assert lock is not None
+    with repo._db.orm_session() as db:
+        db.query(BotRestartLockModel).filter(
+            BotRestartLockModel.id == lock.id
+        ).update({BotRestartLockModel.gmt_modified: datetime(2000, 1, 1)})
+
+    stale = repo.get_if_stale("dev", "ent_reap", "bot_reap", 1)
+    assert stale is not None
+    assert repo.refresh("dev", "ent_reap", "bot_reap", lock.lock_token) is True
+
+    assert repo.release(
+        "dev",
+        "ent_reap",
+        "bot_reap",
+        lock.lock_token,
+        expected_gmt_modified=stale.gmt_modified,
+    ) is False
+    assert repo.get("dev", "ent_reap", "bot_reap") is not None

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -391,6 +391,22 @@ def test_status_callbacks_do_not_reopen_released_binding(repo):
     assert repo.get_by_id(bid).status == "RELEASED"
 
 
+def test_props_update_does_not_reopen_claimed_release(repo):
+    bid = repo.insert_binding(**_binding(status="ACTIVE"))
+    assert repo.claim_binding_release(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    ) is True
+
+    repo.update_device_props(
+        binding_id=bid, props={"destroy_publish_id": "publish-1"}
+    )
+
+    record = repo.get_by_id(bid)
+    assert record.status == "RELEASING"
+    assert record.release_reason == "bot deleted"
+    assert record.device_props["destroy_publish_id"] == "publish-1"
+
+
 def test_update_status_advances_gmt_modified(repo):
     bid = repo.insert_binding(**_binding())
     pre = repo.get_by_id(bid).gmt_modified

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -350,6 +350,14 @@ def test_release_binding_is_soft_delete(repo, db):
     assert rec.gmt_modified > pre  # advanced DB-side
 
 
+def test_claim_binding_release_claims_stopped_binding(repo):
+    bid = repo.insert_binding(**_binding(status="STOPPED"))
+
+    assert repo.claim_binding_release(binding_id=bid) is True
+    assert repo.get_by_id(bid).status == "RELEASED"
+    assert repo.claim_binding_release(binding_id=bid) is False
+
+
 def test_update_status_advances_gmt_modified(repo):
     bid = repo.insert_binding(**_binding())
     pre = repo.get_by_id(bid).gmt_modified

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -366,6 +366,19 @@ def test_claim_binding_release_claims_stopped_binding(repo):
     ) is False
 
 
+def test_release_binding_finalizes_claimed_binding(repo):
+    bid = repo.insert_binding(**_binding(status="ACTIVE"))
+    assert repo.claim_binding_release(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    ) is True
+
+    repo.release_binding(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    )
+
+    assert repo.get_by_id(bid).status == "RELEASED"
+
+
 def test_status_callbacks_do_not_reopen_released_binding(repo):
     bid = repo.insert_binding(**_binding(status="ACTIVE"))
     repo.release_binding(

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -353,9 +353,29 @@ def test_release_binding_is_soft_delete(repo, db):
 def test_claim_binding_release_claims_stopped_binding(repo):
     bid = repo.insert_binding(**_binding(status="STOPPED"))
 
-    assert repo.claim_binding_release(binding_id=bid) is True
+    assert repo.claim_binding_release(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    ) is True
+    record = repo.get_by_id(bid)
+    assert record.status == "RELEASED"
+    assert record.release_reason == "bot deleted"
+    assert record.released_by == "emp-9"
+    assert record.released_at is not None
+    assert repo.claim_binding_release(
+        binding_id=bid, release_reason="retry", released_by="emp-10"
+    ) is False
+
+
+def test_status_callbacks_do_not_reopen_released_binding(repo):
+    bid = repo.insert_binding(**_binding(status="ACTIVE"))
+    repo.release_binding(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    )
+
+    repo.update_status(binding_id=bid, status="FAILED")
+    repo.update_status_and_alive_at(binding_id=bid, status="ACTIVE")
+
     assert repo.get_by_id(bid).status == "RELEASED"
-    assert repo.claim_binding_release(binding_id=bid) is False
 
 
 def test_update_status_advances_gmt_modified(repo):

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -357,7 +357,7 @@ def test_claim_binding_release_claims_stopped_binding(repo):
         binding_id=bid, release_reason="bot deleted", released_by="emp-9"
     ) is True
     record = repo.get_by_id(bid)
-    assert record.status == "RELEASED"
+    assert record.status == "RELEASING"
     assert record.release_reason == "bot deleted"
     assert record.released_by == "emp-9"
     assert record.released_at is not None

--- a/src/backend/tests/community/repository/devices/test_device_repository_unified.py
+++ b/src/backend/tests/community/repository/devices/test_device_repository_unified.py
@@ -391,6 +391,23 @@ def test_status_callbacks_do_not_reopen_released_binding(repo):
     assert repo.get_by_id(bid).status == "RELEASED"
 
 
+def test_publish_activation_restores_only_unclaimed_release(repo):
+    bid = repo.insert_binding(**_binding(status="RELEASED"))
+
+    assert repo.activate_publish_binding(binding_id=bid) is True
+    assert repo.get_by_id(bid).status == "ACTIVE"
+
+
+def test_publish_activation_does_not_restore_claimed_release(repo):
+    bid = repo.insert_binding(**_binding(status="ACTIVE"))
+    repo.release_binding(
+        binding_id=bid, release_reason="bot deleted", released_by="emp-9"
+    )
+
+    assert repo.activate_publish_binding(binding_id=bid) is False
+    assert repo.get_by_id(bid).status == "RELEASED"
+
+
 def test_props_update_does_not_reopen_claimed_release(repo):
     bid = repo.insert_binding(**_binding(status="ACTIVE"))
     assert repo.claim_binding_release(


### PR DESCRIPTION
## What changed

- Atomically claim a releasable device binding in the database before invoking provider destruction.
- Treat an already released binding as an idempotent release result.
- Add regression coverage for the losing concurrent caller, which must not invoke physical release.

## Root cause

Two DELETE requests could both observe an ACTIVE binding before either performed the physical BaaS destroy. The later request then failed after the first changed the binding to RELEASED.

## Validation

- `pytest tests/community/core/devices/services/test_device_service.py tests/community/repository/devices/test_device_repository_unified.py -q`
- `pytest tests/community/core/bot_management/services/test_delete_default_bot.py tests/community/core/bot_management/services/test_bot_service_search_bots.py tests/community/core/bot_management/services/test_bot_service_misc.py tests/community/adapters/http/openapi_v1/test_bots_endpoints.py -q`