### PR TITLE
feat(baas): run startup scripts unbounded and bracket runs with log markers

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -1084,21 +1084,26 @@ that one design choice, and none of it is visible in the OpenAPI document.
   A script written after a bot was created reaches a container only once that
   bot restarts. The first write therefore always needs a restart.
 - **A failure degrades rather than blocks — the script's *execution*, that is.**
-  A non-zero exit, a crash, or a timeout leaves the agent running: the script is
+  A non-zero exit or a crash leaves the agent running: the script is
   guarded so it cannot change the boot's outcome, and it is skipped entirely if
   the boot itself failed. That is not a promise to start anyway if the platform
   *cannot read* your stored script: a start that could not resolve it fails
   rather than bringing up a bot that looks ready and is not provisioned.
-- **Limits:** body ≤ **24 KiB** (413 above that, naming the limit); each run
-  capped at **300s** by `timeout`, sized against the 600s publish budget the
-  start reports into. The cap is enforced as TERM at 300s followed by an
-  uncatchable KILL **10s** later, so a script that traps or ignores TERM cannot
-  hold the start open past **310s**. The cap bounds **the start**, not your
-  descendants: a process the script deliberately backgrounds (`something &`)
-  outlives it, because the script itself has exited and the start has already
-  completed — nothing reaps it, so it runs until it ends or the container does.
+- **Limits:** body ≤ **24 KiB** (413 above that, naming the limit). There is
+  currently **no cap on the run itself**: the per-run `timeout` was removed, so
+  the script runs to completion however long it takes. The start only reports
+  once the script exits, and the 600s publish budget the start reports into
+  does not stop the script — a run that overstays it leaves the publish marked
+  failed while the script (and the container's boot) carries on. A script that
+  never exits holds the start open indefinitely, so bound your own long-running
+  work (background it with `something &` if it should outlive the start).
   Interpreter is `bash`; the body runs as `admin`, the same user every platform
   step runs as.
+- **Each run brackets itself in the log.** The platform writes a timestamped
+  `[startup_script] started at ...` line before your body runs and a
+  `[startup_script] finished at ... rc=<exit code>` line after it, into the
+  same log the body's output goes to — with no cap on the run, those markers
+  are how you tell a still-running script apart from a finished one.
 - **Do not put secrets in the body.** This is a hard requirement, not advice.
   The body is stored as written, and it is **logged in recoverable form**: the
   backend elides it from its own payload log, but the start command travels to

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -90,25 +90,6 @@ STARTUP_SCRIPT_LOG = "/home/admin/logs/startup_script.log"
 #: log redaction splits on so the platform half stays readable.
 _USER_STAGE_MARKER = "\n__OCB_RC=$?\n"
 
-#: Wall-clock cap on the user stage.
-#:
-#: Sized against the create budget on the other side of the callback: the
-#: backend's publish poller gives up at _CREATE_PUBLISH_TIMEOUT_SECONDS (600s,
-#: baas_publish_task_handlers.py) and the device only reports once this whole
-#: sequence exits. Half that budget leaves room for the platform steps and for
-#: the callback's own retries.
-STARTUP_SCRIPT_TIMEOUT_SECONDS = 300
-
-#: Grace period between ``timeout``'s TERM and its KILL.
-#:
-#: ``timeout N`` alone sends TERM and then *waits* — a script that traps or
-#: ignores TERM keeps the hook alive indefinitely, and nothing upstream would
-#: cut it short (see the ``after_create_hook_wait_seconds`` note in
-#: ``_build_create_bot_payload``: BaaS accepts that value and ignores it, and
-#: the wrapper is nohup'd). ``-k`` follows up with KILL, which cannot be
-#: caught, so the cap holds against a hostile or merely buggy script. The grace
-#: is short but non-zero so a well-behaved trap can still flush its own log.
-STARTUP_SCRIPT_KILL_GRACE_SECONDS = 10
 ENGINE_DIR_MOUNT_WHITELIST_PARAM_CODE = "engine_dir_mount_whitelist"
 
 
@@ -850,9 +831,11 @@ class BaasService:  # pragma: no cover
             # NOTE: this does not bound the hook. BaaS threads it into
             # dispatch_start_hook as ``hook_timeout`` and then ignores it
             # (``# noqa: ARG001 - kept for API compatibility``); the wrapper is
-            # nohup'd and runs unbounded. So it does not contradict
-            # STARTUP_SCRIPT_TIMEOUT_SECONDS, which is enforced by ``timeout``
-            # in the command itself — and it is why that one has to be.
+            # nohup'd and runs unbounded. The per-bot startup script stage is
+            # currently unbounded too (its ``timeout`` wrapper was removed), so
+            # nothing caps a start that runs a long script — the publish poller
+            # gives up at _CREATE_PUBLISH_TIMEOUT_SECONDS while the start keeps
+            # running.
             after_create_hook_wait_seconds=10,
             before_destroy_cmd_hook=destroy_cmd,
             before_destroy_hook_wait_seconds=10,
@@ -2437,13 +2420,16 @@ class BaasService:  # pragma: no cover
             entity_id=entity_id, bot_id=bot_id
         )
 
-    def _get_startup_script_segment(
-        self,
-        script: str,
-        timeout_seconds: int = STARTUP_SCRIPT_TIMEOUT_SECONDS,
-        kill_grace_seconds: int = STARTUP_SCRIPT_KILL_GRACE_SECONDS,
-    ) -> str:
-        """Emit the user stage: decode, run under a timeout, never fail the boot.
+    def _get_startup_script_segment(self, script: str) -> str:
+        """Emit the user stage: decode, run to completion, never fail the boot.
+
+        The stage is deliberately *unbounded* — the ``timeout -k`` wrapper it
+        used to run under was removed, so a script runs for as long as it takes.
+        A script that outlives the publish budget leaves the poller to give up
+        on its own (_CREATE_PUBLISH_TIMEOUT_SECONDS, baas_publish_task_handlers)
+        while the start keeps running; nothing else upstream bounds the hook
+        (BaaS ignores ``after_create_hook_wait_seconds`` and the wrapper is
+        nohup'd).
 
         The body is base64-encoded here rather than quoted. Two reasons, both
         load-bearing:
@@ -2457,7 +2443,11 @@ class BaasService:  # pragma: no cover
 
         Output goes to its own log so the script's chatter is separable from the
         platform's inside the container, even though the two share one exit
-        status upstream.
+        status upstream. The stage brackets the run with timestamped
+        ``started`` / ``finished`` marker lines in that same log — with no
+        deadline on the run, those markers are what tells a still-running script
+        apart from a finished one, and the ``finished`` line carries the
+        script's exit code.
         """
         encoded = base64.b64encode(script.encode("utf-8")).decode("ascii")
         # Runs as ``admin``, like every platform step (``_get_bootstrap_cmp``
@@ -2471,13 +2461,18 @@ class BaasService:  # pragma: no cover
         #
         # Single-quoting is safe here: everything interpolated is either a fixed
         # path or base64 (alphabet [A-Za-z0-9+/=]), so the body cannot contain a
-        # quote that closes this string. ``$f`` is expanded by the su'd shell at
-        # runtime, not by this f-string.
+        # quote that closes this string. ``$f``/``$rc`` and the ``$(date ...)``
+        # in the marker lines are expanded by the su'd shell at runtime, not by
+        # this f-string.
         inner = (
             "f=$(mktemp)"
             f' && echo {encoded} | base64 -d > "$f"'
-            f" && timeout -k {kill_grace_seconds} {timeout_seconds}"
-            f' bash "$f" >> {STARTUP_SCRIPT_LOG} 2>&1'
+            f' && echo "[startup_script] started at $(date +%Y-%m-%dT%H:%M:%S%z)"'
+            f" >> {STARTUP_SCRIPT_LOG}"
+            f' && bash "$f" >> {STARTUP_SCRIPT_LOG} 2>&1'
+            "; rc=$?"
+            f'; echo "[startup_script] finished at $(date +%Y-%m-%dT%H:%M:%S%z)'
+            f' rc=$rc" >> {STARTUP_SCRIPT_LOG}'
             '; rm -f "$f"'
         )
         return f"  su admin -c '{inner}' || true"

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_start_cmd.py
@@ -268,55 +268,42 @@ class TestStartupScriptSegment:
         assert encoded in cmd
         assert _b64.b64decode(encoded).decode("utf-8") == body
 
-    # --- runtime bounds -----------------------------------------------------
+    # --- runtime behavior ---------------------------------------------------
 
-    def test_user_stage_runs_under_a_timeout(self):
-        from agentclaw.community.core.service_bot.services.baas_service import (
-            STARTUP_SCRIPT_KILL_GRACE_SECONDS,
-            STARTUP_SCRIPT_TIMEOUT_SECONDS,
-        )
+    def test_user_stage_runs_without_a_timeout(self):
+        """The ``timeout -k`` wrapper was deliberately removed: the script runs
+        to completion however long it takes, and only the publish poller's own
+        budget gives up on a start that overstays."""
+        cmd = self._cmd("echo hi")
+        stage = cmd[cmd.index("__OCB_RC=$?") :]
+        assert "timeout" not in stage
+        assert 'bash "$f"' in stage  # invoked directly, unwrapped
 
-        assert (
-            f"timeout -k {STARTUP_SCRIPT_KILL_GRACE_SECONDS} "
-            f"{STARTUP_SCRIPT_TIMEOUT_SECONDS} bash"
-        ) in self._cmd("echo hi")
+    def test_start_and_finish_markers_bracket_the_run(self):
+        """With no deadline on the run, the log markers are what tells a
+        still-running script apart from a finished one."""
+        cmd = self._cmd("echo hi")
+        stage = cmd[cmd.index("__OCB_RC=$?") :]
+        started = stage.index("[startup_script] started at ")
+        run = stage.index('bash "$f"')
+        finished = stage.index("[startup_script] finished at ")
+        assert started < run < finished
 
-    def test_the_timeout_cannot_be_defeated_by_trapping_term(self):
-        """``timeout N`` alone sends TERM and then waits forever if the script
-        traps it — and nothing upstream bounds the hook (BaaS ignores
-        ``after_create_hook_wait_seconds`` and the wrapper is nohup'd), so this
-        one flag is the whole guarantee that a start terminates."""
-        from agentclaw.community.core.service_bot.services.baas_service import (
-            STARTUP_SCRIPT_KILL_GRACE_SECONDS,
-        )
+    def test_markers_go_to_the_script_log_with_timestamps(self):
+        cmd = self._cmd("echo hi")
+        stage = cmd[cmd.index("__OCB_RC=$?") :]
+        # started marker, script output, finished marker — all in the same log.
+        assert stage.count(">> /home/admin/logs/startup_script.log") == 3
+        # Expanded by the su'd shell at run time, once per marker.
+        assert stage.count("$(date +%Y-%m-%dT%H:%M:%S%z)") == 2
 
-        cmd = self._cmd("trap '' TERM; sleep 100000\n")
-        assert "timeout -k " in cmd
-        assert STARTUP_SCRIPT_KILL_GRACE_SECONDS > 0
-
-    def test_timeout_leaves_headroom_in_the_create_budget(self):
-        """The device only reports once this sequence exits; the poller gives
-        up at 600s (_CREATE_PUBLISH_TIMEOUT_SECONDS).
-
-        Two bounds, because there are two cases. A script that exits or accepts
-        TERM is capped at the deadline, and that is the one sized at half the
-        budget so the platform steps and the callback's retries have the other
-        half. A script that *traps* TERM runs to the KILL instead; that case
-        only has to remain bounded and clear of the poller, not stay under
-        half.
-        """
-        from agentclaw.community.core.service_bot.services.baas_service import (
-            STARTUP_SCRIPT_KILL_GRACE_SECONDS,
-            STARTUP_SCRIPT_TIMEOUT_SECONDS,
-        )
-        from agentclaw.community.core.devices.services.baas_publish_task_handlers import (
-            _CREATE_PUBLISH_TIMEOUT_SECONDS,
-        )
-
-        assert STARTUP_SCRIPT_TIMEOUT_SECONDS <= _CREATE_PUBLISH_TIMEOUT_SECONDS / 2
-
-        hard_cap = STARTUP_SCRIPT_TIMEOUT_SECONDS + STARTUP_SCRIPT_KILL_GRACE_SECONDS
-        assert hard_cap < _CREATE_PUBLISH_TIMEOUT_SECONDS
+    def test_finish_marker_carries_the_scripts_exit_code(self):
+        """``rc`` is captured from ``$?`` immediately after the run, before the
+        marker echo and the mktemp cleanup can overwrite it."""
+        cmd = self._cmd("exit 3")
+        stage = cmd[cmd.index("__OCB_RC=$?") :]
+        assert "; rc=$?; echo " in stage
+        assert 'rc=$rc" >> /home/admin/logs/startup_script.log' in stage
 
     def test_output_goes_to_its_own_log(self):
         cmd = self._cmd("echo hi")


### PR DESCRIPTION
## Problem

The per-bot startup script's user stage ran under `timeout -k 10 300`, capping every run at 300s (TERM) + 10s (KILL). That cap is unwanted for now: scripts that legitimately need longer than five minutes get killed mid-provisioning. Separately, the script's log (`/home/admin/logs/startup_script.log`) only contained the body's own output, so there was no way to tell from the log when a run began, whether it was still going, or how it ended.

## Solution

- Removed the `timeout -k` wrapper from `_get_startup_script_segment` along with both sizing constants (`STARTUP_SCRIPT_TIMEOUT_SECONDS`, `STARTUP_SCRIPT_KILL_GRACE_SECONDS`) and the method's now-unused parameters. The script runs to completion however long it takes; a run that outlives the 600s publish budget leaves the poller to give up on its own while the start keeps running.
- The stage now brackets each run in the same log: a timestamped `[startup_script] started at ...` line before the body runs, and `[startup_script] finished at ... rc=<exit code>` after it, with `rc` captured from `$?` immediately after the run. With no deadline on the run, these markers are what distinguishes a still-running script from a finished one.
- Everything else about the stage is unchanged: base64-encoded body (no single quotes can enter the `su admin -c '...'` wrapper — the markers use double quotes only), mktemp drop path, `|| true` guard, `__OCB_RC` exit-status re-assertion, payload log redaction, and the byte-identical no-script chain.
- Updated the startup-script contract section in `docs/openapi-v1/README.md` (the only doc that stated the 300s cap) to describe the unbounded run and the new log markers.

## Validation

- `tests/community/core/service_bot/services/test_baas_service_start_cmd.py`: replaced the three timeout tests with four covering the unwrapped invocation, marker ordering (started → run → finished), all three redirects targeting `startup_script.log`, and the exit-code capture — 41 passed.
- Wider sweep: `tests/community/core/service_bot/`, `tests/community/core/bot_startup_script/`, both startup-script repository test files, and `tests/community/endpoints/test_openapi_startup_script.py` — 936 passed; the 2 failures in `test_bot_build_service_skill_artifact.py` are pre-existing (reproduced on the clean base commit).
- Manually executed the rendered user stage against a scratch log with a body of `echo hello-from-script; exit 3`: log shows the started marker, the body's output, then `finished at ... rc=3`, and the wrapper still exits 0.
- `ruff check` clean on both changed Python files (`ruff format --check` drift on them is pre-existing at the base).

## Compatibility and risk

- Published-contract change: the documented 300s/310s cap no longer exists; a script that never exits now holds the start open indefinitely (the publish is marked failed by the poller's own 600s budget, but the hook keeps running). This is the requested behavior "for now"; the rollback path is re-adding the `timeout -k` wrapper and constants.
- Log format addition only — the marker lines share the script's log file and do not alter what the body writes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzJRZmu51hrwgftGCKvHWc)_