### PR TITLE
refactor(backend): split grant check into per-admission-mode dependencies

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -20,8 +20,10 @@ argument to the call, and a client that must be told to put the same id in two
 places has been told the address twice.
 
 That is also what makes authorization mostly mechanical rather than
-per-operation. ``require_granted_bot`` reads the addressed bot off the path, the
-same way, for all but four operations on the surface.
+per-operation. The grant dependencies (``require_granted_own_bot`` /
+``require_granted_addressed_bot`` — one per grant-checked admission mode, so
+the declaration says which id model a route has) read the addressed bot off
+the path, the same way, for all but four operations on the surface.
 
 **The four are not an oversight, and their handler-side checks are
 load-bearing.** The ``{skill_id}`` skills operations resolve by
@@ -186,7 +188,7 @@ from .contracts import (
     USER_SCOPED_ERROR_RESPONSES,
 )
 from .dependencies import require_principal
-from .principal import require_granted_bot
+from .principal import require_granted_addressed_bot, require_granted_own_bot
 from .engine_runtime.approvals import router as engine_approvals_router
 from .engine_runtime.connection import router as engine_connection_router
 from .engine_runtime.engine import router as engine_engine_router
@@ -265,11 +267,12 @@ _SUBGROUPS = [
 # outright, which is exactly wrong for the listings (Mode B) and the
 # account-level reads (C/OPEN). `bots` is mixed and declares it per route;
 # `admission.py` is the authority on which is which, and
-# `test_principal_seam.py` fails if a route's declaration and its mode disagree.
+# `test_admission_inventory.py` fails if a route's declaration and its mode
+# disagree.
 #
-# The engine-runtime groups need no entry here: their `OwnerIdDep` already
-# depends on the same check, because it is where the addressed owner comes from
-# for an application caller.
+# The engine-runtime groups are not here because they are not own-bot: they may
+# address a shared bot, so their mount below declares the *addressed-bot*
+# dependency instead.
 _GRANT_CHECKED_SUBGROUPS = [
     # Engine config is bots-component work at an engine-component address: it
     # reads and writes a stored blob, so it takes the ordinary error table
@@ -315,7 +318,14 @@ _PUBLIC_AUTH = [Depends(require_principal)]
 # wholly own-bot. A no-op for a caller that names an end user — their own
 # operation's owner-scoped resolve already refuses a bot that is not theirs, and
 # re-deciding it here would risk a second, different answer.
-_GRANT_CHECKED = [Depends(require_granted_bot)]
+_GRANT_CHECKED_OWN_BOT = [Depends(require_granted_own_bot)]
+
+# The same authorization for the groups that may address a *shared* bot: the
+# grant is checked against the `owner_id` the request names (defaulting to the
+# caller) rather than pinned to the caller. Which of the two a mount gets is the
+# route's admission mode made visible — `admission.py` records the decision, and
+# `test_admission_inventory.py` fails if a mount and a mode disagree.
+_GRANT_CHECKED_ADDRESSED_BOT = [Depends(require_granted_addressed_bot)]
 
 
 def build_public_router() -> APIRouter:
@@ -344,31 +354,37 @@ def build_public_router() -> APIRouter:
         public.include_router(
             router,
             responses=USER_SCOPED_ERROR_RESPONSES,
-            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED,
+            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED_OWN_BOT,
         )
+    # The engine-runtime groups already run this exact check transitively —
+    # their `OwnerIdDep` consumes the owner it returns — so declaring it at the
+    # mount adds no second lookup (FastAPI caches a dependency per request).
+    # It is declared anyway so the mount says what governs the group, the same
+    # way the own-bot mounts above do, instead of the check being visible only
+    # inside `engine_runtime/params.py`.
     for router in _ENGINE_RUNTIME_GROUPS:
         public.include_router(
             router,
             responses=ENGINE_RUNTIME_ERROR_RESPONSES,
-            dependencies=_PUBLIC_AUTH,
+            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED_ADDRESSED_BOT,
         )
     # The addresses this surface used to have. Each legacy group is mounted the
     # way its replacement is, because the mount decides half of what a caller
     # experiences and parity means the old address answers as it always did.
     # The exception is `skills`, whose retiring item operations name no bot for
-    # `require_granted_bot` to read and so check it themselves — see
+    # the grant dependencies to read and so check it themselves — see
     # `deprecated/__init__.py`.
     for router in _LEGACY_ENGINE_RUNTIME:
         public.include_router(
             router,
             responses=ENGINE_RUNTIME_ERROR_RESPONSES,
-            dependencies=_PUBLIC_AUTH,
+            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED_ADDRESSED_BOT,
         )
     for router in _LEGACY_GRANT_CHECKED:
         public.include_router(
             router,
             responses=USER_SCOPED_ERROR_RESPONSES,
-            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED,
+            dependencies=_PUBLIC_AUTH + _GRANT_CHECKED_OWN_BOT,
         )
     for router in _LEGACY_SELF_CHECKED:
         public.include_router(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -65,17 +65,30 @@ class AdmissionMode(StrEnum):
     permission rule: both run the identical grant check. They differ only in
     where the addressed bot's owner comes from, because ``bot_id`` alone does
     not identify a bot.
+
+    **Each mode with something to enforce has a dependency that spells it**, so
+    a route's declaration and its table entry say the same thing in two places
+    and ``test_admission_inventory.py`` fails when they disagree:
+    ``require_granted_own_bot`` for own-bot, ``require_granted_addressed_bot``
+    for addressed-bot, ``refuse_app_only_caller`` for refused (all in
+    ``principal.py``). ``GRANT_FILTERED`` and ``USER_GATED`` cannot be a route
+    dependency — they shape the *result* through
+    :meth:`ActingCaller.granted_bot_ids` — and ``OPEN`` has nothing to declare.
     """
 
     #: **One bot, always the delegating user's own.** These groups resolve
     #: through ``get_by_id_and_owner(bot_id, delegating user)``, so the owner is
     #: that user by construction and the request cannot name another. Admitted
-    #: iff a live grant covers ``(app, bot, delegating user)``.
+    #: iff a live grant covers ``(app, bot, delegating user)``. Declared as
+    #: ``Depends(require_granted_own_bot)``, which never reads an owner off the
+    #: wire.
     GRANT_CHECKED_OWN_BOT = "grant-checked"
     #: **One bot, possibly someone else's.** The same check, against the bot
     #: the request addresses: these operations publish an ``owner_id`` query
     #: parameter that defaults to the caller's own, and the grant is looked up
-    #: on ``(app, bot, that owner, delegating user)``.
+    #: on ``(app, bot, that owner, delegating user)``. Declared as
+    #: ``Depends(require_granted_addressed_bot)``, the one dependency entitled
+    #: to read that parameter.
     #:
     #: The owner therefore comes *from the request*, not from the grant record.
     #: An earlier revision had it the other way round — the lookup asked "any
@@ -99,6 +112,10 @@ class AdmissionMode(StrEnum):
     #: **Refused**, with a ``401``. Also what an operation *absent* from the
     #: table gets, which is the point: a route added tomorrow is refused until
     #: someone decides otherwise, rather than admitted because nobody noticed.
+    #: A *listed* refused operation additionally declares
+    #: ``Depends(refuse_app_only_caller)``, so the decision is visible on the
+    #: route and holds even if this table were mislabelled; the absent-by-default
+    #: refusal has no route to declare anything on and stays central.
     REFUSED = "refused"
 
 
@@ -268,15 +285,16 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
 #: This is what remains of ``TODO(#960)``. Bot-first addressing removed the
 #: reason for three of the original seven — routines' create takes its bot on
 #: the path, and the two skills collection reads name their owner in the query
-#: where ``_addressed_owner`` can see it. These four are not an oversight left
-#: behind: an operation addressed by skill has no owner to check *until it has
-#: read the skill*, so the check belongs after that read or nowhere.
+#: where ``require_granted_addressed_bot`` can see it. These four are not an
+#: oversight left behind: an operation addressed by skill has no owner to check
+#: *until it has read the skill*, so the check belongs after that read or
+#: nowhere.
 #:
 #: **Naming them is what keeps the exception closed.** Deferring is about where
 #: the check runs, never whether: all four stay in a grant-checked mode, they
 #: are mounted without the group-level dependency rather than exempted from it,
 #: and ``test_admission_inventory.py`` asserts both. Any *other* operation that
-#: reached ``require_granted_bot`` without a bot id is refused, not waved past.
+#: reached a grant dependency without a bot id is refused, not waved past.
 SKILL_SCOPED_OPERATIONS = frozenset(
     {
         ("GET", "/openapi/v1/bots/{bot_id}/skills/{skill_id}"),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/router.py
@@ -76,7 +76,10 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     require_user_and_app_principal,
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
-from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    UserIdDep,
+    refuse_app_only_caller,
+)
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     deleted as deleted_envelope,
@@ -95,9 +98,16 @@ from agentclaw.community.core.bot_app_grant.models import BotAppGrantRecord
 from agentclaw.community.core.gateway_principal import PrincipalType
 from agentclaw.community.di import Injected
 
-#: The bot-scoped group — the owner's three operations.
+#: The bot-scoped group — the owner's three operations. All three are
+#: ``REFUSED`` to a machine caller: delegation is a human act, so an
+#: application must not widen its own access, withdraw a competitor's, or
+#: enumerate what else reaches a bot. The refusal already happens centrally in
+#: ``require_principal``; declaring it here makes the decision visible on the
+#: group that carries it and holds even if the admission table were mislabelled.
 router = APIRouter(
-    prefix="/openapi/v1/bots/{bot_id}/authorized-apps", tags=["authorized-apps"]
+    prefix="/openapi/v1/bots/{bot_id}/authorized-apps",
+    tags=["authorized-apps"],
+    dependencies=[Depends(refuse_app_only_caller)],
 )
 
 #: The app-scoped read, as its own literal component under the base. A second

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
@@ -11,6 +11,9 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     Principal,
     require_user_and_app_principal,
 )
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    refuse_app_only_caller,
+)
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -22,7 +25,17 @@ from agentclaw.community.core.bot_chat.schemas import (
 )
 from agentclaw.community.di import Injected
 
-router = APIRouter(prefix="/openapi/v1/bots/logs", tags=["bot-logs"])
+# Every operation here is ``REFUSED`` to a machine caller acting alone: on this
+# group ``user_id`` means *whose traces to read* over a tenant-level
+# observability surface, not *whose call this is*, and a grant covers a bot —
+# it does not translate into that meaning. The refusal already happens
+# centrally in ``require_principal``; declaring it here makes the decision
+# visible on the group that carries it. See ``refuse_app_only_caller``.
+router = APIRouter(
+    prefix="/openapi/v1/bots/logs",
+    tags=["bot-logs"],
+    dependencies=[Depends(refuse_app_only_caller)],
+)
 
 PrincipalDep = Annotated[Principal, Depends(require_user_and_app_principal)]
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -46,7 +46,8 @@ from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     ActingCallerDep,
     UserIdDep,
-    require_granted_bot,
+    refuse_app_only_caller,
+    require_granted_own_bot,
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     accepted,
@@ -117,9 +118,15 @@ logger = get_logger()
 #: (Mode B), the ceiling (C), the name check (OPEN) and bot creation (refused),
 #: none of which names a bot — and on those the check would refuse an
 #: application outright rather than authorize it. ``admission.py`` is the
-#: authority on which route is which; ``test_principal_seam.py`` fails if a
-#: declaration and a mode disagree.
-_GRANT_CHECKED = [Depends(require_granted_bot)]
+#: authority on which route is which; ``test_admission_inventory.py`` fails if
+#: a declaration and a mode disagree.
+_GRANT_CHECKED_OWN_BOT = [Depends(require_granted_own_bot)]
+
+#: What a ``REFUSED`` operation declares: no caller without an end user. The
+#: refusal already happens centrally in ``require_principal`` — this makes the
+#: decision visible on the route that carries it, and holds even if the table
+#: entry were ever mislabelled. See ``refuse_app_only_caller``.
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 
 router = APIRouter(prefix="/openapi/v1/bots", tags=["bots"])
 
@@ -242,6 +249,9 @@ def _sync_passport_identity(
     "",
     status_code=201,
     response_model=Envelope[Bot],
+    # REFUSED to a machine caller: no bot exists yet for a grant to cover, and
+    # creation spends the user's quota — see the mode's entry in `admission.py`.
+    dependencies=_REFUSES_APP_ONLY,
     responses={
         **USER_SCOPED_403,
         202: {
@@ -493,7 +503,7 @@ async def get_bots_ceiling(
     "/{bot_id}",
     response_model=Envelope[Bot],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def get_bot(
@@ -511,7 +521,7 @@ async def get_bot(
     "/{bot_id}",
     response_model=Envelope[Bot],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def update_bot(
@@ -567,7 +577,7 @@ async def update_bot(
     "/{bot_id}",
     response_model=Envelope[Deleted],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def delete_bot(
@@ -591,7 +601,7 @@ async def delete_bot(
     "/{bot_id}/restart",
     response_model=Envelope[Bot],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def restart_bot(
@@ -641,7 +651,7 @@ async def restart_bot(
             },
         },
     },
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def get_bot_auth_status(
@@ -746,7 +756,7 @@ async def get_bot_auth_status(
     "/{bot_id}/status",
     response_model=Envelope[BotStatus],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def get_bot_status(
@@ -774,7 +784,7 @@ async def get_bot_status(
     "/{bot_id}/passport",
     response_model=Envelope[Passport],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def get_bot_passport(
@@ -819,7 +829,7 @@ def _audit_actor(caller: ActingCaller, owner_id: str) -> str:
     "/{bot_id}/startup-script",
     response_model=Envelope[StartupScript],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def get_bot_startup_script(
@@ -847,7 +857,7 @@ async def get_bot_startup_script(
     "/{bot_id}/startup-script",
     response_model=Envelope[StartupScript],
     responses=STARTUP_SCRIPT_WRITE_RESPONSES,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def update_bot_startup_script(
@@ -898,7 +908,7 @@ async def update_bot_startup_script(
     "/{bot_id}/startup-script",
     response_model=Envelope[Deleted],
     responses=USER_SCOPED_403,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_OWN_BOT,
 )
 @envelope_errors
 async def delete_bot_startup_script(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/__init__.py
@@ -44,9 +44,10 @@ from . import skills as _skills
 #: Mounted with the engine-runtime response table, like their replacements.
 ENGINE_RUNTIME_GROUPS = _engine_runtime.ENGINE_RUNTIME + [_approvals.router]
 
-#: Mounted grant-checked, like their replacements. ``require_granted_bot`` reads
-#: the bot off the path *or* the query string, so the resources and routines
-#: legacy addresses are covered by it exactly as the new ones are.
+#: Mounted grant-checked (own-bot), like their replacements.
+#: ``require_granted_own_bot`` reads the bot off the path *or* the query
+#: string, so the resources and routines legacy addresses are covered by it
+#: exactly as the new ones are.
 GRANT_CHECKED_GROUPS = _engine_runtime.GRANT_CHECKED + [
     _bots.router,
     _resources.router,
@@ -79,9 +80,9 @@ def _inherit_admission_modes() -> None:
     second copy of one decision, free to drift from the first.
 
     Run at import, before any request: ``ADMISSION`` is read per request by
-    ``require_granted_bot`` and ``_addressed_owner``, and an operation missing
-    from it is refused. ``test_admission_inventory`` is what fails if a legacy
-    address ever names a replacement that is not itself in the table.
+    ``require_principal``'s admission check, and an operation missing from it
+    is refused. ``test_admission_inventory`` is what fails if a legacy address
+    ever names a replacement that is not itself in the table.
     """
     for (method, legacy_path), replacement in LEGACY_ROUTES.items():
         mode = ADMISSION.get((method, replacement))

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/resources.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/resources.py
@@ -7,7 +7,7 @@ parameter re-annotated, registered at the address it used to have — and its
 response model and response table read off the real route rather than restated
 (``download`` has its own, for the octet-stream body).
 
-``require_granted_bot`` reads the bot off the path *or* the query string, so
+``require_granted_own_bot`` reads the bot off the path *or* the query string, so
 these mount grant-checked exactly as their replacements do: the same code
 deciding the same thing, which is what makes the parity claim true rather than
 hopeful.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/routines.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/routines.py
@@ -5,7 +5,7 @@ Six of the seven took ``bot_id`` as a required query parameter beside a
 
 The seventh is the create, and it is the reason this package needs an
 authorization mechanism of its own. It took the bot in the request body, which
-``require_granted_bot`` cannot see — the body is not parsed when dependencies
+the grant dependencies cannot see — the body is not parsed when dependencies
 resolve — so the check has to run inside the shim, first, before anything
 touches the bot. That is exactly the arrangement ``TODO(#960)`` recorded as a
 defect, and the *routines* create no longer has it on the current surface — its
@@ -144,7 +144,7 @@ async def create_routine_legacy(
 
 
 #: The create is mounted **without** the shared grant check, on its own router.
-#: Not a style choice: require_granted_bot reads the bot off the path or the
+#: Not a style choice: require_granted_own_bot reads the bot off the path or the
 #: query string, finds neither here, and *refuses* an application caller rather
 #: than deferring — so mounting it with the others would turn a working legacy
 #: call into a 404. The old contract kept this operation out of the dependency's

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/skills.py
@@ -9,7 +9,7 @@ the collection.
 
 **The four ``{skill_id}`` operations** named no bot at all — the skill id
 resolved its own — so there is nothing to put back in the query and nothing for
-``require_granted_bot`` to read. They resolve the bot from the skill exactly as
+the grant dependencies to read. They resolve the bot from the skill exactly as
 they used to, and check the grant against the ``(bot, owner)`` the record names.
 
 That last part is the second authorization mechanism in the one place it is

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
@@ -43,7 +43,7 @@ from agentclaw.community.adapters.http.openapi_v1.errors import (
 from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     ActingCallerDep,
-    GrantCheckedDep,
+    AddressedBotGrantDep,
 )
 from agentclaw.community.log import get_logger
 
@@ -85,7 +85,7 @@ WRITE_STAGE_DESCRIPTION = (
 
 async def resolve_owner_id(
     caller: ActingCallerDep,
-    granted_owner_id: GrantCheckedDep,
+    granted_owner_id: AddressedBotGrantDep,
     owner_id: Annotated[
         str | None,
         Query(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/loadtest/router.py
@@ -40,6 +40,9 @@ from fastapi import APIRouter, Depends, Request, WebSocket, WebSocketDisconnect
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    refuse_app_only_caller,
+)
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -53,12 +56,15 @@ router = APIRouter(prefix="/openapi/v1/bots/loadtest", tags=["loadtest"])
 #: places, so the test asserts the same bytes the handler returns.
 HELLO_WORLD = "hello world"
 
-# Authenticated, but not user-scoped. Declared on each route rather than
-# inherited from ``build_public_router`` for the reason ``check_bot_name`` does
-# the same: the guard is visible where the operation is, and
+# Authenticated, but not user-scoped — and ``REFUSED`` to a machine caller: no
+# user scope, no bot, and nothing this feature is about (see the admission
+# table). Declared on each route rather than inherited from
+# ``build_public_router`` for the reason ``check_bot_name`` does the same: the
+# guard is visible where the operation is, and
 # ``test_public_routes_require_principal`` walks each route's own dependant,
-# which a group-level dependency does not appear in.
-_AUTH = [Depends(require_principal)]
+# which a group-level dependency does not appear in. The refusal dependency
+# answers the socket plane with the same 1008 close ``require_principal`` uses.
+_AUTH = [Depends(require_principal), Depends(refuse_app_only_caller)]
 
 
 @router.get("/hello", response_model=Envelope[HelloWorld], dependencies=_AUTH)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -33,7 +33,10 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     require_principal,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    UserIdDep,
+    refuse_app_only_caller,
+)
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -69,6 +72,14 @@ from .schemas import (
 )
 
 router = APIRouter(prefix="/openapi/v1/bots/mcp", tags=["mcp"])
+
+#: What the *configuration* operations declare: ``REFUSED`` to a machine
+#: caller. They read and write account-level state with no bot dimension — a
+#: grant is consent to reach a bot, not to reconfigure an account. The
+#: catalogue reads above them are OPEN and carry nothing. The refusal already
+#: happens centrally in ``require_principal``; the declaration makes the
+#: decision visible on the routes that carry it. See ``refuse_app_only_caller``.
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 
 #: The path parameter naming the MCP server an operation addresses.
 ServerCodePath = Annotated[
@@ -246,6 +257,7 @@ async def get_mcp_server(
     "/servers/{server_code}/permissions",
     response_model=Envelope[McpPermission],
     responses=USER_SCOPED_403,
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def check_mcp_permission(
@@ -288,6 +300,7 @@ async def check_mcp_permission(
     "/servers/{server_code}/config",
     response_model=Envelope[McpConfig],
     responses=USER_SCOPED_403,
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def get_mcp_config(
@@ -311,6 +324,7 @@ async def get_mcp_config(
     "/servers/{server_code}/config",
     response_model=Envelope[McpConfig],
     responses=USER_SCOPED_403,
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def update_mcp_config(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/principal.py
@@ -56,7 +56,8 @@ checked against, and that follows from whether the credential names a person:
 - **An application acting alone** names no end user, so there is nothing to
   compare with. Its ``user_id`` is authorized against the **grant** instead —
   "has this person delegated to this application, for this bot?" — which happens
-  in :data:`GrantCheckedDep` below, because only there is the bot known.
+  in the grant dependencies below (:func:`require_granted_own_bot` /
+  :func:`require_granted_addressed_bot`), because only there is the bot known.
 
 This is the split :func:`require_user_id`'s own docstring predicted: acquisition
 here, adjudication one step later. It is why the parameter had to exist before
@@ -90,14 +91,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import Depends, Query, Request
+from starlette.requests import HTTPConnection
 
-from agentclaw.community.adapters.http.openapi_v1.admission import (
-    ADMISSION,
-    ActingCaller,
-    AdmissionMode,
-)
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     Principal,
+    _refuse,
     require_principal,
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import (
@@ -231,9 +230,9 @@ async def require_user_id(
     naming no end user — an application acting alone — there is no second id to
     compare with, so the comparison is skipped and the parameter is authorized
     against the delegation instead. That check needs the bot, which this
-    dependency does not have, so it happens one step later in
-    :data:`GrantCheckedDep`. Nothing else moved: no handler, schema or path
-    changed, because none of them ever named the user.
+    dependency does not have, so it happens one step later, in whichever grant
+    dependency the route declares. Nothing else moved: no handler, schema or
+    path changed, because none of them ever named the user.
 
     Skipping the comparison is not skipping a check. An application that reaches
     an operation without also taking the grant-checked dependency would be
@@ -364,11 +363,62 @@ _BOT_ID_KEY = "bot_id"
 _OWNER_ID_KEY = "owner_id"
 
 
-async def require_granted_bot(
+async def require_granted_own_bot(
     request: Request,
     caller: ActingCallerDep,
 ) -> str:
-    """Authorize the addressed bot for an application caller; a no-op for a human.
+    """Authorize the addressed bot as the **delegating user's own**.
+
+    The dependency every ``GRANT_CHECKED_OWN_BOT`` operation declares — at
+    ``include_router`` for the wholly own-bot groups, per route in the mixed
+    ``bots`` group — and the declaration *is* the mode: a route says which id
+    model it has by naming this dependency or its addressed-bot sibling, and
+    ``test_admission_inventory.py`` fails if the name and the table disagree.
+
+    The owner is ``caller.user_id`` and nothing else, which is not shorthand —
+    it is the security property. ``request.query_params`` is the raw parsed
+    query string, not the parameters a route declares, so an operation that
+    never publishes ``owner_id`` would still be handed one if a client appended
+    it. An earlier revision read it wherever it appeared, and that let an
+    application aim the *check* at a bot it held a grant on while the *handler*
+    — reading only its own ``user_id`` — resolved and acted on the delegating
+    user's own, different, ungranted bot of the same id. A grant on anyone's
+    ``default`` became access to the delegator's ``default``. This function
+    cannot repeat that mistake because it never consults the wire at all: check
+    and resolution read the same value by construction.
+    """
+    return _require_granted_bot(request, caller, owner_id=caller.user_id)
+
+
+async def require_granted_addressed_bot(
+    request: Request,
+    caller: ActingCallerDep,
+) -> str:
+    """Authorize the bot the request **addresses**, which may be shared.
+
+    The dependency every ``GRANT_CHECKED_ADDRESSED_BOT`` operation declares —
+    the engine-runtime groups through :data:`AddressedBotGrantDep` (their
+    ``resolve_owner_id`` consumes the returned owner), the skills collection
+    operations per route. Declaring it is what entitles an operation to an
+    owner off the wire: these operations publish an ``owner_id`` query
+    parameter, defaulting to the caller, and this reads the same value the
+    handler acts on — so the check and the resolution mean the same bot here
+    for the same reason the own-bot dependency's constant does there.
+
+    An operation that does *not* publish ``owner_id`` must declare
+    :func:`require_granted_own_bot` instead; giving it this dependency would
+    reintroduce the surface's oldest defect (see that function's docstring).
+    ``test_admission_inventory.py`` holds each route to the dependency its
+    admission mode calls for.
+    """
+    addressed_owner = request.query_params.get(_OWNER_ID_KEY) or caller.user_id
+    return _require_granted_bot(request, caller, owner_id=addressed_owner)
+
+
+def _require_granted_bot(
+    request: Request, caller: ActingCaller, *, owner_id: str
+) -> str:
+    """The shared half: find the bot on the wire, ask the grant, return the owner.
 
     Returns the resolved **owner** of the addressed bot — which the
     engine-runtime groups need and the user-scoped groups discard. One lookup,
@@ -379,37 +429,29 @@ async def require_granted_bot(
     would risk a second, different answer.
 
     For an application it is the authorization: no live grant for
-    ``(app, bot, delegating user)`` raises :class:`GrantNotResolvableError`,
-    which the app maps to a ``404`` byte-identical to a nonexistent bot.
+    ``(app, bot, owner, delegating user)`` raises
+    :class:`GrantNotResolvableError`, which the app maps to a ``404``
+    byte-identical to a nonexistent bot.
 
     **What this needs is a bot *and an owner*, because ``bot_id`` alone does not
-    identify a bot.** Seven operations could not supply both, so the check ran
-    in their handlers instead — one carried its bot in the request body, four
-    named only a skill, and two named a bot but addressed an owner under a
-    parameter this dependency did not know. That was ``TODO(#960)``: two
-    mechanisms doing one job, and it had already cost one real defect, because a
-    handler-side check is a place the check and the resolution can drift apart.
+    identify a bot.** The two callers above differ only in where the owner comes
+    from; everything both need — and the ``TODO(#960)`` history of the
+    operations that could not supply a bot here — lives once, in this body.
 
-    Bot-first addressing removed the reason for **three of the seven**. The
-    routines create takes its bot on the path; the two skills collection
-    operations spell their owner locator ``owner_id``, so
-    :func:`_addressed_owner` reads the same value the handler acts on.
-
-    The four ``{skill_id}`` operations remain, and not by omission. They resolve
-    by ``(skill, actor)``, so the bot's owner arrives *on the record* — a
-    collaborator reaches a skill on someone else's bot routinely — and there is
-    nothing here to look a grant up against until that read has happened. They
-    are named in ``admission.SKILL_SCOPED_OPERATIONS``, mounted without this
-    dependency rather than exempted from it, and check the pair the record
-    carries before acting.
+    The four ``{skill_id}`` operations declare neither caller, and not by
+    omission. They resolve by ``(skill, actor)``, so the bot's owner arrives
+    *on the record* — a collaborator reaches a skill on someone else's bot
+    routinely — and there is nothing here to look a grant up against until that
+    read has happened. They are named in ``admission.SKILL_SCOPED_OPERATIONS``,
+    mounted without either dependency rather than exempted from one, and check
+    the pair the record carries before acting.
 
     The refusal below is what stays. An operation that reaches here without a
-    bot id is refused rather than waved through. The *legacy* addresses cannot
-    be checked here either — their bot really is in a body or behind a skill id
-    — so they check themselves, inside ``openapi_v1/deprecated``, and that half
-    of the mechanism is deleted when they are.
+    bot id is refused rather than waved through. The *legacy* addresses that
+    cannot be checked here — their bot really is in a body or behind a skill id
+    — check themselves, inside ``openapi_v1/deprecated``, and that half of the
+    mechanism is deleted when they are.
     """
-    addressed_owner = _addressed_owner(request, caller.user_id)
     bot_id = request.path_params.get(_BOT_ID_KEY) or request.query_params.get(
         _BOT_ID_KEY
     )
@@ -422,50 +464,37 @@ async def require_granted_bot(
             "no bot id on a grant-checked request; the operation must resolve "
             "its own bot before acting"
         )
-    return caller.require_bot(str(bot_id), owner_id=addressed_owner)
+    return caller.require_bot(str(bot_id), owner_id=owner_id)
 
 
-def _addressed_owner(request: Request, caller_id: str) -> str:
-    """Whose bot this request addresses — never a guess, and never ``None``.
+#: What an engine-runtime handler's ``resolve_owner_id`` declares to have the
+#: addressed bot authorized *and* receive the owner the grant actually covers.
+AddressedBotGrantDep = Annotated[str, Depends(require_granted_addressed_bot)]
 
-    ``bot_id`` does not identify a bot; ``(owner_id, bot_id)`` does. So the
-    grant lookup needs an owner, and every operation on this surface already
-    knows one:
 
-    - The **user-scoped groups** resolve through ``get_by_id_and_owner`` with
-      the delegating user. The owner is the caller, full stop, and **nothing on
-      the wire may say otherwise** — see below.
-    - The **engine-runtime groups** publish an ``owner_id`` query parameter that
-      defaults to the caller, and adjudicate it in ``resolve_owner_id``. There
-      the request is entitled to name an owner, so this reads the same value the
-      operation will act on.
+async def refuse_app_only_caller(
+    connection: HTTPConnection,
+    principal: Annotated[Principal, Depends(require_principal)],
+) -> None:
+    """The declaration a ``REFUSED`` operation carries: no machine callers.
 
-    **The mode decides whether the wire is consulted at all, and that gate is
-    load-bearing.** ``request.query_params`` is the raw parsed query string, not
-    the parameters a route declares, so an operation that never publishes
-    ``owner_id`` will still hand one over if a client appends it. Trusting it
-    unconditionally let an application aim the *check* at a bot it held a grant
-    on while the *handler* — reading only its own ``user_id`` — resolved and
-    acted on the delegating user's own, different, ungranted bot of the same id.
-    A grant on anyone's ``default`` became access to the delegator's ``default``.
+    The refusal itself already happens centrally — :func:`require_principal`
+    admits a caller naming no end user only on an operation whose table entry
+    is in ``ADMITTING_MODES``, and an operation *absent* from the table refuses
+    by omission. That fail-closed default stays, and this dependency does not
+    replace it.
 
-    That failure is this surface's oldest one, in a new place: the check and the
-    resolution must never be able to mean different bots. Reading the wire only
-    where the operation itself reads it keeps them the same value by
-    construction.
+    What this adds is the same thing the two grant dependencies above add to
+    their modes: the decision is visible on the route that carries it, and
+    checked there. A ``REFUSED`` operation whose table entry were ever
+    mislabelled to an admitting mode would still refuse here, instead of
+    silently widening — and ``test_admission_inventory.py`` holds the set of
+    routes declaring this to exactly the table's ``REFUSED`` entries.
 
-    An operation this cannot classify answers with the caller's own id, the
-    stricter side — it has not been placed in a mode and is refused a moment
-    later anyway.
+    Refuses in the shape :func:`require_principal` refuses — the same ``401``
+    on HTTP, the same ``1008`` close on a WebSocket handshake — so a caller
+    cannot tell which of the two said no.
     """
-    route = request.scope.get("route")
-    path = getattr(route, "path", None)
-    if path is None:
-        return caller_id
-    if ADMISSION.get((request.method, path)) is not AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT:
-        return caller_id
-    return request.query_params.get(_OWNER_ID_KEY) or caller_id
-
-
-#: What a grant-checked handler declares to have its bot authorized.
-GrantCheckedDep = Annotated[str, Depends(require_granted_bot)]
+    if caller_names_a_user(principal):
+        return
+    _refuse(connection, "this operation requires a caller naming an end user")

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -25,7 +25,7 @@ from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     ActingCallerDep,
     UserIdDep,
-    require_granted_bot,
+    require_granted_addressed_bot,
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
@@ -55,18 +55,19 @@ from .schemas import Skill, SkillState, SkillUpload
 router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/skills", tags=["skills"])
 
 #: The bot authorization for an application caller, on the two operations the
-#: shared dependency can decide.
+#: shared dependency can decide — the **addressed-bot** dependency, because the
+#: collection operations publish ``owner_id`` and may address a shared bot.
 #:
 #: Declared per route rather than at ``include_router``, because this group is
 #: mixed in the one way that matters to this check: the collection operations
 #: name their bot's owner in the query, so the dependency can look the grant up
 #: against the pair the handler will act on — while the four ``{skill_id}``
 #: operations learn that owner only by reading the skill. Mounting the whole
-#: group under it refused an application holding a valid grant on a *shared*
-#: bot, because the dependency fell back to the delegating user. ``admission.py``
-#: is the authority on which route is which; ``test_admission_inventory.py``
-#: fails if a declaration and a mode disagree.
-_GRANT_CHECKED = [Depends(require_granted_bot)]
+#: group under a grant check refused an application holding a valid grant on a
+#: *shared* bot, because the check fell back to the delegating user.
+#: ``admission.py`` is the authority on which route is which;
+#: ``test_admission_inventory.py`` fails if a declaration and a mode disagree.
+_GRANT_CHECKED_ADDRESSED_BOT = [Depends(require_granted_addressed_bot)]
 
 #: The path parameter naming the skill an operation addresses. The id alone
 #: still resolves the skill's bot and owner; the address names the bot as well
@@ -180,7 +181,9 @@ def _to_skill(record: dict[str, Any]) -> Skill:
     )
 
 
-@router.get("", response_model=Envelope[Page[Skill]], dependencies=_GRANT_CHECKED)
+@router.get(
+    "", response_model=Envelope[Page[Skill]], dependencies=_GRANT_CHECKED_ADDRESSED_BOT
+)
 @envelope_errors
 async def list_skills(
     page: PageParamsDep,
@@ -249,7 +252,7 @@ async def get_skill(
 @router.post(
     "",
     status_code=201,
-    dependencies=_GRANT_CHECKED,
+    dependencies=_GRANT_CHECKED_ADDRESSED_BOT,
     response_model=Envelope[SkillUpload],
     responses={
         200: {

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
@@ -39,15 +39,23 @@ from agentclaw.community.adapters.http.openapi_v1.admission import (
     AdmissionMode,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
-from agentclaw.community.adapters.http.openapi_v1.principal import require_granted_bot
-
-#: The modes whose contract is "a grant is checked for the addressed bot".
-_GRANT_CHECKED_MODES = frozenset(
-    {
-        AdmissionMode.GRANT_CHECKED_OWN_BOT,
-        AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    }
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    refuse_app_only_caller,
+    require_granted_addressed_bot,
+    require_granted_own_bot,
 )
+
+#: The modes whose contract is "a grant is checked for the addressed bot",
+#: each mapped to the one dependency that spells it. The declaration *is* the
+#: mode — the own-bot dependency never reads an owner off the wire, the
+#: addressed-bot one is the only thing entitled to — so a route carrying the
+#: wrong one is not a naming slip, it is the wrong check.
+_GRANT_DEPENDENCY_BY_MODE = {
+    AdmissionMode.GRANT_CHECKED_OWN_BOT: require_granted_own_bot,
+    AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT: require_granted_addressed_bot,
+}
+
+_GRANT_CHECKED_MODES = frozenset(_GRANT_DEPENDENCY_BY_MODE)
 
 
 def _effective_routes():
@@ -152,67 +160,79 @@ def test_every_public_operation_still_requires_a_principal():
     assert not missing, f"public operations not gated by require_principal: {missing}"
 
 
-def test_every_grant_checked_operation_actually_checks():
-    """A grant-checked mode must mean the check runs, not that someone meant it to.
+@pytest.mark.parametrize(
+    "mode", sorted(_GRANT_DEPENDENCY_BY_MODE, key=lambda m: m.name)
+)
+def test_every_grant_checked_operation_declares_its_modes_dependency(mode):
+    """A grant-checked mode must mean *its* check runs, not just *a* check.
 
     Verified against the assembled router rather than the handler signature,
     because the check is declared three different ways — at ``include_router``
-    for the wholly own-bot groups, per route in the mixed ``bots`` group, and
-    transitively through ``OwnerIdDep`` on the engine-runtime groups. A test
-    that looked for one spelling would pass while the other two rotted.
+    for the wholly own-bot groups, per route in the mixed ``bots`` and
+    ``skills`` groups, and (alongside the mount) transitively through
+    ``OwnerIdDep`` on the engine-runtime groups. A test that looked for one
+    spelling would pass while the others rotted.
+
+    Since the split there is one dependency per mode, and this asserts the
+    pairing in both directions: an own-bot operation carrying the addressed-bot
+    dependency would let an appended ``owner_id`` aim the check at a bot the
+    handler is not acting on — the surface's oldest defect — and an
+    addressed-bot operation carrying the own-bot dependency would refuse every
+    valid grant on a shared bot. Neither is a smaller mistake than a missing
+    check.
 
     Two named sets are excluded, for the same underlying reason and with
     different lifetimes. ``SKILL_SCOPED_OPERATIONS`` — the four current
     ``{skill_id}`` operations — resolve the bot's owner from the skill record,
-    so there is nothing for the dependency to look a grant up against until the
+    so there is nothing for a dependency to look a grant up against until the
     handler has read it. The retiring addresses in ``SELF_CHECKED_ROUTES`` are
     the same problem in the old contract's shape: their bot is in a request body
-    or behind a skill id, and mounting them under the dependency would refuse an
+    or behind a skill id, and mounting them under a dependency would refuse an
     application outright rather than defer, turning a working legacy call into a
     404. Both check it themselves, first, before acting; the second set is empty
     the day the deprecated package goes. ``test_only_the_named_operations_
     check_their_own_grant`` is what stops either from growing quietly.
     """
+    dependency = _GRANT_DEPENDENCY_BY_MODE[mode]
     expected = {
         key
-        for key, mode in ADMISSION.items()
-        if mode in _GRANT_CHECKED_MODES
+        for key, table_mode in ADMISSION.items()
+        if table_mode is mode
         and key not in SELF_CHECKED_ROUTES
         and key not in SKILL_SCOPED_OPERATIONS
     }
     actual = {
         key
         for key, ctx in _operations()
-        if _depends_on(_dependant_of(ctx), require_granted_bot)
+        if _depends_on(_dependant_of(ctx), dependency)
     }
 
     unchecked = sorted(f"{m} {p}" for m, p in expected - actual)
     unexpected = sorted(f"{m} {p}" for m, p in actual - expected)
 
     assert not unchecked, (
-        "operations marked grant-checked that do not run the check — an "
-        "application would reach these with no authorization at all:\n  "
-        + "\n  ".join(unchecked)
+        f"operations whose mode is {mode.name} that do not declare "
+        f"{dependency.__name__} — an application would reach these with the "
+        "wrong authorization, or none at all:\n  " + "\n  ".join(unchecked)
     )
     assert not unexpected, (
-        "operations running the grant check without a mode that calls for it. "
-        "On an operation that names no bot the check refuses an application "
-        "outright, so this is a refusal nobody asked for:\n  "
-        + "\n  ".join(unexpected)
+        f"operations declaring {dependency.__name__} whose mode is not "
+        f"{mode.name}. The declaration and the table must say the same thing — "
+        "fix whichever one is wrong:\n  " + "\n  ".join(unexpected)
     )
 
 
 def test_only_the_named_operations_check_their_own_grant():
     """``TODO(#960)`` shrank from seven to four, and this is what holds the line.
 
-    Seven operations used to have their bot somewhere ``require_granted_bot``
+    Seven operations used to have their bot somewhere the shared dependency
     could not see it — one in a request body, four behind a skill id, two under
     an owner parameter the dependency did not know. Two mechanisms doing one
     job, and it had already cost one real defect.
 
     Bot-first addressing removed the reason for three: routines' create takes
     its bot on the path, and the two skills collection operations name their
-    owner in the query, where ``_addressed_owner`` reads it.
+    owner in the query, where ``require_granted_addressed_bot`` reads it.
 
     The four ``{skill_id}`` operations are not a leftover. They resolve by
     ``(skill, actor)``, so the bot's owner is an *output* of the read — a
@@ -229,7 +249,8 @@ def test_only_the_named_operations_check_their_own_grant():
         key
         for key, ctx in _operations()
         if ADMISSION.get(key) in _GRANT_CHECKED_MODES
-        and not _depends_on(_dependant_of(ctx), require_granted_bot)
+        and not _depends_on(_dependant_of(ctx), require_granted_own_bot)
+        and not _depends_on(_dependant_of(ctx), require_granted_addressed_bot)
         and key not in LEGACY_ROUTES
     }
     assert self_checking == SKILL_SCOPED_OPERATIONS, (
@@ -256,6 +277,51 @@ def test_the_self_checking_operations_are_still_grant_checked():
     )
     assert not not_in_table, (
         f"self-checking legacy operations absent from ADMISSION: {not_in_table}"
+    )
+
+
+def test_every_refused_operation_declares_its_refusal():
+    """A ``REFUSED`` entry and a ``refuse_app_only_caller`` declaration are one
+    decision written twice, and they must not drift.
+
+    The refusal a machine caller actually receives comes centrally, from
+    ``require_principal`` reading the table — that stays, and it is also the
+    only thing covering an operation *absent* from the table, which has no
+    route to declare anything on. What the declaration adds is that the
+    decision is visible on the route that carries it and holds even if the
+    table entry were mislabelled to an admitting mode.
+
+    Both directions matter: a ``REFUSED`` operation without the declaration is
+    a decision readable only in the table, and an operation declaring it under
+    an admitting mode would refuse callers its mode says to admit. The legacy
+    addresses are exempt in the first direction only — they inherit their
+    replacements' modes and are retiring, so nothing new is declared on them —
+    and today none of them is ``REFUSED`` anyway.
+    """
+    expected = {
+        key
+        for key, mode in ADMISSION.items()
+        if mode is AdmissionMode.REFUSED and key not in LEGACY_ROUTES
+    }
+    actual = {
+        key
+        for key, ctx in _operations()
+        if _depends_on(_dependant_of(ctx), refuse_app_only_caller)
+    }
+
+    undeclared = sorted(f"{m} {p}" for m, p in expected - actual)
+    unexpected = sorted(f"{m} {p}" for m, p in actual - expected - set(LEGACY_ROUTES))
+
+    assert not undeclared, (
+        "REFUSED operations that do not declare refuse_app_only_caller — the "
+        "central check still refuses them, but the decision is invisible at "
+        "the route and unprotected against a mislabelled table entry:\n  "
+        + "\n  ".join(undeclared)
+    )
+    assert not unexpected, (
+        "operations declaring refuse_app_only_caller whose mode is not "
+        "REFUSED — they would refuse callers their mode says to admit:\n  "
+        + "\n  ".join(unexpected)
     )
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_bot_not_on_the_wire.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_bot_not_on_the_wire.py
@@ -25,7 +25,9 @@ from fastapi_injector import attach_injector
 from injector import Injector, Module
 
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
-from agentclaw.community.adapters.http.openapi_v1.principal import require_granted_bot
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    require_granted_own_bot,
+)
 from agentclaw.community.adapters.http.openapi_v1.routines import (
     router as routines_router,
 )
@@ -185,16 +187,19 @@ def client(skills, cron):
             binder.bind(LocalSkillUploadServiceProtocol, to=skills)
             binder.bind(CronRelayServiceProtocol, to=cron)
 
-    # Both groups are mounted with the shared grant check in build_public_router,
-    # and this file is about what an application caller may reach — so the
-    # fixture mounts them the same way. Mounting them bare used to pass because
-    # routines checked the grant inside its handler; now that the check is the
-    # dependency's for every route, a bare mount would assert against an
-    # assembly production does not have.
-    grant_checked = [Depends(require_granted_bot)]
+    # Mounted exactly as build_public_router mounts them, because this file is
+    # about what an application caller may reach and the mount is half of that.
+    # Routines is a wholly own-bot group and gets its dependency at include;
+    # skills is mounted bare — its two collection routes carry the
+    # addressed-bot dependency in their own decorators (which travel with the
+    # router), and its four ``{skill_id}`` routes check the grant in their
+    # handlers (``SKILL_SCOPED_OPERATIONS``). A group-level dependency on
+    # skills here would assert against an assembly production does not have.
     app = FastAPI()
-    app.include_router(skills_router, dependencies=grant_checked)
-    app.include_router(routines_router, dependencies=grant_checked)
+    app.include_router(skills_router)
+    app.include_router(
+        routines_router, dependencies=[Depends(require_granted_own_bot)]
+    )
     app.dependency_overrides[require_principal] = _app_caller
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -22,11 +22,16 @@ from fastapi import FastAPI
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
+from agentclaw.community.adapters.http.openapi_v1.admission import (
+    ADMISSION,
+    AdmissionMode,
+)
 from agentclaw.community.adapters.http.openapi_v1.authorized_apps import (
     app_view_router,
 )
 from agentclaw.community.adapters.http.openapi_v1.bots import router as bots_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.bot_app_grant.models import BotAppGrantRecord
@@ -393,3 +398,87 @@ def test_the_name_check_needs_no_delegation(make_client):
 
     assert response.status_code == 200, response.json()
     assert response.json()["data"]["exists"] is False
+
+
+# ── derived from the table: every filtered/gated operation is covered ────────
+#
+# The hand-written tests above pin the *behavior* of the three operations that
+# exist today. What they cannot do is notice a fourth: GRANT_FILTERED and
+# USER_GATED have no dependency a structural test could look for — the
+# narrowing is the handler's own work, through `granted_bot_ids` — so an
+# operation added tomorrow with a correct table entry and no narrowing in its
+# handler would fail nothing. These two tests parametrize over the table
+# itself: a new entry appears here automatically, and until someone writes it
+# an ungranted-app case in `_UNGRANTED_APP_CASES`, the test fails loudly
+# instead of silently covering nothing. That is the same ratchet
+# `test_self_checked_routes_refuse.py` uses for its BODIES map.
+
+#: How to call each filtered/gated operation as an application granted
+#: *nothing*, and what the empty answer must look like. `assert_starved` gets
+#: the response; it must assert the app learned nothing.
+_UNGRANTED_APP_CASES = {
+    ("GET", "/openapi/v1/bots"): {
+        "request": lambda client: client.get("/openapi/v1/bots"),
+        "assert_starved": lambda response: (
+            _data(response)["items"] == [] and _data(response)["total"] == 0
+        ),
+    },
+    ("GET", "/openapi/v1/bots/authorized"): {
+        "request": lambda client: client.get("/openapi/v1/bots/authorized"),
+        "assert_starved": lambda response: (
+            _data(response)["items"] == [] and _data(response)["total"] == 0
+        ),
+    },
+    ("GET", "/openapi/v1/bots/ceiling"): {
+        "request": lambda client: client.get("/openapi/v1/bots/ceiling"),
+        # USER_GATED: no delegation, no relationship — masked as not-found, so
+        # a stranger app cannot read a person's quota by naming them.
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+}
+
+_FILTERED_OR_GATED = sorted(
+    key
+    for key, mode in ADMISSION.items()
+    if mode in {AdmissionMode.GRANT_FILTERED, AdmissionMode.USER_GATED}
+    and key not in LEGACY_ROUTES
+)
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    _FILTERED_OR_GATED,
+    ids=[f"{m} {p}" for m, p in _FILTERED_OR_GATED],
+)
+def test_every_filtered_or_gated_operation_starves_an_ungranted_app(
+    make_client, method, path
+):
+    """An application granted nothing learns nothing, on every such operation.
+
+    Parametrized over the admission table so a new GRANT_FILTERED or USER_GATED
+    entry is covered the day it is written — the failure below is the demand
+    for its case, not a bug in this test.
+    """
+    case = _UNGRANTED_APP_CASES.get((method, path))
+    assert case is not None, (
+        f"{method} {path} is GRANT_FILTERED or USER_GATED but has no "
+        "ungranted-app case in _UNGRANTED_APP_CASES. Add one asserting an "
+        "application granted nothing gets an empty answer (filtered) or a "
+        "masked 404 (gated) — the mode's promise is only real if it is tested."
+    )
+    client = make_client()  # no grants at all
+
+    response = case["request"](client)
+
+    assert case["assert_starved"](response), (
+        f"{method} {path} answered an application granted nothing with "
+        f"{response.status_code}: {response.text[:300]}"
+    )
+
+
+def test_the_derived_set_is_not_empty():
+    """If both modes ever empty out, delete the ratchet deliberately."""
+    assert _FILTERED_OR_GATED, (
+        "no GRANT_FILTERED or USER_GATED operations left — remove these "
+        "derived tests along with the modes, not silently"
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
@@ -1,7 +1,7 @@
 """Every self-checking operation must actually refuse an ungranted application.
 
 ``test_admission_inventory.py`` asserts that each grant-checked operation runs
-``require_granted_bot`` — and then *excludes* the operations that check inside
+the grant dependencies — and then *excludes* the operations that check inside
 their handlers, because for those the assertion is untrue by construction. That
 exclusion is a hole exactly the size of this file: an operation can be named
 self-checking, be excluded from the structural assertion on that basis, and

--- a/src/backend/tests/community/endpoints/test_openapi_startup_script.py
+++ b/src/backend/tests/community/endpoints/test_openapi_startup_script.py
@@ -8,7 +8,7 @@ These are declared cases, not baseline entries. The claim that ``/openapi/v1``
 routes cannot be covered until the #651 principal minter exists does not hold
 for them — a case can mint its own gateway principal (as the skills group
 already does), and a **user** principal is enough here because
-``require_granted_bot`` is a no-op for a human caller; only an application
+``require_granted_own_bot`` is a no-op for a human caller; only an application
 needs a live grant.
 """
 
@@ -59,7 +59,7 @@ def _principal() -> str:
     """A gateway-signed principal naming a **user** and no application.
 
     No ``app`` entry on purpose: that is what makes the caller a human, and a
-    human is waved through ``require_granted_bot`` because the operation's own
+    human is waved through ``require_granted_own_bot`` because the operation's own
     owner-scoped resolve already refuses a bot that is not theirs.
     """
     now = int(time.time())


### PR DESCRIPTION
## Problem

The public surface enforced its grant-checked admission modes through one mode-aware dependency, `require_granted_bot`, whose `_addressed_owner` helper consulted the `ADMISSION` table **per request** to decide whether the addressed owner may be read off the wire. Three consequences:

- A route's admission mode was invisible at the route itself: `GRANT_CHECKED_OWN_BOT` and `GRANT_CHECKED_ADDRESSED_BOT` looked identical in a router file, and the engine-runtime groups carried their check only transitively through `OwnerIdDep`, which is hard to discover for anyone new to the seam.
- Relabelling a table entry `OWN_BOT → ADDRESSED_BOT` silently changed runtime authorization — the one behavioral test for an injected `owner_id` was the only thing standing between that relabel and the surface's oldest defect (a grant on anyone's `default` becoming access to the delegator's `default`).
- `REFUSED` was enforced only centrally in `require_principal`, so nothing on a refused route said so, and `GRANT_FILTERED` / `USER_GATED` had no derived test coverage at all: a new operation in either mode with a correct table entry and no narrowing in its handler would have failed nothing.

## Solution

Give each admission mode with something to enforce its own explicit dependency, so the declaration *is* the mode and the table becomes purely declarative:

- **`require_granted_own_bot`** — owner is the delegating user, never read off the wire; an appended `?owner_id=` is structurally inert rather than table-guarded. Declared at `include_router` for the wholly own-bot groups (current and legacy) and per route in the mixed `bots` group.
- **`require_granted_addressed_bot`** — the one dependency entitled to read the `owner_id` query parameter (defaulting to the caller). Declared per route on the two skills collection operations and at the engine-runtime mounts; `OwnerIdDep` keeps consuming its returned owner (`AddressedBotGrantDep`), and the mount-level declaration adds no second lookup since FastAPI caches a dependency per request.
- **`refuse_app_only_caller`** — the `REFUSED` declaration, added to bot creation, the authorized-apps group, bot logs, the MCP config/permissions operations, and both loadtest routes (it answers the socket plane with the same 1008 close). The central fail-closed refusal in `require_principal` stays and still covers operations absent from the table; the declaration makes the decision visible on the route and holds even if a table entry were mislabelled.
- `_addressed_owner` and the runtime `ADMISSION` lookup in `principal.py` are deleted; the shared body (`bot_id` extraction, grant lookup, masked 404) lives once in `_require_granted_bot`.
- `GRANT_FILTERED` / `USER_GATED` cannot be route dependencies — they shape the *result* through `granted_bot_ids` — so their coverage is now **derived from the table**: `test_app_only_listings.py` parametrizes over every entry in those modes and fails loudly until each has an ungranted-app case (the same ratchet `test_self_checked_routes_refuse.py` uses).
- `test_admission_inventory.py` now pins each grant-checked mode to *its* dependency in both directions, and pins the `REFUSED` declarations the same way. The four `SKILL_SCOPED_OPERATIONS` and the retiring self-checked addresses are excluded exactly as before. Legacy routes are otherwise untouched (they are retiring); their mounts pick up the renamed dependencies mechanically.

Rejected alternative: keeping one dependency and asserting the mount↔mode pairing only in CI — that leaves the mode invisible at the route and the relabel hazard in place, which is what this change exists to remove.

## Validation

- Full `src/backend` public-surface suite: `pytest tests/community/adapters/http/openapi_v1/ tests/community/endpoints/test_openapi_startup_script.py` → **852 passed, 1 skipped** (pre-change baseline 846 passed, 1 skipped; the delta is the new structural and derived tests).
- Mutation check (in-memory, not committed): relabelling all 56 `GRANT_CHECKED_OWN_BOT` entries to `GRANT_CHECKED_ADDRESSED_BOT` now alters **no** behavioral test — including the injected-`owner_id` attack test — while failing the structural inventory tests in both directions. Before this change the same relabel changed runtime authorization behavior.
- FastAPI dependency-caching probe confirms the mount-level addressed-bot declaration performs no second grant lookup (1 invocation with and without the route-level declaration).
- SAST block rules (`python_sast_local.sh` rule set) via flake8 on all 19 changed files: clean.
- Not run: the full module CI gates (coverage/E2E) — lint-only pre-push per `AGENTS.md` default; CI on this PR is the authority.

## Compatibility and risk

No wire contract, schema, or status-code change: every operation keeps its admission mode, and refusals keep their existing shapes (masked 404 for grant misses, uniform 401 for refused shapes). The gateway `route_security` counterpart is untouched — `ADMISSION`'s `REFUSED` set is unchanged, so the pinning test on the gateway side is unaffected. Rollback is a plain revert; no data or config migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLhFySftnBWVDzg1dh9xt8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLhFySftnBWVDzg1dh9xt8)_