### PR TITLE
fix(bcs): classify direct chat timeout failures

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -1157,7 +1157,7 @@ fn direct_chat_failure_reason(error: &str) -> DirectChatRunReason {
     // This is intentionally limited to bot-emitted chat.event error text.
     // Store and transport paths pass typed DirectChatRunReason values.
     let normalized = error.to_ascii_lowercase();
-    if normalized.contains("timeout") {
+    if is_timeout_text(&normalized) {
         DirectChatRunReason::Timeout
     } else if normalized.contains("bot_not_connected") || normalized.contains("not connected") {
         DirectChatRunReason::BotNotConnected
@@ -1177,8 +1177,15 @@ fn direct_chat_service_error_reason(error: &ServiceError) -> DirectChatRunReason
             DirectChatRunReason::Blocked
         }
         ServiceError::MessageLimitReached(_) => DirectChatRunReason::StoreCapacity,
+        ServiceError::InternalError(message) if is_timeout_text(&message.to_ascii_lowercase()) => {
+            DirectChatRunReason::Timeout
+        }
         _ => DirectChatRunReason::InternalError,
     }
+}
+
+fn is_timeout_text(normalized: &str) -> bool {
+    normalized.contains("timeout") || normalized.contains("timed out")
 }
 
 fn ensure_run_owner(record: &ChatRunRecord, from_bot_id: &str) -> ServiceResult<()> {
@@ -1342,6 +1349,10 @@ mod tests {
             DirectChatRunReason::Timeout
         );
         assert_eq!(
+            direct_chat_failure_reason("Agent response timed out before completion."),
+            DirectChatRunReason::Timeout
+        );
+        assert_eq!(
             direct_chat_failure_reason("target bot is not connected"),
             DirectChatRunReason::BotNotConnected
         );
@@ -1352,6 +1363,18 @@ mod tests {
         assert_eq!(
             direct_chat_failure_reason("unexpected model error"),
             DirectChatRunReason::InternalError
+        );
+        assert_eq!(
+            direct_chat_service_error_reason(&ServiceError::InternalError(
+                "provider response header timeout after 5000ms".to_string()
+            )),
+            DirectChatRunReason::Timeout
+        );
+        assert_eq!(
+            direct_chat_service_error_reason(&ServiceError::InternalError(
+                "provider request failed: operation timed out".to_string()
+            )),
+            DirectChatRunReason::Timeout
         );
     }
 }


### PR DESCRIPTION
## Problem
  Direct chat timeout failures were being misclassified as internal_error in bcs_direct_chat_run_events_total.

  Production logs showed bot callback errors with the message:

  Agent response timed out before completion.

  The existing direct chat failure classifier only matched the substring timeout, so messages using timed out fell through to DirectChatRunReason::InternalError. Provider delivery timeout
  errors wrapped in ServiceError::InternalError(...) could also be reported as internal_error instead of timeout.

  ## Solution

  Updated the direct chat failure classification logic to consistently recognize timeout text through a shared helper.

  Changes include:

  - Added timeout text matching for both:
      - timeout
      - timed out

  - Reused the timeout classifier for bot-emitted chat event errors.
  - Applied the same timeout detection to ServiceError::InternalError(...) messages during direct chat delivery failure classification.
  - Added regression coverage for:
      - Agent response timed out before completion.
      - provider response header timeout after 5000ms
      - provider request failed: operation timed out

  This keeps the metric label set unchanged while correcting known timeout cases from internal_error to timeout.