### PR TITLE
feat(backend): support template preset CLI defaults

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -365,7 +365,11 @@ def create_bot_with_authorization(
             engine_type=spec.engine_type,
         ),
         cli_items=get_default_cli_items(
-            spec.engine_type, spec.template_type
+            spec.engine_type,
+            spec.template_type,
+            ext_info={"aicoding": {"template_config": spec.template_config}}
+            if spec.template_config
+            else None,
         ),
         use_first_passport=use_first_passport,
     )

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -367,7 +367,7 @@ def create_bot_with_authorization(
         cli_items=get_default_cli_items(
             spec.engine_type,
             spec.template_type,
-            ext_info={"aicoding": {"template_config": spec.template_config}}
+            ext_info={"template_config": spec.template_config}
             if spec.template_config
             else None,
         ),

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/cli_defaults.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/cli_defaults.py
@@ -1,0 +1,29 @@
+"""AICoding-specific CLI default resolution."""
+from __future__ import annotations
+
+from typing import Any, List, Mapping, Optional
+
+from agentclaw.community.core.bot_management.engines.aicoding.default_capabilities import (
+    merge_template_preset_capabilities,
+)
+
+
+class AicodingCliDefaultsResolver:
+    """Resolve effective default CLIs for AICoding bots.
+
+    AICoding templates may preset CLI capabilities at
+    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities.cli``.
+    These are merged by ``cli_code`` onto the AICoding engine default CLI list.
+    """
+
+    def resolve(
+        self,
+        default_items: List[dict],
+        ext_info: Optional[Mapping[str, Any]] = None,
+    ) -> List[dict]:
+        return merge_template_preset_capabilities(
+            default_items,
+            ext_info,
+            capability_key="cli",
+            identity_key="cli_code",
+        )

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/cli_defaults.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/cli_defaults.py
@@ -12,7 +12,7 @@ class AicodingCliDefaultsResolver:
     """Resolve effective default CLIs for AICoding bots.
 
     AICoding templates may preset CLI capabilities at
-    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities.cli``.
+    ``ext_info.template_config.bot_template_config.preset_capabilities.cli``.
     These are merged by ``cli_code`` onto the AICoding engine default CLI list.
     """
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_capabilities.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 _AICODING_EXT_KEY = "aicoding"
 
@@ -39,3 +39,76 @@ class AicodingDefaultCapabilitiesExtInfo:
             if isinstance(template_config, Mapping)
             else None,
         )
+
+
+def merge_template_preset_capabilities(
+    default_items: List[dict],
+    ext_info: Optional[Mapping[str, Any]],
+    *,
+    capability_key: str,
+    identity_key: str,
+) -> List[dict]:
+    """Merge AICoding template preset capabilities onto engine defaults.
+
+    Reads presets from
+    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities``
+    and merges the selected capability list by its identity field. Existing
+    default entries keep their original position and are field-overridden by the
+    template entry; new template entries are appended in template order.
+    """
+    items = [dict(cfg) for cfg in default_items]
+    positions = {
+        cfg.get(identity_key): idx
+        for idx, cfg in enumerate(items)
+        if cfg.get(identity_key)
+    }
+
+    for entry in _template_preset_entries(
+        ext_info,
+        capability_key=capability_key,
+        identity_key=identity_key,
+    ):
+        key = entry[identity_key]
+        existing_idx = positions.get(key)
+        if existing_idx is None:
+            positions[key] = len(items)
+            items.append(dict(entry))
+        else:
+            items[existing_idx] = {**items[existing_idx], **entry}
+
+    return items
+
+
+def _template_preset_entries(
+    ext_info: Optional[Mapping[str, Any]],
+    *,
+    capability_key: str,
+    identity_key: str,
+) -> List[dict]:
+    """Return normalized AICoding template preset entries."""
+    template_config = AicodingDefaultCapabilitiesExtInfo.from_ext_info(
+        ext_info
+    ).template_config
+    if template_config is None:
+        return []
+    bot_template_config = template_config.get("bot_template_config")
+    if not isinstance(bot_template_config, Mapping):
+        return []
+    preset_capabilities = bot_template_config.get("preset_capabilities")
+    if not isinstance(preset_capabilities, Mapping):
+        return []
+    raw_items = preset_capabilities.get(capability_key)
+    if not isinstance(raw_items, list):
+        return []
+
+    entries: List[dict] = []
+    for item in raw_items:
+        if not isinstance(item, Mapping):
+            continue
+        raw_key = item.get(identity_key)
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            continue
+        entry = dict(item)
+        entry[identity_key] = raw_key.strip()
+        entries.append(entry)
+    return entries

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_capabilities.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional
 
-_AICODING_EXT_KEY = "aicoding"
-
-
 @dataclass(frozen=True)
 class AicodingDefaultCapabilitiesExtInfo:
     template_config: Mapping[str, Any] | None = None
@@ -21,19 +18,13 @@ class AicodingDefaultCapabilitiesExtInfo:
         Expected shape::
 
             {
-                "aicoding": {
-                    "template_config": template_config,
-                }
+                "template_config": template_config,
             }
         """
         if not isinstance(ext_info, Mapping):
             return cls()
 
-        aicoding_info = ext_info.get(_AICODING_EXT_KEY)
-        if not isinstance(aicoding_info, Mapping):
-            return cls()
-
-        template_config = aicoding_info.get("template_config")
+        template_config = ext_info.get("template_config")
         return cls(
             template_config=template_config
             if isinstance(template_config, Mapping)
@@ -51,7 +42,7 @@ def merge_template_preset_capabilities(
     """Merge AICoding template preset capabilities onto engine defaults.
 
     Reads presets from
-    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities``
+    ``ext_info.template_config.bot_template_config.preset_capabilities``
     and merges the selected capability list by its identity field. Existing
     default entries keep their original position and are field-overridden by the
     template entry; new template entries are appended in template order.

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
@@ -12,7 +12,7 @@ class AicodingMcpDefaultsResolver:
     """Resolve effective default MCPs for AICoding bots.
 
     AICoding templates may preset MCP capabilities at
-    ``ext_info.aicoding.template_config.bot_template_config.preset_capabilities.mcp``.
+    ``ext_info.template_config.bot_template_config.preset_capabilities.mcp``.
     These are merged by ``server_code`` onto the AICoding engine default MCP list.
     """
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/mcp_defaults.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Any, List, Mapping, Optional
 
 from agentclaw.community.core.bot_management.engines.aicoding.default_capabilities import (
-    AicodingDefaultCapabilitiesExtInfo,
+    merge_template_preset_capabilities,
 )
 
 
@@ -21,52 +21,9 @@ class AicodingMcpDefaultsResolver:
         default_servers: List[dict],
         ext_info: Optional[Mapping[str, Any]] = None,
     ) -> List[dict]:
-        servers = [dict(cfg) for cfg in default_servers]
-        positions = {
-            cfg.get("server_code"): idx
-            for idx, cfg in enumerate(servers)
-            if cfg.get("server_code")
-        }
-
-        for entry in self._preset_mcp_entries(ext_info):
-            code = entry["server_code"]
-            existing_idx = positions.get(code)
-            if existing_idx is None:
-                positions[code] = len(servers)
-                servers.append(dict(entry))
-            else:
-                servers[existing_idx] = {**servers[existing_idx], **entry}
-
-        return servers
-
-    def _preset_mcp_entries(
-        self,
-        ext_info: Optional[Mapping[str, Any]],
-    ) -> List[dict]:
-        """Return normalized AICoding MCP presets from ext_info."""
-        template_config = AicodingDefaultCapabilitiesExtInfo.from_ext_info(
-            ext_info
-        ).template_config
-        if template_config is None:
-            return []
-        bot_template_config = template_config.get("bot_template_config")
-        if not isinstance(bot_template_config, Mapping):
-            return []
-        preset_capabilities = bot_template_config.get("preset_capabilities")
-        if not isinstance(preset_capabilities, Mapping):
-            return []
-        raw_mcps = preset_capabilities.get("mcp")
-        if not isinstance(raw_mcps, list):
-            return []
-
-        entries: List[dict] = []
-        for item in raw_mcps:
-            if not isinstance(item, Mapping):
-                continue
-            code = item.get("server_code")
-            if not isinstance(code, str) or not code.strip():
-                continue
-            entry = dict(item)
-            entry["server_code"] = code.strip()
-            entries.append(entry)
-        return entries
+        return merge_template_preset_capabilities(
+            default_servers,
+            ext_info,
+            capability_key="mcp",
+            identity_key="server_code",
+        )

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -11,6 +11,7 @@ from .aicoding.strategy import (
     AicodingProvisioningStrategy,
     CODING_TEMPLATE_TYPES,
 )
+from .aicoding.cli_defaults import AicodingCliDefaultsResolver
 from .aicoding.mcp_defaults import AicodingMcpDefaultsResolver
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
@@ -107,32 +108,48 @@ class DefaultCapabilitiesEngineBucketResolverRegistry:
         return normalized_engine
 
 
-class McpDefaultsResolver(Protocol):
-    """Bucket-specific hook for deriving effective default MCP configs."""
+class DefaultItemsResolver(Protocol):
+    """Bucket-specific hook for deriving effective default capability configs."""
 
     def resolve(
         self,
-        default_servers: list[dict],
+        default_items: list[dict],
         ext_info: dict | None = None,
     ) -> list[dict]:
-        """Return effective default MCP configs for one engine bucket."""
+        """Return effective default capability configs for one engine bucket."""
 
 
-class McpDefaultsResolverRegistry:
-    """Registry for engine-contributed MCP default resolvers."""
+class DefaultItemsResolverRegistry:
+    """Registry for engine-contributed default capability resolvers."""
 
-    def __init__(self) -> None:
-        self._resolvers: dict[str, McpDefaultsResolver] = {}
+    def __init__(self, capability_name: str) -> None:
+        self._capability_name = capability_name
+        self._resolvers: dict[str, DefaultItemsResolver] = {}
 
-    def register(self, engine_bucket: str, resolver: McpDefaultsResolver) -> None:
+    def register(self, engine_bucket: str, resolver: DefaultItemsResolver) -> None:
         if engine_bucket in self._resolvers:
             raise ValueError(
-                f"MCP defaults resolver already registered: {engine_bucket}"
+                f"{self._capability_name} defaults resolver already registered: "
+                f"{engine_bucket}"
             )
         self._resolvers[engine_bucket] = resolver
 
-    def resolve(self, engine_bucket: str) -> McpDefaultsResolver | None:
+    def resolve(self, engine_bucket: str) -> DefaultItemsResolver | None:
         return self._resolvers.get(engine_bucket)
+
+
+class CliDefaultsResolverRegistry(DefaultItemsResolverRegistry):
+    """Registry for engine-contributed CLI default resolvers."""
+
+    def __init__(self) -> None:
+        super().__init__("CLI")
+
+
+class McpDefaultsResolverRegistry(DefaultItemsResolverRegistry):
+    """Registry for engine-contributed MCP default resolvers."""
+
+    def __init__(self) -> None:
+        super().__init__("MCP")
 
 
 class EngineProvisioningRegistry:
@@ -305,6 +322,21 @@ _MCP_DEFAULTS_RESOLVER_REGISTRY = _build_mcp_defaults_resolver_registry()
 def get_mcp_defaults_resolver_registry() -> McpDefaultsResolverRegistry:
     """Return the process-wide MCP defaults resolver registry."""
     return _MCP_DEFAULTS_RESOLVER_REGISTRY
+
+
+def _build_cli_defaults_resolver_registry() -> CliDefaultsResolverRegistry:
+    """Assemble the process-wide CLI defaults resolver registry."""
+    registry = CliDefaultsResolverRegistry()
+    registry.register(AICODING_ENGINE_TYPE, AicodingCliDefaultsResolver())
+    return registry
+
+
+_CLI_DEFAULTS_RESOLVER_REGISTRY = _build_cli_defaults_resolver_registry()
+
+
+def get_cli_defaults_resolver_registry() -> CliDefaultsResolverRegistry:
+    """Return the process-wide CLI defaults resolver registry."""
+    return _CLI_DEFAULTS_RESOLVER_REGISTRY
 
 
 def resolve_provisioning(
@@ -483,6 +515,7 @@ __all__ = [
     "DefaultCapabilitiesEngineBucketResolverRegistry",
     "EngineProvisioningRegistry",
     "get_baas_engine_bucket_resolver_registry",
+    "get_cli_defaults_resolver_registry",
     "get_default_capabilities_engine_bucket_resolver_registry",
     "get_mcp_defaults_resolver_registry",
     "get_engine_provisioning_registry",

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
@@ -149,7 +149,7 @@ class DefaultBotPassportRepairService:
                     cli_items=get_default_cli_items(
                         bot.get("active_engine"),
                         bot.get("template_type"),
-                        ext_info={"aicoding": {"template_config": bot.get("template_config")}}
+                        ext_info={"template_config": bot.get("template_config")}
                         if bot.get("template_config")
                         else None,
                     ),

--- a/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/default_bot_passport_repair_service.py
@@ -147,7 +147,11 @@ class DefaultBotPassportRepairService:
                     owner_workno=target_user_id,
                     mcp_codes=mcp_codes,
                     cli_items=get_default_cli_items(
-                        bot.get("active_engine"), bot.get("template_type")
+                        bot.get("active_engine"),
+                        bot.get("template_type"),
+                        ext_info={"aicoding": {"template_config": bot.get("template_config")}}
+                        if bot.get("template_config")
+                        else None,
                     ),
                     bot_name=bot.get("bot_name"),
                     bot_desc=bot.get("bot_desc"),

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.default_capabilities import (
     resolve_default_capabilities_engine_type,
 )
 from agentclaw.community.core.bot_management.engines.registry import (
+    get_cli_defaults_resolver_registry,
     get_mcp_defaults_resolver_registry,
 )
 
@@ -147,6 +148,20 @@ class _EngineMcpDefaultsResolver:
 _DEFAULT_MCP_RESOLVER = _EngineMcpDefaultsResolver()
 
 
+class _EngineCliDefaultsResolver:
+    """Default hook for deriving effective CLI configs."""
+
+    def resolve(
+        self,
+        default_items: List[dict],
+        ext_info: Optional[Mapping[str, Any]] = None,
+    ) -> List[dict]:
+        return [dict(item) for item in default_items]
+
+
+_DEFAULT_CLI_RESOLVER = _EngineCliDefaultsResolver()
+
+
 def _resolve_default_mcp_engine_bucket(
     engine_type: Optional[str],
     template_type: Any = None,
@@ -253,21 +268,31 @@ _DEFAULT_CLI_ITEMS_BY_ENGINE: Dict[str, List[dict]] = {
 }
 
 
+def _cli_defaults_resolver(engine_bucket: str):
+    return (
+        get_cli_defaults_resolver_registry().resolve(engine_bucket)
+        or _DEFAULT_CLI_RESOLVER
+    )
+
+
 def get_default_cli_items(
     engine_type: Optional[str] = None,
     template_type: Optional[str] = None,
+    *,
+    ext_info: Optional[Mapping[str, Any]] = None,
 ) -> List[dict]:
     """返回默认 CLI 列表（CliItem dict 形式）。
 
     默认能力分桶规则由对应引擎维护；CLI 这里只按分桶结果读取默认
     CLI 列表，未知桶返回空列表（fail-closed，避免误授权 CLI）。
+    引擎可通过 resolver 基于 ext_info 合并模板预置 CLI。
     """
-    from agentclaw.community.core.default_capabilities import (
-        resolve_default_capabilities_engine_type,
-    )
-
     key = resolve_default_capabilities_engine_type(
         engine_type,
         template_type,
     )
-    return [dict(item) for item in _DEFAULT_CLI_ITEMS_BY_ENGINE.get(key, [])]
+    resolver = _cli_defaults_resolver(key)
+    return resolver.resolve(
+        _DEFAULT_CLI_ITEMS_BY_ENGINE.get(key, []),
+        ext_info,
+    )

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -872,12 +872,16 @@ class MCPSyncService:
         bot_name: Optional[str] = None
         bot_desc: Optional[str] = None
         template_type: Optional[str] = None
+        template_config: Optional[Mapping[str, Any]] = None
         try:
             bot = self.bot_repository.get_by_id_and_owner(bot_id, user_id)
             if bot:
                 bot_name = bot.get("bot_name")
                 bot_desc = bot.get("bot_desc")
                 template_type = bot.get("template_type")
+                raw_template_config = bot.get("template_config")
+                if isinstance(raw_template_config, Mapping):
+                    template_config = raw_template_config
                 engine_type = (
                     bot.get("active_engine") or bot.get("engine_type") or engine_type
                 )
@@ -896,7 +900,13 @@ class MCPSyncService:
             logger.error("[MCPSyncService] %s", error)
             return {"success": False, "error": error}
 
-        default_cli_items = get_default_cli_items(engine_type, template_type)
+        default_cli_items = get_default_cli_items(
+            engine_type,
+            template_type,
+            ext_info={"aicoding": {"template_config": template_config}}
+            if template_config
+            else None,
+        )
         cli_items = _merge_cli_items(current_cli_items, default_cli_items)
         if default_cli_items:
             logger.info(

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -903,7 +903,7 @@ class MCPSyncService:
         default_cli_items = get_default_cli_items(
             engine_type,
             template_type,
-            ext_info={"aicoding": {"template_config": template_config}}
+            ext_info={"template_config": template_config}
             if template_config
             else None,
         )

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -303,7 +303,7 @@ def test_template_config_mcps_append_and_override_defaults():
         }
     }
 
-    ext_info = {"aicoding": {"template_config": template_config}}
+    ext_info = {"template_config": template_config}
     servers = get_default_mcp_servers("aicoding", ext_info=ext_info)
     codes = [s["server_code"] for s in servers]
 
@@ -339,7 +339,7 @@ def test_resolved_template_config_mcps_append_defaults():
 
     codes = get_default_mcp_server_codes(
         "aicoding",
-        ext_info={"aicoding": {"template_config": template_config}},
+        ext_info={"template_config": template_config},
     )
 
     assert "mcp.ant.agentix.112858.baishitong" in codes
@@ -359,7 +359,7 @@ def test_template_config_top_level_mcp_presets_are_ignored():
     }
 
     assert "mcp.ant.custom.template.server" not in get_default_mcp_server_codes(
-        "aicoding", ext_info={"aicoding": {"template_config": template_config}}
+        "aicoding", ext_info={"template_config": template_config}
     )
 
 
@@ -378,7 +378,7 @@ def test_legacy_wrapped_template_config_mcp_presets_are_ignored():
     }
 
     assert "mcp.ant.custom.template.server" not in get_default_mcp_server_codes(
-        "aicoding", ext_info={"aicoding": {"template_config": template_config}}
+        "aicoding", ext_info={"template_config": template_config}
     )
 
 
@@ -398,13 +398,13 @@ def test_template_config_mcp_presets_are_aicoding_specific():
     }
 
     assert "mcp.ant.custom.template.server" in get_default_mcp_server_codes(
-        "aicoding", ext_info={"aicoding": {"template_config": template_config}}
+        "aicoding", ext_info={"template_config": template_config}
     )
     assert "mcp.ant.custom.template.server" not in get_default_mcp_server_codes(
-        "claude_code", ext_info={"aicoding": {"template_config": template_config}}
+        "claude_code", ext_info={"template_config": template_config}
     )
     assert "mcp.ant.custom.template.server" not in get_default_mcp_server_codes(
-        "openclaw", ext_info={"aicoding": {"template_config": template_config}}
+        "openclaw", ext_info={"template_config": template_config}
     )
 
 
@@ -421,7 +421,7 @@ def test_claude_code_coding_template_uses_aicoding_mcp_bucket():
             }
         }
     }
-    ext_info = {"aicoding": {"template_config": template_config}}
+    ext_info = {"template_config": template_config}
 
     codes = get_default_mcp_server_codes(
         "claude_code",
@@ -447,7 +447,7 @@ def test_claude_code_template_factory_non_normal_uses_aicoding_mcp_bucket():
             }
         }
     }
-    ext_info = {"aicoding": {"template_config": template_config}}
+    ext_info = {"template_config": template_config}
 
     codes = get_default_mcp_server_codes(
         "claude_code",
@@ -492,7 +492,7 @@ def test_template_config_clis_append_and_override_defaults():
 
     items = get_default_cli_items(
         "aicoding",
-        ext_info={"aicoding": {"template_config": template_config}},
+        ext_info={"template_config": template_config},
     )
     codes = [it["cli_code"] for it in items]
 
@@ -521,7 +521,7 @@ def test_template_config_top_level_cli_presets_are_ignored():
         it["cli_code"]
         for it in get_default_cli_items(
             "aicoding",
-            ext_info={"aicoding": {"template_config": template_config}},
+            ext_info={"template_config": template_config},
         )
     ]
     assert "custom-cli" not in codes
@@ -543,5 +543,5 @@ def test_template_config_cli_presets_are_aicoding_specific():
 
     assert get_default_cli_items(
         "openclaw",
-        ext_info={"aicoding": {"template_config": template_config}},
+        ext_info={"template_config": template_config},
     ) == []

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -468,3 +468,80 @@ def test_claude_code_normal_template_keeps_claude_mcp_bucket():
 
     assert "clawmind" in codes
     assert "mcp.ant.agentix.112858.aixAicoding" not in codes
+
+
+def test_template_config_clis_append_and_override_defaults():
+    template_config = {
+        "bot_template_config": {
+            "preset_capabilities": {
+                "cli": [
+                    {
+                        "cli_code": "antcode-cli",
+                        "cli_name": "Template AntCode",
+                        "cli_desc": "template override",
+                    },
+                    {
+                        "cli_code": "custom-cli",
+                        "cli_name": "Custom CLI",
+                        "cli_desc": "template appended",
+                    },
+                ]
+            }
+        }
+    }
+
+    items = get_default_cli_items(
+        "aicoding",
+        ext_info={"aicoding": {"template_config": template_config}},
+    )
+    codes = [it["cli_code"] for it in items]
+
+    assert codes.count("antcode-cli") == 1
+    assert "custom-cli" in codes
+    overridden = next(it for it in items if it["cli_code"] == "antcode-cli")
+    assert overridden["cli_name"] == "Template AntCode"
+    assert overridden["cli_desc"] == "template override"
+    appended = next(it for it in items if it["cli_code"] == "custom-cli")
+    assert appended["cli_name"] == "Custom CLI"
+
+
+def test_template_config_top_level_cli_presets_are_ignored():
+    template_config = {
+        "preset_capabilities": {
+            "cli": [
+                {
+                    "cli_code": "custom-cli",
+                    "cli_name": "Custom CLI",
+                }
+            ]
+        }
+    }
+
+    codes = [
+        it["cli_code"]
+        for it in get_default_cli_items(
+            "aicoding",
+            ext_info={"aicoding": {"template_config": template_config}},
+        )
+    ]
+    assert "custom-cli" not in codes
+
+
+def test_template_config_cli_presets_are_aicoding_specific():
+    template_config = {
+        "bot_template_config": {
+            "preset_capabilities": {
+                "cli": [
+                    {
+                        "cli_code": "custom-cli",
+                        "cli_name": "Custom CLI",
+                    }
+                ]
+            }
+        }
+    }
+
+    assert get_default_cli_items(
+        "openclaw",
+        ext_info={"aicoding": {"template_config": template_config}},
+    ) == []


### PR DESCRIPTION
## Summary
- add AICoding CLI defaults resolver for template preset_capabilities.cli
- share default capability registry and template preset merge logic between MCP and CLI defaults
- pass template_config into CLI default resolution for bot creation, passport repair, and MCP sync refresh

## Tests
- uv run pytest tests/community/core/mcp/test_defaults_per_engine.py tests/community/core/bot_management/services/test_engine_resolver.py