### PR TITLE
feat(gateway): add singlebox lifecycle scripts

### DIFF
--- a/scripts/modules/gateway.sh
+++ b/scripts/modules/gateway.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scripts/modules/gateway.sh — Gateway service module
+[[ -n "${_GATEWAY_SH_LOADED:-}" ]] && return 0
+_GATEWAY_SH_LOADED=1
+
+# Service-specific constants
+GATEWAY_LOG="${LOG_DIR}/gateway.log"
+GATEWAY_PID_FILE="${DEP_DIR}/gateway.pid"
+GATEWAY_APP_SCRIPT="${GATEWAY_DIR}/scripts/app.sh"
+GATEWAY_PORT="${GATEWAY_PORT:-8889}"
+
+
+gateway_setup() {
+    if ! check_directory_exists "${GATEWAY_DIR}" "gateway"; then
+        return 1
+    fi
+
+    check_uv_installed || { log_error "uv not found. Run: singlebox.sh install-tools"; return 1; }
+
+    cd "${GATEWAY_DIR}"
+    log_info "Syncing Python dependencies for Gateway..."
+    if ! uv sync --python ">=3.12,<3.13" --index-url "${PYPI_INDEX_URL}"; then
+        log_error "Failed to sync Python dependencies for Gateway"
+        return 1
+    fi
+    log_info "Gateway dependencies synced successfully"
+}
+
+
+gateway_start() {
+    mkdir -p "${LOG_DIR}"
+
+    if ! check_directory_exists "${GATEWAY_DIR}" "gateway"; then
+        return 1
+    fi
+    if [ ! -x "${GATEWAY_APP_SCRIPT}" ]; then
+        log_error "Gateway lifecycle script not executable: ${GATEWAY_APP_SCRIPT}"
+        return 1
+    fi
+
+    gateway_setup || return 1
+
+    stop_port_processes_if_owned "${GATEWAY_PORT}" "${GATEWAY_DIR}" "existing gateway"
+    stop_matching_processes_if_owned "gateway/community/main.py" "${GATEWAY_DIR}" "existing gateway process"
+    require_port_available_after_owned_stop "${GATEWAY_PORT}" "gateway" "set GATEWAY_PORT=<free-port> in .env.local or pass --gateway-port <free-port>" || return 1
+
+    log_info "Starting Gateway service on port ${GATEWAY_PORT}..."
+    log_info "Log: ${GATEWAY_LOG}"
+
+    (
+        cd "${GATEWAY_DIR}"
+        GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
+    ) >> "${GATEWAY_LOG}" 2>&1
+
+    local gateway_pid=""
+    if [ -f "${GATEWAY_DIR}/tmp/app.pid" ]; then
+        gateway_pid="$(cat "${GATEWAY_DIR}/tmp/app.pid" 2>/dev/null || true)"
+        if [ -n "${gateway_pid}" ]; then
+            echo "${gateway_pid}" > "${GATEWAY_PID_FILE}"
+        fi
+    fi
+
+    if gateway_ready; then
+        log_info "Gateway started successfully${gateway_pid:+ (PID: ${gateway_pid})}"
+        log_info "Gateway health: http://127.0.0.1:${GATEWAY_PORT}/health"
+        return 0
+    fi
+
+    log_error "Gateway failed to become ready; check ${GATEWAY_LOG} and ${GATEWAY_DIR}/tmp/app.log"
+    return 1
+}
+
+
+gateway_stop() {
+    log_info "Stopping Gateway..."
+
+    if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
+        (cd "${GATEWAY_DIR}" && GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
+    fi
+
+    if [ -f "${GATEWAY_PID_FILE}" ]; then
+        local gateway_pid
+        gateway_pid="$(cat "${GATEWAY_PID_FILE}" 2>/dev/null || true)"
+        if [ -n "${gateway_pid}" ]; then
+            stop_process_if_owned "${gateway_pid}" "${GATEWAY_DIR}" "gateway pidfile process" || true
+        fi
+        rm -f "${GATEWAY_PID_FILE}"
+    fi
+
+    stop_port_processes_if_owned "${GATEWAY_PORT}" "${GATEWAY_DIR}" "gateway"
+    stop_matching_processes_if_owned "gateway/community/main.py" "${GATEWAY_DIR}" "gateway process"
+    log_info "Gateway stopped"
+}
+
+
+gateway_status() {
+    local gateway_pid=""
+    gateway_pid="$(lsof -tiTCP:${GATEWAY_PORT} -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+    if [ -n "${gateway_pid}" ]; then
+        if gateway_ready; then
+            echo "  Gateway:   Running (PID: ${gateway_pid}, port: ${GATEWAY_PORT}, health: OK)"
+        else
+            echo "  Gateway:   Running (PID: ${gateway_pid}, port: ${GATEWAY_PORT}, health: FAIL)"
+        fi
+    else
+        echo "  Gateway:   Stopped (port: ${GATEWAY_PORT})"
+    fi
+}
+
+
+gateway_ready() {
+    curl --noproxy '*' --connect-timeout 1 --max-time 2 -s "http://127.0.0.1:${GATEWAY_PORT}/health" > /dev/null 2>&1
+}
+
+
+gateway_prereqs() {
+    local has_error=false
+
+    echo -e "${CYAN}[gateway] Prerequisites${NC}"
+
+    if check_uv_installed; then
+        prereq_ok "uv: $(uv --version 2>&1 | head -1)"
+    else
+        prereq_error "uv not found. Run: singlebox.sh install-tools"
+        has_error=true
+    fi
+
+    if check_directory_exists "${GATEWAY_DIR}" "gateway" 2>/dev/null; then
+        prereq_ok "directory: ${GATEWAY_DIR}"
+    else
+        prereq_error "directory not found: ${GATEWAY_DIR}"
+        has_error=true
+    fi
+
+    if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
+        prereq_ok "lifecycle script: ${GATEWAY_APP_SCRIPT}"
+    else
+        prereq_error "lifecycle script not executable: ${GATEWAY_APP_SCRIPT}"
+        has_error=true
+    fi
+
+    if [ -f "${GATEWAY_DIR}/.venv/bin/activate" ]; then
+        prereq_ok "venv: ${GATEWAY_DIR}/.venv"
+    else
+        prereq_warn "venv not found: ${GATEWAY_DIR}/.venv — run: singlebox.sh setup gateway"
+    fi
+
+    if check_port_available "${GATEWAY_PORT}"; then
+        prereq_ok "Port ${GATEWAY_PORT} available"
+    else
+        prereq_warn "Port ${GATEWAY_PORT} is in use"
+    fi
+
+    if [ "${has_error}" = true ]; then
+        return 1
+    fi
+    return 0
+}
+
+
+gateway_help() {
+    echo "gateway - Gateway service (port ${GATEWAY_PORT})"
+}

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -53,6 +53,7 @@ BCS_DIR="${PROJECT_ROOT}/src/bcs"
 BCSFUSE_DIR="${PROJECT_ROOT}/src/bcsfuse"
 RELAY_DIR="${RELAY_DIR:-${PROJECT_ROOT}/../teamclaw-aicoding-relay}"
 BAAS_DIR="${PROJECT_ROOT}/src/baas"
+GATEWAY_DIR="${PROJECT_ROOT}/src/gateway"
 
 # 默认版本
 DEFAULT_OPENCLAW_VERSION=">=2026.3.28"
@@ -63,6 +64,7 @@ DEFAULT_HERMES_PORT_START="18700"
 DEFAULT_HERMES_PORT_END="18799"
 DEFAULT_BCSFUSE_PORT="8765"
 DEFAULT_FRONTEND_PORT="8000"
+DEFAULT_GATEWAY_PORT="8889"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-${DEFAULT_OPENCLAW_VERSION}}"
 BCS_PORT="${BCS_PORT:-${DEFAULT_BCS_PORT}}"
 RELAY_PORT="${RELAY_PORT:-${DEFAULT_RELAY_PORT}}"
@@ -73,6 +75,7 @@ HERMES_PORT_START="${HERMES_PORT_START:-${DEFAULT_HERMES_PORT_START}}"
 HERMES_PORT_END="${HERMES_PORT_END:-${DEFAULT_HERMES_PORT_END}}"
 BCSFUSE_PORT="${BCSFUSE_PORT:-${DEFAULT_BCSFUSE_PORT}}"
 FRONTEND_PORT="${FRONTEND_PORT:-${DEFAULT_FRONTEND_PORT}}"
+GATEWAY_PORT="${GATEWAY_PORT:-${DEFAULT_GATEWAY_PORT}}"
 CHAT_ENGINE="${CHAT_ENGINE:-openclaw}"
 BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-}"
 BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
@@ -164,6 +167,7 @@ source "${SCRIPT_DIR}/modules/engine.sh"
 source "${SCRIPT_DIR}/modules/baas.sh"
 source "${SCRIPT_DIR}/modules/backend.sh"
 source "${SCRIPT_DIR}/modules/frontend.sh"
+source "${SCRIPT_DIR}/modules/gateway.sh"
 source "${SCRIPT_DIR}/modules/bcs.sh"
 source "${SCRIPT_DIR}/modules/bcsfuse.sh"
 source "${SCRIPT_DIR}/modules/bots.sh"
@@ -421,6 +425,7 @@ show_help() {
     echo "  --openclaw-version, -ov VERSION Specify openclaw npm version/range (default: ${DEFAULT_OPENCLAW_VERSION})"
     echo "  --bcs-port, -bp PORT          Specify BCS port (default: ${DEFAULT_BCS_PORT})"
     echo "  --frontend-port, -fp PORT     Specify frontend dev server port (default: ${DEFAULT_FRONTEND_PORT})"
+    echo "  --gateway-port PORT           Specify Gateway dev server port (default: ${DEFAULT_GATEWAY_PORT})"
     echo "  --bcs-env local|dev           BCS runtime env; default: local"
     echo "  --bcn-plugin-source source|npm  BCN plugin source: build from repo (source, default) or install"
     echo "                                  @avernet-plugin/openclaw-channel-bcn (npm). Env: BCN_PLUGIN_SOURCE,"
@@ -438,7 +443,7 @@ show_help() {
     echo ""
     echo "Services:"
     # 从各模块收集帮助信息
-    for svc in baas backend bcs bcsfuse frontend engine bots; do
+    for svc in baas backend gateway bcs bcsfuse frontend engine bots; do
         if type -t "${svc}_help" &>/dev/null; then
             echo "  $( "${svc}_help" )"
         fi
@@ -882,6 +887,15 @@ main() {
                 FRONTEND_PORT="$2"
                 shift 2
                 ;;
+            --gateway-port)
+                if [ -z "$2" ] || [ "$2" = -* ]; then
+                    log_error "Port number required for $1"
+                    show_help
+                    exit 1
+                fi
+                GATEWAY_PORT="$2"
+                shift 2
+                ;;
             --engine|-e)
                 if [ -z "$2" ] || [ "$2" = -* ]; then
                     log_error "Engine type required for $1"
@@ -984,7 +998,7 @@ main() {
                 LOCAL_MODE=true
                 shift
                 ;;
-            baas|backend|bcs|bcsfuse|frontend|engine|bots|bcs_bots|bcs_frontend|hybrid|merchant_hybrid|all)
+            baas|backend|gateway|bcs|bcsfuse|frontend|engine|bots|bcs_bots|bcs_frontend|hybrid|merchant_hybrid|all)
                 # Legacy: service name without command defaults to start
                 services+=("$1")
                 if [ -z "$command" ]; then

--- a/src/gateway/scripts/app.sh
+++ b/src/gateway/scripts/app.sh
@@ -4,7 +4,7 @@ WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 CONFIG_DIR="$WORK_DIR/configs"
 VENV_DIR="$WORK_DIR/.venv"
-APP_PORT="8888"
+APP_PORT="${GATEWAY_PORT:-${APP_PORT:-8888}}"
 APP_MODE=""
 APP_LOG_DIR="$HOME/logs/gateway"
 

--- a/src/gateway/src/gateway/community/config/_config_loader.py
+++ b/src/gateway/src/gateway/community/config/_config_loader.py
@@ -109,8 +109,12 @@ def _merge(base: dict, overlay: dict) -> dict:
 def _parse_config(raw: dict, *, config_dir: Path | None = None) -> Config:
     module_raw = raw.get("module_config") or {}
     web_raw = module_raw.get("web") or {}
+    port = int(web_raw.get("port", 8888))
+    env_port = os.getenv("GATEWAY_PORT", "").strip()
+    if env_port:
+        port = int(env_port)
     web = WebConfig(
-        port=int(web_raw.get("port", 8888)),
+        port=port,
         start=web_raw.get("start", WebConfig.start),
         enable_api_docs=bool(web_raw.get("enable_api_docs", True)),
     )

--- a/src/gateway/tests/unit/conftest.py
+++ b/src/gateway/tests/unit/conftest.py
@@ -12,6 +12,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run tests in bare mode without leaking the host's GW_* env vars."""
     monkeypatch.delenv("GATEWAY_RUN_MODE", raising=False)
     monkeypatch.delenv("GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("GATEWAY_PORT", raising=False)
     monkeypatch.delenv("SOFAPY_CONFIG_PATH", raising=False)
     monkeypatch.delenv("SERVER_ENV", raising=False)
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)

--- a/src/gateway/tests/unit/plugins/test_config.py
+++ b/src/gateway/tests/unit/plugins/test_config.py
@@ -161,6 +161,16 @@ class TestParseConfig:
         assert config.module_config.web is not None
         assert config.module_config.web.port == 7000
 
+    def test_gateway_port_env_overrides_web_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GATEWAY_PORT", "8899")
+
+        config = _parse_config({"module_config": {"web": {"port": 7000}}})
+
+        assert config.module_config.web is not None
+        assert config.module_config.web.port == 8899
+
 
 # ── _resolve_base_path / _resolve_overlay_path ───────────────────────────────
 


### PR DESCRIPTION
## Problem

  `src/gateway` lacked integration with the repository's `scripts/singlebox.sh` local development entrypoint. Developers could not manage Gateway with the same setup/start/stop/status/check
  workflow used by other local services, which made Gateway local startup less consistent and harder to operate alongside the rest of the stack.

  ## Solution

  Added Gateway as a first-class singlebox service without adding it to the default `all` stack, avoiding a port conflict with the existing backend default on `8888`.

  The change includes:

  - Added `scripts/modules/gateway.sh` with Gateway lifecycle functions:
    - `gateway_setup`
    - `gateway_start`
    - `gateway_stop`
    - `gateway_status`
    - `gateway_ready`
    - `gateway_prereqs`
    - `gateway_help`
  - Wired `gateway` into `scripts/singlebox.sh` service dispatch and help output.
  - Added `--gateway-port` support, with default Gateway singlebox port `8889`.
  - Updated `src/gateway/scripts/app.sh` to honor `GATEWAY_PORT` / `APP_PORT` for lifecycle health checks.
  - Updated Gateway config loading so `GATEWAY_PORT` overrides `application.yaml`'s web port, ensuring the actual uvicorn listener uses the selected singlebox port.
  - Added unit test coverage for the Gateway port override behavior.

  Rejected alternative:

  - Did not add Gateway to the default `all` stack because the Gateway default application config uses port `8888`, which conflicts with the Backend service. Keeping Gateway opt-in preserves
  current local stack behavior.

  ## Validation

  Ran shell syntax validation:

  ```bash
  bash -n scripts/singlebox.sh scripts/modules/gateway.sh src/gateway/scripts/app.sh

  Ran singlebox Gateway status check with an overridden port:

  OCB_SKIP_GIT_HOOKS=1 ./scripts/singlebox.sh --gateway-port 8899 status gateway

  Result:

  Gateway: Stopped (port: 8899)

  Ran focused Gateway config unit tests:

  UV_CACHE_DIR="$PWD/scripts/.dependencies/uv-cache" uv run --project src/gateway pytest src/gateway/tests/unit/plugins/test_config.py -q

  Result:

  45 passed

  Pre-push hook also passed in lint-only mode during push. Gateway heavier CI / coverage was not run locally because the default pre-push mode is lint-only unless OCB_PRE_PUSH_RUN_CI=1 is
  set.

  ## Compatibility and risk

  This is an additive local development workflow change.

  Compatibility impact:

  - Existing singlebox.sh all behavior is unchanged.
  - Gateway is opt-in via ./scripts/singlebox.sh start gateway.
  - Gateway singlebox defaults to port 8889 to avoid conflict with Backend on 8888.
  - Existing Gateway config files continue to work; GATEWAY_PORT only overrides the web port when explicitly provided by the environment or singlebox.

  Rollback path:

  - Remove scripts/modules/gateway.sh.
  - Remove gateway wiring and --gateway-port handling from scripts/singlebox.sh.
  - Revert the GATEWAY_PORT override in Gateway config loading and app lifecycle script.
