### PR TITLE
feat(backend): flatten stdio MCP launch instruction onto artifact server entries

### DIFF
--- a/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
+++ b/src/backend/src/agentclaw/community/configs/local-mcp-servers.yaml
@@ -27,6 +27,7 @@
 # this matter is not in this repo.
 servers:
   hitl:
+    name: "HITL"
     stdioConfigs:
       - command: "python3"
         arguments:

--- a/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/mcporter_composer.py
@@ -19,11 +19,11 @@ produces (see ``plugins/prod/mcp_device_payload.convert_to_device_format``):
    engine can reconstruct its own mcporter.json.
 
 Scope: both MCP forms. A REMOTE (URL-based) server gets an endpoint selected and
-its credential inlined; a LOCAL/stdio server is emitted as a ``stdio`` entry
-carrying its launch instruction. Which form an entry takes is **not decided
-here** — the collector resolves it into ``McpComposeInput.stdio``, so this stays
-a pure function of its inputs (and cannot be fooled by a failed MCP Center
-enrichment; see that field's docstring).
+its credential inlined; a LOCAL/stdio server is emitted with its launch
+instruction flattened onto the entry (``command``/``args``/``env``). Which form
+an entry takes is **not decided here** — the collector resolves it into
+``McpComposeInput.stdio``, so this stays a pure function of its inputs (and
+cannot be fooled by a failed MCP Center enrichment; see that field's docstring).
 
 The inlining rule is replicated from ``convert_to_device_format`` (a plugins-layer
 function this core module must not import); a parity test
@@ -35,7 +35,7 @@ import json
 from typing import Any, Iterable
 
 from agentclaw.community.core.config_compose.models import McpComposeInput, StdioLaunch
-from agentclaw.community.kernel.bot_config import McpManifest, McpServerRef, StdioSpec
+from agentclaw.community.kernel.bot_config import McpManifest, McpServerRef
 
 
 __all__ = [
@@ -121,11 +121,9 @@ class McporterComposer:
             server_code=server_code,
             name=name,
             transport=STDIO_TRANSPORT,
-            stdio=StdioSpec(
-                command=launch.command,
-                args=list(launch.args),
-                env=dict(launch.env),
-            ),
+            command=launch.command,
+            args=list(launch.args),
+            env=dict(launch.env),
         )
 
     def _compose_remote(

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -60,7 +60,7 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
         # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
         # last to match the other engines' lists.
-        {"server_code": "hitl"},
+        {"server_code": "hitl", "name": "HITL"},
     ],
     "claude_code": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp", "name": "任务中心MCP", "description": "任务中心待办任务，已办任务等相关任务查询MCP"},

--- a/src/backend/src/agentclaw/community/kernel/bot_config/__init__.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/__init__.py
@@ -19,7 +19,6 @@ from .artifact import (  # noqa: F401  (relative intra-kernel import — no cros
     McpServerRef,
     ResourceRef,
     SkillRef,
-    StdioSpec,
     StoreRef,
 )
 
@@ -32,6 +31,5 @@ __all__ = [
     "McpServerRef",
     "ResourceRef",
     "SkillRef",
-    "StdioSpec",
     "StoreRef",
 ]

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
@@ -27,8 +27,9 @@ Module rules (kernel is the lowest layer):
   compose time and the engine consumes it directly, with no secret broker.
 * An MCP server entry comes in two mutually exclusive forms, discriminated by
   ``transport``: a **remote** one (``http`` / ``sse``) carrying ``endpoint`` +
-  ``headers``, and a **local** one (``stdio``) carrying a ``stdio`` launch
-  instruction. See :class:`McpServerRef`.
+  ``headers``, and a **local** one (``stdio``) carrying its launch instruction
+  flattened onto the entry (``command`` / ``args`` / ``env``). See
+  :class:`McpServerRef`.
 """
 from __future__ import annotations
 
@@ -40,7 +41,10 @@ from typing import Any
 # engine could observe. Distinct from the per-bot content ``version`` below.
 # v4: MCP credentials are inlined into the server entry; the ``auth_ref``
 # secret-by-reference field was removed (no container-side secret broker).
-SCHEMA_VERSION = 4
+# v5: the local (stdio) MCP launch instruction is flattened onto the server
+# entry — top-level ``command``/``args``/``env`` replace the nested ``stdio``
+# object, matching the flat shape MCP clients themselves consume.
+SCHEMA_VERSION = 5
 
 
 @dataclass(frozen=True)
@@ -102,34 +106,22 @@ class FileRef:
 
 
 @dataclass(frozen=True)
-class StdioSpec:
-    """How to launch a local (stdio) MCP server.
-
-    Present only on entries whose ``transport`` is ``"stdio"``. Unlike a remote
-    entry — which is pure data (a URL plus headers) — this is an **instruction to
-    execute**, so it is only meaningful in an engine whose image actually carries
-    ``command`` at that path. Placement/lifecycle of the child process is the
-    engine owner's decision; the backend only names what to run.
-
-    Carries no credentials: a stdio server is a child of the engine process on the
-    same host, so there is no endpoint to authenticate against.
-    """
-
-    command: str
-    args: list[str] = field(default_factory=list)
-    env: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
 class McpServerRef:
     """One MCP server entry, in one of two mutually exclusive forms.
 
     ``transport`` is the discriminator:
 
-    * ``"stdio"`` — a local server. Read :attr:`stdio` for the launch
-      instruction; ``endpoint`` / ``headers`` are unset.
+    * ``"stdio"`` — a local server. Read ``command`` / ``args`` / ``env`` for
+      the launch instruction; ``endpoint`` / ``headers`` are unset. Unlike a
+      remote entry — which is pure data (a URL plus headers) — the launch
+      instruction is an **instruction to execute**, so it is only meaningful in
+      an engine whose image actually carries ``command`` at that path.
+      Placement/lifecycle of the child process is the engine owner's decision;
+      the backend only names what to run. It carries no credentials: a stdio
+      server is a child of the engine process on the same host, so there is no
+      endpoint to authenticate against.
     * ``"http"`` / ``"sse"`` — a remote server. Read ``endpoint`` and
-      ``headers``; ``stdio`` is ``None``.
+      ``headers``; ``command`` is ``None``.
 
     For the remote form, resolved credentials are **inlined**: an
     ``authorization`` key rides in the ``endpoint`` query string and any secret
@@ -147,9 +139,12 @@ class McpServerRef:
     endpoint: str | None = None  # remote form
     transport: str | None = None  # discriminator, see above
     headers: dict[str, str] = field(default_factory=dict)  # remote form
-    # Local form. ``None`` is a meaningful contract state, not an "unset"
+    # Local form, flattened onto the entry (the shape MCP clients consume).
+    # ``command`` being ``None`` is a meaningful contract state, not an "unset"
     # placeholder: a remote server genuinely has no launch instruction.
-    stdio: StdioSpec | None = None
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -160,17 +155,19 @@ class McpManifest:
 
 
 def _mcp_server_from_dict(data: dict[str, Any]) -> McpServerRef:
-    """Rebuild one server entry, re-nesting ``stdio`` into its dataclass.
+    """Rebuild one server entry from its published dict.
 
-    A remote entry (no ``stdio`` key, or an explicit ``null``) yields
-    ``stdio=None`` — so artifacts published before the local form existed
-    deserialize unchanged.
+    A remote entry omits ``command``/``args``/``env`` entirely, so the dataclass
+    defaults apply — and artifacts published before the local form existed
+    deserialize unchanged. A pre-v5 local entry (nested ``{"stdio": {...}}``,
+    as pinned by schema_version 4 snapshots) is re-flattened on read so stored
+    artifacts stay loadable across the contract bump.
     """
-    stdio = data.get("stdio")
-    return McpServerRef(
-        **{k: v for k, v in data.items() if k != "stdio"},
-        stdio=StdioSpec(**stdio) if stdio else None,
-    )
+    legacy_stdio = data.get("stdio")
+    fields = {k: v for k, v in data.items() if k != "stdio"}
+    if legacy_stdio:
+        fields.update(legacy_stdio)
+    return McpServerRef(**fields)
 
 
 @dataclass(frozen=True)
@@ -196,18 +193,19 @@ class BotConfigArtifact:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the published JSON shape (matches ``artifact.schema.json``).
 
-        A remote MCP entry omits ``stdio`` entirely rather than emitting it as
-        ``null``. ``asdict`` would include the key on every entry, which changes
-        the wire shape of artifacts that contain no local server at all — and a
-        consumer validating them against the pre-``stdio`` definition (which is
-        ``additionalProperties: false``) would reject them. Omitting it keeps
-        those bytes exactly what they were, so only artifacts that genuinely
-        carry the new form differ.
+        A remote MCP entry omits ``command``/``args``/``env`` entirely rather
+        than emitting them as ``null``/empty. ``asdict`` would include the keys
+        on every entry, which changes the wire shape of artifacts that contain
+        no local server at all — and a consumer validating them against the
+        pre-local-form definition (which is ``additionalProperties: false``)
+        would reject them. Omitting them keeps those bytes exactly what they
+        were, so only artifacts that genuinely carry the local form differ.
         """
         data = asdict(self)
         for server in data.get("mcp", {}).get("servers", []):
-            if server.get("stdio") is None:
-                server.pop("stdio", None)
+            if server.get("command") is None:
+                for key in ("command", "args", "env"):
+                    server.pop(key, None)
         return data
 
     @classmethod
@@ -279,16 +277,15 @@ EXAMPLE_ARTIFACT = BotConfigArtifact(
                 headers={"x-ling-auth": "<resolved-token>"},
             ),
             # local form — the engine spawns it as a child process and speaks
-            # JSON-RPC over its stdin/stdout. No endpoint, and no credential:
-            # it runs inside the engine's own container as the same user.
+            # JSON-RPC over its stdin/stdout. The launch instruction rides flat
+            # on the entry. No endpoint, and no credential: it runs inside the
+            # engine's own container as the same user.
             McpServerRef(
                 server_code="hitl",
-                name="hitl",
+                name="HITL",
                 transport="stdio",
-                stdio=StdioSpec(
-                    command="python3",
-                    args=["/home/admin/hitl/hitl_mcp_server.py"],
-                ),
+                command="python3",
+                args=["/home/admin/hitl/hitl_mcp_server.py"],
             ),
         ],
     ),

--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.schema.json
@@ -110,7 +110,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["server_code"],
-      "description": "One MCP server, in one of two mutually exclusive forms discriminated by 'transport'. The 'oneOf' below is the authority: a local entry ('stdio') must carry the 'stdio' launch object and no endpoint/headers; a remote entry ('http'/'sse') must carry no 'stdio'. Validating against this schema is enough to reject a half-formed entry — no engine-side launch attempt required.",
+      "description": "One MCP server, in one of two mutually exclusive forms discriminated by 'transport'. The 'oneOf' below is the authority: a local entry ('stdio') must carry a launch instruction — top-level 'command'/'args'/'env' — and no endpoint/headers; a remote entry ('http'/'sse') must carry no launch instruction. Validating against this schema is enough to reject a half-formed entry — no engine-side launch attempt required.",
       "properties": {
         "server_code": { "type": "string" },
         "name": { "type": ["string", "null"] },
@@ -121,19 +121,18 @@
           "description": "Remote form. May carry inlined secret headers (e.g. x-ling-auth).",
           "additionalProperties": { "type": "string" }
         },
-        "stdio": {
-          "oneOf": [{ "$ref": "#/definitions/stdioSpec" }, { "type": "null" }],
-          "description": "Local form (transport == 'stdio'). Null/absent for a remote server."
-        }
+        "command": { "type": ["string", "null"], "description": "Local form (transport == 'stdio'): the executable the engine spawns as a child process, speaking JSON-RPC over its stdin/stdout, e.g. 'python3'. Carries no credentials — the child runs inside the engine's own container. Null/absent for a remote server." },
+        "args": { "type": "array", "items": { "type": "string" }, "description": "Local form. Arguments for 'command'. Empty/absent for a remote server." },
+        "env": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Local form. Environment variables for the child process. Empty/absent for a remote server." }
       },
       "oneOf": [
         {
           "title": "local (stdio)",
           "description": "transport 'stdio' ⇒ a launch instruction, and none of the remote fields.",
-          "required": ["transport", "stdio"],
+          "required": ["transport", "command"],
           "properties": {
             "transport": { "const": "stdio" },
-            "stdio": { "$ref": "#/definitions/stdioSpec" },
+            "command": { "type": "string", "minLength": 1 },
             "endpoint": { "type": "null" },
             "headers": { "type": "object", "maxProperties": 0 }
           }
@@ -145,21 +144,12 @@
           "properties": {
             "transport": { "enum": ["http", "sse"] },
             "endpoint": { "type": "string", "minLength": 1 },
-            "stdio": { "type": "null" }
+            "command": { "type": "null" },
+            "args": { "type": "array", "maxItems": 0 },
+            "env": { "type": "object", "maxProperties": 0 }
           }
         }
       ]
-    },
-    "stdioSpec": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["command"],
-      "description": "How to launch a local MCP server: the engine spawns 'command' as a child process and speaks JSON-RPC over its stdin/stdout. Carries no credentials — the child runs inside the engine's own container.",
-      "properties": {
-        "command": { "type": "string", "minLength": 1, "description": "Executable, e.g. 'python3'." },
-        "args": { "type": "array", "items": { "type": "string" } },
-        "env": { "type": "object", "additionalProperties": { "type": "string" } }
-      }
     }
   }
 }

--- a/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
+++ b/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
@@ -207,14 +207,13 @@ def test_composed_stdio_mcp_carries_launch_and_no_credential() -> None:
 
     local = by_code["hitl"]
     assert local.transport == STDIO_TRANSPORT
-    assert local.stdio is not None
-    assert local.stdio.command == "python3"
-    assert local.stdio.args == ["/home/admin/hitl/hitl_mcp_server.py"]
+    assert local.command == "python3"
+    assert local.args == ["/home/admin/hitl/hitl_mcp_server.py"]
     assert local.endpoint is None and local.headers == {}
 
     # The remote entry is unaffected: it still inlines its secret.
     remote = by_code["github"]
-    assert remote.stdio is None
+    assert remote.command is None
     assert _SECRET in json.dumps(asdict(remote), ensure_ascii=False)
 
 

--- a/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
+++ b/src/backend/tests/community/core/config_compose/test_mcporter_composer.py
@@ -14,7 +14,6 @@ from agentclaw.community.core.config_compose.services.mcporter_composer import (
     McporterComposer,
     mcp_network_priority_for,
 )
-from agentclaw.community.kernel.bot_config import StdioSpec
 
 
 SECRET_TOKEN = "supersecrettoken-inlined-123"
@@ -176,7 +175,7 @@ def test_local_without_resolved_launch_raises_naming_the_registry() -> None:
 
 
 def test_compose_emits_local_stdio_servers() -> None:
-    """LOCAL servers ride the artifact as ``stdio`` entries, no longer dropped."""
+    """LOCAL servers ride the artifact with a flat launch instruction."""
     composer = McporterComposer()
     manifest = composer.compose(
         [
@@ -196,11 +195,10 @@ def test_compose_emits_local_stdio_servers() -> None:
 
     local = manifest.servers[1]
     assert local.transport == STDIO_TRANSPORT
-    assert local.stdio == StdioSpec(
-        command="python3",
-        args=["/home/admin/hitl/hitl_mcp_server.py"],
-        env={"MCP_TRANSPORT": "stdio"},
-    )
+    # The launch instruction rides flat on the entry, not nested under "stdio".
+    assert local.command == "python3"
+    assert local.args == ["/home/admin/hitl/hitl_mcp_server.py"]
+    assert local.env == {"MCP_TRANSPORT": "stdio"}
     # The local form carries no remote fields — a stdio child needs no endpoint
     # and has nothing to authenticate against.
     assert local.endpoint is None

--- a/src/backend/tests/community/kernel/test_bot_config_artifact.py
+++ b/src/backend/tests/community/kernel/test_bot_config_artifact.py
@@ -20,7 +20,6 @@ from agentclaw.community.kernel.bot_config import (
     McpServerRef,
     ResourceRef,
     SkillRef,
-    StdioSpec,
     StoreRef,
 )
 
@@ -35,23 +34,22 @@ _SCHEMA_PATH = (
 )
 
 
-def test_remote_entry_omits_the_stdio_key_entirely() -> None:
-    """An artifact with no local server keeps its pre-``stdio`` wire shape.
+def test_remote_entry_omits_the_launch_keys_entirely() -> None:
+    """An artifact with no local server keeps its pre-local-form wire shape.
 
-    ``asdict`` would emit ``"stdio": null`` on every remote entry, changing the
-    bytes of artifacts that never use the new form — and a consumer validating
-    those against the pre-``stdio`` definition (``additionalProperties: false``)
-    would reject them. Only artifacts that genuinely carry a local server may
-    differ.
+    ``asdict`` would emit ``"command": null`` / empty ``args``/``env`` on every
+    remote entry, changing the bytes of artifacts that never use the local form
+    — and a consumer validating those against the pre-local-form definition
+    (``additionalProperties: false``) would reject them. Only artifacts that
+    genuinely carry a local server may differ.
     """
     artifact = _sample_artifact()
     entry = artifact.to_dict()["mcp"]["servers"][0]
 
-    assert "stdio" not in entry
     assert set(entry) == {"server_code", "name", "endpoint", "transport", "headers"}
 
 
-def test_local_entry_keeps_its_stdio_key() -> None:
+def test_local_entry_carries_its_launch_instruction_flat() -> None:
     artifact = BotConfigArtifact(
         schema_version=SCHEMA_VERSION,
         engine_type="teclaw",
@@ -59,15 +57,52 @@ def test_local_entry_keeps_its_stdio_key() -> None:
             servers=[
                 McpServerRef(
                     server_code="hitl",
+                    name="HITL",
                     transport="stdio",
-                    stdio=StdioSpec(command="python3", args=["/a.py"]),
+                    command="python3",
+                    args=["/a.py"],
                 )
             ]
         ),
     )
     entry = artifact.to_dict()["mcp"]["servers"][0]
 
-    assert entry["stdio"] == {"command": "python3", "args": ["/a.py"], "env": {}}
+    # The launch instruction is flat on the entry — no nested "stdio" object.
+    assert "stdio" not in entry
+    assert entry == {
+        "server_code": "hitl",
+        "name": "HITL",
+        "endpoint": None,
+        "transport": "stdio",
+        "headers": {},
+        "command": "python3",
+        "args": ["/a.py"],
+        "env": {},
+    }
+
+
+def test_from_dict_reflattens_a_pre_v5_nested_stdio_entry() -> None:
+    """A pinned schema_version-4 artifact (nested ``{"stdio": {...}}``) still
+    loads — its launch instruction lands on the flat fields."""
+    restored = BotConfigArtifact.from_dict(
+        {
+            "schema_version": 4,
+            "engine_type": "teclaw",
+            "mcp": {
+                "servers": [
+                    {
+                        "server_code": "hitl",
+                        "transport": "stdio",
+                        "stdio": {"command": "python3", "args": ["/a.py"], "env": {}},
+                    }
+                ]
+            },
+        }
+    )
+    server = restored.mcp.servers[0]
+    assert server.command == "python3"
+    assert server.args == ["/a.py"]
+    assert server.env == {}
 
 
 def _sample_artifact() -> BotConfigArtifact:


### PR DESCRIPTION
## Problem

The bot-config artifact's local (stdio) MCP entry nests its launch instruction under a `stdio` object:

```json
{
  "server_code": "hitl",
  "name": "hitl",
  "endpoint": null,
  "transport": "stdio",
  "headers": {},
  "stdio": {
    "command": "python3",
    "args": ["/usr/local/bin/teclaw_hitl_mcp_server.py"],
    "env": {}
  }
}
```

Engines consume the flat MCP client shape (`command`/`args`/`env` on the entry itself — the shape the teclaw artifact consumer, the claude_code gateway's MCP config, and the engine adapters all speak), so the nested object forces every consumer to re-flatten. The entry should read:

```json
{
  "server_code": "hitl",
  "name": "HITL",
  "endpoint": null,
  "transport": "stdio",
  "headers": {},
  "command": "python3",
  "args": ["/usr/local/bin/teclaw_hitl_mcp_server.py"],
  "env": {}
}
```

## Solution

- `McpServerRef` (kernel `bot_config/artifact.py`) now carries `command: str | None`, `args`, `env` directly; the `StdioSpec` dataclass is removed. `command is None` remains the meaningful "remote form" contract state, mirroring the old `stdio: None`.
- `SCHEMA_VERSION` bumps 4 → 5, and `artifact.schema.json` is updated in lockstep: the `mcpServerRef` `oneOf` now requires top-level `command` for the local form and forbids a launch instruction (`command` null, `args`/`env` empty) on the remote form; the `stdioSpec` definition is gone.
- `to_dict` omits `command`/`args`/`env` entirely on remote entries — remote-only artifacts keep byte-identical wire shape, exactly as the nested `stdio` key was omitted before.
- `from_dict` re-flattens a pre-v5 nested `{"stdio": {...}}` entry on read, so pinned schema_version-4 snapshots stay loadable.
- `McporterComposer._compose_stdio` emits the flat fields; the collector/`StdioLaunch` plumbing upstream is unchanged.
- The `hitl` server gets its display name `HITL` in `local-mcp-servers.yaml` (the fallback metadata the MCP Center plugins serve for LOCAL servers, which the compose path merges over the association) and in the teclaw default MCP list (the name stored when the default is added and enrichment cannot supply one).

Alternative rejected: keeping `StdioSpec` internally and flattening only at (de)serialization — the kernel contract states "field names ARE the external API", so the dataclass tracks the wire shape.

## Validation

- `pytest tests/community/kernel tests/community/contracts tests/community/core/config_compose tests/community/core/mcp tests/community/endpoints/test_service_bot_publish_flow.py` — 516 passed.
- Full backend suite `pytest tests` — 11851 passed, 31 skipped, 2 failed: `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]` fail because the sandbox lacks the `rsync` binary (`exec: rsync: not found`) — environmental, unrelated to this diff.
- `scripts/ci/python_sast_local.sh src/backend 1 --base HEAD~1` — clean (exit 0).

## Compatibility and risk

Published-contract change, versioned via `SCHEMA_VERSION` 5. External engine consumers of the artifact must read the flat `command`/`args`/`env` instead of the nested `stdio` object (remote entries are byte-identical to v4). Backend reads of pinned v4 artifacts keep working via the `from_dict` re-flatten. Rollback is a revert; no data migration is involved — pinned artifacts are re-composed on the next publish.


---
_Generated by [Claude Code](https://claude.ai/code/session_019sSzYR6CNANS2XuZifiMC2)_