### PR TITLE
feat(bcs-channel): add /new slash command to archive session and start fresh

### DIFF
--- a/docs/superpowers/plans/2026-08-17-channel-new-command.md
+++ b/docs/superpowers/plans/2026-08-17-channel-new-command.md
@@ -1,0 +1,81 @@
+# BCS Channel `/new` 命令：归档当前会话并开启全新会话
+
+> 状态：已实现（2026-08-17，worktree `bcs-channel-new-command`）
+> 设计/分析过程见本文档；实现位于 `src/bcs/crates/services/bcs-channel/src/commands.rs` + `lib.rs` 挂载点。
+
+## Context
+
+Channel（钉钉等 IM）用户的 chat session 一旦创建就**永不自动结束**（timeout_scanner 只覆盖 service_invocation，chat 会话无超时），同一 IM 会话里的消息永远进入同一个 BCS session，上下文无限累积。`/new` 让用户主动开启全新会话。
+
+**需求语义**（与需求方确认）：
+1. `/new` 后旧会话**归档**（Running → Completed，历史保留可查），后续消息进入全新会话
+2. **所有 channel 统一支持** —— 在 bcs-channel 服务层实现（DingTalk provider 在仓库外）
+3. 当前会话有 agent run 在途时**排队等待**：先回复"任务运行中"，run 结束后自动执行切换
+
+## 关键架构事实
+
+- **唯一拦截点**：`BcsChannelService::handle_inbound`（`bcs-channel/src/lib.rs`），所有 channel 文本消息的唯一入口
+- **session id 构造**：`new_session_id`（`bcs-service-api/src/core/session.rs`）= `{group_id}:{8位随机hex}`。`/new` 不改变构造规则也不改 group_id —— 下一条消息走既有 `sessions.create` 生成"同 group 前缀 + 新随机后缀"的 id；新 id 天然带来映射覆盖、bot 侧隔离（`session_key = session_id`，bcs-message-flow/group_flow.rs）、历史按旧 id 保留的效果
+- **归档原语**：`SessionRepoPort::complete_if_running`（CAS，幂等，保留 bcs_messages 历史）
+- **懒 rollover**：映射原地保留作为触发器；`resolve_or_create_chat_session` / `start_state_machine_from_inbound` 在映射指向的 session 非 Running 时自动创建新 session 并 upsert 重指映射，无需 `delete_if_session`
+- **Run 终态信号**：
+  - chat run → `ChatFinal`（或 `System`+`purpose:Conversation`+`raw_payload.state ∈ {"error","aborted"}`，见 bcs-message-flow/bot_event.rs `channel_event_kind`/`try_channel_outbound`）流经 `try_outbound`
+  - state-machine run → `publish_state_machine_terminal` 每次终态必被调用（即使无 IM 通知），**不**经过 try_outbound —— 两个 hook 点都要
+- **旧会话迟到回复仍可送达**：`try_outbound` 经 `list_by_bcs_session` + `channel_route_from_session_meta` 兜底，归档不打断在途 run 的回复投递
+
+## 实现
+
+### `commands.rs`（新文件）
+
+- `parse_channel_command`：仅精确匹配 `text.trim() == "/new"`；match 结构便于后续扩展
+- `SessionResetTracker`（仿 `InboundDedupGuard` 的 tokio Mutex + FIFO 有界）：
+  - `seed_runs`（dispatch 后播种 active_run_ids）、`active_run_ids`（/new 时快照）
+  - `begin_pending`（同 conversation 幂等）、`take_pending`（竞态闭合用）、`take_pending_if_stale`（30min bot 假死兜底）、`observe_run_terminal`（终态扣减 waiting_on，清空时返回待执行重置）
+  - **快照语义**：/new 之后新起的 run 不延长等待
+- `impl BcsChannelService`：
+  - `try_execute_channel_command`：解析 → resolve_inbound_context → 分发；位于 `try_consume_human_input` **之前**（HumanInput 卡片不得吞掉 /new）
+  - `execute_new_session`：重复 /new 幂等重答 → 无会话答 NOTHING → state-machine <30s 启动窗口答"流程正在启动" → 收集 waiting_on（chat 快照 + SM run 视图）→ 空则立即执行，否则登记 pending 并**重查竞态闭合**后答 QUEUED
+  - `execute_session_reset`：持 `chat_session_resolution_lock` 复查映射仍指向旧会话 → `complete_if_running`（output `{"reason":"channel_command_new"}`）→ provider 直接投递确认（仿 `deliver_human_input_event`；失败仅 warn!，归档已持久化；binding 下线则跳过回复）
+  - `observe_outbound_terminal` / `observe_state_machine_terminal` / `maybe_execute_stale_reset`（30min 兜底，入站顺带执行，无后台扫描器）
+- 回复经 **provider 直接投递**而非 try_outbound：无会话场景（/new 为首条消息）没有可供路由的 session；`kind: System`、`purpose: HumanInputAck`、`raw_payload: {"type":"channel.command","command":"new"}`、`source_im_message_id` 指向 /new 的 msg_id
+
+### `lib.rs` 挂载点（8 处，无重构）
+
+1. `mod commands;`；2. struct + 构造函数增加 `session_reset_tracker` / `chat_session_resolution_lock`（签名不变）；
+3. `handle_inbound` 在 actor 解析后、`try_consume_human_input` 前插入命令拦截（dedup 失败忘记机制自然覆盖命令失败）；
+4. context 解析后插入 `maybe_execute_stale_reset`；
+5. `resolve_or_create_chat_session` + `conversations.upsert` 包入 `chat_session_resolution_lock`（关闭"并发消息同见 Completed 双双建会话"竞态；dispatch 在锁外）；
+6. dispatch 成功后 `seed_runs`；
+7. `try_outbound` 在 `source_is_channel` 守卫后调 `observe_outbound_terminal`（所有提前 return 之前）；
+8. `publish_state_machine_terminal` 首句调 `observe_state_machine_terminal`。
+
+### 回复文案
+
+| 场景 | 文案 |
+|---|---|
+| 重置完成（即时/deferred） | `已开启全新会话，此前的聊天记录已归档。` |
+| 已排队（含重复 /new 幂等回复） | `当前任务仍在运行中，任务结束后将自动开启新会话。` |
+| 无会话可重置 | `当前没有进行中的会话，直接发送消息即可开始新会话。` |
+| state-machine 启动窗口 | `流程正在启动，请稍后再试。`（复用现有文案） |
+
+### 明确的取舍 / 边界
+
+- 群聊 /new 仍需 @bot（沿用既有丢弃逻辑）；per-sender scope 只重置发送者自己的会话；conversation-shared scope 任何成员可重置共享会话
+- pending 与 tracker 为进程内存：重启丢失 → 重启后 /new 立即执行（迟到回复仍可送达），v1 不做 DB 持久化
+- /new 排队期间用户新消息继续进入旧会话（不阻塞）
+- 不清理旧会话的 HumanInputRequest 行（按既有 expire/fail 逻辑自然收场）
+- 并发 /new 的回复组合不确定（赢家 DONE；输家看到 Completed 答 NOTHING），不变量：恰好各答一条、只归档一次
+- 集成风险（上线前验证）：无会话场景的确认回复 `bcs_session_id` 传 `""`，需确认仓库外 DingTalk provider 容忍
+
+## 测试
+
+- `commands.rs` 12 个单测：解析器（精确匹配/空白容忍/拒绝变体）；tracker（seed→drain、未知 run no-op、重复终态幂等、多 run 等待、重复 pending 拒绝、stale 阈值、FIFO 驱逐、take_pending）
+- `lib.rs` 12 个集成测试：无会话 / 空闲即时重置+dedup 重放+rollover / 排队+ChatFinal / error 终态 / per-sender 隔离 / shared 群 / state-machine 三态（空闲立即、Running 排队+终态执行、启动窗口）/ HumanInput 不吞 /new / 并发幂等+恰好一个新会话 / 30min stale 兜底
+- harness 扩展：`RecordingMessageFlow.active_run_ids` 可配置；`TestHarness::new_with_clock` 支持可变时钟
+
+## 验证
+
+- `cargo test --package bcs-channel`：83 通过（59 基线 + 24 新增）
+- 并发测试重复 5 次稳定
+- `cargo test --workspace` 回归
+- 钉钉联调（内部 provider 环境）待进行：单聊/群聊 @bot 全流程 + 空 `bcs_session_id` 回复兼容性

--- a/src/bcs/crates/services/bcs-channel/src/commands.rs
+++ b/src/bcs/crates/services/bcs-channel/src/commands.rs
@@ -1,0 +1,815 @@
+//! Channel(IM)slash 命令拦截：`/new` 会话重置。
+//!
+//! 当前仅支持 `/new`：归档当前会话（Running → Completed，历史保留），
+//! 后续消息经既有 lazy rollover 自动创建全新会话。解析器为 match 结构，
+//! 后续命令（/help 等）在这里扩展。
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+use bcs_domain::{ChannelBinding, SessionScope};
+use bcs_service_api::application::channel::{
+    ChannelUseCaseError, InboundMessage, OutboundMessage,
+};
+use bcs_service_api::StateMachineTerminalEvent;
+
+use crate::{BcsChannelService, ResolvedInboundContext};
+
+/// 排队重置的兜底过期：bot 假死导致终态事件永远不到达时，
+/// 由下一条入站消息顺带执行超过该阈值的排队重置。
+pub(crate) const PENDING_RESET_STALE_MS: u64 = 1_800_000;
+
+pub(crate) const RESET_DONE_TEXT: &str = "已开启全新会话，此前的聊天记录已归档。";
+pub(crate) const RESET_QUEUED_TEXT: &str = "当前任务仍在运行中，任务结束后将自动开启新会话。";
+pub(crate) const NOTHING_TO_RESET_TEXT: &str = "当前没有进行中的会话，直接发送消息即可开始新会话。";
+pub(crate) const STATE_MACHINE_STARTING_TEXT: &str = "流程正在启动，请稍后再试。";
+
+/// 识别出的 channel 命令。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChannelCommand {
+    NewSession,
+}
+
+/// 仅精确匹配（去首尾空白）；`/new foo`、`//new` 视为普通消息。
+pub(crate) fn parse_channel_command(text: &str) -> Option<ChannelCommand> {
+    match text.trim() {
+        "/new" => Some(ChannelCommand::NewSession),
+        _ => None,
+    }
+}
+
+/// 排队中的会话重置请求（等待在途 run 结束）。
+#[derive(Debug, Clone)]
+pub(crate) struct PendingSessionReset {
+    pub(crate) old_session_id: String,
+    pub(crate) binding_id: String,
+    pub(crate) im_conversation_id: String,
+    pub(crate) im_conversation_type: String,
+    pub(crate) session_scope: SessionScope,
+    pub(crate) im_user_id: Option<String>,
+    pub(crate) source_im_message_id: String,
+    /// `/new` 时刻快照的在途 run 集合；之后新起的 run 不延长等待。
+    pub(crate) waiting_on: HashSet<String>,
+    pub(crate) requested_at_ms: u64,
+}
+
+/// channel 层 chat run 在途跟踪 + 排队重置记录。
+///
+/// chat run 只在 dispatch 时（`handle_web_send` 返回 active_run_ids）和
+/// 终态事件经过 `try_outbound`（ChatFinal / error / aborted）时可见，
+/// 因此在 channel 层自行维护快照，不跨 crate 新增查询 API。
+pub(crate) struct SessionResetTracker {
+    state: Mutex<SessionResetState>,
+    active_run_limit: usize,
+}
+
+#[derive(Default)]
+struct SessionResetState {
+    /// session_id -> 在途 chat run 集合。
+    active_runs: HashMap<String, HashSet<String>>,
+    /// run_id -> session_id 反向索引。
+    run_sessions: HashMap<String, String>,
+    /// run 播种顺序（FIFO 驱逐用）。
+    run_order: VecDeque<String>,
+    /// conversation_key -> 排队中的重置。
+    pending: HashMap<String, PendingSessionReset>,
+}
+
+impl SessionResetTracker {
+    pub(crate) fn new(active_run_limit: usize) -> Self {
+        Self {
+            state: Mutex::new(SessionResetState::default()),
+            active_run_limit,
+        }
+    }
+
+    /// dispatch 成功后播种该 session 新起的 run。
+    pub(crate) async fn seed_runs(&self, session_id: &str, run_ids: &[String]) {
+        let mut state = self.state.lock().await;
+        for run_id in run_ids {
+            if run_id.is_empty() {
+                continue;
+            }
+            state
+                .active_runs
+                .entry(session_id.to_string())
+                .or_default()
+                .insert(run_id.clone());
+            state
+                .run_sessions
+                .insert(run_id.clone(), session_id.to_string());
+            state.run_order.push_back(run_id.clone());
+        }
+        while state.run_order.len() > self.active_run_limit {
+            let Some(oldest) = state.run_order.pop_front() else {
+                break;
+            };
+            if let Some(session_id) = state.run_sessions.remove(&oldest)
+                && let Some(runs) = state.active_runs.get_mut(&session_id)
+            {
+                runs.remove(&oldest);
+                if runs.is_empty() {
+                    state.active_runs.remove(&session_id);
+                }
+            }
+        }
+    }
+
+    /// `/new` 时刻该 session 的在途 run 快照。
+    pub(crate) async fn active_run_ids(&self, session_id: &str) -> HashSet<String> {
+        let state = self.state.lock().await;
+        state.active_runs.get(session_id).cloned().unwrap_or_default()
+    }
+
+    pub(crate) async fn has_pending(&self, conversation_key: &str) -> bool {
+        let state = self.state.lock().await;
+        state.pending.contains_key(conversation_key)
+    }
+
+    /// 登记排队重置；同一 conversation 已有排队时拒绝（幂等）。
+    pub(crate) async fn begin_pending(
+        &self,
+        conversation_key: String,
+        reset: PendingSessionReset,
+    ) -> bool {
+        let mut state = self.state.lock().await;
+        if state.pending.contains_key(&conversation_key) {
+            return false;
+        }
+        state.pending.insert(conversation_key, reset);
+        true
+    }
+
+    /// bot 假死兜底：超过 stale_ms 的排队重置被取走执行。
+    pub(crate) async fn take_pending_if_stale(
+        &self,
+        conversation_key: &str,
+        now_ms: u64,
+        stale_ms: u64,
+    ) -> Option<PendingSessionReset> {
+        let mut state = self.state.lock().await;
+        let stale = state
+            .pending
+            .get(conversation_key)
+            .is_some_and(|reset| now_ms.saturating_sub(reset.requested_at_ms) > stale_ms);
+        if stale {
+            state.pending.remove(conversation_key)
+        } else {
+            None
+        }
+    }
+
+    /// run 终态观测：从索引中移除该 run，并扣减所有排队的 waiting_on；
+    /// 返回因此清空了等待集合、可以执行的排队重置。
+    pub(crate) async fn observe_run_terminal(&self, run_id: &str) -> Vec<PendingSessionReset> {
+        let mut state = self.state.lock().await;
+        if let Some(session_id) = state.run_sessions.remove(run_id)
+            && let Some(runs) = state.active_runs.get_mut(&session_id)
+        {
+            runs.remove(run_id);
+            if runs.is_empty() {
+                state.active_runs.remove(&session_id);
+            }
+        }
+        let mut drained = Vec::new();
+        state.pending.retain(|_, reset| {
+            reset.waiting_on.remove(run_id);
+            if reset.waiting_on.is_empty() {
+                drained.push(reset.clone());
+                false
+            } else {
+                true
+            }
+        });
+        drained
+    }
+
+    /// 无条件取走排队重置（竞态闭合：登记后发现在途 run 已结束时立即执行）。
+    pub(crate) async fn take_pending(&self, conversation_key: &str) -> Option<PendingSessionReset> {
+        let mut state = self.state.lock().await;
+        state.pending.remove(conversation_key)
+    }
+}
+
+/// 排队重置的 conversation 键（SessionScope 无 Hash，用字符串标签）。
+pub(crate) fn reset_conversation_key(
+    binding_id: &str,
+    im_conversation_id: &str,
+    scope: SessionScope,
+    im_user_id: Option<&str>,
+) -> String {
+    format!(
+        "{}|{}|{}|{}",
+        binding_id,
+        im_conversation_id,
+        crate::session_scope_label(scope),
+        im_user_id.unwrap_or("")
+    )
+}
+
+impl BcsChannelService {
+    /// 入站命令拦截：是命令则完整处理并返回 Ok(Some(()))。
+    ///
+    /// 位于 `try_consume_human_input` 之前：等待回复的 HumanInput 卡片
+    /// 不得把 `/new` 吞作卡片回复。
+    pub(crate) async fn try_execute_channel_command(
+        &self,
+        binding: &ChannelBinding,
+        msg: &InboundMessage,
+        actor_id: &str,
+    ) -> Result<Option<()>, ChannelUseCaseError> {
+        let Some(command) = parse_channel_command(&msg.text) else {
+            return Ok(None);
+        };
+        info!(
+            channel_type = %msg.channel_type,
+            account_ref = %msg.account_ref,
+            binding_id = %binding.id,
+            msg_id = %msg.msg_id,
+            im_conversation_id = %msg.im_conversation_id,
+            command = ?command,
+            "channel command: received"
+        );
+        match command {
+            ChannelCommand::NewSession => {
+                let ctx = self.resolve_inbound_context(binding, msg, actor_id).await?;
+                self.execute_new_session(&ctx, binding, msg).await?;
+            }
+        }
+        Ok(Some(()))
+    }
+
+    async fn execute_new_session(
+        &self,
+        ctx: &ResolvedInboundContext,
+        binding: &ChannelBinding,
+        msg: &InboundMessage,
+    ) -> Result<(), ChannelUseCaseError> {
+        let conversation_key = reset_conversation_key(
+            &ctx.binding_id,
+            &msg.im_conversation_id,
+            ctx.session_scope,
+            ctx.im_user_id.as_deref(),
+        );
+        // 重复 /new 幂等：已有排队重置时仅重答排队文案。
+        if self.session_reset_tracker.has_pending(&conversation_key).await {
+            self.send_command_reply(
+                binding,
+                &msg.im_conversation_id,
+                &msg.conversation_type,
+                ctx.im_user_id.as_deref(),
+                "",
+                RESET_QUEUED_TEXT,
+                Some(&msg.msg_id),
+            )
+            .await?;
+            return Ok(());
+        }
+        let mapping = self
+            .conversations
+            .get(
+                &ctx.binding_id,
+                &msg.im_conversation_id,
+                ctx.session_scope,
+                ctx.im_user_id.as_deref(),
+            )
+            .await?;
+        let active = match &mapping {
+            Some(map) => match self.sessions.get(&map.bcs_session_id).await {
+                // 与 resolve_or_create_chat_session 的复用判定保持一致：
+                // 仅 Running 且同 group 的会话才算"进行中的会话"。
+                Some(session)
+                    if session.status == crate::SessionStatus::Running
+                        && session.group_id == ctx.group_id =>
+                {
+                    Some((map.clone(), session))
+                }
+                _ => None,
+            },
+            None => None,
+        };
+        let Some((mapping, session)) = active else {
+            self.send_command_reply(
+                binding,
+                &msg.im_conversation_id,
+                &msg.conversation_type,
+                ctx.im_user_id.as_deref(),
+                "",
+                NOTHING_TO_RESET_TEXT,
+                Some(&msg.msg_id),
+            )
+            .await?;
+            return Ok(());
+        };
+
+        // state-machine 启动窗口：映射新鲜但 run 尚未落库，与
+        // start_state_machine_from_inbound 的判定保持一致。
+        if ctx.state_machine_trigger {
+            let run_view = self
+                .collaboration_runtime
+                .get_state_machine_run_by_session_id(&session.id)
+                .await
+                .map_err(|error| {
+                    ChannelUseCaseError::Internal(crate::ServiceError::InternalError(
+                        error.to_string(),
+                    ))
+                })?;
+            if run_view.is_none()
+                && (self.now_ms)().saturating_sub(mapping.last_active_at)
+                    < crate::CHANNEL_START_STALE_MS
+            {
+                self.send_command_reply(
+                    binding,
+                    &msg.im_conversation_id,
+                    &msg.conversation_type,
+                    ctx.im_user_id.as_deref(),
+                    &session.id,
+                    STATE_MACHINE_STARTING_TEXT,
+                    Some(&msg.msg_id),
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+
+        let waiting_on = self.collect_waiting_runs(ctx, &session.id).await?;
+        let reset = PendingSessionReset {
+            old_session_id: session.id.clone(),
+            binding_id: ctx.binding_id.clone(),
+            im_conversation_id: msg.im_conversation_id.clone(),
+            im_conversation_type: msg.conversation_type.clone(),
+            session_scope: ctx.session_scope,
+            im_user_id: ctx.im_user_id.clone(),
+            source_im_message_id: msg.msg_id.clone(),
+            waiting_on,
+            requested_at_ms: (self.now_ms)(),
+        };
+        if reset.waiting_on.is_empty() {
+            self.execute_session_reset(reset).await?;
+            return Ok(());
+        }
+        let waiting_count = reset.waiting_on.len();
+        let old_session_id = reset.old_session_id.clone();
+        if self
+            .session_reset_tracker
+            .begin_pending(conversation_key.clone(), reset)
+            .await
+        {
+            info!(
+                binding_id = %ctx.binding_id,
+                bcs_session_id = %old_session_id,
+                waiting_run_count = waiting_count,
+                "channel command: session reset queued"
+            );
+            // 竞态闭合：登记后重新收集，若在途 run 恰好已全部结束则立即执行。
+            if self
+                .collect_waiting_runs(ctx, &old_session_id)
+                .await?
+                .is_empty()
+            {
+                if let Some(reset) = self.session_reset_tracker.take_pending(&conversation_key).await
+                {
+                    self.execute_session_reset(reset).await?;
+                }
+                return Ok(());
+            }
+        }
+        self.send_command_reply(
+            binding,
+            &msg.im_conversation_id,
+            &msg.conversation_type,
+            ctx.im_user_id.as_deref(),
+            &old_session_id,
+            RESET_QUEUED_TEXT,
+            Some(&msg.msg_id),
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// `/new` 时刻的在途 run 集合：chat run 取 tracker 快照；
+    /// state-machine group 额外查 DB 中的 run 视图。
+    async fn collect_waiting_runs(
+        &self,
+        ctx: &ResolvedInboundContext,
+        session_id: &str,
+    ) -> Result<HashSet<String>, ChannelUseCaseError> {
+        let mut waiting = self.session_reset_tracker.active_run_ids(session_id).await;
+        if ctx.state_machine_trigger
+            && let Some(view) = self
+                .collaboration_runtime
+                .get_state_machine_run_by_session_id(session_id)
+                .await
+                .map_err(|error| {
+                    ChannelUseCaseError::Internal(crate::ServiceError::InternalError(
+                        error.to_string(),
+                    ))
+                })?
+            && view.run.status == bcs_domain::StateMachineRunStatus::Running
+            && view.run.group_id == ctx.group_id
+        {
+            waiting.insert(view.run.run_id);
+        }
+        Ok(waiting)
+    }
+
+    /// 锁保护的重置执行：复查映射仍指向旧会话 → CAS 归档 → 确认回复。
+    /// 幂等：并发 /new 或重复终态事件下安全。
+    async fn execute_session_reset(&self, reset: PendingSessionReset) -> Result<(), ChannelUseCaseError> {
+        {
+            let _guard = self.chat_session_resolution_lock.lock().await;
+            let current = self
+                .conversations
+                .get(
+                    &reset.binding_id,
+                    &reset.im_conversation_id,
+                    reset.session_scope,
+                    reset.im_user_id.as_deref(),
+                )
+                .await?;
+            if current
+                .as_ref()
+                .is_none_or(|map| map.bcs_session_id != reset.old_session_id)
+            {
+                info!(
+                    binding_id = %reset.binding_id,
+                    bcs_session_id = %reset.old_session_id,
+                    "channel command: session reset skipped (mapping moved)"
+                );
+                return Ok(());
+            }
+            self.sessions
+                .complete_if_running(
+                    &reset.old_session_id,
+                    Some(serde_json::json!({"reason": "channel_command_new"})),
+                    None,
+                )
+                .await?;
+        }
+        info!(
+            binding_id = %reset.binding_id,
+            bcs_session_id = %reset.old_session_id,
+            im_conversation_id = %reset.im_conversation_id,
+            "channel command: session reset executed"
+        );
+        // 确认回复失败不阻碍归档（归档已持久化）；deferred 路径下
+        // binding 可能已下线，此时跳过回复。
+        let binding = self.bindings.get(&reset.binding_id).await?;
+        match binding {
+            Some(binding) if binding.status == bcs_domain::BindingStatus::Active => {
+                if let Err(error) = self
+                    .send_command_reply(
+                        &binding,
+                        &reset.im_conversation_id,
+                        &reset.im_conversation_type,
+                        reset.im_user_id.as_deref(),
+                        &reset.old_session_id,
+                        RESET_DONE_TEXT,
+                        Some(&reset.source_im_message_id),
+                    )
+                    .await
+                {
+                    warn!(
+                        binding_id = %reset.binding_id,
+                        bcs_session_id = %reset.old_session_id,
+                        error = %error,
+                        "channel command: reset confirmation delivery failed"
+                    );
+                }
+            }
+            _ => {
+                info!(
+                    binding_id = %reset.binding_id,
+                    "channel command: reset confirmation skipped (binding inactive)"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// `try_outbound` 顶部 hook：观测 chat run 终态并执行因此排干的重置。
+    /// 必须在所有提前 return 之前调用，保证可见性过滤或投递失败不饿死重置。
+    pub(crate) async fn observe_outbound_terminal(&self, msg: &OutboundMessage) {
+        let terminal = match msg.kind {
+            crate::ChannelOutboundEventKind::ChatFinal => true,
+            crate::ChannelOutboundEventKind::System => {
+                msg.purpose == crate::ChannelOutboundPurpose::Conversation
+                    && matches!(
+                        msg.raw_payload.get("state").and_then(serde_json::Value::as_str),
+                        Some("error" | "aborted")
+                    )
+            }
+            _ => false,
+        };
+        if !terminal || msg.run_id.is_empty() {
+            return;
+        }
+        let drained = self.session_reset_tracker.observe_run_terminal(&msg.run_id).await;
+        for reset in drained {
+            info!(
+                run_id = %msg.run_id,
+                bcs_session_id = %reset.old_session_id,
+                "channel command: run terminal observed, executing queued reset"
+            );
+            self.execute_deferred_reset(reset).await;
+        }
+    }
+
+    /// `publish_state_machine_terminal` 顶部 hook：state-machine run 终态观测。
+    /// 该方法在 run 终态时必被调用（即使无 IM 通知），是可靠的观测点。
+    pub(crate) async fn observe_state_machine_terminal(&self, event: &StateMachineTerminalEvent) {
+        let drained = self
+            .session_reset_tracker
+            .observe_run_terminal(&event.run_id)
+            .await;
+        for reset in drained {
+            info!(
+                run_id = %event.run_id,
+                bcs_session_id = %reset.old_session_id,
+                "channel command: state-machine terminal observed, executing queued reset"
+            );
+            self.execute_deferred_reset(reset).await;
+        }
+    }
+
+    /// 入站顺带执行超时的排队重置（bot 假死导致终态事件永远不到达的兜底）。
+    pub(crate) async fn maybe_execute_stale_reset(
+        &self,
+        ctx: &ResolvedInboundContext,
+        msg: &InboundMessage,
+    ) {
+        let conversation_key = reset_conversation_key(
+            &ctx.binding_id,
+            &msg.im_conversation_id,
+            ctx.session_scope,
+            ctx.im_user_id.as_deref(),
+        );
+        let Some(reset) = self
+            .session_reset_tracker
+            .take_pending_if_stale(&conversation_key, (self.now_ms)(), PENDING_RESET_STALE_MS)
+            .await
+        else {
+            return;
+        };
+        info!(
+            binding_id = %ctx.binding_id,
+            bcs_session_id = %reset.old_session_id,
+            "channel command: executing stale queued reset"
+        );
+        self.execute_deferred_reset(reset).await;
+    }
+
+    async fn execute_deferred_reset(&self, reset: PendingSessionReset) {
+        if let Err(error) = self.execute_session_reset(reset).await {
+            warn!(error = %error, "channel command: deferred session reset failed");
+        }
+    }
+
+    /// 命令回复走 provider 直接投递（仿 deliver_human_input_event），
+    /// 不依赖 try_outbound —— 无会话场景（/new 为首条消息）没有可供
+    /// 路由的 session。bcs_session_id 在无会话时传空串。
+    #[allow(clippy::too_many_arguments)]
+    async fn send_command_reply(
+        &self,
+        binding: &ChannelBinding,
+        im_conversation_id: &str,
+        im_conversation_type: &str,
+        im_user_id: Option<&str>,
+        bcs_session_id: &str,
+        text: &str,
+        source_im_message_id: Option<&str>,
+    ) -> Result<(), ChannelUseCaseError> {
+        let provider = self.provider_for(&binding.channel_type)?;
+        let binding_ref = crate::ChannelBindingRef {
+            channel_type: binding.channel_type.clone(),
+            account_ref: binding.account_ref.clone(),
+        };
+        if !provider.delivery().is_available(&binding_ref).await {
+            return Err(ChannelUseCaseError::InvalidParams(
+                "channel command reply delivery is unavailable".to_string(),
+            ));
+        }
+        let result = provider
+            .delivery()
+            .deliver_event(crate::ChannelOutboundEvent {
+                binding_ref,
+                im_conversation_id: im_conversation_id.to_string(),
+                im_conversation_type: im_conversation_type.to_string(),
+                im_user_id: im_user_id.map(str::to_string),
+                im_user_display_name: None,
+                bcs_session_id: bcs_session_id.to_string(),
+                run_id: String::new(),
+                sender_actor_id: "bcs_channel".to_string(),
+                sender_label: "BCS".to_string(),
+                render_sender_label: false,
+                sender_role: bcs_domain::ParticipantRole::Driver,
+                kind: crate::ChannelOutboundEventKind::System,
+                purpose: crate::ChannelOutboundPurpose::HumanInputAck,
+                text: Some(text.to_string()),
+                raw_payload: serde_json::json!({
+                    "type": "channel.command",
+                    "command": "new",
+                }),
+                render_hint: crate::ChannelRenderHint::Render,
+                source_im_message_id: source_im_message_id.map(str::to_string),
+            })
+            .await?;
+        if !result.delivered {
+            return Err(ChannelUseCaseError::Internal(
+                result.error.unwrap_or_else(|| {
+                    crate::ServiceError::InternalError(
+                        "channel command reply was not confirmed".to_string(),
+                    )
+                }),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending_reset(run_ids: &[&str]) -> PendingSessionReset {
+        PendingSessionReset {
+            old_session_id: "group_1:00000001".to_string(),
+            binding_id: "binding_1".to_string(),
+            im_conversation_id: "conv_1".to_string(),
+            im_conversation_type: "1".to_string(),
+            session_scope: SessionScope::Conversation,
+            im_user_id: Some("u1".to_string()),
+            source_im_message_id: "msg_new".to_string(),
+            waiting_on: run_ids.iter().map(|id| id.to_string()).collect(),
+            requested_at_ms: 100,
+        }
+    }
+
+    #[test]
+    fn parse_accepts_exact_new_command() {
+        assert_eq!(parse_channel_command("/new"), Some(ChannelCommand::NewSession));
+    }
+
+    #[test]
+    fn parse_tolerates_surrounding_whitespace() {
+        assert_eq!(
+            parse_channel_command("  /new \n"),
+            Some(ChannelCommand::NewSession)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_command_texts() {
+        for text in ["", "new", "/new x", "//new", "/NEW", "/new/"] {
+            assert_eq!(parse_channel_command(text), None, "text: {text:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn seeded_runs_are_reported_as_active() {
+        let tracker = SessionResetTracker::new(16);
+        tracker
+            .seed_runs("session_1", &["run_1".to_string(), "run_2".to_string()])
+            .await;
+
+        let active = tracker.active_run_ids("session_1").await;
+        assert_eq!(
+            active,
+            ["run_1".to_string(), "run_2".to_string()]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+        assert!(tracker.active_run_ids("session_2").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_drains_run_from_active_set() {
+        let tracker = SessionResetTracker::new(16);
+        tracker
+            .seed_runs("session_1", &["run_1".to_string(), "run_2".to_string()])
+            .await;
+
+        tracker.observe_run_terminal("run_1").await;
+
+        assert_eq!(
+            tracker.active_run_ids("session_1").await,
+            ["run_2".to_string()].into_iter().collect::<HashSet<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_for_unknown_run_is_noop() {
+        let tracker = SessionResetTracker::new(16);
+        tracker.seed_runs("session_1", &["run_1".to_string()]).await;
+
+        let drained = tracker.observe_run_terminal("run_unknown").await;
+
+        assert!(drained.is_empty());
+        assert_eq!(tracker.active_run_ids("session_1").await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_terminal_is_idempotent() {
+        let tracker = SessionResetTracker::new(16);
+        tracker.seed_runs("session_1", &["run_1".to_string()]).await;
+        tracker
+            .begin_pending("key_1".to_string(), pending_reset(&["run_1"]))
+            .await;
+
+        let first = tracker.observe_run_terminal("run_1").await;
+        let second = tracker.observe_run_terminal("run_1").await;
+
+        assert_eq!(first.len(), 1);
+        assert!(second.is_empty());
+        assert!(tracker.active_run_ids("session_1").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_waits_for_all_snapshotted_runs() {
+        let tracker = SessionResetTracker::new(16);
+        tracker
+            .seed_runs("session_1", &["run_1".to_string(), "run_2".to_string()])
+            .await;
+        tracker
+            .begin_pending("key_1".to_string(), pending_reset(&["run_1", "run_2"]))
+            .await;
+
+        assert!(tracker.observe_run_terminal("run_1").await.is_empty());
+        let drained = tracker.observe_run_terminal("run_2").await;
+
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].old_session_id, "group_1:00000001");
+    }
+
+    #[tokio::test]
+    async fn begin_pending_rejects_duplicate_conversation() {
+        let tracker = SessionResetTracker::new(16);
+        assert!(
+            tracker
+                .begin_pending("key_1".to_string(), pending_reset(&["run_1"]))
+                .await
+        );
+        assert!(
+            !tracker
+                .begin_pending("key_1".to_string(), pending_reset(&["run_2"]))
+                .await
+        );
+        assert!(tracker.has_pending("key_1").await);
+        assert!(!tracker.has_pending("key_2").await);
+    }
+
+    #[tokio::test]
+    async fn stale_pending_is_taken_only_past_threshold() {
+        let tracker = SessionResetTracker::new(16);
+        tracker
+            .begin_pending("key_1".to_string(), pending_reset(&["run_1"]))
+            .await;
+
+        assert!(
+            tracker
+                .take_pending_if_stale("key_1", 100 + 1_000, 1_800_000)
+                .await
+                .is_none()
+        );
+        let taken = tracker
+            .take_pending_if_stale("key_1", 100 + 1_800_001, 1_800_000)
+            .await;
+        assert!(taken.is_some());
+        assert!(!tracker.has_pending("key_1").await);
+    }
+
+    #[tokio::test]
+    async fn fifo_eviction_bounds_active_run_tracking() {
+        let tracker = SessionResetTracker::new(2);
+        tracker
+            .seed_runs("session_1", &["run_1".to_string(), "run_2".to_string()])
+            .await;
+        tracker.seed_runs("session_1", &["run_3".to_string()]).await;
+
+        let active = tracker.active_run_ids("session_1").await;
+        assert_eq!(
+            active,
+            ["run_2".to_string(), "run_3".to_string()]
+                .into_iter()
+                .collect::<HashSet<_>>()
+        );
+        // 被驱逐的 run 终态不再有任何效果。
+        assert!(tracker.observe_run_terminal("run_1").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn take_pending_removes_registration() {
+        let tracker = SessionResetTracker::new(16);
+        tracker
+            .begin_pending("key_1".to_string(), pending_reset(&["run_1"]))
+            .await;
+
+        let taken = tracker.take_pending("key_1").await;
+
+        assert!(taken.is_some());
+        assert!(!tracker.has_pending("key_1").await);
+        assert!(tracker.take_pending("key_1").await.is_none());
+    }
+}

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -1,5 +1,6 @@
 //! Channel(IM bridge) application service implementation.
 
+mod commands;
 pub mod visibility;
 
 use std::collections::{HashSet, VecDeque};
@@ -68,6 +69,8 @@ pub struct BcsChannelService {
     inbound_dedup: InboundDedupGuard,
     binding_admin_lock: Mutex<()>,
     state_machine_session_resolution_lock: Mutex<()>,
+    chat_session_resolution_lock: Mutex<()>,
+    session_reset_tracker: commands::SessionResetTracker,
 }
 
 struct ResolvedInboundContext {
@@ -117,6 +120,8 @@ impl BcsChannelService {
             inbound_dedup: InboundDedupGuard::new(DEFAULT_INBOUND_DEDUP_LIMIT),
             binding_admin_lock: Mutex::new(()),
             state_machine_session_resolution_lock: Mutex::new(()),
+            chat_session_resolution_lock: Mutex::new(()),
+            session_reset_tracker: commands::SessionResetTracker::new(DEFAULT_INBOUND_DEDUP_LIMIT),
         }
     }
 
@@ -1029,6 +1034,16 @@ impl ChannelService for BcsChannelService {
                 "channel inbound: actor resolved"
             );
             if self
+                .try_execute_channel_command(&binding, &msg, &actor_id)
+                .await
+                .map_err(|error| {
+                    inbound_failure(ChannelInboundFailureKind::DispatchFailed, true, error)
+                })?
+                .is_some()
+            {
+                return Ok(());
+            }
+            if self
                 .try_consume_human_input(&binding, &msg, &actor_id)
                 .await
                 .map_err(|error| {
@@ -1066,6 +1081,7 @@ impl ChannelService for BcsChannelService {
                 state_machine_trigger = ctx.state_machine_trigger,
                 "channel inbound: context resolved"
             );
+            self.maybe_execute_stale_reset(&ctx, &msg).await;
 
             if ctx.state_machine_trigger {
                 return self
@@ -1076,16 +1092,40 @@ impl ChannelService for BcsChannelService {
                     });
             }
 
-            let (session_id, reused_session) = self
-                .resolve_or_create_chat_session(&ctx, &msg)
-                .await
-                .map_err(|error| {
-                    inbound_failure(
-                        ChannelInboundFailureKind::SessionResolutionFailed,
-                        true,
-                        error,
-                    )
-                })?;
+            // /new 归档旧会话后，并发消息可能同时看到 Completed 状态；
+            // 锁内完成"解析或创建 + 映射重指"，保证只建一个新会话。
+            let (session_id, reused_session) = {
+                let _guard = self.chat_session_resolution_lock.lock().await;
+                let resolved = self
+                    .resolve_or_create_chat_session(&ctx, &msg)
+                    .await
+                    .map_err(|error| {
+                        inbound_failure(
+                            ChannelInboundFailureKind::SessionResolutionFailed,
+                            true,
+                            error,
+                        )
+                    })?;
+                self.conversations
+                    .upsert(ConversationSessionMap {
+                        binding_id: binding.id.clone(),
+                        im_conversation_id: msg.im_conversation_id.clone(),
+                        im_conversation_type: msg.conversation_type.clone(),
+                        session_scope: ctx.session_scope,
+                        im_user_id: ctx.im_user_id.clone(),
+                        bcs_session_id: resolved.0.clone(),
+                        last_active_at: (self.now_ms)(),
+                    })
+                    .await
+                    .map_err(|error| {
+                        inbound_failure(
+                            ChannelInboundFailureKind::SessionResolutionFailed,
+                            true,
+                            error,
+                        )
+                    })?;
+                resolved
+            };
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -1097,24 +1137,6 @@ impl ChannelService for BcsChannelService {
                 session_scope = session_scope_label(ctx.session_scope),
                 "channel inbound: session resolved"
             );
-            self.conversations
-                .upsert(ConversationSessionMap {
-                    binding_id: binding.id,
-                    im_conversation_id: msg.im_conversation_id.clone(),
-                    im_conversation_type: msg.conversation_type.clone(),
-                    session_scope: ctx.session_scope,
-                    im_user_id: ctx.im_user_id.clone(),
-                    bcs_session_id: session_id.clone(),
-                    last_active_at: (self.now_ms)(),
-                })
-                .await
-                .map_err(|error| {
-                    inbound_failure(
-                        ChannelInboundFailureKind::SessionResolutionFailed,
-                        true,
-                        error,
-                    )
-                })?;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -1185,6 +1207,9 @@ impl ChannelService for BcsChannelService {
                     ),
                 ));
             }
+            self.session_reset_tracker
+                .seed_runs(&dispatch_session_id, &outcome.active_run_ids)
+                .await;
             info!(
                 channel_type = %msg.channel_type,
                 account_ref = %account_ref,
@@ -1210,6 +1235,7 @@ impl ChannelService for BcsChannelService {
         if msg.source_is_channel {
             return Ok(());
         }
+        self.observe_outbound_terminal(&msg).await;
         let require_confirmed_delivery = msg
             .raw_payload
             .get("type")
@@ -1881,6 +1907,7 @@ impl SessionChannelOutboundPort for BcsChannelService {
         &self,
         event: StateMachineTerminalEvent,
     ) -> ServiceResult<SessionChannelDeliveryOutcome> {
+        self.observe_state_machine_terminal(&event).await;
         let requests = self.human_input_requests.list_by_run(&event.run_id).await?;
         let reply_scopes = requests
             .iter()
@@ -2536,6 +2563,25 @@ mod tests {
             env: &str,
             new_id: Arc<dyn Fn() -> String + Send + Sync>,
         ) -> ServiceResult<Self> {
+            Self::new_with_env_id_clock(group, env, new_id, Arc::new(AtomicU64::new(42))).await
+        }
+
+        async fn new_with_clock(group: Group, clock: Arc<AtomicU64>) -> ServiceResult<Self> {
+            Self::new_with_env_id_clock(
+                group,
+                "pre",
+                Arc::new(|| "generated_id".to_string()),
+                clock,
+            )
+            .await
+        }
+
+        async fn new_with_env_id_clock(
+            group: Group,
+            env: &str,
+            new_id: Arc<dyn Fn() -> String + Send + Sync>,
+            clock: Arc<AtomicU64>,
+        ) -> ServiceResult<Self> {
             let binding_repo = Arc::new(MemoryChannelBindingRepo::new(env));
             let conversation_repo = Arc::new(MemoryConversationSessionRepo::new());
             let participant_repo = Arc::new(MemoryImParticipantRepo::new());
@@ -2566,7 +2612,7 @@ mod tests {
                 registry.clone(),
                 providers,
                 env,
-                Arc::new(|| 42),
+                Arc::new(move || clock.load(Ordering::SeqCst)),
                 new_id,
             );
 
@@ -6043,6 +6089,7 @@ mod tests {
     struct RecordingMessageFlow {
         web_sends: Mutex<Vec<WebSendCommand>>,
         failed_dispatch_count: Mutex<usize>,
+        active_run_ids: Mutex<Vec<String>>,
     }
 
     #[async_trait]
@@ -6050,10 +6097,11 @@ mod tests {
         async fn handle_web_send(&self, cmd: WebSendCommand) -> ServiceResult<WebSendOutcome> {
             self.web_sends.lock().await.push(cmd);
             let failed_count = *self.failed_dispatch_count.lock().await;
+            let active_run_ids = self.active_run_ids.lock().await.clone();
             Ok(WebSendOutcome {
                 primary_run_id: "run_1".to_string(),
                 status: "accepted".to_string(),
-                active_run_ids: Vec::new(),
+                active_run_ids,
                 bot_deliveries: Vec::new(),
                 frontend_deliveries: Vec::new(),
                 mentions: Vec::new(),
@@ -6612,5 +6660,754 @@ mod tests {
             message: format!("{name} is not configured"),
             request_id: None,
         }
+    }
+
+    // ── /new slash 命令 ─────────────────────────────────────────
+
+    fn new_command(conversation_id: &str, user_id: &str, msg_id: &str) -> InboundMessage {
+        let mut msg = inbound(conversation_id, user_id, Some("张三"), msg_id);
+        msg.text = "/new".to_string();
+        msg
+    }
+
+    fn group_new_command(conversation_id: &str, user_id: &str, msg_id: &str) -> InboundMessage {
+        let mut msg = group_inbound(conversation_id, user_id, Some("张三"), msg_id, true);
+        msg.text = "/new".to_string();
+        msg
+    }
+
+    async fn create_group_binding(
+        harness: &TestHarness,
+        group_id: &str,
+        scope: GroupChatScope,
+    ) -> TestResult {
+        harness
+            .service
+            .create_binding(CreateBindingCommand {
+                channel_type: channel_type(),
+                account_ref: "robot_1".to_string(),
+                target: BindingTarget::Group {
+                    group_id: group_id.to_string(),
+                },
+                group_chat_scope: Some(scope),
+                outbound_visibility: Visibility::FullTranscript,
+                env: "dev".to_string(),
+                created_by: Some("creator".to_string()),
+                config: dingtalk_config("robot_1"),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn delivered_texts(harness: &TestHarness) -> Vec<String> {
+        harness
+            .delivery
+            .events
+            .lock()
+            .await
+            .iter()
+            .filter_map(|event| event.text.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn new_command_without_session_replies_nothing_to_reset() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+
+        let events = harness.delivery.events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].text.as_deref(),
+            Some(crate::commands::NOTHING_TO_RESET_TEXT)
+        );
+        assert_eq!(events[0].kind, ChannelOutboundEventKind::System);
+        assert_eq!(events[0].source_im_message_id.as_deref(), Some("msg_new"));
+        assert!(events[0].bcs_session_id.is_empty());
+        assert!(harness.message_flow.web_sends.lock().await.is_empty());
+        assert!(harness.session_repo.sessions.lock().await.is_empty());
+        assert!(
+            harness
+                .conversation_repo
+                .get(
+                    "generated_id",
+                    "conv_1",
+                    SessionScope::Conversation,
+                    Some("u1"),
+                )
+                .await?
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_completes_idle_session_and_next_message_rolls_over() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_1"))
+            .await?;
+        let mapping = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping after first message");
+        let old_session_id = mapping.bcs_session_id.clone();
+
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+
+        let old_session = harness
+            .session_repo
+            .get(&old_session_id)
+            .await
+            .expect("old session");
+        assert_eq!(old_session.status, SessionStatus::Completed);
+        assert!(
+            old_session
+                .output
+                .as_ref()
+                .is_some_and(|output| output.to_string().contains("channel_command_new"))
+        );
+        // 映射原地保留，作为下一条消息 rollover 的触发器。
+        let mapping_after = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping kept");
+        assert_eq!(mapping_after.bcs_session_id, old_session_id);
+        assert_eq!(
+            delivered_texts(&harness).await,
+            vec![crate::commands::RESET_DONE_TEXT.to_string()]
+        );
+        assert_eq!(harness.message_flow.web_sends.lock().await.len(), 1);
+
+        // 相同 msg_id 的 webhook 重放被 dedup，不重复回复。
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+        assert_eq!(delivered_texts(&harness).await.len(), 1);
+
+        // 下一条普通消息恰好创建一个新会话并重指映射。
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_2"))
+            .await?;
+        let mapping_new = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping rolled over");
+        assert_ne!(mapping_new.bcs_session_id, old_session_id);
+        let new_session = harness
+            .session_repo
+            .get(&mapping_new.bcs_session_id)
+            .await
+            .expect("new session");
+        assert_eq!(new_session.status, SessionStatus::Running);
+        assert_eq!(harness.session_repo.sessions.lock().await.len(), 2);
+        let web_sends = harness.message_flow.web_sends.lock().await;
+        assert_eq!(web_sends.len(), 2);
+        assert_eq!(
+            web_sends[1].session_id.as_deref(),
+            Some(mapping_new.bcs_session_id.as_str())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_queues_behind_active_run_and_executes_on_chat_final() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        *harness.message_flow.active_run_ids.lock().await = vec!["run_1".to_string()];
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_1"))
+            .await?;
+        let old_session_id = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping")
+            .bcs_session_id;
+
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Running
+        );
+        assert_eq!(
+            delivered_texts(&harness).await,
+            vec![crate::commands::RESET_QUEUED_TEXT.to_string()]
+        );
+
+        // run 终态（ChatFinal）经过 try_outbound → 自动执行排队的重置。
+        harness
+            .service
+            .try_outbound(outbound(&old_session_id, ParticipantRole::Worker, false))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Completed
+        );
+        let events = harness.delivery.events.lock().await;
+        let done = events
+            .iter()
+            .find(|event| event.text.as_deref() == Some(crate::commands::RESET_DONE_TEXT))
+            .expect("deferred reset confirmation");
+        assert_eq!(done.source_im_message_id.as_deref(), Some("msg_new"));
+        assert_eq!(done.bcs_session_id, old_session_id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_queued_reset_executes_on_error_terminal() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        *harness.message_flow.active_run_ids.lock().await = vec!["run_1".to_string()];
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_1"))
+            .await?;
+        let old_session_id = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping")
+            .bcs_session_id;
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+
+        let mut terminal = outbound(&old_session_id, ParticipantRole::Worker, false);
+        terminal.kind = ChannelOutboundEventKind::System;
+        terminal.raw_payload = serde_json::json!({"state": "error"});
+        terminal.text = Some("机器人连接或执行失败，请稍后重试。".to_string());
+        harness.service.try_outbound(terminal).await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Completed
+        );
+        assert!(
+            delivered_texts(&harness)
+                .await
+                .contains(&crate::commands::RESET_DONE_TEXT.to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_per_sender_group_resets_only_sender_session() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::PerSender).await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_1", "u1", Some("张三"), "msg_1", true))
+            .await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_1", "u2", Some("李四"), "msg_2", true))
+            .await?;
+        let session_u1 = harness
+            .conversation_repo
+            .get("generated_id", "conv_1", SessionScope::PerSender, Some("u1"))
+            .await?
+            .expect("u1 mapping")
+            .bcs_session_id;
+        let session_u2 = harness
+            .conversation_repo
+            .get("generated_id", "conv_1", SessionScope::PerSender, Some("u2"))
+            .await?
+            .expect("u2 mapping")
+            .bcs_session_id;
+        assert_ne!(session_u1, session_u2);
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_1", "u1", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session_u1)
+                .await
+                .expect("u1 session")
+                .status,
+            SessionStatus::Completed
+        );
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session_u2)
+                .await
+                .expect("u2 session")
+                .status,
+            SessionStatus::Running
+        );
+        let events = harness.delivery.events.lock().await;
+        let done = events
+            .iter()
+            .find(|event| event.text.as_deref() == Some(crate::commands::RESET_DONE_TEXT))
+            .expect("reset confirmation");
+        assert_eq!(done.im_user_id.as_deref(), Some("u1"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_shared_group_resets_shared_session() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_1", "u1", Some("张三"), "msg_1", true))
+            .await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_1", "u2", Some("李四"), "msg_2", true))
+            .await?;
+        let shared = harness
+            .conversation_repo
+            .get("generated_id", "conv_1", SessionScope::Conversation, None)
+            .await?
+            .expect("shared mapping")
+            .bcs_session_id;
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_1", "u2", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&shared)
+                .await
+                .expect("shared session")
+                .status,
+            SessionStatus::Completed
+        );
+        let events = harness.delivery.events.lock().await;
+        let done = events
+            .iter()
+            .find(|event| event.text.as_deref() == Some(crate::commands::RESET_DONE_TEXT))
+            .expect("reset confirmation");
+        assert_eq!(done.im_user_id, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_state_machine_idle_resets_immediately() -> TestResult {
+        let clock = Arc::new(AtomicU64::new(100_000));
+        let harness = TestHarness::new_with_clock(state_machine_group("group_sm"), clock).await?;
+        create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
+        let session = harness
+            .session_repo
+            .create("group_sm", NewSessionParams::default())
+            .await?;
+        harness
+            .conversation_repo
+            .upsert(bcs_domain::ConversationSessionMap {
+                binding_id: "generated_id".to_string(),
+                im_conversation_id: "conv_sm".to_string(),
+                im_conversation_type: "2".to_string(),
+                session_scope: SessionScope::Conversation,
+                im_user_id: None,
+                bcs_session_id: session.id.clone(),
+                last_active_at: 0,
+            })
+            .await?;
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_sm", "u1", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session.id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Completed
+        );
+        assert!(
+            delivered_texts(&harness)
+                .await
+                .contains(&crate::commands::RESET_DONE_TEXT.to_string())
+        );
+        assert!(harness.collaboration_runtime.starts.lock().await.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_state_machine_running_run_queues_then_terminal_executes() -> TestResult {
+        let harness = TestHarness::new(state_machine_group("group_sm")).await?;
+        create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_sm", "u1", Some("张三"), "msg_start", true))
+            .await?;
+        let session_id = harness.collaboration_runtime.starts.lock().await[0]
+            .session_id
+            .clone()
+            .expect("state-machine session");
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_sm", "u1", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Running
+        );
+        assert!(
+            delivered_texts(&harness)
+                .await
+                .contains(&crate::commands::RESET_QUEUED_TEXT.to_string())
+        );
+
+        SessionChannelOutboundPort::publish_state_machine_terminal(
+            &harness.service,
+            bcs_service_api::StateMachineTerminalEvent {
+                group_id: "group_sm".to_string(),
+                session_id: session_id.clone(),
+                run_id: "state_run_1".to_string(),
+                workflow_name: "wf".to_string(),
+                status: bcs_service_api::StateMachineTerminalStatus::Completed,
+                output: None,
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Completed
+        );
+        let events = harness.delivery.events.lock().await;
+        let done = events
+            .iter()
+            .find(|event| event.text.as_deref() == Some(crate::commands::RESET_DONE_TEXT))
+            .expect("deferred reset confirmation");
+        assert_eq!(done.source_im_message_id.as_deref(), Some("msg_new"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_state_machine_starting_window_replies_wait() -> TestResult {
+        let harness = TestHarness::new(state_machine_group("group_sm")).await?;
+        create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
+        let session = harness
+            .session_repo
+            .create("group_sm", NewSessionParams::default())
+            .await?;
+        harness
+            .conversation_repo
+            .upsert(bcs_domain::ConversationSessionMap {
+                binding_id: "generated_id".to_string(),
+                im_conversation_id: "conv_sm".to_string(),
+                im_conversation_type: "2".to_string(),
+                session_scope: SessionScope::Conversation,
+                im_user_id: None,
+                bcs_session_id: session.id.clone(),
+                last_active_at: 42,
+            })
+            .await?;
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_sm", "u1", "msg_new"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&session.id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Running
+        );
+        let texts = delivered_texts(&harness).await;
+        assert_eq!(texts.len(), 1);
+        assert!(texts[0].contains("流程正在启动"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn new_command_is_not_consumed_by_active_human_input() -> TestResult {
+        let harness = TestHarness::new(state_machine_group("group_sm")).await?;
+        create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
+        harness
+            .service
+            .handle_inbound(group_inbound("conv_sm", "u1", Some("张三"), "msg_start", true))
+            .await?;
+        let session_id = harness.collaboration_runtime.starts.lock().await[0]
+            .session_id
+            .clone()
+            .expect("state-machine session");
+        SessionChannelOutboundPort::publish_human_input_ready(
+            &harness.service,
+            HumanInputReadyEvent {
+                event_id: "human-ready-state-run-1-human-review".to_string(),
+                group_id: "group_sm".to_string(),
+                session_id,
+                run_id: "state_run_1".to_string(),
+                node_id: "human_review".to_string(),
+                display_name: "Human review".to_string(),
+                instruction: "Review the draft".to_string(),
+                assignee_actor_id: "human_u1".to_string(),
+                channel_type: channel_type(),
+                notification_mode: HumanInputNotificationMode::FixedGroup,
+                fixed_group_conversation_id: Some("conv_sm".to_string()),
+                response_ref: "state_run_1:human_review".to_string(),
+                judge_outcomes: vec!["approve".to_string(), "reject".to_string()],
+                timeout_deadline_ms: Some(60_000),
+                upstream_artifacts: Vec::new(),
+            },
+        )
+        .await?;
+
+        harness
+            .service
+            .handle_inbound(group_new_command("conv_sm", "u1", "msg_new"))
+            .await?;
+
+        // /new 不得被 HumanInput 卡片吞作回复；run 在途 → 重置排队。
+        assert!(
+            harness
+                .collaboration_runtime
+                .human_responses
+                .lock()
+                .await
+                .is_empty()
+        );
+        assert!(
+            delivered_texts(&harness)
+                .await
+                .contains(&crate::commands::RESET_QUEUED_TEXT.to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_new_commands_complete_session_once() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_1"))
+            .await?;
+        let old_session_id = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping")
+            .bcs_session_id;
+
+        let (first, second) = tokio::join!(
+            harness
+                .service
+                .handle_inbound(new_command("conv_1", "u1", "msg_new_a")),
+            harness
+                .service
+                .handle_inbound(new_command("conv_1", "u1", "msg_new_b")),
+        );
+        first?;
+        second?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Completed
+        );
+        assert_eq!(harness.session_repo.sessions.lock().await.len(), 1);
+        // 竞态下回复组合不确定（赢家 DONE；输家看到 Completed 会答 NOTHING_TO_RESET），
+        // 不变量：恰好各答一条、至少一条 DONE、只归档一次。
+        let texts = delivered_texts(&harness).await;
+        assert_eq!(texts.len(), 2);
+        assert!(
+            texts
+                .iter()
+                .all(|text| text.as_str() == crate::commands::RESET_DONE_TEXT
+                    || text.as_str() == crate::commands::NOTHING_TO_RESET_TEXT)
+        );
+        assert!(
+            texts
+                .iter()
+                .any(|text| text.as_str() == crate::commands::RESET_DONE_TEXT)
+        );
+
+        // 归档后并发普通消息：恰好创建一个新会话。
+        let (msg_a, msg_b) = tokio::join!(
+            harness
+                .service
+                .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_a")),
+            harness
+                .service
+                .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_b")),
+        );
+        msg_a?;
+        msg_b?;
+        assert_eq!(harness.session_repo.sessions.lock().await.len(), 2);
+        let web_sends = harness.message_flow.web_sends.lock().await;
+        assert_eq!(web_sends.len(), 3);
+        assert_eq!(web_sends[1].session_id, web_sends[2].session_id);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_pending_reset_executes_on_next_inbound() -> TestResult {
+        let clock = Arc::new(AtomicU64::new(42));
+        let harness = TestHarness::new_with_clock(manager_group("group_1"), clock.clone()).await?;
+        create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
+        *harness.message_flow.active_run_ids.lock().await = vec!["run_1".to_string()];
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_1"))
+            .await?;
+        let old_session_id = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping")
+            .bcs_session_id;
+        harness
+            .service
+            .handle_inbound(new_command("conv_1", "u1", "msg_new"))
+            .await?;
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("session")
+                .status,
+            SessionStatus::Running
+        );
+
+        // bot 假死、终态事件不到达：超过兜底阈值后由下一条消息顺带执行。
+        clock.store(42 + crate::commands::PENDING_RESET_STALE_MS + 1, Ordering::SeqCst);
+        harness
+            .service
+            .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_2"))
+            .await?;
+
+        assert_eq!(
+            harness
+                .session_repo
+                .get(&old_session_id)
+                .await
+                .expect("old session")
+                .status,
+            SessionStatus::Completed
+        );
+        assert!(
+            delivered_texts(&harness)
+                .await
+                .contains(&crate::commands::RESET_DONE_TEXT.to_string())
+        );
+        // 该消息进入 rollover 后的新会话。
+        let mapping = harness
+            .conversation_repo
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::Conversation,
+                Some("u1"),
+            )
+            .await?
+            .expect("mapping rolled over");
+        assert_ne!(mapping.bcs_session_id, old_session_id);
+        let web_sends = harness.message_flow.web_sends.lock().await;
+        assert_eq!(web_sends.len(), 2);
+        assert_eq!(
+            web_sends[1].session_id.as_deref(),
+            Some(mapping.bcs_session_id.as_str())
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
## Problem
Channel chat sessions never auto-complete (`timeout_scanner` only covers `service_invocation`), so a user's IM conversation accumulates context indefinitely across every message in the same BCS session. There is no way for an end user to start a brand-new conversation from within an IM channel (DingTalk etc.) — they are stuck with the original session forever.

## Solution
Add a `/new` slash command, intercepted uniformly in the shared channel service layer (works for every channel type; the DingTalk provider itself is out-of-repo). Semantics, confirmed with the requester:

- `/new` **archives** the current session (`Running -> Completed` via `complete_if_running`; message history preserved and still queryable), and the conversation binding rolls over to a fresh session on the next message via the existing lazy-rollover path (mapping kept as the trigger; new `group_id`-prefixed random session id). No `delete_if_session` needed.
- If the current session has an agent run in flight, `/new` **queues** the reset: it replies "任务仍在运行中" and executes the switch automatically once the run terminates.
- Channel-layer in-memory `SessionResetTracker` snapshots the in-flight runs at `/new` time; terminal events (chat `ChatFinal`/`error`/`aborted` via `try_outbound`; state-machine runs via `publish_state_machine_terminal`, which fires on every terminal even with no IM notification) drain the wait and execute the queued reset. A 30-min staleness guard runs a pending reset off the next inbound message if a terminal event never arrives.
- Interception sits **before** HumanInput consumption so a pending input card never swallows `/new` as its reply.
- Replies use direct provider delivery (`kind: System`, `purpose: HumanInputAck`) so the feature works even when `/new` is the very first message (no session to route through `try_outbound`); `bcs_session_id` is empty in that edge case — verified against the out-of-repo DingTalk provider that it tolerates empty (the field is tracing-only there, routing is keyed on `account_ref` + `im_conversation_*`).
- A new `chat_session_resolution_lock` closes the "two concurrent messages both see Completed and create two sessions" race; dispatch stays outside the lock.

Files:
- `src/bcs/crates/services/bcs-channel/src/commands.rs` (new): extensible command parser, `SessionResetTracker`, and the `BcsChannelService` command handlers.
- `src/bcs/crates/services/bcs-channel/src/lib.rs`: eight surgical hook points (struct fields, interception, staleness piggyback, resolution lock, `seed_runs` after dispatch, and the two terminal hooks). No service-api / repo-port / store / provider changes.
- `docs/superpowers/plans/2026-08-17-channel-new-command.md`: design doc.

## Validation
- `cargo test --package bcs-channel`: 83 passed (59 baseline + 24 new: 12 `commands.rs` unit tests for parser + tracker state machine; 12 integration tests covering no-session, idle-rollover, queue+ChatFinal, error terminal, per-sender isolation, shared group, state-machine idle/running/starting-window, HumanInput-not-consumed, concurrent idempotence, and stale-reset).
- `cargo clippy --package bcs-channel --no-deps`: zero warnings on `commands.rs`.
- `cargo test --workspace`: full regression exit 0, no failures.
- DingTalk provider (out-of-repo, `ocb_2`) tolerance of empty `bcs_session_id` confirmed by code audit of its `deliver_event` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)