### PR TITLE
feat(mcp): give teclaw its own default MCP server list

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -45,6 +45,23 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "hitl"},
     ],
     "moltis": [],
+    "teclaw": [
+        {"server_code": "mcp.ant.lwawchat.cogmessagemcp", "name": "蚂蚁钉协作群消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver", "name": "蚂蚁钉日志服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver", "name": "蚂蚁钉群服务"},
+        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp", "name": "蚂蚁钉协作群文档相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver", "name": "蚂蚁钉日程相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver", "name": "蚂蚁钉机器人相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver", "name": "蚂蚁钉消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver", "name": "蚂蚁钉待办服务"},
+        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver", "name": "语雀 MCP"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima-MCP服务"},
+        {"server_code": "mcp.ant.homistudio.recordmcp", "name": "会中会话记录查询服务"},
+        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
+        # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
+        # last to match the other engines' lists.
+        {"server_code": "hitl"},
+    ],
     "claude_code": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp", "name": "任务中心MCP", "description": "任务中心待办任务，已办任务等相关任务查询MCP"},
         {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima MCP", "description": "Dima MCP"},

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -468,3 +468,51 @@ def test_claude_code_normal_template_keeps_claude_mcp_bucket():
 
     assert "clawmind" in codes
     assert "mcp.ant.agentix.112858.aixAicoding" not in codes
+
+
+# The teclaw roster, spelled out independently of the source list. The publish
+# suite's ``_install_default_mcp_catalog`` derives its mock *from*
+# ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so it proves only that a build
+# resolves whatever the roster happens to hold — a typo'd or duplicated
+# ``server_code`` would sail straight through it. This second, independent copy
+# is what makes such an edit fail loudly.
+TECLAW_DEFAULT_MCP_CODES = (
+    "mcp.ant.lwawchat.cogmessagemcp",
+    "mcp.ant.antdingopenapi.antdingreportmcpserver",
+    "mcp.ant.antdingopenapi.antdinggroupmcpserver",
+    "mcp.ant.lwawchat.cogdocumentmcp",
+    "mcp.ant.antdingopenapi.antdingeventmcpserver",
+    "mcp.ant.antdingopenapi.antdingrobotmcpserver",
+    "mcp.ant.antdingopenapi.antdingmessagemcpserver",
+    "mcp.ant.antdingopenapi.antdingtodomcpserver",
+    "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver",
+    "mcp.ant.arkai.dimamcpserver",
+    "mcp.ant.homistudio.recordmcp",
+    "mcp.ant.rpc.dcanttouch.adminservice",
+    "hitl",
+)
+
+
+def test_teclaw_default_roster_shape():
+    """teclaw's roster: exact codes, exact order, no dupes, local entry last."""
+    codes = [s["server_code"] for s in get_default_mcp_servers("teclaw")]
+    assert codes == list(TECLAW_DEFAULT_MCP_CODES)
+    assert len(codes) == len(set(codes)), "duplicate server_code in the teclaw roster"
+    # ``hitl`` is the only local/stdio entry and stays last, matching how the
+    # other engines list it. The artifact path resolves its launch instruction
+    # through LocalMCPRegistry, not MCP Center — see ``_stdio_launch_for``.
+    assert codes[-1] == "hitl"
+
+
+def test_teclaw_roster_is_its_own_bucket():
+    """teclaw resolves its own defaults rather than inheriting another engine's.
+
+    ``_resolve_default_mcp_engine_bucket`` normalizes case and delegates bucket
+    overrides to the engine registry; an alias onto ``openclaw`` would silently
+    swap the whole roster, so pin both the normalization and the distinctness.
+    """
+    assert [s["server_code"] for s in get_default_mcp_servers("TECLAW")] == list(
+        TECLAW_DEFAULT_MCP_CODES
+    )
+    openclaw_codes = {s["server_code"] for s in get_default_mcp_servers("openclaw")}
+    assert "mcp.ant.lwawchat.cogmessagemcp" not in openclaw_codes

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
@@ -37,6 +37,7 @@ from agentclaw.community.plugin_api.http_client import (
     QUALIFIER_GENERAL,
     HttpClient,
 )
+from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
 from tests.community.factories.access import make_staff_user
 from tests.community.framework import (
@@ -138,6 +139,7 @@ def _seed_draft(world) -> None:
     # Local mode roots skills-local at ~/.openclaw/...; null it so the user-skill
     # host path uses the prod bolt-data root the SourceRefResolver knows.
     world.get(SkillRepoSyncPlugin).set_override("get_local_skills_root", lambda: None)
+    _install_default_mcp_catalog(world)
 
     binding_repo = world.get(DeviceBindingRepository)
     src_binding_id = binding_repo.insert_binding(
@@ -150,8 +152,9 @@ def _seed_draft(world) -> None:
         "owner_id": _OWNER, "owner_name": _OWNER,
         "bot_type": "service", "status": "ACTIVE",
         "entity_id": _OWNER, "entity_type": "staff", "creator_id": _OWNER,
-        # teclaw engine: no default MCP servers, and its skill paths fall back to
-        # openclaw's so the SourceRefResolver resolves shared + user skills.
+        # teclaw engine: its default MCP roster is resolved through the seam
+        # installed by ``_install_default_mcp_catalog``, and its skill paths fall
+        # back to openclaw's so the SourceRefResolver resolves shared + user skills.
         # TODO(task-15): teclaw inherits openclaw skill paths only via the
         # ENGINE_SKILLS_DIR_MAP `.get(default=openclaw)` fallback — give teclaw an
         # explicit entry + matching resolver rule once its layout is pinned.
@@ -212,6 +215,59 @@ def _advance(world, pid: int, target, ext: dict) -> None:
     world.get(BotPublishRepositoryProtocol).update_status_with_ext(
         publish_id=pid, target_status=target, ext=ext, source_status=PublishStatus.DRAFT,
     )
+
+
+def _install_default_mcp_catalog(world) -> None:
+    """Resolve the engine's *default* MCP roster through the MCP Center seam.
+
+    The teclaw artifact path composes every MCP as a unit and fails the whole
+    build when one cannot be resolved — deliberate, since a silently dropped
+    MCP boots the bot without a capability its owner configured.
+    ``NoopMCPCenterPlugin`` resolves nothing, so once teclaw gained a default
+    roster the seeding alone failed every publish here, for a reason unrelated
+    to what these cases assert.
+
+    Derived from ``_DEFAULT_MCP_SERVERS_BY_ENGINE`` rather than a hardcoded
+    list: adding a server to the roster must not silently skip it here.
+    Servers the local-MCP registry owns (``hitl``) are left unresolved on
+    purpose — they are stdio, and the collector resolves their launch
+    instruction from that registry, so answering REMOTE here would misclassify
+    them. Anything outside the roster still resolves to ``None``, which is what
+    ``_seed_failing_mcp`` relies on to drive the build-failure case.
+    """
+    from agentclaw.community.core.mcp.services._defaults import (
+        _DEFAULT_MCP_SERVERS_BY_ENGINE,
+    )
+    from agentclaw.community.core.mcp.services.local_mcp_registry import (
+        LocalMCPRegistry,
+    )
+
+    registry = LocalMCPRegistry()
+    remote_roster = {
+        code
+        for cfg in _DEFAULT_MCP_SERVERS_BY_ENGINE.get(_ENGINE, [])
+        if (code := cfg["server_code"]) and registry.get_mcp_detail(code) is None
+    }
+
+    def _detail(server_code: str):
+        if server_code not in remote_roster:
+            return None
+        return {
+            "server_code": server_code,
+            "serverCode": server_code,
+            "name": server_code,
+            "runMode": "REMOTE",
+            "endpoints": [
+                {
+                    "env": "PROD",
+                    "networkType": "OFFICE",
+                    "transportProtocol": "STREAMABLE_HTTP",
+                    "url": f"https://mcp.test.invalid/{server_code}",
+                }
+            ],
+        }
+
+    world.get(MCPCenterPlugin).set_override("get_mcp_detail", _detail)
 
 
 def _seed_failing_mcp(world) -> None:


### PR DESCRIPTION
## Problem

`_DEFAULT_MCP_SERVERS_BY_ENGINE` had no `teclaw` key, so `get_default_mcp_servers("teclaw")` returned `[]` and every teclaw bot shipped with no platform MCPs at all — no DingTalk group/message/todo/calendar servers, no Yuque, no Dima, and no `hitl`. Every other engine bucket (`openclaw`, `claude_code`, `hermes`, `aicoding`) has carried a roster for some time.

This is the second half of the teclaw MCP work. The first half (#1083) taught the artifact path to carry stdio servers; without it `hitl` could not have been listed here at all, since teclaw boots from the whole composed artifact rather than incremental `/api/mcp` pushes.

## Solution

A `teclaw` bucket with the 12 remote servers from the requirement doc plus `hitl`, which is local/stdio and resolved through `LocalMCPRegistry` rather than MCP Center. `hitl` is placed last, matching how the other engines list it.

Entries carry `server_code` and `name`. `description` is deliberately omitted: the requirement doc specifies no descriptions, and `McporterComposer.compose_server` reads `md.get("name") or md.get("description")` into the artifact's `name` field — inventing prose here would put fabricated text on the published contract.

Giving the roster its first non-empty value exposed a test dependency. The teclaw artifact path composes every MCP as a unit and fails the whole build when one cannot be resolved (deliberate — a silently dropped MCP boots the bot without a capability its owner configured). `NoopMCPCenterPlugin` resolves nothing, so the publish suites failed on the first roster code for a reason unrelated to what they assert.

The fixture seeds the MCP Center seam from `_DEFAULT_MCP_SERVERS_BY_ENGINE` itself rather than a hardcoded list, so a server added to the roster later cannot silently skip it. Two exclusions are load-bearing:

- **`hitl` is left unresolved on purpose.** It is stdio, and the collector resolves its launch instruction from `LocalMCPRegistry`. Answering `runMode: REMOTE` for it would hit the short-circuit in `_stdio_launch_for` and misclassify it as remote — the fixture would have masked exactly the behaviour #1083 added. It is filtered by asking the registry, not by name, so a future local server needs no fixture edit.
- **Codes outside the roster still resolve to `None`.** `_seed_failing_mcp` depends on that to drive `_seed_process_build_fail`, which asserts the fail-early raise. Making everything resolve would have quietly disarmed that case.

Rejected alternative: degrading unresolvable *defaults* to a warning-and-drop while keeping user-added MCPs fatal. That would have removed the fixture need entirely and hardened the roster against an upstream code being retired, but it weakens a contract that was chosen deliberately, and the failures in question were test-double wiring rather than evidence of a product defect.

## Validation

- **Full community suite, identical on both trees**: base `8d8584fa` → `2 failed, 11867 passed, 4 skipped`; this branch → `2 failed, 11867 passed, 4 skipped`. The two failures are `rsync: not found` in the build container, unrelated to this change and present on base.
- Both runs were done in **fresh worktrees with the same command**. An earlier comparison run in the main working tree was discarded: these publish tests are state- and order-sensitive, and the mismatched conditions produced a misleading failure count.
- Narrowed the previously failing suites (`e2e/publish_boundary`, `endpoints/test_endpoint_runner`, `endpoints/test_publish_durable_pipeline`, `endpoints/test_service_bot_publish_flow`) from **17 failures to 0**.
- `test_c1_upgrade_chain` fails in a subset run and passes in the full suite, on this branch *and* on base — it depends on an earlier test's app bootstrap creating `ac_default_skillset_mcp_exclusion`. Pre-existing, untouched here, and called out rather than papered over.
- Verified `get_default_mcp_servers("teclaw")` resolves to 13 entries and that `teclaw` is not bucket-aliased onto another engine (`_resolve_default_mcp_engine_bucket("teclaw") == "teclaw"`), so the roster is genuinely new rather than inherited.

## Compatibility and risk

Every teclaw publish now depends on MCP Center resolving all 12 remote codes. Because the artifact path composes defaults as a unit — unlike arca/baas, which pushes per-server and tolerates one failure — a single retired or renamed code fails the whole publish rather than dropping one server. This is the fail-early contract working as designed, but reviewers hitting a sudden teclaw publish failure should look here first.

Deployments whose MCP Center does not carry these codes are affected the same way. `CommunityMCPCenter` serves an empty catalog unless an operator configures `registry_config_path`.

Rollback is a plain revert of the roster commit; teclaw returns to `[]` defaults and the fixture becomes inert (it derives from the roster, so an empty roster overrides nothing).


---
_Generated by [Claude Code](https://claude.ai/code/session_01N6jGHBFagXrdjjrZCDUkLE)_