### PR TITLE
fix(baas): target ARCA TTL at now+23h to stay under 24h cap

### DIFF
--- a/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_arca_paas_service.py
@@ -901,7 +901,7 @@ class ArcaPaasService(PaasService):
             raise self._translate_error(e, ErrorCode.DEVICE_UNAVAILABLE)
 
     async def update_device_ttl(self, paas_device_id: str) -> TTLInfo:
-        """Extend device TTL - target is now() + 24 hours (Arca platform limit).
+        """Extend device TTL - target is now() + 23 hours (under Arca's 24h cap + skew headroom).
 
         Args:
             paas_device_id: Arca sandbox ID (without @tenant_id suffix).
@@ -924,7 +924,9 @@ class ArcaPaasService(PaasService):
         )
 
         now = datetime.now()
-        target_expiration = now + timedelta(hours=24)  # Arca platform limit
+        target_expiration = now + timedelta(
+            hours=23
+        )  # under Arca's 24h cap + skew headroom
 
         self._logger.info(
             f"[update_device_ttl] Extending TTL for {sandbox_id}, target={target_expiration}"

--- a/src/baas/tests/unit/core/service/paas/test_arca_paas_service_coverage.py
+++ b/src/baas/tests/unit/core/service/paas/test_arca_paas_service_coverage.py
@@ -1271,8 +1271,31 @@ class TestUpdateDeviceTtl:
         assert result.paas_device_id == "dev-001"
         assert result.old_expiration_time is not None
         assert result.new_expiration_time is not None
-        # New expiration should be ~24 hours from now
+        # New expiration should be ~23 hours from now
         assert result.new_expiration_time > result.old_expiration_time
+
+    def test_update_device_ttl_sync_target_points_to_now_plus_23h(
+        self, service, mock_sandbox
+    ):
+        """The requested TTL target is now() + 23h (headroom under Arca's 24h cap)."""
+        old_expiration = datetime.now() - timedelta(hours=1)
+        old_ts = int(old_expiration.timestamp() * 1000)
+        info = _make_sandbox_info(ttl_timestamp=old_ts)
+        mock_sandbox.get_info.return_value = info
+        mock_sandbox.extend_ttl.return_value = True
+
+        service._update_device_ttl_sync("dev-001")
+
+        # target = now() + 23h; ttl_minutes = (target - old) truncated to whole minutes.
+        # Recompute after the call; bound the drift to ±1 minute.
+        now = datetime.now()
+        target_expiration = now + timedelta(hours=23)
+        expected_minutes = int(
+            (target_expiration - old_expiration).total_seconds() / 60
+        )
+        actual = mock_sandbox.extend_ttl.call_args[0][0]
+        assert abs(actual - expected_minutes) <= 1
+        assert actual > 0
 
     def test_update_device_ttl_sync_with_at_suffix(self, service, mock_sandbox):
         """Test with @template_id suffix in paas_device_id."""


### PR DESCRIPTION
## Problem

The Arca platform rejects TTL extension requests when the requested absolute TTL exceeds its max-allowed cap (currently 24h from the sandbox's current TTL). Observed error:

```
ERROR ArcASandboxServiceImpl - TTL timestamp exceeds max allowed ttl ... requested: 1787052938000, maxAllowed: 1787051835886
```

The locally-computed `now + 24h` target leaves zero headroom against Arca's `current + 24h` cap, so any clock/anchor drift pushes the requested timestamp past the cap and the renewal fails.

## Solution

Reduce the extension target from `now + 24h` to `now + 23h`. This keeps the requested absolute TTL comfortably under Arca's 24h cap while still topping devices back up after the `extend_when_remaining_hours` (default 16h) gate.

## Validation

- Unit tests for the ARCA PaaS service pass (existing assertions are relative, not tied to the exact 24h target).
- No contract/schema/config changes.
- Deployed behavior requires a live Arca sandbox (not run here).

## Compatibility and risk

Behavioral change only: devices are topped up to `now + 23h` instead of `now + 24h`. Rollback is a one-line revert of the target constant.