### PR TITLE
refactor(backend): type conn_info as ConnInfo dict subclass

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/services/README.md
@@ -51,7 +51,7 @@ ctx = resolver.resolve_for_bot(bot_id: str, user_id: str) -> DeviceContext
 | 字段          | 含义                                       |
 | ------------- | ------------------------------------------ |
 | `provider`    | `arca` / `baas` / `teclaw` / `local`       |
-| `conn_info`   | 拨号字段（`ConnInfo` typed 只读 Mapping，命名经 resolver schema 归一；字段清单/类型/示例见 `device_context.ConnInfo`，dict 式读取继续兼容）|
+| `conn_info`   | Dial-out fields (`ConnInfo`, a typed read-only Mapping, naming normalized by the resolver schema; see `device_context.ConnInfo` for the field list, types, and examples — dict-style reads stay compatible) |
 | `binding_id`  | `ac_entity_device_binding.id`              |
 | `bot_id`      | caller 透传                                |
 | `user_id`     | caller 透传（用于 device_affinity / 审计）|

--- a/src/backend/src/agentclaw/community/core/devices/services/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/services/README.md
@@ -51,7 +51,7 @@ ctx = resolver.resolve_for_bot(bot_id: str, user_id: str) -> DeviceContext
 | 字段          | 含义                                       |
 | ------------- | ------------------------------------------ |
 | `provider`    | `arca` / `baas` / `teclaw` / `local`       |
-| `conn_info`   | Dial-out fields (`ConnInfo`, a typed read-only Mapping, naming normalized by the resolver schema; see `device_context.ConnInfo` for the field list, types, and examples — dict-style reads stay compatible) |
+| `conn_info`   | Dial-out fields (`ConnInfo`, a typed Mapping view, naming normalized by the resolver schema; see `device_context.ConnInfo` for the field list, types, and examples — dict-style access stays compatible) |
 | `binding_id`  | `ac_entity_device_binding.id`              |
 | `bot_id`      | caller 透传                                |
 | `user_id`     | caller 透传（用于 device_affinity / 审计）|

--- a/src/backend/src/agentclaw/community/core/devices/services/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/services/README.md
@@ -51,7 +51,7 @@ ctx = resolver.resolve_for_bot(bot_id: str, user_id: str) -> DeviceContext
 | 字段          | 含义                                       |
 | ------------- | ------------------------------------------ |
 | `provider`    | `arca` / `baas` / `teclaw` / `local`       |
-| `conn_info`   | 拨号字段 dict（命名经 resolver schema 归一）|
+| `conn_info`   | 拨号字段（`ConnInfo` typed 只读 Mapping，命名经 resolver schema 归一；字段清单/类型/示例见 `device_context.ConnInfo`，dict 式读取继续兼容）|
 | `binding_id`  | `ac_entity_device_binding.id`              |
 | `bot_id`      | caller 透传                                |
 | `user_id`     | caller 透传（用于 device_affinity / 审计）|

--- a/src/backend/src/agentclaw/community/core/devices/services/README.md
+++ b/src/backend/src/agentclaw/community/core/devices/services/README.md
@@ -51,7 +51,7 @@ ctx = resolver.resolve_for_bot(bot_id: str, user_id: str) -> DeviceContext
 | 字段          | 含义                                       |
 | ------------- | ------------------------------------------ |
 | `provider`    | `arca` / `baas` / `teclaw` / `local`       |
-| `conn_info`   | Dial-out fields (`ConnInfo`, a typed Mapping view, naming normalized by the resolver schema; see `device_context.ConnInfo` for the field list, types, and examples — dict-style access stays compatible) |
+| `conn_info`   | Dial-out fields (`ConnInfo`, a `dict` subclass with typed properties, naming normalized by the resolver schema; see `device_context.ConnInfo` for the field list, types, and examples — all dict behavior is inherited) |
 | `binding_id`  | `ac_entity_device_binding.id`              |
 | `bot_id`      | caller 透传                                |
 | `user_id`     | caller 透传（用于 device_affinity / 审计）|

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context.py
@@ -38,9 +38,11 @@ class ConnInfo(dict):
     ``tests/community/contract/test_conn_info_schema.py``):
     ``url`` / ``token`` / ``headers`` / ``use_proxy`` / ``sandbox_id`` /
     ``target`` / ``engine_type``. The one exception is the binding-routed
-    path of ``DeviceContextResolver.resolve_for_binding_invoke``, where the
-    transport fetches address/token per binding at call time, so no
-    transport fields are pre-filled.
+    path of ``DeviceContextResolver.resolve_for_binding_invoke``: it
+    pre-fills only routing fields (``engine_type`` / ``engine_port`` /
+    ``type`` / ``headers={}`` / ``device_affinity``) and no address or
+    credential fields (``url`` / ``token`` / ``target`` / ``sandbox_id`` /
+    ``use_proxy``) — the transport fetches those per binding at call time.
     """
 
     __slots__ = ()
@@ -61,8 +63,8 @@ class ConnInfo(dict):
         example (baas invoke-http):
         ``"https://<baas-host>/api/v1/bots/<tenant>/<bot_uuid>/invoke-http/20003"``;
         example (local direct): ``"http://127.0.0.1:20003"``.
-        Default ``""`` — the binding-routed path pre-fills nothing; the
-        transport fetches the address per binding.
+        Default ``""`` — the binding-routed path carries no address fields;
+        the transport fetches the address per binding.
         """
         return self.get("url", "")
 
@@ -76,6 +78,9 @@ class ConnInfo(dict):
         """HTTP headers the request must carry.
 
         Example: ``{"x-proxypass-token": "tok"}``; ``{}`` for local direct.
+        When the key is absent the default is a fresh throwaway dict — do
+        not add headers by mutating the returned value; write
+        ``conn_info["headers"] = {...}`` instead.
         """
         return self.get("headers", {})
 
@@ -135,11 +140,16 @@ class ConnInfo(dict):
     def binding_id(self) -> int | None:
         """``ac_entity_device_binding.id``. Example: ``201``.
 
-        ``None`` means this path didn't carry it (e.g. the legacy arca
-        path) — the transport's ``invoke`` branches on its presence to pick
-        baas /http-info vs the fallback.
+        Falls back to the legacy ``bind_id`` key when ``binding_id`` is
+        absent, so the typed property also works on conn_info that never
+        went through the resolver's ``_normalize_schema`` alias step (e.g.
+        the filesystem dispatcher's legacy path wraps builder-raw dicts).
+        ``None`` means neither key is present (e.g. the legacy arca path) —
+        the transport's ``invoke`` branches on its presence to pick baas
+        /http-info vs the fallback.
         """
-        return self.get("binding_id")
+        binding_id = self.get("binding_id")
+        return binding_id if binding_id is not None else self.get("bind_id")
 
     @property
     def bind_id(self) -> int | None:

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context.py
@@ -6,25 +6,29 @@ dispatchers pick a plugin instance by ``provider``; plugins dial with
 """
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
 ProviderType = Literal["arca", "baas", "teclaw", "local"]
 
 
-class ConnInfo(MutableMapping[str, Any]):
+class ConnInfo(dict):
     """Dial-out info — typed view over the provider-built conn_info.
 
     Historically conn_info was a bare ``dict[str, Any]``; the only way to
     learn its fields was reading the builder sources. This class declares
-    every known field as a typed property with an example, while also
-    implementing the ``MutableMapping`` protocol so existing dict-style
-    access keeps working unchanged — reads (``conn_info["url"]`` /
-    ``conn_info.get("tenant")``), legacy in-place writes (e.g. expert_chat
-    overwrites ``conn["engine_type"]`` per session), the key set, and ``==``
-    semantics all match the underlying dict, and unknown builder-produced
-    keys pass through (dict-style access only).
+    every known field as a typed property with an example, on top of a
+    plain ``dict``. It IS a dict, so every legacy behavior is inherited
+    unchanged: reads (``conn_info["url"]`` / ``.get("tenant")``), in-place
+    writes (e.g. expert_chat overwrites ``conn["engine_type"]`` per
+    session), ``==``, ``json.dumps``, and pydantic/FastAPI response
+    serialization (conn_info is embedded in HTTP responses, e.g. the
+    expert-chat session endpoint's ``connection`` field). Unknown
+    builder-produced keys pass through (dict-style access only).
+
+    Construct it like a dict: ``ConnInfo(mapping)`` shallow-copies the
+    mapping, ``ConnInfo(url=...)`` takes keyword fields, and both combine
+    (keywords win on clashes).
 
     Each provider writes only the field subset it needs (see
     ``conn_info_builders/``); a property whose field is absent returns the
@@ -39,44 +43,12 @@ class ConnInfo(MutableMapping[str, Any]):
     transport fields are pre-filled.
     """
 
-    __slots__ = ("_data",)
-
-    def __init__(self, data: Mapping[str, Any] | None = None, /, **fields: Any) -> None:
-        """Build from a mapping and/or keyword fields (keywords win on clashes).
-
-        The input is shallow-copied; mutating the source dict afterwards
-        does not affect this object.
-        """
-        merged: dict[str, Any] = dict(data) if data is not None else {}
-        merged.update(fields)
-        self._data = merged
-
-    # ── MutableMapping protocol (keeps legacy dict-style access working;
-    #    get/keys/items/__contains__/__eq__/pop/update/setdefault come from
-    #    collections.abc) ────────────────────────────────────────────────
-
-    def __getitem__(self, key: str) -> Any:
-        return self._data[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self._data[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self._data[key]
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._data)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __repr__(self) -> str:
-        return f"ConnInfo({self._data!r})"
+    __slots__ = ()
 
     def to_dict(self) -> dict[str, Any]:
-        """Export a plain dict copy (when a real dict is required, e.g. JSON
-        serialization)."""
-        return dict(self._data)
+        """Export a plain dict copy (for callers that want to detach from
+        this view)."""
+        return dict(self)
 
     # ── Seven-field schema contract (all providers) ────────────────────
 
@@ -92,12 +64,12 @@ class ConnInfo(MutableMapping[str, Any]):
         Default ``""`` — the binding-routed path pre-fills nothing; the
         transport fetches the address per binding.
         """
-        return self._data.get("url", "")
+        return self.get("url", "")
 
     @property
     def token(self) -> str:
         """Proxypass auth token. Example: ``"tok"``; ``""`` for local direct."""
-        return self._data.get("token", "")
+        return self.get("token", "")
 
     @property
     def headers(self) -> dict[str, str]:
@@ -105,7 +77,7 @@ class ConnInfo(MutableMapping[str, Any]):
 
         Example: ``{"x-proxypass-token": "tok"}``; ``{}`` for local direct.
         """
-        return self._data.get("headers", {})
+        return self.get("headers", {})
 
     @property
     def use_proxy(self) -> bool:
@@ -113,7 +85,7 @@ class ConnInfo(MutableMapping[str, Any]):
 
         Example: ``True`` for arca/baas, ``False`` for local.
         """
-        return self._data.get("use_proxy", False)
+        return self.get("use_proxy", False)
 
     @property
     def sandbox_id(self) -> str | None:
@@ -122,7 +94,7 @@ class ConnInfo(MutableMapping[str, Any]):
         Example: ``"ARCA_ARCA-SANDBOX-xxx@0:20003"``. ``None`` is the norm —
         neither local direct nor the baas invoke-http path lands on a sandbox.
         """
-        return self._data.get("sandbox_id")
+        return self.get("sandbox_id")
 
     @property
     def target(self) -> str:
@@ -131,7 +103,7 @@ class ConnInfo(MutableMapping[str, Any]):
         Example: ``"<baas-target>:20003"`` / ``"127.0.0.1:20003"``.
         Default ``""``.
         """
-        return self._data.get("target", "")
+        return self.get("target", "")
 
     @property
     def engine_type(self) -> str:
@@ -139,7 +111,7 @@ class ConnInfo(MutableMapping[str, Any]):
 
         Example: ``"openclaw"`` / ``"teclaw"``. Default ``""``.
         """
-        return self._data.get("engine_type", "")
+        return self.get("engine_type", "")
 
     # ── Extension fields (written as needed by baas / teclaw / v2 desktop) ──
 
@@ -150,14 +122,14 @@ class ConnInfo(MutableMapping[str, Any]):
         Example: ``"desktop"`` (bare ws direct) / ``"baas"`` (proxypass wss).
         Default ``""`` — the legacy arca/local paths don't write it.
         """
-        return self._data.get("type", "")
+        return self.get("type", "")
 
     @property
     def bot_type(self) -> str:
         """``ac_bots.bot_type``. Example: ``"desktop"`` / ``"personal"`` /
         ``"service"``. Default ``""`` (bot lookup failed).
         """
-        return self._data.get("bot_type", "")
+        return self.get("bot_type", "")
 
     @property
     def binding_id(self) -> int | None:
@@ -167,7 +139,7 @@ class ConnInfo(MutableMapping[str, Any]):
         path) — the transport's ``invoke`` branches on its presence to pick
         baas /http-info vs the fallback.
         """
-        return self._data.get("binding_id")
+        return self.get("binding_id")
 
     @property
     def bind_id(self) -> int | None:
@@ -178,7 +150,7 @@ class ConnInfo(MutableMapping[str, Any]):
         ``binding_id``; both keys coexist with the same value. New code
         should read :attr:`binding_id`.
         """
-        return self._data.get("bind_id")
+        return self.get("bind_id")
 
     @property
     def bot_uuid(self) -> str:
@@ -187,13 +159,13 @@ class ConnInfo(MutableMapping[str, Any]):
         Example: ``"device-201"``. Default ``""`` — only the baas/teclaw
         paths write it.
         """
-        return self._data.get("bot_uuid", "")
+        return self.get("bot_uuid", "")
 
     @property
     def tenant(self) -> str:
         """BaaS tenant. Example: ``"<tenant>"``. Default ``""`` — only the
         baas path writes it."""
-        return self._data.get("tenant", "")
+        return self.get("tenant", "")
 
     @property
     def baas_base_url(self) -> str:
@@ -202,7 +174,7 @@ class ConnInfo(MutableMapping[str, Any]):
         Default ``""`` — only the baas path writes it; the invoke-http URL
         is assembled from it.
         """
-        return self._data.get("baas_base_url", "")
+        return self.get("baas_base_url", "")
 
     @property
     def engine_port(self) -> int | None:
@@ -211,13 +183,13 @@ class ConnInfo(MutableMapping[str, Any]):
         ``None`` means this path didn't carry it (the legacy arca/local
         paths fold the port into ``url``).
         """
-        return self._data.get("engine_port")
+        return self.get("engine_port")
 
     @property
     def paas_device_id(self) -> str | None:
         """BaaS-side physical device ID. ``None`` means this path didn't
         carry it (non-baas)."""
-        return self._data.get("paas_device_id")
+        return self.get("paas_device_id")
 
     @property
     def device_affinity(self) -> str:
@@ -227,7 +199,7 @@ class ConnInfo(MutableMapping[str, Any]):
         Example: ``"user-1"``. Default ``""`` (legacy callsites didn't pass
         user_id).
         """
-        return self._data.get("device_affinity", "")
+        return self.get("device_affinity", "")
 
     @property
     def device_uuid(self) -> str | None:
@@ -237,7 +209,7 @@ class ConnInfo(MutableMapping[str, Any]):
         ``None`` is the norm — no pinning; BaaS auto-selects an active
         instance.
         """
-        return self._data.get("device_uuid")
+        return self.get("device_uuid")
 
     # ── v2 offline-branch fields ───────────────────────────────────────
 
@@ -245,13 +217,13 @@ class ConnInfo(MutableMapping[str, Any]):
     def available(self) -> bool:
         """Whether the device is online. Default ``True`` — only the v2
         offline branch explicitly writes ``False``."""
-        return self._data.get("available", True)
+        return self.get("available", True)
 
     @property
     def message(self) -> str:
         """Reason the device is unavailable (accompanies ``available=False``).
         Default ``""``."""
-        return self._data.get("message", "")
+        return self.get("message", "")
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context.py
@@ -6,23 +6,25 @@ dispatchers pick a plugin instance by ``provider``; plugins dial with
 """
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
 ProviderType = Literal["arca", "baas", "teclaw", "local"]
 
 
-class ConnInfo(Mapping[str, Any]):
-    """Dial-out info — typed read-only view over the provider-built conn_info.
+class ConnInfo(MutableMapping[str, Any]):
+    """Dial-out info — typed view over the provider-built conn_info.
 
     Historically conn_info was a bare ``dict[str, Any]``; the only way to
     learn its fields was reading the builder sources. This class declares
     every known field as a typed property with an example, while also
-    implementing the ``Mapping`` protocol so existing dict-style reads
-    (``conn_info["url"]`` / ``conn_info.get("tenant")``) keep working
-    unchanged — the key set and ``==`` semantics match the underlying dict,
-    and unknown builder-produced keys pass through (dict-style access only).
+    implementing the ``MutableMapping`` protocol so existing dict-style
+    access keeps working unchanged — reads (``conn_info["url"]`` /
+    ``conn_info.get("tenant")``), legacy in-place writes (e.g. expert_chat
+    overwrites ``conn["engine_type"]`` per session), the key set, and ``==``
+    semantics all match the underlying dict, and unknown builder-produced
+    keys pass through (dict-style access only).
 
     Each provider writes only the field subset it needs (see
     ``conn_info_builders/``); a property whose field is absent returns the
@@ -49,11 +51,18 @@ class ConnInfo(Mapping[str, Any]):
         merged.update(fields)
         self._data = merged
 
-    # ── Mapping protocol (keeps legacy dict-style reads working; get/keys/
-    #    items/__contains__/__eq__ come from collections.abc.Mapping) ─────
+    # ── MutableMapping protocol (keeps legacy dict-style access working;
+    #    get/keys/items/__contains__/__eq__/pop/update/setdefault come from
+    #    collections.abc) ────────────────────────────────────────────────
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._data[key]
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._data)

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context.py
@@ -1,14 +1,221 @@
 """DeviceContext — DeviceContextResolver 的 typed 出口。
 
 全仓唯一 provider 解析结果的数据契约。下游 dispatcher 用 ``provider``
-选 plugin 实例,plugin 用 ``conn_info`` dict 拨号。
+选 plugin 实例,plugin 用 ``conn_info``(:class:`ConnInfo`)拨号。
 """
 from __future__ import annotations
 
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
 ProviderType = Literal["arca", "baas", "teclaw", "local"]
+
+
+class ConnInfo(Mapping[str, Any]):
+    """拨号信息 — provider 构建的 conn_info 的 typed 只读视图。
+
+    历史上 conn_info 是裸 ``dict[str, Any]``,字段只能翻 builder 源码才知道。
+    本类把每个已知字段收敛成带类型 + 示例的 property,同时实现 ``Mapping``
+    协议,存量 ``conn_info["url"]`` / ``conn_info.get("tenant")`` 式读取原样
+    兼容 — key 集合、``==`` 语义都与底层 dict 一致,builder 产出的未知 key
+    也原样透传(仅 dict 式访问)。
+
+    各 provider 只写自己需要的字段子集(见 ``conn_info_builders/``);缺席
+    字段的 property 返回文档标注的缺省值,语义为"该链路不适用"。
+
+    七字段 schema 契约(全 provider 必写,见
+    ``tests/community/contract/test_conn_info_schema.py``):
+    ``url`` / ``token`` / ``headers`` / ``use_proxy`` / ``sandbox_id`` /
+    ``target`` / ``engine_type``。唯一例外是
+    ``DeviceContextResolver.resolve_for_binding_invoke`` 的 binding 路由链路,
+    地址/令牌由 transport 调用时按 binding 现取,不预置传输字段。
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: Mapping[str, Any] | None = None, /, **fields: Any) -> None:
+        """从 mapping 和/或 keyword 字段构造(keyword 覆盖同名 key)。
+
+        入参浅拷贝,构造后外部改源 dict 不影响本对象。
+        """
+        merged: dict[str, Any] = dict(data) if data is not None else {}
+        merged.update(fields)
+        self._data = merged
+
+    # ── Mapping 协议(兼容存量 dict 式读取;get/keys/items/__contains__/__eq__
+    #    由 collections.abc.Mapping 提供) ──────────────────────────────
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return f"ConnInfo({self._data!r})"
+
+    def to_dict(self) -> dict[str, Any]:
+        """导出 plain dict 副本(需要真 dict 的场景,如 JSON 序列化)。"""
+        return dict(self._data)
+
+    # ── 七字段 schema 契约(全 provider) ─────────────────────────────
+
+    @property
+    def url(self) -> str:
+        """engine adapter 的 HTTP(S) base URL,caller 拿它拼 path 直接请求。
+
+        例(arca proxy): ``"https://<arca-host>/proxypass/<target>:20003"``;
+        例(baas invoke-http):
+        ``"https://<baas-host>/api/v1/bots/<tenant>/<bot_uuid>/invoke-http/20003"``;
+        例(local 直连): ``"http://127.0.0.1:20003"``。
+        缺省 ``""`` — binding 路由链路不预置,transport 按 binding 现取。
+        """
+        return self._data.get("url", "")
+
+    @property
+    def token(self) -> str:
+        """proxypass 鉴权 token。例: ``"tok"``;local 直连为 ``""``。"""
+        return self._data.get("token", "")
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """请求需带的 HTTP header。
+
+        例: ``{"x-proxypass-token": "tok"}``;local 直连为 ``{}``。
+        """
+        return self._data.get("headers", {})
+
+    @property
+    def use_proxy(self) -> bool:
+        """是否经 proxypass 代理拨号。例: arca/baas ``True``,local ``False``。"""
+        return self._data.get("use_proxy", False)
+
+    @property
+    def sandbox_id(self) -> str | None:
+        """ARCA 沙箱标识。
+
+        例: ``"ARCA_ARCA-SANDBOX-xxx@0:20003"``。``None`` 为常态 —
+        local 直连和 baas invoke-http 链路都不落沙箱。
+        """
+        return self._data.get("sandbox_id")
+
+    @property
+    def target(self) -> str:
+        """拨号目标地址(host:port 或 sandbox target)。
+
+        例: ``"<baas-target>:20003"`` / ``"127.0.0.1:20003"``。缺省 ``""``。
+        """
+        return self._data.get("target", "")
+
+    @property
+    def engine_type(self) -> str:
+        """engine 类型,来自 ``ac_bots.active_engine``。
+
+        例: ``"openclaw"`` / ``"teclaw"``。缺省 ``""``。
+        """
+        return self._data.get("engine_type", "")
+
+    # ── 扩展字段(baas / teclaw / v2 desktop 链路按需写入) ────────────
+
+    @property
+    def type(self) -> str:
+        """connection type,前端 WS 路由分流键。
+
+        例: ``"desktop"``(裸 ws 直连)/ ``"baas"``(proxypass wss)。
+        缺省 ``""`` — arca/local 老链路不写。
+        """
+        return self._data.get("type", "")
+
+    @property
+    def bot_type(self) -> str:
+        """``ac_bots.bot_type``。例: ``"desktop"`` / ``"personal"`` /
+        ``"service"``。缺省 ``""``(bot 反查不到)。
+        """
+        return self._data.get("bot_type", "")
+
+    @property
+    def binding_id(self) -> int | None:
+        """``ac_entity_device_binding.id``。例: ``201``。
+
+        ``None`` 表示该链路没带(如 arca 老路径)—— transport
+        ``invoke`` 按有无该字段分流 baas /http-info vs fallback。
+        """
+        return self._data.get("binding_id")
+
+    @property
+    def bind_id(self) -> int | None:
+        """:attr:`binding_id` 的 legacy 别名(baas 链路历史命名)。例: ``201``。
+
+        resolver ``_normalize_schema`` 会把 ``bind_id`` alias 成
+        ``binding_id``,两个 key 同值并存;新代码读 :attr:`binding_id`。
+        """
+        return self._data.get("bind_id")
+
+    @property
+    def bot_uuid(self) -> str:
+        """BaaS 侧 bot 实例 UUID(= ``ac_entity_device_binding.device_id``)。
+
+        例: ``"device-201"``。缺省 ``""`` — 仅 baas/teclaw 链路写。
+        """
+        return self._data.get("bot_uuid", "")
+
+    @property
+    def tenant(self) -> str:
+        """BaaS 租户。例: ``"<tenant>"``。缺省 ``""`` — 仅 baas 链路写。"""
+        return self._data.get("tenant", "")
+
+    @property
+    def baas_base_url(self) -> str:
+        """BaaS 网关 base URL。例: ``"https://<baas-host>"``。
+
+        缺省 ``""`` — 仅 baas 链路写,invoke-http URL 由它拼出。
+        """
+        return self._data.get("baas_base_url", "")
+
+    @property
+    def engine_port(self) -> int | None:
+        """engine adapter 监听端口。例: ``20003``。
+
+        ``None`` 表示该链路没带(arca/local 老路径端口已并入 ``url``)。
+        """
+        return self._data.get("engine_port")
+
+    @property
+    def paas_device_id(self) -> str | None:
+        """BaaS 侧物理设备 ID。``None`` 表示该链路没带(非 baas)。"""
+        return self._data.get("paas_device_id")
+
+    @property
+    def device_affinity(self) -> str:
+        """设备亲和键(= 操作者 user_id),BaaS 多实例选径用。
+
+        例: ``"user-1"``。缺省 ``""``(旧 callsite 未传 user_id)。
+        """
+        return self._data.get("device_affinity", "")
+
+    @property
+    def device_uuid(self) -> str | None:
+        """多实例场景锁定的设备 UUID。例: ``"DEVICE-002"``。
+
+        ``None`` 为常态 — 不锁实例,由 BaaS 自动选活跃实例。
+        """
+        return self._data.get("device_uuid")
+
+    # ── v2 offline 分支字段 ─────────────────────────────────────────
+
+    @property
+    def available(self) -> bool:
+        """设备是否在线。缺省 ``True`` — 仅 v2 offline 分支显式写 ``False``。"""
+        return self._data.get("available", True)
+
+    @property
+    def message(self) -> str:
+        """设备不可用原因(随 ``available=False`` 出现)。缺省 ``""``。"""
+        return self._data.get("message", "")
 
 
 @dataclass(frozen=True)
@@ -18,11 +225,14 @@ class DeviceContext:
     分流 caller 和 plugin 之间的数据契约:
     - dispatcher 用 ``(provider, bot_type)`` 选 plugin 实例(本期新增 bot_type 维度,
       原因见 docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md)
-    - plugin 用 ``conn_info`` 拨号(各 provider 字段子集不同,本期保 dict)
+    - plugin 用 ``conn_info`` 拨号(各 provider 字段子集不同,typed 视图见
+      :class:`ConnInfo`)
 
     Fields:
         provider: 来自 ``ac_entity_device_binding.device_provider`` 的事实值
-        conn_info: 拨号字段(命名经 resolver 对齐)
+        conn_info: 拨号字段(命名经 resolver 对齐)。构造时传 plain dict 会被
+            ``__post_init__`` 自动包成 :class:`ConnInfo` — 字段清单/类型/示例
+            都看它;dict 式读取(``ctx.conn_info["url"]``)继续兼容
         binding_id: 来自 binding 表
         bot_id: caller 透传。两条入口都必填 — ``resolve_for_bot`` 入参自带,
             ``resolve_for_binding`` 由 caller 显式 kwarg 传(downstream
@@ -34,11 +244,17 @@ class DeviceContext:
             desktop 走自拼 URL,其他走 invoke_http)。数据未知时为 ``""``。
     """
     provider: ProviderType
-    conn_info: dict[str, Any]
+    conn_info: ConnInfo
     binding_id: int
     bot_id: str
     user_id: str
     bot_type: str = ""  # Task 1 默认 "" — Task 2 后 resolver 内部 bot_repo 注入真值
+
+    def __post_init__(self) -> None:
+        # 存量测试/caller 仍传 plain dict — 统一包成 ConnInfo,保证
+        # ``ctx.conn_info`` 的 typed 属性访问在任何构造路径下都可用。
+        if not isinstance(self.conn_info, ConnInfo):
+            object.__setattr__(self, "conn_info", ConnInfo(self.conn_info))
 
 
 class BotNotFoundError(RuntimeError):

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context.py
@@ -1,7 +1,8 @@
-"""DeviceContext — DeviceContextResolver 的 typed 出口。
+"""DeviceContext — the typed exit of DeviceContextResolver.
 
-全仓唯一 provider 解析结果的数据契约。下游 dispatcher 用 ``provider``
-选 plugin 实例,plugin 用 ``conn_info``(:class:`ConnInfo`)拨号。
+The repo-wide data contract for provider resolution results. Downstream
+dispatchers pick a plugin instance by ``provider``; plugins dial with
+``conn_info`` (:class:`ConnInfo`).
 """
 from __future__ import annotations
 
@@ -13,38 +14,43 @@ ProviderType = Literal["arca", "baas", "teclaw", "local"]
 
 
 class ConnInfo(Mapping[str, Any]):
-    """拨号信息 — provider 构建的 conn_info 的 typed 只读视图。
+    """Dial-out info — typed read-only view over the provider-built conn_info.
 
-    历史上 conn_info 是裸 ``dict[str, Any]``,字段只能翻 builder 源码才知道。
-    本类把每个已知字段收敛成带类型 + 示例的 property,同时实现 ``Mapping``
-    协议,存量 ``conn_info["url"]`` / ``conn_info.get("tenant")`` 式读取原样
-    兼容 — key 集合、``==`` 语义都与底层 dict 一致,builder 产出的未知 key
-    也原样透传(仅 dict 式访问)。
+    Historically conn_info was a bare ``dict[str, Any]``; the only way to
+    learn its fields was reading the builder sources. This class declares
+    every known field as a typed property with an example, while also
+    implementing the ``Mapping`` protocol so existing dict-style reads
+    (``conn_info["url"]`` / ``conn_info.get("tenant")``) keep working
+    unchanged — the key set and ``==`` semantics match the underlying dict,
+    and unknown builder-produced keys pass through (dict-style access only).
 
-    各 provider 只写自己需要的字段子集(见 ``conn_info_builders/``);缺席
-    字段的 property 返回文档标注的缺省值,语义为"该链路不适用"。
+    Each provider writes only the field subset it needs (see
+    ``conn_info_builders/``); a property whose field is absent returns the
+    documented default, meaning "not applicable on this path".
 
-    七字段 schema 契约(全 provider 必写,见
+    Seven-field schema contract (written by every provider, see
     ``tests/community/contract/test_conn_info_schema.py``):
     ``url`` / ``token`` / ``headers`` / ``use_proxy`` / ``sandbox_id`` /
-    ``target`` / ``engine_type``。唯一例外是
-    ``DeviceContextResolver.resolve_for_binding_invoke`` 的 binding 路由链路,
-    地址/令牌由 transport 调用时按 binding 现取,不预置传输字段。
+    ``target`` / ``engine_type``. The one exception is the binding-routed
+    path of ``DeviceContextResolver.resolve_for_binding_invoke``, where the
+    transport fetches address/token per binding at call time, so no
+    transport fields are pre-filled.
     """
 
     __slots__ = ("_data",)
 
     def __init__(self, data: Mapping[str, Any] | None = None, /, **fields: Any) -> None:
-        """从 mapping 和/或 keyword 字段构造(keyword 覆盖同名 key)。
+        """Build from a mapping and/or keyword fields (keywords win on clashes).
 
-        入参浅拷贝,构造后外部改源 dict 不影响本对象。
+        The input is shallow-copied; mutating the source dict afterwards
+        does not affect this object.
         """
         merged: dict[str, Any] = dict(data) if data is not None else {}
         merged.update(fields)
         self._data = merged
 
-    # ── Mapping 协议(兼容存量 dict 式读取;get/keys/items/__contains__/__eq__
-    #    由 collections.abc.Mapping 提供) ──────────────────────────────
+    # ── Mapping protocol (keeps legacy dict-style reads working; get/keys/
+    #    items/__contains__/__eq__ come from collections.abc.Mapping) ─────
 
     def __getitem__(self, key: str) -> Any:
         return self._data[key]
@@ -59,218 +65,251 @@ class ConnInfo(Mapping[str, Any]):
         return f"ConnInfo({self._data!r})"
 
     def to_dict(self) -> dict[str, Any]:
-        """导出 plain dict 副本(需要真 dict 的场景,如 JSON 序列化)。"""
+        """Export a plain dict copy (when a real dict is required, e.g. JSON
+        serialization)."""
         return dict(self._data)
 
-    # ── 七字段 schema 契约(全 provider) ─────────────────────────────
+    # ── Seven-field schema contract (all providers) ────────────────────
 
     @property
     def url(self) -> str:
-        """engine adapter 的 HTTP(S) base URL,caller 拿它拼 path 直接请求。
+        """HTTP(S) base URL of the engine adapter; callers append a path and
+        request it directly.
 
-        例(arca proxy): ``"https://<arca-host>/proxypass/<target>:20003"``;
-        例(baas invoke-http):
+        Example (arca proxy): ``"https://<arca-host>/proxypass/<target>:20003"``;
+        example (baas invoke-http):
         ``"https://<baas-host>/api/v1/bots/<tenant>/<bot_uuid>/invoke-http/20003"``;
-        例(local 直连): ``"http://127.0.0.1:20003"``。
-        缺省 ``""`` — binding 路由链路不预置,transport 按 binding 现取。
+        example (local direct): ``"http://127.0.0.1:20003"``.
+        Default ``""`` — the binding-routed path pre-fills nothing; the
+        transport fetches the address per binding.
         """
         return self._data.get("url", "")
 
     @property
     def token(self) -> str:
-        """proxypass 鉴权 token。例: ``"tok"``;local 直连为 ``""``。"""
+        """Proxypass auth token. Example: ``"tok"``; ``""`` for local direct."""
         return self._data.get("token", "")
 
     @property
     def headers(self) -> dict[str, str]:
-        """请求需带的 HTTP header。
+        """HTTP headers the request must carry.
 
-        例: ``{"x-proxypass-token": "tok"}``;local 直连为 ``{}``。
+        Example: ``{"x-proxypass-token": "tok"}``; ``{}`` for local direct.
         """
         return self._data.get("headers", {})
 
     @property
     def use_proxy(self) -> bool:
-        """是否经 proxypass 代理拨号。例: arca/baas ``True``,local ``False``。"""
+        """Whether to dial through the proxypass proxy.
+
+        Example: ``True`` for arca/baas, ``False`` for local.
+        """
         return self._data.get("use_proxy", False)
 
     @property
     def sandbox_id(self) -> str | None:
-        """ARCA 沙箱标识。
+        """ARCA sandbox identifier.
 
-        例: ``"ARCA_ARCA-SANDBOX-xxx@0:20003"``。``None`` 为常态 —
-        local 直连和 baas invoke-http 链路都不落沙箱。
+        Example: ``"ARCA_ARCA-SANDBOX-xxx@0:20003"``. ``None`` is the norm —
+        neither local direct nor the baas invoke-http path lands on a sandbox.
         """
         return self._data.get("sandbox_id")
 
     @property
     def target(self) -> str:
-        """拨号目标地址(host:port 或 sandbox target)。
+        """Dial target address (host:port or sandbox target).
 
-        例: ``"<baas-target>:20003"`` / ``"127.0.0.1:20003"``。缺省 ``""``。
+        Example: ``"<baas-target>:20003"`` / ``"127.0.0.1:20003"``.
+        Default ``""``.
         """
         return self._data.get("target", "")
 
     @property
     def engine_type(self) -> str:
-        """engine 类型,来自 ``ac_bots.active_engine``。
+        """Engine type, from ``ac_bots.active_engine``.
 
-        例: ``"openclaw"`` / ``"teclaw"``。缺省 ``""``。
+        Example: ``"openclaw"`` / ``"teclaw"``. Default ``""``.
         """
         return self._data.get("engine_type", "")
 
-    # ── 扩展字段(baas / teclaw / v2 desktop 链路按需写入) ────────────
+    # ── Extension fields (written as needed by baas / teclaw / v2 desktop) ──
 
     @property
     def type(self) -> str:
-        """connection type,前端 WS 路由分流键。
+        """Connection type, the frontend's WS routing key.
 
-        例: ``"desktop"``(裸 ws 直连)/ ``"baas"``(proxypass wss)。
-        缺省 ``""`` — arca/local 老链路不写。
+        Example: ``"desktop"`` (bare ws direct) / ``"baas"`` (proxypass wss).
+        Default ``""`` — the legacy arca/local paths don't write it.
         """
         return self._data.get("type", "")
 
     @property
     def bot_type(self) -> str:
-        """``ac_bots.bot_type``。例: ``"desktop"`` / ``"personal"`` /
-        ``"service"``。缺省 ``""``(bot 反查不到)。
+        """``ac_bots.bot_type``. Example: ``"desktop"`` / ``"personal"`` /
+        ``"service"``. Default ``""`` (bot lookup failed).
         """
         return self._data.get("bot_type", "")
 
     @property
     def binding_id(self) -> int | None:
-        """``ac_entity_device_binding.id``。例: ``201``。
+        """``ac_entity_device_binding.id``. Example: ``201``.
 
-        ``None`` 表示该链路没带(如 arca 老路径)—— transport
-        ``invoke`` 按有无该字段分流 baas /http-info vs fallback。
+        ``None`` means this path didn't carry it (e.g. the legacy arca
+        path) — the transport's ``invoke`` branches on its presence to pick
+        baas /http-info vs the fallback.
         """
         return self._data.get("binding_id")
 
     @property
     def bind_id(self) -> int | None:
-        """:attr:`binding_id` 的 legacy 别名(baas 链路历史命名)。例: ``201``。
+        """Legacy alias of :attr:`binding_id` (historical baas naming).
+        Example: ``201``.
 
-        resolver ``_normalize_schema`` 会把 ``bind_id`` alias 成
-        ``binding_id``,两个 key 同值并存;新代码读 :attr:`binding_id`。
+        The resolver's ``_normalize_schema`` aliases ``bind_id`` into
+        ``binding_id``; both keys coexist with the same value. New code
+        should read :attr:`binding_id`.
         """
         return self._data.get("bind_id")
 
     @property
     def bot_uuid(self) -> str:
-        """BaaS 侧 bot 实例 UUID(= ``ac_entity_device_binding.device_id``)。
+        """BaaS-side bot instance UUID (= ``ac_entity_device_binding.device_id``).
 
-        例: ``"device-201"``。缺省 ``""`` — 仅 baas/teclaw 链路写。
+        Example: ``"device-201"``. Default ``""`` — only the baas/teclaw
+        paths write it.
         """
         return self._data.get("bot_uuid", "")
 
     @property
     def tenant(self) -> str:
-        """BaaS 租户。例: ``"<tenant>"``。缺省 ``""`` — 仅 baas 链路写。"""
+        """BaaS tenant. Example: ``"<tenant>"``. Default ``""`` — only the
+        baas path writes it."""
         return self._data.get("tenant", "")
 
     @property
     def baas_base_url(self) -> str:
-        """BaaS 网关 base URL。例: ``"https://<baas-host>"``。
+        """BaaS gateway base URL. Example: ``"https://<baas-host>"``.
 
-        缺省 ``""`` — 仅 baas 链路写,invoke-http URL 由它拼出。
+        Default ``""`` — only the baas path writes it; the invoke-http URL
+        is assembled from it.
         """
         return self._data.get("baas_base_url", "")
 
     @property
     def engine_port(self) -> int | None:
-        """engine adapter 监听端口。例: ``20003``。
+        """Engine adapter listen port. Example: ``20003``.
 
-        ``None`` 表示该链路没带(arca/local 老路径端口已并入 ``url``)。
+        ``None`` means this path didn't carry it (the legacy arca/local
+        paths fold the port into ``url``).
         """
         return self._data.get("engine_port")
 
     @property
     def paas_device_id(self) -> str | None:
-        """BaaS 侧物理设备 ID。``None`` 表示该链路没带(非 baas)。"""
+        """BaaS-side physical device ID. ``None`` means this path didn't
+        carry it (non-baas)."""
         return self._data.get("paas_device_id")
 
     @property
     def device_affinity(self) -> str:
-        """设备亲和键(= 操作者 user_id),BaaS 多实例选径用。
+        """Device affinity key (= operator user_id), used by BaaS
+        multi-instance routing.
 
-        例: ``"user-1"``。缺省 ``""``(旧 callsite 未传 user_id)。
+        Example: ``"user-1"``. Default ``""`` (legacy callsites didn't pass
+        user_id).
         """
         return self._data.get("device_affinity", "")
 
     @property
     def device_uuid(self) -> str | None:
-        """多实例场景锁定的设备 UUID。例: ``"DEVICE-002"``。
+        """Device UUID pinning a specific instance in multi-instance
+        scenarios. Example: ``"DEVICE-002"``.
 
-        ``None`` 为常态 — 不锁实例,由 BaaS 自动选活跃实例。
+        ``None`` is the norm — no pinning; BaaS auto-selects an active
+        instance.
         """
         return self._data.get("device_uuid")
 
-    # ── v2 offline 分支字段 ─────────────────────────────────────────
+    # ── v2 offline-branch fields ───────────────────────────────────────
 
     @property
     def available(self) -> bool:
-        """设备是否在线。缺省 ``True`` — 仅 v2 offline 分支显式写 ``False``。"""
+        """Whether the device is online. Default ``True`` — only the v2
+        offline branch explicitly writes ``False``."""
         return self._data.get("available", True)
 
     @property
     def message(self) -> str:
-        """设备不可用原因(随 ``available=False`` 出现)。缺省 ``""``。"""
+        """Reason the device is unavailable (accompanies ``available=False``).
+        Default ``""``."""
         return self._data.get("message", "")
 
 
 @dataclass(frozen=True)
 class DeviceContext:
-    """容器访问上下文 — DeviceContextResolver 的 typed 出口。
+    """Container access context — the typed exit of DeviceContextResolver.
 
-    分流 caller 和 plugin 之间的数据契约:
-    - dispatcher 用 ``(provider, bot_type)`` 选 plugin 实例(本期新增 bot_type 维度,
-      原因见 docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md)
-    - plugin 用 ``conn_info`` 拨号(各 provider 字段子集不同,typed 视图见
-      :class:`ConnInfo`)
+    The data contract between routing callers and plugins:
+    - dispatchers pick a plugin instance by ``(provider, bot_type)`` (the
+      bot_type dimension is new this phase; rationale in
+      docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md)
+    - plugins dial with ``conn_info`` (field subsets differ per provider;
+      see :class:`ConnInfo` for the typed view)
 
     Fields:
-        provider: 来自 ``ac_entity_device_binding.device_provider`` 的事实值
-        conn_info: 拨号字段(命名经 resolver 对齐)。构造时传 plain dict 会被
-            ``__post_init__`` 自动包成 :class:`ConnInfo` — 字段清单/类型/示例
-            都看它;dict 式读取(``ctx.conn_info["url"]``)继续兼容
-        binding_id: 来自 binding 表
-        bot_id: caller 透传。两条入口都必填 — ``resolve_for_bot`` 入参自带,
-            ``resolve_for_binding`` 由 caller 显式 kwarg 传(downstream
-            ``_build_binding_ctx`` 真用它去 bot_repo 做 owner 校验)。
-        user_id: caller 透传(操作者身份;非 owner 时通过权限校验)
-        bot_type: ``ac_bots.bot_type`` 字段值(``"desktop"`` / ``"personal"`` /
-            ``"service"`` 等),resolver 内部从 ``bot_repo`` 拿。dispatcher 用
-            ``(provider, bot_type)`` 二维分流(本期 baas 内部按 bot_type 二次分,
-            desktop 走自拼 URL,其他走 invoke_http)。数据未知时为 ``""``。
+        provider: The factual value from
+            ``ac_entity_device_binding.device_provider``
+        conn_info: Dial-out fields (naming aligned by the resolver). A plain
+            dict passed at construction is wrapped into :class:`ConnInfo` by
+            ``__post_init__`` — see it for the field list, types, and
+            examples; dict-style reads (``ctx.conn_info["url"]``) keep working
+        binding_id: From the binding table
+        bot_id: Passed through from the caller. Required on both entry
+            points — ``resolve_for_bot`` takes it as an argument, and
+            ``resolve_for_binding`` callers pass it as an explicit kwarg
+            (downstream ``_build_binding_ctx`` really does use it against
+            bot_repo for the owner check).
+        user_id: Passed through from the caller (operator identity;
+            non-owners go through the permission check)
+        bot_type: The ``ac_bots.bot_type`` value (``"desktop"`` /
+            ``"personal"`` / ``"service"`` etc.), fetched internally by the
+            resolver from ``bot_repo``. Dispatchers route on the
+            two-dimensional ``(provider, bot_type)`` (this phase baas
+            branches again on bot_type internally: desktop builds its own
+            URL, everything else goes through invoke_http). ``""`` when the
+            data is unknown.
     """
     provider: ProviderType
     conn_info: ConnInfo
     binding_id: int
     bot_id: str
     user_id: str
-    bot_type: str = ""  # Task 1 默认 "" — Task 2 后 resolver 内部 bot_repo 注入真值
+    bot_type: str = ""  # Task 1 defaults to "" — since Task 2 the resolver injects the real value from bot_repo
 
     def __post_init__(self) -> None:
-        # 存量测试/caller 仍传 plain dict — 统一包成 ConnInfo,保证
-        # ``ctx.conn_info`` 的 typed 属性访问在任何构造路径下都可用。
+        # Legacy tests/callers still pass a plain dict — wrap it into
+        # ConnInfo so ``ctx.conn_info``'s typed attribute access works on
+        # every construction path.
         if not isinstance(self.conn_info, ConnInfo):
             object.__setattr__(self, "conn_info", ConnInfo(self.conn_info))
 
 
 class BotNotFoundError(RuntimeError):
-    """bot_id 不存在,或 caller 无权访问该 bot。"""
+    """The bot_id does not exist, or the caller may not access the bot."""
 
 
 class DeviceNotBoundError(RuntimeError):
-    """bot 存在但无 active binding(未 apply / 已 release)。"""
+    """The bot exists but has no active binding (not applied / released)."""
 
 
 class UnknownProviderError(RuntimeError):
-    """binding.device_provider 是 resolver 不认识的值。
+    """binding.device_provider is a value the resolver does not recognize.
 
-    不应在生产中发生 — 触发即说明 binding 表数据异常。
+    Should never happen in production — hitting this means the binding
+    table data is corrupt.
     """
 
 
 class ConnInfoBuildError(RuntimeError):
-    """ConnInfoBuilder 调底层(baas /http-info、arca proxy 等)失败。"""
+    """A ConnInfoBuilder's underlying call (baas /http-info, arca proxy,
+    etc.) failed."""

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
@@ -262,5 +262,6 @@ class DeviceContextResolver:
         # bind_id → binding_id(为兼容期保留 alias,本期两个都暴露)
         if "bind_id" in conn_info and "binding_id" not in conn_info:
             conn_info["binding_id"] = conn_info["bind_id"]
-        # typed 只读视图 — 字段清单/类型/示例见 ConnInfo;dict 式读取原样兼容
+        # Typed read-only view — see ConnInfo for the field list, types, and
+        # examples; dict-style reads stay compatible.
         return ConnInfo(conn_info)

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
@@ -22,6 +22,7 @@ from agentclaw.community.core.devices.services.conn_info_builders.teclaw_builder
     TeclawConnInfoBuilder,
 )
 from agentclaw.community.core.devices.services.device_context import (
+    ConnInfo,
     DeviceContext,
     DeviceNotBoundError,
     UnknownProviderError,
@@ -231,7 +232,7 @@ class DeviceContextResolver:
 
     def _normalize_schema(
         self, raw_conn_info: dict[str, Any], provider: str
-    ) -> dict[str, Any]:
+    ) -> ConnInfo:
         """统一字段命名 — 桥接 builder 输出与 caller 期望的 schema。
 
         当前对齐范围(Step 1.7 + 方案 X 后稳定):
@@ -261,4 +262,5 @@ class DeviceContextResolver:
         # bind_id → binding_id(为兼容期保留 alias,本期两个都暴露)
         if "bind_id" in conn_info and "binding_id" not in conn_info:
             conn_info["binding_id"] = conn_info["bind_id"]
-        return conn_info
+        # typed 只读视图 — 字段清单/类型/示例见 ConnInfo;dict 式读取原样兼容
+        return ConnInfo(conn_info)

--- a/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_context_resolver.py
@@ -262,6 +262,6 @@ class DeviceContextResolver:
         # bind_id → binding_id(为兼容期保留 alias,本期两个都暴露)
         if "bind_id" in conn_info and "binding_id" not in conn_info:
             conn_info["binding_id"] = conn_info["bind_id"]
-        # Typed read-only view — see ConnInfo for the field list, types, and
-        # examples; dict-style reads stay compatible.
+        # Typed view — see ConnInfo for the field list, types, and examples;
+        # dict-style access (reads and legacy writes) stays compatible.
         return ConnInfo(conn_info)

--- a/src/backend/tests/community/core/devices/services/test_device_context.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context.py
@@ -184,6 +184,35 @@ def test_conn_info_copies_source_on_construction():
     assert ci.url == "http://written-via-view"
 
 
+def test_conn_info_is_a_dict_and_json_serializable():
+    """conn_info is embedded in HTTP responses (e.g. the expert-chat session
+    endpoint's "connection" field) — it must behave as a real dict for
+    json.dumps and downstream serializers."""
+    import json
+
+    ci = ConnInfo({"url": "http://test", "use_proxy": True})
+    assert isinstance(ci, dict)
+    assert json.loads(json.dumps({"connection": ci})) == {
+        "connection": {"url": "http://test", "use_proxy": True}
+    }
+
+
+def test_conn_info_survives_pydantic_any_field_serialization():
+    """Regression: the expert-chat session endpoint returns a pydantic
+    ApiResponse whose Any-typed data field nests conn_info; a non-dict
+    Mapping raises PydanticSerializationError there and FastAPI answers
+    500 (singlebox coverage failure on this PR's second round)."""
+    from typing import Any
+
+    from pydantic import BaseModel
+
+    class _Resp(BaseModel):
+        data: Any = None
+
+    resp = _Resp(data={"connection": ConnInfo({"url": "http://test"})})
+    assert '"url":"http://test"' in resp.model_dump_json().replace(" ", "")
+
+
 def test_conn_info_kwargs_construction():
     ci = ConnInfo(url="http://test", use_proxy=False)
     assert ci.url == "http://test"

--- a/src/backend/tests/community/core/devices/services/test_device_context.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context.py
@@ -3,6 +3,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import (
+    ConnInfo,
     DeviceContext,
     BotNotFoundError,
     DeviceNotBoundError,
@@ -58,3 +59,142 @@ def test_exception_classes_exist():
         e = exc_cls("test")
         assert isinstance(e, RuntimeError)
         assert str(e) == "test"
+
+
+# ── ConnInfo:typed 只读视图 ──
+
+_BAAS_STYLE_CONN_INFO = {
+    "url": "https://<baas-host>/api/v1/bots/team_claw/device-201/invoke-http/20003",
+    "token": "tok",
+    "headers": {"x-proxypass-token": "tok"},
+    "use_proxy": True,
+    "sandbox_id": None,
+    "target": "<baas-target>:20003",
+    "engine_type": "openclaw",
+    "type": "baas",
+    "bot_type": "service",
+    "bind_id": 201,
+    "binding_id": 201,
+    "bot_uuid": "device-201",
+    "tenant": "team_claw",
+    "baas_base_url": "https://<baas-host>",
+    "engine_port": 20003,
+    "paas_device_id": "paas-dev-1",
+    "device_affinity": "user-1",
+    "device_uuid": "DEVICE-002",
+}
+
+
+def test_conn_info_typed_attribute_access():
+    ci = ConnInfo(_BAAS_STYLE_CONN_INFO)
+    assert ci.url == _BAAS_STYLE_CONN_INFO["url"]
+    assert ci.token == "tok"
+    assert ci.headers == {"x-proxypass-token": "tok"}
+    assert ci.use_proxy is True
+    assert ci.sandbox_id is None
+    assert ci.target == "<baas-target>:20003"
+    assert ci.engine_type == "openclaw"
+    assert ci.type == "baas"
+    assert ci.bot_type == "service"
+    assert ci.bind_id == 201
+    assert ci.binding_id == 201
+    assert ci.bot_uuid == "device-201"
+    assert ci.tenant == "team_claw"
+    assert ci.baas_base_url == "https://<baas-host>"
+    assert ci.engine_port == 20003
+    assert ci.paas_device_id == "paas-dev-1"
+    assert ci.device_affinity == "user-1"
+    assert ci.device_uuid == "DEVICE-002"
+    assert ci.available is True
+    assert ci.message == ""
+
+
+def test_conn_info_defaults_for_absent_fields():
+    """binding 路由链路(resolve_for_binding_invoke)不预置传输字段 —
+    缺席字段的 property 返回文档标注的缺省值,不 KeyError。"""
+    ci = ConnInfo({"bind_id": 201, "engine_type": "teclaw"})
+    assert ci.url == ""
+    assert ci.token == ""
+    assert ci.headers == {}
+    assert ci.use_proxy is False
+    assert ci.sandbox_id is None
+    assert ci.target == ""
+    assert ci.binding_id is None  # alias 由 resolver 层补,不在 ConnInfo 里推导
+    assert ci.engine_port is None
+    assert ci.paas_device_id is None
+    assert ci.device_uuid is None
+    assert ci.available is True
+    assert ci.message == ""
+
+
+def test_conn_info_mapping_compat_with_plain_dict_reads():
+    """存量 conn_info["url"] / .get / in / dict() / == 读法原样兼容。"""
+    ci = ConnInfo(_BAAS_STYLE_CONN_INFO)
+    assert ci["url"] == _BAAS_STYLE_CONN_INFO["url"]
+    assert ci.get("tenant") == "team_claw"
+    assert ci.get("nonexistent", "fallback") == "fallback"
+    assert "bind_id" in ci
+    assert "nonexistent" not in ci
+    # key 集合与底层 dict 一致 — 不因缺席 property 长出幻影 key
+    assert set(ci.keys()) == set(_BAAS_STYLE_CONN_INFO.keys())
+    assert dict(ci) == _BAAS_STYLE_CONN_INFO
+    assert len(ci) == len(_BAAS_STYLE_CONN_INFO)
+    # 等值比较双向成立(Mapping.__eq__)
+    assert ci == _BAAS_STYLE_CONN_INFO
+    assert _BAAS_STYLE_CONN_INFO == ci
+
+
+def test_conn_info_unknown_keys_pass_through():
+    """builder 产出的未知 key 原样透传(dict 式访问)。"""
+    ci = ConnInfo({"url": "http://test", "_provider_mark": "baas-built"})
+    assert ci["_provider_mark"] == "baas-built"
+    assert set(ci.keys()) == {"url", "_provider_mark"}
+
+
+def test_conn_info_is_read_only_and_copies_source():
+    source = {"url": "http://test"}
+    ci = ConnInfo(source)
+    with pytest.raises(TypeError):
+        ci["url"] = "http://mutated"  # type: ignore[index]
+    # 构造时浅拷贝 — 外部改源 dict 不影响本对象
+    source["url"] = "http://mutated"
+    assert ci.url == "http://test"
+    # to_dict 是副本,改它也不影响本对象
+    exported = ci.to_dict()
+    exported["url"] = "http://mutated"
+    assert ci.url == "http://test"
+
+
+def test_conn_info_kwargs_construction():
+    ci = ConnInfo(url="http://test", use_proxy=False)
+    assert ci.url == "http://test"
+    assert ci == {"url": "http://test", "use_proxy": False}
+    # mapping + kwargs 合并,kwargs 覆盖同名 key
+    merged = ConnInfo({"url": "http://a", "token": "tok"}, url="http://b")
+    assert merged.url == "http://b"
+    assert merged.token == "tok"
+
+
+def test_device_context_wraps_plain_dict_conn_info():
+    ctx = DeviceContext(
+        provider="baas",
+        conn_info={"url": "http://test"},
+        binding_id=42,
+        bot_id="bot-1",
+        user_id="user-1",
+    )
+    assert isinstance(ctx.conn_info, ConnInfo)
+    assert ctx.conn_info.url == "http://test"
+    assert ctx.conn_info["url"] == "http://test"
+
+
+def test_device_context_keeps_conn_info_instance():
+    ci = ConnInfo({"url": "http://test"})
+    ctx = DeviceContext(
+        provider="baas",
+        conn_info=ci,
+        binding_id=42,
+        bot_id="bot-1",
+        user_id="user-1",
+    )
+    assert ctx.conn_info is ci

--- a/src/backend/tests/community/core/devices/services/test_device_context.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context.py
@@ -61,7 +61,7 @@ def test_exception_classes_exist():
         assert str(e) == "test"
 
 
-# ── ConnInfo: typed read-only view ──
+# ── ConnInfo: typed view ──
 
 _BAAS_STYLE_CONN_INFO = {
     "url": "https://<baas-host>/api/v1/bots/team_claw/device-201/invoke-http/20003",
@@ -154,19 +154,34 @@ def test_conn_info_unknown_keys_pass_through():
     assert set(ci.keys()) == {"url", "_provider_mark"}
 
 
-def test_conn_info_is_read_only_and_copies_source():
+def test_conn_info_mutation_parity_with_dict():
+    """Legacy in-place writes keep working (expert_chat overwrites
+    conn["engine_type"] per session) and stay in sync with the typed
+    properties."""
+    ci = ConnInfo({"url": "http://test", "engine_type": "openclaw"})
+    ci["engine_type"] = "teclaw"
+    assert ci.engine_type == "teclaw"
+    assert ci["engine_type"] == "teclaw"
+    ci["device_uuid"] = "DEVICE-002"  # new key
+    assert ci.device_uuid == "DEVICE-002"
+    del ci["device_uuid"]
+    assert ci.device_uuid is None
+    assert "device_uuid" not in ci
+
+
+def test_conn_info_copies_source_on_construction():
     source = {"url": "http://test"}
     ci = ConnInfo(source)
-    with pytest.raises(TypeError):
-        ci["url"] = "http://mutated"  # type: ignore[index]
     # shallow-copied at construction — mutating the source dict afterwards
-    # does not affect the object
+    # does not affect the object, and vice versa
     source["url"] = "http://mutated"
     assert ci.url == "http://test"
+    ci["url"] = "http://written-via-view"
+    assert source["url"] == "http://mutated"
     # to_dict returns a copy; mutating it doesn't affect the object either
     exported = ci.to_dict()
     exported["url"] = "http://mutated"
-    assert ci.url == "http://test"
+    assert ci.url == "http://written-via-view"
 
 
 def test_conn_info_kwargs_construction():

--- a/src/backend/tests/community/core/devices/services/test_device_context.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context.py
@@ -61,7 +61,7 @@ def test_exception_classes_exist():
         assert str(e) == "test"
 
 
-# ── ConnInfo:typed 只读视图 ──
+# ── ConnInfo: typed read-only view ──
 
 _BAAS_STYLE_CONN_INFO = {
     "url": "https://<baas-host>/api/v1/bots/team_claw/device-201/invoke-http/20003",
@@ -110,8 +110,9 @@ def test_conn_info_typed_attribute_access():
 
 
 def test_conn_info_defaults_for_absent_fields():
-    """binding 路由链路(resolve_for_binding_invoke)不预置传输字段 —
-    缺席字段的 property 返回文档标注的缺省值,不 KeyError。"""
+    """The binding-routed path (resolve_for_binding_invoke) pre-fills no
+    transport fields — properties of absent fields return their documented
+    defaults instead of raising KeyError."""
     ci = ConnInfo({"bind_id": 201, "engine_type": "teclaw"})
     assert ci.url == ""
     assert ci.token == ""
@@ -119,7 +120,8 @@ def test_conn_info_defaults_for_absent_fields():
     assert ci.use_proxy is False
     assert ci.sandbox_id is None
     assert ci.target == ""
-    assert ci.binding_id is None  # alias 由 resolver 层补,不在 ConnInfo 里推导
+    # the alias is added by the resolver layer, not derived inside ConnInfo
+    assert ci.binding_id is None
     assert ci.engine_port is None
     assert ci.paas_device_id is None
     assert ci.device_uuid is None
@@ -128,24 +130,25 @@ def test_conn_info_defaults_for_absent_fields():
 
 
 def test_conn_info_mapping_compat_with_plain_dict_reads():
-    """存量 conn_info["url"] / .get / in / dict() / == 读法原样兼容。"""
+    """Legacy conn_info["url"] / .get / in / dict() / == reads keep working."""
     ci = ConnInfo(_BAAS_STYLE_CONN_INFO)
     assert ci["url"] == _BAAS_STYLE_CONN_INFO["url"]
     assert ci.get("tenant") == "team_claw"
     assert ci.get("nonexistent", "fallback") == "fallback"
     assert "bind_id" in ci
     assert "nonexistent" not in ci
-    # key 集合与底层 dict 一致 — 不因缺席 property 长出幻影 key
+    # key set matches the underlying dict — absent properties don't grow
+    # phantom keys
     assert set(ci.keys()) == set(_BAAS_STYLE_CONN_INFO.keys())
     assert dict(ci) == _BAAS_STYLE_CONN_INFO
     assert len(ci) == len(_BAAS_STYLE_CONN_INFO)
-    # 等值比较双向成立(Mapping.__eq__)
+    # equality holds in both directions (Mapping.__eq__)
     assert ci == _BAAS_STYLE_CONN_INFO
     assert _BAAS_STYLE_CONN_INFO == ci
 
 
 def test_conn_info_unknown_keys_pass_through():
-    """builder 产出的未知 key 原样透传(dict 式访问)。"""
+    """Unknown builder-produced keys pass through (dict-style access)."""
     ci = ConnInfo({"url": "http://test", "_provider_mark": "baas-built"})
     assert ci["_provider_mark"] == "baas-built"
     assert set(ci.keys()) == {"url", "_provider_mark"}
@@ -156,10 +159,11 @@ def test_conn_info_is_read_only_and_copies_source():
     ci = ConnInfo(source)
     with pytest.raises(TypeError):
         ci["url"] = "http://mutated"  # type: ignore[index]
-    # 构造时浅拷贝 — 外部改源 dict 不影响本对象
+    # shallow-copied at construction — mutating the source dict afterwards
+    # does not affect the object
     source["url"] = "http://mutated"
     assert ci.url == "http://test"
-    # to_dict 是副本,改它也不影响本对象
+    # to_dict returns a copy; mutating it doesn't affect the object either
     exported = ci.to_dict()
     exported["url"] = "http://mutated"
     assert ci.url == "http://test"
@@ -169,7 +173,7 @@ def test_conn_info_kwargs_construction():
     ci = ConnInfo(url="http://test", use_proxy=False)
     assert ci.url == "http://test"
     assert ci == {"url": "http://test", "use_proxy": False}
-    # mapping + kwargs 合并,kwargs 覆盖同名 key
+    # mapping + kwargs merge; kwargs win on clashing keys
     merged = ConnInfo({"url": "http://a", "token": "tok"}, url="http://b")
     assert merged.url == "http://b"
     assert merged.token == "tok"

--- a/src/backend/tests/community/core/devices/services/test_device_context.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context.py
@@ -120,13 +120,23 @@ def test_conn_info_defaults_for_absent_fields():
     assert ci.use_proxy is False
     assert ci.sandbox_id is None
     assert ci.target == ""
-    # the alias is added by the resolver layer, not derived inside ConnInfo
-    assert ci.binding_id is None
     assert ci.engine_port is None
     assert ci.paas_device_id is None
     assert ci.device_uuid is None
     assert ci.available is True
     assert ci.message == ""
+
+
+def test_conn_info_binding_id_falls_back_to_legacy_bind_id():
+    """The typed property also works on conn_info that never went through
+    the resolver's bind_id → binding_id alias step (the filesystem
+    dispatcher's legacy path wraps builder-raw dicts)."""
+    assert ConnInfo({"bind_id": 201}).binding_id == 201
+    # the resolver-normalized binding_id key wins when both are present
+    assert ConnInfo({"bind_id": 201, "binding_id": 202}).binding_id == 202
+    assert ConnInfo({}).binding_id is None
+    # bind_id stays strict — it reports only its own key
+    assert ConnInfo({"binding_id": 202}).bind_id is None
 
 
 def test_conn_info_mapping_compat_with_plain_dict_reads():

--- a/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentclaw.community.core.devices.services.device_context import (
+    ConnInfo,
     DeviceNotBoundError,
     UnknownProviderError,
 )
@@ -310,3 +311,25 @@ def test_resolve_for_binding_handles_missing_bot_gracefully(
     ctx = resolver.resolve_for_binding(3, "user-1", bot_id="bot-orphan")
 
     assert ctx.bot_type == ""
+
+
+# ── conn_info typed 出口 ──
+
+def test_resolver_exits_carry_typed_conn_info(resolver, fake_binding_repo):
+    """三条 resolve 入口的 ctx.conn_info 都是 ConnInfo — typed 属性访问与
+    dict 式读取指向同一份数据。"""
+    fake_binding_repo.get_active_by_bot_and_owner.return_value = _mock_binding(2, "baas")
+    fake_binding_repo.get_by_id.return_value = _mock_binding(2, "baas")
+
+    for ctx in (
+        resolver.resolve_for_bot("bot-2", "user-1"),
+        resolver.resolve_for_binding(2, "user-1", bot_id="bot-2"),
+        resolver.resolve_for_binding_invoke(2, "user-1", bot_id="bot-2"),
+    ):
+        assert isinstance(ctx.conn_info, ConnInfo)
+
+    # builder 出 bind_id → _normalize_schema 补 binding_id alias,typed 属性同源
+    ctx = resolver.resolve_for_bot("bot-2", "user-1")
+    assert ctx.conn_info.bind_id == 42
+    assert ctx.conn_info.binding_id == 42
+    assert ctx.conn_info["binding_id"] == 42

--- a/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
+++ b/src/backend/tests/community/core/devices/services/test_device_context_resolver.py
@@ -313,11 +313,11 @@ def test_resolve_for_binding_handles_missing_bot_gracefully(
     assert ctx.bot_type == ""
 
 
-# ── conn_info typed 出口 ──
+# ── conn_info typed exit ──
 
 def test_resolver_exits_carry_typed_conn_info(resolver, fake_binding_repo):
-    """三条 resolve 入口的 ctx.conn_info 都是 ConnInfo — typed 属性访问与
-    dict 式读取指向同一份数据。"""
+    """All three resolve entry points return ctx.conn_info as ConnInfo —
+    typed attribute access and dict-style reads point at the same data."""
     fake_binding_repo.get_active_by_bot_and_owner.return_value = _mock_binding(2, "baas")
     fake_binding_repo.get_by_id.return_value = _mock_binding(2, "baas")
 
@@ -328,7 +328,8 @@ def test_resolver_exits_carry_typed_conn_info(resolver, fake_binding_repo):
     ):
         assert isinstance(ctx.conn_info, ConnInfo)
 
-    # builder 出 bind_id → _normalize_schema 补 binding_id alias,typed 属性同源
+    # builder emits bind_id → _normalize_schema adds the binding_id alias;
+    # the typed properties read the same data
     ctx = resolver.resolve_for_bot("bot-2", "user-1")
     assert ctx.conn_info.bind_id == 42
     assert ctx.conn_info.binding_id == 42


### PR DESCRIPTION
## Problem

`DeviceContext.conn_info` was a bare `dict[str, Any]`. The field names, their types, and which providers write which subset were undiscoverable from the contract module — the only way to learn the keys was reading the four `ConnInfoBuilder` implementations plus `baas_conn_info.py` and the v2 branches of `device_service.py`.

## Solution

Introduce `ConnInfo` in `device_context.py`: a `dict` subclass that declares every known field as a typed property with a docstring example — the seven-field schema contract (`url` / `token` / `headers` / `use_proxy` / `sandbox_id` / `target` / `engine_type`) plus the baas/teclaw/v2 extension fields (`type`, `bot_type`, `binding_id`, `bind_id`, `bot_uuid`, `tenant`, `baas_base_url`, `engine_port`, `paas_device_id`, `device_affinity`, `device_uuid`, `available`, `message`). No field name collides with a `dict` method.

- `DeviceContextResolver._normalize_schema` now returns `ConnInfo`, so every resolver exit carries the typed object; `DeviceContext.conn_info` is annotated `ConnInfo`.
- `DeviceContext.__post_init__` wraps a plain-dict `conn_info` into `ConnInfo`, so direct constructors (tests, `device_filesystem_dispatcher`) keep working unchanged.
- Because it **is** a dict, every legacy behavior is inherited rather than re-implemented: reads (`conn_info["url"]`, `.get(...)`, `in`, `dict(...)`, `==` both ways), in-place writes (`ExpertChatSessionRuntime` overwrites `conn["engine_type"]` per session), `json.dumps`, and pydantic/FastAPI response serialization (the expert-chat session endpoint embeds conn_info as its `connection` field). Unknown builder keys pass through.
- All docstrings and comments in the touched files are in English; `device_context.py`'s pre-existing docstrings were translated so the contract module reads in one language.

Rejected alternatives, each disproven by a CI round or blast-radius analysis:
- A plain dataclass with attribute-only access — touches the `DeviceAdapterTransport` protocol and ~100 files of plugins/tests at once.
- A read-only `Mapping` view — singlebox round 1 failed: expert_chat mutates the resolved conn_info in place.
- A `MutableMapping` wrapper — singlebox round 2 failed: pydantic v2 cannot serialize a non-dict Mapping under an `Any`-typed response field, so the session endpoint 500'd during response serialization (after the handler returned, which is why the router's catch-all never fired).

## Validation

- New `ConnInfo` contract tests in `test_device_context.py`: typed attribute access, per-provider absent-field defaults, mapping compatibility, mutation parity (the expert_chat `engine_type` write pattern), `json.dumps` and pydantic `Any`-field serialization regressions, unknown-key pass-through, copy-on-construct, kwargs construction, `DeviceContext` dict wrapping — all pass.
- `test_device_context_resolver.py` — new test asserting all three resolver entry points return `ConnInfo` with the `bind_id`/`binding_id` alias intact.
- `tests/community/contract/test_conn_info_schema.py` — unchanged, passing.
- Reproduced the singlebox 500 locally with a FastAPI `TestClient` serving `ApiResponse(data={"connection": <Mapping>})` (500 before the fix, 200 after).
- Full backend suite (`pytest tests/community -n auto --dist loadfile`): 11867 passed, 4 skipped, 2 failed — the 2 `test_bot_build_service_skill_artifact` NFS-snapshot failures reproduce on a clean checkout and are unrelated.
- Singlebox coverage CI: round 1 failed on the read-only view (expert_chat core 46.08% < 63.49%), round 2 on Mapping serialization (49.46% < 63.49%); the dict-subclass fix (`082f0a4`) is validated locally by the TestClient repro, CI re-run pending.
- `python_sast_local.sh` block rules (flake8 subset) on changed files: clean.

## Compatibility and risk

No behavior change intended. `ConnInfo` differs from the previous plain dict only by its type name and the added read-only properties/`to_dict()`; construction, mutation, equality, and serialization are `dict`'s own. Rollback is reverting this branch; no schema, config, or migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyjwBg2oUNNVVYfsW9C1G8