### PR TITLE
Refactor qt

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -148,6 +148,7 @@ from agentclaw.community.adapters.http.bot_management import router as bot_manag
 from agentclaw.community.adapters.http.caller_identity.router import router as caller_identity_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_dormant import router as bot_dormant_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_dormant.router import internal_router as bot_dormant_internal_router  # noqa: E402
+from agentclaw.community.adapters.http.spaces_internal import router as spaces_internal_router  # noqa: E402
 from agentclaw.community.adapters.http.service_bot.router_build import router as service_bot_router  # noqa: E402
 from agentclaw.community.adapters.http.service_bot.router_publish import router as service_bot_publish_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_collaborator import router as bot_collaborator_router  # noqa: E402
@@ -799,6 +800,7 @@ app.include_router(bot_management_router.router)
 app.include_router(caller_identity_router)
 app.include_router(bot_dormant_router.router)
 app.include_router(bot_dormant_internal_router)
+app.include_router(spaces_internal_router)
 app.include_router(service_bot_router)
 app.include_router(service_bot_publish_router)
 app.include_router(bot_collaborator_router)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -186,6 +186,7 @@ from .contracts import (
     ENGINE_RUNTIME_ERROR_RESPONSES,
     ERROR_RESPONSES,
     USER_SCOPED_ERROR_RESPONSES,
+    SPACE_SCOPED_ERROR_RESPONSES,
 )
 from .dependencies import require_principal
 from .principal import require_granted_addressed_bot, require_granted_own_bot
@@ -201,6 +202,8 @@ from .bot_logs import router as logs_router
 from .resources import router as resources_router
 from .routines import router as routines_router
 from .skills import router as skills_router
+from .spaces import router as spaces_router
+from .work_orders import router as work_orders_router
 
 # Every public route lives under this prefix. Exported so app-level handlers can
 # tell a public request from an internal one (e.g. to envelope validation errors
@@ -342,6 +345,18 @@ def build_public_router() -> APIRouter:
     user" above).
     """
     public = APIRouter()
+    # Space APIs are user-only in the first phase. They are top-level
+    # resources, so they intentionally do not inherit any bot grant gate.
+    public.include_router(
+        spaces_router,
+        responses=SPACE_SCOPED_ERROR_RESPONSES,
+        dependencies=_PUBLIC_AUTH,
+    )
+    public.include_router(
+        work_orders_router,
+        responses=SPACE_SCOPED_ERROR_RESPONSES,
+        dependencies=_PUBLIC_AUTH,
+    )
     for router in _GROUPS_WITHOUT_CALLER_SCOPE + _MIXED_GROUPS:
         public.include_router(
             router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -142,38 +142,95 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("PUT", "/openapi/v1/bots/{bot_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("DELETE", "/openapi/v1/bots/{bot_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("POST", "/openapi/v1/bots/{bot_id}/restart"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/auth-status"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/auth-status",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/{bot_id}/status"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/{bot_id}/passport"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/engine/config"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("PUT", "/openapi/v1/bots/{bot_id}/engine/config"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/startup-script"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("PUT", "/openapi/v1/bots/{bot_id}/startup-script"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/startup-script"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/engine/config",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "PUT",
+        "/openapi/v1/bots/{bot_id}/engine/config",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/startup-script",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "PUT",
+        "/openapi/v1/bots/{bot_id}/startup-script",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/startup-script",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("GET", "/openapi/v1/bots/{bot_id}/identity"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/identity/{file_type}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("PUT", "/openapi/v1/bots/{bot_id}/identity/{file_type}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/identity/{file_type}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "PUT",
+        "/openapi/v1/bots/{bot_id}/identity/{file_type}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     # resources — ``bot_id`` is a required query parameter on all seven, and
     # every one of them is addressed by workspace path. There are no record-id
     # routes left: a record id cannot address a file the bot created itself, and
     # links are no longer part of this group. Each resolves its workspace from
     # the caller-supplied ``bot_id``, so each carries the own-bot grant check.
     ("GET", "/openapi/v1/bots/{bot_id}/resources"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/resources"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/resources/stat"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/resources/upload"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/resources/download"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/resources/preview"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/resources/mkdir"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/resources",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/resources/stat",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/resources/upload",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/resources/download",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/resources/preview",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/resources/mkdir",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     # routines — query ``bot_id``, except the create, which carries it in the
     # path, so the shared dependency checks it like every other operation.
     ("GET", "/openapi/v1/bots/{bot_id}/routines"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("POST", "/openapi/v1/bots/{bot_id}/routines"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/routines/{routine_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("PATCH", "/openapi/v1/bots/{bot_id}/routines/{routine_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/routines/{routine_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/routines/{routine_id}/run"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/routines/{routine_id}/runs"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/routines/{routine_id}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "PATCH",
+        "/openapi/v1/bots/{bot_id}/routines/{routine_id}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/routines/{routine_id}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/routines/{routine_id}/run",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/routines/{routine_id}/runs",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     # skills — the group serves **shared** bots, and the six split on where the
     # owner of the addressed bot comes from.
     #
@@ -192,17 +249,50 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     # and a client naming it up front would be predicting an answer rather than
     # addressing a resource. They are checked in their handlers against the pair
     # the record actually carries; see ``SKILL_SCOPED_OPERATIONS`` below.
-    ("GET", "/openapi/v1/bots/{bot_id}/skills"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/skills"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/skills/{skill_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/skills/{skill_id}"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/sessions"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("POST", "/openapi/v1/bots/{bot_id}/sessions"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/sessions/{session_id}"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("PATCH", "/openapi/v1/bots/{bot_id}/sessions/{session_id}"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/sessions/{session_id}"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/skills",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/skills",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/skills/{skill_id}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/skills/{skill_id}",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate",
+    ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/sessions",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/sessions",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/sessions/{session_id}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "PATCH",
+        "/openapi/v1/bots/{bot_id}/sessions/{session_id}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/sessions/{session_id}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/sessions/{session_id}/messages",
@@ -211,15 +301,42 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "DELETE",
         "/openapi/v1/bots/{bot_id}/sessions/{session_id}/messages",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/engine/available"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/engine/capabilities"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/engine/status"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/approvals/mode"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("PUT", "/openapi/v1/bots/{bot_id}/approvals/mode"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/approvals/modes"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/models"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/models/{model_id:path}"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
-    ("GET", "/openapi/v1/bots/{bot_id}/connection"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/engine/available",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/engine/capabilities",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/engine/status",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/approvals/mode",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "PUT",
+        "/openapi/v1/bots/{bot_id}/approvals/mode",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/approvals/modes",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/models",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/models/{model_id:path}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/connection",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # ── B: returns a set of bots, narrowed to the granted ones ───────────────
     ("GET", "/openapi/v1/bots"): AdmissionMode.GRANT_FILTERED,
     # The application's own view, and the **complete** one: a granted bot the
@@ -235,6 +352,48 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("GET", "/openapi/v1/bots/mcp/servers"): AdmissionMode.OPEN,
     ("GET", "/openapi/v1/bots/mcp/servers/{server_code}"): AdmissionMode.OPEN,
     ("GET", "/openapi/v1/bots/mcp/tenants"): AdmissionMode.OPEN,
+    # ── Space and work-order APIs ───────────────────────────────────────────
+    # Read and self-service operations resolve an application-only caller to
+    # its delegating user and continue enforcing live Space membership or
+    # work-order recipient checks. Space ownership initialization, team/member
+    # administration, and work-order review remain human-only.
+    ("GET", "/openapi/v1/spaces"): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/spaces/personal/initialize"): AdmissionMode.REFUSED,
+    ("POST", "/openapi/v1/spaces/create"): AdmissionMode.REFUSED,
+    ("GET", "/openapi/v1/spaces/{space_id}/members"): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/spaces/{space_id}/members"): AdmissionMode.REFUSED,
+    (
+        "DELETE",
+        "/openapi/v1/spaces/{space_id}/members/{user_id}",
+    ): AdmissionMode.REFUSED,
+    (
+        "PUT",
+        "/openapi/v1/spaces/{space_id}/members/{user_id}/role",
+    ): AdmissionMode.REFUSED,
+    ("POST", "/openapi/v1/spaces/{space_id}/market-favorites"): AdmissionMode.USER_GATED,
+    (
+        "POST",
+        "/openapi/v1/spaces/{space_id}/market-favorites/cancel",
+    ): AdmissionMode.USER_GATED,
+    (
+        "POST",
+        "/openapi/v1/spaces/{space_id}/market-favorites/search",
+    ): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/spaces/{space_id}/join-requests"): AdmissionMode.USER_GATED,
+    ("GET", "/openapi/v1/work-orders"): AdmissionMode.USER_GATED,
+    ("GET", "/openapi/v1/work-orders/{work_order_id}"): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/work-orders/{work_order_id}/approve"): AdmissionMode.REFUSED,
+    ("POST", "/openapi/v1/work-orders/{work_order_id}/reject"): AdmissionMode.REFUSED,
+    (
+        "GET",
+        "/openapi/v1/work-order-notifications/{notification_id}",
+    ): AdmissionMode.USER_GATED,
+    ("GET", "/openapi/v1/work-order-notifications/unread-count"): AdmissionMode.USER_GATED,
+    (
+        "POST",
+        "/openapi/v1/work-order-notifications/{notification_id}/read",
+    ): AdmissionMode.USER_GATED,
+    ("POST", "/openapi/v1/work-order-notifications/read-all"): AdmissionMode.USER_GATED,
     # ── REFUSED — each for its own reason ────────────────────────────────────
     # No bot exists yet for a grant to cover, and creation spends the user's
     # quota. Auto-granting the new bot would invent consent nobody gave.
@@ -252,7 +411,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     # covers a bot; it does not translate into that meaning.
     ("GET", "/openapi/v1/bots/logs/traces"): AdmissionMode.REFUSED,
     ("GET", "/openapi/v1/bots/logs/traces/{trace_id}"): AdmissionMode.REFUSED,
-    ("GET", "/openapi/v1/bots/logs/sessions/{session_key}/traces"): AdmissionMode.REFUSED,
+    (
+        "GET",
+        "/openapi/v1/bots/logs/sessions/{session_key}/traces",
+    ): AdmissionMode.REFUSED,
     ("GET", "/openapi/v1/bots/logs/groups/{group_id}/traces"): AdmissionMode.REFUSED,
     (
         "GET",
@@ -422,7 +584,9 @@ class ActingCaller:
             )
         return record.owner_id
 
-    def granted_bot_ids(self, *, owned_by_delegator: bool = False) -> frozenset[str] | None:
+    def granted_bot_ids(
+        self, *, owned_by_delegator: bool = False
+    ) -> frozenset[str] | None:
         """The bots to narrow a listing to, or ``None`` to not narrow at all.
 
         ``None`` and the empty set are different answers and must stay so:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -364,13 +364,16 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("POST", "/openapi/v1/spaces/{space_id}/members"): AdmissionMode.REFUSED,
     (
         "DELETE",
-        "/openapi/v1/spaces/{space_id}/members/{user_id}",
+        "/openapi/v1/spaces/{space_id}/members/{member_user_id}",
     ): AdmissionMode.REFUSED,
     (
         "PUT",
-        "/openapi/v1/spaces/{space_id}/members/{user_id}/role",
+        "/openapi/v1/spaces/{space_id}/members/{member_user_id}/role",
     ): AdmissionMode.REFUSED,
-    ("POST", "/openapi/v1/spaces/{space_id}/market-favorites"): AdmissionMode.USER_GATED,
+    (
+        "POST",
+        "/openapi/v1/spaces/{space_id}/market-favorites",
+    ): AdmissionMode.USER_GATED,
     (
         "POST",
         "/openapi/v1/spaces/{space_id}/market-favorites/cancel",
@@ -388,7 +391,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "GET",
         "/openapi/v1/work-order-notifications/{notification_id}",
     ): AdmissionMode.USER_GATED,
-    ("GET", "/openapi/v1/work-order-notifications/unread-count"): AdmissionMode.USER_GATED,
+    (
+        "GET",
+        "/openapi/v1/work-order-notifications/unread-count",
+    ): AdmissionMode.USER_GATED,
     (
         "POST",
         "/openapi/v1/work-order-notifications/{notification_id}/read",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py
@@ -232,6 +232,18 @@ USER_SCOPED_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
     **USER_SCOPED_403,
 }
 
+# Space/member/favorite routes derive the actor from the verified principal and
+# can answer 403 for a valid caller lacking the required space role. This is a
+# different contract from USER_SCOPED_403: there is no caller-supplied user_id.
+SPACE_SCOPED_ERROR_RESPONSES: dict[int | str, dict[str, object]] = {
+    **ERROR_RESPONSES,
+    403: {
+        "model": ErrorEnvelope,
+        "description": "The authenticated user lacks the required space membership or role",
+        **error_example(403, "Forbidden"),
+    },
+}
+
 # Extra failures only the engine-runtime groups can produce. Attached to those
 # routers, NOT merged into ``ERROR_RESPONSES``: that dict is applied surface-wide
 # in ``build_public_router``, and ``test_openapi_error_schema`` asserts every

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
@@ -1,0 +1,11 @@
+"""Stable OpenAPI error code and message for Space operations."""
+
+from enum import IntEnum, StrEnum
+
+
+class SpaceErrorCode(IntEnum):
+    SKILL_CENTER_TEAM_CREATE_FAILED = 502201
+
+
+class SpacePublicErrorMessage(StrEnum):
+    SKILL_CENTER_TEAM_CREATE_FAILED = "Skill Center team creation failed"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_work_order.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_work_order.py
@@ -1,0 +1,28 @@
+"""Stable OpenAPI error codes and fixed public messages for work orders."""
+
+from enum import IntEnum, StrEnum
+
+
+class WorkOrderErrorCode(IntEnum):
+    INVALID_REASON = 400201
+    INVALID_REMARK = 400202
+    ACCESS_DENIED = 403201
+    NOT_FOUND = 404201
+    NOTIFICATION_NOT_FOUND = 404202
+    ALREADY_PENDING = 409201
+    ALREADY_PROCESSED = 409202
+    APPLICANT_ALREADY_MEMBER = 409203
+    NO_REVIEWER = 409204
+    JOIN_NOT_ALLOWED = 409205
+
+
+class WorkOrderPublicErrorMessage(StrEnum):
+    INVALID_REASON = "Invalid application reason"
+    INVALID_REMARK = "Invalid review remark"
+    FORBIDDEN = "Forbidden"
+    NOT_FOUND = "Not found"
+    ALREADY_PENDING = "A pending application already exists"
+    ALREADY_PROCESSED = "The work order has already been processed"
+    APPLICANT_ALREADY_MEMBER = "Applicant is already a space member"
+    NO_REVIEWER = "The space has no available approver"
+    JOIN_NOT_ALLOWED = "The space does not accept join requests"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -52,6 +52,14 @@ from agentclaw.community.adapters.http.openapi_v1.errors import (
     UnsupportedEngineError,
     UserIdMismatchError,
 )
+from agentclaw.community.adapters.http.openapi_v1.errors_space import (
+    SpaceErrorCode,
+    SpacePublicErrorMessage,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors_work_order import (
+    WorkOrderErrorCode,
+    WorkOrderPublicErrorMessage,
+)
 from agentclaw.community.core.bot_app_grant.errors import (
     GrantBotNotLiveError,
     GrantIdentityTooLongError,
@@ -93,6 +101,33 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineUpstreamError,
 )
 from agentclaw.community.core.gateway_principal import PrincipalVerificationError
+from agentclaw.community.core.market_favorites.errors import (
+    FavoriteNotFoundError,
+    FavoriteTargetInvalidError,
+)
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAccessDeniedError,
+    WorkOrderAlreadyPendingError,
+    WorkOrderAlreadyProcessedError,
+    WorkOrderApplicantAlreadyMemberError,
+    WorkOrderInvalidReasonError,
+    WorkOrderInvalidRemarkError,
+    WorkOrderJoinNotAllowedError,
+    WorkOrderNoReviewerError,
+    WorkOrderNotFoundError,
+    WorkOrderNotificationNotFoundError,
+)
+from agentclaw.community.core.spaces.errors import (
+    PersonalSpaceInvariantError,
+    SpaceAccessDeniedError,
+    SpaceAlreadyExistsError,
+    SpaceCreatorInvariantError,
+    SpaceMemberAlreadyExistsError,
+    SpaceMemberInvalidError,
+    SpaceMemberNotFoundError,
+    SpaceNameInvalidError,
+    SpaceNotFoundError,
+)
 from agentclaw.community.core.mcp.errors import (
     McpConfigValueError,
     McpHeadersInvalidError,
@@ -131,6 +166,9 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
     DeviceAdapterTimeoutError,
 )
 from agentclaw.community.plugin_api.passport import PassportError
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterTeamCreateError,
+)
 
 T = TypeVar("T")
 
@@ -195,6 +233,55 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # two have different fixes. The message says nothing about which user was
     # asked for; both ids are on the warning line in ``principal.py``.
     UserIdMismatchError: (403, "Forbidden"),
+    SpaceAccessDeniedError: (403, "Forbidden"),
+    SpaceNotFoundError: (404, "Not found"),
+    SpaceMemberInvalidError: (400, "Invalid space member"),
+    SpaceMemberNotFoundError: (404, "Not found"),
+    SpaceNameInvalidError: (400, "Invalid space name"),
+    FavoriteTargetInvalidError: (400, "Invalid favorite target"),
+    FavoriteNotFoundError: (404, "Not found"),
+    SpaceAlreadyExistsError: (409, "Space already exists"),
+    SpaceMemberAlreadyExistsError: (409, "Space member already exists"),
+    SpaceCreatorInvariantError: (409, "Space creator cannot be removed or demoted"),
+    PersonalSpaceInvariantError: (409, "Personal space membership is immutable"),
+    SkillCenterTeamCreateError: (
+        502,
+        SpacePublicErrorMessage.SKILL_CENTER_TEAM_CREATE_FAILED,
+    ),
+    WorkOrderAccessDeniedError: (403, WorkOrderPublicErrorMessage.FORBIDDEN),
+    WorkOrderNotFoundError: (404, WorkOrderPublicErrorMessage.NOT_FOUND),
+    WorkOrderNotificationNotFoundError: (
+        404,
+        WorkOrderPublicErrorMessage.NOT_FOUND,
+    ),
+    WorkOrderInvalidReasonError: (
+        400,
+        WorkOrderPublicErrorMessage.INVALID_REASON,
+    ),
+    WorkOrderInvalidRemarkError: (
+        400,
+        WorkOrderPublicErrorMessage.INVALID_REMARK,
+    ),
+    WorkOrderAlreadyPendingError: (
+        409,
+        WorkOrderPublicErrorMessage.ALREADY_PENDING,
+    ),
+    WorkOrderAlreadyProcessedError: (
+        409,
+        WorkOrderPublicErrorMessage.ALREADY_PROCESSED,
+    ),
+    WorkOrderApplicantAlreadyMemberError: (
+        409,
+        WorkOrderPublicErrorMessage.APPLICANT_ALREADY_MEMBER,
+    ),
+    WorkOrderJoinNotAllowedError: (
+        409,
+        WorkOrderPublicErrorMessage.JOIN_NOT_ALLOWED,
+    ),
+    WorkOrderNoReviewerError: (
+        409,
+        WorkOrderPublicErrorMessage.NO_REVIEWER,
+    ),
     InvalidBotLogQueryError: (400, "Invalid log query"),
     SessionNotFoundError: (404, "Not found"),
     BotNotFoundError: (404, "Not found"),
@@ -394,6 +481,17 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
 # small, explicit override table lets a category expose a stable actionable
 # subcode without changing any existing public response.
 ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
+    SkillCenterTeamCreateError: SpaceErrorCode.SKILL_CENTER_TEAM_CREATE_FAILED,
+    WorkOrderInvalidReasonError: WorkOrderErrorCode.INVALID_REASON,
+    WorkOrderInvalidRemarkError: WorkOrderErrorCode.INVALID_REMARK,
+    WorkOrderAccessDeniedError: WorkOrderErrorCode.ACCESS_DENIED,
+    WorkOrderNotFoundError: WorkOrderErrorCode.NOT_FOUND,
+    WorkOrderNotificationNotFoundError: WorkOrderErrorCode.NOTIFICATION_NOT_FOUND,
+    WorkOrderAlreadyPendingError: WorkOrderErrorCode.ALREADY_PENDING,
+    WorkOrderAlreadyProcessedError: WorkOrderErrorCode.ALREADY_PROCESSED,
+    WorkOrderApplicantAlreadyMemberError: WorkOrderErrorCode.APPLICANT_ALREADY_MEMBER,
+    WorkOrderNoReviewerError: WorkOrderErrorCode.NO_REVIEWER,
+    WorkOrderJoinNotAllowedError: WorkOrderErrorCode.JOIN_NOT_ALLOWED,
     LocalSkillOwnerAmbiguousError: 409104,
     LocalSkillInvalidPackageError: 400101,
     LocalSkillNotReadyError: 409101,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
@@ -1,0 +1,349 @@
+"""OpenAPI v1 adapter for spaces, members and market favorites.
+
+Application-only admission is intentionally refused in ``admission.py`` for
+this first phase. The acting user therefore comes from the verified human
+principal; no caller-supplied ``user_id`` is accepted by these routes.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, Page
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    created,
+    envelope,
+    envelope_errors,
+    page,
+)
+from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
+    AddSpaceMemberRequest,
+    CreateSpaceRequest,
+    FavoriteAddedResult,
+    FavoriteCanceledResult,
+    FavoriteTargetRequest,
+    MarketFavoriteItem,
+    PersonalSpaceInitialized,
+    SearchFavoritesRequest,
+    SpaceCreated,
+    SpaceItem,
+    SpaceMemberDeletedResult,
+    SpaceMemberItem,
+    SpaceMemberMutationResult,
+    UpdateSpaceMemberRoleRequest,
+)
+from agentclaw.community.api.market_favorite_service import (
+    MarketFavoriteServiceProtocol,
+)
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
+from agentclaw.community.core.market_favorites.models import MarketFavoriteRecord
+from agentclaw.community.core.spaces.models import (
+    SpaceMemberSummaryRecord,
+    SpaceRole,
+    SpaceSummaryRecord,
+    SpaceType,
+)
+from agentclaw.community.di import Injected
+
+
+router = APIRouter(prefix="/openapi/v1/spaces", tags=["spaces"])
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+SpaceIdPath = Annotated[int, Path(ge=1, description="Space primary identifier.")]
+PageNoQuery = Annotated[int, Query(ge=1)]
+PageSizeQuery = Annotated[int, Query(ge=1, le=100)]
+
+
+def _space_item(record: SpaceSummaryRecord) -> SpaceItem:
+    return SpaceItem(
+        space_id=record.space.id,
+        space_code=record.space.space_code,
+        space_name=record.space.name,
+        space_type=record.space.space_type,
+        current_user_role=record.current_user_role,
+        join_status=record.join_status,
+        member_count=record.member_count,
+        owner_count=record.owner_count,
+        gmt_modified=record.space.gmt_modified,
+    )
+
+
+def _created_space(record) -> SpaceCreated:
+    return SpaceCreated(
+        space_id=record.id,
+        space_code=record.space_code,
+        space_name=record.name,
+        space_type=record.space_type,
+        current_user_role=SpaceRole.OWNER,
+        is_creator=True,
+        member_count=1,
+        owner_count=1,
+        gmt_created=record.gmt_created,
+        gmt_modified=record.gmt_modified,
+    )
+
+
+def _member_item(record: SpaceMemberSummaryRecord) -> SpaceMemberItem:
+    return SpaceMemberItem(
+        user_id=record.member.user_id,
+        role=record.member.role,
+        is_creator=record.is_creator,
+        gmt_modified=record.member.gmt_modified,
+    )
+
+
+def _favorite_item(record: MarketFavoriteRecord) -> MarketFavoriteItem:
+    return MarketFavoriteItem(
+        favorite_id=record.id,
+        target_type=record.target_type,
+        target_code=record.target_code,
+        favorite_at=record.gmt_created,
+    )
+
+
+@router.get("", response_model=Envelope[Page[SpaceItem]])
+@envelope_errors
+async def list_spaces(
+    request: Request,
+    principal: PrincipalDep,
+    keyword: Annotated[str | None, Query(max_length=128)] = None,
+    space_type: Annotated[SpaceType | None, Query()] = None,
+    page_no: PageNoQuery = 1,
+    page_size: PageSizeQuery = 20,
+    service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
+) -> Envelope[Page[SpaceItem]]:
+    actor_id = caller_owner_id(principal)
+    total, records = service.list_spaces(
+        user_id=actor_id,
+        keyword=keyword,
+        space_type=space_type,
+        page_no=page_no,
+        page_size=page_size,
+    )
+    return page(total, [_space_item(record) for record in records], request)
+
+
+@router.post(
+    "/personal/initialize",
+    response_model=Envelope[PersonalSpaceInitialized],
+)
+@envelope_errors
+async def initialize_personal_space(
+    request: Request,
+    principal: PrincipalDep,
+    service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
+) -> Envelope[PersonalSpaceInitialized]:
+    record, was_created = service.initialize_personal(
+        user_id=caller_owner_id(principal)
+    )
+    result = PersonalSpaceInitialized(
+        **_created_space(record).model_dump(), created=was_created
+    )
+    return envelope(result, request)
+
+
+@router.post(
+    "/create",
+    status_code=201,
+    response_model=Envelope[SpaceCreated],
+)
+@envelope_errors
+async def create_team_space(
+    body: CreateSpaceRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
+) -> Envelope[SpaceCreated]:
+    record = service.create_team(
+        name=body.space_name, creator_id=caller_owner_id(principal)
+    )
+    return created(_created_space(record), request)
+
+
+@router.get(
+    "/{space_id}/members",
+    response_model=Envelope[Page[SpaceMemberItem]],
+)
+@envelope_errors
+async def list_space_members(
+    space_id: SpaceIdPath,
+    request: Request,
+    principal: PrincipalDep,
+    keyword: Annotated[str | None, Query(max_length=256)] = None,
+    page_no: PageNoQuery = 1,
+    page_size: PageSizeQuery = 20,
+    service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
+) -> Envelope[Page[SpaceMemberItem]]:
+    total, records = service.list_members(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        keyword=keyword,
+        page_no=page_no,
+        page_size=page_size,
+    )
+    return page(total, [_member_item(record) for record in records], request)
+
+
+@router.post(
+    "/{space_id}/members",
+    status_code=201,
+    response_model=Envelope[SpaceMemberMutationResult],
+)
+@envelope_errors
+async def add_space_member(
+    space_id: SpaceIdPath,
+    body: AddSpaceMemberRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
+) -> Envelope[SpaceMemberMutationResult]:
+    record = service.add_member(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        user_id=body.user_id,
+        role=body.role,
+    )
+    return created(
+        SpaceMemberMutationResult(
+            space_id=space_id, user_id=record.user_id, role=record.role
+        ),
+        request,
+    )
+
+
+@router.delete(
+    "/{space_id}/members/{user_id}",
+    response_model=Envelope[SpaceMemberDeletedResult],
+)
+@envelope_errors
+async def delete_space_member(
+    space_id: SpaceIdPath,
+    user_id: Annotated[str, Path(min_length=1, max_length=256)],
+    request: Request,
+    principal: PrincipalDep,
+    service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
+) -> Envelope[SpaceMemberDeletedResult]:
+    service.delete_member(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        user_id=user_id,
+    )
+    return envelope(
+        SpaceMemberDeletedResult(space_id=space_id, user_id=user_id), request
+    )
+
+
+@router.put(
+    "/{space_id}/members/{user_id}/role",
+    response_model=Envelope[SpaceMemberMutationResult],
+)
+@envelope_errors
+async def update_space_member_role(
+    space_id: SpaceIdPath,
+    user_id: Annotated[str, Path(min_length=1, max_length=256)],
+    body: UpdateSpaceMemberRoleRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
+) -> Envelope[SpaceMemberMutationResult]:
+    summary = service.update_role(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        user_id=user_id,
+        role=body.role,
+    )
+    return envelope(
+        SpaceMemberMutationResult(
+            space_id=space_id,
+            user_id=summary.member.user_id,
+            role=summary.member.role,
+        ),
+        request,
+    )
+
+
+@router.post(
+    "/{space_id}/market-favorites",
+    response_model=Envelope[FavoriteAddedResult],
+)
+@envelope_errors
+async def add_market_favorite(
+    space_id: SpaceIdPath,
+    body: FavoriteTargetRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
+) -> Envelope[FavoriteAddedResult]:
+    record = service.add(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        target_type=body.target_type,
+        target_code=body.target_code,
+    )
+    return envelope(
+        FavoriteAddedResult(
+            favorite_id=record.id,
+            target_type=record.target_type,
+            target_code=record.target_code,
+        ),
+        request,
+    )
+
+
+@router.post(
+    "/{space_id}/market-favorites/cancel",
+    response_model=Envelope[FavoriteCanceledResult],
+)
+@envelope_errors
+async def cancel_market_favorite(
+    space_id: SpaceIdPath,
+    body: FavoriteTargetRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
+) -> Envelope[FavoriteCanceledResult]:
+    service.cancel(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        target_type=body.target_type,
+        target_code=body.target_code,
+    )
+    return envelope(
+        FavoriteCanceledResult(
+            target_type=body.target_type,
+            target_code=body.target_code.strip(),
+        ),
+        request,
+    )
+
+
+@router.post(
+    "/{space_id}/market-favorites/search",
+    response_model=Envelope[Page[MarketFavoriteItem]],
+)
+@envelope_errors
+async def search_market_favorites(
+    space_id: SpaceIdPath,
+    body: SearchFavoritesRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
+) -> Envelope[Page[MarketFavoriteItem]]:
+    total, records = service.search(
+        space_id=space_id,
+        actor_id=caller_owner_id(principal),
+        target_type=body.target_type,
+        keyword=body.keyword,
+        page_no=body.page_no,
+        page_size=body.page_size,
+    )
+    return page(total, [_favorite_item(record) for record in records], request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
@@ -1,8 +1,8 @@
 """OpenAPI v1 adapter for spaces, members and market favorites.
 
-Application-only admission is intentionally refused in ``admission.py`` for
-this first phase. The acting user therefore comes from the verified human
-principal; no caller-supplied ``user_id`` is accepted by these routes.
+Every user-scoped operation names its acting user through the shared
+``user_id`` query dependency. Admission decides whether an application may
+reach the operation; Space ownership rules remain in the core services.
 """
 
 from __future__ import annotations
@@ -11,12 +11,14 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Query, Request
 
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, Page
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
+from agentclaw.community.adapters.http.openapi_v1.errors import GrantNotResolvableError
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    ActingCallerDep,
+    UserIdDep,
+    refuse_app_only_caller,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     envelope,
@@ -33,6 +35,8 @@ from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
     PersonalSpaceInitialized,
     SearchFavoritesRequest,
     SpaceCreated,
+    SpaceRole,
+    SpaceType,
     SpaceItem,
     SpaceMemberDeletedResult,
     SpaceMemberItem,
@@ -46,21 +50,35 @@ from agentclaw.community.api.space_service import (
     SpaceMemberServiceProtocol,
     SpaceServiceProtocol,
 )
-from agentclaw.community.core.market_favorites.models import MarketFavoriteRecord
+from agentclaw.community.core.market_favorites.models import (
+    FavoriteTargetType as DomainFavoriteTargetType,
+    MarketFavoriteRecord,
+)
 from agentclaw.community.core.spaces.models import (
     SpaceMemberSummaryRecord,
-    SpaceRole,
+    SpaceRole as DomainSpaceRole,
     SpaceSummaryRecord,
-    SpaceType,
+    SpaceType as DomainSpaceType,
 )
 from agentclaw.community.di import Injected
 
 
 router = APIRouter(prefix="/openapi/v1/spaces", tags=["spaces"])
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
 SpaceIdPath = Annotated[int, Path(ge=1, description="Space primary identifier.")]
-PageNoQuery = Annotated[int, Query(ge=1)]
-PageSizeQuery = Annotated[int, Query(ge=1, le=100)]
+PageNoQuery = Annotated[int, Query(ge=1, description="One-based page number.")]
+PageSizeQuery = Annotated[
+    int, Query(ge=1, le=100, description="Maximum items returned per page.")
+]
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+
+
+def _require_user_delegation(caller: ActingCaller) -> str:
+    granted = caller.granted_bot_ids()
+    if granted is not None and not granted:
+        raise GrantNotResolvableError(
+            "application holds no live delegation from the named user"
+        )
+    return caller.user_id
 
 
 def _space_item(record: SpaceSummaryRecord) -> SpaceItem:
@@ -95,6 +113,8 @@ def _created_space(record) -> SpaceCreated:
 def _member_item(record: SpaceMemberSummaryRecord) -> SpaceMemberItem:
     return SpaceMemberItem(
         user_id=record.member.user_id,
+        user_name=record.user_name,
+        display_name=record.display_name,
         role=record.member.role,
         is_creator=record.is_creator,
         gmt_modified=record.member.gmt_modified,
@@ -114,18 +134,23 @@ def _favorite_item(record: MarketFavoriteRecord) -> MarketFavoriteItem:
 @envelope_errors
 async def list_spaces(
     request: Request,
-    principal: PrincipalDep,
-    keyword: Annotated[str | None, Query(max_length=128)] = None,
-    space_type: Annotated[SpaceType | None, Query()] = None,
+    caller: ActingCallerDep,
+    keyword: Annotated[
+        str | None,
+        Query(max_length=128, description="Optional Space-name search text."),
+    ] = None,
+    space_type: Annotated[
+        SpaceType | None, Query(description="Optional Space type filter.")
+    ] = None,
     page_no: PageNoQuery = 1,
     page_size: PageSizeQuery = 20,
     service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
 ) -> Envelope[Page[SpaceItem]]:
-    actor_id = caller_owner_id(principal)
+    actor_id = _require_user_delegation(caller)
     total, records = service.list_spaces(
         user_id=actor_id,
         keyword=keyword,
-        space_type=space_type,
+        space_type=DomainSpaceType(space_type) if space_type is not None else None,
         page_no=page_no,
         page_size=page_size,
     )
@@ -135,16 +160,15 @@ async def list_spaces(
 @router.post(
     "/personal/initialize",
     response_model=Envelope[PersonalSpaceInitialized],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def initialize_personal_space(
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
 ) -> Envelope[PersonalSpaceInitialized]:
-    record, was_created = service.initialize_personal(
-        user_id=caller_owner_id(principal)
-    )
+    record, was_created = service.initialize_personal(user_id=user_id)
     result = PersonalSpaceInitialized(
         **_created_space(record).model_dump(), created=was_created
     )
@@ -155,17 +179,16 @@ async def initialize_personal_space(
     "/create",
     status_code=201,
     response_model=Envelope[SpaceCreated],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def create_team_space(
     body: CreateSpaceRequest,
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
 ) -> Envelope[SpaceCreated]:
-    record = service.create_team(
-        name=body.space_name, creator_id=caller_owner_id(principal)
-    )
+    record = service.create_team(name=body.space_name, creator_id=user_id)
     return created(_created_space(record), request)
 
 
@@ -177,15 +200,18 @@ async def create_team_space(
 async def list_space_members(
     space_id: SpaceIdPath,
     request: Request,
-    principal: PrincipalDep,
-    keyword: Annotated[str | None, Query(max_length=256)] = None,
+    caller: ActingCallerDep,
+    keyword: Annotated[
+        str | None, Query(max_length=256, description="Optional member-id search text.")
+    ] = None,
     page_no: PageNoQuery = 1,
     page_size: PageSizeQuery = 20,
     service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
 ) -> Envelope[Page[SpaceMemberItem]]:
+    actor_id = _require_user_delegation(caller)
     total, records = service.list_members(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
+        actor_id=actor_id,
         keyword=keyword,
         page_no=page_no,
         page_size=page_size,
@@ -197,20 +223,21 @@ async def list_space_members(
     "/{space_id}/members",
     status_code=201,
     response_model=Envelope[SpaceMemberMutationResult],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def add_space_member(
     space_id: SpaceIdPath,
     body: AddSpaceMemberRequest,
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
 ) -> Envelope[SpaceMemberMutationResult]:
     record = service.add_member(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        user_id=body.user_id,
-        role=body.role,
+        actor_id=user_id,
+        user_id=body.member_user_id,
+        role=DomainSpaceRole(body.role),
     )
     return created(
         SpaceMemberMutationResult(
@@ -221,45 +248,61 @@ async def add_space_member(
 
 
 @router.delete(
-    "/{space_id}/members/{user_id}",
+    "/{space_id}/members/{member_user_id}",
     response_model=Envelope[SpaceMemberDeletedResult],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def delete_space_member(
     space_id: SpaceIdPath,
-    user_id: Annotated[str, Path(min_length=1, max_length=256)],
+    member_user_id: Annotated[
+        str,
+        Path(
+            min_length=1,
+            max_length=256,
+            description="Identifier of the Space member to remove.",
+        ),
+    ],
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
 ) -> Envelope[SpaceMemberDeletedResult]:
     service.delete_member(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        user_id=user_id,
+        actor_id=user_id,
+        user_id=member_user_id,
     )
     return envelope(
-        SpaceMemberDeletedResult(space_id=space_id, user_id=user_id), request
+        SpaceMemberDeletedResult(space_id=space_id, user_id=member_user_id), request
     )
 
 
 @router.put(
-    "/{space_id}/members/{user_id}/role",
+    "/{space_id}/members/{member_user_id}/role",
     response_model=Envelope[SpaceMemberMutationResult],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def update_space_member_role(
     space_id: SpaceIdPath,
-    user_id: Annotated[str, Path(min_length=1, max_length=256)],
+    member_user_id: Annotated[
+        str,
+        Path(
+            min_length=1,
+            max_length=256,
+            description="Identifier of the Space member whose role will change.",
+        ),
+    ],
     body: UpdateSpaceMemberRoleRequest,
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: SpaceMemberServiceProtocol = Injected(SpaceMemberServiceProtocol),
 ) -> Envelope[SpaceMemberMutationResult]:
     summary = service.update_role(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        user_id=user_id,
-        role=body.role,
+        actor_id=user_id,
+        user_id=member_user_id,
+        role=DomainSpaceRole(body.role),
     )
     return envelope(
         SpaceMemberMutationResult(
@@ -280,13 +323,14 @@ async def add_market_favorite(
     space_id: SpaceIdPath,
     body: FavoriteTargetRequest,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
 ) -> Envelope[FavoriteAddedResult]:
+    actor_id = _require_user_delegation(caller)
     record = service.add(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        target_type=body.target_type,
+        actor_id=actor_id,
+        target_type=DomainFavoriteTargetType(body.target_type),
         target_code=body.target_code,
     )
     return envelope(
@@ -308,13 +352,14 @@ async def cancel_market_favorite(
     space_id: SpaceIdPath,
     body: FavoriteTargetRequest,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
 ) -> Envelope[FavoriteCanceledResult]:
+    actor_id = _require_user_delegation(caller)
     service.cancel(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        target_type=body.target_type,
+        actor_id=actor_id,
+        target_type=DomainFavoriteTargetType(body.target_type),
         target_code=body.target_code,
     )
     return envelope(
@@ -335,13 +380,18 @@ async def search_market_favorites(
     space_id: SpaceIdPath,
     body: SearchFavoritesRequest,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: MarketFavoriteServiceProtocol = Injected(MarketFavoriteServiceProtocol),
 ) -> Envelope[Page[MarketFavoriteItem]]:
+    actor_id = _require_user_delegation(caller)
     total, records = service.search(
         space_id=space_id,
-        actor_id=caller_owner_id(principal),
-        target_type=body.target_type,
+        actor_id=actor_id,
+        target_type=(
+            DomainFavoriteTargetType(body.target_type)
+            if body.target_type is not None
+            else None
+        ),
         keyword=body.keyword,
         page_no=body.page_no,
         page_size=body.page_size,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -1,0 +1,150 @@
+"""HTTP schemas for spaces, members and market favorites."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field, field_serializer
+
+from agentclaw.community.core.market_favorites.models import FavoriteTargetType
+from agentclaw.community.core.spaces.models import (
+    SpaceJoinStatus,
+    SpaceRole,
+    SpaceType,
+)
+
+
+def _utc_datetime(value: datetime) -> str:
+    """Serialize persisted timestamps as explicit UTC on the public wire."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+class _UtcResponseModel(BaseModel):
+    @field_serializer(
+        "gmt_created",
+        "gmt_modified",
+        "favorite_at",
+        check_fields=False,
+        when_used="json",
+    )
+    def _serialize_utc_datetime(self, value: datetime) -> str:
+        return _utc_datetime(value)
+
+
+class SpaceItem(_UtcResponseModel):
+    space_id: int
+    space_code: str
+    space_name: str
+    space_type: SpaceType
+    current_user_role: SpaceRole | None
+    join_status: SpaceJoinStatus
+    member_count: int
+    owner_count: int
+    gmt_modified: datetime = Field(
+        description="UTC time when the Space metadata was last modified.",
+        json_schema_extra={"format": "date-time"},
+    )
+
+
+class SpaceCreated(_UtcResponseModel):
+    space_id: int
+    space_code: str
+    space_name: str
+    space_type: SpaceType
+    current_user_role: SpaceRole
+    is_creator: bool
+    member_count: int
+    owner_count: int
+    gmt_created: datetime = Field(
+        description="UTC time when the Space was created.",
+        json_schema_extra={"format": "date-time"},
+    )
+    gmt_modified: datetime = Field(
+        description="UTC time when the Space metadata was last modified.",
+        json_schema_extra={"format": "date-time"},
+    )
+
+
+class PersonalSpaceInitialized(SpaceCreated):
+    created: bool
+
+
+class CreateSpaceRequest(BaseModel):
+    space_name: str = Field(min_length=1, max_length=128)
+
+
+class SpaceMemberItem(_UtcResponseModel):
+    user_id: str
+    role: SpaceRole
+    is_creator: bool
+    gmt_modified: datetime = Field(
+        description=(
+            "UTC time when this membership relation was created or its role "
+            "was last changed."
+        ),
+        json_schema_extra={"format": "date-time"},
+    )
+
+
+class AddSpaceMemberRequest(BaseModel):
+    user_id: str = Field(min_length=1, max_length=256)
+    role: SpaceRole = Field(
+        default=SpaceRole.MEMBER,
+        description="Role granted when the member is added; defaults to MEMBER.",
+    )
+
+
+class UpdateSpaceMemberRoleRequest(BaseModel):
+    role: SpaceRole
+
+
+class SpaceMemberMutationResult(BaseModel):
+    space_id: int
+    user_id: str
+    role: SpaceRole
+
+
+class SpaceMemberDeletedResult(BaseModel):
+    space_id: int
+    user_id: str
+    deleted: bool = True
+
+
+class FavoriteTargetRequest(BaseModel):
+    target_type: FavoriteTargetType
+    target_code: str = Field(min_length=1, max_length=128)
+
+
+class SearchFavoritesRequest(BaseModel):
+    target_type: FavoriteTargetType | None = None
+    keyword: str | None = Field(default=None, max_length=128)
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+
+
+class FavoriteAddedResult(BaseModel):
+    favorite_id: int
+    target_type: FavoriteTargetType
+    target_code: str
+    is_favorited: bool = True
+
+
+class FavoriteCanceledResult(BaseModel):
+    target_type: FavoriteTargetType
+    target_code: str
+    is_favorited: bool = False
+
+
+class MarketFavoriteItem(_UtcResponseModel):
+    favorite_id: int
+    target_type: FavoriteTargetType
+    target_code: str
+    favorite_at: datetime = Field(
+        description="UTC time when the target was added to this Space's favorites.",
+        json_schema_extra={"format": "date-time"},
+    )
+    is_favorited: bool = True

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -6,12 +6,57 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field, field_serializer
 
-from agentclaw.community.core.market_favorites.models import FavoriteTargetType
-from agentclaw.community.core.spaces.models import (
-    SpaceJoinStatus,
-    SpaceRole,
-    SpaceType,
-)
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
+
+
+class SpaceType(_DocumentedEnum):
+    """Kind of Space and its ownership model."""
+
+    PERSONAL = "PERSONAL"
+    TEAM = "TEAM"
+
+    __descriptions__ = {
+        "PERSONAL": "A private Space initialized for one user.",
+        "TEAM": "A shared Space managed by one or more owners.",
+    }
+
+
+class SpaceRole(_DocumentedEnum):
+    """Role held by a user in a Space."""
+
+    OWNER = "OWNER"
+    MEMBER = "MEMBER"
+
+    __descriptions__ = {
+        "OWNER": "May manage the Space and its membership.",
+        "MEMBER": "May use the Space without managing its membership.",
+    }
+
+
+class SpaceJoinStatus(_DocumentedEnum):
+    """Current user's membership state for a Space."""
+
+    JOINED = "JOINED"
+    APPLYING = "APPLYING"
+    NOT_JOINED = "NOT_JOINED"
+
+    __descriptions__ = {
+        "JOINED": "The user is currently a member of the Space.",
+        "APPLYING": "The user's join request is awaiting review.",
+        "NOT_JOINED": "The user is not a member and has no pending request.",
+    }
+
+
+class FavoriteTargetType(_DocumentedEnum):
+    """Type of marketplace item saved as a favorite."""
+
+    SKILL = "SKILL"
+    MCP = "MCP"
+
+    __descriptions__ = {
+        "SKILL": "A published Skill.",
+        "MCP": "A published MCP server.",
+    }
 
 
 def _utc_datetime(value: datetime) -> str:
@@ -36,14 +81,20 @@ class _UtcResponseModel(BaseModel):
 
 
 class SpaceItem(_UtcResponseModel):
-    space_id: int
-    space_code: str
-    space_name: str
-    space_type: SpaceType
-    current_user_role: SpaceRole | None
-    join_status: SpaceJoinStatus
-    member_count: int
-    owner_count: int
+    """Summary of a Space visible to the current user."""
+
+    space_id: int = Field(description="Unique numeric identifier of the Space.")
+    space_code: str = Field(description="Stable external code of the Space.")
+    space_name: str = Field(description="Display name of the Space.")
+    space_type: SpaceType = Field(description="Ownership model of the Space.")
+    current_user_role: SpaceRole | None = Field(
+        description="Current user's role, or null when the user has not joined."
+    )
+    join_status: SpaceJoinStatus = Field(
+        description="Current user's membership or application state."
+    )
+    member_count: int = Field(description="Number of members in the Space.")
+    owner_count: int = Field(description="Number of owners in the Space.")
     gmt_modified: datetime = Field(
         description="UTC time when the Space metadata was last modified.",
         json_schema_extra={"format": "date-time"},
@@ -51,14 +102,16 @@ class SpaceItem(_UtcResponseModel):
 
 
 class SpaceCreated(_UtcResponseModel):
-    space_id: int
-    space_code: str
-    space_name: str
-    space_type: SpaceType
-    current_user_role: SpaceRole
-    is_creator: bool
-    member_count: int
-    owner_count: int
+    """Details returned after a Space is created."""
+
+    space_id: int = Field(description="Unique numeric identifier of the Space.")
+    space_code: str = Field(description="Stable external code of the Space.")
+    space_name: str = Field(description="Display name of the Space.")
+    space_type: SpaceType = Field(description="Ownership model of the Space.")
+    current_user_role: SpaceRole = Field(description="Creator's role in the new Space.")
+    is_creator: bool = Field(description="Whether the current user created the Space.")
+    member_count: int = Field(description="Number of members in the Space.")
+    owner_count: int = Field(description="Number of owners in the Space.")
     gmt_created: datetime = Field(
         description="UTC time when the Space was created.",
         json_schema_extra={"format": "date-time"},
@@ -70,17 +123,35 @@ class SpaceCreated(_UtcResponseModel):
 
 
 class PersonalSpaceInitialized(SpaceCreated):
-    created: bool
+    """Result of ensuring that the current user's personal Space exists."""
+
+    created: bool = Field(
+        description="True when a new personal Space was created by this request."
+    )
 
 
 class CreateSpaceRequest(BaseModel):
-    space_name: str = Field(min_length=1, max_length=128)
+    """Request for creating a shared team Space."""
+
+    space_name: str = Field(
+        min_length=1, max_length=128, description="Display name for the new Space."
+    )
 
 
 class SpaceMemberItem(_UtcResponseModel):
-    user_id: str
-    role: SpaceRole
-    is_creator: bool
+    """Membership details for one user in a Space."""
+
+    user_id: str = Field(description="Identifier of the member user.")
+    user_name: str | None = Field(
+        default=None, description="Account name of the member, when available."
+    )
+    display_name: str | None = Field(
+        default=None, description="Display name of the member, when available."
+    )
+    role: SpaceRole = Field(description="Role currently held by the member.")
+    is_creator: bool = Field(
+        description="Whether this member originally created the Space."
+    )
     gmt_modified: datetime = Field(
         description=(
             "UTC time when this membership relation was created or its role "
@@ -91,7 +162,11 @@ class SpaceMemberItem(_UtcResponseModel):
 
 
 class AddSpaceMemberRequest(BaseModel):
-    user_id: str = Field(min_length=1, max_length=256)
+    """Request for adding a user to a Space."""
+
+    member_user_id: str = Field(
+        min_length=1, max_length=256, description="Identifier of the user to add."
+    )
     role: SpaceRole = Field(
         default=SpaceRole.MEMBER,
         description="Role granted when the member is added; defaults to MEMBER.",
@@ -99,52 +174,96 @@ class AddSpaceMemberRequest(BaseModel):
 
 
 class UpdateSpaceMemberRoleRequest(BaseModel):
-    role: SpaceRole
+    """Request for changing a Space member's role."""
+
+    role: SpaceRole = Field(description="New role to assign to the member.")
 
 
 class SpaceMemberMutationResult(BaseModel):
-    space_id: int
-    user_id: str
-    role: SpaceRole
+    """Membership state returned after an add or role update."""
+
+    space_id: int = Field(description="Identifier of the affected Space.")
+    user_id: str = Field(description="Identifier of the affected member.")
+    role: SpaceRole = Field(description="Role held after the operation.")
 
 
 class SpaceMemberDeletedResult(BaseModel):
-    space_id: int
-    user_id: str
-    deleted: bool = True
+    """Confirmation that a member was removed from a Space."""
+
+    space_id: int = Field(description="Identifier of the affected Space.")
+    user_id: str = Field(description="Identifier of the removed member.")
+    deleted: bool = Field(
+        description="Whether the membership was deleted.", default=True
+    )
 
 
 class FavoriteTargetRequest(BaseModel):
-    target_type: FavoriteTargetType
-    target_code: str = Field(min_length=1, max_length=128)
+    """Marketplace target to add to or remove from favorites."""
+
+    target_type: FavoriteTargetType = Field(
+        description="Marketplace category of the target."
+    )
+    target_code: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Stable marketplace code of the target.",
+    )
 
 
 class SearchFavoritesRequest(BaseModel):
-    target_type: FavoriteTargetType | None = None
-    keyword: str | None = Field(default=None, max_length=128)
-    page_no: int = Field(default=1, ge=1)
-    page_size: int = Field(default=20, ge=1, le=100)
+    """Filters and pagination for searching Space favorites."""
+
+    target_type: FavoriteTargetType | None = Field(
+        default=None, description="Target category filter, or null for all categories."
+    )
+    keyword: str | None = Field(
+        default=None,
+        max_length=128,
+        description="Optional case-insensitive target-code search text.",
+    )
+    page_no: int = Field(default=1, ge=1, description="One-based page number.")
+    page_size: int = Field(
+        default=20, ge=1, le=100, description="Maximum items returned per page."
+    )
 
 
 class FavoriteAddedResult(BaseModel):
-    favorite_id: int
-    target_type: FavoriteTargetType
-    target_code: str
-    is_favorited: bool = True
+    """Favorite state returned after a target is added."""
+
+    favorite_id: int = Field(description="Identifier of the favorite record.")
+    target_type: FavoriteTargetType = Field(
+        description="Marketplace category of the target."
+    )
+    target_code: str = Field(description="Stable marketplace code of the target.")
+    is_favorited: bool = Field(
+        default=True, description="Whether the target is now favorited."
+    )
 
 
 class FavoriteCanceledResult(BaseModel):
-    target_type: FavoriteTargetType
-    target_code: str
-    is_favorited: bool = False
+    """Favorite state returned after a target is removed."""
+
+    target_type: FavoriteTargetType = Field(
+        description="Marketplace category of the target."
+    )
+    target_code: str = Field(description="Stable marketplace code of the target.")
+    is_favorited: bool = Field(
+        default=False, description="Whether the target remains favorited."
+    )
 
 
 class MarketFavoriteItem(_UtcResponseModel):
-    favorite_id: int
-    target_type: FavoriteTargetType
-    target_code: str
+    """One marketplace favorite saved in a Space."""
+
+    favorite_id: int = Field(description="Identifier of the favorite record.")
+    target_type: FavoriteTargetType = Field(
+        description="Marketplace category of the target."
+    )
+    target_code: str = Field(description="Stable marketplace code of the target.")
     favorite_at: datetime = Field(
         description="UTC time when the target was added to this Space's favorites.",
         json_schema_extra={"format": "date-time"},
     )
-    is_favorited: bool = True
+    is_favorited: bool = Field(
+        default=True, description="Whether the target is currently favorited."
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -1,0 +1,335 @@
+"""OpenAPI v1 adapter for work orders and recipient notifications."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, Page
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    created,
+    envelope,
+    envelope_errors,
+    page,
+)
+from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
+    CreateSpaceJoinRequest,
+    NotificationDetailResponse,
+    NotificationReadResponse,
+    NotificationsReadAllResponse,
+    SpaceJoinRequestCreated,
+    UnreadCountResponse,
+    WorkOrderDetailContent,
+    WorkOrderDetailResponse,
+    WorkOrderListItem,
+    WorkOrderReviewRequest,
+    WorkOrderReviewResponse,
+)
+from agentclaw.community.api.work_order_service import (
+    WorkOrderNotificationServiceProtocol,
+    WorkOrderServiceProtocol,
+)
+from agentclaw.community.core.work_orders.models import (
+    WorkOrderItemType,
+    WorkOrderListItem as DomainListItem,
+    WorkOrderQueryType,
+)
+from agentclaw.community.di import Injected
+
+
+router = APIRouter(tags=["work-orders"])
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+PositiveIdPath = Annotated[int, Path(ge=1)]
+PageNoQuery = Annotated[int, Query(ge=1)]
+PageSizeQuery = Annotated[int, Query(ge=1, le=100)]
+
+
+def _list_item(item: DomainListItem) -> WorkOrderListItem:
+    work_order = item.work_order
+    notification = item.notification
+    modified = (
+        notification.gmt_modified
+        if notification is not None
+        else work_order.gmt_modified
+    )
+    category = notification.notification_category if notification is not None else None
+    item_type = (
+        WorkOrderItemType(category.value)
+        if category is not None
+        else WorkOrderItemType.APPROVAL
+    )
+    return WorkOrderListItem(
+        item_id=(
+            f"NOTIFICATION_{notification.id}"
+            if notification is not None
+            else f"WORK_ORDER_{work_order.id}"
+        ),
+        item_type=item_type,
+        work_order_id=work_order.id,
+        work_order_no=work_order.work_order_no,
+        notification_id=notification.id if notification is not None else None,
+        notification_category=category,
+        biz_type=work_order.biz_type,
+        biz_id=work_order.biz_id,
+        applicant_user_id=work_order.applicant_user_id,
+        apply_reason=work_order.apply_reason,
+        reviewer_user_id=work_order.reviewer_user_id,
+        review_remark=work_order.review_remark,
+        reviewed_at=work_order.reviewed_at,
+        recipient_user_id=(
+            notification.recipient_user_id if notification is not None else None
+        ),
+        event_type=notification.event_type if notification is not None else None,
+        title=notification.title if notification is not None else None,
+        content=notification.content if notification is not None else None,
+        status=work_order.status,
+        is_read=notification.is_read if notification is not None else None,
+        read_at=notification.read_at if notification is not None else None,
+        env=work_order.env,
+        can_approve=item.can_approve,
+        gmt_created=work_order.gmt_created,
+        gmt_modified=modified,
+    )
+
+
+@router.post(
+    "/openapi/v1/spaces/{space_id}/join-requests",
+    status_code=201,
+    response_model=Envelope[SpaceJoinRequestCreated],
+)
+@envelope_errors
+async def create_space_join_request(
+    space_id: PositiveIdPath,
+    body: CreateSpaceJoinRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[SpaceJoinRequestCreated]:
+    record = service.create_space_join_request(
+        space_id=space_id,
+        applicant_user_id=caller_owner_id(principal),
+        reason=body.reason,
+    )
+    return created(
+        SpaceJoinRequestCreated(
+            work_order_id=record.id,
+            work_order_no=record.work_order_no,
+            status=record.status,
+        ),
+        request,
+    )
+
+
+@router.get(
+    "/openapi/v1/work-orders",
+    response_model=Envelope[Page[WorkOrderListItem]],
+)
+@envelope_errors
+async def list_work_orders(
+    request: Request,
+    principal: PrincipalDep,
+    query_type: Annotated[
+        WorkOrderQueryType, Query()
+    ] = WorkOrderQueryType.PENDING_FOR_ME,
+    item_type: Annotated[WorkOrderItemType, Query()] = WorkOrderItemType.ALL,
+    page_no: PageNoQuery = 1,
+    page_size: PageSizeQuery = 20,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[Page[WorkOrderListItem]]:
+    total, items = service.list_items(
+        actor_id=caller_owner_id(principal),
+        query_type=query_type,
+        item_type=item_type,
+        page_no=page_no,
+        page_size=page_size,
+    )
+    return page(total, [_list_item(item) for item in items], request)
+
+
+@router.get(
+    "/openapi/v1/work-orders/{work_order_id}",
+    response_model=Envelope[WorkOrderDetailResponse],
+)
+@envelope_errors
+async def get_work_order(
+    work_order_id: PositiveIdPath,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[WorkOrderDetailResponse]:
+    detail = service.get_detail(
+        work_order_id=work_order_id, actor_id=caller_owner_id(principal)
+    )
+    work_order = detail.work_order
+    return envelope(
+        WorkOrderDetailResponse(
+            work_order_id=work_order.id,
+            work_order_no=work_order.work_order_no,
+            biz_type=work_order.biz_type,
+            biz_id=detail.space_id,
+            event_type=detail.event_type,
+            title=detail.title,
+            content=WorkOrderDetailContent(
+                space_id=detail.space_id,
+                space_name=detail.space_name,
+                applicant_user_id=work_order.applicant_user_id,
+                applicant_name=detail.applicant_name,
+                reason=work_order.apply_reason,
+            ),
+            status=work_order.status,
+            reviewer_user_id=work_order.reviewer_user_id,
+            review_remark=work_order.review_remark,
+            reviewed_at=work_order.reviewed_at,
+            can_approve=detail.can_approve,
+        ),
+        request,
+    )
+
+
+def _review_response(result) -> WorkOrderReviewResponse:
+    return WorkOrderReviewResponse(
+        work_order_id=result.work_order_id,
+        status=result.status,
+        reviewer_user_id=result.reviewer_user_id,
+        review_remark=result.review_remark,
+        reviewed_at=result.reviewed_at,
+    )
+
+
+@router.post(
+    "/openapi/v1/work-orders/{work_order_id}/approve",
+    response_model=Envelope[WorkOrderReviewResponse],
+)
+@envelope_errors
+async def approve_work_order(
+    work_order_id: PositiveIdPath,
+    body: WorkOrderReviewRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[WorkOrderReviewResponse]:
+    result = service.approve(
+        work_order_id=work_order_id,
+        actor_id=caller_owner_id(principal),
+        review_remark=body.review_remark,
+    )
+    return envelope(_review_response(result), request)
+
+
+@router.post(
+    "/openapi/v1/work-orders/{work_order_id}/reject",
+    response_model=Envelope[WorkOrderReviewResponse],
+)
+@envelope_errors
+async def reject_work_order(
+    work_order_id: PositiveIdPath,
+    body: WorkOrderReviewRequest,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[WorkOrderReviewResponse]:
+    result = service.reject(
+        work_order_id=work_order_id,
+        actor_id=caller_owner_id(principal),
+        review_remark=body.review_remark,
+    )
+    return envelope(_review_response(result), request)
+
+
+@router.get(
+    "/openapi/v1/work-order-notifications/unread-count",
+    response_model=Envelope[UnreadCountResponse],
+)
+@envelope_errors
+async def unread_notification_count(
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderNotificationServiceProtocol = Injected(
+        WorkOrderNotificationServiceProtocol
+    ),
+) -> Envelope[UnreadCountResponse]:
+    count = service.unread_count(actor_id=caller_owner_id(principal))
+    return envelope(UnreadCountResponse(unread_count=count), request)
+
+
+@router.post(
+    "/openapi/v1/work-order-notifications/read-all",
+    response_model=Envelope[NotificationsReadAllResponse],
+)
+@envelope_errors
+async def mark_all_notifications_read(
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderNotificationServiceProtocol = Injected(
+        WorkOrderNotificationServiceProtocol
+    ),
+) -> Envelope[NotificationsReadAllResponse]:
+    count = service.mark_all_read(actor_id=caller_owner_id(principal))
+    return envelope(NotificationsReadAllResponse(updated_count=count), request)
+
+
+@router.get(
+    "/openapi/v1/work-order-notifications/{notification_id}",
+    response_model=Envelope[NotificationDetailResponse],
+)
+@envelope_errors
+async def get_notification(
+    notification_id: PositiveIdPath,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderNotificationServiceProtocol = Injected(
+        WorkOrderNotificationServiceProtocol
+    ),
+) -> Envelope[NotificationDetailResponse]:
+    detail = service.get_detail(
+        notification_id=notification_id, actor_id=caller_owner_id(principal)
+    )
+    record = detail.notification
+    return envelope(
+        NotificationDetailResponse(
+            notification_id=record.id,
+            work_order_id=record.work_order_id,
+            notification_category=record.notification_category,
+            event_type=record.event_type,
+            title=record.title,
+            content=record.content,
+            is_read=record.is_read,
+            work_order_status=detail.work_order_status,
+            can_approve=detail.can_approve,
+            biz_type=record.biz_type,
+            biz_id=record.biz_id,
+        ),
+        request,
+    )
+
+
+@router.post(
+    "/openapi/v1/work-order-notifications/{notification_id}/read",
+    response_model=Envelope[NotificationReadResponse],
+)
+@envelope_errors
+async def mark_notification_read(
+    notification_id: PositiveIdPath,
+    request: Request,
+    principal: PrincipalDep,
+    service: WorkOrderNotificationServiceProtocol = Injected(
+        WorkOrderNotificationServiceProtocol
+    ),
+) -> Envelope[NotificationReadResponse]:
+    record = service.mark_read(
+        notification_id=notification_id, actor_id=caller_owner_id(principal)
+    )
+    return envelope(
+        NotificationReadResponse(
+            notification_id=record.id,
+            is_read=record.is_read,
+            read_at=record.read_at,
+        ),
+        request,
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -6,12 +6,14 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, Query, Request
 
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, Page
-from agentclaw.community.adapters.http.openapi_v1.dependencies import (
-    Principal,
-    require_principal,
+from agentclaw.community.adapters.http.openapi_v1.errors import GrantNotResolvableError
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    ActingCallerDep,
+    UserIdDep,
+    refuse_app_only_caller,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import caller_owner_id
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     envelope,
@@ -27,7 +29,9 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
     UnreadCountResponse,
     WorkOrderDetailContent,
     WorkOrderDetailResponse,
+    WorkOrderItemType,
     WorkOrderListItem,
+    WorkOrderQueryType,
     WorkOrderReviewRequest,
     WorkOrderReviewResponse,
 )
@@ -36,18 +40,29 @@ from agentclaw.community.api.work_order_service import (
     WorkOrderServiceProtocol,
 )
 from agentclaw.community.core.work_orders.models import (
-    WorkOrderItemType,
+    WorkOrderItemType as DomainWorkOrderItemType,
     WorkOrderListItem as DomainListItem,
-    WorkOrderQueryType,
+    WorkOrderQueryType as DomainWorkOrderQueryType,
 )
 from agentclaw.community.di import Injected
 
 
 router = APIRouter(tags=["work-orders"])
-PrincipalDep = Annotated[Principal, Depends(require_principal)]
-PositiveIdPath = Annotated[int, Path(ge=1)]
-PageNoQuery = Annotated[int, Query(ge=1)]
-PageSizeQuery = Annotated[int, Query(ge=1, le=100)]
+PositiveIdPath = Annotated[int, Path(ge=1, description="Positive numeric identifier.")]
+PageNoQuery = Annotated[int, Query(ge=1, description="One-based page number.")]
+PageSizeQuery = Annotated[
+    int, Query(ge=1, le=100, description="Maximum items returned per page.")
+]
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+
+
+def _require_user_delegation(caller: ActingCaller) -> str:
+    granted = caller.granted_bot_ids()
+    if granted is not None and not granted:
+        raise GrantNotResolvableError(
+            "application holds no live delegation from the named user"
+        )
+    return caller.user_id
 
 
 def _list_item(item: DomainListItem) -> WorkOrderListItem:
@@ -108,12 +123,13 @@ async def create_space_join_request(
     space_id: PositiveIdPath,
     body: CreateSpaceJoinRequest,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[SpaceJoinRequestCreated]:
+    actor_id = _require_user_delegation(caller)
     record = service.create_space_join_request(
         space_id=space_id,
-        applicant_user_id=caller_owner_id(principal),
+        applicant_user_id=actor_id,
         reason=body.reason,
     )
     return created(
@@ -133,19 +149,23 @@ async def create_space_join_request(
 @envelope_errors
 async def list_work_orders(
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     query_type: Annotated[
-        WorkOrderQueryType, Query()
+        WorkOrderQueryType,
+        Query(description="Relationship between the current user and returned items."),
     ] = WorkOrderQueryType.PENDING_FOR_ME,
-    item_type: Annotated[WorkOrderItemType, Query()] = WorkOrderItemType.ALL,
+    item_type: Annotated[
+        WorkOrderItemType, Query(description="Category of inbox item to return.")
+    ] = WorkOrderItemType.ALL,
     page_no: PageNoQuery = 1,
     page_size: PageSizeQuery = 20,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[Page[WorkOrderListItem]]:
+    actor_id = _require_user_delegation(caller)
     total, items = service.list_items(
-        actor_id=caller_owner_id(principal),
-        query_type=query_type,
-        item_type=item_type,
+        actor_id=actor_id,
+        query_type=DomainWorkOrderQueryType(query_type),
+        item_type=DomainWorkOrderItemType(item_type),
         page_no=page_no,
         page_size=page_size,
     )
@@ -160,12 +180,11 @@ async def list_work_orders(
 async def get_work_order(
     work_order_id: PositiveIdPath,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[WorkOrderDetailResponse]:
-    detail = service.get_detail(
-        work_order_id=work_order_id, actor_id=caller_owner_id(principal)
-    )
+    actor_id = _require_user_delegation(caller)
+    detail = service.get_detail(work_order_id=work_order_id, actor_id=actor_id)
     work_order = detail.work_order
     return envelope(
         WorkOrderDetailResponse(
@@ -205,18 +224,19 @@ def _review_response(result) -> WorkOrderReviewResponse:
 @router.post(
     "/openapi/v1/work-orders/{work_order_id}/approve",
     response_model=Envelope[WorkOrderReviewResponse],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def approve_work_order(
     work_order_id: PositiveIdPath,
     body: WorkOrderReviewRequest,
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[WorkOrderReviewResponse]:
     result = service.approve(
         work_order_id=work_order_id,
-        actor_id=caller_owner_id(principal),
+        actor_id=user_id,
         review_remark=body.review_remark,
     )
     return envelope(_review_response(result), request)
@@ -225,18 +245,19 @@ async def approve_work_order(
 @router.post(
     "/openapi/v1/work-orders/{work_order_id}/reject",
     response_model=Envelope[WorkOrderReviewResponse],
+    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def reject_work_order(
     work_order_id: PositiveIdPath,
     body: WorkOrderReviewRequest,
     request: Request,
-    principal: PrincipalDep,
+    user_id: UserIdDep,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[WorkOrderReviewResponse]:
     result = service.reject(
         work_order_id=work_order_id,
-        actor_id=caller_owner_id(principal),
+        actor_id=user_id,
         review_remark=body.review_remark,
     )
     return envelope(_review_response(result), request)
@@ -249,12 +270,13 @@ async def reject_work_order(
 @envelope_errors
 async def unread_notification_count(
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderNotificationServiceProtocol = Injected(
         WorkOrderNotificationServiceProtocol
     ),
 ) -> Envelope[UnreadCountResponse]:
-    count = service.unread_count(actor_id=caller_owner_id(principal))
+    actor_id = _require_user_delegation(caller)
+    count = service.unread_count(actor_id=actor_id)
     return envelope(UnreadCountResponse(unread_count=count), request)
 
 
@@ -265,12 +287,13 @@ async def unread_notification_count(
 @envelope_errors
 async def mark_all_notifications_read(
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderNotificationServiceProtocol = Injected(
         WorkOrderNotificationServiceProtocol
     ),
 ) -> Envelope[NotificationsReadAllResponse]:
-    count = service.mark_all_read(actor_id=caller_owner_id(principal))
+    actor_id = _require_user_delegation(caller)
+    count = service.mark_all_read(actor_id=actor_id)
     return envelope(NotificationsReadAllResponse(updated_count=count), request)
 
 
@@ -282,14 +305,13 @@ async def mark_all_notifications_read(
 async def get_notification(
     notification_id: PositiveIdPath,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderNotificationServiceProtocol = Injected(
         WorkOrderNotificationServiceProtocol
     ),
 ) -> Envelope[NotificationDetailResponse]:
-    detail = service.get_detail(
-        notification_id=notification_id, actor_id=caller_owner_id(principal)
-    )
+    actor_id = _require_user_delegation(caller)
+    detail = service.get_detail(notification_id=notification_id, actor_id=actor_id)
     record = detail.notification
     return envelope(
         NotificationDetailResponse(
@@ -317,14 +339,13 @@ async def get_notification(
 async def mark_notification_read(
     notification_id: PositiveIdPath,
     request: Request,
-    principal: PrincipalDep,
+    caller: ActingCallerDep,
     service: WorkOrderNotificationServiceProtocol = Injected(
         WorkOrderNotificationServiceProtocol
     ),
 ) -> Envelope[NotificationReadResponse]:
-    record = service.mark_read(
-        notification_id=notification_id, actor_id=caller_owner_id(principal)
-    )
+    actor_id = _require_user_delegation(caller)
+    record = service.mark_read(notification_id=notification_id, actor_id=actor_id)
     return envelope(
         NotificationReadResponse(
             notification_id=record.id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -1,0 +1,138 @@
+"""HTTP request and response schemas for work orders and notifications."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field, field_serializer
+
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderEventType,
+    WorkOrderItemType,
+    WorkOrderStatus,
+)
+
+
+def _utc_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+class _UtcResponseModel(BaseModel):
+    @field_serializer(
+        "reviewed_at",
+        "read_at",
+        "gmt_created",
+        "gmt_modified",
+        check_fields=False,
+        when_used="json",
+    )
+    def _serialize_utc_datetime(self, value: datetime | None) -> str | None:
+        return _utc_datetime(value)
+
+
+class CreateSpaceJoinRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=512)
+
+
+class SpaceJoinRequestCreated(BaseModel):
+    work_order_id: int
+    work_order_no: str
+    status: WorkOrderStatus
+
+
+class WorkOrderReviewRequest(BaseModel):
+    review_remark: str = Field(min_length=1, max_length=512)
+
+
+class WorkOrderReviewResponse(_UtcResponseModel):
+    work_order_id: int
+    status: WorkOrderStatus
+    reviewer_user_id: str
+    review_remark: str
+    reviewed_at: datetime
+
+
+class WorkOrderListItem(_UtcResponseModel):
+    item_id: str
+    item_type: WorkOrderItemType
+    work_order_id: int
+    work_order_no: str
+    notification_id: int | None
+    notification_category: NotificationCategory | None
+    biz_type: WorkOrderBizType
+    biz_id: str
+    applicant_user_id: str
+    apply_reason: str | None
+    reviewer_user_id: str | None
+    review_remark: str | None
+    reviewed_at: datetime | None
+    recipient_user_id: str | None
+    event_type: WorkOrderEventType | None
+    title: str | None
+    content: str | None
+    status: WorkOrderStatus
+    is_read: bool | None
+    read_at: datetime | None
+    env: str
+    can_approve: bool
+    gmt_created: datetime
+    gmt_modified: datetime
+
+
+class WorkOrderDetailContent(BaseModel):
+    space_id: int
+    space_name: str
+    applicant_user_id: str
+    applicant_name: str
+    reason: str | None
+
+
+class WorkOrderDetailResponse(_UtcResponseModel):
+    work_order_id: int
+    work_order_no: str
+    biz_type: WorkOrderBizType
+    biz_id: int
+    event_type: WorkOrderEventType
+    title: str
+    content: WorkOrderDetailContent
+    status: WorkOrderStatus
+    reviewer_user_id: str | None
+    review_remark: str | None
+    reviewed_at: datetime | None
+    can_approve: bool
+
+
+class NotificationDetailResponse(BaseModel):
+    notification_id: int
+    work_order_id: int | None
+    notification_category: NotificationCategory
+    event_type: WorkOrderEventType
+    title: str
+    content: str | None
+    is_read: bool
+    work_order_status: WorkOrderStatus | None
+    can_approve: bool
+    biz_type: WorkOrderBizType
+    biz_id: str
+
+
+class UnreadCountResponse(BaseModel):
+    unread_count: int
+
+
+class NotificationReadResponse(_UtcResponseModel):
+    notification_id: int
+    is_read: bool
+    read_at: datetime | None
+
+
+class NotificationsReadAllResponse(BaseModel):
+    updated_count: int

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -6,13 +6,105 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field, field_serializer
 
-from agentclaw.community.core.work_orders.models import (
-    NotificationCategory,
-    WorkOrderBizType,
-    WorkOrderEventType,
-    WorkOrderItemType,
-    WorkOrderStatus,
-)
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
+
+
+class WorkOrderStatus(_DocumentedEnum):
+    """Current processing state of a work order."""
+
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+    __descriptions__ = {
+        "PENDING": "Awaiting review.",
+        "APPROVED": "Approved by an authorized reviewer.",
+        "REJECTED": "Rejected by an authorized reviewer.",
+    }
+
+
+class WorkOrderBizType(_DocumentedEnum):
+    """Business object represented by a work order."""
+
+    SPACE_JOIN = "SPACE_JOIN"
+
+    __descriptions__ = {"SPACE_JOIN": "A request to join a Space."}
+
+
+class NotificationCategory(_DocumentedEnum):
+    """How a notification is presented to its recipient."""
+
+    APPROVAL = "APPROVAL"
+    NOTICE = "NOTICE"
+
+    __descriptions__ = {
+        "APPROVAL": "Requires a review decision from the recipient.",
+        "NOTICE": "Reports an event and requires no review decision.",
+    }
+
+
+class WorkOrderQueryType(_DocumentedEnum):
+    """Relationship between the current user and listed work orders."""
+
+    PENDING_FOR_ME = "PENDING_FOR_ME"
+    INITIATED_BY_ME = "INITIATED_BY_ME"
+    PROCESSED_BY_ME = "PROCESSED_BY_ME"
+
+    __descriptions__ = {
+        "PENDING_FOR_ME": "Pending work orders awaiting the current user's review.",
+        "INITIATED_BY_ME": "Work orders submitted by the current user.",
+        "PROCESSED_BY_ME": "Work orders already reviewed by the current user.",
+    }
+
+
+class WorkOrderItemType(_DocumentedEnum):
+    """Category of item included in a work-order list."""
+
+    ALL = "ALL"
+    APPROVAL = "APPROVAL"
+    NOTICE = "NOTICE"
+
+    __descriptions__ = {
+        "ALL": "Both approval items and informational notices.",
+        "APPROVAL": "Items that represent reviewable work orders.",
+        "NOTICE": "Items that represent informational notifications.",
+    }
+
+
+class WorkOrderEventType(_DocumentedEnum):
+    """Business event that created a work order or notification."""
+
+    SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
+    SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
+    SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
+    BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
+    BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
+    BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
+    HUMAN2BOT_FRIEND_APPLIED = "HUMAN2BOT_FRIEND_APPLIED"
+    HUMAN2BOT_FRIEND_REVIEWED = "HUMAN2BOT_FRIEND_REVIEWED"
+    BOT2BOT_FRIEND_APPLIED = "BOT2BOT_FRIEND_APPLIED"
+    BOT2BOT_FRIEND_REVIEWED = "BOT2BOT_FRIEND_REVIEWED"
+    HUMAN2BOT_PUBLIC_ORDER_CREATED = "HUMAN2BOT_PUBLIC_ORDER_CREATED"
+    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
+    BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
+    BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+
+    __descriptions__ = {
+        "SPACE_JOIN_APPLIED": "A user submitted a request to join a Space.",
+        "SPACE_JOIN_REVIEWED": "A Space join request received a review decision.",
+        "SPACE_MEMBER_ADDED": "A user was directly added to a Space.",
+        "BOT_COLLABORATOR_APPLIED": "A bot collaborator request was submitted.",
+        "BOT_COLLABORATOR_REVIEWED": "A bot collaborator request was reviewed.",
+        "BOT_MEMBER_ADDED": "A member was directly added to a bot.",
+        "HUMAN2BOT_FRIEND_APPLIED": "A user-to-bot friend request was submitted.",
+        "HUMAN2BOT_FRIEND_REVIEWED": "A user-to-bot friend request was reviewed.",
+        "BOT2BOT_FRIEND_APPLIED": "A bot-to-bot friend request was submitted.",
+        "BOT2BOT_FRIEND_REVIEWED": "A bot-to-bot friend request was reviewed.",
+        "HUMAN2BOT_PUBLIC_ORDER_CREATED": "A user created a public order for a bot.",
+        "HUMAN2BOT_PUBLIC_ORDER_COMPLETED": "A user's public bot order completed.",
+        "BOT2BOT_PUBLIC_ORDER_CREATED": "A bot created a public order for another bot.",
+        "BOT2BOT_PUBLIC_ORDER_COMPLETED": "A bot-to-bot public order completed.",
+    }
 
 
 def _utc_datetime(value: datetime | None) -> str | None:
@@ -39,100 +131,182 @@ class _UtcResponseModel(BaseModel):
 
 
 class CreateSpaceJoinRequest(BaseModel):
-    reason: str = Field(min_length=1, max_length=512)
+    """Request for joining a Space."""
+
+    reason: str = Field(
+        min_length=1, max_length=512, description="Reason for requesting membership."
+    )
 
 
 class SpaceJoinRequestCreated(BaseModel):
-    work_order_id: int
-    work_order_no: str
-    status: WorkOrderStatus
+    """Work-order identity returned for a new Space join request."""
+
+    work_order_id: int = Field(description="Identifier of the created work order.")
+    work_order_no: str = Field(description="Human-readable work-order number.")
+    status: WorkOrderStatus = Field(description="Initial work-order status.")
 
 
 class WorkOrderReviewRequest(BaseModel):
-    review_remark: str = Field(min_length=1, max_length=512)
+    """Review comment supplied with an approval or rejection."""
+
+    review_remark: str = Field(
+        min_length=1, max_length=512, description="Reviewer comment for the decision."
+    )
 
 
 class WorkOrderReviewResponse(_UtcResponseModel):
-    work_order_id: int
-    status: WorkOrderStatus
-    reviewer_user_id: str
-    review_remark: str
-    reviewed_at: datetime
+    """Final state returned after reviewing a work order."""
+
+    work_order_id: int = Field(description="Identifier of the reviewed work order.")
+    status: WorkOrderStatus = Field(description="Status after the review decision.")
+    reviewer_user_id: str = Field(description="Identifier of the reviewer.")
+    review_remark: str = Field(
+        description="Reviewer comment recorded with the decision."
+    )
+    reviewed_at: datetime = Field(
+        description="UTC time when the review decision was recorded."
+    )
 
 
 class WorkOrderListItem(_UtcResponseModel):
-    item_id: str
-    item_type: WorkOrderItemType
-    work_order_id: int
-    work_order_no: str
-    notification_id: int | None
-    notification_category: NotificationCategory | None
-    biz_type: WorkOrderBizType
-    biz_id: str
-    applicant_user_id: str
-    apply_reason: str | None
-    reviewer_user_id: str | None
-    review_remark: str | None
-    reviewed_at: datetime | None
-    recipient_user_id: str | None
-    event_type: WorkOrderEventType | None
-    title: str | None
-    content: str | None
-    status: WorkOrderStatus
-    is_read: bool | None
-    read_at: datetime | None
-    env: str
-    can_approve: bool
-    gmt_created: datetime
-    gmt_modified: datetime
+    """Approval or notification item in a user's work-order inbox."""
+
+    item_id: str = Field(description="Stable identifier of this combined list item.")
+    item_type: WorkOrderItemType = Field(description="Category of the list item.")
+    work_order_id: int = Field(description="Identifier of the related work order.")
+    work_order_no: str = Field(description="Human-readable work-order number.")
+    notification_id: int | None = Field(
+        description="Related notification identifier, or null for approval-only items."
+    )
+    notification_category: NotificationCategory | None = Field(
+        description="Notification category, or null when no notification is attached."
+    )
+    biz_type: WorkOrderBizType = Field(description="Business object type.")
+    biz_id: str = Field(description="Identifier of the related business object.")
+    applicant_user_id: str = Field(description="Identifier of the applicant.")
+    apply_reason: str | None = Field(description="Application reason, when supplied.")
+    reviewer_user_id: str | None = Field(
+        description="Identifier of the reviewer after processing, otherwise null."
+    )
+    review_remark: str | None = Field(
+        description="Review comment after processing, otherwise null."
+    )
+    reviewed_at: datetime | None = Field(
+        description="UTC review time after processing, otherwise null."
+    )
+    recipient_user_id: str | None = Field(
+        description="Notification recipient, or null when no notification is attached."
+    )
+    event_type: WorkOrderEventType | None = Field(
+        description="Originating event, or null when no notification is attached."
+    )
+    title: str | None = Field(description="Notification title, when available.")
+    content: str | None = Field(description="Notification content, when available.")
+    status: WorkOrderStatus = Field(description="Current work-order status.")
+    is_read: bool | None = Field(
+        description="Notification read state, or null when no notification is attached."
+    )
+    read_at: datetime | None = Field(
+        description="UTC notification read time, or null when unread or unavailable."
+    )
+    env: str = Field(description="Environment scope of the work order.")
+    can_approve: bool = Field(
+        description="Whether the current user may approve or reject this item."
+    )
+    gmt_created: datetime = Field(
+        description="UTC time when the work order was created."
+    )
+    gmt_modified: datetime = Field(
+        description="UTC time when the displayed item was last modified."
+    )
 
 
 class WorkOrderDetailContent(BaseModel):
-    space_id: int
-    space_name: str
-    applicant_user_id: str
-    applicant_name: str
-    reason: str | None
+    """Business details for a Space join work order."""
+
+    space_id: int = Field(description="Identifier of the requested Space.")
+    space_name: str = Field(description="Display name of the requested Space.")
+    applicant_user_id: str = Field(description="Identifier of the applicant.")
+    applicant_name: str = Field(description="Display name of the applicant.")
+    reason: str | None = Field(description="Applicant's reason, when supplied.")
 
 
 class WorkOrderDetailResponse(_UtcResponseModel):
-    work_order_id: int
-    work_order_no: str
-    biz_type: WorkOrderBizType
-    biz_id: int
-    event_type: WorkOrderEventType
-    title: str
-    content: WorkOrderDetailContent
-    status: WorkOrderStatus
-    reviewer_user_id: str | None
-    review_remark: str | None
-    reviewed_at: datetime | None
-    can_approve: bool
+    """Detailed view of one work order."""
+
+    work_order_id: int = Field(description="Identifier of the work order.")
+    work_order_no: str = Field(description="Human-readable work-order number.")
+    biz_type: WorkOrderBizType = Field(description="Business object type.")
+    biz_id: int = Field(description="Identifier of the related Space.")
+    event_type: WorkOrderEventType = Field(
+        description="Event that created the work order."
+    )
+    title: str = Field(description="Display title of the work order.")
+    content: WorkOrderDetailContent = Field(description="Space join request details.")
+    status: WorkOrderStatus = Field(description="Current work-order status.")
+    reviewer_user_id: str | None = Field(
+        description="Identifier of the reviewer after processing, otherwise null."
+    )
+    review_remark: str | None = Field(
+        description="Review comment after processing, otherwise null."
+    )
+    reviewed_at: datetime | None = Field(
+        description="UTC review time after processing, otherwise null."
+    )
+    can_approve: bool = Field(
+        description="Whether the current user may approve or reject this work order."
+    )
 
 
 class NotificationDetailResponse(BaseModel):
-    notification_id: int
-    work_order_id: int | None
-    notification_category: NotificationCategory
-    event_type: WorkOrderEventType
-    title: str
-    content: str | None
-    is_read: bool
-    work_order_status: WorkOrderStatus | None
-    can_approve: bool
-    biz_type: WorkOrderBizType
-    biz_id: str
+    """Detailed view of a notification addressed to the current user."""
+
+    notification_id: int = Field(description="Identifier of the notification.")
+    work_order_id: int | None = Field(
+        description="Related work-order identifier, when one exists."
+    )
+    notification_category: NotificationCategory = Field(
+        description="Presentation category of the notification."
+    )
+    event_type: WorkOrderEventType = Field(
+        description="Business event represented by the notification."
+    )
+    title: str = Field(description="Display title of the notification.")
+    content: str | None = Field(
+        description="Notification message content, when present."
+    )
+    is_read: bool = Field(
+        description="Whether the recipient has read the notification."
+    )
+    work_order_status: WorkOrderStatus | None = Field(
+        description="Related work-order status, when a work order exists."
+    )
+    can_approve: bool = Field(
+        description="Whether the recipient may review the related work order."
+    )
+    biz_type: WorkOrderBizType = Field(description="Business object type.")
+    biz_id: str = Field(description="Identifier of the related business object.")
 
 
 class UnreadCountResponse(BaseModel):
-    unread_count: int
+    """Unread notification total for the current user."""
+
+    unread_count: int = Field(description="Number of unread notifications.")
 
 
 class NotificationReadResponse(_UtcResponseModel):
-    notification_id: int
-    is_read: bool
-    read_at: datetime | None
+    """Read state returned after one notification is marked read."""
+
+    notification_id: int = Field(description="Identifier of the notification.")
+    is_read: bool = Field(description="Whether the notification is now read.")
+    read_at: datetime | None = Field(
+        description="UTC time when the notification was marked read."
+    )
 
 
 class NotificationsReadAllResponse(BaseModel):
-    updated_count: int
+    """Result of marking all current user's notifications read."""
+
+    updated_count: int = Field(
+        description="Number of notifications changed from unread to read."
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/spaces_internal/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/spaces_internal/__init__.py
@@ -1,0 +1,5 @@
+"""Internal HTTP adapter for Space maintenance queries."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/spaces_internal/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/spaces_internal/router.py
@@ -1,0 +1,41 @@
+"""Internal Space endpoints used by trusted service integrations."""
+
+from fastapi import APIRouter, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.responses import envelope
+from agentclaw.community.adapters.http.spaces_internal.schemas import (
+    PersonalSpaceBatchQueryItem,
+    PersonalSpaceBatchQueryRequest,
+    PersonalSpaceBatchQueryResult,
+)
+from agentclaw.community.api.space_service import SpaceServiceProtocol
+from agentclaw.community.di import Injected
+
+
+router = APIRouter(prefix="/api/internal/spaces", tags=["spaces-internal"])
+
+
+@router.post(
+    "/personal/batch-query",
+    response_model=Envelope[PersonalSpaceBatchQueryResult],
+)
+async def batch_query_personal_spaces(
+    body: PersonalSpaceBatchQueryRequest,
+    request: Request,
+    service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
+) -> Envelope[PersonalSpaceBatchQueryResult]:
+    records = service.batch_query_personal(user_ids=body.user_id)
+    return envelope(
+        PersonalSpaceBatchQueryResult(
+            list=[
+                PersonalSpaceBatchQueryItem(
+                    user_id=record.user_id,
+                    space_id=record.space_id,
+                    found=record.found,
+                )
+                for record in records
+            ]
+        ),
+        request,
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/spaces_internal/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/spaces_internal/schemas.py
@@ -1,0 +1,35 @@
+"""Schemas for internal Space maintenance endpoints."""
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class PersonalSpaceBatchQueryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: list[str] = Field(min_length=1)
+
+    @field_validator("user_id")
+    @classmethod
+    def normalize_user_ids(cls, values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for user_id in values:
+            value = user_id.strip()
+            if not value:
+                raise ValueError("user_id must not contain blank values")
+            if value not in seen:
+                seen.add(value)
+                normalized.append(value)
+        if len(normalized) > 500:
+            raise ValueError("user_id must contain at most 500 unique values")
+        return normalized
+
+
+class PersonalSpaceBatchQueryItem(BaseModel):
+    user_id: str
+    space_id: int | None
+    found: bool
+
+
+class PersonalSpaceBatchQueryResult(BaseModel):
+    list: list[PersonalSpaceBatchQueryItem]

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -68,6 +68,9 @@ internal_dependencies:
   - agentclaw.community.core.quality.models          # QualityTaskRecord — typed in quality_service.py and task_processor_service.py
   - agentclaw.community.core.service_bot.repository.models  # BotPublishRecord — typed in engine_config_service.py
   - agentclaw.community.core.resources.models        # Resource / ResourceType — typed in resource_service.py (Protocol signatures mirror slim ResourceService verbatim; round-2 review #4)
+  - agentclaw.community.core.spaces.models           # Space/member records and enums — typed in space_service.py
+  - agentclaw.community.core.market_favorites.models # Favorite records and target enum — typed in market_favorite_service.py
+  - agentclaw.community.core.work_orders.models       # Work-order, notification, query, status, and event contracts
   - agentclaw.community.core.service_bot.services.baas_service  # BotWsConnectionInfoResponse / HttpConnectionInfo — typed in baas_service.py (BaasService is a plain core service)
   - agentclaw.community.core.service_bot.types       # PublishStage enum — typed in baas_service.py
   - agentclaw.community.core.skills_pool             # Skills Pool rollout/query/recovery domain DTOs used by operator Service API Protocols

--- a/src/backend/src/agentclaw/community/api/market_favorite_service.py
+++ b/src/backend/src/agentclaw/community/api/market_favorite_service.py
@@ -1,0 +1,47 @@
+"""Service API contract for space-scoped market favorites."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.market_favorites.models import (
+        FavoriteTargetType,
+        MarketFavoriteRecord,
+    )
+
+
+@runtime_checkable
+class MarketFavoriteServiceProtocol(Protocol):
+    @abstractmethod
+    def add(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType,
+        target_code: str,
+    ) -> MarketFavoriteRecord: ...
+
+    @abstractmethod
+    def cancel(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType,
+        target_code: str,
+    ) -> bool: ...
+
+    @abstractmethod
+    def search(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType | None,
+        keyword: str | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[MarketFavoriteRecord]]: ...

--- a/src/backend/src/agentclaw/community/api/space_service.py
+++ b/src/backend/src/agentclaw/community/api/space_service.py
@@ -7,6 +7,7 @@ from typing import Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
     from agentclaw.community.core.spaces.models import (
+        PersonalSpaceLookupRecord,
         SpaceMemberRecord,
         SpaceMemberSummaryRecord,
         SpaceRecord,
@@ -23,6 +24,11 @@ class SpaceServiceProtocol(Protocol):
 
     @abstractmethod
     def create_team(self, *, name: str, creator_id: str) -> SpaceRecord: ...
+
+    @abstractmethod
+    def batch_query_personal(
+        self, *, user_ids: list[str]
+    ) -> list[PersonalSpaceLookupRecord]: ...
 
     @abstractmethod
     def list_spaces(

--- a/src/backend/src/agentclaw/community/api/space_service.py
+++ b/src/backend/src/agentclaw/community/api/space_service.py
@@ -1,0 +1,68 @@
+"""Service API contracts for spaces and members."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.spaces.models import (
+        SpaceMemberRecord,
+        SpaceMemberSummaryRecord,
+        SpaceRecord,
+        SpaceRole,
+        SpaceSummaryRecord,
+        SpaceType,
+    )
+
+
+@runtime_checkable
+class SpaceServiceProtocol(Protocol):
+    @abstractmethod
+    def initialize_personal(self, *, user_id: str) -> tuple[SpaceRecord, bool]: ...
+
+    @abstractmethod
+    def create_team(self, *, name: str, creator_id: str) -> SpaceRecord: ...
+
+    @abstractmethod
+    def list_spaces(
+        self,
+        *,
+        user_id: str,
+        keyword: str | None,
+        space_type: SpaceType | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[SpaceSummaryRecord]]: ...
+
+
+@runtime_checkable
+class SpaceMemberServiceProtocol(Protocol):
+    @abstractmethod
+    def list_members(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        keyword: str | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[SpaceMemberSummaryRecord]]: ...
+
+    @abstractmethod
+    def add_member(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        user_id: str,
+        role: SpaceRole,
+    ) -> SpaceMemberRecord: ...
+
+    @abstractmethod
+    def delete_member(self, *, space_id: int, actor_id: str, user_id: str) -> bool: ...
+
+    @abstractmethod
+    def update_role(
+        self, *, space_id: int, actor_id: str, user_id: str, role: SpaceRole
+    ) -> SpaceMemberSummaryRecord: ...

--- a/src/backend/src/agentclaw/community/api/work_order_service.py
+++ b/src/backend/src/agentclaw/community/api/work_order_service.py
@@ -1,0 +1,69 @@
+"""Service API contracts for work orders and recipient notifications."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.work_orders.models import (
+        WorkOrderDetail,
+        WorkOrderItemType,
+        WorkOrderListItem,
+        WorkOrderNotificationDetail,
+        WorkOrderNotificationRecord,
+        WorkOrderQueryType,
+        WorkOrderRecord,
+        WorkOrderReviewResult,
+    )
+
+
+@runtime_checkable
+class WorkOrderServiceProtocol(Protocol):
+    @abstractmethod
+    def create_space_join_request(
+        self, *, space_id: int, applicant_user_id: str, reason: str
+    ) -> WorkOrderRecord: ...
+
+    @abstractmethod
+    def list_items(
+        self,
+        *,
+        actor_id: str,
+        query_type: WorkOrderQueryType,
+        item_type: WorkOrderItemType,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[WorkOrderListItem]]: ...
+
+    @abstractmethod
+    def get_detail(self, *, work_order_id: int, actor_id: str) -> WorkOrderDetail: ...
+
+    @abstractmethod
+    def approve(
+        self, *, work_order_id: int, actor_id: str, review_remark: str
+    ) -> WorkOrderReviewResult: ...
+
+    @abstractmethod
+    def reject(
+        self, *, work_order_id: int, actor_id: str, review_remark: str
+    ) -> WorkOrderReviewResult: ...
+
+
+@runtime_checkable
+class WorkOrderNotificationServiceProtocol(Protocol):
+    @abstractmethod
+    def get_detail(
+        self, *, notification_id: int, actor_id: str
+    ) -> WorkOrderNotificationDetail: ...
+
+    @abstractmethod
+    def unread_count(self, *, actor_id: str) -> int: ...
+
+    @abstractmethod
+    def mark_read(
+        self, *, notification_id: int, actor_id: str
+    ) -> WorkOrderNotificationRecord: ...
+
+    @abstractmethod
+    def mark_all_read(self, *, actor_id: str) -> int: ...

--- a/src/backend/src/agentclaw/community/core/market_favorites/README.md
+++ b/src/backend/src/agentclaw/community/core/market_favorites/README.md
@@ -1,0 +1,37 @@
+# `agentclaw.community.core.market_favorites`
+
+Stores a Space's favorite references as `(target_type, target_code)`. Adding an
+already-favorited target is idempotent; canceling requires an existing favorite
+and reports not found when there is nothing to remove.
+This phase intentionally does not import Skill or MCP catalogue implementations.
+Catalogue names, descriptions, icons, versions and owners are not exposed at
+the HTTP boundary until a governed catalogue lookup contract is implemented.
+
+## Context Boundary
+
+```yaml
+purpose: "Own idempotent Space-scoped marketplace favorite references without owning catalogue metadata."
+provides:
+  - MarketFavoriteService
+  - MarketFavoriteModel
+  - MarketFavoriteRecord
+  - FavoriteTargetType
+consumes:
+  - "MarketFavoriteRepositoryProtocol (core.repository) — favorite persistence"
+  - "SpaceAccessService (core.spaces) — membership authorization"
+consumed_by:
+  - "adapters/http/openapi_v1/spaces — favorite, cancel and search operations"
+internal_dependencies:
+  - agentclaw.community.core.base
+  - agentclaw.community.core.repository
+  - agentclaw.community.core.spaces
+  - agentclaw.community.plugin_api.models
+  - agentclaw.community.utils.avernet_tenant_guard
+  - agentclaw.community.utils.env_utils
+```
+
+### Change impact
+
+The unique key defines favorite idempotency. Metadata enrichment must be added
+through an explicit Service/Plugin contract; this module must not reach directly
+into Skill Center or an HTTP client.

--- a/src/backend/src/agentclaw/community/core/market_favorites/__init__.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/__init__.py
@@ -1,0 +1,1 @@
+"""Space-scoped market favorites bounded context."""

--- a/src/backend/src/agentclaw/community/core/market_favorites/errors.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/errors.py
@@ -1,0 +1,9 @@
+"""Domain errors for market favorites."""
+
+
+class FavoriteTargetInvalidError(ValueError):
+    pass
+
+
+class FavoriteNotFoundError(LookupError):
+    pass

--- a/src/backend/src/agentclaw/community/core/market_favorites/models.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/models.py
@@ -1,0 +1,24 @@
+"""Domain records and enums for market favorites."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class FavoriteTargetType(StrEnum):
+    SKILL = "SKILL"
+    MCP = "MCP"
+
+
+class MarketFavoriteRecord(BaseModel):
+    id: int
+    space_id: int
+    target_type: FavoriteTargetType
+    target_code: str
+    created_by: str
+    env: str
+    gmt_created: datetime
+    gmt_modified: datetime

--- a/src/backend/src/agentclaw/community/core/market_favorites/repository/__init__.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/repository/__init__.py
@@ -1,0 +1,3 @@
+from .models import MarketFavoriteModel
+
+__all__ = ["MarketFavoriteModel"]

--- a/src/backend/src/agentclaw/community/core/market_favorites/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/repository/models.py
@@ -1,0 +1,64 @@
+"""SQLAlchemy model for ``ac_market_favorite``."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Index, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.market_favorites.models import (
+    FavoriteTargetType,
+    MarketFavoriteRecord,
+)
+from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class MarketFavoriteModel(Base):
+    __tablename__ = "ac_market_favorite"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    space_id = Column(AutoIncrementBigInteger, nullable=False)
+    target_type = Column(String(32), nullable=False)
+    target_code = Column(String(128), nullable=False)
+    created_by = Column(String(256), nullable=False)
+    env = Column(String(20), nullable=False, default=get_current_env)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    gmt_created = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant",
+            "space_id",
+            "target_type",
+            "target_code",
+            "env",
+            name="uk_market_favorite_target_env",
+        ),
+        Index(
+            "idx_market_favorite_space",
+            "avernet_tenant",
+            "space_id",
+            "env",
+            "gmt_modified",
+        ),
+    )
+
+    def to_record(self) -> MarketFavoriteRecord:
+        return MarketFavoriteRecord(
+            id=self.id,
+            space_id=self.space_id,
+            target_type=FavoriteTargetType(self.target_type),
+            target_code=self.target_code,
+            created_by=self.created_by,
+            env=self.env,
+            gmt_created=self.gmt_created,
+            gmt_modified=self.gmt_modified,
+        )
+
+
+register_avernet_tenant_guard(MarketFavoriteModel)

--- a/src/backend/src/agentclaw/community/core/market_favorites/services/__init__.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/services/__init__.py
@@ -1,0 +1,3 @@
+from .favorite_service import MarketFavoriteService
+
+__all__ = ["MarketFavoriteService"]

--- a/src/backend/src/agentclaw/community/core/market_favorites/services/favorite_service.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/services/favorite_service.py
@@ -1,0 +1,101 @@
+"""Space-scoped market favorite service.
+
+This phase stores only stable target references. Market metadata enrichment is
+intentionally deferred with the Skill/MCP catalogue integration.
+"""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.market_favorites.errors import (
+    FavoriteNotFoundError,
+    FavoriteTargetInvalidError,
+)
+from agentclaw.community.core.market_favorites.models import (
+    FavoriteTargetType,
+    MarketFavoriteRecord,
+)
+from agentclaw.community.core.repository.protocols.market_favorites import (
+    MarketFavoriteRepositoryProtocol,
+)
+from agentclaw.community.core.spaces.services.space_access_service import (
+    SpaceAccessService,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class MarketFavoriteService:
+    @inject
+    def __init__(
+        self,
+        repository: MarketFavoriteRepositoryProtocol,
+        access: SpaceAccessService,
+    ) -> None:
+        self._repository = repository
+        self._access = access
+
+    @staticmethod
+    def _target_code(value: str) -> str:
+        normalized = value.strip()
+        if not normalized or len(normalized) > 128:
+            raise FavoriteTargetInvalidError(
+                "favorite target code must contain 1-128 characters"
+            )
+        return normalized
+
+    def add(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType,
+        target_code: str,
+    ) -> MarketFavoriteRecord:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        return self._repository.add(
+            space_id=space_id,
+            target_type=target_type,
+            target_code=self._target_code(target_code),
+            created_by=actor_id,
+            env=get_current_env(),
+        )
+
+    def cancel(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType,
+        target_code: str,
+    ) -> bool:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        deleted = self._repository.cancel(
+            space_id=space_id,
+            target_type=target_type,
+            target_code=self._target_code(target_code),
+            env=get_current_env(),
+        )
+        if not deleted:
+            raise FavoriteNotFoundError("market favorite not found")
+        return True
+
+    def search(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        target_type: FavoriteTargetType | None,
+        keyword: str | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[MarketFavoriteRecord]]:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        return self._repository.search(
+            space_id=space_id,
+            target_type=target_type,
+            keyword=keyword.strip() if keyword and keyword.strip() else None,
+            env=get_current_env(),
+            offset=(page_no - 1) * page_size,
+            limit=page_size,
+        )

--- a/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_17_market_favorites.sql
+++ b/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_17_market_favorites.sql
@@ -1,0 +1,19 @@
+-- Space-scoped stable references to marketplace resources.
+CREATE TABLE IF NOT EXISTS ac_market_favorite (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    space_id BIGINT UNSIGNED NOT NULL,
+    target_type VARCHAR(32) NOT NULL COMMENT 'SKILL | MCP',
+    target_code VARCHAR(128) NOT NULL,
+    created_by VARCHAR(256) NOT NULL,
+    env VARCHAR(20) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_market_favorite_target_env (
+        avernet_tenant, space_id, target_type, target_code, env
+    ),
+    KEY idx_market_favorite_space (
+        avernet_tenant, space_id, env, gmt_modified
+    )
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -17,7 +17,7 @@ puts them here rather than there.
 
 ## Domains
 
-Eleven subdirectories, mirrored on both sides. A domain is the consumer seam, not
+Thirteen domains, mirrored on both sides. A domain is the consumer seam, not
 the table: single-repository domains merge into the sibling that shares their
 consumer, so `protocols/<domain>.py` and `implementations/<domain>/` always name
 the same thing.
@@ -35,6 +35,9 @@ the same thing.
 | `devices` | device bindings |
 | `publishing` | service_bot |
 | `config` | system_config, common_config |
+| `spaces` | spaces and space membership |
+| `market_favorites` | space-scoped market favorites |
+| `work_orders` | approval work orders and recipient notifications |
 
 `protocols/bot/` is a package rather than a module only because the single file
 would exceed the Rule 9 size cap; its `__init__.py` re-exports every contract, so
@@ -92,6 +95,10 @@ provides:
   - RenderScreenRepository
   - TemplateRepository
   - UserMCPConfigRepository
+  # spaces / market_favorites
+  - SpaceRepositoryProtocol
+  - MarketFavoriteRepositoryProtocol
+  - WorkOrderRepositoryProtocol
   # chat
   - BotChatDbRepositoryProtocol
   - ChannelRepository
@@ -149,6 +156,10 @@ provides:
   - BotRestartLockRepository
   - BotStartupScriptRepository
   - CollaboratorRepository
+  # spaces / market_favorites
+  - SpaceRepository
+  - MarketFavoriteRepository
+  - WorkOrderRepository
   # chat
   - BotChatDbRepository
   - OpenBotChatRepository
@@ -203,6 +214,8 @@ internal_dependencies:
   - agentclaw.community.core.quality
   - agentclaw.community.core.service_bot
   - agentclaw.community.core.session_resources
+  - agentclaw.community.core.spaces
+  - agentclaw.community.core.market_favorites
   - agentclaw.community.core.skill_center
   - agentclaw.community.core.skills_pool
   - agentclaw.community.core.system_config

--- a/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/__init__.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/__init__.py
@@ -1,0 +1,3 @@
+from .favorite import MarketFavoriteRepository
+
+__all__ = ["MarketFavoriteRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/favorite.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/favorite.py
@@ -1,0 +1,115 @@
+"""Unified ORM repository for market favorites."""
+
+from __future__ import annotations
+
+from injector import inject
+from sqlalchemy.exc import IntegrityError
+
+from agentclaw.community.core.market_favorites.repository.models import (
+    MarketFavoriteModel,
+)
+from agentclaw.community.core.repository.protocols.market_favorites import (
+    MarketFavoriteRepositoryProtocol,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+        self._Favorite = MarketFavoriteModel
+
+    def add(
+        self,
+        *,
+        space_id,
+        target_type,
+        target_code,
+        created_by,
+        env,
+    ):
+        try:
+            with self._db.orm_session() as db:
+                existing = (
+                    db.query(self._Favorite)
+                    .filter(
+                        self._Favorite.space_id == space_id,
+                        self._Favorite.target_type == target_type.value,
+                        self._Favorite.target_code == target_code,
+                        self._Favorite.env == env,
+                    )
+                    .one_or_none()
+                )
+                if existing is not None:
+                    return existing.to_record()
+                row = self._Favorite(
+                    space_id=space_id,
+                    target_type=target_type.value,
+                    target_code=target_code,
+                    created_by=created_by,
+                    env=env,
+                )
+                db.add(row)
+                db.flush()
+                db.refresh(row)
+                return row.to_record()
+        except IntegrityError:
+            with self._db.orm_session() as db:
+                existing = (
+                    db.query(self._Favorite)
+                    .filter(
+                        self._Favorite.space_id == space_id,
+                        self._Favorite.target_type == target_type.value,
+                        self._Favorite.target_code == target_code,
+                        self._Favorite.env == env,
+                    )
+                    .one_or_none()
+                )
+                if existing is None:
+                    raise
+                return existing.to_record()
+
+    def cancel(self, *, space_id, target_type, target_code, env) -> bool:
+        with self._db.orm_session() as db:
+            deleted = (
+                db.query(self._Favorite)
+                .filter(
+                    self._Favorite.space_id == space_id,
+                    self._Favorite.target_type == target_type.value,
+                    self._Favorite.target_code == target_code,
+                    self._Favorite.env == env,
+                )
+                .delete(synchronize_session=False)
+            )
+            return deleted > 0
+
+    def search(
+        self,
+        *,
+        space_id,
+        target_type,
+        keyword,
+        env,
+        offset,
+        limit,
+    ):
+        with self._db.orm_session() as db:
+            query = db.query(self._Favorite).filter(
+                self._Favorite.space_id == space_id,
+                self._Favorite.env == env,
+            )
+            if target_type is not None:
+                query = query.filter(self._Favorite.target_type == target_type.value)
+            if keyword:
+                query = query.filter(self._Favorite.target_code.ilike(f"%{keyword}%"))
+            total = query.count()
+            rows = (
+                query.order_by(
+                    self._Favorite.gmt_modified.desc(), self._Favorite.id.desc()
+                )
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return total, [row.to_record() for row in rows]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/__init__.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/__init__.py
@@ -1,0 +1,3 @@
+from .space import SpaceRepository
+
+__all__ = ["SpaceRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -1,0 +1,319 @@
+"""Unified ORM repository for spaces and members."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from uuid import uuid4
+
+from injector import inject
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.spaces.errors import (
+    SpaceAlreadyExistsError,
+    SpaceMemberAlreadyExistsError,
+)
+from agentclaw.community.core.spaces.models import (
+    SpaceJoinStatus,
+    SpaceMemberSummaryRecord,
+    SpaceRole,
+    SpaceSummaryRecord,
+    SpaceType,
+)
+from agentclaw.community.core.spaces.repository.models import (
+    SpaceMemberModel,
+    SpaceModel,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class SpaceRepository(SpaceRepositoryProtocol):
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+        self._Space = SpaceModel
+        self._Member = SpaceMemberModel
+
+    @staticmethod
+    def _new_code() -> str:
+        return f"spc-{uuid4().hex[:20]}"
+
+    def initialize_personal(self, *, user_id: str, env: str):
+        try:
+            with self._db.transactional_orm_session() as db:
+                existing = (
+                    db.query(self._Space)
+                    .filter(
+                        self._Space.personal_owner_id == user_id,
+                        self._Space.env == env,
+                    )
+                    .one_or_none()
+                )
+                if existing is not None:
+                    return existing.to_record(), False
+
+                space = self._Space(
+                    space_code=self._new_code(),
+                    space_type=SpaceType.PERSONAL.value,
+                    name="个人空间",
+                    personal_owner_id=user_id,
+                    env=env,
+                    created_by=user_id,
+                    updated_by=user_id,
+                )
+                db.add(space)
+                db.flush()
+                db.add(
+                    self._Member(
+                        space_id=space.id,
+                        user_id=user_id,
+                        role=SpaceRole.OWNER.value,
+                        env=env,
+                        created_by=user_id,
+                    )
+                )
+                db.flush()
+                db.refresh(space)
+                return space.to_record(), True
+        except IntegrityError:
+            # Concurrent initialization: the unique personal-owner key decides
+            # the winner; the loser returns the same established space.
+            with self._db.orm_session() as db:
+                existing = (
+                    db.query(self._Space)
+                    .filter(
+                        self._Space.personal_owner_id == user_id,
+                        self._Space.env == env,
+                    )
+                    .one_or_none()
+                )
+                if existing is None:
+                    raise
+                return existing.to_record(), False
+
+    @contextmanager
+    def create_team_transaction(self, *, name: str, creator_id: str, env: str):
+        try:
+            with self._db.transactional_orm_session() as db:
+                space = self._Space(
+                    space_code=self._new_code(),
+                    space_type=SpaceType.TEAM.value,
+                    name=name,
+                    personal_owner_id=None,
+                    env=env,
+                    created_by=creator_id,
+                    updated_by=creator_id,
+                )
+                db.add(space)
+                db.flush()
+                db.add(
+                    self._Member(
+                        space_id=space.id,
+                        user_id=creator_id,
+                        role=SpaceRole.OWNER.value,
+                        env=env,
+                        created_by=creator_id,
+                    )
+                )
+                db.flush()
+                db.refresh(space)
+                # The caller performs required external synchronization while
+                # this transaction remains open. Any exception raised before
+                # this context exits rolls both rows back. After SC succeeds,
+                # the caller assigns its returned team id to this record; the
+                # repository persists it in the same OB transaction.
+                record = space.to_record()
+                yield record
+                space.sc_team_id = record.sc_team_id
+                db.flush()
+        except IntegrityError as exc:
+            raise SpaceAlreadyExistsError("unable to allocate space code") from exc
+
+    def get_space(self, *, space_id: int, env: str):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Space)
+                .filter(self._Space.id == space_id, self._Space.env == env)
+                .one_or_none()
+            )
+            return row.to_record() if row is not None else None
+
+    def list_spaces(
+        self,
+        *,
+        user_id: str,
+        env: str,
+        keyword: str | None,
+        space_type: str | None,
+        offset: int,
+        limit: int,
+    ):
+        with self._db.orm_session() as db:
+            query = db.query(self._Space).filter(
+                self._Space.env == env,
+                or_(
+                    self._Space.space_type != SpaceType.PERSONAL.value,
+                    self._Space.personal_owner_id == user_id,
+                ),
+            )
+            if keyword:
+                query = query.filter(self._Space.name.ilike(f"%{keyword}%"))
+            if space_type:
+                query = query.filter(self._Space.space_type == space_type)
+            total = query.count()
+            rows = (
+                query.order_by(self._Space.gmt_modified.desc(), self._Space.id.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            items = []
+            for row in rows:
+                current = (
+                    db.query(self._Member)
+                    .filter(
+                        self._Member.space_id == row.id,
+                        self._Member.user_id == user_id,
+                        self._Member.env == env,
+                    )
+                    .one_or_none()
+                )
+                member_count = (
+                    db.query(func.count(self._Member.id))
+                    .filter(self._Member.space_id == row.id, self._Member.env == env)
+                    .scalar()
+                    or 0
+                )
+                owner_count = (
+                    db.query(func.count(self._Member.id))
+                    .filter(
+                        self._Member.space_id == row.id,
+                        self._Member.role == SpaceRole.OWNER.value,
+                        self._Member.env == env,
+                    )
+                    .scalar()
+                    or 0
+                )
+                role = SpaceRole(current.role) if current is not None else None
+                items.append(
+                    SpaceSummaryRecord(
+                        space=row.to_record(),
+                        current_user_role=role,
+                        join_status=(
+                            SpaceJoinStatus.JOINED
+                            if current is not None
+                            else SpaceJoinStatus.NOT_JOINED
+                        ),
+                        member_count=member_count,
+                        owner_count=owner_count,
+                    )
+                )
+            return total, items
+
+    def get_member(self, *, space_id: int, user_id: str, env: str):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Member)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.user_id == user_id,
+                    self._Member.env == env,
+                )
+                .one_or_none()
+            )
+            return row.to_record() if row is not None else None
+
+    def list_members(
+        self,
+        *,
+        space_id: int,
+        env: str,
+        keyword: str | None,
+        offset: int,
+        limit: int,
+    ):
+        with self._db.orm_session() as db:
+            query = db.query(self._Member).filter(
+                self._Member.space_id == space_id, self._Member.env == env
+            )
+            if keyword:
+                query = query.filter(self._Member.user_id.ilike(f"%{keyword}%"))
+            total = query.count()
+            rows = (
+                query.order_by(self._Member.gmt_modified.desc(), self._Member.id.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            space = (
+                db.query(self._Space)
+                .filter(self._Space.id == space_id, self._Space.env == env)
+                .one_or_none()
+            )
+            creator_id = space.created_by if space is not None else ""
+            return total, [
+                SpaceMemberSummaryRecord(
+                    member=row.to_record(), is_creator=row.user_id == creator_id
+                )
+                for row in rows
+            ]
+
+    def add_member(
+        self,
+        *,
+        space_id: int,
+        user_id: str,
+        role: SpaceRole,
+        creator_id: str,
+        env: str,
+    ):
+        try:
+            with self._db.orm_session() as db:
+                row = self._Member(
+                    space_id=space_id,
+                    user_id=user_id,
+                    role=role.value,
+                    env=env,
+                    created_by=creator_id,
+                )
+                db.add(row)
+                db.flush()
+                db.refresh(row)
+                return row.to_record()
+        except IntegrityError as exc:
+            raise SpaceMemberAlreadyExistsError("space member already exists") from exc
+
+    def delete_member(self, *, space_id: int, user_id: str, env: str) -> bool:
+        with self._db.orm_session() as db:
+            deleted = (
+                db.query(self._Member)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.user_id == user_id,
+                    self._Member.env == env,
+                )
+                .delete(synchronize_session=False)
+            )
+            return deleted > 0
+
+    def update_member_role(
+        self, *, space_id: int, user_id: str, role: SpaceRole, env: str
+    ):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Member)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.user_id == user_id,
+                    self._Member.env == env,
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            row.role = role.value
+            row.gmt_modified = func.now()
+            db.flush()
+            db.refresh(row)
+            return row.to_record()

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.spaces.errors import (
     SpaceMemberAlreadyExistsError,
 )
 from agentclaw.community.core.spaces.models import (
+    PersonalSpaceLookupRecord,
     SpaceJoinStatus,
     SpaceMemberSummaryRecord,
     SpaceRole,
@@ -138,6 +139,29 @@ class SpaceRepository(SpaceRepositoryProtocol):
                 .one_or_none()
             )
             return row.to_record() if row is not None else None
+
+    def batch_query_personal(
+        self, *, user_ids: list[str], env: str
+    ) -> list[PersonalSpaceLookupRecord]:
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self._Space.personal_owner_id, self._Space.id)
+                .filter(
+                    self._Space.personal_owner_id.in_(user_ids),
+                    self._Space.space_type == SpaceType.PERSONAL.value,
+                    self._Space.env == env,
+                )
+                .all()
+            )
+        space_ids = {str(user_id): int(space_id) for user_id, space_id in rows}
+        return [
+            PersonalSpaceLookupRecord(
+                user_id=user_id,
+                space_id=space_ids.get(user_id),
+                found=user_id in space_ids,
+            )
+            for user_id in user_ids
+        ]
 
     def list_spaces(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/__init__.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/__init__.py
@@ -1,0 +1,3 @@
+from .work_order import WorkOrderRepository
+
+__all__ = ["WorkOrderRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -1,0 +1,555 @@
+"""SQLAlchemy persistence and transactional state changes for work orders."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from injector import inject
+from sqlalchemy import and_, func, or_
+from sqlalchemy.exc import IntegrityError
+
+from agentclaw.community.core.repository.protocols.work_orders import (
+    WorkOrderRepositoryProtocol,
+)
+from agentclaw.community.core.spaces.models import SpaceRole
+from agentclaw.community.core.spaces.repository.models import (
+    SpaceMemberModel,
+    SpaceModel,
+)
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAlreadyPendingError,
+    WorkOrderAccessDeniedError,
+    WorkOrderAlreadyProcessedError,
+    WorkOrderApplicantAlreadyMemberError,
+    WorkOrderNoReviewerError,
+    WorkOrderNotFoundError,
+)
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderDetail,
+    WorkOrderEventType,
+    WorkOrderItemType,
+    WorkOrderListItem,
+    WorkOrderMessageContent,
+    WorkOrderMessageTitle,
+    WorkOrderNotificationDetail,
+    WorkOrderNotificationDraft,
+    WorkOrderQueryType,
+    WorkOrderReviewResult,
+    WorkOrderStatus,
+)
+from agentclaw.community.core.work_orders.repository.models import (
+    WorkOrderModel,
+    WorkOrderNotificationModel,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class WorkOrderRepository(WorkOrderRepositoryProtocol):
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+        self._WorkOrder = WorkOrderModel
+        self._Notification = WorkOrderNotificationModel
+        self._Space = SpaceModel
+        self._Member = SpaceMemberModel
+
+    @staticmethod
+    def _new_no() -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        return f"WO{stamp}{uuid4().hex[:10].upper()}"
+
+    def create_space_join_request(
+        self,
+        *,
+        space_id: int,
+        applicant_user_id: str,
+        applicant_name: str,
+        apply_reason: str,
+        env: str,
+    ):
+        with self._db.transactional_orm_session() as db:
+            # The DDL cannot express a partial unique key for status=PENDING.
+            # Locking the Space serializes competing applications for it.
+            space = (
+                db.query(self._Space)
+                .filter(self._Space.id == space_id, self._Space.env == env)
+                .with_for_update()
+                .one_or_none()
+            )
+            if space is None:
+                raise WorkOrderNotFoundError("space not found during request creation")
+
+            pending = (
+                db.query(self._WorkOrder.id)
+                .filter(
+                    self._WorkOrder.biz_type == WorkOrderBizType.SPACE_JOIN.value,
+                    self._WorkOrder.biz_id == str(space_id),
+                    self._WorkOrder.applicant_user_id == applicant_user_id,
+                    self._WorkOrder.status == WorkOrderStatus.PENDING.value,
+                    self._WorkOrder.env == env,
+                )
+                .first()
+            )
+            if pending is not None:
+                raise WorkOrderAlreadyPendingError("pending request already exists")
+
+            owners = (
+                db.query(self._Member.user_id)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.env == env,
+                )
+                .all()
+            )
+            if not owners:
+                raise WorkOrderNoReviewerError("space has no owner")
+
+            row = self._WorkOrder(
+                work_order_no=self._new_no(),
+                biz_type=WorkOrderBizType.SPACE_JOIN.value,
+                biz_id=str(space_id),
+                applicant_user_id=applicant_user_id,
+                apply_reason=apply_reason,
+                status=WorkOrderStatus.PENDING.value,
+                env=env,
+            )
+            db.add(row)
+            db.flush()
+            title = WorkOrderMessageTitle.SPACE_JOIN_PENDING.value
+            content = WorkOrderMessageContent.SPACE_JOIN_PENDING.value.format(
+                applicant_name=applicant_name, space_name=space.name
+            )
+            for (owner_id,) in owners:
+                db.add(
+                    self._Notification(
+                        work_order_id=row.id,
+                        recipient_user_id=owner_id,
+                        notification_category=NotificationCategory.APPROVAL.value,
+                        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED.value,
+                        biz_type=WorkOrderBizType.SPACE_JOIN.value,
+                        biz_id=str(space_id),
+                        title=title,
+                        content=content,
+                        env=env,
+                    )
+                )
+            db.flush()
+            db.refresh(row)
+            return row.to_record()
+
+    def list_items(
+        self,
+        *,
+        actor_id: str,
+        env: str,
+        query_type: WorkOrderQueryType,
+        item_type: WorkOrderItemType,
+        offset: int,
+        limit: int,
+    ):
+        with self._db.orm_session() as db:
+            owner_space_ids = {
+                str(space_id)
+                for (space_id,) in db.query(self._Member.space_id)
+                .filter(
+                    self._Member.user_id == actor_id,
+                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.env == env,
+                )
+                .all()
+            }
+            query = db.query(self._WorkOrder, self._Notification)
+            if query_type is WorkOrderQueryType.INITIATED_BY_ME:
+                query = query.outerjoin(
+                    self._Notification,
+                    and_(
+                        self._Notification.work_order_id == self._WorkOrder.id,
+                        self._Notification.recipient_user_id == actor_id,
+                        self._Notification.env == env,
+                    ),
+                ).filter(
+                    self._WorkOrder.applicant_user_id == actor_id,
+                    self._WorkOrder.env == env,
+                )
+            else:
+                query = query.join(
+                    self._Notification,
+                    self._Notification.work_order_id == self._WorkOrder.id,
+                ).filter(
+                    self._Notification.recipient_user_id == actor_id,
+                    self._Notification.env == env,
+                    self._WorkOrder.env == env,
+                )
+                if query_type is WorkOrderQueryType.PENDING_FOR_ME:
+                    query = query.filter(
+                        or_(
+                            and_(
+                                self._Notification.notification_category
+                                == NotificationCategory.APPROVAL.value,
+                                self._WorkOrder.status == WorkOrderStatus.PENDING.value,
+                            ),
+                            and_(
+                                self._Notification.notification_category
+                                == NotificationCategory.NOTICE.value,
+                                self._Notification.is_read.is_(False),
+                            ),
+                        )
+                    )
+                else:
+                    query = query.filter(
+                        self._Notification.notification_category
+                        == NotificationCategory.APPROVAL.value,
+                        self._WorkOrder.status.in_(
+                            [
+                                WorkOrderStatus.APPROVED.value,
+                                WorkOrderStatus.REJECTED.value,
+                            ]
+                        ),
+                    )
+
+            if item_type is not WorkOrderItemType.ALL:
+                if query_type is WorkOrderQueryType.INITIATED_BY_ME:
+                    if item_type is WorkOrderItemType.NOTICE:
+                        query = query.filter(
+                            self._Notification.notification_category
+                            == NotificationCategory.NOTICE.value
+                        )
+                    else:
+                        query = query.filter(
+                            or_(
+                                self._Notification.id.is_(None),
+                                self._Notification.notification_category
+                                == NotificationCategory.APPROVAL.value,
+                            )
+                        )
+                else:
+                    query = query.filter(
+                        self._Notification.notification_category == item_type.value
+                    )
+
+            total = query.count()
+            rows = (
+                query.order_by(
+                    func.coalesce(
+                        self._Notification.gmt_modified,
+                        self._WorkOrder.gmt_modified,
+                    ).desc(),
+                    self._WorkOrder.id.desc(),
+                )
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return total, [
+                WorkOrderListItem(
+                    work_order=work_order.to_record(),
+                    notification=(
+                        notification.to_record() if notification is not None else None
+                    ),
+                    can_approve=(
+                        query_type is not WorkOrderQueryType.INITIATED_BY_ME
+                        and work_order.status == WorkOrderStatus.PENDING.value
+                        and notification is not None
+                        and notification.notification_category
+                        == NotificationCategory.APPROVAL.value
+                        and work_order.biz_id in owner_space_ids
+                    ),
+                )
+                for work_order, notification in rows
+            ]
+
+    def get_detail(self, *, work_order_id: int, actor_id: str, env: str):
+        with self._db.orm_session() as db:
+            work_order = (
+                db.query(self._WorkOrder)
+                .filter(self._WorkOrder.id == work_order_id, self._WorkOrder.env == env)
+                .one_or_none()
+            )
+            if work_order is None:
+                return None
+            notification = (
+                db.query(self._Notification)
+                .filter(
+                    self._Notification.work_order_id == work_order_id,
+                    self._Notification.recipient_user_id == actor_id,
+                    self._Notification.env == env,
+                )
+                .order_by(self._Notification.gmt_modified.desc())
+                .first()
+            )
+            if work_order.applicant_user_id != actor_id and notification is None:
+                return None
+            space = (
+                db.query(self._Space)
+                .filter(
+                    self._Space.id == int(work_order.biz_id), self._Space.env == env
+                )
+                .one_or_none()
+            )
+            if space is None:
+                return None
+            is_current_owner = (
+                db.query(self._Member.id)
+                .filter(
+                    self._Member.space_id == space.id,
+                    self._Member.user_id == actor_id,
+                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.env == env,
+                )
+                .first()
+                is not None
+            )
+            can_approve = bool(
+                notification is not None
+                and notification.notification_category
+                == NotificationCategory.APPROVAL.value
+                and work_order.status == WorkOrderStatus.PENDING.value
+                and is_current_owner
+            )
+            event_type = (
+                WorkOrderEventType(notification.event_type)
+                if notification is not None
+                else WorkOrderEventType.SPACE_JOIN_APPLIED
+            )
+            title = (
+                notification.title
+                if notification is not None
+                else WorkOrderMessageTitle.SPACE_JOIN_PENDING.value
+            )
+            return WorkOrderDetail(
+                work_order=work_order.to_record(),
+                event_type=event_type,
+                title=title,
+                space_id=space.id,
+                space_name=space.name,
+                applicant_name=work_order.applicant_user_id,
+                can_approve=can_approve,
+            )
+
+    def review_space_join(
+        self,
+        *,
+        work_order_id: int,
+        reviewer_user_id: str,
+        review_remark: str,
+        target_status: WorkOrderStatus,
+        notification: WorkOrderNotificationDraft,
+        env: str,
+    ):
+        reviewed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        with self._db.transactional_orm_session() as db:
+            work_order = (
+                db.query(self._WorkOrder)
+                .filter(self._WorkOrder.id == work_order_id, self._WorkOrder.env == env)
+                .one_or_none()
+            )
+            if work_order is None:
+                raise WorkOrderNotFoundError("work order not found")
+            owner = (
+                db.query(self._Member.id)
+                .filter(
+                    self._Member.space_id == int(work_order.biz_id),
+                    self._Member.user_id == reviewer_user_id,
+                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.env == env,
+                )
+                .first()
+            )
+            if owner is None:
+                raise WorkOrderAccessDeniedError("space owner role required")
+            updated = (
+                db.query(self._WorkOrder)
+                .filter(
+                    self._WorkOrder.id == work_order_id,
+                    self._WorkOrder.status == WorkOrderStatus.PENDING.value,
+                    self._WorkOrder.env == env,
+                )
+                .update(
+                    {
+                        self._WorkOrder.status: target_status.value,
+                        self._WorkOrder.reviewer_user_id: reviewer_user_id,
+                        self._WorkOrder.review_remark: review_remark,
+                        self._WorkOrder.reviewed_at: reviewed_at,
+                        self._WorkOrder.gmt_modified: reviewed_at,
+                    },
+                    synchronize_session=False,
+                )
+            )
+            if updated != 1:
+                raise WorkOrderAlreadyProcessedError("work order already processed")
+
+            space_id = int(work_order.biz_id)
+            space = (
+                db.query(self._Space)
+                .filter(self._Space.id == space_id, self._Space.env == env)
+                .one_or_none()
+            )
+            if space is None:
+                raise WorkOrderNotFoundError("work-order business object not found")
+
+            if target_status is WorkOrderStatus.APPROVED:
+                existing = (
+                    db.query(self._Member.id)
+                    .filter(
+                        self._Member.space_id == space_id,
+                        self._Member.user_id == work_order.applicant_user_id,
+                        self._Member.env == env,
+                    )
+                    .first()
+                )
+                if existing is not None:
+                    raise WorkOrderApplicantAlreadyMemberError(
+                        "applicant is already a member"
+                    )
+                db.add(
+                    self._Member(
+                        space_id=space_id,
+                        user_id=work_order.applicant_user_id,
+                        role=SpaceRole.MEMBER.value,
+                        env=env,
+                        created_by=reviewer_user_id,
+                    )
+                )
+
+            db.add(
+                self._Notification(
+                    work_order_id=work_order_id,
+                    recipient_user_id=notification.recipient_user_id,
+                    notification_category=notification.notification_category.value,
+                    event_type=notification.event_type.value,
+                    biz_type=notification.biz_type.value,
+                    biz_id=notification.biz_id,
+                    title=notification.title,
+                    content=notification.content,
+                    env=env,
+                )
+            )
+            db.query(self._Notification).filter(
+                self._Notification.work_order_id == work_order_id,
+                self._Notification.notification_category
+                == NotificationCategory.APPROVAL.value,
+                self._Notification.env == env,
+            ).update(
+                {self._Notification.gmt_modified: reviewed_at},
+                synchronize_session=False,
+            )
+            try:
+                db.flush()
+            except IntegrityError as exc:
+                raise WorkOrderApplicantAlreadyMemberError(
+                    "unable to create approved membership"
+                ) from exc
+            return WorkOrderReviewResult(
+                work_order_id=work_order_id,
+                status=target_status,
+                reviewer_user_id=reviewer_user_id,
+                review_remark=review_remark,
+                reviewed_at=reviewed_at,
+            )
+
+    def get_notification(
+        self,
+        *,
+        notification_id: int,
+        recipient_user_id: str,
+        env: str,
+        mark_read: bool,
+    ):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Notification)
+                .filter(
+                    self._Notification.id == notification_id,
+                    self._Notification.recipient_user_id == recipient_user_id,
+                    self._Notification.env == env,
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            if mark_read and not row.is_read:
+                now = datetime.now(timezone.utc).replace(tzinfo=None)
+                row.is_read = True
+                row.read_at = now
+                row.gmt_modified = now
+                db.flush()
+                db.refresh(row)
+            status = None
+            can_approve = False
+            if row.work_order_id is not None:
+                work_order = (
+                    db.query(self._WorkOrder)
+                    .filter(
+                        self._WorkOrder.id == row.work_order_id,
+                        self._WorkOrder.env == env,
+                    )
+                    .one_or_none()
+                )
+                if work_order is not None:
+                    status = WorkOrderStatus(work_order.status)
+                    can_approve = bool(
+                        row.notification_category == NotificationCategory.APPROVAL.value
+                        and status is WorkOrderStatus.PENDING
+                        and db.query(self._Member.id)
+                        .filter(
+                            self._Member.space_id == int(work_order.biz_id),
+                            self._Member.user_id == recipient_user_id,
+                            self._Member.role == SpaceRole.OWNER.value,
+                            self._Member.env == env,
+                        )
+                        .first()
+                        is not None
+                    )
+            return WorkOrderNotificationDetail(
+                notification=row.to_record(),
+                work_order_status=status,
+                can_approve=can_approve,
+            )
+
+    def count_unread(self, *, recipient_user_id: str, env: str) -> int:
+        with self._db.orm_session() as db:
+            return (
+                db.query(func.count(self._Notification.id))
+                .filter(
+                    self._Notification.recipient_user_id == recipient_user_id,
+                    self._Notification.is_read.is_(False),
+                    self._Notification.env == env,
+                )
+                .scalar()
+                or 0
+            )
+
+    def mark_notification_read(
+        self, *, notification_id: int, recipient_user_id: str, env: str
+    ):
+        result = self.get_notification(
+            notification_id=notification_id,
+            recipient_user_id=recipient_user_id,
+            env=env,
+            mark_read=True,
+        )
+        return result.notification if result is not None else None
+
+    def mark_all_notifications_read(self, *, recipient_user_id: str, env: str) -> int:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        with self._db.orm_session() as db:
+            return (
+                db.query(self._Notification)
+                .filter(
+                    self._Notification.recipient_user_id == recipient_user_id,
+                    self._Notification.is_read.is_(False),
+                    self._Notification.env == env,
+                )
+                .update(
+                    {
+                        self._Notification.is_read: True,
+                        self._Notification.read_at: now,
+                        self._Notification.gmt_modified: now,
+                    },
+                    synchronize_session=False,
+                )
+            )

--- a/src/backend/src/agentclaw/community/core/repository/protocols/market_favorites.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/market_favorites.py
@@ -1,0 +1,48 @@
+"""Persistence contract for space-scoped market favorites."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.market_favorites.models import (
+        FavoriteTargetType,
+        MarketFavoriteRecord,
+    )
+
+
+@runtime_checkable
+class MarketFavoriteRepositoryProtocol(Protocol):
+    @abstractmethod
+    def add(
+        self,
+        *,
+        space_id: int,
+        target_type: FavoriteTargetType,
+        target_code: str,
+        created_by: str,
+        env: str,
+    ) -> MarketFavoriteRecord: ...
+
+    @abstractmethod
+    def cancel(
+        self,
+        *,
+        space_id: int,
+        target_type: FavoriteTargetType,
+        target_code: str,
+        env: str,
+    ) -> bool: ...
+
+    @abstractmethod
+    def search(
+        self,
+        *,
+        space_id: int,
+        target_type: FavoriteTargetType | None,
+        keyword: str | None,
+        env: str,
+        offset: int,
+        limit: int,
+    ) -> tuple[int, list[MarketFavoriteRecord]]: ...

--- a/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
@@ -7,6 +7,7 @@ from typing import ContextManager, Protocol, TYPE_CHECKING, runtime_checkable
 
 if TYPE_CHECKING:
     from agentclaw.community.core.spaces.models import (
+        PersonalSpaceLookupRecord,
         SpaceMemberRecord,
         SpaceMemberSummaryRecord,
         SpaceRecord,
@@ -29,6 +30,11 @@ class SpaceRepositoryProtocol(Protocol):
 
     @abstractmethod
     def get_space(self, *, space_id: int, env: str) -> SpaceRecord | None: ...
+
+    @abstractmethod
+    def batch_query_personal(
+        self, *, user_ids: list[str], env: str
+    ) -> list[PersonalSpaceLookupRecord]: ...
 
     @abstractmethod
     def list_spaces(

--- a/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
@@ -1,0 +1,78 @@
+"""Persistence contracts for spaces and space membership."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import ContextManager, Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.spaces.models import (
+        SpaceMemberRecord,
+        SpaceMemberSummaryRecord,
+        SpaceRecord,
+        SpaceRole,
+        SpaceSummaryRecord,
+    )
+
+
+@runtime_checkable
+class SpaceRepositoryProtocol(Protocol):
+    @abstractmethod
+    def initialize_personal(
+        self, *, user_id: str, env: str
+    ) -> tuple[SpaceRecord, bool]: ...
+
+    @abstractmethod
+    def create_team_transaction(
+        self, *, name: str, creator_id: str, env: str
+    ) -> ContextManager[SpaceRecord]: ...
+
+    @abstractmethod
+    def get_space(self, *, space_id: int, env: str) -> SpaceRecord | None: ...
+
+    @abstractmethod
+    def list_spaces(
+        self,
+        *,
+        user_id: str,
+        env: str,
+        keyword: str | None,
+        space_type: str | None,
+        offset: int,
+        limit: int,
+    ) -> tuple[int, list[SpaceSummaryRecord]]: ...
+
+    @abstractmethod
+    def get_member(
+        self, *, space_id: int, user_id: str, env: str
+    ) -> SpaceMemberRecord | None: ...
+
+    @abstractmethod
+    def list_members(
+        self,
+        *,
+        space_id: int,
+        env: str,
+        keyword: str | None,
+        offset: int,
+        limit: int,
+    ) -> tuple[int, list[SpaceMemberSummaryRecord]]: ...
+
+    @abstractmethod
+    def add_member(
+        self,
+        *,
+        space_id: int,
+        user_id: str,
+        role: SpaceRole,
+        creator_id: str,
+        env: str,
+    ) -> SpaceMemberRecord: ...
+
+    @abstractmethod
+    def delete_member(self, *, space_id: int, user_id: str, env: str) -> bool: ...
+
+    @abstractmethod
+    def update_member_role(
+        self, *, space_id: int, user_id: str, role: SpaceRole, env: str
+    ) -> SpaceMemberRecord | None: ...

--- a/src/backend/src/agentclaw/community/core/repository/protocols/work_orders.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/work_orders.py
@@ -1,0 +1,86 @@
+"""Persistence contract for work orders and notifications."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.work_orders.models import (
+        WorkOrderDetail,
+        WorkOrderItemType,
+        WorkOrderListItem,
+        WorkOrderNotificationDetail,
+        WorkOrderNotificationDraft,
+        WorkOrderNotificationRecord,
+        WorkOrderQueryType,
+        WorkOrderRecord,
+        WorkOrderReviewResult,
+        WorkOrderStatus,
+    )
+
+
+@runtime_checkable
+class WorkOrderRepositoryProtocol(Protocol):
+    @abstractmethod
+    def create_space_join_request(
+        self,
+        *,
+        space_id: int,
+        applicant_user_id: str,
+        applicant_name: str,
+        apply_reason: str,
+        env: str,
+    ) -> WorkOrderRecord: ...
+
+    @abstractmethod
+    def list_items(
+        self,
+        *,
+        actor_id: str,
+        env: str,
+        query_type: WorkOrderQueryType,
+        item_type: WorkOrderItemType,
+        offset: int,
+        limit: int,
+    ) -> tuple[int, list[WorkOrderListItem]]: ...
+
+    @abstractmethod
+    def get_detail(
+        self, *, work_order_id: int, actor_id: str, env: str
+    ) -> WorkOrderDetail | None: ...
+
+    @abstractmethod
+    def review_space_join(
+        self,
+        *,
+        work_order_id: int,
+        reviewer_user_id: str,
+        review_remark: str,
+        target_status: WorkOrderStatus,
+        notification: WorkOrderNotificationDraft,
+        env: str,
+    ) -> WorkOrderReviewResult: ...
+
+    @abstractmethod
+    def get_notification(
+        self,
+        *,
+        notification_id: int,
+        recipient_user_id: str,
+        env: str,
+        mark_read: bool,
+    ) -> WorkOrderNotificationDetail | None: ...
+
+    @abstractmethod
+    def count_unread(self, *, recipient_user_id: str, env: str) -> int: ...
+
+    @abstractmethod
+    def mark_notification_read(
+        self, *, notification_id: int, recipient_user_id: str, env: str
+    ) -> WorkOrderNotificationRecord | None: ...
+
+    @abstractmethod
+    def mark_all_notifications_read(
+        self, *, recipient_user_id: str, env: str
+    ) -> int: ...

--- a/src/backend/src/agentclaw/community/core/spaces/README.md
+++ b/src/backend/src/agentclaw/community/core/spaces/README.md
@@ -1,0 +1,45 @@
+# `agentclaw.community.core.spaces`
+
+Owns Space lifecycle, membership, roles, and the centralized authorization rules
+used by every Space-scoped feature. Personal-space initialization and team-space
+creation persist the Space and its creator OWNER membership in one transaction.
+
+Application-only OpenAPI access is deliberately not decided here. The HTTP
+adapter inventories every operation as `AdmissionMode.REFUSED` until a
+Space-specific delegation model is approved.
+
+## Context Boundary
+
+```yaml
+purpose: "Own Space lifecycle, membership, roles, and reusable Space authorization decisions."
+provides:
+  - SpaceService
+  - SpaceMemberService
+  - SpaceAccessService
+  - SpaceModel
+  - SpaceMemberModel
+  - SpaceRecord
+  - SpaceMemberRecord
+consumes:
+  - "SpaceRepositoryProtocol (core.repository) — transactional persistence for spaces and members"
+  - "SkillCenterClient (plugin_api) — mirrors a pending team-space creation to SC before local commit"
+consumed_by:
+  - "adapters/http/openapi_v1/spaces — public Space and member operations"
+  - "core/market_favorites — Space membership authorization"
+internal_dependencies:
+  - agentclaw.community.core.base
+  - agentclaw.community.core.repository
+  - agentclaw.community.plugin_api.models
+  - agentclaw.community.plugin_api.skill_center_client
+  - agentclaw.community.utils.avernet_tenant_guard
+  - agentclaw.community.utils.env_utils
+```
+
+### Change impact
+
+Team-space creation keeps its OB transaction open until required Skill Center
+team creation succeeds; a Skill Center failure rolls the local rows back.
+Role and creator invariants are authorization rules. Changes affect every
+Space-scoped feature, not only member management. The tenant column, tenant
+guard registration, and tenant-leading unique keys are one isolation mechanism
+and must change together.

--- a/src/backend/src/agentclaw/community/core/spaces/__init__.py
+++ b/src/backend/src/agentclaw/community/core/spaces/__init__.py
@@ -1,0 +1,1 @@
+"""Space and member bounded context."""

--- a/src/backend/src/agentclaw/community/core/spaces/errors.py
+++ b/src/backend/src/agentclaw/community/core/spaces/errors.py
@@ -1,0 +1,41 @@
+"""Domain errors for spaces and members."""
+
+
+class SpaceError(RuntimeError):
+    """Base class for space-domain failures."""
+
+
+class SpaceNotFoundError(SpaceError):
+    pass
+
+
+class SpaceAccessDeniedError(SpaceError):
+    pass
+
+
+class SpaceNameInvalidError(SpaceError):
+    pass
+
+
+class SpaceAlreadyExistsError(SpaceError):
+    pass
+
+
+class SpaceMemberAlreadyExistsError(SpaceError):
+    pass
+
+
+class SpaceMemberInvalidError(SpaceError):
+    pass
+
+
+class SpaceMemberNotFoundError(SpaceError):
+    pass
+
+
+class SpaceCreatorInvariantError(SpaceError):
+    pass
+
+
+class PersonalSpaceInvariantError(SpaceError):
+    pass

--- a/src/backend/src/agentclaw/community/core/spaces/models.py
+++ b/src/backend/src/agentclaw/community/core/spaces/models.py
@@ -1,0 +1,62 @@
+"""Domain records and enums for spaces and space membership."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class SpaceType(StrEnum):
+    PERSONAL = "PERSONAL"
+    TEAM = "TEAM"
+
+
+class SpaceRole(StrEnum):
+    OWNER = "OWNER"
+    MEMBER = "MEMBER"
+
+
+class SpaceJoinStatus(StrEnum):
+    JOINED = "JOINED"
+    APPLYING = "APPLYING"
+    NOT_JOINED = "NOT_JOINED"
+
+
+class SpaceRecord(BaseModel):
+    id: int
+    space_code: str
+    space_type: SpaceType
+    name: str
+    personal_owner_id: str | None
+    sc_team_id: str | None = None
+    env: str
+    created_by: str
+    updated_by: str
+    gmt_created: datetime
+    gmt_modified: datetime
+
+
+class SpaceMemberRecord(BaseModel):
+    id: int
+    space_id: int
+    user_id: str
+    role: SpaceRole
+    env: str
+    created_by: str
+    gmt_created: datetime
+    gmt_modified: datetime
+
+
+class SpaceSummaryRecord(BaseModel):
+    space: SpaceRecord
+    current_user_role: SpaceRole | None
+    join_status: SpaceJoinStatus
+    member_count: int
+    owner_count: int
+
+
+class SpaceMemberSummaryRecord(BaseModel):
+    member: SpaceMemberRecord
+    is_creator: bool

--- a/src/backend/src/agentclaw/community/core/spaces/models.py
+++ b/src/backend/src/agentclaw/community/core/spaces/models.py
@@ -60,3 +60,11 @@ class SpaceSummaryRecord(BaseModel):
 class SpaceMemberSummaryRecord(BaseModel):
     member: SpaceMemberRecord
     is_creator: bool
+    user_name: str | None = None
+    display_name: str | None = None
+
+
+class PersonalSpaceLookupRecord(BaseModel):
+    user_id: str
+    space_id: int | None
+    found: bool

--- a/src/backend/src/agentclaw/community/core/spaces/repository/__init__.py
+++ b/src/backend/src/agentclaw/community/core/spaces/repository/__init__.py
@@ -1,0 +1,3 @@
+from .models import SpaceMemberModel, SpaceModel
+
+__all__ = ["SpaceMemberModel", "SpaceModel"]

--- a/src/backend/src/agentclaw/community/core/spaces/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/spaces/repository/models.py
@@ -1,0 +1,115 @@
+"""SQLAlchemy models for ``ac_space`` and ``ac_space_member``."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Index, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.spaces.models import (
+    SpaceMemberRecord,
+    SpaceRecord,
+    SpaceRole,
+    SpaceType,
+)
+from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class SpaceModel(Base):
+    __tablename__ = "ac_space"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    space_code = Column(String(64), nullable=False)
+    space_type = Column(String(32), nullable=False)
+    name = Column(String(128), nullable=False)
+    personal_owner_id = Column(String(256), nullable=True)
+    sc_team_id = Column(String(64), nullable=True)
+    env = Column(String(20), nullable=False, default=get_current_env)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    created_by = Column(String(256), nullable=False)
+    updated_by = Column(String(256), nullable=False)
+    gmt_created = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant", "space_code", "env", name="uk_space_code_env"
+        ),
+        UniqueConstraint(
+            "avernet_tenant",
+            "personal_owner_id",
+            "env",
+            name="uk_space_personal_owner_env",
+        ),
+        UniqueConstraint("sc_team_id", "env", name="uk_sc_team_id_env"),
+        Index("idx_space_type_env", "avernet_tenant", "space_type", "env"),
+    )
+
+    def to_record(self) -> SpaceRecord:
+        return SpaceRecord(
+            id=self.id,
+            space_code=self.space_code,
+            space_type=SpaceType(self.space_type),
+            name=self.name,
+            personal_owner_id=self.personal_owner_id,
+            sc_team_id=self.sc_team_id,
+            env=self.env,
+            created_by=self.created_by,
+            updated_by=self.updated_by,
+            gmt_created=self.gmt_created,
+            gmt_modified=self.gmt_modified,
+        )
+
+
+class SpaceMemberModel(Base):
+    __tablename__ = "ac_space_member"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    space_id = Column(AutoIncrementBigInteger, nullable=False)
+    user_id = Column(String(256), nullable=False)
+    role = Column(String(32), nullable=False)
+    env = Column(String(20), nullable=False, default=get_current_env)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    created_by = Column(String(256), nullable=False)
+    gmt_created = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant",
+            "space_id",
+            "user_id",
+            "env",
+            name="uk_space_member_user_env",
+        ),
+        Index("idx_space_member_user", "avernet_tenant", "user_id", "env"),
+        Index(
+            "idx_space_member_role",
+            "avernet_tenant",
+            "space_id",
+            "role",
+            "env",
+        ),
+    )
+
+    def to_record(self) -> SpaceMemberRecord:
+        return SpaceMemberRecord(
+            id=self.id,
+            space_id=self.space_id,
+            user_id=self.user_id,
+            role=SpaceRole(self.role),
+            env=self.env,
+            created_by=self.created_by,
+            gmt_created=self.gmt_created,
+            gmt_modified=self.gmt_modified,
+        )
+
+
+register_avernet_tenant_guard(SpaceModel)
+register_avernet_tenant_guard(SpaceMemberModel)

--- a/src/backend/src/agentclaw/community/core/spaces/services/__init__.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/__init__.py
@@ -1,0 +1,5 @@
+from .space_access_service import SpaceAccessService
+from .space_member_service import SpaceMemberService
+from .space_service import SpaceService
+
+__all__ = ["SpaceAccessService", "SpaceMemberService", "SpaceService"]

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_access_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_access_service.py
@@ -1,0 +1,52 @@
+"""Central authorization rules for space-scoped operations."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNotFoundError,
+)
+from agentclaw.community.core.spaces.models import SpaceRole
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class SpaceAccessService:
+    @inject
+    def __init__(self, repository: SpaceRepositoryProtocol) -> None:
+        self._repository = repository
+
+    def require_space(self, *, space_id: int):
+        space = self._repository.get_space(space_id=space_id, env=get_current_env())
+        if space is None:
+            raise SpaceNotFoundError("space not found")
+        return space
+
+    def get_space_role(self, *, space_id: int, user_id: str) -> SpaceRole | None:
+        member = self._repository.get_member(
+            space_id=space_id, user_id=user_id, env=get_current_env()
+        )
+        return member.role if member is not None else None
+
+    def require_space_member(self, *, space_id: int, user_id: str):
+        space = self.require_space(space_id=space_id)
+        member = self._repository.get_member(
+            space_id=space_id, user_id=user_id, env=get_current_env()
+        )
+        if member is None:
+            raise SpaceAccessDeniedError("space membership required")
+        return space, member
+
+    def require_space_owner(self, *, space_id: int, user_id: str):
+        space, member = self.require_space_member(space_id=space_id, user_id=user_id)
+        if member.role is not SpaceRole.OWNER:
+            raise SpaceAccessDeniedError("space owner role required")
+        return space, member
+
+    def require_space_creator(self, *, space_id: int, user_id: str):
+        space = self.require_space(space_id=space_id)
+        if space.created_by != user_id:
+            raise SpaceAccessDeniedError("space creator required")
+        return space

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -1,0 +1,120 @@
+"""Space member management service."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.spaces.errors import (
+    PersonalSpaceInvariantError,
+    SpaceCreatorInvariantError,
+    SpaceMemberAlreadyExistsError,
+    SpaceMemberInvalidError,
+    SpaceMemberNotFoundError,
+)
+from agentclaw.community.core.spaces.models import (
+    SpaceMemberRecord,
+    SpaceMemberSummaryRecord,
+    SpaceRole,
+    SpaceType,
+)
+from agentclaw.community.core.spaces.services.space_access_service import (
+    SpaceAccessService,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class SpaceMemberService:
+    @staticmethod
+    def _user_id(value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise SpaceMemberInvalidError("member user id is empty")
+        return normalized
+
+    @inject
+    def __init__(
+        self,
+        repository: SpaceRepositoryProtocol,
+        access: SpaceAccessService,
+    ) -> None:
+        self._repository = repository
+        self._access = access
+
+    def list_members(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        keyword: str | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[SpaceMemberSummaryRecord]]:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        return self._repository.list_members(
+            space_id=space_id,
+            env=get_current_env(),
+            keyword=keyword.strip() if keyword and keyword.strip() else None,
+            offset=(page_no - 1) * page_size,
+            limit=page_size,
+        )
+
+    def add_member(
+        self,
+        *,
+        space_id: int,
+        actor_id: str,
+        user_id: str,
+        role: SpaceRole,
+    ) -> SpaceMemberRecord:
+        space, _ = self._access.require_space_owner(space_id=space_id, user_id=actor_id)
+        if space.space_type is SpaceType.PERSONAL:
+            raise PersonalSpaceInvariantError("personal space cannot add members")
+        normalized = self._user_id(user_id)
+        if (
+            self._repository.get_member(
+                space_id=space_id, user_id=normalized, env=get_current_env()
+            )
+            is not None
+        ):
+            raise SpaceMemberAlreadyExistsError("space member already exists")
+        return self._repository.add_member(
+            space_id=space_id,
+            user_id=normalized,
+            role=role,
+            creator_id=actor_id,
+            env=get_current_env(),
+        )
+
+    def delete_member(self, *, space_id: int, actor_id: str, user_id: str) -> bool:
+        space, _ = self._access.require_space_owner(space_id=space_id, user_id=actor_id)
+        normalized = self._user_id(user_id)
+        if normalized == space.created_by:
+            raise SpaceCreatorInvariantError("space creator cannot be removed")
+        deleted = self._repository.delete_member(
+            space_id=space_id, user_id=normalized, env=get_current_env()
+        )
+        if not deleted:
+            raise SpaceMemberNotFoundError("space member not found")
+        return True
+
+    def update_role(
+        self, *, space_id: int, actor_id: str, user_id: str, role: SpaceRole
+    ) -> SpaceMemberSummaryRecord:
+        space, _ = self._access.require_space_owner(space_id=space_id, user_id=actor_id)
+        if space.space_type is SpaceType.PERSONAL:
+            raise PersonalSpaceInvariantError("personal space role is immutable")
+        normalized = self._user_id(user_id)
+        if normalized == space.created_by and role is not SpaceRole.OWNER:
+            raise SpaceCreatorInvariantError("space creator cannot be demoted")
+        updated = self._repository.update_member_role(
+            space_id=space_id,
+            user_id=normalized,
+            role=role,
+            env=get_current_env(),
+        )
+        if updated is None:
+            raise SpaceMemberNotFoundError("space member not found")
+        return SpaceMemberSummaryRecord(
+            member=updated, is_creator=updated.user_id == space.created_by
+        )

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
@@ -1,0 +1,69 @@
+"""Space lifecycle service."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.spaces.errors import SpaceNameInvalidError
+from agentclaw.community.core.spaces.models import (
+    SpaceRecord,
+    SpaceSummaryRecord,
+    SpaceType,
+)
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterClient,
+    SkillCenterTeamCreateRequest,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class SpaceService:
+    @inject
+    def __init__(
+        self,
+        repository: SpaceRepositoryProtocol,
+        skill_center_client: SkillCenterClient,
+    ) -> None:
+        self._repository = repository
+        self._skill_center_client = skill_center_client
+
+    def initialize_personal(self, *, user_id: str) -> tuple[SpaceRecord, bool]:
+        return self._repository.initialize_personal(
+            user_id=user_id, env=get_current_env()
+        )
+
+    def create_team(self, *, name: str, creator_id: str) -> SpaceRecord:
+        normalized = name.strip()
+        if not normalized or len(normalized) > 128:
+            raise SpaceNameInvalidError("space name must contain 1-128 characters")
+        with self._repository.create_team_transaction(
+            name=normalized, creator_id=creator_id, env=get_current_env()
+        ) as record:
+            result = self._skill_center_client.create_team(
+                SkillCenterTeamCreateRequest(
+                    team_code=record.space_code,
+                    team_name=record.name,
+                    ref_source_id=str(record.id),
+                )
+            )
+            record.sc_team_id = result.team_id
+        return record
+
+    def list_spaces(
+        self,
+        *,
+        user_id: str,
+        keyword: str | None,
+        space_type: SpaceType | None,
+        page_no: int,
+        page_size: int,
+    ) -> tuple[int, list[SpaceSummaryRecord]]:
+        return self._repository.list_spaces(
+            user_id=user_id,
+            env=get_current_env(),
+            keyword=keyword.strip() if keyword and keyword.strip() else None,
+            space_type=space_type.value if space_type is not None else None,
+            offset=(page_no - 1) * page_size,
+            limit=page_size,
+        )

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
@@ -7,6 +7,7 @@ from injector import inject
 from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
 from agentclaw.community.core.spaces.errors import SpaceNameInvalidError
 from agentclaw.community.core.spaces.models import (
+    PersonalSpaceLookupRecord,
     SpaceRecord,
     SpaceSummaryRecord,
     SpaceType,
@@ -31,6 +32,26 @@ class SpaceService:
     def initialize_personal(self, *, user_id: str) -> tuple[SpaceRecord, bool]:
         return self._repository.initialize_personal(
             user_id=user_id, env=get_current_env()
+        )
+
+    def batch_query_personal(
+        self, *, user_ids: list[str]
+    ) -> list[PersonalSpaceLookupRecord]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for user_id in user_ids:
+            value = user_id.strip()
+            if not value:
+                raise ValueError("user_id must not contain blank values")
+            if value not in seen:
+                seen.add(value)
+                normalized.append(value)
+        if not normalized:
+            raise ValueError("user_id must not be empty")
+        if len(normalized) > 500:
+            raise ValueError("user_id must contain at most 500 unique values")
+        return self._repository.batch_query_personal(
+            user_ids=normalized, env=get_current_env()
         )
 
     def create_team(self, *, name: str, creator_id: str) -> SpaceRecord:

--- a/src/backend/src/agentclaw/community/core/spaces/sql/2026_08_17_spaces.sql
+++ b/src/backend/src/agentclaw/community/core/spaces/sql/2026_08_17_spaces.sql
@@ -1,0 +1,34 @@
+-- Space and member foundation for the Skill Space refactor.
+CREATE TABLE IF NOT EXISTS ac_space (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    space_code VARCHAR(64) NOT NULL,
+    space_type VARCHAR(32) NOT NULL COMMENT 'PERSONAL | TEAM',
+    name VARCHAR(128) NOT NULL,
+    personal_owner_id VARCHAR(256) NULL,
+    env VARCHAR(20) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    created_by VARCHAR(256) NOT NULL,
+    updated_by VARCHAR(256) NOT NULL,
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_space_code_env (avernet_tenant, space_code, env),
+    UNIQUE KEY uk_space_personal_owner_env (avernet_tenant, personal_owner_id, env),
+    KEY idx_space_type_env (avernet_tenant, space_type, env)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_space_member (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    space_id BIGINT UNSIGNED NOT NULL,
+    user_id VARCHAR(256) NOT NULL,
+    role VARCHAR(32) NOT NULL COMMENT 'OWNER | MEMBER',
+    env VARCHAR(20) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    created_by VARCHAR(256) NOT NULL,
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_space_member_user_env (avernet_tenant, space_id, user_id, env),
+    KEY idx_space_member_user (avernet_tenant, user_id, env),
+    KEY idx_space_member_role (avernet_tenant, space_id, role, env)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/backend/src/agentclaw/community/core/work_orders/README.md
+++ b/src/backend/src/agentclaw/community/core/work_orders/README.md
@@ -1,0 +1,106 @@
+# `agentclaw.community.core.work_orders`
+
+Owns work-order lifecycle, recipient-scoped notifications, fixed event-to-message
+mapping, conditional approval transitions, and the atomic Space-join approval
+unit of work.
+
+## Context Boundary
+
+```yaml
+purpose: "Own approval work orders, recipient notifications, and transactional Space-join decisions."
+provides:
+  - WorkOrderService
+  - WorkOrderNotificationService
+  - WorkOrderModel
+  - WorkOrderNotificationModel
+  - WorkOrderStatus
+  - WorkOrderBizType
+  - WorkOrderEventType
+  - NotificationCategory
+  - WorkOrderQueryType
+  - WorkOrderItemType
+  - WorkOrderMessageTitle
+  - WorkOrderMessageContent
+  - WorkOrderNotificationDetail
+consumes:
+  - "WorkOrderRepositoryProtocol (core.repository) — persistence and transactional state changes"
+  - "SpaceRepositoryProtocol and SpaceAccessService — Space existence, membership, and OWNER authorization"
+consumed_by:
+  - "adapters/http/openapi_v1/work_orders — public work-order and notification operations"
+internal_dependencies:
+  - agentclaw.community.core.base
+  - agentclaw.community.core.repository
+  - agentclaw.community.core.spaces
+  - agentclaw.community.plugin_api.models
+  - agentclaw.community.utils.avernet_tenant_guard
+  - agentclaw.community.utils.env_utils
+```
+
+### Change impact
+
+Event values, statuses, titles, and content templates are persisted public
+semantics. Rename or wording changes require coordinated client and data
+compatibility review. Approval, membership creation, and result-notification
+creation are one transaction and must not be split across best-effort writes.
+
+## Stable enum contract
+
+The following values are wire or persistence contracts. They must not be
+renamed, repurposed, or written with values outside their enum without a data
+and client compatibility plan.
+
+| Contract | Values |
+| --- | --- |
+| Work-order status | `PENDING`, `APPROVED`, `REJECTED` |
+| Persisted notification category | `APPROVAL`, `NOTICE` |
+| List category filter | `ALL`, `APPROVAL`, `NOTICE` |
+| List query type | `PENDING_FOR_ME`, `INITIATED_BY_ME`, `PROCESSED_BY_ME` |
+| Supported business type | `SPACE_JOIN` |
+
+`ALL` is a query-only filter and must never be persisted as a notification
+category. `WorkOrderEventType` is also a persisted whitelist. This phase
+implements only the `SPACE_JOIN` handler; the remaining event values reserve
+the names defined by the system design for later business handlers.
+
+## Space-join message templates
+
+Titles and content are generated only from `WorkOrderMessageTitle` and
+`WorkOrderMessageContent`, then the final rendered text is stored on the
+notification row. Clients display the stored text directly.
+
+| Scenario | Event | Category | Title | Content |
+| --- | --- | --- | --- | --- |
+| Waiting for review | `SPACE_JOIN_APPLIED` | `APPROVAL` | `空间加入申请待审批` | `用户「{applicant_name}」申请加入空间「{space_name}」，请及时处理。` |
+| Approved | `SPACE_JOIN_REVIEWED` | `NOTICE` | `空间加入申请已通过` | `你加入空间「{space_name}」的申请已通过。` |
+| Rejected | `SPACE_JOIN_REVIEWED` | `NOTICE` | `空间加入申请未通过` | `你加入空间「{space_name}」的申请未通过。拒绝原因：{review_remark}` |
+| Added directly | `SPACE_MEMBER_ADDED` | `NOTICE` | `你已被添加到空间` | `你已被添加到空间「{space_name}」。` |
+
+`SPACE_JOIN_REVIEWED` deliberately uses one event value for both outcomes;
+the associated work-order status selects the approved or rejected template.
+
+## OpenAPI error contract
+
+The OpenAPI adapter maps only concrete work-order exceptions. Public messages
+are fixed strings and must never be replaced with `str(exc)`, because exception
+text may contain internal identifiers or implementation details. Access to a
+notification belonging to another recipient is deliberately indistinguishable
+from an absent notification.
+
+| Business code | HTTP | Exception | Fixed public message |
+| --- | --- | --- | --- |
+| `400201` | 400 | `WorkOrderInvalidReasonError` | `Invalid application reason` |
+| `400202` | 400 | `WorkOrderInvalidRemarkError` | `Invalid review remark` |
+| `403201` | 403 | `WorkOrderAccessDeniedError` | `Forbidden` |
+| `404201` | 404 | `WorkOrderNotFoundError` | `Not found` |
+| `404202` | 404 | `WorkOrderNotificationNotFoundError` | `Not found` |
+| `409201` | 409 | `WorkOrderAlreadyPendingError` | `A pending application already exists` |
+| `409202` | 409 | `WorkOrderAlreadyProcessedError` | `The work order has already been processed` |
+| `409203` | 409 | `WorkOrderApplicantAlreadyMemberError` | `Applicant is already a space member` |
+| `409204` | 409 | `WorkOrderNoReviewerError` | `The space has no available approver` |
+| `409205` | 409 | `WorkOrderJoinNotAllowedError` | `The space does not accept join requests` |
+
+The numeric codes and fixed messages are enums in
+`adapters/http/openapi_v1/errors_work_order.py`; the centralized
+`responses.py` mapping binds those values to concrete domain exceptions.
+Changing either value is an OpenAPI contract change rather than an internal
+refactor.

--- a/src/backend/src/agentclaw/community/core/work_orders/__init__.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/__init__.py
@@ -1,0 +1,1 @@
+"""Work-order and recipient-scoped notification bounded context."""

--- a/src/backend/src/agentclaw/community/core/work_orders/errors.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/errors.py
@@ -1,0 +1,45 @@
+"""Leaf failures exposed by the work-order Service API."""
+
+
+class WorkOrderError(RuntimeError):
+    """Base class for work-order failures."""
+
+
+class WorkOrderNotFoundError(WorkOrderError):
+    pass
+
+
+class WorkOrderNotificationNotFoundError(WorkOrderError):
+    pass
+
+
+class WorkOrderAccessDeniedError(WorkOrderError):
+    pass
+
+
+class WorkOrderInvalidReasonError(WorkOrderError):
+    pass
+
+
+class WorkOrderInvalidRemarkError(WorkOrderError):
+    pass
+
+
+class WorkOrderAlreadyPendingError(WorkOrderError):
+    pass
+
+
+class WorkOrderAlreadyProcessedError(WorkOrderError):
+    pass
+
+
+class WorkOrderApplicantAlreadyMemberError(WorkOrderError):
+    pass
+
+
+class WorkOrderJoinNotAllowedError(WorkOrderError):
+    pass
+
+
+class WorkOrderNoReviewerError(WorkOrderError):
+    pass

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -1,0 +1,161 @@
+"""Domain records, persisted enums, query enums and message templates."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class WorkOrderStatus(StrEnum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+
+
+class WorkOrderBizType(StrEnum):
+    SPACE_JOIN = "SPACE_JOIN"
+
+
+class NotificationCategory(StrEnum):
+    APPROVAL = "APPROVAL"
+    NOTICE = "NOTICE"
+
+
+class WorkOrderQueryType(StrEnum):
+    PENDING_FOR_ME = "PENDING_FOR_ME"
+    INITIATED_BY_ME = "INITIATED_BY_ME"
+    PROCESSED_BY_ME = "PROCESSED_BY_ME"
+
+
+class WorkOrderItemType(StrEnum):
+    ALL = "ALL"
+    APPROVAL = "APPROVAL"
+    NOTICE = "NOTICE"
+
+
+class WorkOrderEventType(StrEnum):
+    SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
+    SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
+    SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
+    BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
+    BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
+    BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
+    HUMAN2BOT_FRIEND_APPLIED = "HUMAN2BOT_FRIEND_APPLIED"
+    HUMAN2BOT_FRIEND_REVIEWED = "HUMAN2BOT_FRIEND_REVIEWED"
+    BOT2BOT_FRIEND_APPLIED = "BOT2BOT_FRIEND_APPLIED"
+    BOT2BOT_FRIEND_REVIEWED = "BOT2BOT_FRIEND_REVIEWED"
+    HUMAN2BOT_PUBLIC_ORDER_CREATED = "HUMAN2BOT_PUBLIC_ORDER_CREATED"
+    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
+    BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
+    BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+
+
+EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
+    WorkOrderEventType.SPACE_JOIN_APPLIED: NotificationCategory.APPROVAL,
+    WorkOrderEventType.SPACE_JOIN_REVIEWED: NotificationCategory.NOTICE,
+    WorkOrderEventType.SPACE_MEMBER_ADDED: NotificationCategory.NOTICE,
+    WorkOrderEventType.BOT_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
+    WorkOrderEventType.BOT_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
+    WorkOrderEventType.BOT_MEMBER_ADDED: NotificationCategory.NOTICE,
+    WorkOrderEventType.HUMAN2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
+    WorkOrderEventType.HUMAN2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
+    WorkOrderEventType.BOT2BOT_FRIEND_APPLIED: NotificationCategory.APPROVAL,
+    WorkOrderEventType.BOT2BOT_FRIEND_REVIEWED: NotificationCategory.NOTICE,
+    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
+    WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
+    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
+    WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
+}
+
+
+class WorkOrderMessageTitle(StrEnum):
+    SPACE_JOIN_PENDING = "空间加入申请待审批"
+    SPACE_JOIN_APPROVED = "空间加入申请已通过"
+    SPACE_JOIN_REJECTED = "空间加入申请未通过"
+    SPACE_MEMBER_ADDED = "你已被添加到空间"
+
+
+class WorkOrderMessageContent(StrEnum):
+    SPACE_JOIN_PENDING = (
+        "用户「{applicant_name}」申请加入空间「{space_name}」，请及时处理。"
+    )
+    SPACE_JOIN_APPROVED = "你加入空间「{space_name}」的申请已通过。"
+    SPACE_JOIN_REJECTED = (
+        "你加入空间「{space_name}」的申请未通过。拒绝原因：{review_remark}"
+    )
+    SPACE_MEMBER_ADDED = "你已被添加到空间「{space_name}」。"
+
+
+class WorkOrderRecord(BaseModel):
+    id: int
+    work_order_no: str
+    biz_type: WorkOrderBizType
+    biz_id: str
+    applicant_user_id: str
+    apply_reason: str | None
+    status: WorkOrderStatus
+    reviewer_user_id: str | None
+    review_remark: str | None
+    reviewed_at: datetime | None
+    env: str
+    gmt_created: datetime
+    gmt_modified: datetime
+
+
+class WorkOrderNotificationRecord(BaseModel):
+    id: int
+    work_order_id: int | None
+    recipient_user_id: str
+    notification_category: NotificationCategory
+    event_type: WorkOrderEventType
+    biz_type: WorkOrderBizType
+    biz_id: str
+    title: str
+    content: str | None
+    is_read: bool
+    read_at: datetime | None
+    env: str
+    gmt_created: datetime
+    gmt_modified: datetime
+
+
+class WorkOrderNotificationDraft(BaseModel):
+    recipient_user_id: str
+    notification_category: NotificationCategory
+    event_type: WorkOrderEventType
+    biz_type: WorkOrderBizType
+    biz_id: str
+    title: str
+    content: str
+
+
+class WorkOrderNotificationDetail(BaseModel):
+    notification: WorkOrderNotificationRecord
+    work_order_status: WorkOrderStatus | None
+    can_approve: bool
+
+
+class WorkOrderListItem(BaseModel):
+    work_order: WorkOrderRecord
+    notification: WorkOrderNotificationRecord | None
+    can_approve: bool
+
+
+class WorkOrderDetail(BaseModel):
+    work_order: WorkOrderRecord
+    event_type: WorkOrderEventType
+    title: str
+    space_id: int
+    space_name: str
+    applicant_name: str
+    can_approve: bool
+
+
+class WorkOrderReviewResult(BaseModel):
+    work_order_id: int
+    status: WorkOrderStatus
+    reviewer_user_id: str
+    review_remark: str
+    reviewed_at: datetime

--- a/src/backend/src/agentclaw/community/core/work_orders/repository/__init__.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/repository/__init__.py
@@ -1,0 +1,1 @@
+"""ORM declarations owned by the work-order domain."""

--- a/src/backend/src/agentclaw/community/core/work_orders/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/repository/models.py
@@ -1,0 +1,155 @@
+"""SQLAlchemy models for work orders and recipient notifications."""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Column, DateTime, Index, String, Text, UniqueConstraint
+from sqlalchemy.sql import func
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderEventType,
+    WorkOrderNotificationRecord,
+    WorkOrderRecord,
+    WorkOrderStatus,
+)
+from agentclaw.community.plugin_api.models import AutoIncrementBigInteger
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class WorkOrderModel(Base):
+    __tablename__ = "ac_work_order"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    work_order_no = Column(String(64), nullable=False)
+    biz_type = Column(String(64), nullable=False)
+    biz_id = Column(String(128), nullable=False)
+    applicant_user_id = Column(String(256), nullable=False)
+    apply_reason = Column(String(512), nullable=True)
+    status = Column(String(32), nullable=False)
+    reviewer_user_id = Column(String(256), nullable=True)
+    review_remark = Column(String(512), nullable=True)
+    reviewed_at = Column(DateTime, nullable=True)
+    env = Column(String(20), nullable=False, default=get_current_env)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    gmt_created = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant", "work_order_no", "env", name="uk_work_order_no_env"
+        ),
+        Index(
+            "idx_work_order_applicant_status_env",
+            "avernet_tenant",
+            "applicant_user_id",
+            "status",
+            "env",
+        ),
+        Index(
+            "idx_work_order_reviewer_status_env",
+            "avernet_tenant",
+            "reviewer_user_id",
+            "status",
+            "env",
+        ),
+        Index(
+            "idx_work_order_biz_status_env",
+            "avernet_tenant",
+            "biz_type",
+            "biz_id",
+            "status",
+            "env",
+        ),
+    )
+
+    def to_record(self) -> WorkOrderRecord:
+        return WorkOrderRecord(
+            id=self.id,
+            work_order_no=self.work_order_no,
+            biz_type=WorkOrderBizType(self.biz_type),
+            biz_id=self.biz_id,
+            applicant_user_id=self.applicant_user_id,
+            apply_reason=self.apply_reason,
+            status=WorkOrderStatus(self.status),
+            reviewer_user_id=self.reviewer_user_id,
+            review_remark=self.review_remark,
+            reviewed_at=self.reviewed_at,
+            env=self.env,
+            gmt_created=self.gmt_created,
+            gmt_modified=self.gmt_modified,
+        )
+
+
+class WorkOrderNotificationModel(Base):
+    __tablename__ = "ac_work_order_notification"
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    work_order_id = Column(AutoIncrementBigInteger, nullable=True)
+    recipient_user_id = Column(String(256), nullable=False)
+    notification_category = Column(String(32), nullable=False)
+    event_type = Column(String(64), nullable=False)
+    biz_type = Column(String(64), nullable=False)
+    biz_id = Column(String(128), nullable=False)
+    title = Column(String(256), nullable=False)
+    content = Column(Text, nullable=True)
+    is_read = Column(Boolean, nullable=False, default=False, server_default="0")
+    read_at = Column(DateTime, nullable=True)
+    env = Column(String(20), nullable=False, default=get_current_env)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    gmt_created = Column(DateTime, nullable=False, server_default=func.now())
+    gmt_modified = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_work_order_notification_recipient_read",
+            "avernet_tenant",
+            "recipient_user_id",
+            "is_read",
+            "env",
+            "gmt_modified",
+        ),
+        Index(
+            "idx_work_order_notification_work_order",
+            "avernet_tenant",
+            "work_order_id",
+            "recipient_user_id",
+            "env",
+        ),
+        Index(
+            "idx_work_order_notification_biz",
+            "avernet_tenant",
+            "biz_type",
+            "biz_id",
+            "recipient_user_id",
+            "env",
+        ),
+    )
+
+    def to_record(self) -> WorkOrderNotificationRecord:
+        return WorkOrderNotificationRecord(
+            id=self.id,
+            work_order_id=self.work_order_id,
+            recipient_user_id=self.recipient_user_id,
+            notification_category=NotificationCategory(self.notification_category),
+            event_type=WorkOrderEventType(self.event_type),
+            biz_type=WorkOrderBizType(self.biz_type),
+            biz_id=self.biz_id,
+            title=self.title,
+            content=self.content,
+            is_read=bool(self.is_read),
+            read_at=self.read_at,
+            env=self.env,
+            gmt_created=self.gmt_created,
+            gmt_modified=self.gmt_modified,
+        )
+
+
+register_avernet_tenant_guard(WorkOrderModel)
+register_avernet_tenant_guard(WorkOrderNotificationModel)

--- a/src/backend/src/agentclaw/community/core/work_orders/services/__init__.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/__init__.py
@@ -1,0 +1,3 @@
+from .work_order_service import WorkOrderNotificationService, WorkOrderService
+
+__all__ = ["WorkOrderNotificationService", "WorkOrderService"]

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -1,0 +1,231 @@
+"""Transport-agnostic work-order orchestration and authorization."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.repository.protocols.work_orders import (
+    WorkOrderRepositoryProtocol,
+)
+from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
+from agentclaw.community.core.spaces.models import SpaceType
+from agentclaw.community.core.spaces.services.space_access_service import (
+    SpaceAccessService,
+)
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAccessDeniedError,
+    WorkOrderApplicantAlreadyMemberError,
+    WorkOrderInvalidReasonError,
+    WorkOrderInvalidRemarkError,
+    WorkOrderJoinNotAllowedError,
+    WorkOrderNotificationNotFoundError,
+    WorkOrderNotFoundError,
+)
+from agentclaw.community.core.work_orders.models import (
+    EVENT_CATEGORIES,
+    WorkOrderDetail,
+    WorkOrderEventType,
+    WorkOrderItemType,
+    WorkOrderMessageContent,
+    WorkOrderMessageTitle,
+    WorkOrderNotificationDraft,
+    WorkOrderQueryType,
+    WorkOrderStatus,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class WorkOrderService:
+    @inject
+    def __init__(
+        self,
+        repository: WorkOrderRepositoryProtocol,
+        spaces: SpaceRepositoryProtocol,
+        access: SpaceAccessService,
+        notifications: WorkOrderNotificationService,
+    ) -> None:
+        self._repository = repository
+        self._spaces = spaces
+        self._access = access
+        self._notifications = notifications
+
+    @staticmethod
+    def _required_text(value: str, *, limit: int, error: type[Exception]) -> str:
+        normalized = value.strip()
+        if not normalized or len(normalized) > limit:
+            raise error(f"value must contain 1-{limit} characters")
+        return normalized
+
+    def create_space_join_request(
+        self, *, space_id: int, applicant_user_id: str, reason: str
+    ):
+        reason = self._required_text(
+            reason, limit=512, error=WorkOrderInvalidReasonError
+        )
+        space = self._access.require_space(space_id=space_id)
+        if space.space_type is not SpaceType.TEAM:
+            raise WorkOrderJoinNotAllowedError(
+                "personal spaces do not accept join requests"
+            )
+        if (
+            self._spaces.get_member(
+                space_id=space_id,
+                user_id=applicant_user_id,
+                env=get_current_env(),
+            )
+            is not None
+        ):
+            raise WorkOrderApplicantAlreadyMemberError(
+                "applicant is already a space member"
+            )
+        return self._repository.create_space_join_request(
+            space_id=space_id,
+            applicant_user_id=applicant_user_id,
+            applicant_name=applicant_user_id,
+            apply_reason=reason,
+            env=get_current_env(),
+        )
+
+    def list_items(
+        self,
+        *,
+        actor_id: str,
+        query_type: WorkOrderQueryType,
+        item_type: WorkOrderItemType,
+        page_no: int,
+        page_size: int,
+    ):
+        return self._repository.list_items(
+            actor_id=actor_id,
+            env=get_current_env(),
+            query_type=query_type,
+            item_type=item_type,
+            offset=(page_no - 1) * page_size,
+            limit=page_size,
+        )
+
+    def get_detail(self, *, work_order_id: int, actor_id: str):
+        detail = self._repository.get_detail(
+            work_order_id=work_order_id,
+            actor_id=actor_id,
+            env=get_current_env(),
+        )
+        if detail is None:
+            raise WorkOrderNotFoundError("work order not found")
+        return detail
+
+    def approve(self, *, work_order_id: int, actor_id: str, review_remark: str):
+        return self._review(
+            work_order_id=work_order_id,
+            actor_id=actor_id,
+            review_remark=review_remark,
+            target_status=WorkOrderStatus.APPROVED,
+        )
+
+    def reject(self, *, work_order_id: int, actor_id: str, review_remark: str):
+        return self._review(
+            work_order_id=work_order_id,
+            actor_id=actor_id,
+            review_remark=review_remark,
+            target_status=WorkOrderStatus.REJECTED,
+        )
+
+    def _review(
+        self,
+        *,
+        work_order_id: int,
+        actor_id: str,
+        review_remark: str,
+        target_status: WorkOrderStatus,
+    ):
+        remark = self._required_text(
+            review_remark, limit=512, error=WorkOrderInvalidRemarkError
+        )
+        detail = self.get_detail(work_order_id=work_order_id, actor_id=actor_id)
+        try:
+            self._access.require_space_owner(space_id=detail.space_id, user_id=actor_id)
+        except SpaceAccessDeniedError as exc:
+            raise WorkOrderAccessDeniedError("space owner role required") from exc
+        notification = self._notifications.build_space_join_review_result(
+            detail=detail,
+            target_status=target_status,
+            review_remark=remark,
+        )
+        return self._repository.review_space_join(
+            work_order_id=work_order_id,
+            reviewer_user_id=actor_id,
+            review_remark=remark,
+            target_status=target_status,
+            notification=notification,
+            env=get_current_env(),
+        )
+
+
+class WorkOrderNotificationService:
+    @inject
+    def __init__(self, repository: WorkOrderRepositoryProtocol) -> None:
+        self._repository = repository
+
+    @staticmethod
+    def build_space_join_review_result(
+        *,
+        detail: WorkOrderDetail,
+        target_status: WorkOrderStatus,
+        review_remark: str,
+    ) -> WorkOrderNotificationDraft:
+        if target_status is WorkOrderStatus.APPROVED:
+            title = WorkOrderMessageTitle.SPACE_JOIN_APPROVED.value
+            content = WorkOrderMessageContent.SPACE_JOIN_APPROVED.value.format(
+                space_name=detail.space_name
+            )
+        elif target_status is WorkOrderStatus.REJECTED:
+            title = WorkOrderMessageTitle.SPACE_JOIN_REJECTED.value
+            content = WorkOrderMessageContent.SPACE_JOIN_REJECTED.value.format(
+                space_name=detail.space_name,
+                review_remark=review_remark,
+            )
+        else:
+            raise ValueError(f"unsupported review status: {target_status}")
+
+        event_type = WorkOrderEventType.SPACE_JOIN_REVIEWED
+        return WorkOrderNotificationDraft(
+            recipient_user_id=detail.work_order.applicant_user_id,
+            notification_category=EVENT_CATEGORIES[event_type],
+            event_type=event_type,
+            biz_type=detail.work_order.biz_type,
+            biz_id=detail.work_order.biz_id,
+            title=title,
+            content=content,
+        )
+
+    def get_detail(self, *, notification_id: int, actor_id: str):
+        result = self._repository.get_notification(
+            notification_id=notification_id,
+            recipient_user_id=actor_id,
+            env=get_current_env(),
+            mark_read=True,
+        )
+        if result is None:
+            raise WorkOrderNotificationNotFoundError("notification not found")
+        return result
+
+    def unread_count(self, *, actor_id: str) -> int:
+        return self._repository.count_unread(
+            recipient_user_id=actor_id, env=get_current_env()
+        )
+
+    def mark_read(self, *, notification_id: int, actor_id: str):
+        record = self._repository.mark_notification_read(
+            notification_id=notification_id,
+            recipient_user_id=actor_id,
+            env=get_current_env(),
+        )
+        if record is None:
+            raise WorkOrderNotificationNotFoundError("notification not found")
+        return record
+
+    def mark_all_read(self, *, actor_id: str) -> int:
+        return self._repository.mark_all_notifications_read(
+            recipient_user_id=actor_id, env=get_current_env()
+        )

--- a/src/backend/src/agentclaw/community/core/work_orders/sql/2026_08_17_work_orders.sql
+++ b/src/backend/src/agentclaw/community/core/work_orders/sql/2026_08_17_work_orders.sql
@@ -1,0 +1,44 @@
+-- Unified work orders and recipient-scoped notifications.
+CREATE TABLE IF NOT EXISTS ac_work_order (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    work_order_no VARCHAR(64) NOT NULL,
+    biz_type VARCHAR(64) NOT NULL COMMENT 'SPACE_JOIN',
+    biz_id VARCHAR(128) NOT NULL,
+    applicant_user_id VARCHAR(256) NOT NULL,
+    apply_reason VARCHAR(512) NULL,
+    status VARCHAR(32) NOT NULL COMMENT 'PENDING | APPROVED | REJECTED',
+    reviewer_user_id VARCHAR(256) NULL,
+    review_remark VARCHAR(512) NULL,
+    reviewed_at DATETIME NULL,
+    env VARCHAR(20) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_work_order_no_env (avernet_tenant, work_order_no, env),
+    KEY idx_work_order_applicant_status_env (avernet_tenant, applicant_user_id, status, env),
+    KEY idx_work_order_reviewer_status_env (avernet_tenant, reviewer_user_id, status, env),
+    KEY idx_work_order_biz_status_env (avernet_tenant, biz_type, biz_id, status, env)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_work_order_notification (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    work_order_id BIGINT UNSIGNED NULL,
+    recipient_user_id VARCHAR(256) NOT NULL,
+    notification_category VARCHAR(32) NOT NULL COMMENT 'APPROVAL | NOTICE',
+    event_type VARCHAR(64) NOT NULL,
+    biz_type VARCHAR(64) NOT NULL,
+    biz_id VARCHAR(128) NOT NULL,
+    title VARCHAR(256) NOT NULL,
+    content TEXT NULL,
+    is_read TINYINT(1) NOT NULL DEFAULT 0,
+    read_at DATETIME NULL,
+    env VARCHAR(20) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_work_order_notification_recipient_read (avernet_tenant, recipient_user_id, is_read, env, gmt_modified),
+    KEY idx_work_order_notification_work_order (avernet_tenant, work_order_id, recipient_user_id, env),
+    KEY idx_work_order_notification_biz (avernet_tenant, biz_type, biz_id, recipient_user_id, env)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -43,12 +43,14 @@ from agentclaw.community.di.modules.quality_module import QualityModule
 from agentclaw.community.di.modules.resources_module import ResourcesModule
 from agentclaw.community.di.modules.service_bot_module import ServiceBotModule
 from agentclaw.community.di.modules.session_resources_module import SessionResourcesModule
+from agentclaw.community.di.modules.spaces_module import SpacesModule
 from agentclaw.community.di.modules.skill_center_module import SkillCenterModule
 from agentclaw.community.di.modules.skills_pool_module import SkillsPoolModule
 from agentclaw.community.di.modules.system_config_module import SystemConfigModule
 from agentclaw.community.di.modules.task_queue_module import TaskQueueModule
 from agentclaw.community.di.modules.economy_governance_module import EconomyGovernanceModule
 from agentclaw.community.di.modules.user_list_module import UserListModule
+from agentclaw.community.di.modules.work_orders_module import WorkOrdersModule
 from agentclaw.community.di.profile import DeployProfile
 from agentclaw.community.di.profile_modules import modules_for
 from agentclaw.community.log import get_logger
@@ -116,6 +118,8 @@ def build_injector(
         AccessModule(),
         ResourcesModule(),
         SessionResourcesModule(),
+        SpacesModule(),
+        WorkOrdersModule(),
         HarnessModule(),
         BotCollaboratorModule(),
         BotAppGrantModule(),

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -1,0 +1,45 @@
+"""DI bindings for spaces, members and market favorites."""
+
+from __future__ import annotations
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.api.market_favorite_service import (
+    MarketFavoriteServiceProtocol,
+)
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
+from agentclaw.community.core.market_favorites.services import MarketFavoriteService
+from agentclaw.community.core.repository.implementations.market_favorites import (
+    MarketFavoriteRepository,
+)
+from agentclaw.community.core.repository.implementations.spaces import SpaceRepository
+from agentclaw.community.core.repository.protocols.market_favorites import (
+    MarketFavoriteRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
+from agentclaw.community.core.spaces.services import (
+    SpaceAccessService,
+    SpaceMemberService,
+    SpaceService,
+)
+
+
+class SpacesModule(Module):
+    def configure(self, binder: Binder) -> None:
+        binder.bind(SpaceRepositoryProtocol, to=SpaceRepository, scope=singleton)
+        binder.bind(
+            MarketFavoriteRepositoryProtocol,
+            to=MarketFavoriteRepository,
+            scope=singleton,
+        )
+        binder.bind(SpaceAccessService, to=SpaceAccessService, scope=singleton)
+        binder.bind(SpaceServiceProtocol, to=SpaceService, scope=singleton)
+        binder.bind(SpaceMemberServiceProtocol, to=SpaceMemberService, scope=singleton)
+        binder.bind(
+            MarketFavoriteServiceProtocol,
+            to=MarketFavoriteService,
+            scope=singleton,
+        )

--- a/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
@@ -1,0 +1,31 @@
+"""DI bindings for work orders and recipient notifications."""
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.api.work_order_service import (
+    WorkOrderNotificationServiceProtocol,
+    WorkOrderServiceProtocol,
+)
+from agentclaw.community.core.repository.implementations.work_orders import (
+    WorkOrderRepository,
+)
+from agentclaw.community.core.repository.protocols.work_orders import (
+    WorkOrderRepositoryProtocol,
+)
+from agentclaw.community.core.work_orders.services import (
+    WorkOrderNotificationService,
+    WorkOrderService,
+)
+
+
+class WorkOrdersModule(Module):
+    def configure(self, binder: Binder) -> None:
+        binder.bind(
+            WorkOrderRepositoryProtocol, to=WorkOrderRepository, scope=singleton
+        )
+        binder.bind(WorkOrderServiceProtocol, to=WorkOrderService, scope=singleton)
+        binder.bind(
+            WorkOrderNotificationServiceProtocol,
+            to=WorkOrderNotificationService,
+            scope=singleton,
+        )

--- a/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
@@ -9,13 +9,50 @@
 - GET  /api/v1/skills/{skillCode}/versions/{ver}/download （版本下载）
 """
 
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+
 from agentclaw.community.plugin_api.base import Plugin
+
+
+class SkillCenterTeamCreateError(RuntimeError):
+    """Raised when Skill Center rejects or cannot complete team creation."""
+
+
+@dataclass(frozen=True)
+class SkillCenterTeamCreateRequest:
+    """Transport-neutral data required to mirror one OCB Space to SC."""
+
+    team_code: str
+    team_name: str
+    ref_source_id: str
+    description: str | None = None
+    icon: str | None = None
+    ref_source_platform: str | None = None
+
+
+@dataclass(frozen=True)
+class SkillCenterTeamCreateResult:
+    """Confirmed SC team identity returned after a successful creation."""
+
+    team_id: str
 
 
 @runtime_checkable
 class SkillCenterClient(Plugin, Protocol):
     """SkillCenter 开放 API 客户端。"""
+
+    def create_team(
+        self, request: SkillCenterTeamCreateRequest
+    ) -> SkillCenterTeamCreateResult:
+        """Create the SC team corresponding to an OCB team Space.
+
+        Implementations obtain endpoint, appKey and source from deployment
+        configuration. A failed or rejected creation raises
+        :class:`SkillCenterTeamCreateError`; it must not return a false-success
+        result.
+        """
+        ...
 
     def upload_and_publish(self, payload: dict) -> dict:
         """上传并发布技能（异步，返回后需轮询状态）。
@@ -48,7 +85,11 @@ class SkillCenterClient(Plugin, Protocol):
         ...
 
     def search_market_skills(
-        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20,
+        self,
+        keyword: str = "",
+        tag: str = "",
+        page: int = 1,
+        page_size: int = 20,
         team_id: str | None = None,
     ) -> dict:
         """搜索公开市场技能。"""
@@ -81,7 +122,9 @@ class SkillCenterClient(Plugin, Protocol):
         """
         ...
 
-    def get_file_content(self, skill_code: str, file_path: str, version: str = "") -> dict:
+    def get_file_content(
+        self, skill_code: str, file_path: str, version: str = ""
+    ) -> dict:
         """获取技能指定文件内容。
 
         Args:

--- a/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
@@ -7,9 +7,15 @@ production); the real skills pipeline is the local skills source (see
 so a caller that actually tries to use the marketplace fails loudly rather than
 silently receiving a fake result.
 """
+
 from __future__ import annotations
 
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterClient,
+    SkillCenterTeamCreateError,
+    SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
+)
 
 
 class SkillCenterUnsupportedError(RuntimeError):
@@ -22,6 +28,11 @@ _MSG = "Skill Center is not available in the community build"
 
 class CommunitySkillCenterClient(SkillCenterClient):
     """Skill Center marketplace bypass for the community profile (raises)."""
+
+    def create_team(
+        self, request: SkillCenterTeamCreateRequest
+    ) -> SkillCenterTeamCreateResult:
+        raise SkillCenterTeamCreateError(_MSG)
 
     def upload_and_publish(self, payload: dict) -> dict:
         raise SkillCenterUnsupportedError(_MSG)

--- a/src/backend/src/agentclaw/community/plugins/local/README.md
+++ b/src/backend/src/agentclaw/community/plugins/local/README.md
@@ -25,6 +25,9 @@ internal_dependencies:
   - agentclaw.community.core.bot_dormant   # SQLite ORM side-effect import for local table creation
   - agentclaw.community.core.caller_identity.models  # SQLite ORM side-effect import for caller identity tables
   - agentclaw.community.core.user_list.models  # SQLite ORM side-effect import for user-list tables
+  - agentclaw.community.core.spaces.repository.models  # SQLite ORM side-effect import for Space tables
+  - agentclaw.community.core.market_favorites.repository.models  # SQLite ORM side-effect import for favorites table
+  - agentclaw.community.core.work_orders.repository.models  # SQLite ORM side-effect import for work-order tables
   - agentclaw.community.core.economy.governance.contracts.models  # SQLite ORM side-effect import for local table creation
   - agentclaw.community.core.economy.governance.repositories.orm  # SQLite ORM side-effect import for local table creation
   - agentclaw.community.core.system_config.orm  # SQLite ORM side-effect import for ac_config_* table creation

--- a/src/backend/src/agentclaw/community/plugins/local/database.py
+++ b/src/backend/src/agentclaw/community/plugins/local/database.py
@@ -18,6 +18,7 @@ Trade-off: ``./scripts/local_setup.sh --local`` no longer persists DB
 state across backend restarts. Documented in the project ``CLAUDE.md``
 "Running Modes" table.
 """
+
 import os
 import threading
 from contextlib import contextmanager
@@ -163,6 +164,9 @@ class SqliteDB(MockSeam, DatabasePlugin, LifecycleBase):
         import agentclaw.community.core.caller_identity.models  # noqa: F401  caller identity tables
         import agentclaw.community.core.bot_app_grant.models  # noqa: F401  ac_bot_app_grant / ac_bot_app_grant_log
         import agentclaw.community.core.user_list.models  # noqa: F401  ac_entity_user_list
+        import agentclaw.community.core.spaces.repository.models  # noqa: F401  ac_space / ac_space_member
+        import agentclaw.community.core.market_favorites.repository.models  # noqa: F401  ac_market_favorite
+        import agentclaw.community.core.work_orders.repository.models  # noqa: F401  ac_work_order / ac_work_order_notification
 
         # bot_chat uses a private ``Base = declarative_base()`` instead of
         # the canonical ``agentclaw.community.core.base.Base``. Side-effect import

--- a/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
@@ -4,7 +4,11 @@
 """
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterClient,
+    SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
+)
 from agentclaw.community.plugin_api.impl_registry import Flavor, Mode, plugin_impl
 from agentclaw.community.plugins.local._mock_seam import MockSeam
 
@@ -18,6 +22,12 @@ logger = get_logger()
 )
 class LocalSkillCenterClient(MockSeam, SkillCenterClient):
     """Mock 客户端：发布立即成功，用于本地开发调试。"""
+
+    def create_team(
+        self, request: SkillCenterTeamCreateRequest
+    ) -> SkillCenterTeamCreateResult:
+        logger.info("[LocalMock] create_team: %s", request.team_code)
+        return SkillCenterTeamCreateResult(team_id=f"mock-{request.team_code}")
 
     def upload_and_publish(self, payload: dict) -> dict:
         skill_code = payload.get("skillCode", "local-mock")
@@ -52,10 +62,19 @@ class LocalSkillCenterClient(MockSeam, SkillCenterClient):
         return []
 
     def search_market_skills(
-        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20,
+        self,
+        keyword: str = "",
+        tag: str = "",
+        page: int = 1,
+        page_size: int = 20,
         team_id: str | None = None,
     ) -> dict:
-        logger.info("[LocalMock] search_market_skills: keyword=%s tag=%s team_id=%s", keyword, tag, team_id)
+        logger.info(
+            "[LocalMock] search_market_skills: keyword=%s tag=%s team_id=%s",
+            keyword,
+            tag,
+            team_id,
+        )
         return {"success": True, "data": [], "total": 0}
 
     def get_market_tags(self) -> list[dict]:
@@ -64,7 +83,10 @@ class LocalSkillCenterClient(MockSeam, SkillCenterClient):
 
     def get_download_url(self, skill_code: str, version_number: str) -> dict:
         logger.info("[LocalMock] get_download_url: %s v%s", skill_code, version_number)
-        return {"success": True, "data": {"downloadUrl": "file:///local-mock/skill.zip"}}
+        return {
+            "success": True,
+            "data": {"downloadUrl": "file:///local-mock/skill.zip"},
+        }
 
     def delete_skill(self, skill_code: str) -> dict:
         logger.info("[LocalMock] delete_skill: %s", skill_code)
@@ -79,16 +101,35 @@ class LocalSkillCenterClient(MockSeam, SkillCenterClient):
                 "type": "DIR",
                 "description": None,
                 "children": [
-                    {"name": "SKILL.md", "type": "FILE", "description": "技能描述文件", "children": None},
-                    {"name": "src", "type": "DIR", "description": None, "children": [
-                        {"name": "main.py", "type": "FILE", "description": "主入口文件", "children": None},
-                    ]},
+                    {
+                        "name": "SKILL.md",
+                        "type": "FILE",
+                        "description": "技能描述文件",
+                        "children": None,
+                    },
+                    {
+                        "name": "src",
+                        "type": "DIR",
+                        "description": None,
+                        "children": [
+                            {
+                                "name": "main.py",
+                                "type": "FILE",
+                                "description": "主入口文件",
+                                "children": None,
+                            },
+                        ],
+                    },
                 ],
             },
         }
 
-    def get_file_content(self, skill_code: str, file_path: str, version: str = "") -> dict:
-        logger.info("[LocalMock] get_file_content: %s %s v%s", skill_code, file_path, version)
+    def get_file_content(
+        self, skill_code: str, file_path: str, version: str = ""
+    ) -> dict:
+        logger.info(
+            "[LocalMock] get_file_content: %s %s v%s", skill_code, file_path, version
+        )
         return {
             "success": True,
             "data": {

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -1,0 +1,416 @@
+"""Contract tests for the public Space/member/favorite HTTP surface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.spaces.router import router
+from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
+    MarketFavoriteItem,
+    SpaceMemberItem,
+)
+from agentclaw.community.api.market_favorite_service import (
+    MarketFavoriteServiceProtocol,
+)
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
+from agentclaw.community.core.market_favorites.errors import FavoriteNotFoundError
+from agentclaw.community.core.market_favorites.models import (
+    FavoriteTargetType,
+    MarketFavoriteRecord,
+)
+from agentclaw.community.core.spaces.models import (
+    SpaceJoinStatus,
+    SpaceMemberRecord,
+    SpaceMemberSummaryRecord,
+    SpaceRecord,
+    SpaceRole,
+    SpaceSummaryRecord,
+    SpaceType,
+)
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+)
+
+
+@pytest.fixture
+def member_service():
+    service = MagicMock()
+    service.add_member.side_effect = lambda **kwargs: SpaceMemberRecord(
+        id=2,
+        space_id=kwargs["space_id"],
+        user_id=kwargs["user_id"].strip(),
+        role=kwargs["role"],
+        env="test",
+        created_by="owner-1",
+        gmt_created=datetime(2026, 8, 17, 7, 50, 45),
+        gmt_modified=datetime(2026, 8, 17, 7, 50, 45),
+    )
+    return service
+
+
+@pytest.fixture
+def space_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def favorite_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def client(member_service, space_service, favorite_service):
+    class _Bindings(Module):
+        def configure(self, binder):
+            binder.bind(SpaceMemberServiceProtocol, to=member_service)
+            binder.bind(SpaceServiceProtocol, to=space_service)
+            binder.bind(MarketFavoriteServiceProtocol, to=favorite_service)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "owner-1"}
+    attach_injector(app, Injector([_Bindings()]))
+    mount_public_error_handlers(app)
+    return TestClient(app)
+
+
+
+def test_endpoint_serializes_persisted_datetime_with_utc_marker(client, space_service):
+    timestamp = datetime(2026, 8, 17, 7, 50, 45)
+    space_service.list_spaces.return_value = (
+        1,
+        [
+            SpaceSummaryRecord(
+                space=SpaceRecord(
+                    id=7,
+                    space_code="spc-7",
+                    space_type=SpaceType.TEAM,
+                    name="Team",
+                    personal_owner_id=None,
+                    env="test",
+                    created_by="owner-1",
+                    updated_by="owner-1",
+                    gmt_created=timestamp,
+                    gmt_modified=timestamp,
+                ),
+                current_user_role=SpaceRole.OWNER,
+                join_status=SpaceJoinStatus.JOINED,
+                member_count=1,
+                owner_count=1,
+            )
+        ],
+    )
+
+    response = client.get("/openapi/v1/spaces")
+
+    assert response.status_code == 200
+    assert (
+        response.json()["data"]["items"][0]["gmt_modified"]
+        == "2026-08-17T07:50:45Z"
+    )
+
+def test_naive_persisted_datetime_is_serialized_as_explicit_utc():
+    item = SpaceMemberItem(
+        user_id="member-1",
+        role=SpaceRole.MEMBER,
+        is_creator=False,
+        gmt_modified=datetime(2026, 8, 17, 7, 50, 45),
+    )
+
+    assert item.model_dump(mode="json")["gmt_modified"] == "2026-08-17T07:50:45Z"
+
+
+def test_aware_datetime_is_normalized_to_utc():
+    item = MarketFavoriteItem(
+        favorite_id=1,
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+        favorite_at=datetime(
+            2026, 8, 17, 0, 50, 45, tzinfo=timezone(timedelta(hours=8))
+        ),
+    )
+
+    assert item.model_dump(mode="json")["favorite_at"] == "2026-08-16T16:50:45Z"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_role"),
+    [
+        ({"user_id": "member-1"}, SpaceRole.MEMBER),
+        ({"user_id": "owner-2", "role": "OWNER"}, SpaceRole.OWNER),
+    ],
+)
+def test_add_member_accepts_an_optional_role(client, member_service, payload, expected_role):
+    response = client.post("/openapi/v1/spaces/7/members", json=payload)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["code"] == 201000
+    assert body["message"] == "Created"
+    assert body["data"] == {
+        "space_id": 7,
+        "user_id": payload["user_id"],
+        "role": expected_role.value,
+    }
+    assert member_service.add_member.call_args.kwargs["role"] is expected_role
+
+
+def test_openapi_does_not_advertise_unavailable_profile_or_catalogue_fields(client):
+    schemas = client.get("/openapi.json").json()["components"]["schemas"]
+
+    member_properties = schemas["SpaceMemberItem"]["properties"]
+    assert "user_name" not in member_properties
+    assert "display_name" not in member_properties
+    assert "membership relation" in member_properties["gmt_modified"]["description"]
+    assert member_properties["gmt_modified"]["format"] == "date-time"
+
+    favorite_properties = schemas["MarketFavoriteItem"]["properties"]
+    assert set(favorite_properties) == {
+        "favorite_id",
+        "target_type",
+        "target_code",
+        "favorite_at",
+        "is_favorited",
+    }
+
+
+def test_cancel_missing_favorite_returns_not_found(client, favorite_service):
+    favorite_service.cancel.side_effect = FavoriteNotFoundError(
+        "market favorite not found"
+    )
+
+    response = client.post(
+        "/openapi/v1/spaces/7/market-favorites/cancel",
+        json={"target_type": "SKILL", "target_code": "skill-1"},
+    )
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["code"] == 404000
+    assert body["message"] == "Not found"
+    assert body["data"] is None
+
+
+
+def _space_record(space_type=SpaceType.TEAM):
+    timestamp = datetime(2026, 8, 18, 1, 2, 3)
+    return SpaceRecord(
+        id=7,
+        space_code="spc-7",
+        space_type=space_type,
+        name="Team" if space_type is SpaceType.TEAM else "Personal",
+        personal_owner_id=("owner-1" if space_type is SpaceType.PERSONAL else None),
+        env="test",
+        created_by="owner-1",
+        updated_by="owner-1",
+        gmt_created=timestamp,
+        gmt_modified=timestamp,
+    )
+
+
+def _member_summary(user_id="member-1", role=SpaceRole.MEMBER):
+    timestamp = datetime(2026, 8, 18, 1, 2, 3)
+    return SpaceMemberSummaryRecord(
+        member=SpaceMemberRecord(
+            id=2,
+            space_id=7,
+            user_id=user_id,
+            role=role,
+            env="test",
+            created_by="owner-1",
+            gmt_created=timestamp,
+            gmt_modified=timestamp,
+        ),
+        is_creator=user_id == "owner-1",
+    )
+
+
+def _favorite_record():
+    timestamp = datetime(2026, 8, 18, 1, 2, 3)
+    return MarketFavoriteRecord(
+        id=31,
+        space_id=7,
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+        created_by="owner-1",
+        env="test",
+        gmt_created=timestamp,
+        gmt_modified=timestamp,
+    )
+
+
+def test_list_spaces_forwards_filters_and_maps_page(client, space_service):
+    space_service.list_spaces.return_value = (
+        1,
+        [
+            SpaceSummaryRecord(
+                space=_space_record(),
+                current_user_role=SpaceRole.OWNER,
+                join_status=SpaceJoinStatus.JOINED,
+                member_count=3,
+                owner_count=1,
+            )
+        ],
+    )
+
+    response = client.get(
+        "/openapi/v1/spaces",
+        params={"keyword": "team", "space_type": "TEAM", "page_no": 2, "page_size": 5},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["total"] == 1
+    assert response.json()["data"]["items"][0]["space_id"] == 7
+    space_service.list_spaces.assert_called_once_with(
+        user_id="owner-1",
+        keyword="team",
+        space_type=SpaceType.TEAM,
+        page_no=2,
+        page_size=5,
+    )
+
+
+@pytest.mark.parametrize("was_created", [True, False])
+def test_initialize_personal_space_exposes_created_state(
+    client, space_service, was_created
+):
+    space_service.initialize_personal.return_value = (
+        _space_record(SpaceType.PERSONAL),
+        was_created,
+    )
+
+    response = client.post("/openapi/v1/spaces/personal/initialize")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["space_type"] == "PERSONAL"
+    assert data["created"] is was_created
+    assert data["current_user_role"] == "OWNER"
+    space_service.initialize_personal.assert_called_once_with(user_id="owner-1")
+
+
+def test_create_team_space_returns_owner_metadata(client, space_service):
+    space_service.create_team.return_value = _space_record()
+
+    response = client.post(
+        "/openapi/v1/spaces/create", json={"space_name": "Team"}
+    )
+
+    assert response.status_code == 201
+    data = response.json()["data"]
+    assert data["space_id"] == 7
+    assert data["is_creator"] is True
+    assert data["member_count"] == data["owner_count"] == 1
+    space_service.create_team.assert_called_once_with(
+        name="Team", creator_id="owner-1"
+    )
+
+
+def test_member_list_delete_and_role_update(client, member_service):
+    member_service.list_members.return_value = (1, [_member_summary()])
+    member_service.update_role.return_value = _member_summary(
+        user_id="member-1", role=SpaceRole.OWNER
+    )
+
+    listed = client.get(
+        "/openapi/v1/spaces/7/members",
+        params={"keyword": "mem", "page_no": 2, "page_size": 10},
+    )
+    deleted = client.delete("/openapi/v1/spaces/7/members/member-1")
+    updated = client.put(
+        "/openapi/v1/spaces/7/members/member-1/role", json={"role": "OWNER"}
+    )
+
+    assert listed.status_code == deleted.status_code == updated.status_code == 200
+    assert listed.json()["data"]["items"][0]["user_id"] == "member-1"
+    assert deleted.json()["data"] == {
+        "space_id": 7,
+        "user_id": "member-1",
+        "deleted": True,
+    }
+    assert updated.json()["data"]["role"] == "OWNER"
+    member_service.list_members.assert_called_once_with(
+        space_id=7,
+        actor_id="owner-1",
+        keyword="mem",
+        page_no=2,
+        page_size=10,
+    )
+    member_service.delete_member.assert_called_once_with(
+        space_id=7, actor_id="owner-1", user_id="member-1"
+    )
+    member_service.update_role.assert_called_once_with(
+        space_id=7,
+        actor_id="owner-1",
+        user_id="member-1",
+        role=SpaceRole.OWNER,
+    )
+
+
+def test_favorite_add_cancel_and_search(client, favorite_service):
+    favorite_service.add.return_value = _favorite_record()
+    favorite_service.search.return_value = (1, [_favorite_record()])
+
+    added = client.post(
+        "/openapi/v1/spaces/7/market-favorites",
+        json={"target_type": "SKILL", "target_code": "skill-1"},
+    )
+    canceled = client.post(
+        "/openapi/v1/spaces/7/market-favorites/cancel",
+        json={"target_type": "SKILL", "target_code": " skill-1 "},
+    )
+    searched = client.post(
+        "/openapi/v1/spaces/7/market-favorites/search",
+        json={
+            "target_type": "SKILL",
+            "keyword": "skill",
+            "page_no": 2,
+            "page_size": 5,
+        },
+    )
+
+    assert added.status_code == canceled.status_code == searched.status_code == 200
+    assert added.json()["data"]["is_favorited"] is True
+    assert canceled.json()["data"] == {
+        "target_type": "SKILL",
+        "target_code": "skill-1",
+        "is_favorited": False,
+    }
+    assert searched.json()["data"]["items"][0] == {
+        "favorite_id": 31,
+        "target_type": "SKILL",
+        "target_code": "skill-1",
+        "favorite_at": "2026-08-18T01:02:03Z",
+        "is_favorited": True,
+    }
+    favorite_service.add.assert_called_once_with(
+        space_id=7,
+        actor_id="owner-1",
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+    )
+    favorite_service.cancel.assert_called_once_with(
+        space_id=7,
+        actor_id="owner-1",
+        target_type=FavoriteTargetType.SKILL,
+        target_code=" skill-1 ",
+    )
+    favorite_service.search.assert_called_once_with(
+        space_id=7,
+        actor_id="owner-1",
+        target_type=FavoriteTargetType.SKILL,
+        keyword="skill",
+        page_no=2,
+        page_size=5,
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
@@ -40,6 +39,7 @@ from agentclaw.community.core.spaces.models import (
 )
 from tests.community.adapters.http.openapi_v1.conftest import (
     mount_public_error_handlers,
+    user_scoped_client,
 )
 
 
@@ -82,8 +82,7 @@ def client(member_service, space_service, favorite_service):
     app.dependency_overrides[require_principal] = lambda: {"user_id": "owner-1"}
     attach_injector(app, Injector([_Bindings()]))
     mount_public_error_handlers(app)
-    return TestClient(app)
-
+    return user_scoped_client(app, "owner-1")
 
 
 def test_endpoint_serializes_persisted_datetime_with_utc_marker(client, space_service):
@@ -115,14 +114,14 @@ def test_endpoint_serializes_persisted_datetime_with_utc_marker(client, space_se
     response = client.get("/openapi/v1/spaces")
 
     assert response.status_code == 200
-    assert (
-        response.json()["data"]["items"][0]["gmt_modified"]
-        == "2026-08-17T07:50:45Z"
-    )
+    assert response.json()["data"]["items"][0]["gmt_modified"] == "2026-08-17T07:50:45Z"
+
 
 def test_naive_persisted_datetime_is_serialized_as_explicit_utc():
     item = SpaceMemberItem(
         user_id="member-1",
+        user_name=None,
+        display_name=None,
         role=SpaceRole.MEMBER,
         is_creator=False,
         gmt_modified=datetime(2026, 8, 17, 7, 50, 45),
@@ -147,11 +146,13 @@ def test_aware_datetime_is_normalized_to_utc():
 @pytest.mark.parametrize(
     ("payload", "expected_role"),
     [
-        ({"user_id": "member-1"}, SpaceRole.MEMBER),
-        ({"user_id": "owner-2", "role": "OWNER"}, SpaceRole.OWNER),
+        ({"member_user_id": "member-1"}, SpaceRole.MEMBER),
+        ({"member_user_id": "owner-2", "role": "OWNER"}, SpaceRole.OWNER),
     ],
 )
-def test_add_member_accepts_an_optional_role(client, member_service, payload, expected_role):
+def test_add_member_accepts_an_optional_role(
+    client, member_service, payload, expected_role
+):
     response = client.post("/openapi/v1/spaces/7/members", json=payload)
 
     assert response.status_code == 201
@@ -160,18 +161,18 @@ def test_add_member_accepts_an_optional_role(client, member_service, payload, ex
     assert body["message"] == "Created"
     assert body["data"] == {
         "space_id": 7,
-        "user_id": payload["user_id"],
+        "user_id": payload["member_user_id"],
         "role": expected_role.value,
     }
     assert member_service.add_member.call_args.kwargs["role"] is expected_role
 
 
-def test_openapi_does_not_advertise_unavailable_profile_or_catalogue_fields(client):
+def test_openapi_advertises_nullable_member_profile_fields(client):
     schemas = client.get("/openapi.json").json()["components"]["schemas"]
 
     member_properties = schemas["SpaceMemberItem"]["properties"]
-    assert "user_name" not in member_properties
-    assert "display_name" not in member_properties
+    assert "user_name" in member_properties
+    assert "display_name" in member_properties
     assert "membership relation" in member_properties["gmt_modified"]["description"]
     assert member_properties["gmt_modified"]["format"] == "date-time"
 
@@ -202,7 +203,6 @@ def test_cancel_missing_favorite_returns_not_found(client, favorite_service):
     assert body["data"] is None
 
 
-
 def _space_record(space_type=SpaceType.TEAM):
     timestamp = datetime(2026, 8, 18, 1, 2, 3)
     return SpaceRecord(
@@ -219,7 +219,12 @@ def _space_record(space_type=SpaceType.TEAM):
     )
 
 
-def _member_summary(user_id="member-1", role=SpaceRole.MEMBER):
+def _member_summary(
+    user_id="member-1",
+    role=SpaceRole.MEMBER,
+    user_name=None,
+    display_name=None,
+):
     timestamp = datetime(2026, 8, 18, 1, 2, 3)
     return SpaceMemberSummaryRecord(
         member=SpaceMemberRecord(
@@ -233,6 +238,8 @@ def _member_summary(user_id="member-1", role=SpaceRole.MEMBER):
             gmt_modified=timestamp,
         ),
         is_creator=user_id == "owner-1",
+        user_name=user_name,
+        display_name=display_name,
     )
 
 
@@ -303,22 +310,21 @@ def test_initialize_personal_space_exposes_created_state(
 def test_create_team_space_returns_owner_metadata(client, space_service):
     space_service.create_team.return_value = _space_record()
 
-    response = client.post(
-        "/openapi/v1/spaces/create", json={"space_name": "Team"}
-    )
+    response = client.post("/openapi/v1/spaces/create", json={"space_name": "Team"})
 
     assert response.status_code == 201
     data = response.json()["data"]
     assert data["space_id"] == 7
     assert data["is_creator"] is True
     assert data["member_count"] == data["owner_count"] == 1
-    space_service.create_team.assert_called_once_with(
-        name="Team", creator_id="owner-1"
-    )
+    space_service.create_team.assert_called_once_with(name="Team", creator_id="owner-1")
 
 
 def test_member_list_delete_and_role_update(client, member_service):
-    member_service.list_members.return_value = (1, [_member_summary()])
+    member_service.list_members.return_value = (
+        1,
+        [_member_summary(user_name="Zhang San", display_name="Xiao Ming")],
+    )
     member_service.update_role.return_value = _member_summary(
         user_id="member-1", role=SpaceRole.OWNER
     )
@@ -333,7 +339,10 @@ def test_member_list_delete_and_role_update(client, member_service):
     )
 
     assert listed.status_code == deleted.status_code == updated.status_code == 200
-    assert listed.json()["data"]["items"][0]["user_id"] == "member-1"
+    listed_member = listed.json()["data"]["items"][0]
+    assert listed_member["user_id"] == "member-1"
+    assert listed_member["user_name"] == "Zhang San"
+    assert listed_member["display_name"] == "Xiao Ming"
     assert deleted.json()["data"] == {
         "space_id": 7,
         "user_id": "member-1",

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -31,9 +31,24 @@ from agentclaw.community.adapters.http.openapi_v1.authorized_apps import (
 )
 from agentclaw.community.adapters.http.openapi_v1.bots import router as bots_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.spaces import router as spaces_router
+from agentclaw.community.adapters.http.openapi_v1.work_orders import (
+    router as work_orders_router,
+)
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.market_favorite_service import (
+    MarketFavoriteServiceProtocol,
+)
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
+from agentclaw.community.api.work_order_service import (
+    WorkOrderNotificationServiceProtocol,
+    WorkOrderServiceProtocol,
+)
 from agentclaw.community.core.bot_app_grant.models import BotAppGrantRecord
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
@@ -118,6 +133,13 @@ class _Grants:
         ]
 
 
+class _UnexpectedService:
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        raise AssertionError(f"business service must not be called: {name}")
+
+
 class _Bots:
     """Two bots owned by ``USER``. ``SHARED`` is not among them, by design."""
 
@@ -141,7 +163,12 @@ class _Bots:
         """Owner-scoped, as production is — and it resolves the *user's* bot."""
         if user_id != USER:
             raise BotNotFoundError(f"Bot not found: {bot_id}")
-        return {"id": 1, "bot_id": bot_id, "owner_id": USER, "bot_name": "the user's own"}
+        return {
+            "id": 1,
+            "bot_id": bot_id,
+            "owner_id": USER,
+            "bot_name": "the user's own",
+        }
 
     def get_bots_ceiling_for_owner(self, owner_id: str) -> int:
         return 5
@@ -162,6 +189,12 @@ def make_client(bots):
             def configure(self, binder):
                 binder.bind(BotServiceProtocol, to=bots)
                 binder.bind(BotAppGrantServiceProtocol, to=_Grants(*grant_ids))
+                unexpected = _UnexpectedService()
+                binder.bind(SpaceServiceProtocol, to=unexpected)
+                binder.bind(SpaceMemberServiceProtocol, to=unexpected)
+                binder.bind(MarketFavoriteServiceProtocol, to=unexpected)
+                binder.bind(WorkOrderServiceProtocol, to=unexpected)
+                binder.bind(WorkOrderNotificationServiceProtocol, to=unexpected)
 
         app = FastAPI()
         # The literal before the wildcard, exactly as ``build_public_router``
@@ -169,6 +202,8 @@ def make_client(bots):
         # ``/openapi/v1/bots/authorized`` as "the bot named authorized".
         app.include_router(app_view_router)
         app.include_router(bots_router)
+        app.include_router(spaces_router)
+        app.include_router(work_orders_router)
         app.dependency_overrides[require_principal] = lambda: _caller(
             with_user=with_user
         )
@@ -433,6 +468,70 @@ _UNGRANTED_APP_CASES = {
         "request": lambda client: client.get("/openapi/v1/bots/ceiling"),
         # USER_GATED: no delegation, no relationship — masked as not-found, so
         # a stranger app cannot read a person's quota by naming them.
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/spaces"): {
+        "request": lambda client: client.get("/openapi/v1/spaces"),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/spaces/{space_id}/members"): {
+        "request": lambda client: client.get("/openapi/v1/spaces/1/members"),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/spaces/{space_id}/market-favorites"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/spaces/1/market-favorites",
+            json={"target_type": "SKILL", "target_code": "skill-1"},
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/spaces/{space_id}/market-favorites/cancel"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/spaces/1/market-favorites/cancel",
+            json={"target_type": "SKILL", "target_code": "skill-1"},
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/spaces/{space_id}/market-favorites/search"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/spaces/1/market-favorites/search", json={}
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/spaces/{space_id}/join-requests"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/spaces/1/join-requests", json={"reason": "join"}
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/work-orders"): {
+        "request": lambda client: client.get("/openapi/v1/work-orders"),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/work-orders/{work_order_id}"): {
+        "request": lambda client: client.get("/openapi/v1/work-orders/1"),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/work-order-notifications/unread-count"): {
+        "request": lambda client: client.get(
+            "/openapi/v1/work-order-notifications/unread-count"
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/work-order-notifications/{notification_id}"): {
+        "request": lambda client: client.get("/openapi/v1/work-order-notifications/1"),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/work-order-notifications/read-all"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/work-order-notifications/read-all"
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("POST", "/openapi/v1/work-order-notifications/{notification_id}/read"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/work-order-notifications/1/read"
+        ),
         "assert_starved": lambda response: response.status_code == 404,
     },
 }

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -189,9 +189,7 @@ def test_a_rejected_id_cannot_choose_how_much_it_logs(caplog):
 
     with caplog.at_level(logging.WARNING):
         with pytest.raises(UserIdMismatchError):
-            asyncio.run(
-                require_user_id(principal={"user_id": _CALLER}, user_id=flood)
-            )
+            asyncio.run(require_user_id(principal={"user_id": _CALLER}, user_id=flood))
 
     logged = "\n".join(record.getMessage() for record in caplog.records)
     assert len(logged) < 500, "a caller must not choose the size of the log line"
@@ -317,7 +315,11 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: placement the rule deliberately keeps. ``none`` fell 21 → 16 because the five
 #: operations that named no bot at all (the resources and routines collection
 #: roots, skills list and upload) now do.
-_BOT_ID_PLACEMENT = {"path": 54, "query": 1, "none": 16}
+#:
+#: ``none`` then moved 16 → 35 when the 19 collaboration operations for Spaces,
+#: work orders and recipient notifications were added. None of those operations
+#: addresses a bot, so the path and query counts remain unchanged.
+_BOT_ID_PLACEMENT = {"path": 54, "query": 1, "none": 35}
 
 
 def _schema() -> dict:
@@ -358,8 +360,7 @@ def _param(operation: dict, name: str) -> dict | None:
 
 def _user_scoped(path: str, method: str) -> bool:
     return (
-        not path.startswith(_LOGS_PREFIX)
-        and (method, path) not in _NO_USER_DIMENSION
+        not path.startswith(_LOGS_PREFIX) and (method, path) not in _NO_USER_DIMENSION
     )
 
 
@@ -396,8 +397,9 @@ def test_the_pinned_number_of_operations_take_it():
     ]
     # 60 on the merge base, +3 for the startup-script operations, +2 for the
     # resources file endpoints re-addressed by workspace path (#1000), then -4
-    # for the files-only resources group.
-    assert len(taking) == 61
+    # for the files-only resources group, then +19 for Spaces, work orders and
+    # recipient-notification operations added by the collaboration API.
+    assert len(taking) == 80
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
@@ -51,7 +51,11 @@ def _document() -> dict:
 
 def _paths() -> list[str]:
     """Every published address — the current ones and the retiring ones."""
-    return list(_document()["paths"])
+    return [
+        path
+        for path in _document()["paths"]
+        if path == _BASE or path.startswith(f"{_BASE}/")
+    ]
 
 
 def _current_paths() -> list[str]:
@@ -66,6 +70,7 @@ def _current_paths() -> list[str]:
     return [
         path
         for path, item in document["paths"].items()
+        if path == _BASE or path.startswith(f"{_BASE}/")
         if any(
             isinstance(operation, dict)
             and "responses" in operation
@@ -105,14 +110,14 @@ def _components() -> set[str]:
     }
 
 
-def test_every_path_lives_under_the_bots_base():
+def test_bot_path_selection_lives_under_the_bots_base():
     """The gateway resolves by the segment after the version base.
 
     A path outside ``/openapi/v1/bots`` would route to a different upstream —
     or to none — and the mistake is invisible until deploy.
     """
-    offenders = [p for p in _paths() if p != _BASE and not p.startswith(f"{_BASE}/")]
-    assert not offenders, f"paths outside {_BASE}: {offenders}"
+    assert _paths(), "no bot paths found on the public surface"
+    assert all(path == _BASE or path.startswith(f"{_BASE}/") for path in _paths())
 
 
 def test_no_path_repeats_bot_before_the_id():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -223,9 +223,7 @@ def test_end_to_end_through_a_real_route(caplog):
         raise BotNotFoundError(f"Bot not found: {bot_id}")
 
     with caplog.at_level(logging.DEBUG):
-        resp = TestClient(app).post(
-            "/openapi/v1/bots/b-42", json={"bot_name": "alpha"}
-        )
+        resp = TestClient(app).post("/openapi/v1/bots/b-42", json={"bot_name": "alpha"})
 
     assert resp.status_code == 404
     assert json.loads(resp.content)["message"] == "Not found"
@@ -337,7 +335,10 @@ def _lookup(exc: Exception) -> tuple[int, str]:
     ("error", "expected"),
     [
         (LocalSkillEditBusyError(), (409, "Another Skill update is in progress")),
-        (LocalSkillLayoutRollbackError(), (409, "Skill layout rollback is in progress")),
+        (
+            LocalSkillLayoutRollbackError(),
+            (409, "Skill layout rollback is in progress"),
+        ),
         (
             LocalSkillEditLockUnavailableError(),
             (503, "Skill update service is temporarily unavailable"),
@@ -546,6 +547,7 @@ def test_engine_runtime_messages_are_fixed_not_exception_text():
         assert leak not in message
         assert message.isascii(), f"{name}: public messages are always English"
 
+
 # ── MCP category error mappings (Track B mcp, Task 6) ───────────────
 
 
@@ -566,7 +568,11 @@ async def test_mcp_errors_map_to_status_and_fixed_message():
         # Internal-language / identifier-bearing text that must NOT leak.
         (McpServerNotFoundError("mcp.secret.server"), 404, "Not found"),
         (McpHeadersInvalidError("Header 键不能为空"), 400, "Invalid MCP headers"),
-        (McpConfigValueError("endpoint_env must be PROD or PRE"), 400, "Invalid MCP configuration"),
+        (
+            McpConfigValueError("endpoint_env must be PROD or PRE"),
+            400,
+            "Invalid MCP configuration",
+        ),
         (McpSyncFailedError("bot b-123 device down"), 502, "Device sync failed"),
         (McpMarketUnavailableError("upstream 500"), 502, "MCP service error"),
     ]
@@ -605,3 +611,87 @@ async def test_mcp_not_found_is_indistinguishable_from_bots_not_found():
     b = await bot_missing(request=_request())
     assert a.status_code == b.status_code == 404
     assert json.loads(bytes(a.body)) == json.loads(bytes(b.body))
+
+
+@pytest.mark.asyncio
+async def test_skill_center_team_create_error_has_stable_space_contract():
+    import json
+
+    from agentclaw.community.adapters.http.openapi_v1.errors_space import (
+        SpaceErrorCode,
+        SpacePublicErrorMessage,
+    )
+    from agentclaw.community.plugin_api.skill_center_client import (
+        SkillCenterTeamCreateError,
+    )
+
+    @envelope_errors
+    async def handler(request: Request):
+        raise SkillCenterTeamCreateError("private SC diagnostics")
+
+    response = await handler(request=_request())
+    body = json.loads(bytes(response.body))
+
+    assert response.status_code == 502
+    assert body["code"] == SpaceErrorCode.SKILL_CENTER_TEAM_CREATE_FAILED
+    assert body["message"] == SpacePublicErrorMessage.SKILL_CENTER_TEAM_CREATE_FAILED
+    assert "private SC diagnostics" not in body["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "status", "code", "message"),
+    [
+        ("WorkOrderInvalidReasonError", 400, 400201, "Invalid application reason"),
+        ("WorkOrderInvalidRemarkError", 400, 400202, "Invalid review remark"),
+        ("WorkOrderAccessDeniedError", 403, 403201, "Forbidden"),
+        ("WorkOrderNotFoundError", 404, 404201, "Not found"),
+        ("WorkOrderNotificationNotFoundError", 404, 404202, "Not found"),
+        (
+            "WorkOrderAlreadyPendingError",
+            409,
+            409201,
+            "A pending application already exists",
+        ),
+        (
+            "WorkOrderAlreadyProcessedError",
+            409,
+            409202,
+            "The work order has already been processed",
+        ),
+        (
+            "WorkOrderApplicantAlreadyMemberError",
+            409,
+            409203,
+            "Applicant is already a space member",
+        ),
+        ("WorkOrderNoReviewerError", 409, 409204, "The space has no available approver"),
+        (
+            "WorkOrderJoinNotAllowedError",
+            409,
+            409205,
+            "The space does not accept join requests",
+        ),
+    ],
+)
+async def test_work_order_errors_have_stable_codes_and_fixed_messages(
+    error_type, status, code, message
+):
+    import json
+
+    from agentclaw.community.core.work_orders import errors
+
+    private_detail = "private work-order id and database diagnostics"
+
+    @envelope_errors
+    async def handler(request: Request):
+        raise getattr(errors, error_type)(private_detail)
+
+    response = await handler(request=_request())
+    body = json.loads(bytes(response.body))
+
+    assert response.status_code == status
+    assert body["code"] == code
+    assert body["message"] == message
+    assert body["data"] is None
+    assert private_detail not in body["message"]

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -1,0 +1,318 @@
+"""Contract tests for work-order and notification OpenAPI handlers."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.work_orders.router import router
+from agentclaw.community.api.work_order_service import (
+    WorkOrderNotificationServiceProtocol,
+    WorkOrderServiceProtocol,
+)
+from agentclaw.community.core.work_orders.errors import WorkOrderNotFoundError
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderDetail,
+    WorkOrderEventType,
+    WorkOrderListItem,
+    WorkOrderNotificationDetail,
+    WorkOrderNotificationRecord,
+    WorkOrderRecord,
+    WorkOrderReviewResult,
+    WorkOrderStatus,
+)
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+)
+
+CREATED = datetime(2026, 8, 18, 1, 2, 3)
+MODIFIED = datetime(2026, 8, 18, 2, 3, 4)
+NOTIFICATION_MODIFIED = datetime(2026, 8, 18, 3, 4, 5)
+
+
+def _work_order(status: WorkOrderStatus = WorkOrderStatus.PENDING) -> WorkOrderRecord:
+    return WorkOrderRecord(
+        id=11,
+        work_order_no="WO-11",
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        applicant_user_id="applicant-1",
+        apply_reason="join",
+        status=status,
+        reviewer_user_id=None,
+        review_remark=None,
+        reviewed_at=None,
+        env="dev",
+        gmt_created=CREATED,
+        gmt_modified=MODIFIED,
+    )
+
+
+def _notification(
+    category: NotificationCategory = NotificationCategory.NOTICE,
+) -> WorkOrderNotificationRecord:
+    return WorkOrderNotificationRecord(
+        id=21,
+        work_order_id=11,
+        recipient_user_id="owner-1",
+        notification_category=category,
+        event_type=WorkOrderEventType.SPACE_JOIN_REVIEWED,
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        title="reviewed",
+        content="approved",
+        is_read=False,
+        read_at=None,
+        env="dev",
+        gmt_created=CREATED,
+        gmt_modified=NOTIFICATION_MODIFIED,
+    )
+
+
+@pytest.fixture
+def work_order_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def notification_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def client(work_order_service, notification_service):
+    class _Bindings(Module):
+        def configure(self, binder):
+            binder.bind(WorkOrderServiceProtocol, to=work_order_service)
+            binder.bind(
+                WorkOrderNotificationServiceProtocol, to=notification_service
+            )
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "owner-1"}
+    attach_injector(app, Injector([_Bindings()]))
+    mount_public_error_handlers(app)
+    return TestClient(app)
+
+
+def test_create_join_request_uses_principal_and_returns_created(
+    client, work_order_service
+):
+    work_order_service.create_space_join_request.return_value = _work_order()
+
+    response = client.post(
+        "/openapi/v1/spaces/7/join-requests", json={"reason": "join"}
+    )
+
+    assert response.status_code == 201
+    assert response.json()["data"] == {
+        "work_order_id": 11,
+        "work_order_no": "WO-11",
+        "status": "PENDING",
+    }
+    work_order_service.create_space_join_request.assert_called_once_with(
+        space_id=7, applicant_user_id="owner-1", reason="join"
+    )
+
+
+def test_list_work_orders_maps_plain_and_notification_items(
+    client, work_order_service
+):
+    work_order_service.list_items.return_value = (
+        2,
+        [
+            WorkOrderListItem(
+                work_order=_work_order(), notification=None, can_approve=True
+            ),
+            WorkOrderListItem(
+                work_order=_work_order(WorkOrderStatus.APPROVED),
+                notification=_notification(),
+                can_approve=False,
+            ),
+        ],
+    )
+
+    response = client.get(
+        "/openapi/v1/work-orders",
+        params={
+            "query_type": "INITIATED_BY_ME",
+            "item_type": "ALL",
+            "page_no": 2,
+            "page_size": 5,
+        },
+    )
+
+    assert response.status_code == 200
+    items = response.json()["data"]["items"]
+    assert items[0]["item_id"] == "WORK_ORDER_11"
+    assert items[0]["item_type"] == "APPROVAL"
+    assert items[0]["notification_id"] is None
+    assert items[0]["gmt_modified"] == "2026-08-18T02:03:04Z"
+    assert items[1]["item_id"] == "NOTIFICATION_21"
+    assert items[1]["item_type"] == "NOTICE"
+    assert items[1]["notification_id"] == 21
+    assert items[1]["gmt_modified"] == "2026-08-18T03:04:05Z"
+    work_order_service.list_items.assert_called_once()
+    assert work_order_service.list_items.call_args.kwargs == {
+        "actor_id": "owner-1",
+        "query_type": "INITIATED_BY_ME",
+        "item_type": "ALL",
+        "page_no": 2,
+        "page_size": 5,
+    }
+
+
+def test_get_work_order_maps_nested_content(client, work_order_service):
+    work_order_service.get_detail.return_value = WorkOrderDetail(
+        work_order=_work_order(),
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED,
+        title="pending",
+        space_id=7,
+        space_name="Team",
+        applicant_name="Applicant",
+        can_approve=True,
+    )
+
+    response = client.get("/openapi/v1/work-orders/11")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["work_order_id"] == 11
+    assert data["biz_id"] == 7
+    assert data["content"] == {
+        "space_id": 7,
+        "space_name": "Team",
+        "applicant_user_id": "applicant-1",
+        "applicant_name": "Applicant",
+        "reason": "join",
+    }
+    assert data["can_approve"] is True
+    work_order_service.get_detail.assert_called_once_with(
+        work_order_id=11, actor_id="owner-1"
+    )
+
+
+@pytest.mark.parametrize(
+    ("operation", "status"),
+    [("approve", WorkOrderStatus.APPROVED), ("reject", WorkOrderStatus.REJECTED)],
+)
+def test_review_endpoints_return_explicit_result(
+    client, work_order_service, operation, status
+):
+    getattr(work_order_service, operation).return_value = WorkOrderReviewResult(
+        work_order_id=11,
+        status=status,
+        reviewer_user_id="owner-1",
+        review_remark="done",
+        reviewed_at=MODIFIED,
+    )
+
+    response = client.post(
+        f"/openapi/v1/work-orders/11/{operation}",
+        json={"review_remark": "done"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "work_order_id": 11,
+        "status": status.value,
+        "reviewer_user_id": "owner-1",
+        "review_remark": "done",
+        "reviewed_at": "2026-08-18T02:03:04Z",
+    }
+    getattr(work_order_service, operation).assert_called_once_with(
+        work_order_id=11, actor_id="owner-1", review_remark="done"
+    )
+
+
+def test_notification_count_and_read_all(client, notification_service):
+    notification_service.unread_count.return_value = 4
+    notification_service.mark_all_read.return_value = 3
+
+    unread = client.get("/openapi/v1/work-order-notifications/unread-count")
+    read_all = client.post("/openapi/v1/work-order-notifications/read-all")
+
+    assert unread.status_code == 200
+    assert unread.json()["data"] == {"unread_count": 4}
+    assert read_all.status_code == 200
+    assert read_all.json()["data"] == {"updated_count": 3}
+    notification_service.unread_count.assert_called_once_with(actor_id="owner-1")
+    notification_service.mark_all_read.assert_called_once_with(actor_id="owner-1")
+
+
+def test_notification_detail_and_mark_read(client, notification_service):
+    notification_service.get_detail.return_value = WorkOrderNotificationDetail(
+        notification=_notification(NotificationCategory.APPROVAL),
+        work_order_status=WorkOrderStatus.PENDING,
+        can_approve=True,
+    )
+    notification_service.mark_read.return_value = _notification().model_copy(
+        update={"is_read": True, "read_at": MODIFIED}
+    )
+
+    detail = client.get("/openapi/v1/work-order-notifications/21")
+    marked = client.post("/openapi/v1/work-order-notifications/21/read")
+
+    assert detail.status_code == 200
+    assert detail.json()["data"] == {
+        "notification_id": 21,
+        "work_order_id": 11,
+        "notification_category": "APPROVAL",
+        "event_type": "SPACE_JOIN_REVIEWED",
+        "title": "reviewed",
+        "content": "approved",
+        "is_read": False,
+        "work_order_status": "PENDING",
+        "can_approve": True,
+        "biz_type": "SPACE_JOIN",
+        "biz_id": "7",
+    }
+    assert marked.status_code == 200
+    assert marked.json()["data"] == {
+        "notification_id": 21,
+        "is_read": True,
+        "read_at": "2026-08-18T02:03:04Z",
+    }
+    notification_service.get_detail.assert_called_once_with(
+        notification_id=21, actor_id="owner-1"
+    )
+    notification_service.mark_read.assert_called_once_with(
+        notification_id=21, actor_id="owner-1"
+    )
+
+
+def test_domain_error_is_mapped_to_public_work_order_contract(
+    client, work_order_service
+):
+    work_order_service.get_detail.side_effect = WorkOrderNotFoundError("private id")
+
+    response = client.get("/openapi/v1/work-orders/999")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["code"] == 404201
+    assert body["message"] == "Not found"
+    assert body["data"] is None
+    assert "private id" not in body["message"]
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "payload"),
+    [
+        ("/openapi/v1/spaces/0/join-requests", "post", {"reason": "join"}),
+        ("/openapi/v1/spaces/7/join-requests", "post", {"reason": ""}),
+        ("/openapi/v1/work-orders?page_no=0", "get", None),
+        ("/openapi/v1/work-orders/0", "get", None),
+    ],
+)
+def test_request_validation_rejects_invalid_contract(client, path, method, payload):
+    response = getattr(client, method)(path, json=payload) if payload is not None else getattr(client, method)(path)
+    assert response.status_code == 422

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
@@ -30,6 +29,7 @@ from agentclaw.community.core.work_orders.models import (
 )
 from tests.community.adapters.http.openapi_v1.conftest import (
     mount_public_error_handlers,
+    user_scoped_client,
 )
 
 CREATED = datetime(2026, 8, 18, 1, 2, 3)
@@ -91,16 +91,14 @@ def client(work_order_service, notification_service):
     class _Bindings(Module):
         def configure(self, binder):
             binder.bind(WorkOrderServiceProtocol, to=work_order_service)
-            binder.bind(
-                WorkOrderNotificationServiceProtocol, to=notification_service
-            )
+            binder.bind(WorkOrderNotificationServiceProtocol, to=notification_service)
 
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[require_principal] = lambda: {"user_id": "owner-1"}
     attach_injector(app, Injector([_Bindings()]))
     mount_public_error_handlers(app)
-    return TestClient(app)
+    return user_scoped_client(app, "owner-1")
 
 
 def test_create_join_request_uses_principal_and_returns_created(
@@ -123,9 +121,7 @@ def test_create_join_request_uses_principal_and_returns_created(
     )
 
 
-def test_list_work_orders_maps_plain_and_notification_items(
-    client, work_order_service
-):
+def test_list_work_orders_maps_plain_and_notification_items(client, work_order_service):
     work_order_service.list_items.return_value = (
         2,
         [
@@ -314,5 +310,9 @@ def test_domain_error_is_mapped_to_public_work_order_contract(
     ],
 )
 def test_request_validation_rejects_invalid_contract(client, path, method, payload):
-    response = getattr(client, method)(path, json=payload) if payload is not None else getattr(client, method)(path)
+    response = (
+        getattr(client, method)(path, json=payload)
+        if payload is not None
+        else getattr(client, method)(path)
+    )
     assert response.status_code == 422

--- a/src/backend/tests/community/adapters/http/spaces_internal/test_spaces_internal_contract.py
+++ b/src/backend/tests/community/adapters/http/spaces_internal/test_spaces_internal_contract.py
@@ -1,0 +1,74 @@
+"""Contract tests for the internal personal-Space batch query."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_injector import attach_injector
+from injector import Injector, Module
+
+from agentclaw.community.adapters.http.spaces_internal.router import router
+from agentclaw.community.api.space_service import SpaceServiceProtocol
+from agentclaw.community.core.spaces.models import PersonalSpaceLookupRecord
+
+
+@pytest.fixture
+def service():
+    return MagicMock()
+
+
+@pytest.fixture
+def client(service):
+    class _Bindings(Module):
+        def configure(self, binder):
+            binder.bind(SpaceServiceProtocol, to=service)
+
+    app = FastAPI()
+    app.include_router(router)
+    attach_injector(app, Injector([_Bindings()]))
+    return TestClient(app)
+
+
+def test_batch_query_returns_found_and_missing_in_request_order(client, service):
+    service.batch_query_personal.return_value = [
+        PersonalSpaceLookupRecord(user_id="user-2", space_id=22, found=True),
+        PersonalSpaceLookupRecord(user_id="user-1", space_id=None, found=False),
+    ]
+
+    response = client.post(
+        "/api/internal/spaces/personal/batch-query",
+        json={"user_id": [" user-2 ", "user-1", "user-2"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["list"] == [
+        {"user_id": "user-2", "space_id": 22, "found": True},
+        {"user_id": "user-1", "space_id": None, "found": False},
+    ]
+    service.batch_query_personal.assert_called_once_with(user_ids=["user-2", "user-1"])
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"user_id": []},
+        {"user_id": [" "]},
+        {"user_id": [str(index) for index in range(501)]},
+        {"user_id": ["user-1"], "env": "prod"},
+        {"user_ids": ["user-1"]},
+    ],
+)
+def test_batch_query_rejects_invalid_user_id_lists(client, service, payload):
+    response = client.post("/api/internal/spaces/personal/batch-query", json=payload)
+
+    assert response.status_code == 422
+    service.batch_query_personal.assert_not_called()
+
+
+def test_batch_query_contract_uses_singular_user_id_field(client):
+    schema = client.get("/openapi.json").json()["components"]["schemas"]
+    properties = schema["PersonalSpaceBatchQueryRequest"]["properties"]
+
+    assert set(properties) == {"user_id"}

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -61,6 +61,13 @@ from agentclaw.community.api.local_skill_state_service import (
 from agentclaw.community.api.local_skill_delete_service import (
     LocalSkillDeleteServiceProtocol,
 )
+from agentclaw.community.api.market_favorite_service import (
+    MarketFavoriteServiceProtocol,
+)
+from agentclaw.community.api.space_service import (
+    SpaceMemberServiceProtocol,
+    SpaceServiceProtocol,
+)
 from agentclaw.community.core.bot_startup_script.services.startup_script_service import (
     BotStartupScriptService,
 )
@@ -80,6 +87,8 @@ from agentclaw.community.core.bot_app_grant.services import BotAppGrantService
 from agentclaw.community.core.skill_center.services.local_skill_delete_service import (
     LocalSkillDeleteService,
 )
+from agentclaw.community.core.market_favorites.services import MarketFavoriteService
+from agentclaw.community.core.spaces.services import SpaceMemberService, SpaceService
 
 
 # (Protocol, ConcreteService) pairs whose Protocol declares real signatures.
@@ -93,6 +102,9 @@ _PAIRS = [
     (LocalSkillUploadServiceProtocol, LocalSkillUploadService),
     (LocalSkillStateServiceProtocol, LocalSkillStateService),
     (LocalSkillDeleteServiceProtocol, LocalSkillDeleteService),
+    (SpaceServiceProtocol, SpaceService),
+    (SpaceMemberServiceProtocol, SpaceMemberService),
+    (MarketFavoriteServiceProtocol, MarketFavoriteService),
 ]
 
 _IDS = [f"{p.__name__}->{c.__name__}" for p, c in _PAIRS]

--- a/src/backend/tests/community/contracts/test_skill_center_client.py
+++ b/src/backend/tests/community/contracts/test_skill_center_client.py
@@ -9,13 +9,16 @@ Driving ``SkillPublishService.publish`` requires substantial bot +
 skill repository fixtures; the contract is verified through the
 DI-bound instance the service receives.
 
-Plugin-hit assertion: the local mock's envelope contains
-``status="PUBLISHED"`` + the input skillCode — a fingerprint no
-bypass could produce.
+Plugin-hit assertions: publish returns the local mock fingerprint, and team
+creation is recorded by ``MockSeam.calls_to`` with the exact request DTO.
 """
+
 from __future__ import annotations
 
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterClient,
+    SkillCenterTeamCreateRequest,
+)
 
 
 def test_local_skill_center_client_upload_returns_mock_envelope(world) -> None:
@@ -32,3 +35,20 @@ def test_local_skill_center_client_query_status_envelope(world) -> None:
     client = world.get(SkillCenterClient)
     result = client.query_publish_status("demo_skill")
     assert result["success"] is True
+
+
+def test_local_skill_center_client_create_team_records_plugin_hit(world) -> None:
+    client = world.get(SkillCenterClient)
+    request = SkillCenterTeamCreateRequest(
+        team_code="spc-0123456789abcdef0123",
+        team_name="Demo Team",
+        ref_source_id="7",
+    )
+
+    result = client.create_team(request)
+
+    assert result.team_id == f"mock-{request.team_code}"
+    calls = client.calls_to("create_team")
+    assert len(calls) == 1
+    assert calls[0].args == (request,)
+    assert calls[0].kwargs == {}

--- a/src/backend/tests/community/core/market_favorites/test_favorite_service.py
+++ b/src/backend/tests/community/core/market_favorites/test_favorite_service.py
@@ -1,0 +1,151 @@
+"""Behavior tests for Space-scoped market favorites."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.market_favorites.errors import (
+    FavoriteNotFoundError,
+    FavoriteTargetInvalidError,
+)
+from agentclaw.community.core.market_favorites.models import (
+    FavoriteTargetType,
+    MarketFavoriteRecord,
+)
+from agentclaw.community.core.market_favorites.services.favorite_service import (
+    MarketFavoriteService,
+)
+
+
+def _record(*, target_code: str = "skill-1") -> MarketFavoriteRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return MarketFavoriteRecord(
+        id=1,
+        space_id=7,
+        target_type=FavoriteTargetType.SKILL,
+        target_code=target_code,
+        created_by="member-1",
+        env="dev",
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def _service():
+    repository = MagicMock()
+    access = MagicMock()
+    return MarketFavoriteService(repository, access), repository, access
+
+
+def test_add_requires_membership_and_normalizes_target_code() -> None:
+    service, repository, access = _service()
+    repository.add.return_value = _record()
+
+    assert service.add(
+        space_id=7,
+        actor_id="member-1",
+        target_type=FavoriteTargetType.SKILL,
+        target_code=" skill-1 ",
+    ) == _record()
+
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="member-1"
+    )
+    repository.add.assert_called_once_with(
+        space_id=7,
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+        created_by="member-1",
+        env="dev",
+    )
+
+
+@pytest.mark.parametrize("target_code", ["", "   ", "x" * 129])
+def test_add_rejects_invalid_target_code(target_code: str) -> None:
+    service, repository, _ = _service()
+
+    with pytest.raises(FavoriteTargetInvalidError, match="1-128"):
+        service.add(
+            space_id=7,
+            actor_id="member-1",
+            target_type=FavoriteTargetType.MCP,
+            target_code=target_code,
+        )
+
+    repository.add.assert_not_called()
+
+
+def test_cancel_missing_favorite_is_not_reported_as_success() -> None:
+    service, repository, access = _service()
+    repository.cancel.return_value = False
+
+    with pytest.raises(FavoriteNotFoundError, match="not found"):
+        service.cancel(
+            space_id=7,
+            actor_id="member-1",
+            target_type=FavoriteTargetType.SKILL,
+            target_code=" skill-1 ",
+        )
+
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="member-1"
+    )
+    assert repository.cancel.call_args.kwargs["target_code"] == "skill-1"
+
+
+def test_cancel_existing_favorite_returns_true() -> None:
+    service, repository, _ = _service()
+    repository.cancel.return_value = True
+
+    assert service.cancel(
+        space_id=7,
+        actor_id="member-1",
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+    ) is True
+
+
+def test_search_requires_membership_and_normalizes_filters() -> None:
+    service, repository, access = _service()
+    repository.search.return_value = (1, [_record()])
+
+    result = service.search(
+        space_id=7,
+        actor_id="member-1",
+        target_type=FavoriteTargetType.SKILL,
+        keyword="  skill  ",
+        page_no=2,
+        page_size=10,
+    )
+
+    assert result == (1, [_record()])
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="member-1"
+    )
+    repository.search.assert_called_once_with(
+        space_id=7,
+        target_type=FavoriteTargetType.SKILL,
+        keyword="skill",
+        env="dev",
+        offset=10,
+        limit=10,
+    )
+
+
+def test_search_turns_blank_keyword_into_none() -> None:
+    service, repository, _ = _service()
+    repository.search.return_value = (0, [])
+
+    service.search(
+        space_id=7,
+        actor_id="member-1",
+        target_type=None,
+        keyword="  ",
+        page_no=1,
+        page_size=20,
+    )
+
+    assert repository.search.call_args.kwargs["keyword"] is None

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -83,6 +83,19 @@ def test_space_repository_full_member_lifecycle(db) -> None:
     )
     assert repository.get_space(space_id=999, env="dev") is None
 
+    other_env_personal, _ = repository.initialize_personal(
+        user_id="user-other-env", env="pre"
+    )
+    batch = repository.batch_query_personal(
+        user_ids=["missing", "user-1", "user-other-env"], env="dev"
+    )
+    assert [item.model_dump() for item in batch] == [
+        {"user_id": "missing", "space_id": None, "found": False},
+        {"user_id": "user-1", "space_id": personal.id, "found": True},
+        {"user_id": "user-other-env", "space_id": None, "found": False},
+    ]
+    assert other_env_personal.id is not None
+
     total, spaces = repository.list_spaces(
         user_id="user-1", env="dev", keyword=None, space_type=None, offset=0, limit=20
     )

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -1,0 +1,449 @@
+"""SQLite-backed unit tests for the new unified ORM repositories."""
+
+import asyncio
+
+import pytest
+
+from agentclaw.community.core.market_favorites.models import FavoriteTargetType
+from agentclaw.community.core.repository.implementations.market_favorites.favorite import (
+    MarketFavoriteRepository,
+)
+from agentclaw.community.core.repository.implementations.spaces.space import (
+    SpaceRepository,
+)
+from agentclaw.community.core.repository.implementations.work_orders.work_order import (
+    WorkOrderRepository,
+)
+from agentclaw.community.core.spaces.errors import SpaceMemberAlreadyExistsError
+from agentclaw.community.core.spaces.models import SpaceRole, SpaceType
+from agentclaw.community.core.spaces.repository.models import SpaceModel
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAccessDeniedError,
+    WorkOrderAlreadyPendingError,
+    WorkOrderAlreadyProcessedError,
+    WorkOrderNoReviewerError,
+    WorkOrderNotFoundError,
+)
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderEventType,
+    WorkOrderItemType,
+    WorkOrderNotificationDraft,
+    WorkOrderQueryType,
+    WorkOrderStatus,
+)
+from agentclaw.community.plugins.local.database import SqliteDB, reset_for_tests
+
+
+@pytest.fixture
+def db():
+    reset_for_tests()
+    plugin = SqliteDB()
+    asyncio.run(plugin.bootstrap())
+    yield plugin
+    reset_for_tests()
+
+
+def _team(spaces: SpaceRepository, name="Team", creator="owner-1"):
+    with spaces.create_team_transaction(
+        name=name, creator_id=creator, env="dev"
+    ) as row:
+        row.sc_team_id = f"sc-{name}-{creator}"
+        return row
+
+
+def _review_notification(
+    *, applicant_user_id: str, space_id: int, title: str, content: str
+) -> WorkOrderNotificationDraft:
+    return WorkOrderNotificationDraft(
+        recipient_user_id=applicant_user_id,
+        notification_category=NotificationCategory.NOTICE,
+        event_type=WorkOrderEventType.SPACE_JOIN_REVIEWED,
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id=str(space_id),
+        title=title,
+        content=content,
+    )
+
+
+def test_space_repository_full_member_lifecycle(db) -> None:
+    repository = SpaceRepository(db)
+
+    personal, created = repository.initialize_personal(user_id="user-1", env="dev")
+    same, created_again = repository.initialize_personal(user_id="user-1", env="dev")
+    team = _team(repository)
+
+    assert created is True
+    assert created_again is False
+    assert same.id == personal.id
+    assert (
+        repository.get_space(space_id=team.id, env="dev").sc_team_id
+        == "sc-Team-owner-1"
+    )
+    assert repository.get_space(space_id=999, env="dev") is None
+
+    total, spaces = repository.list_spaces(
+        user_id="user-1", env="dev", keyword=None, space_type=None, offset=0, limit=20
+    )
+    assert total == 2
+    assert {item.space.id for item in spaces} == {personal.id, team.id}
+    personal_summary = next(item for item in spaces if item.space.id == personal.id)
+    assert personal_summary.current_user_role is SpaceRole.OWNER
+
+    filtered_total, filtered = repository.list_spaces(
+        user_id="owner-1",
+        env="dev",
+        keyword="Tea",
+        space_type=SpaceType.TEAM.value,
+        offset=0,
+        limit=20,
+    )
+    assert filtered_total == 1
+    assert filtered[0].space.id == team.id
+
+    added = repository.add_member(
+        space_id=team.id,
+        user_id="member-1",
+        role=SpaceRole.MEMBER,
+        creator_id="owner-1",
+        env="dev",
+    )
+    assert (
+        repository.get_member(space_id=team.id, user_id="member-1", env="dev") == added
+    )
+    assert repository.get_member(space_id=team.id, user_id="missing", env="dev") is None
+    with pytest.raises(SpaceMemberAlreadyExistsError):
+        repository.add_member(
+            space_id=team.id,
+            user_id="member-1",
+            role=SpaceRole.MEMBER,
+            creator_id="owner-1",
+            env="dev",
+        )
+
+    member_total, members = repository.list_members(
+        space_id=team.id, env="dev", keyword="member", offset=0, limit=20
+    )
+    assert member_total == 1
+    assert members[0].is_creator is False
+    updated = repository.update_member_role(
+        space_id=team.id, user_id="member-1", role=SpaceRole.OWNER, env="dev"
+    )
+    assert updated.role is SpaceRole.OWNER
+    assert (
+        repository.update_member_role(
+            space_id=team.id, user_id="missing", role=SpaceRole.OWNER, env="dev"
+        )
+        is None
+    )
+    assert (
+        repository.delete_member(space_id=team.id, user_id="member-1", env="dev")
+        is True
+    )
+    assert (
+        repository.delete_member(space_id=team.id, user_id="member-1", env="dev")
+        is False
+    )
+
+
+def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:
+    spaces = SpaceRepository(db)
+    space = _team(spaces)
+    repository = MarketFavoriteRepository(db)
+
+    first = repository.add(
+        space_id=space.id,
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+        created_by="owner-1",
+        env="dev",
+    )
+    duplicate = repository.add(
+        space_id=space.id,
+        target_type=FavoriteTargetType.SKILL,
+        target_code="skill-1",
+        created_by="owner-1",
+        env="dev",
+    )
+    repository.add(
+        space_id=space.id,
+        target_type=FavoriteTargetType.MCP,
+        target_code="mcp-1",
+        created_by="owner-1",
+        env="dev",
+    )
+
+    assert duplicate.id == first.id
+    total, rows = repository.search(
+        space_id=space.id,
+        target_type=FavoriteTargetType.SKILL,
+        keyword="skill",
+        env="dev",
+        offset=0,
+        limit=10,
+    )
+    assert total == 1
+    assert rows[0].target_code == "skill-1"
+    assert (
+        repository.cancel(
+            space_id=space.id,
+            target_type=FavoriteTargetType.SKILL,
+            target_code="skill-1",
+            env="dev",
+        )
+        is True
+    )
+    assert (
+        repository.cancel(
+            space_id=space.id,
+            target_type=FavoriteTargetType.SKILL,
+            target_code="skill-1",
+            env="dev",
+        )
+        is False
+    )
+
+
+def test_work_order_repository_approve_and_notification_lifecycle(db) -> None:
+    spaces = SpaceRepository(db)
+    space = _team(spaces)
+    repository = WorkOrderRepository(db)
+
+    record = repository.create_space_join_request(
+        space_id=space.id,
+        applicant_user_id="applicant-1",
+        applicant_name="Applicant",
+        apply_reason="join",
+        env="dev",
+    )
+    assert record.status is WorkOrderStatus.PENDING
+    assert record.work_order_no.startswith("WO")
+    with pytest.raises(WorkOrderAlreadyPendingError):
+        repository.create_space_join_request(
+            space_id=space.id,
+            applicant_user_id="applicant-1",
+            applicant_name="Applicant",
+            apply_reason="join",
+            env="dev",
+        )
+    with pytest.raises(WorkOrderNotFoundError):
+        repository.create_space_join_request(
+            space_id=999,
+            applicant_user_id="applicant-1",
+            applicant_name="Applicant",
+            apply_reason="join",
+            env="dev",
+        )
+
+    total, pending = repository.list_items(
+        actor_id="owner-1",
+        env="dev",
+        query_type=WorkOrderQueryType.PENDING_FOR_ME,
+        item_type=WorkOrderItemType.ALL,
+        offset=0,
+        limit=20,
+    )
+    assert total == 1
+    assert pending[0].can_approve is True
+    initiated_total, initiated = repository.list_items(
+        actor_id="applicant-1",
+        env="dev",
+        query_type=WorkOrderQueryType.INITIATED_BY_ME,
+        item_type=WorkOrderItemType.APPROVAL,
+        offset=0,
+        limit=20,
+    )
+    assert initiated_total == 1
+    assert initiated[0].notification is None
+    repository.list_items(
+        actor_id="owner-1",
+        env="dev",
+        query_type=WorkOrderQueryType.PENDING_FOR_ME,
+        item_type=WorkOrderItemType.APPROVAL,
+        offset=0,
+        limit=20,
+    )
+    repository.list_items(
+        actor_id="applicant-1",
+        env="dev",
+        query_type=WorkOrderQueryType.INITIATED_BY_ME,
+        item_type=WorkOrderItemType.NOTICE,
+        offset=0,
+        limit=20,
+    )
+
+    owner_detail = repository.get_detail(
+        work_order_id=record.id, actor_id="owner-1", env="dev"
+    )
+    assert owner_detail.can_approve is True
+    assert (
+        repository.get_detail(work_order_id=record.id, actor_id="intruder", env="dev")
+        is None
+    )
+    assert (
+        repository.get_detail(work_order_id=999, actor_id="owner-1", env="dev") is None
+    )
+
+    notification = pending[0].notification
+    assert repository.count_unread(recipient_user_id="owner-1", env="dev") == 1
+    detail = repository.get_notification(
+        notification_id=notification.id,
+        recipient_user_id="owner-1",
+        env="dev",
+        mark_read=True,
+    )
+    assert detail.notification.is_read is True
+    assert detail.can_approve is True
+    assert (
+        repository.mark_notification_read(
+            notification_id=999, recipient_user_id="owner-1", env="dev"
+        )
+        is None
+    )
+
+    with pytest.raises(WorkOrderAccessDeniedError):
+        repository.review_space_join(
+            work_order_id=record.id,
+            reviewer_user_id="intruder",
+            review_remark="ok",
+            target_status=WorkOrderStatus.APPROVED,
+            notification=_review_notification(
+                applicant_user_id="applicant-1",
+                space_id=space.id,
+                title="approved",
+                content="approved content",
+            ),
+            env="dev",
+        )
+    approved_notification = _review_notification(
+        applicant_user_id="applicant-1",
+        space_id=space.id,
+        title="custom approved title",
+        content="custom approved content",
+    )
+    result = repository.review_space_join(
+        work_order_id=record.id,
+        reviewer_user_id="owner-1",
+        review_remark="ok",
+        target_status=WorkOrderStatus.APPROVED,
+        notification=approved_notification,
+        env="dev",
+    )
+    assert result.status is WorkOrderStatus.APPROVED
+    assert (
+        spaces.get_member(space_id=space.id, user_id="applicant-1", env="dev")
+        is not None
+    )
+    with pytest.raises(WorkOrderAlreadyProcessedError):
+        repository.review_space_join(
+            work_order_id=record.id,
+            reviewer_user_id="owner-1",
+            review_remark="again",
+            target_status=WorkOrderStatus.REJECTED,
+            notification=_review_notification(
+                applicant_user_id="applicant-1",
+                space_id=space.id,
+                title="rejected",
+                content="rejected content",
+            ),
+            env="dev",
+        )
+
+    processed_total, processed = repository.list_items(
+        actor_id="owner-1",
+        env="dev",
+        query_type=WorkOrderQueryType.PROCESSED_BY_ME,
+        item_type=WorkOrderItemType.ALL,
+        offset=0,
+        limit=20,
+    )
+    assert processed_total == 1
+    assert processed[0].work_order.status is WorkOrderStatus.APPROVED
+    applicant_total, applicant_items = repository.list_items(
+        actor_id="applicant-1",
+        env="dev",
+        query_type=WorkOrderQueryType.PENDING_FOR_ME,
+        item_type=WorkOrderItemType.NOTICE,
+        offset=0,
+        limit=20,
+    )
+    assert applicant_total == 1
+    applicant_notification = applicant_items[0].notification
+    assert applicant_notification.title == approved_notification.title
+    assert applicant_notification.content == approved_notification.content
+    assert (
+        repository.mark_notification_read(
+            notification_id=applicant_notification.id,
+            recipient_user_id="applicant-1",
+            env="dev",
+        ).is_read
+        is True
+    )
+    assert (
+        repository.mark_all_notifications_read(
+            recipient_user_id="applicant-1", env="dev"
+        )
+        == 0
+    )
+
+
+def test_work_order_repository_rejects_and_requires_reviewer(db) -> None:
+    spaces = SpaceRepository(db)
+    no_owner = SpaceModel(
+        space_code="spc-no-owner",
+        space_type=SpaceType.TEAM.value,
+        name="No Owner",
+        personal_owner_id=None,
+        env="dev",
+        created_by="creator",
+        updated_by="creator",
+    )
+    with db.orm_session() as session:
+        session.add(no_owner)
+        session.flush()
+        session.refresh(no_owner)
+        no_owner_id = no_owner.id
+    repository = WorkOrderRepository(db)
+    with pytest.raises(WorkOrderNoReviewerError):
+        repository.create_space_join_request(
+            space_id=no_owner_id,
+            applicant_user_id="applicant-1",
+            applicant_name="Applicant",
+            apply_reason="join",
+            env="dev",
+        )
+
+    team = _team(spaces, name="Reject Team", creator="owner-2")
+    record = repository.create_space_join_request(
+        space_id=team.id,
+        applicant_user_id="applicant-2",
+        applicant_name="Applicant 2",
+        apply_reason="join",
+        env="dev",
+    )
+    result = repository.review_space_join(
+        work_order_id=record.id,
+        reviewer_user_id="owner-2",
+        review_remark="capacity",
+        target_status=WorkOrderStatus.REJECTED,
+        notification=_review_notification(
+            applicant_user_id="applicant-2",
+            space_id=team.id,
+            title="custom rejected title",
+            content="custom rejected content",
+        ),
+        env="dev",
+    )
+    assert result.status is WorkOrderStatus.REJECTED
+    assert spaces.get_member(space_id=team.id, user_id="applicant-2", env="dev") is None
+    _, applicant_items = repository.list_items(
+        actor_id="applicant-2",
+        env="dev",
+        query_type=WorkOrderQueryType.PENDING_FOR_ME,
+        item_type=WorkOrderItemType.NOTICE,
+        offset=0,
+        limit=20,
+    )
+    assert applicant_items[0].notification.title == "custom rejected title"
+    assert applicant_items[0].notification.content == "custom rejected content"

--- a/src/backend/tests/community/core/spaces/test_space_access_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_access_service.py
@@ -1,0 +1,127 @@
+"""Unit tests for centralized Space authorization."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNotFoundError,
+)
+from agentclaw.community.core.spaces.models import (
+    SpaceMemberRecord,
+    SpaceRecord,
+    SpaceRole,
+    SpaceType,
+)
+from agentclaw.community.core.spaces.services.space_access_service import (
+    SpaceAccessService,
+)
+
+
+def _space(*, created_by: str = "owner-1") -> SpaceRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return SpaceRecord(
+        id=7,
+        space_code="spc-7",
+        space_type=SpaceType.TEAM,
+        name="Team",
+        personal_owner_id=None,
+        env="test",
+        created_by=created_by,
+        updated_by=created_by,
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def _member(*, role: SpaceRole = SpaceRole.MEMBER) -> SpaceMemberRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return SpaceMemberRecord(
+        id=2,
+        space_id=7,
+        user_id="member-1",
+        role=role,
+        env="test",
+        created_by="owner-1",
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def test_require_space_returns_existing_space() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = _space()
+
+    result = SpaceAccessService(repository).require_space(space_id=7)
+
+    assert result.id == 7
+    repository.get_space.assert_called_once_with(space_id=7, env="dev")
+
+
+def test_require_space_rejects_missing_space() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = None
+
+    with pytest.raises(SpaceNotFoundError, match="space not found"):
+        SpaceAccessService(repository).require_space(space_id=7)
+
+
+def test_get_space_role_returns_role_or_none() -> None:
+    repository = MagicMock()
+    repository.get_member.side_effect = [_member(role=SpaceRole.OWNER), None]
+    service = SpaceAccessService(repository)
+
+    assert service.get_space_role(space_id=7, user_id="owner-1") is SpaceRole.OWNER
+    assert service.get_space_role(space_id=7, user_id="stranger") is None
+
+
+def test_require_space_member_returns_space_and_membership() -> None:
+    repository = MagicMock()
+    space = _space()
+    member = _member()
+    repository.get_space.return_value = space
+    repository.get_member.return_value = member
+
+    assert SpaceAccessService(repository).require_space_member(
+        space_id=7, user_id="member-1"
+    ) == (space, member)
+
+
+def test_require_space_member_rejects_non_member() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = _space()
+    repository.get_member.return_value = None
+
+    with pytest.raises(SpaceAccessDeniedError, match="membership required"):
+        SpaceAccessService(repository).require_space_member(
+            space_id=7, user_id="stranger"
+        )
+
+
+def test_require_space_owner_accepts_owner_and_rejects_member() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = _space()
+    repository.get_member.side_effect = [
+        _member(role=SpaceRole.OWNER),
+        _member(role=SpaceRole.MEMBER),
+    ]
+    service = SpaceAccessService(repository)
+
+    _, owner = service.require_space_owner(space_id=7, user_id="owner-1")
+    assert owner.role is SpaceRole.OWNER
+    with pytest.raises(SpaceAccessDeniedError, match="owner role required"):
+        service.require_space_owner(space_id=7, user_id="member-1")
+
+
+def test_require_space_creator_accepts_creator_and_rejects_other_user() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = _space(created_by="owner-1")
+    service = SpaceAccessService(repository)
+
+    assert service.require_space_creator(space_id=7, user_id="owner-1").id == 7
+    with pytest.raises(SpaceAccessDeniedError, match="creator required"):
+        service.require_space_creator(space_id=7, user_id="owner-2")

--- a/src/backend/tests/community/core/spaces/test_space_member_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_member_service.py
@@ -1,0 +1,244 @@
+"""Behavior tests for Space member management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.spaces.errors import (
+    PersonalSpaceInvariantError,
+    SpaceCreatorInvariantError,
+    SpaceMemberAlreadyExistsError,
+    SpaceMemberInvalidError,
+    SpaceMemberNotFoundError,
+)
+from agentclaw.community.core.spaces.models import (
+    SpaceMemberRecord,
+    SpaceRole,
+    SpaceRecord,
+    SpaceType,
+)
+from agentclaw.community.core.spaces.services.space_member_service import (
+    SpaceMemberService,
+)
+
+
+def _space(
+    *, space_type: SpaceType = SpaceType.TEAM, created_by: str = "owner-1"
+) -> SpaceRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return SpaceRecord(
+        id=7,
+        space_code="spc-7",
+        space_type=space_type,
+        name="Team",
+        personal_owner_id=created_by if space_type is SpaceType.PERSONAL else None,
+        env="test",
+        created_by=created_by,
+        updated_by=created_by,
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def _member(
+    *, user_id: str = "member-1", role: SpaceRole = SpaceRole.MEMBER
+) -> SpaceMemberRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return SpaceMemberRecord(
+        id=2,
+        space_id=7,
+        user_id=user_id,
+        role=role,
+        env="test",
+        created_by="owner-1",
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+def _service(*, space: SpaceRecord | None = None):
+    repository = MagicMock()
+    access = MagicMock()
+    access.require_space_owner.return_value = (space or _space(), MagicMock())
+    return SpaceMemberService(repository, access), repository, access
+
+
+def test_list_members_checks_membership_and_normalizes_pagination() -> None:
+    service, repository, access = _service()
+    repository.list_members.return_value = (0, [])
+
+    assert service.list_members(
+        space_id=7,
+        actor_id="member-1",
+        keyword="  alice  ",
+        page_no=3,
+        page_size=20,
+    ) == (0, [])
+
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="member-1"
+    )
+    repository.list_members.assert_called_once_with(
+        space_id=7, env="dev", keyword="alice", offset=40, limit=20
+    )
+
+
+def test_list_members_turns_blank_keyword_into_none() -> None:
+    service, repository, _ = _service()
+    repository.list_members.return_value = (0, [])
+
+    service.list_members(
+        space_id=7, actor_id="member-1", keyword="  ", page_no=1, page_size=10
+    )
+
+    assert repository.list_members.call_args.kwargs["keyword"] is None
+
+
+def test_add_member_propagates_requested_role_to_repository() -> None:
+    service, repository, _ = _service()
+    repository.get_member.return_value = None
+    repository.add_member.return_value = _member(
+        user_id="owner-2", role=SpaceRole.OWNER
+    )
+
+    record = service.add_member(
+        space_id=7,
+        actor_id="owner-1",
+        user_id=" owner-2 ",
+        role=SpaceRole.OWNER,
+    )
+
+    assert record.role is SpaceRole.OWNER
+    repository.add_member.assert_called_once_with(
+        space_id=7,
+        user_id="owner-2",
+        role=SpaceRole.OWNER,
+        creator_id="owner-1",
+        env="dev",
+    )
+
+
+@pytest.mark.parametrize("user_id", ["", "   "])
+def test_add_member_rejects_blank_user_id(user_id: str) -> None:
+    service, _, _ = _service()
+
+    with pytest.raises(SpaceMemberInvalidError, match="user id is empty"):
+        service.add_member(
+            space_id=7,
+            actor_id="owner-1",
+            user_id=user_id,
+            role=SpaceRole.MEMBER,
+        )
+
+
+def test_add_member_rejects_personal_space() -> None:
+    service, _, _ = _service(space=_space(space_type=SpaceType.PERSONAL))
+
+    with pytest.raises(PersonalSpaceInvariantError, match="cannot add members"):
+        service.add_member(
+            space_id=7,
+            actor_id="owner-1",
+            user_id="member-1",
+            role=SpaceRole.MEMBER,
+        )
+
+
+def test_add_member_rejects_existing_member() -> None:
+    service, repository, _ = _service()
+    repository.get_member.return_value = _member()
+
+    with pytest.raises(SpaceMemberAlreadyExistsError, match="already exists"):
+        service.add_member(
+            space_id=7,
+            actor_id="owner-1",
+            user_id="member-1",
+            role=SpaceRole.MEMBER,
+        )
+
+
+def test_delete_member_returns_true_for_existing_non_creator() -> None:
+    service, repository, _ = _service()
+    repository.delete_member.return_value = True
+
+    assert service.delete_member(
+        space_id=7, actor_id="owner-1", user_id=" member-1 "
+    ) is True
+    repository.delete_member.assert_called_once_with(
+        space_id=7, user_id="member-1", env="dev"
+    )
+
+
+def test_delete_member_rejects_creator() -> None:
+    service, repository, _ = _service()
+
+    with pytest.raises(SpaceCreatorInvariantError, match="cannot be removed"):
+        service.delete_member(space_id=7, actor_id="owner-1", user_id="owner-1")
+
+    repository.delete_member.assert_not_called()
+
+
+def test_delete_member_reports_missing_target() -> None:
+    service, repository, _ = _service()
+    repository.delete_member.return_value = False
+
+    with pytest.raises(SpaceMemberNotFoundError, match="not found"):
+        service.delete_member(space_id=7, actor_id="owner-1", user_id="member-1")
+
+
+def test_update_role_returns_summary_and_creator_flag() -> None:
+    service, repository, _ = _service()
+    repository.update_member_role.return_value = _member(
+        user_id="owner-1", role=SpaceRole.OWNER
+    )
+
+    summary = service.update_role(
+        space_id=7,
+        actor_id="owner-1",
+        user_id=" owner-1 ",
+        role=SpaceRole.OWNER,
+    )
+
+    assert summary.is_creator is True
+    assert summary.member.role is SpaceRole.OWNER
+
+
+def test_update_role_rejects_personal_space() -> None:
+    service, _, _ = _service(space=_space(space_type=SpaceType.PERSONAL))
+
+    with pytest.raises(PersonalSpaceInvariantError, match="immutable"):
+        service.update_role(
+            space_id=7,
+            actor_id="owner-1",
+            user_id="owner-1",
+            role=SpaceRole.OWNER,
+        )
+
+
+def test_update_role_rejects_creator_demotion() -> None:
+    service, repository, _ = _service()
+
+    with pytest.raises(SpaceCreatorInvariantError, match="cannot be demoted"):
+        service.update_role(
+            space_id=7,
+            actor_id="owner-1",
+            user_id="owner-1",
+            role=SpaceRole.MEMBER,
+        )
+
+    repository.update_member_role.assert_not_called()
+
+
+def test_update_role_reports_missing_member() -> None:
+    service, repository, _ = _service()
+    repository.update_member_role.return_value = None
+
+    with pytest.raises(SpaceMemberNotFoundError, match="not found"):
+        service.update_role(
+            space_id=7,
+            actor_id="owner-1",
+            user_id="member-1",
+            role=SpaceRole.OWNER,
+        )

--- a/src/backend/tests/community/core/spaces/test_space_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_service.py
@@ -165,3 +165,25 @@ def test_list_spaces_turns_blank_optional_filters_into_none() -> None:
 
     assert repository.list_spaces.call_args.kwargs["keyword"] is None
     assert repository.list_spaces.call_args.kwargs["space_type"] is None
+
+
+def test_batch_query_personal_deduplicates_and_preserves_first_occurrence() -> None:
+    repository = MagicMock()
+    repository.batch_query_personal.return_value = []
+    service = SpaceService(repository, MagicMock())
+
+    assert service.batch_query_personal(user_ids=[" user-2 ", "user-1", "user-2"]) == []
+    repository.batch_query_personal.assert_called_once_with(
+        user_ids=["user-2", "user-1"], env="dev"
+    )
+
+
+@pytest.mark.parametrize("user_ids", [[], ["  "], [str(index) for index in range(501)]])
+def test_batch_query_personal_rejects_invalid_ids(user_ids: list[str]) -> None:
+    repository = MagicMock()
+    service = SpaceService(repository, MagicMock())
+
+    with pytest.raises(ValueError, match="user_id"):
+        service.batch_query_personal(user_ids=user_ids)
+
+    repository.batch_query_personal.assert_not_called()

--- a/src/backend/tests/community/core/spaces/test_space_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_service.py
@@ -1,0 +1,167 @@
+"""Focused behavior tests for team Space creation and SC synchronization."""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.repository.implementations.spaces.space import (
+    SpaceRepository,
+)
+from agentclaw.community.core.spaces.models import SpaceRecord, SpaceType
+from agentclaw.community.core.spaces.services.space_service import SpaceService
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterTeamCreateError,
+    SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
+)
+
+
+def _space() -> SpaceRecord:
+    now = datetime(2026, 8, 18, 10, 0, 0)
+    return SpaceRecord(
+        id=7,
+        space_code="spc-0123456789abcdef0123",
+        space_type=SpaceType.TEAM,
+        name="Demo Team",
+        personal_owner_id=None,
+        env="dev",
+        created_by="owner-1",
+        updated_by="owner-1",
+        gmt_created=now,
+        gmt_modified=now,
+    )
+
+
+class _TransactionRepository:
+    def __init__(self, record: SpaceRecord) -> None:
+        self.record = record
+        self.committed = False
+        self.rolled_back = False
+        self.arguments: dict[str, str] = {}
+
+    @contextmanager
+    def create_team_transaction(self, *, name: str, creator_id: str, env: str):
+        self.arguments = {"name": name, "creator_id": creator_id, "env": env}
+        try:
+            yield self.record
+        except Exception:
+            self.rolled_back = True
+            raise
+        else:
+            self.committed = True
+
+
+def test_create_team_pushes_to_sc_before_transaction_commit() -> None:
+    repository = _TransactionRepository(_space())
+    skill_center = MagicMock()
+    skill_center.create_team.return_value = SkillCenterTeamCreateResult(
+        team_id="sc-team-9001"
+    )
+    service = SpaceService(repository, skill_center)
+
+    record = service.create_team(name="  Demo Team  ", creator_id="owner-1")
+
+    assert record == repository.record
+    assert repository.arguments == {
+        "name": "Demo Team",
+        "creator_id": "owner-1",
+        "env": "dev",
+    }
+    skill_center.create_team.assert_called_once_with(
+        SkillCenterTeamCreateRequest(
+            team_code="spc-0123456789abcdef0123",
+            team_name="Demo Team",
+            ref_source_id="7",
+        )
+    )
+    assert record.sc_team_id == "sc-team-9001"
+    assert repository.committed is True
+    assert repository.rolled_back is False
+
+
+def test_create_team_rolls_back_when_sc_creation_fails() -> None:
+    repository = _TransactionRepository(_space())
+    skill_center = MagicMock()
+    skill_center.create_team.side_effect = SkillCenterTeamCreateError("SC failed")
+    service = SpaceService(repository, skill_center)
+
+    with pytest.raises(SkillCenterTeamCreateError, match="SC failed"):
+        service.create_team(name="Demo Team", creator_id="owner-1")
+
+    assert repository.committed is False
+    assert repository.rolled_back is True
+
+
+def test_generated_space_code_matches_sc_format() -> None:
+    code = SpaceRepository._new_code()
+
+    assert len(code) == 24
+    assert re.fullmatch(r"spc-[0-9a-f]{20}", code)
+
+
+@pytest.mark.parametrize("name", ["", "   ", "x" * 129])
+def test_create_team_rejects_invalid_name(name: str) -> None:
+    repository = MagicMock()
+    skill_center = MagicMock()
+    service = SpaceService(repository, skill_center)
+
+    from agentclaw.community.core.spaces.errors import SpaceNameInvalidError
+
+    with pytest.raises(SpaceNameInvalidError, match="1-128"):
+        service.create_team(name=name, creator_id="owner-1")
+
+    repository.create_team_transaction.assert_not_called()
+    skill_center.create_team.assert_not_called()
+
+
+def test_initialize_personal_delegates_to_repository() -> None:
+    repository = MagicMock()
+    repository.initialize_personal.return_value = (_space(), True)
+    service = SpaceService(repository, MagicMock())
+
+    assert service.initialize_personal(user_id="owner-1") == (_space(), True)
+    repository.initialize_personal.assert_called_once_with(user_id="owner-1", env="dev")
+
+
+def test_list_spaces_normalizes_filters_and_pagination() -> None:
+    repository = MagicMock()
+    repository.list_spaces.return_value = (0, [])
+    service = SpaceService(repository, MagicMock())
+
+    assert service.list_spaces(
+        user_id="owner-1",
+        keyword="  Demo  ",
+        space_type=SpaceType.TEAM,
+        page_no=2,
+        page_size=25,
+    ) == (0, [])
+    repository.list_spaces.assert_called_once_with(
+        user_id="owner-1",
+        env="dev",
+        keyword="Demo",
+        space_type="TEAM",
+        offset=25,
+        limit=25,
+    )
+
+
+def test_list_spaces_turns_blank_optional_filters_into_none() -> None:
+    repository = MagicMock()
+    repository.list_spaces.return_value = (0, [])
+    service = SpaceService(repository, MagicMock())
+
+    service.list_spaces(
+        user_id="owner-1",
+        keyword="  ",
+        space_type=None,
+        page_no=1,
+        page_size=20,
+    )
+
+    assert repository.list_spaces.call_args.kwargs["keyword"] is None
+    assert repository.list_spaces.call_args.kwargs["space_type"] is None

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -1,0 +1,361 @@
+"""Unit tests for work-order orchestration and recipient notifications."""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
+from agentclaw.community.core.spaces.models import SpaceRecord, SpaceType
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAccessDeniedError,
+    WorkOrderApplicantAlreadyMemberError,
+    WorkOrderInvalidReasonError,
+    WorkOrderInvalidRemarkError,
+    WorkOrderJoinNotAllowedError,
+    WorkOrderNotificationNotFoundError,
+    WorkOrderNotFoundError,
+)
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderBizType,
+    WorkOrderDetail,
+    WorkOrderEventType,
+    WorkOrderItemType,
+    WorkOrderNotificationDetail,
+    WorkOrderNotificationDraft,
+    WorkOrderNotificationRecord,
+    WorkOrderQueryType,
+    WorkOrderRecord,
+    WorkOrderReviewResult,
+    WorkOrderStatus,
+)
+from agentclaw.community.core.work_orders.services.work_order_service import (
+    WorkOrderNotificationService,
+    WorkOrderService,
+)
+
+NOW = datetime(2026, 8, 18, 8, 0, 0)
+
+
+def _space(space_type: SpaceType = SpaceType.TEAM) -> SpaceRecord:
+    return SpaceRecord(
+        id=7,
+        space_code="spc-7",
+        space_type=space_type,
+        name="Team",
+        personal_owner_id=None,
+        env="dev",
+        created_by="owner-1",
+        updated_by="owner-1",
+        gmt_created=NOW,
+        gmt_modified=NOW,
+    )
+
+
+def _work_order() -> WorkOrderRecord:
+    return WorkOrderRecord(
+        id=11,
+        work_order_no="WO-11",
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        applicant_user_id="applicant-1",
+        apply_reason="join",
+        status=WorkOrderStatus.PENDING,
+        reviewer_user_id=None,
+        review_remark=None,
+        reviewed_at=None,
+        env="dev",
+        gmt_created=NOW,
+        gmt_modified=NOW,
+    )
+
+
+def _detail() -> WorkOrderDetail:
+    return WorkOrderDetail(
+        work_order=_work_order(),
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED,
+        title="pending",
+        space_id=7,
+        space_name="Team",
+        applicant_name="Applicant",
+        can_approve=True,
+    )
+
+
+def _notification() -> WorkOrderNotificationRecord:
+    return WorkOrderNotificationRecord(
+        id=21,
+        work_order_id=11,
+        recipient_user_id="owner-1",
+        notification_category=NotificationCategory.APPROVAL,
+        event_type=WorkOrderEventType.SPACE_JOIN_APPLIED,
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        title="pending",
+        content="content",
+        is_read=False,
+        read_at=None,
+        env="dev",
+        gmt_created=NOW,
+        gmt_modified=NOW,
+    )
+
+
+def _service():
+    repository = MagicMock()
+    spaces = MagicMock()
+    access = MagicMock()
+    notifications = MagicMock(spec=WorkOrderNotificationService)
+    return (
+        WorkOrderService(repository, spaces, access, notifications),
+        repository,
+        spaces,
+        access,
+        notifications,
+    )
+
+
+@pytest.mark.parametrize("value", ["", "   ", "x" * 513])
+def test_create_rejects_invalid_reason(value: str) -> None:
+    service, repository, _, _, _ = _service()
+
+    with pytest.raises(WorkOrderInvalidReasonError, match="1-512"):
+        service.create_space_join_request(
+            space_id=7, applicant_user_id="applicant-1", reason=value
+        )
+
+    repository.create_space_join_request.assert_not_called()
+
+
+def test_create_space_join_request_normalizes_and_delegates() -> None:
+    service, repository, spaces, access, _ = _service()
+    access.require_space.return_value = _space()
+    spaces.get_member.return_value = None
+    repository.create_space_join_request.return_value = _work_order()
+
+    result = service.create_space_join_request(
+        space_id=7, applicant_user_id="applicant-1", reason="  join  "
+    )
+
+    assert result == _work_order()
+    access.require_space.assert_called_once_with(space_id=7)
+    spaces.get_member.assert_called_once_with(
+        space_id=7, user_id="applicant-1", env="dev"
+    )
+    repository.create_space_join_request.assert_called_once_with(
+        space_id=7,
+        applicant_user_id="applicant-1",
+        applicant_name="applicant-1",
+        apply_reason="join",
+        env="dev",
+    )
+
+
+def test_create_rejects_personal_space() -> None:
+    service, repository, spaces, access, _ = _service()
+    access.require_space.return_value = _space(SpaceType.PERSONAL)
+
+    with pytest.raises(WorkOrderJoinNotAllowedError):
+        service.create_space_join_request(
+            space_id=7, applicant_user_id="applicant-1", reason="join"
+        )
+
+    spaces.get_member.assert_not_called()
+    repository.create_space_join_request.assert_not_called()
+
+
+def test_create_rejects_existing_member() -> None:
+    service, repository, spaces, access, _ = _service()
+    access.require_space.return_value = _space()
+    spaces.get_member.return_value = object()
+
+    with pytest.raises(WorkOrderApplicantAlreadyMemberError):
+        service.create_space_join_request(
+            space_id=7, applicant_user_id="applicant-1", reason="join"
+        )
+
+    repository.create_space_join_request.assert_not_called()
+
+
+def test_list_items_forwards_filters_and_normalizes_pagination() -> None:
+    service, repository, _, _, _ = _service()
+    repository.list_items.return_value = (0, [])
+
+    assert service.list_items(
+        actor_id="owner-1",
+        query_type=WorkOrderQueryType.PROCESSED_BY_ME,
+        item_type=WorkOrderItemType.NOTICE,
+        page_no=3,
+        page_size=10,
+    ) == (0, [])
+    repository.list_items.assert_called_once_with(
+        actor_id="owner-1",
+        env="dev",
+        query_type=WorkOrderQueryType.PROCESSED_BY_ME,
+        item_type=WorkOrderItemType.NOTICE,
+        offset=20,
+        limit=10,
+    )
+
+
+def test_get_detail_returns_record_and_missing_raises() -> None:
+    service, repository, _, _, _ = _service()
+    repository.get_detail.side_effect = [_detail(), None]
+
+    assert service.get_detail(work_order_id=11, actor_id="owner-1") == _detail()
+    with pytest.raises(WorkOrderNotFoundError):
+        service.get_detail(work_order_id=12, actor_id="owner-1")
+
+
+@pytest.mark.parametrize(
+    ("method", "status"),
+    [("approve", WorkOrderStatus.APPROVED), ("reject", WorkOrderStatus.REJECTED)],
+)
+def test_review_requires_owner_and_delegates(
+    method: str, status: WorkOrderStatus
+) -> None:
+    service, repository, _, access, notifications = _service()
+    repository.get_detail.return_value = _detail()
+    notification = WorkOrderNotificationDraft(
+        recipient_user_id="applicant-1",
+        notification_category=NotificationCategory.NOTICE,
+        event_type=WorkOrderEventType.SPACE_JOIN_REVIEWED,
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        title="reviewed",
+        content="result",
+    )
+    notifications.build_space_join_review_result.return_value = notification
+    expected = WorkOrderReviewResult(
+        work_order_id=11,
+        status=status,
+        reviewer_user_id="owner-1",
+        review_remark="ok",
+        reviewed_at=NOW,
+    )
+    repository.review_space_join.return_value = expected
+
+    result = getattr(service, method)(
+        work_order_id=11, actor_id="owner-1", review_remark="  ok  "
+    )
+
+    assert result == expected
+    access.require_space_owner.assert_called_once_with(space_id=7, user_id="owner-1")
+    notifications.build_space_join_review_result.assert_called_once_with(
+        detail=_detail(),
+        target_status=status,
+        review_remark="ok",
+    )
+    repository.review_space_join.assert_called_once_with(
+        work_order_id=11,
+        reviewer_user_id="owner-1",
+        review_remark="ok",
+        target_status=status,
+        notification=notification,
+        env="dev",
+    )
+
+
+@pytest.mark.parametrize("value", ["", "   ", "x" * 513])
+def test_review_rejects_invalid_remark(value: str) -> None:
+    service, repository, _, _, _ = _service()
+
+    with pytest.raises(WorkOrderInvalidRemarkError, match="1-512"):
+        service.approve(work_order_id=11, actor_id="owner-1", review_remark=value)
+
+    repository.get_detail.assert_not_called()
+
+
+def test_review_maps_space_access_denied_to_work_order_error() -> None:
+    service, repository, _, access, notifications = _service()
+    repository.get_detail.return_value = _detail()
+    access.require_space_owner.side_effect = SpaceAccessDeniedError("private")
+
+    with pytest.raises(WorkOrderAccessDeniedError) as exc_info:
+        service.reject(work_order_id=11, actor_id="member-1", review_remark="no")
+
+    assert isinstance(exc_info.value.__cause__, SpaceAccessDeniedError)
+    notifications.build_space_join_review_result.assert_not_called()
+    repository.review_space_join.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_title", "expected_content"),
+    [
+        (
+            WorkOrderStatus.APPROVED,
+            "空间加入申请已通过",
+            "你加入空间「Team」的申请已通过。",
+        ),
+        (
+            WorkOrderStatus.REJECTED,
+            "空间加入申请未通过",
+            "你加入空间「Team」的申请未通过。拒绝原因：capacity",
+        ),
+    ],
+)
+def test_notification_service_builds_space_join_review_result(
+    status: WorkOrderStatus, expected_title: str, expected_content: str
+) -> None:
+    draft = WorkOrderNotificationService.build_space_join_review_result(
+        detail=_detail(),
+        target_status=status,
+        review_remark="capacity",
+    )
+
+    assert draft == WorkOrderNotificationDraft(
+        recipient_user_id="applicant-1",
+        notification_category=NotificationCategory.NOTICE,
+        event_type=WorkOrderEventType.SPACE_JOIN_REVIEWED,
+        biz_type=WorkOrderBizType.SPACE_JOIN,
+        biz_id="7",
+        title=expected_title,
+        content=expected_content,
+    )
+
+
+def test_notification_service_rejects_unsupported_review_status() -> None:
+    with pytest.raises(ValueError, match="unsupported review status: PENDING"):
+        WorkOrderNotificationService.build_space_join_review_result(
+            detail=_detail(),
+            target_status=WorkOrderStatus.PENDING,
+            review_remark="pending",
+        )
+
+
+def test_notification_service_delegates_and_maps_missing_records() -> None:
+    repository = MagicMock()
+    service = WorkOrderNotificationService(repository)
+    detail = WorkOrderNotificationDetail(
+        notification=_notification(),
+        work_order_status=WorkOrderStatus.PENDING,
+        can_approve=True,
+    )
+    read = _notification().model_copy(update={"is_read": True, "read_at": NOW})
+    repository.get_notification.side_effect = [detail, None]
+    repository.mark_notification_read.side_effect = [read, None]
+    repository.count_unread.return_value = 3
+    repository.mark_all_notifications_read.return_value = 2
+
+    assert service.get_detail(notification_id=21, actor_id="owner-1") == detail
+    with pytest.raises(WorkOrderNotificationNotFoundError):
+        service.get_detail(notification_id=22, actor_id="owner-1")
+    assert service.unread_count(actor_id="owner-1") == 3
+    assert service.mark_read(notification_id=21, actor_id="owner-1") == read
+    with pytest.raises(WorkOrderNotificationNotFoundError):
+        service.mark_read(notification_id=22, actor_id="owner-1")
+    assert service.mark_all_read(actor_id="owner-1") == 2
+
+    repository.get_notification.assert_any_call(
+        notification_id=21,
+        recipient_user_id="owner-1",
+        env="dev",
+        mark_read=True,
+    )
+    repository.count_unread.assert_called_once_with(
+        recipient_user_id="owner-1", env="dev"
+    )
+    repository.mark_all_notifications_read.assert_called_once_with(
+        recipient_user_id="owner-1", env="dev"
+    )

--- a/src/backend/tests/community/plugins/community/test_skill_center_client.py
+++ b/src/backend/tests/community/plugins/community/test_skill_center_client.py
@@ -4,10 +4,15 @@ Skill Center marketplace is unsupported in the community build: every method
 raises ``SkillCenterUnsupportedError`` so a caller fails loudly rather than
 silently receiving a fake result.
 """
+
 from __future__ import annotations
 
 import pytest
 
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterTeamCreateError,
+    SkillCenterTeamCreateRequest,
+)
 from agentclaw.community.plugins.community.skill_center_client import (
     CommunitySkillCenterClient,
     SkillCenterUnsupportedError,
@@ -16,6 +21,16 @@ from agentclaw.community.plugins.community.skill_center_client import (
 
 def _client() -> CommunitySkillCenterClient:
     return CommunitySkillCenterClient()
+
+
+def test_create_team_raises_stable_sync_error():
+    request = SkillCenterTeamCreateRequest(
+        team_code="spc-0123456789abcdef0123",
+        team_name="Demo Team",
+        ref_source_id="7",
+    )
+    with pytest.raises(SkillCenterTeamCreateError):
+        _client().create_team(request)
 
 
 def test_upload_and_publish_raises():

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -148,6 +148,17 @@ user_config:
 
     # ── The refusals: operations that still require a human on the wire ──────
 
+    # Space/member/favorite OpenAPI operations are user-only in the first
+    # refactor phase. Keep this explicit even though /** also requires a user:
+    # when the broader public API policy evolves, these routes must remain
+    # fail-closed until app identity semantics for spaces are approved.
+    "/openapi/v1/spaces/**":
+      user: required
+    "/openapi/v1/work-orders/**":
+      user: required
+    "/openapi/v1/work-order-notifications/**":
+      user: required
+
     # Creating a bot. No bot exists yet for a grant to cover, and creation
     # spends the user's quota.
     "POST /openapi/v1/bots":
@@ -377,6 +388,24 @@ user_config:
         #     source: object_store
         #     url: "${BOTS_OPENAPI_URL}"   # e.g. https://<bucket>/bots/openapi-latest.json
         #     refresh_seconds: 300
+        schema:
+          source: file
+          path: schemas/bots.openapi.json
+          refresh_seconds: 300
+      spaces:
+        server: backend
+        schema:
+          source: file
+          path: schemas/bots.openapi.json
+          refresh_seconds: 300
+      work-orders:
+        server: backend
+        schema:
+          source: file
+          path: schemas/bots.openapi.json
+          refresh_seconds: 300
+      work-order-notifications:
+        server: backend
         schema:
           source: file
           path: schemas/bots.openapi.json

--- a/src/gateway/configs/schemas/README.md
+++ b/src/gateway/configs/schemas/README.md
@@ -16,9 +16,10 @@ of a surface the upstream does not serve, and nothing downstream would catch it.
 - `bcn.internal.openapi.json` — BCN collaboration service internal API spec for `/internal-docs`
 - `bcsfuse-fusion.openapi.json` — bcsfuse group-fusion endpoint served under `/openapi/v1/bcsfuse/groups/**`
 - `bcsfuse-workers.openapi.json` — bcsfuse worker-config + fusable-query endpoints served under `/openapi/v1/bcsfuse/workers/**`
-- `bots.openapi.json` — Bots service OpenAPI spec (the backend's public
-  `/openapi/v1/bots` surface, narrowed to public paths and the components they
-  reference)
+- `bots.openapi.json` — Backend public OpenAPI spec (currently the
+  `/openapi/v1/bots`, `/openapi/v1/spaces`, `/openapi/v1/work-orders`, and
+  `/openapi/v1/work-order-notifications` surfaces, narrowed to public paths and
+  the components they reference)
 
 ## Future: build-time generation
 

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -1,6 +1,26 @@
 {
   "components": {
     "schemas": {
+      "AddSpaceMemberRequest": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/SpaceRole",
+            "default": "MEMBER",
+            "description": "Role granted when the member is added; defaults to MEMBER."
+          },
+          "user_id": {
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "title": "AddSpaceMemberRequest",
+        "type": "object"
+      },
       "ApprovalMode": {
         "description": "How much the bot may do without asking first.",
         "enum": [
@@ -1042,6 +1062,36 @@
         "title": "ConversationSession",
         "type": "object"
       },
+      "CreateSpaceJoinRequest": {
+        "properties": {
+          "reason": {
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "title": "CreateSpaceJoinRequest",
+        "type": "object"
+      },
+      "CreateSpaceRequest": {
+        "properties": {
+          "space_name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Space Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_name"
+        ],
+        "title": "CreateSpaceRequest",
+        "type": "object"
+      },
       "Deleted": {
         "description": "Payload returned by delete operations.",
         "example": {
@@ -1675,6 +1725,90 @@
         "title": "Envelope[EngineStatus]",
         "type": "object"
       },
+      "Envelope_FavoriteAddedResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FavoriteAddedResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[FavoriteAddedResult]",
+        "type": "object"
+      },
+      "Envelope_FavoriteCanceledResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FavoriteCanceledResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[FavoriteCanceledResult]",
+        "type": "object"
+      },
       "Envelope_FileEntry_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2137,6 +2271,132 @@
         "title": "Envelope[NameCheck]",
         "type": "object"
       },
+      "Envelope_NotificationDetailResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationDetailResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[NotificationDetailResponse]",
+        "type": "object"
+      },
+      "Envelope_NotificationReadResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationReadResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[NotificationReadResponse]",
+        "type": "object"
+      },
+      "Envelope_NotificationsReadAllResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationsReadAllResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[NotificationsReadAllResponse]",
+        "type": "object"
+      },
       "Envelope_Page_AuthorizedApp__": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2303,6 +2563,48 @@
           "request_id"
         ],
         "title": "Envelope[Page[FileEntry]]",
+        "type": "object"
+      },
+      "Envelope_Page_MarketFavoriteItem__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Page_MarketFavoriteItem_"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Page[MarketFavoriteItem]]",
         "type": "object"
       },
       "Envelope_Page_McpServer__": {
@@ -2515,6 +2817,132 @@
         "title": "Envelope[Page[Skill]]",
         "type": "object"
       },
+      "Envelope_Page_SpaceItem__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Page_SpaceItem_"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Page[SpaceItem]]",
+        "type": "object"
+      },
+      "Envelope_Page_SpaceMemberItem__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Page_SpaceMemberItem_"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Page[SpaceMemberItem]]",
+        "type": "object"
+      },
+      "Envelope_Page_WorkOrderListItem__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Page_WorkOrderListItem_"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Page[WorkOrderListItem]]",
+        "type": "object"
+      },
       "Envelope_Passport_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2555,6 +2983,48 @@
           "request_id"
         ],
         "title": "Envelope[Passport]",
+        "type": "object"
+      },
+      "Envelope_PersonalSpaceInitialized_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PersonalSpaceInitialized"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[PersonalSpaceInitialized]",
         "type": "object"
       },
       "Envelope_Preview_": {
@@ -2935,6 +3405,174 @@
         "title": "Envelope[Skill]",
         "type": "object"
       },
+      "Envelope_SpaceCreated_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceCreated"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SpaceCreated]",
+        "type": "object"
+      },
+      "Envelope_SpaceJoinRequestCreated_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceJoinRequestCreated"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SpaceJoinRequestCreated]",
+        "type": "object"
+      },
+      "Envelope_SpaceMemberDeletedResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceMemberDeletedResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SpaceMemberDeletedResult]",
+        "type": "object"
+      },
+      "Envelope_SpaceMemberMutationResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceMemberMutationResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SpaceMemberMutationResult]",
+        "type": "object"
+      },
       "Envelope_StartupScript_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2975,6 +3613,132 @@
           "request_id"
         ],
         "title": "Envelope[StartupScript]",
+        "type": "object"
+      },
+      "Envelope_UnreadCountResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UnreadCountResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[UnreadCountResponse]",
+        "type": "object"
+      },
+      "Envelope_WorkOrderDetailResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkOrderDetailResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[WorkOrderDetailResponse]",
+        "type": "object"
+      },
+      "Envelope_WorkOrderReviewResponse_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkOrderReviewResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[WorkOrderReviewResponse]",
         "type": "object"
       },
       "Envelope_dict_str__Any__": {
@@ -3193,6 +3957,82 @@
         ],
         "title": "ErrorEnvelope",
         "type": "object"
+      },
+      "FavoriteAddedResult": {
+        "properties": {
+          "favorite_id": {
+            "title": "Favorite Id",
+            "type": "integer"
+          },
+          "is_favorited": {
+            "default": true,
+            "title": "Is Favorited",
+            "type": "boolean"
+          },
+          "target_code": {
+            "title": "Target Code",
+            "type": "string"
+          },
+          "target_type": {
+            "$ref": "#/components/schemas/FavoriteTargetType"
+          }
+        },
+        "required": [
+          "favorite_id",
+          "target_type",
+          "target_code"
+        ],
+        "title": "FavoriteAddedResult",
+        "type": "object"
+      },
+      "FavoriteCanceledResult": {
+        "properties": {
+          "is_favorited": {
+            "default": false,
+            "title": "Is Favorited",
+            "type": "boolean"
+          },
+          "target_code": {
+            "title": "Target Code",
+            "type": "string"
+          },
+          "target_type": {
+            "$ref": "#/components/schemas/FavoriteTargetType"
+          }
+        },
+        "required": [
+          "target_type",
+          "target_code"
+        ],
+        "title": "FavoriteCanceledResult",
+        "type": "object"
+      },
+      "FavoriteTargetRequest": {
+        "properties": {
+          "target_code": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Target Code",
+            "type": "string"
+          },
+          "target_type": {
+            "$ref": "#/components/schemas/FavoriteTargetType"
+          }
+        },
+        "required": [
+          "target_type",
+          "target_code"
+        ],
+        "title": "FavoriteTargetRequest",
+        "type": "object"
+      },
+      "FavoriteTargetType": {
+        "enum": [
+          "SKILL",
+          "MCP"
+        ],
+        "title": "FavoriteTargetType",
+        "type": "string"
       },
       "FileEntry": {
         "description": "A file or folder in the bot's workspace.\n\nThe container's own storage layout is never exposed — `path` is relative to\nthe workspace root, not to any real filesystem the bot runs on.",
@@ -3485,6 +4325,40 @@
           "content"
         ],
         "title": "IdentityFileWrite",
+        "type": "object"
+      },
+      "MarketFavoriteItem": {
+        "properties": {
+          "favorite_at": {
+            "description": "UTC time when the target was added to this Space's favorites.",
+            "format": "date-time",
+            "title": "Favorite At",
+            "type": "string"
+          },
+          "favorite_id": {
+            "title": "Favorite Id",
+            "type": "integer"
+          },
+          "is_favorited": {
+            "default": true,
+            "title": "Is Favorited",
+            "type": "boolean"
+          },
+          "target_code": {
+            "title": "Target Code",
+            "type": "string"
+          },
+          "target_type": {
+            "$ref": "#/components/schemas/FavoriteTargetType"
+          }
+        },
+        "required": [
+          "favorite_id",
+          "target_type",
+          "target_code",
+          "favorite_at"
+        ],
+        "title": "MarketFavoriteItem",
         "type": "object"
       },
       "McpConfig": {
@@ -4025,6 +4899,137 @@
         "title": "NameCheck",
         "type": "object"
       },
+      "NotificationCategory": {
+        "enum": [
+          "APPROVAL",
+          "NOTICE"
+        ],
+        "title": "NotificationCategory",
+        "type": "string"
+      },
+      "NotificationDetailResponse": {
+        "properties": {
+          "biz_id": {
+            "title": "Biz Id",
+            "type": "string"
+          },
+          "biz_type": {
+            "$ref": "#/components/schemas/WorkOrderBizType"
+          },
+          "can_approve": {
+            "title": "Can Approve",
+            "type": "boolean"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/WorkOrderEventType"
+          },
+          "is_read": {
+            "title": "Is Read",
+            "type": "boolean"
+          },
+          "notification_category": {
+            "$ref": "#/components/schemas/NotificationCategory"
+          },
+          "notification_id": {
+            "title": "Notification Id",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "work_order_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Work Order Id"
+          },
+          "work_order_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkOrderStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "notification_id",
+          "work_order_id",
+          "notification_category",
+          "event_type",
+          "title",
+          "content",
+          "is_read",
+          "work_order_status",
+          "can_approve",
+          "biz_type",
+          "biz_id"
+        ],
+        "title": "NotificationDetailResponse",
+        "type": "object"
+      },
+      "NotificationReadResponse": {
+        "properties": {
+          "is_read": {
+            "title": "Is Read",
+            "type": "boolean"
+          },
+          "notification_id": {
+            "title": "Notification Id",
+            "type": "integer"
+          },
+          "read_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read At"
+          }
+        },
+        "required": [
+          "notification_id",
+          "is_read",
+          "read_at"
+        ],
+        "title": "NotificationReadResponse",
+        "type": "object"
+      },
+      "NotificationsReadAllResponse": {
+        "properties": {
+          "updated_count": {
+            "title": "Updated Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "updated_count"
+        ],
+        "title": "NotificationsReadAllResponse",
+        "type": "object"
+      },
       "Page_AuthorizedApp_": {
         "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
         "properties": {
@@ -4123,6 +5128,31 @@
           "items"
         ],
         "title": "Page[FileEntry]",
+        "type": "object"
+      },
+      "Page_MarketFavoriteItem_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
+        "properties": {
+          "items": {
+            "description": "Items on the current page (present, possibly empty).",
+            "items": {
+              "$ref": "#/components/schemas/MarketFavoriteItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Total number of items matching the query.",
+            "example": 1,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "Page[MarketFavoriteItem]",
         "type": "object"
       },
       "Page_McpServer_": {
@@ -4250,6 +5280,81 @@
         "title": "Page[Skill]",
         "type": "object"
       },
+      "Page_SpaceItem_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
+        "properties": {
+          "items": {
+            "description": "Items on the current page (present, possibly empty).",
+            "items": {
+              "$ref": "#/components/schemas/SpaceItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Total number of items matching the query.",
+            "example": 1,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "Page[SpaceItem]",
+        "type": "object"
+      },
+      "Page_SpaceMemberItem_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
+        "properties": {
+          "items": {
+            "description": "Items on the current page (present, possibly empty).",
+            "items": {
+              "$ref": "#/components/schemas/SpaceMemberItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Total number of items matching the query.",
+            "example": 1,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "Page[SpaceMemberItem]",
+        "type": "object"
+      },
+      "Page_WorkOrderListItem_": {
+        "description": "One page of a list result: `total` counts every match, `items` holds the current page.",
+        "properties": {
+          "items": {
+            "description": "Items on the current page (present, possibly empty).",
+            "items": {
+              "$ref": "#/components/schemas/WorkOrderListItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Total number of items matching the query.",
+            "example": 1,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "Page[WorkOrderListItem]",
+        "type": "object"
+      },
       "Passport": {
         "description": "Agent Passport (identity credential) summary.",
         "example": {
@@ -4273,6 +5378,71 @@
           "passport_id"
         ],
         "title": "Passport",
+        "type": "object"
+      },
+      "PersonalSpaceInitialized": {
+        "properties": {
+          "created": {
+            "title": "Created",
+            "type": "boolean"
+          },
+          "current_user_role": {
+            "$ref": "#/components/schemas/SpaceRole"
+          },
+          "gmt_created": {
+            "description": "UTC time when the Space was created.",
+            "format": "date-time",
+            "title": "Gmt Created",
+            "type": "string"
+          },
+          "gmt_modified": {
+            "description": "UTC time when the Space metadata was last modified.",
+            "format": "date-time",
+            "title": "Gmt Modified",
+            "type": "string"
+          },
+          "is_creator": {
+            "title": "Is Creator",
+            "type": "boolean"
+          },
+          "member_count": {
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "owner_count": {
+            "title": "Owner Count",
+            "type": "integer"
+          },
+          "space_code": {
+            "title": "Space Code",
+            "type": "string"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "space_name": {
+            "title": "Space Name",
+            "type": "string"
+          },
+          "space_type": {
+            "$ref": "#/components/schemas/SpaceType"
+          }
+        },
+        "required": [
+          "space_id",
+          "space_code",
+          "space_name",
+          "space_type",
+          "current_user_role",
+          "is_creator",
+          "member_count",
+          "owner_count",
+          "gmt_created",
+          "gmt_modified",
+          "created"
+        ],
+        "title": "PersonalSpaceInitialized",
         "type": "object"
       },
       "Preview": {
@@ -4713,6 +5883,47 @@
         "title": "ScheduleTrigger",
         "type": "object"
       },
+      "SearchFavoritesRequest": {
+        "properties": {
+          "keyword": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Keyword"
+          },
+          "page_no": {
+            "default": 1,
+            "minimum": 1.0,
+            "title": "Page No",
+            "type": "integer"
+          },
+          "page_size": {
+            "default": 20,
+            "maximum": 100.0,
+            "minimum": 1.0,
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "target_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FavoriteTargetType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "SearchFavoritesRequest",
+        "type": "object"
+      },
       "Session": {
         "description": "A conversation session on the bot's device.",
         "example": {
@@ -5147,6 +6358,246 @@
           "CHAT"
         ]
       },
+      "SpaceCreated": {
+        "properties": {
+          "current_user_role": {
+            "$ref": "#/components/schemas/SpaceRole"
+          },
+          "gmt_created": {
+            "description": "UTC time when the Space was created.",
+            "format": "date-time",
+            "title": "Gmt Created",
+            "type": "string"
+          },
+          "gmt_modified": {
+            "description": "UTC time when the Space metadata was last modified.",
+            "format": "date-time",
+            "title": "Gmt Modified",
+            "type": "string"
+          },
+          "is_creator": {
+            "title": "Is Creator",
+            "type": "boolean"
+          },
+          "member_count": {
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "owner_count": {
+            "title": "Owner Count",
+            "type": "integer"
+          },
+          "space_code": {
+            "title": "Space Code",
+            "type": "string"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "space_name": {
+            "title": "Space Name",
+            "type": "string"
+          },
+          "space_type": {
+            "$ref": "#/components/schemas/SpaceType"
+          }
+        },
+        "required": [
+          "space_id",
+          "space_code",
+          "space_name",
+          "space_type",
+          "current_user_role",
+          "is_creator",
+          "member_count",
+          "owner_count",
+          "gmt_created",
+          "gmt_modified"
+        ],
+        "title": "SpaceCreated",
+        "type": "object"
+      },
+      "SpaceItem": {
+        "properties": {
+          "current_user_role": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceRole"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gmt_modified": {
+            "description": "UTC time when the Space metadata was last modified.",
+            "format": "date-time",
+            "title": "Gmt Modified",
+            "type": "string"
+          },
+          "join_status": {
+            "$ref": "#/components/schemas/SpaceJoinStatus"
+          },
+          "member_count": {
+            "title": "Member Count",
+            "type": "integer"
+          },
+          "owner_count": {
+            "title": "Owner Count",
+            "type": "integer"
+          },
+          "space_code": {
+            "title": "Space Code",
+            "type": "string"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "space_name": {
+            "title": "Space Name",
+            "type": "string"
+          },
+          "space_type": {
+            "$ref": "#/components/schemas/SpaceType"
+          }
+        },
+        "required": [
+          "space_id",
+          "space_code",
+          "space_name",
+          "space_type",
+          "current_user_role",
+          "join_status",
+          "member_count",
+          "owner_count",
+          "gmt_modified"
+        ],
+        "title": "SpaceItem",
+        "type": "object"
+      },
+      "SpaceJoinRequestCreated": {
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/WorkOrderStatus"
+          },
+          "work_order_id": {
+            "title": "Work Order Id",
+            "type": "integer"
+          },
+          "work_order_no": {
+            "title": "Work Order No",
+            "type": "string"
+          }
+        },
+        "required": [
+          "work_order_id",
+          "work_order_no",
+          "status"
+        ],
+        "title": "SpaceJoinRequestCreated",
+        "type": "object"
+      },
+      "SpaceJoinStatus": {
+        "enum": [
+          "JOINED",
+          "APPLYING",
+          "NOT_JOINED"
+        ],
+        "title": "SpaceJoinStatus",
+        "type": "string"
+      },
+      "SpaceMemberDeletedResult": {
+        "properties": {
+          "deleted": {
+            "default": true,
+            "title": "Deleted",
+            "type": "boolean"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_id",
+          "user_id"
+        ],
+        "title": "SpaceMemberDeletedResult",
+        "type": "object"
+      },
+      "SpaceMemberItem": {
+        "properties": {
+          "gmt_modified": {
+            "description": "UTC time when this membership relation was created or its role was last changed.",
+            "format": "date-time",
+            "title": "Gmt Modified",
+            "type": "string"
+          },
+          "is_creator": {
+            "title": "Is Creator",
+            "type": "boolean"
+          },
+          "role": {
+            "$ref": "#/components/schemas/SpaceRole"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "role",
+          "is_creator",
+          "gmt_modified"
+        ],
+        "title": "SpaceMemberItem",
+        "type": "object"
+      },
+      "SpaceMemberMutationResult": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/SpaceRole"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_id",
+          "user_id",
+          "role"
+        ],
+        "title": "SpaceMemberMutationResult",
+        "type": "object"
+      },
+      "SpaceRole": {
+        "enum": [
+          "OWNER",
+          "MEMBER"
+        ],
+        "title": "SpaceRole",
+        "type": "string"
+      },
+      "SpaceType": {
+        "enum": [
+          "PERSONAL",
+          "TEAM"
+        ],
+        "title": "SpaceType",
+        "type": "string"
+      },
       "StartupScript": {
         "description": "A bot's stored startup script. Every field is server-derived.",
         "example": {
@@ -5232,6 +6683,485 @@
         ],
         "title": "StartupScriptWrite",
         "type": "object"
+      },
+      "UnreadCountResponse": {
+        "properties": {
+          "unread_count": {
+            "title": "Unread Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unread_count"
+        ],
+        "title": "UnreadCountResponse",
+        "type": "object"
+      },
+      "UpdateSpaceMemberRoleRequest": {
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/SpaceRole"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "UpdateSpaceMemberRoleRequest",
+        "type": "object"
+      },
+      "WorkOrderBizType": {
+        "enum": [
+          "SPACE_JOIN"
+        ],
+        "title": "WorkOrderBizType",
+        "type": "string"
+      },
+      "WorkOrderDetailContent": {
+        "properties": {
+          "applicant_name": {
+            "title": "Applicant Name",
+            "type": "string"
+          },
+          "applicant_user_id": {
+            "title": "Applicant User Id",
+            "type": "string"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "space_id": {
+            "title": "Space Id",
+            "type": "integer"
+          },
+          "space_name": {
+            "title": "Space Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "space_id",
+          "space_name",
+          "applicant_user_id",
+          "applicant_name",
+          "reason"
+        ],
+        "title": "WorkOrderDetailContent",
+        "type": "object"
+      },
+      "WorkOrderDetailResponse": {
+        "properties": {
+          "biz_id": {
+            "title": "Biz Id",
+            "type": "integer"
+          },
+          "biz_type": {
+            "$ref": "#/components/schemas/WorkOrderBizType"
+          },
+          "can_approve": {
+            "title": "Can Approve",
+            "type": "boolean"
+          },
+          "content": {
+            "$ref": "#/components/schemas/WorkOrderDetailContent"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/WorkOrderEventType"
+          },
+          "review_remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Remark"
+          },
+          "reviewed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewed At"
+          },
+          "reviewer_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewer User Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkOrderStatus"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "work_order_id": {
+            "title": "Work Order Id",
+            "type": "integer"
+          },
+          "work_order_no": {
+            "title": "Work Order No",
+            "type": "string"
+          }
+        },
+        "required": [
+          "work_order_id",
+          "work_order_no",
+          "biz_type",
+          "biz_id",
+          "event_type",
+          "title",
+          "content",
+          "status",
+          "reviewer_user_id",
+          "review_remark",
+          "reviewed_at",
+          "can_approve"
+        ],
+        "title": "WorkOrderDetailResponse",
+        "type": "object"
+      },
+      "WorkOrderEventType": {
+        "enum": [
+          "SPACE_JOIN_APPLIED",
+          "SPACE_JOIN_REVIEWED",
+          "SPACE_MEMBER_ADDED",
+          "BOT_COLLABORATOR_APPLIED",
+          "BOT_COLLABORATOR_REVIEWED",
+          "BOT_MEMBER_ADDED",
+          "HUMAN2BOT_FRIEND_APPLIED",
+          "HUMAN2BOT_FRIEND_REVIEWED",
+          "BOT2BOT_FRIEND_APPLIED",
+          "BOT2BOT_FRIEND_REVIEWED",
+          "HUMAN2BOT_PUBLIC_ORDER_CREATED",
+          "HUMAN2BOT_PUBLIC_ORDER_COMPLETED",
+          "BOT2BOT_PUBLIC_ORDER_CREATED",
+          "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+        ],
+        "title": "WorkOrderEventType",
+        "type": "string"
+      },
+      "WorkOrderItemType": {
+        "enum": [
+          "ALL",
+          "APPROVAL",
+          "NOTICE"
+        ],
+        "title": "WorkOrderItemType",
+        "type": "string"
+      },
+      "WorkOrderListItem": {
+        "properties": {
+          "applicant_user_id": {
+            "title": "Applicant User Id",
+            "type": "string"
+          },
+          "apply_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apply Reason"
+          },
+          "biz_id": {
+            "title": "Biz Id",
+            "type": "string"
+          },
+          "biz_type": {
+            "$ref": "#/components/schemas/WorkOrderBizType"
+          },
+          "can_approve": {
+            "title": "Can Approve",
+            "type": "boolean"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "env": {
+            "title": "Env",
+            "type": "string"
+          },
+          "event_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkOrderEventType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gmt_created": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gmt Created"
+          },
+          "gmt_modified": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gmt Modified"
+          },
+          "is_read": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Read"
+          },
+          "item_id": {
+            "title": "Item Id",
+            "type": "string"
+          },
+          "item_type": {
+            "$ref": "#/components/schemas/WorkOrderItemType"
+          },
+          "notification_category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NotificationCategory"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notification_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notification Id"
+          },
+          "read_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Read At"
+          },
+          "recipient_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recipient User Id"
+          },
+          "review_remark": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Remark"
+          },
+          "reviewed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewed At"
+          },
+          "reviewer_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewer User Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkOrderStatus"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "work_order_id": {
+            "title": "Work Order Id",
+            "type": "integer"
+          },
+          "work_order_no": {
+            "title": "Work Order No",
+            "type": "string"
+          }
+        },
+        "required": [
+          "item_id",
+          "item_type",
+          "work_order_id",
+          "work_order_no",
+          "notification_id",
+          "notification_category",
+          "biz_type",
+          "biz_id",
+          "applicant_user_id",
+          "apply_reason",
+          "reviewer_user_id",
+          "review_remark",
+          "reviewed_at",
+          "recipient_user_id",
+          "event_type",
+          "title",
+          "content",
+          "status",
+          "is_read",
+          "read_at",
+          "env",
+          "can_approve",
+          "gmt_created",
+          "gmt_modified"
+        ],
+        "title": "WorkOrderListItem",
+        "type": "object"
+      },
+      "WorkOrderQueryType": {
+        "enum": [
+          "PENDING_FOR_ME",
+          "INITIATED_BY_ME",
+          "PROCESSED_BY_ME"
+        ],
+        "title": "WorkOrderQueryType",
+        "type": "string"
+      },
+      "WorkOrderReviewRequest": {
+        "properties": {
+          "review_remark": {
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Review Remark",
+            "type": "string"
+          }
+        },
+        "required": [
+          "review_remark"
+        ],
+        "title": "WorkOrderReviewRequest",
+        "type": "object"
+      },
+      "WorkOrderReviewResponse": {
+        "properties": {
+          "review_remark": {
+            "title": "Review Remark",
+            "type": "string"
+          },
+          "reviewed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reviewed At"
+          },
+          "reviewer_user_id": {
+            "title": "Reviewer User Id",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkOrderStatus"
+          },
+          "work_order_id": {
+            "title": "Work Order Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "work_order_id",
+          "status",
+          "reviewer_user_id",
+          "review_remark",
+          "reviewed_at"
+        ],
+        "title": "WorkOrderReviewResponse",
+        "type": "object"
+      },
+      "WorkOrderStatus": {
+        "enum": [
+          "PENDING",
+          "APPROVED",
+          "REJECTED"
+        ],
+        "title": "WorkOrderStatus",
+        "type": "string"
       }
     }
   },
@@ -27558,6 +29488,3106 @@
         "summary": "Get Bot Status",
         "tags": [
           "bots"
+        ]
+      }
+    },
+    "/openapi/v1/spaces": {
+      "get": {
+        "operationId": "list_spaces_openapi_v1_spaces_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Keyword"
+            }
+          },
+          {
+            "in": "query",
+            "name": "space_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SpaceType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Space Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_no",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page No",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Page_SpaceItem__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Spaces",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/create": {
+      "post": {
+        "operationId": "create_team_space_openapi_v1_spaces_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSpaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceCreated_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Create Team Space",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/personal/initialize": {
+      "post": {
+        "operationId": "initialize_personal_space_openapi_v1_spaces_personal_initialize_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_PersonalSpaceInitialized_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Initialize Personal Space",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/join-requests": {
+      "post": {
+        "operationId": "create_space_join_request_openapi_v1_spaces__space_id__join_requests_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSpaceJoinRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceJoinRequestCreated_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Create Space Join Request",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/market-favorites": {
+      "post": {
+        "operationId": "add_market_favorite_openapi_v1_spaces__space_id__market_favorites_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FavoriteTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_FavoriteAddedResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Add Market Favorite",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/market-favorites/cancel": {
+      "post": {
+        "operationId": "cancel_market_favorite_openapi_v1_spaces__space_id__market_favorites_cancel_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FavoriteTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_FavoriteCanceledResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Cancel Market Favorite",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/market-favorites/search": {
+      "post": {
+        "operationId": "search_market_favorites_openapi_v1_spaces__space_id__market_favorites_search_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchFavoritesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Page_MarketFavoriteItem__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Search Market Favorites",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/members": {
+      "get": {
+        "operationId": "list_space_members_openapi_v1_spaces__space_id__members_get",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Keyword"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_no",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page No",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Page_SpaceMemberItem__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Space Members",
+        "tags": [
+          "spaces"
+        ]
+      },
+      "post": {
+        "operationId": "add_space_member_openapi_v1_spaces__space_id__members_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSpaceMemberRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceMemberMutationResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Add Space Member",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/members/{user_id}": {
+      "delete": {
+        "operationId": "delete_space_member_openapi_v1_spaces__space_id__members__user_id__delete",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceMemberDeletedResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Delete Space Member",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}/members/{user_id}/role": {
+      "put": {
+        "operationId": "update_space_member_role_openapi_v1_spaces__space_id__members__user_id__role_put",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSpaceMemberRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceMemberMutationResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Update Space Member Role",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/work-order-notifications/read-all": {
+      "post": {
+        "operationId": "mark_all_notifications_read_openapi_v1_work_order_notifications_read_all_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_NotificationsReadAllResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Mark All Notifications Read",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-order-notifications/unread-count": {
+      "get": {
+        "operationId": "unread_notification_count_openapi_v1_work_order_notifications_unread_count_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_UnreadCountResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Unread Notification Count",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-order-notifications/{notification_id}": {
+      "get": {
+        "operationId": "get_notification_openapi_v1_work_order_notifications__notification_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Notification Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_NotificationDetailResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Notification",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-order-notifications/{notification_id}/read": {
+      "post": {
+        "operationId": "mark_notification_read_openapi_v1_work_order_notifications__notification_id__read_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "notification_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Notification Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_NotificationReadResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Mark Notification Read",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-orders": {
+      "get": {
+        "operationId": "list_work_orders_openapi_v1_work_orders_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query_type",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WorkOrderQueryType",
+              "default": "PENDING_FOR_ME"
+            }
+          },
+          {
+            "in": "query",
+            "name": "item_type",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/WorkOrderItemType",
+              "default": "ALL"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_no",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page No",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Page_WorkOrderListItem__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Work Orders",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-orders/{work_order_id}": {
+      "get": {
+        "operationId": "get_work_order_openapi_v1_work_orders__work_order_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "work_order_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Work Order Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WorkOrderDetailResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Work Order",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-orders/{work_order_id}/approve": {
+      "post": {
+        "operationId": "approve_work_order_openapi_v1_work_orders__work_order_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "work_order_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Work Order Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkOrderReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WorkOrderReviewResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Approve Work Order",
+        "tags": [
+          "work-orders"
+        ]
+      }
+    },
+    "/openapi/v1/work-orders/{work_order_id}/reject": {
+      "post": {
+        "operationId": "reject_work_order_openapi_v1_work_orders__work_order_id__reject_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "work_order_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Work Order Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkOrderReviewRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_WorkOrderReviewResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Reject Work Order",
+        "tags": [
+          "work-orders"
         ]
       }
     }

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -2,21 +2,23 @@
   "components": {
     "schemas": {
       "AddSpaceMemberRequest": {
+        "description": "Request for adding a user to a Space.",
         "properties": {
+          "member_user_id": {
+            "description": "Identifier of the user to add.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Member User Id",
+            "type": "string"
+          },
           "role": {
             "$ref": "#/components/schemas/SpaceRole",
             "default": "MEMBER",
             "description": "Role granted when the member is added; defaults to MEMBER."
-          },
-          "user_id": {
-            "maxLength": 256,
-            "minLength": 1,
-            "title": "User Id",
-            "type": "string"
           }
         },
         "required": [
-          "user_id"
+          "member_user_id"
         ],
         "title": "AddSpaceMemberRequest",
         "type": "object"
@@ -1063,8 +1065,10 @@
         "type": "object"
       },
       "CreateSpaceJoinRequest": {
+        "description": "Request for joining a Space.",
         "properties": {
           "reason": {
+            "description": "Reason for requesting membership.",
             "maxLength": 512,
             "minLength": 1,
             "title": "Reason",
@@ -1078,8 +1082,10 @@
         "type": "object"
       },
       "CreateSpaceRequest": {
+        "description": "Request for creating a shared team Space.",
         "properties": {
           "space_name": {
+            "description": "Display name for the new Space.",
             "maxLength": 128,
             "minLength": 1,
             "title": "Space Name",
@@ -3959,22 +3965,27 @@
         "type": "object"
       },
       "FavoriteAddedResult": {
+        "description": "Favorite state returned after a target is added.",
         "properties": {
           "favorite_id": {
+            "description": "Identifier of the favorite record.",
             "title": "Favorite Id",
             "type": "integer"
           },
           "is_favorited": {
             "default": true,
+            "description": "Whether the target is now favorited.",
             "title": "Is Favorited",
             "type": "boolean"
           },
           "target_code": {
+            "description": "Stable marketplace code of the target.",
             "title": "Target Code",
             "type": "string"
           },
           "target_type": {
-            "$ref": "#/components/schemas/FavoriteTargetType"
+            "$ref": "#/components/schemas/FavoriteTargetType",
+            "description": "Marketplace category of the target."
           }
         },
         "required": [
@@ -3986,18 +3997,22 @@
         "type": "object"
       },
       "FavoriteCanceledResult": {
+        "description": "Favorite state returned after a target is removed.",
         "properties": {
           "is_favorited": {
             "default": false,
+            "description": "Whether the target remains favorited.",
             "title": "Is Favorited",
             "type": "boolean"
           },
           "target_code": {
+            "description": "Stable marketplace code of the target.",
             "title": "Target Code",
             "type": "string"
           },
           "target_type": {
-            "$ref": "#/components/schemas/FavoriteTargetType"
+            "$ref": "#/components/schemas/FavoriteTargetType",
+            "description": "Marketplace category of the target."
           }
         },
         "required": [
@@ -4008,15 +4023,18 @@
         "type": "object"
       },
       "FavoriteTargetRequest": {
+        "description": "Marketplace target to add to or remove from favorites.",
         "properties": {
           "target_code": {
+            "description": "Stable marketplace code of the target.",
             "maxLength": 128,
             "minLength": 1,
             "title": "Target Code",
             "type": "string"
           },
           "target_type": {
-            "$ref": "#/components/schemas/FavoriteTargetType"
+            "$ref": "#/components/schemas/FavoriteTargetType",
+            "description": "Marketplace category of the target."
           }
         },
         "required": [
@@ -4027,12 +4045,25 @@
         "type": "object"
       },
       "FavoriteTargetType": {
+        "description": "Type of marketplace item saved as a favorite.",
         "enum": [
           "SKILL",
           "MCP"
         ],
         "title": "FavoriteTargetType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "A published Skill.",
+          "A published MCP server."
+        ],
+        "x-enum-varnames": [
+          "SKILL",
+          "MCP"
+        ],
+        "x-enumNames": [
+          "SKILL",
+          "MCP"
+        ]
       },
       "FileEntry": {
         "description": "A file or folder in the bot's workspace.\n\nThe container's own storage layout is never exposed — `path` is relative to\nthe workspace root, not to any real filesystem the bot runs on.",
@@ -4328,6 +4359,7 @@
         "type": "object"
       },
       "MarketFavoriteItem": {
+        "description": "One marketplace favorite saved in a Space.",
         "properties": {
           "favorite_at": {
             "description": "UTC time when the target was added to this Space's favorites.",
@@ -4336,20 +4368,24 @@
             "type": "string"
           },
           "favorite_id": {
+            "description": "Identifier of the favorite record.",
             "title": "Favorite Id",
             "type": "integer"
           },
           "is_favorited": {
             "default": true,
+            "description": "Whether the target is currently favorited.",
             "title": "Is Favorited",
             "type": "boolean"
           },
           "target_code": {
+            "description": "Stable marketplace code of the target.",
             "title": "Target Code",
             "type": "string"
           },
           "target_type": {
-            "$ref": "#/components/schemas/FavoriteTargetType"
+            "$ref": "#/components/schemas/FavoriteTargetType",
+            "description": "Marketplace category of the target."
           }
         },
         "required": [
@@ -4900,23 +4936,40 @@
         "type": "object"
       },
       "NotificationCategory": {
+        "description": "How a notification is presented to its recipient.",
         "enum": [
           "APPROVAL",
           "NOTICE"
         ],
         "title": "NotificationCategory",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "Requires a review decision from the recipient.",
+          "Reports an event and requires no review decision."
+        ],
+        "x-enum-varnames": [
+          "APPROVAL",
+          "NOTICE"
+        ],
+        "x-enumNames": [
+          "APPROVAL",
+          "NOTICE"
+        ]
       },
       "NotificationDetailResponse": {
+        "description": "Detailed view of a notification addressed to the current user.",
         "properties": {
           "biz_id": {
+            "description": "Identifier of the related business object.",
             "title": "Biz Id",
             "type": "string"
           },
           "biz_type": {
-            "$ref": "#/components/schemas/WorkOrderBizType"
+            "$ref": "#/components/schemas/WorkOrderBizType",
+            "description": "Business object type."
           },
           "can_approve": {
+            "description": "Whether the recipient may review the related work order.",
             "title": "Can Approve",
             "type": "boolean"
           },
@@ -4929,23 +4982,29 @@
                 "type": "null"
               }
             ],
+            "description": "Notification message content, when present.",
             "title": "Content"
           },
           "event_type": {
-            "$ref": "#/components/schemas/WorkOrderEventType"
+            "$ref": "#/components/schemas/WorkOrderEventType",
+            "description": "Business event represented by the notification."
           },
           "is_read": {
+            "description": "Whether the recipient has read the notification.",
             "title": "Is Read",
             "type": "boolean"
           },
           "notification_category": {
-            "$ref": "#/components/schemas/NotificationCategory"
+            "$ref": "#/components/schemas/NotificationCategory",
+            "description": "Presentation category of the notification."
           },
           "notification_id": {
+            "description": "Identifier of the notification.",
             "title": "Notification Id",
             "type": "integer"
           },
           "title": {
+            "description": "Display title of the notification.",
             "title": "Title",
             "type": "string"
           },
@@ -4958,6 +5017,7 @@
                 "type": "null"
               }
             ],
+            "description": "Related work-order identifier, when one exists.",
             "title": "Work Order Id"
           },
           "work_order_status": {
@@ -4968,7 +5028,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Related work-order status, when a work order exists."
           }
         },
         "required": [
@@ -4988,12 +5049,15 @@
         "type": "object"
       },
       "NotificationReadResponse": {
+        "description": "Read state returned after one notification is marked read.",
         "properties": {
           "is_read": {
+            "description": "Whether the notification is now read.",
             "title": "Is Read",
             "type": "boolean"
           },
           "notification_id": {
+            "description": "Identifier of the notification.",
             "title": "Notification Id",
             "type": "integer"
           },
@@ -5006,6 +5070,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC time when the notification was marked read.",
             "title": "Read At"
           }
         },
@@ -5018,8 +5083,10 @@
         "type": "object"
       },
       "NotificationsReadAllResponse": {
+        "description": "Result of marking all current user's notifications read.",
         "properties": {
           "updated_count": {
+            "description": "Number of notifications changed from unread to read.",
             "title": "Updated Count",
             "type": "integer"
           }
@@ -5381,13 +5448,16 @@
         "type": "object"
       },
       "PersonalSpaceInitialized": {
+        "description": "Result of ensuring that the current user's personal Space exists.",
         "properties": {
           "created": {
+            "description": "True when a new personal Space was created by this request.",
             "title": "Created",
             "type": "boolean"
           },
           "current_user_role": {
-            "$ref": "#/components/schemas/SpaceRole"
+            "$ref": "#/components/schemas/SpaceRole",
+            "description": "Creator's role in the new Space."
           },
           "gmt_created": {
             "description": "UTC time when the Space was created.",
@@ -5402,31 +5472,38 @@
             "type": "string"
           },
           "is_creator": {
+            "description": "Whether the current user created the Space.",
             "title": "Is Creator",
             "type": "boolean"
           },
           "member_count": {
+            "description": "Number of members in the Space.",
             "title": "Member Count",
             "type": "integer"
           },
           "owner_count": {
+            "description": "Number of owners in the Space.",
             "title": "Owner Count",
             "type": "integer"
           },
           "space_code": {
+            "description": "Stable external code of the Space.",
             "title": "Space Code",
             "type": "string"
           },
           "space_id": {
+            "description": "Unique numeric identifier of the Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "space_name": {
+            "description": "Display name of the Space.",
             "title": "Space Name",
             "type": "string"
           },
           "space_type": {
-            "$ref": "#/components/schemas/SpaceType"
+            "$ref": "#/components/schemas/SpaceType",
+            "description": "Ownership model of the Space."
           }
         },
         "required": [
@@ -5884,6 +5961,7 @@
         "type": "object"
       },
       "SearchFavoritesRequest": {
+        "description": "Filters and pagination for searching Space favorites.",
         "properties": {
           "keyword": {
             "anyOf": [
@@ -5895,16 +5973,19 @@
                 "type": "null"
               }
             ],
+            "description": "Optional case-insensitive target-code search text.",
             "title": "Keyword"
           },
           "page_no": {
             "default": 1,
+            "description": "One-based page number.",
             "minimum": 1.0,
             "title": "Page No",
             "type": "integer"
           },
           "page_size": {
             "default": 20,
+            "description": "Maximum items returned per page.",
             "maximum": 100.0,
             "minimum": 1.0,
             "title": "Page Size",
@@ -5918,7 +5999,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Target category filter, or null for all categories."
           }
         },
         "title": "SearchFavoritesRequest",
@@ -6359,9 +6441,11 @@
         ]
       },
       "SpaceCreated": {
+        "description": "Details returned after a Space is created.",
         "properties": {
           "current_user_role": {
-            "$ref": "#/components/schemas/SpaceRole"
+            "$ref": "#/components/schemas/SpaceRole",
+            "description": "Creator's role in the new Space."
           },
           "gmt_created": {
             "description": "UTC time when the Space was created.",
@@ -6376,31 +6460,38 @@
             "type": "string"
           },
           "is_creator": {
+            "description": "Whether the current user created the Space.",
             "title": "Is Creator",
             "type": "boolean"
           },
           "member_count": {
+            "description": "Number of members in the Space.",
             "title": "Member Count",
             "type": "integer"
           },
           "owner_count": {
+            "description": "Number of owners in the Space.",
             "title": "Owner Count",
             "type": "integer"
           },
           "space_code": {
+            "description": "Stable external code of the Space.",
             "title": "Space Code",
             "type": "string"
           },
           "space_id": {
+            "description": "Unique numeric identifier of the Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "space_name": {
+            "description": "Display name of the Space.",
             "title": "Space Name",
             "type": "string"
           },
           "space_type": {
-            "$ref": "#/components/schemas/SpaceType"
+            "$ref": "#/components/schemas/SpaceType",
+            "description": "Ownership model of the Space."
           }
         },
         "required": [
@@ -6419,6 +6510,7 @@
         "type": "object"
       },
       "SpaceItem": {
+        "description": "Summary of a Space visible to the current user.",
         "properties": {
           "current_user_role": {
             "anyOf": [
@@ -6428,7 +6520,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Current user's role, or null when the user has not joined."
           },
           "gmt_modified": {
             "description": "UTC time when the Space metadata was last modified.",
@@ -6437,30 +6530,37 @@
             "type": "string"
           },
           "join_status": {
-            "$ref": "#/components/schemas/SpaceJoinStatus"
+            "$ref": "#/components/schemas/SpaceJoinStatus",
+            "description": "Current user's membership or application state."
           },
           "member_count": {
+            "description": "Number of members in the Space.",
             "title": "Member Count",
             "type": "integer"
           },
           "owner_count": {
+            "description": "Number of owners in the Space.",
             "title": "Owner Count",
             "type": "integer"
           },
           "space_code": {
+            "description": "Stable external code of the Space.",
             "title": "Space Code",
             "type": "string"
           },
           "space_id": {
+            "description": "Unique numeric identifier of the Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "space_name": {
+            "description": "Display name of the Space.",
             "title": "Space Name",
             "type": "string"
           },
           "space_type": {
-            "$ref": "#/components/schemas/SpaceType"
+            "$ref": "#/components/schemas/SpaceType",
+            "description": "Ownership model of the Space."
           }
         },
         "required": [
@@ -6478,15 +6578,19 @@
         "type": "object"
       },
       "SpaceJoinRequestCreated": {
+        "description": "Work-order identity returned for a new Space join request.",
         "properties": {
           "status": {
-            "$ref": "#/components/schemas/WorkOrderStatus"
+            "$ref": "#/components/schemas/WorkOrderStatus",
+            "description": "Initial work-order status."
           },
           "work_order_id": {
+            "description": "Identifier of the created work order.",
             "title": "Work Order Id",
             "type": "integer"
           },
           "work_order_no": {
+            "description": "Human-readable work-order number.",
             "title": "Work Order No",
             "type": "string"
           }
@@ -6500,26 +6604,46 @@
         "type": "object"
       },
       "SpaceJoinStatus": {
+        "description": "Current user's membership state for a Space.",
         "enum": [
           "JOINED",
           "APPLYING",
           "NOT_JOINED"
         ],
         "title": "SpaceJoinStatus",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "The user is currently a member of the Space.",
+          "The user's join request is awaiting review.",
+          "The user is not a member and has no pending request."
+        ],
+        "x-enum-varnames": [
+          "JOINED",
+          "APPLYING",
+          "NOT_JOINED"
+        ],
+        "x-enumNames": [
+          "JOINED",
+          "APPLYING",
+          "NOT_JOINED"
+        ]
       },
       "SpaceMemberDeletedResult": {
+        "description": "Confirmation that a member was removed from a Space.",
         "properties": {
           "deleted": {
             "default": true,
+            "description": "Whether the membership was deleted.",
             "title": "Deleted",
             "type": "boolean"
           },
           "space_id": {
+            "description": "Identifier of the affected Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "user_id": {
+            "description": "Identifier of the removed member.",
             "title": "User Id",
             "type": "string"
           }
@@ -6532,7 +6656,20 @@
         "type": "object"
       },
       "SpaceMemberItem": {
+        "description": "Membership details for one user in a Space.",
         "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the member, when available.",
+            "title": "Display Name"
+          },
           "gmt_modified": {
             "description": "UTC time when this membership relation was created or its role was last changed.",
             "format": "date-time",
@@ -6540,15 +6677,30 @@
             "type": "string"
           },
           "is_creator": {
+            "description": "Whether this member originally created the Space.",
             "title": "Is Creator",
             "type": "boolean"
           },
           "role": {
-            "$ref": "#/components/schemas/SpaceRole"
+            "$ref": "#/components/schemas/SpaceRole",
+            "description": "Role currently held by the member."
           },
           "user_id": {
+            "description": "Identifier of the member user.",
             "title": "User Id",
             "type": "string"
+          },
+          "user_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Account name of the member, when available.",
+            "title": "User Name"
           }
         },
         "required": [
@@ -6561,15 +6713,19 @@
         "type": "object"
       },
       "SpaceMemberMutationResult": {
+        "description": "Membership state returned after an add or role update.",
         "properties": {
           "role": {
-            "$ref": "#/components/schemas/SpaceRole"
+            "$ref": "#/components/schemas/SpaceRole",
+            "description": "Role held after the operation."
           },
           "space_id": {
+            "description": "Identifier of the affected Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "user_id": {
+            "description": "Identifier of the affected member.",
             "title": "User Id",
             "type": "string"
           }
@@ -6583,20 +6739,46 @@
         "type": "object"
       },
       "SpaceRole": {
+        "description": "Role held by a user in a Space.",
         "enum": [
           "OWNER",
           "MEMBER"
         ],
         "title": "SpaceRole",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "May manage the Space and its membership.",
+          "May use the Space without managing its membership."
+        ],
+        "x-enum-varnames": [
+          "OWNER",
+          "MEMBER"
+        ],
+        "x-enumNames": [
+          "OWNER",
+          "MEMBER"
+        ]
       },
       "SpaceType": {
+        "description": "Kind of Space and its ownership model.",
         "enum": [
           "PERSONAL",
           "TEAM"
         ],
         "title": "SpaceType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "A private Space initialized for one user.",
+          "A shared Space managed by one or more owners."
+        ],
+        "x-enum-varnames": [
+          "PERSONAL",
+          "TEAM"
+        ],
+        "x-enumNames": [
+          "PERSONAL",
+          "TEAM"
+        ]
       },
       "StartupScript": {
         "description": "A bot's stored startup script. Every field is server-derived.",
@@ -6685,8 +6867,10 @@
         "type": "object"
       },
       "UnreadCountResponse": {
+        "description": "Unread notification total for the current user.",
         "properties": {
           "unread_count": {
+            "description": "Number of unread notifications.",
             "title": "Unread Count",
             "type": "integer"
           }
@@ -6698,9 +6882,11 @@
         "type": "object"
       },
       "UpdateSpaceMemberRoleRequest": {
+        "description": "Request for changing a Space member's role.",
         "properties": {
           "role": {
-            "$ref": "#/components/schemas/SpaceRole"
+            "$ref": "#/components/schemas/SpaceRole",
+            "description": "New role to assign to the member."
           }
         },
         "required": [
@@ -6710,19 +6896,32 @@
         "type": "object"
       },
       "WorkOrderBizType": {
+        "description": "Business object represented by a work order.",
         "enum": [
           "SPACE_JOIN"
         ],
         "title": "WorkOrderBizType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "A request to join a Space."
+        ],
+        "x-enum-varnames": [
+          "SPACE_JOIN"
+        ],
+        "x-enumNames": [
+          "SPACE_JOIN"
+        ]
       },
       "WorkOrderDetailContent": {
+        "description": "Business details for a Space join work order.",
         "properties": {
           "applicant_name": {
+            "description": "Display name of the applicant.",
             "title": "Applicant Name",
             "type": "string"
           },
           "applicant_user_id": {
+            "description": "Identifier of the applicant.",
             "title": "Applicant User Id",
             "type": "string"
           },
@@ -6735,13 +6934,16 @@
                 "type": "null"
               }
             ],
+            "description": "Applicant's reason, when supplied.",
             "title": "Reason"
           },
           "space_id": {
+            "description": "Identifier of the requested Space.",
             "title": "Space Id",
             "type": "integer"
           },
           "space_name": {
+            "description": "Display name of the requested Space.",
             "title": "Space Name",
             "type": "string"
           }
@@ -6757,23 +6959,29 @@
         "type": "object"
       },
       "WorkOrderDetailResponse": {
+        "description": "Detailed view of one work order.",
         "properties": {
           "biz_id": {
+            "description": "Identifier of the related Space.",
             "title": "Biz Id",
             "type": "integer"
           },
           "biz_type": {
-            "$ref": "#/components/schemas/WorkOrderBizType"
+            "$ref": "#/components/schemas/WorkOrderBizType",
+            "description": "Business object type."
           },
           "can_approve": {
+            "description": "Whether the current user may approve or reject this work order.",
             "title": "Can Approve",
             "type": "boolean"
           },
           "content": {
-            "$ref": "#/components/schemas/WorkOrderDetailContent"
+            "$ref": "#/components/schemas/WorkOrderDetailContent",
+            "description": "Space join request details."
           },
           "event_type": {
-            "$ref": "#/components/schemas/WorkOrderEventType"
+            "$ref": "#/components/schemas/WorkOrderEventType",
+            "description": "Event that created the work order."
           },
           "review_remark": {
             "anyOf": [
@@ -6784,6 +6992,7 @@
                 "type": "null"
               }
             ],
+            "description": "Review comment after processing, otherwise null.",
             "title": "Review Remark"
           },
           "reviewed_at": {
@@ -6795,6 +7004,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC review time after processing, otherwise null.",
             "title": "Reviewed At"
           },
           "reviewer_user_id": {
@@ -6806,20 +7016,25 @@
                 "type": "null"
               }
             ],
+            "description": "Identifier of the reviewer after processing, otherwise null.",
             "title": "Reviewer User Id"
           },
           "status": {
-            "$ref": "#/components/schemas/WorkOrderStatus"
+            "$ref": "#/components/schemas/WorkOrderStatus",
+            "description": "Current work-order status."
           },
           "title": {
+            "description": "Display title of the work order.",
             "title": "Title",
             "type": "string"
           },
           "work_order_id": {
+            "description": "Identifier of the work order.",
             "title": "Work Order Id",
             "type": "integer"
           },
           "work_order_no": {
+            "description": "Human-readable work-order number.",
             "title": "Work Order No",
             "type": "string"
           }
@@ -6842,6 +7057,7 @@
         "type": "object"
       },
       "WorkOrderEventType": {
+        "description": "Business event that created a work order or notification.",
         "enum": [
           "SPACE_JOIN_APPLIED",
           "SPACE_JOIN_REVIEWED",
@@ -6859,20 +7075,86 @@
           "BOT2BOT_PUBLIC_ORDER_COMPLETED"
         ],
         "title": "WorkOrderEventType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "A user submitted a request to join a Space.",
+          "A Space join request received a review decision.",
+          "A user was directly added to a Space.",
+          "A bot collaborator request was submitted.",
+          "A bot collaborator request was reviewed.",
+          "A member was directly added to a bot.",
+          "A user-to-bot friend request was submitted.",
+          "A user-to-bot friend request was reviewed.",
+          "A bot-to-bot friend request was submitted.",
+          "A bot-to-bot friend request was reviewed.",
+          "A user created a public order for a bot.",
+          "A user's public bot order completed.",
+          "A bot created a public order for another bot.",
+          "A bot-to-bot public order completed."
+        ],
+        "x-enum-varnames": [
+          "SPACE_JOIN_APPLIED",
+          "SPACE_JOIN_REVIEWED",
+          "SPACE_MEMBER_ADDED",
+          "BOT_COLLABORATOR_APPLIED",
+          "BOT_COLLABORATOR_REVIEWED",
+          "BOT_MEMBER_ADDED",
+          "HUMAN2BOT_FRIEND_APPLIED",
+          "HUMAN2BOT_FRIEND_REVIEWED",
+          "BOT2BOT_FRIEND_APPLIED",
+          "BOT2BOT_FRIEND_REVIEWED",
+          "HUMAN2BOT_PUBLIC_ORDER_CREATED",
+          "HUMAN2BOT_PUBLIC_ORDER_COMPLETED",
+          "BOT2BOT_PUBLIC_ORDER_CREATED",
+          "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+        ],
+        "x-enumNames": [
+          "SPACE_JOIN_APPLIED",
+          "SPACE_JOIN_REVIEWED",
+          "SPACE_MEMBER_ADDED",
+          "BOT_COLLABORATOR_APPLIED",
+          "BOT_COLLABORATOR_REVIEWED",
+          "BOT_MEMBER_ADDED",
+          "HUMAN2BOT_FRIEND_APPLIED",
+          "HUMAN2BOT_FRIEND_REVIEWED",
+          "BOT2BOT_FRIEND_APPLIED",
+          "BOT2BOT_FRIEND_REVIEWED",
+          "HUMAN2BOT_PUBLIC_ORDER_CREATED",
+          "HUMAN2BOT_PUBLIC_ORDER_COMPLETED",
+          "BOT2BOT_PUBLIC_ORDER_CREATED",
+          "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+        ]
       },
       "WorkOrderItemType": {
+        "description": "Category of item included in a work-order list.",
         "enum": [
           "ALL",
           "APPROVAL",
           "NOTICE"
         ],
         "title": "WorkOrderItemType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "Both approval items and informational notices.",
+          "Items that represent reviewable work orders.",
+          "Items that represent informational notifications."
+        ],
+        "x-enum-varnames": [
+          "ALL",
+          "APPROVAL",
+          "NOTICE"
+        ],
+        "x-enumNames": [
+          "ALL",
+          "APPROVAL",
+          "NOTICE"
+        ]
       },
       "WorkOrderListItem": {
+        "description": "Approval or notification item in a user's work-order inbox.",
         "properties": {
           "applicant_user_id": {
+            "description": "Identifier of the applicant.",
             "title": "Applicant User Id",
             "type": "string"
           },
@@ -6885,16 +7167,20 @@
                 "type": "null"
               }
             ],
+            "description": "Application reason, when supplied.",
             "title": "Apply Reason"
           },
           "biz_id": {
+            "description": "Identifier of the related business object.",
             "title": "Biz Id",
             "type": "string"
           },
           "biz_type": {
-            "$ref": "#/components/schemas/WorkOrderBizType"
+            "$ref": "#/components/schemas/WorkOrderBizType",
+            "description": "Business object type."
           },
           "can_approve": {
+            "description": "Whether the current user may approve or reject this item.",
             "title": "Can Approve",
             "type": "boolean"
           },
@@ -6907,9 +7193,11 @@
                 "type": "null"
               }
             ],
+            "description": "Notification content, when available.",
             "title": "Content"
           },
           "env": {
+            "description": "Environment scope of the work order.",
             "title": "Env",
             "type": "string"
           },
@@ -6921,7 +7209,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Originating event, or null when no notification is attached."
           },
           "gmt_created": {
             "anyOf": [
@@ -6932,6 +7221,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC time when the work order was created.",
             "title": "Gmt Created"
           },
           "gmt_modified": {
@@ -6943,6 +7233,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC time when the displayed item was last modified.",
             "title": "Gmt Modified"
           },
           "is_read": {
@@ -6954,14 +7245,17 @@
                 "type": "null"
               }
             ],
+            "description": "Notification read state, or null when no notification is attached.",
             "title": "Is Read"
           },
           "item_id": {
+            "description": "Stable identifier of this combined list item.",
             "title": "Item Id",
             "type": "string"
           },
           "item_type": {
-            "$ref": "#/components/schemas/WorkOrderItemType"
+            "$ref": "#/components/schemas/WorkOrderItemType",
+            "description": "Category of the list item."
           },
           "notification_category": {
             "anyOf": [
@@ -6971,7 +7265,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Notification category, or null when no notification is attached."
           },
           "notification_id": {
             "anyOf": [
@@ -6982,6 +7277,7 @@
                 "type": "null"
               }
             ],
+            "description": "Related notification identifier, or null for approval-only items.",
             "title": "Notification Id"
           },
           "read_at": {
@@ -6993,6 +7289,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC notification read time, or null when unread or unavailable.",
             "title": "Read At"
           },
           "recipient_user_id": {
@@ -7004,6 +7301,7 @@
                 "type": "null"
               }
             ],
+            "description": "Notification recipient, or null when no notification is attached.",
             "title": "Recipient User Id"
           },
           "review_remark": {
@@ -7015,6 +7313,7 @@
                 "type": "null"
               }
             ],
+            "description": "Review comment after processing, otherwise null.",
             "title": "Review Remark"
           },
           "reviewed_at": {
@@ -7026,6 +7325,7 @@
                 "type": "null"
               }
             ],
+            "description": "UTC review time after processing, otherwise null.",
             "title": "Reviewed At"
           },
           "reviewer_user_id": {
@@ -7037,10 +7337,12 @@
                 "type": "null"
               }
             ],
+            "description": "Identifier of the reviewer after processing, otherwise null.",
             "title": "Reviewer User Id"
           },
           "status": {
-            "$ref": "#/components/schemas/WorkOrderStatus"
+            "$ref": "#/components/schemas/WorkOrderStatus",
+            "description": "Current work-order status."
           },
           "title": {
             "anyOf": [
@@ -7051,13 +7353,16 @@
                 "type": "null"
               }
             ],
+            "description": "Notification title, when available.",
             "title": "Title"
           },
           "work_order_id": {
+            "description": "Identifier of the related work order.",
             "title": "Work Order Id",
             "type": "integer"
           },
           "work_order_no": {
+            "description": "Human-readable work-order number.",
             "title": "Work Order No",
             "type": "string"
           }
@@ -7092,17 +7397,35 @@
         "type": "object"
       },
       "WorkOrderQueryType": {
+        "description": "Relationship between the current user and listed work orders.",
         "enum": [
           "PENDING_FOR_ME",
           "INITIATED_BY_ME",
           "PROCESSED_BY_ME"
         ],
         "title": "WorkOrderQueryType",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "Pending work orders awaiting the current user's review.",
+          "Work orders submitted by the current user.",
+          "Work orders already reviewed by the current user."
+        ],
+        "x-enum-varnames": [
+          "PENDING_FOR_ME",
+          "INITIATED_BY_ME",
+          "PROCESSED_BY_ME"
+        ],
+        "x-enumNames": [
+          "PENDING_FOR_ME",
+          "INITIATED_BY_ME",
+          "PROCESSED_BY_ME"
+        ]
       },
       "WorkOrderReviewRequest": {
+        "description": "Review comment supplied with an approval or rejection.",
         "properties": {
           "review_remark": {
+            "description": "Reviewer comment for the decision.",
             "maxLength": 512,
             "minLength": 1,
             "title": "Review Remark",
@@ -7116,8 +7439,10 @@
         "type": "object"
       },
       "WorkOrderReviewResponse": {
+        "description": "Final state returned after reviewing a work order.",
         "properties": {
           "review_remark": {
+            "description": "Reviewer comment recorded with the decision.",
             "title": "Review Remark",
             "type": "string"
           },
@@ -7130,16 +7455,20 @@
                 "type": "null"
               }
             ],
+            "description": "UTC time when the review decision was recorded.",
             "title": "Reviewed At"
           },
           "reviewer_user_id": {
+            "description": "Identifier of the reviewer.",
             "title": "Reviewer User Id",
             "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/WorkOrderStatus"
+            "$ref": "#/components/schemas/WorkOrderStatus",
+            "description": "Status after the review decision."
           },
           "work_order_id": {
+            "description": "Identifier of the reviewed work order.",
             "title": "Work Order Id",
             "type": "integer"
           }
@@ -7155,13 +7484,29 @@
         "type": "object"
       },
       "WorkOrderStatus": {
+        "description": "Current processing state of a work order.",
         "enum": [
           "PENDING",
           "APPROVED",
           "REJECTED"
         ],
         "title": "WorkOrderStatus",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "Awaiting review.",
+          "Approved by an authorized reviewer.",
+          "Rejected by an authorized reviewer."
+        ],
+        "x-enum-varnames": [
+          "PENDING",
+          "APPROVED",
+          "REJECTED"
+        ],
+        "x-enumNames": [
+          "PENDING",
+          "APPROVED",
+          "REJECTED"
+        ]
       }
     }
   },
@@ -12141,6 +12486,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -12165,18 +12522,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -15327,6 +15672,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -15351,18 +15708,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -16789,6 +17134,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -16813,18 +17170,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -22427,6 +22772,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -22451,18 +22808,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -25942,6 +26287,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -25966,18 +26323,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -27398,6 +27743,18 @@
             }
           },
           {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
             "description": "1-based page number.",
             "in": "query",
             "name": "page",
@@ -27422,18 +27779,6 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
-            }
-          },
-          {
-            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-            "in": "query",
-            "name": "user_id",
-            "required": true,
-            "schema": {
-              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
-              "minLength": 1,
-              "title": "User Id",
-              "type": "string"
             }
           },
           {
@@ -29496,6 +29841,7 @@
         "operationId": "list_spaces_openapi_v1_spaces_get",
         "parameters": [
           {
+            "description": "Optional Space-name search text.",
             "in": "query",
             "name": "keyword",
             "required": false,
@@ -29509,10 +29855,12 @@
                   "type": "null"
                 }
               ],
+              "description": "Optional Space-name search text.",
               "title": "Keyword"
             }
           },
           {
+            "description": "Optional Space type filter.",
             "in": "query",
             "name": "space_type",
             "required": false,
@@ -29525,30 +29873,47 @@
                   "type": "null"
                 }
               ],
+              "description": "Optional Space type filter.",
               "title": "Space Type"
             }
           },
           {
+            "description": "One-based page number.",
             "in": "query",
             "name": "page_no",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "One-based page number.",
               "minimum": 1,
               "title": "Page No",
               "type": "integer"
             }
           },
           {
+            "description": "Maximum items returned per page.",
             "in": "query",
             "name": "page_size",
             "required": false,
             "schema": {
               "default": 20,
+              "description": "Maximum items returned per page.",
               "maximum": 100,
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -29693,6 +30058,20 @@
     "/openapi/v1/spaces/create": {
       "post": {
         "operationId": "create_team_space_openapi_v1_spaces_create_post",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -29844,6 +30223,20 @@
     "/openapi/v1/spaces/personal/initialize": {
       "post": {
         "operationId": "initialize_personal_space_openapi_v1_spaces_personal_initialize_post",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -29987,13 +30380,27 @@
         "operationId": "create_space_join_request_openapi_v1_spaces__space_id__join_requests_post",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "space_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Space Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -30160,6 +30567,18 @@
               "title": "Space Id",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -30325,6 +30744,18 @@
               "title": "Space Id",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -30489,6 +30920,18 @@
               "minimum": 1,
               "title": "Space Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -30657,6 +31100,7 @@
             }
           },
           {
+            "description": "Optional member-id search text.",
             "in": "query",
             "name": "keyword",
             "required": false,
@@ -30670,30 +31114,47 @@
                   "type": "null"
                 }
               ],
+              "description": "Optional member-id search text.",
               "title": "Keyword"
             }
           },
           {
+            "description": "One-based page number.",
             "in": "query",
             "name": "page_no",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "One-based page number.",
               "minimum": 1,
               "title": "Page No",
               "type": "integer"
             }
           },
           {
+            "description": "Maximum items returned per page.",
             "in": "query",
             "name": "page_size",
             "required": false,
             "schema": {
               "default": 20,
+              "description": "Maximum items returned per page.",
               "maximum": 100,
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -30848,6 +31309,18 @@
               "title": "Space Id",
               "type": "integer"
             }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -30998,9 +31471,9 @@
         ]
       }
     },
-    "/openapi/v1/spaces/{space_id}/members/{user_id}": {
+    "/openapi/v1/spaces/{space_id}/members/{member_user_id}": {
       "delete": {
-        "operationId": "delete_space_member_openapi_v1_spaces__space_id__members__user_id__delete",
+        "operationId": "delete_space_member_openapi_v1_spaces__space_id__members__member_user_id__delete",
         "parameters": [
           {
             "description": "Space primary identifier.",
@@ -31015,11 +31488,25 @@
             }
           },
           {
+            "description": "Identifier of the Space member to remove.",
             "in": "path",
+            "name": "member_user_id",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the Space member to remove.",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "Member User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
             "name": "user_id",
             "required": true,
             "schema": {
-              "maxLength": 256,
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -31164,9 +31651,9 @@
         ]
       }
     },
-    "/openapi/v1/spaces/{space_id}/members/{user_id}/role": {
+    "/openapi/v1/spaces/{space_id}/members/{member_user_id}/role": {
       "put": {
-        "operationId": "update_space_member_role_openapi_v1_spaces__space_id__members__user_id__role_put",
+        "operationId": "update_space_member_role_openapi_v1_spaces__space_id__members__member_user_id__role_put",
         "parameters": [
           {
             "description": "Space primary identifier.",
@@ -31181,11 +31668,25 @@
             }
           },
           {
+            "description": "Identifier of the Space member whose role will change.",
             "in": "path",
+            "name": "member_user_id",
+            "required": true,
+            "schema": {
+              "description": "Identifier of the Space member whose role will change.",
+              "maxLength": 256,
+              "minLength": 1,
+              "title": "Member User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
             "name": "user_id",
             "required": true,
             "schema": {
-              "maxLength": 256,
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
               "minLength": 1,
               "title": "User Id",
               "type": "string"
@@ -31343,6 +31844,20 @@
     "/openapi/v1/work-order-notifications/read-all": {
       "post": {
         "operationId": "mark_all_notifications_read_openapi_v1_work_order_notifications_read_all_post",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -31484,6 +31999,20 @@
     "/openapi/v1/work-order-notifications/unread-count": {
       "get": {
         "operationId": "unread_notification_count_openapi_v1_work_order_notifications_unread_count_get",
+        "parameters": [
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -31627,13 +32156,27 @@
         "operationId": "get_notification_openapi_v1_work_order_notifications__notification_id__get",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "notification_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Notification Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -31780,13 +32323,27 @@
         "operationId": "mark_notification_read_openapi_v1_work_order_notifications__notification_id__read_post",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "notification_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Notification Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -31933,44 +32490,64 @@
         "operationId": "list_work_orders_openapi_v1_work_orders_get",
         "parameters": [
           {
+            "description": "Relationship between the current user and returned items.",
             "in": "query",
             "name": "query_type",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/WorkOrderQueryType",
-              "default": "PENDING_FOR_ME"
+              "default": "PENDING_FOR_ME",
+              "description": "Relationship between the current user and returned items."
             }
           },
           {
+            "description": "Category of inbox item to return.",
             "in": "query",
             "name": "item_type",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/WorkOrderItemType",
-              "default": "ALL"
+              "default": "ALL",
+              "description": "Category of inbox item to return."
             }
           },
           {
+            "description": "One-based page number.",
             "in": "query",
             "name": "page_no",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "One-based page number.",
               "minimum": 1,
               "title": "Page No",
               "type": "integer"
             }
           },
           {
+            "description": "Maximum items returned per page.",
             "in": "query",
             "name": "page_size",
             "required": false,
             "schema": {
               "default": 20,
+              "description": "Maximum items returned per page.",
               "maximum": 100,
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -32117,13 +32694,27 @@
         "operationId": "get_work_order_openapi_v1_work_orders__work_order_id__get",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "work_order_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Work Order Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -32270,13 +32861,27 @@
         "operationId": "approve_work_order_openapi_v1_work_orders__work_order_id__approve_post",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "work_order_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Work Order Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],
@@ -32433,13 +33038,27 @@
         "operationId": "reject_work_order_openapi_v1_work_orders__work_order_id__reject_post",
         "parameters": [
           {
+            "description": "Positive numeric identifier.",
             "in": "path",
             "name": "work_order_id",
             "required": true,
             "schema": {
+              "description": "Positive numeric identifier.",
               "minimum": 1,
               "title": "Work Order Id",
               "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
             }
           }
         ],

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -39,6 +39,16 @@ def test_shipped_config_admits_a_machine_caller_on_the_public_api() -> None:
 #: packages, so the agreement is kept by these tests plus the backend's own
 #: enumeration rather than by a shared import.
 _HUMAN_ONLY = [
+    ("GET", "/openapi/v1/spaces"),
+    ("POST", "/openapi/v1/spaces/personal/initialize"),
+    ("POST", "/openapi/v1/spaces/create"),
+    ("GET", "/openapi/v1/spaces/1/members"),
+    ("POST", "/openapi/v1/spaces/1/members"),
+    ("DELETE", "/openapi/v1/spaces/1/members/user-1"),
+    ("PUT", "/openapi/v1/spaces/1/members/user-1/role"),
+    ("POST", "/openapi/v1/spaces/1/market-favorites"),
+    ("POST", "/openapi/v1/spaces/1/market-favorites/cancel"),
+    ("POST", "/openapi/v1/spaces/1/market-favorites/search"),
     ("POST", "/openapi/v1/bots"),
     ("GET", "/openapi/v1/bots/bot-123/authorized-apps"),
     ("DELETE", "/openapi/v1/bots/bot-123/authorized-apps/42"),

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -78,6 +78,13 @@ def test_shipped_config_loads() -> None:
     dm = DomainMap.from_config(raw["user_config"]["upstreams"], variables=_VARS)
     assert dm.http_domain_for("/openapi/v1/bots") is not None
 
+    spaces = dm.http_domain_for("/openapi/v1/spaces/1/members")
+    assert spaces is not None
+    assert spaces.server.name == "backend"
+    assert spaces.server.base_url == "http://backend:8080"
+    assert spaces.schema.source == "file"
+    assert spaces.schema.location == "schemas/bots.openapi.json"
+
 
 def test_shipped_config_routes_collaboration_verbatim_to_bcs() -> None:
     raw = yaml.safe_load(_CONFIG.read_text())

--- a/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
+++ b/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
@@ -60,6 +60,25 @@ def test_non_public_paths_are_filtered_out() -> None:
     assert "/api/internal/debug" not in _served()["paths"]
 
 
+def test_backend_artifact_serves_spaces_through_its_own_domain() -> None:
+    artifact = json.loads(
+        (_SHIPPED_CONFIG.parent / "schemas" / "bots.openapi.json").read_text()
+    )
+    document = build_served_openapi(
+        ["bots", "spaces"],
+        lambda _domain: artifact,
+        _SHIPPED_RULES,
+        title="gateway",
+        version="0.1.0",
+    )
+
+    assert "/openapi/v1/bots" in document["paths"]
+    assert "/openapi/v1/spaces" in document["paths"]
+    assert document["paths"]["/openapi/v1/spaces"]["get"][
+        "x-avernet-security"
+    ] == {"user": "required"}
+
+
 def test_every_served_operation_carries_security() -> None:
     for path, item in _served()["paths"].items():
         for method, operation in item.items():


### PR DESCRIPTION
- 新增个人/团队空间、成员及角色管理接口。
  - 新增 Skill/MCP 收藏、取消收藏和分页查询接口。
  - 新增加入空间申请、审批/拒绝及通知管理接口，审批关联写入按事务处理。
  - 新增内部个人空间批量查询接口。
  - 补齐 Core Service、Repository、数据库脚本和依赖注入。
  - 修正 Admission 配置、显式 user_id、member_user_id、Schema 字段说明及时间/用户信息返回。
  - 同步更新 Gateway 路由配置和 OpenAPI Schema。