### PR TITLE
fix(bot_runtime)

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -688,12 +688,14 @@ class AsyncChatClient:
         chat_state = payload.get("state", "")
         event_run_id = payload.get("runId") or payload.get("run_id")
         message = payload.get("message", {})
-        content = message.get("content", [])
+        contents = message.get("content", [])
 
         # 提取文本内容
         text = ""
-        if content and len(content) > 0:
-            text = content[0].get("text", "")
+        for content in contents:
+            if content.get("text") is not None:
+                text = content.get("text")
+                break
 
         # No state associated with this session key
         if state is None:

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -469,6 +469,74 @@ class TestOnChatAdditional:
         assert chunk.type == "final"
         assert chunk.content == "final text"
 
+    @pytest.mark.asyncio
+    async def test_on_chat_picks_first_text_content(self, mock_bot_ws):
+        """When contents has multiple elements, _on_chat uses the first
+        one whose ``text`` field is not None (loop breaks on first hit)."""
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_chat(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "message": {
+                    "content": [
+                        {"text": "first"},
+                        {"text": "second"},
+                    ]
+                },
+            }
+        )
+        await asyncio.sleep(0)
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.content == "first"
+        assert state.content == "first"
+
+    @pytest.mark.asyncio
+    async def test_on_chat_skips_content_without_text(self, mock_bot_ws):
+        """Content elements without a ``text`` field are skipped; the
+        first element with ``text`` is used."""
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_chat(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "message": {
+                    "content": [
+                        {"type": "image", "url": "http://x/y.png"},
+                        {"text": "real text"},
+                    ]
+                },
+            }
+        )
+        await asyncio.sleep(0)
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.content == "real text"
+
+    @pytest.mark.asyncio
+    async def test_on_chat_empty_contents_yields_empty_text(self, mock_bot_ws):
+        """When message.content is empty or has no text field, text stays ""."""
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_chat(
+            {
+                "sessionKey": "sk1",
+                "state": "final",
+                "message": {"content": []},
+            }
+        )
+        await asyncio.sleep(0)
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.content == ""
+        assert state.content == ""
+
 
 # ==================== _on_agent additional branches ====================
 


### PR DESCRIPTION
## Problem

`_on_chat` 用 `content[0].get("text", "")` 硬取 message.content 的首元素文本。
当 Engine 下发的 content 数组首元素不含 ``text`` 字段（如 type=image 的元素排在前面，
text 元素排在后面），text 被错误地设为空串。导致 final 事件透传给下游（SSE /
非流式调用方）的最终文本缺失，用户收不到完整回复。

## Solution

把单元素下标取值改为遍历 contents 列表，命中第一个 ``text`` 字段非 None 的元素
即 break：

```python
text = ""
for content in contents:
    if content.get("text") is not None:
        text = content.get("text")
        break
被否决的替代方案：用 "".join 拼接所有 text 元素。未采纳——BCS 协议语义中
content 数组只有一个 text 元素承载最终文本，其余元素是 image/attachment 等非文
本内容；拼接会产生无意义串接。取首个 text 元素既符合协议语义又对乱序输入健壮。

Validation
新增 4 个单测覆盖多 content 场景：
多个 text 元素取第一个（test_on_chat_picks_first_text_content）
跳过无 text 字段的元素（test_on_chat_skips_content_without_text）
空 contents 列表返回空串（test_on_chat_empty_contents_yields_empty_text）
原有单元素场景回归（test_on_chat_final_emits_stream_chunk 等）
覆盖率测试文件 83 passed（0.75s），无回归。
Compatibility and risk
无接口/协议变更：text 提取逻辑纯内部，不影响 payload 解析或下游契约。
回滚路径：还原为 text = content[0].get("text", "") 即可恢复旧行为。