### PR TITLE
feat(baas): add OpenAPI session listing endpoint

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -209,3 +209,31 @@ class SessionMessagesResponse(ApiResponse[SessionMessagesResponseData]):
     data: SessionMessagesResponseData | None = Field(
         default=None, description="Session message data"
     )
+
+
+class SessionListItem(BaseModel):
+    """Session list item for the session listing endpoint."""
+
+    session_id: str = Field(..., description="Session ID")
+    bot_id: str = Field(..., description="Bot ID")
+    status: str = Field(..., description="Session status")
+    created_at: datetime | None = Field(default=None, description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Update time")
+
+
+class SessionListResponseData(BaseModel):
+    """Session list response data."""
+
+    items: list[SessionListItem] = Field(
+        default_factory=list, description="Session list"
+    )
+    total: int = Field(default=0, description="Total sessions")
+    has_more: bool = Field(default=False, description="Whether there are more sessions")
+
+
+class SessionListResponse(ApiResponse[SessionListResponseData]):
+    """Session list standard response"""
+
+    data: SessionListResponseData | None = Field(
+        default=None, description="Session list data"
+    )

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
@@ -14,6 +14,9 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     MessageItem,
+    SessionListResponse,
+    SessionListResponseData,
+    SessionListItem,
     SessionMessagesResponse,
     SessionMessagesResponseData,
     SessionQueryResponse,
@@ -49,6 +52,150 @@ def _check_app_type(api_key_record: APIKeyRecord) -> None:
                 "code": OpenAPICode.FORBIDDEN,
                 "message": get_code_message(OpenAPICode.FORBIDDEN),
             },
+        )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="List sessions",
+    description="List sessions for a specified Bot using a Bearer Token-authenticated API Key",
+    responses={
+        200: {"description": "Query successful"},
+        401: {"description": "Authentication failed"},
+        403: {"description": "Access denied"},
+        404: {"description": "Bot not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+@inject
+async def list_sessions(
+    bot_id: str | None = Query(
+        default=None,
+        description="Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+    ),
+    lifecycle_stage: str = Query(
+        default="online",
+        description="Bot lifecycle stage. Options: online, verify, draft, all",
+    ),
+    limit: int = Query(
+        default=20, ge=1, le=100, description="Maximum number of sessions to return"
+    ),
+    offset: int = Query(
+        default=0, ge=0, description="Offset for pagination"
+    ),
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    context: BotChatContext = Depends(get_bot_chat_context),
+    bot_runner: BotRunner = Depends(Provide[ApplicationContainer.services.bot_runner]),
+) -> SessionListResponse:
+    """List sessions endpoint
+
+    Args:
+        bot_id: Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.
+        lifecycle_stage: Bot lifecycle stage. Options: online, verify, draft, all. Default: online
+        limit: Maximum number of sessions to return. Default 20, range 1-100
+        offset: Offset for pagination. Default 0
+        api_key_record: Record obtained from API Key validation
+        context: Request context (authentication, caller identity, etc.)
+        bot_runner: BotRunner instance
+
+    Returns:
+        SessionListResponse: Session list response
+    """
+    # Only app_type=bot can resolve bot_id from the API Key; other types must pass it explicitly
+    if bot_id:
+        resolved_bot_id = bot_id
+    elif api_key_record.app_type == "bot":
+        resolved_bot_id = resolve_bot_id_from_api_key(api_key_record)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": "bot_id is a required parameter",
+            },
+        )
+
+    _check_app_type(api_key_record)
+    if api_key_record.app_type != "bot":
+        resolved_bot_id = validate_policy(api_key_record, resolved_bot_id)
+
+    logger.info(
+        f"list_sessions: bot_id={resolved_bot_id}, "
+        f"lifecycle_stage={lifecycle_stage}, limit={limit}, offset={offset}, "
+        f"api_key_prefix={api_key_record.api_key_prefix}"
+    )
+
+    try:
+        sessions = await bot_runner.list_sessions(
+            bot_id=resolved_bot_id,
+            context=context,
+            metadata={"bot_options": {"lifecycle_stage": lifecycle_stage}},
+            limit=limit,
+            offset=offset,
+        )
+
+        # Determine if there are more results
+        total = len(sessions)
+        has_more = total > limit
+        items = [
+            SessionListItem(
+                session_id=s.session_id,
+                bot_id=s.bot_id,
+                status=s.status,
+                created_at=s.created_at,
+                updated_at=s.updated_at,
+            )
+            for s in sessions[:limit]
+        ]
+
+        logger.info(
+            f"list_sessions success: bot_id={resolved_bot_id}, "
+            f"total={total}, returned={len(items)}, has_more={has_more}"
+        )
+
+        return SessionListResponse(
+            code=0,
+            message="success",
+            data=SessionListResponseData(
+                items=items,
+                total=total,
+                has_more=has_more,
+            ),
+        )
+
+    except BotBindingNotFoundError as e:
+        logger.warning(
+            f"list_sessions binding not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotNotFoundError as e:
+        logger.warning(
+            f"list_sessions bot not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotServiceError as e:
+        logger.error(
+            f"list_sessions bot service error: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": OpenAPICode.BUSINESS_ERROR, "message": str(e)},
+        )
+    except Exception as e:
+        logger.error(
+            f"list_sessions unexpected error: bot_id={resolved_bot_id}, error={e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": 50001, "message": f"Internal server error: {str(e)}"},
         )
 
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -404,6 +404,31 @@ class BotRunner(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: "BotChatContext",
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list["SessionInfo"]:
+        """查询指定 Bot 下的会话列表
+
+        复用 get_session / get_messages 同一套 AsyncSessionClient 链路。
+
+        Args:
+            bot_id: Bot 唯一标识，格式为 <real_bot_id>:<entity_id>
+            context: 请求上下文
+            metadata: 元数据，支持 bot_options.lifecycle_stage 指定生命周期阶段
+            limit: 返回数量上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            会话信息列表
+        """
+        ...
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -659,6 +659,65 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 Bot 下的会话列表
+
+        通过 AsyncSessionClient 从 adapter 侧查询会话列表。
+
+        Args:
+            bot_id: Bot 唯一标识
+            binding_info: Binding info for HTTP connection.
+            context: Optional request context for tenant extraction.
+            limit: 返回数量上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            会话信息列表
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        try:
+            conn_info = await self._resolve_ws_connection_for_binding(
+                binding_info, context
+            )
+        except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
+
+        session_client = self._create_session_client(
+            conn_info, binding_info.engine_type
+        )
+        try:
+            async with session_client:
+                sessions = await session_client.list_sessions(
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_info(s, binding_info.bot_id)
+                    for s in sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -433,6 +433,54 @@ class ClawBotService(BotService):
         except Exception as e:
             raise BotServiceError(f"Failed to get session: {e}") from e
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 Bot 下的会话列表
+
+        通过 AsyncSessionClient 从 adapter 侧查询会话列表。
+
+        Args:
+            bot_id: Bot 唯一标识
+            binding_info: Binding info for HTTP connection.
+            context: Optional request context (unused in ClawBotService).
+            limit: 返回数量上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            会话信息列表
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        sandbox_id = binding_info.sandbox_id
+        if sandbox_id is None:
+            raise BotServiceError("ClawBotService requires sandbox_id in binding_info.")
+
+        session_client = self._create_session_client(sandbox_id)
+        try:
+            async with session_client:
+                sessions = await session_client.list_sessions(
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_info(s, binding_info.bot_id)
+                    for s in sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            raise BotServiceError(f"Failed to list sessions: {e}") from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -183,6 +183,29 @@ class BotService(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 Bot 下的会话列表
+
+        Args:
+            bot_id: Bot 唯一标识
+            binding_info: 已解析的 binding 信息
+            context: 可选的请求上下文
+            limit: 返回数量上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            会话信息列表
+        """
+        ...
+
 
 @runtime_checkable
 class MessageDispatcher(Protocol):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -440,6 +440,39 @@ class BotRunner:
             context=context,
         )
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: BotChatContext,
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 Bot 下的会话列表
+
+        复用 get_session / get_messages 同一套 AsyncSessionClient 链路，
+        通过 _resolve_bot_route 解析 binding 后调用 bot_service.list_sessions。
+
+        Args:
+            bot_id: Bot 唯一标识
+            context: 请求上下文
+            metadata: 元数据
+            limit: 返回数量上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            会话信息列表
+        """
+        route = await self._resolve_bot_route(bot_id, metadata)
+        return await route.bot_service.list_sessions(
+            bot_id=bot_id,
+            binding_info=route.binding_info,
+            context=context,
+            limit=limit,
+            offset=offset,
+        )
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -19,6 +19,7 @@ from secbaas.community.adapters.web.routers.open_api.session_router import (
     _check_app_type,
     get_session,
     get_session_messages,
+    list_sessions,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
 from secbaas.community.api.bot_runtime import (
@@ -932,3 +933,282 @@ class TestGetSessionMessages:
         assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert exc.value.detail["code"] == 50001
         assert "Internal server error" in exc.value.detail["message"]
+
+
+# ── list_sessions ─────────────────────────────────────────────
+
+
+class TestListSessions:
+    """list_sessions 端点核心逻辑测试。"""
+
+    DEFAULT_LIST_LIMIT = 20
+    DEFAULT_LIST_OFFSET = 0
+
+    @pytest.mark.asyncio
+    async def test_success_returns_session_list(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            return_value=[
+                _make_session_info(session_id="sess-001"),
+                _make_session_info(session_id="sess-002"),
+            ]
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.message == "success"
+        assert len(result.data.items) == 2
+        assert result.data.items[0].session_id == "sess-001"
+        assert result.data.items[1].session_id == "sess-002"
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_success_empty_list(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.data.items == []
+        assert result.data.total == 0
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_has_more_when_results_exceed_limit(self):
+        sessions = [_make_session_info(session_id=f"sess-{i:03d}") for i in range(5)]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=3,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.total == 5
+        assert result.data.has_more is True
+        assert len(result.data.items) == 3
+
+    @pytest.mark.asyncio
+    async def test_bot_app_type_resolves_from_api_key(self):
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-1:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(RESOLVE_PATH, return_value=BOT_ID) as mock_resolve,
+            patch(POLICY_PATH),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_resolve.assert_called_once_with(api_key)
+
+    @pytest.mark.asyncio
+    async def test_system_app_type_without_bot_id_returns_400(self):
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_app_type_returns_403(self):
+        api_key = _make_api_key_record(app_type="user")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_bot_binding_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotBindingNotFoundError(BOT_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=self.DEFAULT_LIST_LIMIT,
+                    offset=self.DEFAULT_LIST_OFFSET,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotNotFoundError("bot-1"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=self.DEFAULT_LIST_LIMIT,
+                    offset=self.DEFAULT_LIST_OFFSET,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_returns_400(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotServiceError("service unavailable"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=self.DEFAULT_LIST_LIMIT,
+                    offset=self.DEFAULT_LIST_OFFSET,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_500(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=self.DEFAULT_LIST_LIMIT,
+                    offset=self.DEFAULT_LIST_OFFSET,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @pytest.mark.asyncio
+    async def test_bot_type_skips_validate_policy(self):
+        api_key = _make_api_key_record(app_type="bot", app_id=BOT_ID)
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(POLICY_PATH) as mock_policy,
+            patch(RESOLVE_PATH, return_value=BOT_ID),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_system_type_calls_validate_policy(self):
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID) as mock_policy:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_called_once_with(api_key, BOT_ID)
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_stage_passed_to_runner(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage="draft",
+                limit=self.DEFAULT_LIST_LIMIT,
+                offset=self.DEFAULT_LIST_OFFSET,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once_with(
+            bot_id=BOT_ID,
+            context=_make_context(),
+            metadata={"bot_options": {"lifecycle_stage": "draft"}},
+            limit=self.DEFAULT_LIST_LIMIT,
+            offset=self.DEFAULT_LIST_OFFSET,
+        )


### PR DESCRIPTION
## Summary

Add `GET /openapi/v1/sessions` endpoint to query session list for a specified bot_id.

- New endpoint with same auth/policy chain as existing session endpoints
- Supports pagination via `limit` (1-100, default 20) and `offset` (default 0)
- Bot-type API Keys can resolve bot_id from the key; other types must pass it explicitly
- Returns `items` array with session_id, bot_id, status, created_at, updated_at
- `has_more` boolean for cursor-style pagination

## Changes

| Layer | File | Change |
|-------|------|--------|
| Protocol | `_protocols.py` | Add `list_sessions` to `BotRunner` Protocol |
| Protocol | `_internal_protocols.py` | Add `list_sessions` to `BotService` Protocol |
| Service | `_runner.py` | Implement `BotRunner.list_sessions` |
| Service | `_baas_service.py` | Implement `BaasBotService.list_sessions` |
| Service | `_claw_service.py` | Implement `ClawBotService.list_sessions` |
| Router | `model.py` | Add `SessionListItem`, `SessionListResponseData`, `SessionListResponse` |
| Router | `session_router.py` | Add `list_sessions` endpoint |
| Tests | `test_session_router.py` | 14 new unit tests (55/55 pass) |

## Auth and Error Handling

- Bot-type API Key: skip `validate_policy` (self-bound)
- System/app API Key: must pass `validate_policy` on 403 on deny
- Missing bot_id for non-bot type on 400
- BotBindingNotFoundError / BotNotFoundError on 404
- BotServiceError on 400
- Unexpected on 500

## Test Plan

- [x] 14 new TestListSessions unit tests pass
- [x] All 55 session router tests pass
- [x] No regressions in existing session endpoints