### PR TITLE
feat(bcs-api-http): surface collected state in openapi list sessions

### DIFF
--- a/src/bcs/api-contracts/v1/domain-models.yaml
+++ b/src/bcs/api-contracts/v1/domain-models.yaml
@@ -977,6 +977,12 @@ SessionSummary:
     updated_at:
       type: integer
       minimum: 0
+    collected:
+      type: boolean
+      description: >
+        Whether the view actor (the `view_bot_id` resolved by the request) has
+        collected this session. Surfaced only when `view_bot_id` is explicitly
+        supplied; absent otherwise.
 
 SessionDetail:
   type: object

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -404,9 +404,14 @@ impl SessionService for FakeSessionService {
     async fn list(&self, command: ListSessions) -> Result<Page<SessionSummary>, ApplicationError> {
         let offset = command.offset;
         let limit = command.limit;
+        let view_bot_id = command.view_bot_id.clone();
         *self.listed.lock().expect("list lock") = Some(command);
+        let mut summary = session_summary();
+        // Mirror the real app: surface `collected` only for an explicitly
+        // named view actor, so the route can be asserted to serialize it.
+        summary.collected = view_bot_id.as_ref().map(|_| true);
         Ok(Page {
-            items: vec![session_summary()],
+            items: vec![summary],
             total: 1,
             offset,
             limit,
@@ -590,6 +595,7 @@ fn session_summary() -> SessionSummary {
         participant_count: Some(1),
         created_at: 1,
         updated_at: 2,
+        collected: None,
     }
 }
 
@@ -1016,6 +1022,8 @@ async fn list_sessions_returns_page_and_forwards_filters() {
     assert_eq!(body["data"]["total"], 1);
     assert_eq!(body["data"]["offset"], 5);
     assert_eq!(body["data"]["limit"], 10);
+    // `collected` is surfaced for an explicitly named view actor.
+    assert_eq!(body["data"]["items"][0]["collected"], true);
     {
         let listed = session.listed.lock().expect("list lock");
         let listed = listed.as_ref().expect("list command");

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -613,7 +613,33 @@ impl SessionService for SessionServiceImpl {
             .count_by_group(&command.group_id, status, None, participant_id)
             .await
             .map_err(map_service_error)?;
-        let items = sessions.iter().map(project_summary).collect::<Vec<_>>();
+        // Surface per-session collected state for the view actor, but only
+        // when the request explicitly names that actor (mirrors the legacy
+        // `list_sessions_for_group` gating: collected is only meaningful
+        // relative to a named participant). When `view_bot_id` is omitted the
+        // field stays `None` and is skipped on serialization.
+        let collected_set: HashSet<String> = if command.view_bot_id.is_some() {
+            let ids: Vec<&str> = sessions.iter().map(|s| s.id.as_str()).collect();
+            self.sessions
+                .collected_at_map(&ids, &view_actor_id)
+                .await
+                .map_err(map_session_error)?
+                .into_iter()
+                .map(|(sid, _collected_at)| sid)
+                .collect()
+        } else {
+            HashSet::new()
+        };
+        let items = sessions
+            .iter()
+            .map(|s| {
+                let mut summary = project_summary(s);
+                if command.view_bot_id.is_some() {
+                    summary.collected = Some(collected_set.contains(&s.id));
+                }
+                summary
+            })
+            .collect::<Vec<_>>();
         Ok(Page {
             items,
             total,
@@ -1018,6 +1044,7 @@ fn project_summary(session: &Session) -> SessionSummary {
         participant_count: Some(session.participants.len()),
         created_at: session.created_at,
         updated_at: session.updated_at,
+        collected: None,
     }
 }
 

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -1062,6 +1062,103 @@ async fn human_collects_and_uncollects_for_owned_participant_bot_idempotently() 
 }
 
 #[tokio::test]
+async fn list_surfaces_per_session_collected_for_explicit_view_actor() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("bot-1").await;
+    fixture
+        .bots
+        .save_created_by("bot-1", "owner-1", true)
+        .await
+        .expect("assign Bot ownership");
+    fixture
+        .store_group_with_originator("g1", "bot-1", "human_owner-1", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+
+    // Seed two sessions both listing bot-1 as a participant.
+    let mk = || Participant::bot("bot-1", ParticipantRole::Driver);
+    let s_a = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![mk()],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed session A");
+    let s_b = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![mk()],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed session B");
+
+    // Collect only session A as the owned participant bot.
+    fixture
+        .service
+        .collect(CollectSession {
+            caller: human_principal("owner-1"),
+            session_id: s_a.id.clone(),
+            participant: "bot-1".into(),
+        })
+        .await
+        .expect("collect session A");
+
+    let page = SessionService::list(
+        &fixture.service,
+        ListSessions {
+            caller: human_principal("owner-1"),
+            group_id: "g1".into(),
+            view_bot_id: Some("bot-1".into()),
+            offset: 0,
+            limit: 10,
+            status: None,
+        },
+    )
+    .await
+    .expect("list sessions");
+
+    let by_id = page
+        .items
+        .iter()
+        .map(|s| (s.session_id.as_str(), s.collected))
+        .collect::<std::collections::HashMap<&str, Option<bool>>>();
+    // The explicitly named view actor sees its per-session collected state.
+    assert_eq!(by_id.get(s_a.id.as_str()), Some(&Some(true)));
+    assert_eq!(by_id.get(s_b.id.as_str()), Some(&Some(false)));
+
+    // When no view actor is named the field is left absent (None). Here the
+    // human views as themselves, so the bot-participant sessions are filtered
+    // out and the page is empty — confirming collected is not synthesized.
+    let none_page = SessionService::list(
+        &fixture.service,
+        ListSessions {
+            caller: human_principal("owner-1"),
+            group_id: "g1".into(),
+            view_bot_id: None,
+            offset: 0,
+            limit: 10,
+            status: None,
+        },
+    )
+    .await
+    .expect("list sessions (no view actor)");
+    assert!(
+        none_page.items.iter().all(|s| s.collected.is_none()),
+        "collected must be absent when view_bot_id is not specified"
+    );
+}
+
+#[tokio::test]
 async fn session_collection_rejects_an_unowned_bot() {
     let fixture = Fixture::new().await;
     fixture.add_bot("bot-1").await;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
@@ -61,6 +61,12 @@ pub struct SessionSummary {
     pub participant_count: Option<usize>,
     pub created_at: u64,
     pub updated_at: u64,
+    /// Whether the view actor (`view_bot_id`) has collected this session.
+    /// Populated only when the request explicitly passes `view_bot_id`; absent
+    /// otherwise. Mirrors the legacy `list_sessions_for_group` participant
+    /// gating (collected is meaningful only relative to a named viewer).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collected: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

The OpenAPI v1 `GET /groups/{group_id}/sessions` endpoint (`bcs_api_http::v1::openapi::routes::session::list_sessions`) did not return whether each session is collected (收藏) by the viewer, while the legacy `bcs_http::routes::sessions::list_sessions_for_group` endpoint does surface this when a `participant` is named. Clients using the OpenAPI surface therefore cannot render the collected/starred indicator.

## Solution

Surface per-session `collected` state on the typed `SessionSummary` response, keyed on the resolved view actor — mirroring the legacy endpoint's participant-gated behavior without changing the route handler or breaking the OpenAPI contract.

- `bcs-service-api/src/application/v1/session.rs`: add `collected: Option<bool>` to `SessionSummary` with `skip_serializing_if = "Option::is_none"` (consistent with `title` / `participant_count`).
- `application/v1/bcs-app-session/src/lib.rs`: `SessionService::list` populates `collected` via the existing `SessionManagementService::collected_at_map(&ids, &view_actor_id)`, but only when the request explicitly passes `view_bot_id` — reusing the same resolved view actor already used for the participant filter. When `view_bot_id` is omitted the field stays `None` and is not serialized.
- No route handler change; the field flows through via serde.

Gating rationale: collected is only meaningful relative to a named viewer. The OpenAPI `view_bot_id` param is the analog of the legacy `participant`; both default the resolved actor to the authenticated human (no bot collections), so a meaningful `collected` value requires the caller to pass the bot identity.

## Validation

- `cargo build -p bcs-service-api -p bcs-app-session -p bcs-api-http` ✅
- `cargo test -p bcs-app-session --test v1_session_service` ✅ (46 passed) — includes new `list_surfaces_per_session_collected_for_explicit_view_actor`: collects one of two sessions, asserts `Some(true)`/`Some(false)` for the named view actor and `None` when `view_bot_id` is omitted.
- `cargo test -p bcs-api-http --test session_routes` ✅ (29 passed) — route-level fake mirrors semantics and asserts `items[0].collected == true` in the JSON envelope.