### PR TITLE
fix(engine): find sessions beyond gateway default limit

### DIFF
--- a/src/engine/src/engine/community/plugins/openclaw/_session.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_session.py
@@ -150,10 +150,21 @@ class _SessionPortMixin:
         sessions fall within it (exact legacy behaviour).
         """
         client = await self._pooled_client(token)
+        requested_session_key = (
+            session_key if session_key and session_key.strip() else None
+        )
+
+        # Push the lookup into the gateway before its default result cap is
+        # applied. Keep the exact local filter because gateway search is fuzzy.
+        list_params = (
+            {"search": requested_session_key}
+            if requested_session_key is not None
+            else {}
+        )
 
         # Step 1: sessions.list RPC
         try:
-            response = await client.send_request("sessions.list", {})
+            response = await client.send_request("sessions.list", list_params)
         except (ConnectionError, TimeoutError):
             # An empty list is a valid answer, so it must not mask an upstream outage.
             raise
@@ -184,7 +195,6 @@ class _SessionPortMixin:
         if agent_id is not None:
             raw_sessions = [s for s in raw_sessions if s.get("agentId") == agent_id]
 
-        requested_session_key = session_key if session_key and session_key.strip() else None
         if requested_session_key is not None:
             # Filter before pagination so a copied key can be found beyond the current page.
             raw_sessions = [s for s in raw_sessions if s.get("key") == requested_session_key]

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_session_port.py
@@ -296,8 +296,26 @@ class TestSessionsList:
         result = await impl.sessions_list(token="tok", session_key="s20", limit=1)
 
         assert [session["key"] for session in result] == ["s20"]
+        sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert sessions_list_calls == [("sessions.list", {"search": "s20"}, None)]
         history_calls = [call for call in client.calls if call[0] == "chat.history"]
         assert [call[1]["sessionKey"] for call in history_calls] == ["s20"]
+
+    async def test_session_key_filter_keeps_exact_match_from_gateway_search(self):
+        impl, client = _make_impl({
+            "sessions.list": self._sessions_payload([
+                {"key": "target-copy", "label": "Fuzzy match", "model": None},
+                {"key": "target", "label": "Exact match", "model": None},
+            ]),
+            "chat.history": self._history_payload([]),
+            "providers.available": self._providers_payload(),
+        })
+
+        result = await impl.sessions_list(token="tok", session_key="target")
+
+        assert [session["key"] for session in result] == ["target"]
+        sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert sessions_list_calls == [("sessions.list", {"search": "target"}, None)]
 
     async def test_session_key_filter_returns_empty_list_for_no_match(self):
         impl, client = _make_impl({
@@ -317,7 +335,7 @@ class TestSessionsList:
             {"key": "s0", "label": "Session 0", "model": None},
             {"key": "s1", "label": "Session 1", "model": None},
         ]
-        impl, _ = _make_impl({
+        impl, client = _make_impl({
             "sessions.list": self._sessions_payload(sessions),
             "chat.history": self._history_payload([
                 {"id": "m1", "role": "user", "content": "hi"},
@@ -328,6 +346,8 @@ class TestSessionsList:
         result = await impl.sessions_list(token="tok", session_key="   ", offset=1, limit=1)
 
         assert [session["key"] for session in result] == ["s1"]
+        sessions_list_calls = [call for call in client.calls if call[0] == "sessions.list"]
+        assert sessions_list_calls == [("sessions.list", {}, None)]
 
     async def test_model_normalization_present(self):
         """_normalized_model is set for each returned session dict."""


### PR DESCRIPTION
## Problem

OpenClaw `sessions.list` applies a bounded default result limit before the Engine adapter receives the session rows. The adapter previously requested `sessions.list` with empty params and only then applied an exact `session_key` filter. As a result, a valid session outside the Gateway's first 100 rows was reported as missing by `/api/sessions` and `/api/sessions/{session_id}`.

## Solution

When a non-blank `session_key` is provided, pass it to OpenClaw through the existing `sessions.list.search` parameter so the Gateway narrows the store before applying its default result cap. Retain the adapter's exact-key filter because Gateway search is substring-based.

Requests without a session key, including blank values, continue to send the original empty params object and preserve existing list behavior.

## Validation

- Engine CI: `2357 passed`, `5 deselected`
- Overall Engine line coverage: `92.94%`
- Changed-line coverage: `100%` (`14/14`)
- Targeted OpenClaw session/adapter/contract tests: `83 passed`
- Ruff checks and `git diff --check` passed
- Verified against a production-compatible OpenClaw Gateway that `sessions.list {"search": <full-session-key>}` locates a session beyond the default first 100 rows

## Compatibility and risk

- No HTTP or Plugin API schema changes.
- Normal session listing remains unchanged when `session_key` is omitted or blank.
- Exact matching remains enforced in the adapter, preventing fuzzy Gateway search results from leaking into the response.
