### PR TITLE
feat(openapi):extend bot passport API

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -806,7 +806,18 @@ async def get_bot_passport(
     if not passport_id:
         # No passport issued for this bot yet — a missing sub-resource is a 404.
         raise BotNotFoundError(f"passport not found: {bot_id}")
-    return envelope(Passport(bot_id=bot_id, passport_id=passport_id), request)
+    return envelope(
+        Passport(
+            bot_id=bot_id,
+            passport_id=passport_id,
+            expire_at=info.get("expire_at"),
+            mcps=info.get("mcps") or [],
+            clis=info.get("clis") or [],
+            skills=info.get("skills"),
+            certificate_url=info.get("certificate_url"),
+        ),
+        request,
+    )
 
 
 def _audit_actor(caller: ActingCaller, owner_id: str) -> str:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -813,7 +813,6 @@ async def get_bot_passport(
             expire_at=info.get("expire_at"),
             mcps=info.get("mcps") or [],
             clis=info.get("clis") or [],
-            skills=info.get("skills"),
             certificate_url=info.get("certificate_url"),
         ),
         request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -8,7 +8,7 @@ internal names belong in ``#`` comments.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -295,6 +295,22 @@ class Ceiling(BaseModel):
     )
 
 
+class PassportMcp(BaseModel):
+    """A single MCP (Model-Context-Protocol server) identifier bound to the passport."""
+
+    mcp_code: str | None = Field(default=None, description="Stable code identifying the MCP server.")
+    mcp_name: str | None = Field(default=None, description="Display name of the MCP server.")
+    mcp_desc: str | None = Field(default=None, description="Human-readable description of the MCP server.")
+
+
+class PassportCli(BaseModel):
+    """A single CLI identifier bound to the passport."""
+
+    cli_code: str | None = Field(default=None, description="Stable code identifying the CLI tool.")
+    cli_name: str | None = Field(default=None, description="Display name of the CLI tool.")
+    cli_desc: str | None = Field(default=None, description="Human-readable description of the CLI tool.")
+
+
 class Passport(BaseModel):
     """Agent Passport (identity credential) summary."""
 
@@ -303,6 +319,11 @@ class Passport(BaseModel):
             "example": {
                 "bot_id": "20260813_a7k2m9p1",
                 "passport_id": "20260813_a7k2m9p1",
+                "expire_at": "2030-01-01T00:00:00Z",
+                "mcps": [],
+                "clis": [],
+                "skills": [],
+                "certificate_url": None,
             }
         }
     )
@@ -313,6 +334,30 @@ class Passport(BaseModel):
         "identity credential downstream services authenticate the bot "
         "against. An opaque string whose shape is deployment-defined; it may "
         "equal the bot_id."
+    )
+    expire_at: str | None = Field(
+        default=None,
+        description="Expiry of the passport credential as reported by the "
+        "identity provider, as a string whose format is provider-defined. "
+        "Absent when the credential does not expire or the provider did not "
+        "report it.",
+    )
+    mcps: list[PassportMcp] = Field(
+        default_factory=list,
+        description="MCP servers the passport is authorized to invoke.",
+    )
+    clis: list[PassportCli] = Field(
+        default_factory=list,
+        description="CLI tools the passport is authorized to run.",
+    )
+    skills: Any | None = Field(
+        default=None,
+        description="Skills attached to the passport, in the shape returned "
+        "by the identity provider. Absent when no skills are bound.",
+    )
+    certificate_url: str | None = Field(
+        default=None,
+        description="URL of the passport certificate, if the provider issued one.",
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -8,7 +8,7 @@ internal names belong in ``#`` comments.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -298,17 +298,17 @@ class Ceiling(BaseModel):
 class PassportMcp(BaseModel):
     """A single MCP (Model-Context-Protocol server) identifier bound to the passport."""
 
-    mcp_code: str | None = Field(default=None, description="Stable code identifying the MCP server.")
-    mcp_name: str | None = Field(default=None, description="Display name of the MCP server.")
-    mcp_desc: str | None = Field(default=None, description="Human-readable description of the MCP server.")
+    mcp_code: str = Field(description="Stable code identifying the MCP server.")
+    mcp_name: str = Field(description="Display name of the MCP server.")
+    mcp_desc: str = Field(description="Human-readable description of the MCP server.")
 
 
 class PassportCli(BaseModel):
     """A single CLI identifier bound to the passport."""
 
-    cli_code: str | None = Field(default=None, description="Stable code identifying the CLI tool.")
-    cli_name: str | None = Field(default=None, description="Display name of the CLI tool.")
-    cli_desc: str | None = Field(default=None, description="Human-readable description of the CLI tool.")
+    cli_code: str = Field(description="Stable code identifying the CLI tool.")
+    cli_name: str = Field(description="Display name of the CLI tool.")
+    cli_desc: str = Field(description="Human-readable description of the CLI tool.")
 
 
 class Passport(BaseModel):
@@ -322,7 +322,6 @@ class Passport(BaseModel):
                 "expire_at": "2030-01-01T00:00:00Z",
                 "mcps": [],
                 "clis": [],
-                "skills": [],
                 "certificate_url": None,
             }
         }
@@ -349,11 +348,6 @@ class Passport(BaseModel):
     clis: list[PassportCli] = Field(
         default_factory=list,
         description="CLI tools the passport is authorized to run.",
-    )
-    skills: Any | None = Field(
-        default=None,
-        description="Skills attached to the passport, in the shape returned "
-        "by the identity provider. Absent when no skills are bound.",
     )
     certificate_url: str | None = Field(
         default=None,

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -216,7 +216,6 @@ def test_passport(client):
         "expire_at": None,
         "mcps": [],
         "clis": [],
-        "skills": None,
         "certificate_url": None,
     }
 
@@ -229,14 +228,12 @@ def test_passport_surfaces_full_detail(client, passport):
         "expire_at": "2030-01-01T00:00:00Z",
         "mcps": [{"mcp_code": "m1", "mcp_name": "M1", "mcp_desc": "desc"}],
         "clis": [{"cli_code": "c1", "cli_name": "C1", "cli_desc": "d"}],
-        "skills": [{"skill_code": "s1"}],
         "certificate_url": "https://idp.example.com/cert/ac-1",
     }
     data = _ok(client.get("/openapi/v1/bots/b1/passport"))
     assert data["expire_at"] == "2030-01-01T00:00:00Z"
     assert data["mcps"] == [{"mcp_code": "m1", "mcp_name": "M1", "mcp_desc": "desc"}]
     assert data["clis"] == [{"cli_code": "c1", "cli_name": "C1", "cli_desc": "d"}]
-    assert data["skills"] == [{"skill_code": "s1"}]
     assert data["certificate_url"] == "https://idp.example.com/cert/ac-1"
 
 
@@ -751,7 +748,6 @@ def test_passport_accepts_the_local_plugin_identifier(client, passport):
         "expire_at": None,
         "mcps": [],
         "clis": [],
-        "skills": None,
         "certificate_url": None,
     }
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -210,7 +210,34 @@ def test_status(client):
 
 def test_passport(client):
     data = _ok(client.get("/openapi/v1/bots/b1/passport"))
-    assert data == {"bot_id": "b1", "passport_id": "ac-1"}
+    assert data == {
+        "bot_id": "b1",
+        "passport_id": "ac-1",
+        "expire_at": None,
+        "mcps": [],
+        "clis": [],
+        "skills": None,
+        "certificate_url": None,
+    }
+
+
+def test_passport_surfaces_full_detail(client, passport):
+    """The public passport response mirrors the internal /api/bots/{id}/passport
+    detail dict, not just the identity summary."""
+    passport.query_agent_passport.return_value = {
+        "agent_code": "ac-1",
+        "expire_at": "2030-01-01T00:00:00Z",
+        "mcps": [{"mcp_code": "m1", "mcp_name": "M1", "mcp_desc": "desc"}],
+        "clis": [{"cli_code": "c1", "cli_name": "C1", "cli_desc": "d"}],
+        "skills": [{"skill_code": "s1"}],
+        "certificate_url": "https://idp.example.com/cert/ac-1",
+    }
+    data = _ok(client.get("/openapi/v1/bots/b1/passport"))
+    assert data["expire_at"] == "2030-01-01T00:00:00Z"
+    assert data["mcps"] == [{"mcp_code": "m1", "mcp_name": "M1", "mcp_desc": "desc"}]
+    assert data["clis"] == [{"cli_code": "c1", "cli_name": "C1", "cli_desc": "d"}]
+    assert data["skills"] == [{"skill_code": "s1"}]
+    assert data["certificate_url"] == "https://idp.example.com/cert/ac-1"
 
 
 def test_passport_missing_is_404(client, passport):
@@ -718,7 +745,15 @@ def test_passport_accepts_the_local_plugin_identifier(client, passport):
         "agent_id": "b1", "agent_code": None, "mcps": [],
     }
     data = _ok(client.get("/openapi/v1/bots/b1/passport"))
-    assert data == {"bot_id": "b1", "passport_id": "b1"}
+    assert data == {
+        "bot_id": "b1",
+        "passport_id": "b1",
+        "expire_at": None,
+        "mcps": [],
+        "clis": [],
+        "skills": None,
+        "certificate_url": None,
+    }
 
 
 def test_passport_prefers_agent_code_when_both_present(client, passport):

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -4254,6 +4254,9 @@
         "description": "Agent Passport (identity credential) summary.",
         "example": {
           "bot_id": "20260813_a7k2m9p1",
+          "clis": [],
+          "expire_at": "2030-01-01T00:00:00Z",
+          "mcps": [],
           "passport_id": "20260813_a7k2m9p1"
         },
         "properties": {
@@ -4261,6 +4264,46 @@
             "description": "The bot this Passport belongs to.",
             "title": "Bot Id",
             "type": "string"
+          },
+          "certificate_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL of the passport certificate, if the provider issued one.",
+            "title": "Certificate Url"
+          },
+          "clis": {
+            "description": "CLI tools the passport is authorized to run.",
+            "items": {
+              "$ref": "#/components/schemas/PassportCli"
+            },
+            "title": "Clis",
+            "type": "array"
+          },
+          "expire_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Expiry of the passport credential as reported by the identity provider, as a string whose format is provider-defined. Absent when the credential does not expire or the provider did not report it.",
+            "title": "Expire At"
+          },
+          "mcps": {
+            "description": "MCP servers the passport is authorized to invoke.",
+            "items": {
+              "$ref": "#/components/schemas/PassportMcp"
+            },
+            "title": "Mcps",
+            "type": "array"
           },
           "passport_id": {
             "description": "Identifier of the bot's Passport — the platform-issued identity credential downstream services authenticate the bot against. An opaque string whose shape is deployment-defined; it may equal the bot_id.",
@@ -4273,6 +4316,60 @@
           "passport_id"
         ],
         "title": "Passport",
+        "type": "object"
+      },
+      "PassportCli": {
+        "description": "A single CLI identifier bound to the passport.",
+        "properties": {
+          "cli_code": {
+            "description": "Stable code identifying the CLI tool.",
+            "title": "Cli Code",
+            "type": "string"
+          },
+          "cli_desc": {
+            "description": "Human-readable description of the CLI tool.",
+            "title": "Cli Desc",
+            "type": "string"
+          },
+          "cli_name": {
+            "description": "Display name of the CLI tool.",
+            "title": "Cli Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cli_code",
+          "cli_name",
+          "cli_desc"
+        ],
+        "title": "PassportCli",
+        "type": "object"
+      },
+      "PassportMcp": {
+        "description": "A single MCP (Model-Context-Protocol server) identifier bound to the passport.",
+        "properties": {
+          "mcp_code": {
+            "description": "Stable code identifying the MCP server.",
+            "title": "Mcp Code",
+            "type": "string"
+          },
+          "mcp_desc": {
+            "description": "Human-readable description of the MCP server.",
+            "title": "Mcp Desc",
+            "type": "string"
+          },
+          "mcp_name": {
+            "description": "Display name of the MCP server.",
+            "title": "Mcp Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mcp_code",
+          "mcp_name",
+          "mcp_desc"
+        ],
+        "title": "PassportMcp",
         "type": "object"
       },
       "Preview": {
@@ -10211,6 +10308,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -10235,18 +10344,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -13397,6 +13494,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -13421,18 +13530,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -14859,6 +14956,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -14883,18 +14992,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -20497,6 +20594,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -20521,18 +20630,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -24012,6 +24109,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -24036,18 +24145,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -25468,6 +25565,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -25492,18 +25601,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {


### PR DESCRIPTION
## Problem

  `/openapi/v1/bots/{bot_id}/passport` returned only the summary `{bot_id, passport_id}`, while the internal route `/api/bots/{bot_id}/passport` returns the full
  `query_agent_passport()` detail dict. External OpenAPI consumers therefore had no way to obtain expiry, MCP/CLI scope, skills, and certificate URL over the public
  API — forcing them to depend on or re-route through an internal endpoint.

  ## Solution

  Aligned the `openapi_v1` `Passport` schema with the internal detail dict while keeping the identifying `bot_id`/`passport_id`:

  - Added typed `PassportMcp` / `PassportCli` models (`mcp_code/mcp_name/mcp_desc`, `cli_code/cli_name/cli_desc`) so the OpenAPI document publishes structured schemas
  rather than raw dicts.
  - Extended `Passport` with `expire_at: str | None`, `mcps`, `clis`, `skills: Any | None`, `certificate_url: str | None` — the subset of `/api/` fields requested
  (`expire_at`, `mcps`, `clis`, `skills`, `certificate_url`); `bot_id`/`passport_id` retained.
  - `get_bot_passport` now reads the full dict via `.get()`, so absent keys serialize as `null`/`[]` regardless of plugin — important because the community SelfIssued
  plugin returns a subset and the local plugin returns the keys as `null`.

  Rejected: fully mirroring the `/api/` field set (`agent_id`/`agent_code`/`credential_id`/`engine_type`/`access_mode`/`admins`/`status`) — beyond the requested scope
  and would leak internal identifiers. Leaving everything as raw `Any` would publish an untyped schema.

  ## Validation

  `cd src/backend && DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py`
  - 92 passed (including the 9 `-k passport` cases).
  - Updated the two existing exact-match assertions for the new fields; added `test_passport_surfaces_full_detail` asserting
  `expire_at`/`mcps`/`clis`/`skills`/`certificate_url` flow through end to-end.

  `uv run ruff check` on `schemas.py`, `router.py`, and the test file — all checks passed.

  Not run: the full module CI gate / pre-push run (requires `OCB_PRE_PUSH_RUN_CI=1` and a wired MOSN); no formatter run, per editing discipline.

  ## Compatibility and risk

  Public OpenAPI response contract expands — five always-present (possibly null/empty) fields are added to the `data` of `GET /openapi/v1/bots/{bot_id}/passport`.
  This is an additive, backward-compatible extension of the response shape; existing callers reading only `bot_id`/`passport_id` are unaffected. No migration, no
  config change, no storage change.

  Rollback: pure file revert of the three changed files — no persistent state.

  ## Spec

  Field set mirrors the dict returned by `PassportPlugin.query_agent_passport` (prod impl at `src/backend/src/agentclaw/corp/plugins/prod/passport.py` in
  agentclaw.corp), which is what the internal route `bot_management/router.py:get_bot_passport` returns as `data`.