### PR TITLE
feat(openapi): add container operations and health diagnostics

### DIFF
--- a/docs/superpowers/specs/2026-08-18-bot-health-diagnosis-openapi.md
+++ b/docs/superpowers/specs/2026-08-18-bot-health-diagnosis-openapi.md
@@ -1,0 +1,154 @@
+# Bot 健康诊断 OpenAPI 契约
+
+- 日期：2026-08-18
+- 状态：已实现，待 Gateway 发布与联调
+- 适用范围：云端 `openclaw` Bot（个人 Bot、服务 Bot 草稿工作区）
+- 授权：Bot Owner 或具备 Member 及以上权限的协作者
+
+## 1. 获取健康状态
+
+```http
+GET /openapi/v1/bots/{bot_id}/diagnostics/health
+```
+
+Query：
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `user_id` | 是 | 当前请求代表的用户 |
+| `owner_id` | 否 | Bot Owner；访问协作 Bot 时填写 |
+| `scan_id` | 否 | `health-check` 返回的任务 ID；不传时返回最近一次完成结果 |
+
+没有历史结果时：
+
+```json
+{
+  "code": 200000,
+  "message": "OK",
+  "data": {
+    "found": false,
+    "bot_id": "bot-001",
+    "scan_id": null,
+    "status": "not_run",
+    "health_score": null,
+    "grade": null,
+    "summary": {},
+    "check_items": [],
+    "findings": [],
+    "failed_reason": null,
+    "duration_ms": null,
+    "created_at": null
+  },
+  "request_id": "trace-id"
+}
+```
+
+完成结果：
+
+```json
+{
+  "code": 200000,
+  "message": "OK",
+  "data": {
+    "found": true,
+    "bot_id": "bot-001",
+    "scan_id": 1024,
+    "status": "completed",
+    "health_score": 86,
+    "grade": "good",
+    "summary": {
+      "pass": 4,
+      "warning": 1,
+      "fail": 0,
+      "error": 0
+    },
+    "check_items": [
+      {
+        "name": "AGENTS.md",
+        "status": "completed",
+        "result": "warning",
+        "score": 86,
+        "duration_ms": 1200
+      }
+    ],
+    "findings": [
+      {
+        "check_item": "AGENTS.md",
+        "findings": [
+          {
+            "rule_id": "D-AGENTS-001",
+            "name": "角色定义诊断",
+            "message": "角色定义不完整",
+            "risk_level": "warning",
+            "result": "warning",
+            "score": 86
+          }
+        ]
+      }
+    ],
+    "failed_reason": null,
+    "duration_ms": 1200,
+    "created_at": "2026-08-18T10:00:00"
+  },
+  "request_id": "trace-id"
+}
+```
+
+## 2. 触发健康检查
+
+```http
+POST /openapi/v1/bots/{bot_id}/diagnostics/health-check
+```
+
+Query：
+
+| 参数 | 必填 | 说明 |
+|---|---|---|
+| `user_id` | 是 | 当前请求代表的用户 |
+| `owner_id` | 否 | Bot Owner；访问协作 Bot 时填写 |
+
+不需要 Request Body。成功后返回 `202 Accepted`：
+
+```json
+{
+  "code": 202000,
+  "message": "Accepted",
+  "data": {
+    "bot_id": "bot-001",
+    "scan_id": 1024,
+    "status": "scanning"
+  },
+  "request_id": "trace-id"
+}
+```
+
+前端使用返回的 `scan_id` 调用：
+
+```http
+GET /openapi/v1/bots/{bot_id}/diagnostics/health?scan_id=1024
+```
+
+直到 `status` 为 `completed` 或 `failed`。
+
+## 3. 状态与错误
+
+任务状态：
+
+- `not_run`：没有完成过健康检查。
+- `scanning`：诊断中。
+- `scan_completed`：扫描完成，正在处理后续结果。
+- `patching`：正在生成修复建议。
+- `completed`：诊断完成，可读取健康分和详细问题。
+- `failed`：诊断失败，读取 `failed_reason`。
+
+主要错误：
+
+| HTTP | 场景 |
+|---:|---|
+| `403` | `user_id` 与认证用户不一致 |
+| `404` | Bot、诊断任务不存在，或者当前用户无权访问 |
+| `409` | 5 分钟内已有进行中的诊断任务 |
+| `409` | Bot 不是受支持的云端 OpenClaw Bot，或者已有检查正在进行 |
+| `502` | 诊断持久化服务暂时不可用 |
+
+`scan_id` 不是授权凭证。后端会在返回记录前再次校验该任务所属的 `bot_id`、Owner 和运行环境。

--- a/docs/superpowers/specs/2026-08-18-bot-workshop-integration-matrix.md
+++ b/docs/superpowers/specs/2026-08-18-bot-workshop-integration-matrix.md
@@ -407,8 +407,8 @@ POST /openapi/v1/bots/{bot_id}/containers/{instance_id}/restart
 | 能力 | 领域现状 | 缺口 | 备注 |
 |---|---|---|---|
 | Runtime logs（含容器实例日志） | Bot Inventory 只有 action 声明；日志来源尚需确定 | Runtime Log Contract、受限参数、公开 Adapter、Gateway | 必须限制日志来源、路径、`tail`、level 和敏感信息；A/B 不实现采集或日志公开接口 |
-| Health score | `community/core/harness` 已有领域与内部 API | 稳定 Service API、OpenAPI、能力限制和 Gateway | 当前规划仅 OpenClaw + cloud；由任务护航团队实现 |
-| Health check | Harness 已有诊断能力 | 触发、轮询、报告 Contract | 由任务护航团队实现 |
+| Health score | `community/core/harness` 已有领域与内部 API | 已新增 Bot-first OpenAPI，待 Gateway 发布和联调 | 当前仅 OpenClaw + cloud；复用 Harness 评分能力 |
+| Health check | Harness 已有诊断能力 | 已新增触发及按 `scan_id` 轮询契约，待 Gateway 发布和联调 | 复用 Harness 扫描与诊断记录 |
 | Evaluation | `community/core/quality` 与 `QualityTaskServiceProtocol` 已存在 | 公开创建/查询、结果页 URL/token Contract | 由 Quality/任务护航相关同学实现 |
 
 推荐按独立领域公开：

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -177,6 +177,8 @@ from .authorized_apps import app_view_router as authorized_bots_router
 from .authorized_apps import router as authorized_apps_router
 from .bots import router as bots_router
 from .bots.engine_config import router as engine_config_router
+from .containers import router as containers_router
+from .diagnostics import router as diagnostics_router
 from .deprecated import (
     ENGINE_RUNTIME_GROUPS as _LEGACY_ENGINE_RUNTIME,
     GRANT_CHECKED_GROUPS as _LEGACY_GRANT_CHECKED,
@@ -269,6 +271,8 @@ _SUBGROUPS = [
     # live Bot collaborator relation at member level before any publication read.
     service_lifecycle_router,
     service_edit_lock_router,
+    containers_router,
+    diagnostics_router,
 ]
 
 # The groups where **every** route is GRANT_CHECKED_OWN_BOT — it names a bot and resolves it

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -236,6 +236,16 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("POST", "/openapi/v1/bots/{bot_id}/edit-lock"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     ("DELETE", "/openapi/v1/bots/{bot_id}/edit-lock"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     ("POST", "/openapi/v1/bots/{bot_id}/edit-lock/steal"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    ("GET", "/openapi/v1/bots/{bot_id}/containers"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/containers/{instance_id}/restart",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    ("GET", "/openapi/v1/bots/{bot_id}/diagnostics/health"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/diagnostics/health-check",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # ── B: returns a set of bots, narrowed to the granted ones ───────────────
     ("GET", "/openapi/v1/bots"): AdmissionMode.GRANT_FILTERED,
     # The application's own view, and the **complete** one: a granted bot the

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/__init__.py
@@ -1,0 +1,5 @@
+"""Public service-Bot container instance endpoints."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/router.py
@@ -1,0 +1,115 @@
+"""Public service-Bot container list and single-instance restart endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import BotIdPath, Envelope
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import OwnerIdDep
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    accepted,
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.service_publication_facade import (
+    ServicePublicationFacadeProtocol,
+)
+from agentclaw.community.di import Injected
+
+from .schemas import (
+    ContainerInstance,
+    ContainerList,
+    ContainerRestart,
+    ContainerSummary,
+    ContainerStatus,
+    InstanceIdPath,
+)
+
+
+router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/containers")
+
+_STATUS_MAP: dict[str, ContainerStatus] = {
+    "ACTIVE": "healthy",
+    "RESTARTING": "restarting",
+    "ABNORMAL": "abnormal",
+    "UNKNOWN": "unknown",
+}
+
+
+def _project_instance(raw: dict[str, Any]) -> ContainerInstance:
+    return ContainerInstance(
+        id=str(raw.get("device_uuid") or ""),
+        status=_STATUS_MAP.get(str(raw.get("health_status") or "").upper(), "unknown"),
+        internal_status=raw.get("status"),
+        engine=str(raw.get("engine_type") or "openclaw"),
+        provider=raw.get("provider_type"),
+        provider_instance_id=raw.get("provider_device_id"),
+        created_at=raw.get("gmt_create"),
+    )
+
+
+def _project_list(raw: dict[str, Any]) -> ContainerList:
+    instances = [_project_instance(item) for item in raw.get("instances", [])]
+    counts = {status: 0 for status in _STATUS_MAP.values()}
+    for instance in instances:
+        counts[instance.status] += 1
+    return ContainerList(
+        bot_id=str(raw["bot_id"]),
+        summary=ContainerSummary(
+            total=len(instances),
+            healthy=counts["healthy"],
+            abnormal=counts["abnormal"],
+            restarting=counts["restarting"],
+            unknown=counts["unknown"],
+        ),
+        instances=instances,
+    )
+
+
+@router.get("", response_model=Envelope[ContainerList])
+@envelope_errors
+async def list_containers(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    facade: ServicePublicationFacadeProtocol = Injected(
+        ServicePublicationFacadeProtocol
+    ),
+) -> Envelope[ContainerList]:
+    """Return the current online instance snapshot for a service Bot."""
+    result = facade.list_containers(
+        bot_id,
+        actor_id=actor_id,
+        owner_id=owner_id,
+    )
+    return envelope(_project_list(result), request)
+
+
+@router.post(
+    "/{instance_id}/restart",
+    status_code=202,
+    response_model=Envelope[ContainerRestart],
+)
+@envelope_errors
+async def restart_container(
+    bot_id: BotIdPath,
+    instance_id: InstanceIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    facade: ServicePublicationFacadeProtocol = Injected(
+        ServicePublicationFacadeProtocol
+    ),
+) -> Envelope[ContainerRestart]:
+    """Restart one abnormal instance; service-Bot owner only."""
+    result = facade.restart_container(
+        bot_id,
+        instance_id,
+        actor_id=actor_id,
+        owner_id=owner_id,
+    )
+    return accepted(ContainerRestart.model_validate(result), request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/containers/schemas.py
@@ -1,0 +1,84 @@
+"""Public contracts for service-Bot container instances."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import Path
+from pydantic import BaseModel, Field
+
+
+ContainerStatus = Literal["healthy", "restarting", "abnormal", "unknown"]
+
+InstanceIdPath = Annotated[
+    str,
+    Path(
+        min_length=1,
+        max_length=128,
+        description="Stable instance identifier returned by the container list.",
+    ),
+]
+
+
+class ContainerSummary(BaseModel):
+    """Counts derived from the current BaaS instance snapshot."""
+
+    total: int = Field(description="Total live instances in the snapshot.")
+    healthy: int = Field(description="Instances whose health probe is healthy.")
+    abnormal: int = Field(description="Instances whose health probe is unhealthy.")
+    restarting: int = Field(description="Instances currently pending or updating.")
+    unknown: int = Field(description="Instances without a usable health result.")
+
+
+class ContainerInstance(BaseModel):
+    """One runtime instance backing a service Bot."""
+
+    id: str = Field(description="Stable instance identifier used by instance actions.")
+    node: str | None = Field(
+        default=None,
+        description="Runtime node name; null until BaaS exposes this metric.",
+    )
+    cpu: str | None = Field(
+        default=None,
+        description="CPU usage or allocation; null until BaaS exposes metrics.",
+    )
+    memory: str | None = Field(
+        default=None,
+        description="Memory usage or allocation; null until BaaS exposes metrics.",
+    )
+    status: ContainerStatus = Field(description="Stable product health state.")
+    internal_status: str | None = Field(
+        default=None, description="Raw BaaS lifecycle state for diagnostics."
+    )
+    engine: str = Field(description="Engine running in this instance.")
+    provider: str | None = Field(default=None, description="Runtime provider type.")
+    provider_instance_id: str | None = Field(
+        default=None, description="Provider-side instance identifier."
+    )
+    created_at: datetime | None = Field(
+        default=None, description="Instance creation timestamp."
+    )
+
+
+class ContainerList(BaseModel):
+    """Current service-Bot instance snapshot and derived summary."""
+
+    bot_id: str = Field(description="Stable Bot identifier.")
+    summary: ContainerSummary = Field(
+        description="Counts derived from the same instance snapshot."
+    )
+    instances: list[ContainerInstance] = Field(
+        description="Current runtime instances backing the service Bot."
+    )
+
+
+class ContainerRestart(BaseModel):
+    """Acknowledgement for an asynchronous single-instance restart."""
+
+    bot_id: str = Field(description="Stable Bot identifier.")
+    instance_id: str = Field(description="Restarted instance identifier.")
+    publish_id: int | None = Field(
+        default=None, description="BaaS publish workflow identifier."
+    )
+    accepted: bool = Field(description="Whether the restart was accepted.")

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/__init__.py
@@ -1,0 +1,5 @@
+"""Public Bot health diagnosis endpoints."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/router.py
@@ -1,0 +1,230 @@
+"""Bot-scoped public access to the existing health diagnosis capability."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, cast
+
+from fastapi import APIRouter, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    OwnerIdDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    accepted,
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.api.health_diagnosis_service import (
+    HealthDiagnosisServiceProtocol,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotOperationNotAllowedError,
+)
+from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
+from agentclaw.community.di import Injected
+
+from .schemas import (
+    BotHealth,
+    HealthCheckAccepted,
+    HealthCheckItem,
+    HealthDiagnosisStatus,
+    HealthFindingDetail,
+    HealthFindingGroup,
+)
+
+
+router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/diagnostics", tags=["diagnostics"])
+
+ScanIdQuery = Annotated[
+    int | None,
+    Query(
+        ge=1,
+        description="Diagnosis identifier returned by health-check; omit for the latest completed result.",
+    ),
+]
+
+_STATUSES = frozenset({"scanning", "scan_completed", "patching", "completed", "failed"})
+
+
+def _status(value: Any) -> HealthDiagnosisStatus:
+    candidate = str(value or "")
+    if candidate == "running":
+        candidate = "scanning"
+    return cast(
+        HealthDiagnosisStatus, candidate if candidate in _STATUSES else "failed"
+    )
+
+
+def _check_items(record: dict[str, Any]) -> list[HealthCheckItem]:
+    status = _status(record.get("status"))
+    result: list[HealthCheckItem] = []
+    for raw in record.get("check_items") or []:
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("check_item") or raw.get("rule_name") or raw.get("rule_id")
+        if not name:
+            continue
+        result.append(
+            HealthCheckItem(
+                name=str(name),
+                status=str(raw.get("status") or status),
+                result=str(raw["result"]) if raw.get("result") is not None else None,
+                score=raw.get("score"),
+                duration_ms=raw.get("cost"),
+            )
+        )
+    return result
+
+
+def _findings(record: dict[str, Any]) -> list[HealthFindingGroup]:
+    result: list[HealthFindingGroup] = []
+    for group in record.get("findings") or []:
+        if not isinstance(group, dict):
+            continue
+        details: list[HealthFindingDetail] = []
+        for raw in group.get("finding_details") or []:
+            if not isinstance(raw, dict):
+                continue
+            rule_id = str(raw.get("rule_id") or "")
+            # Harness system findings can contain the original upstream
+            # exception. Public callers need the diagnosis state, not internal
+            # paths, hosts, or credentials embedded in that exception text.
+            message = (
+                "Diagnostic item failed"
+                if rule_id in {"SYS01", "SYS02"}
+                else str(raw.get("message") or "")
+            )
+            details.append(
+                HealthFindingDetail(
+                    rule_id=rule_id,
+                    name=str(raw.get("name") or ""),
+                    message=message,
+                    risk_level=str(raw.get("risk_level") or ""),
+                    result=str(raw.get("result") or ""),
+                    score=int(raw.get("score") or 0),
+                )
+            )
+        result.append(
+            HealthFindingGroup(
+                check_item=str(group.get("check_item") or ""),
+                findings=details,
+            )
+        )
+    return result
+
+
+def _project(bot_id: str, record: dict[str, Any] | None) -> BotHealth:
+    if record is None:
+        return BotHealth(found=False, bot_id=bot_id, status="not_run")
+    status = _status(record.get("status"))
+    completed = status == "completed"
+    return BotHealth(
+        found=True,
+        bot_id=bot_id,
+        scan_id=int(record["id"]),
+        status=status,
+        health_score=record.get("health_score") if completed else None,
+        grade=(
+            str(record.get("score_grade"))
+            if completed and record.get("score_grade")
+            else None
+        ),
+        summary=record.get("findings_summary") or {},
+        check_items=_check_items(record),
+        findings=_findings(record) if completed else [],
+        failed_reason="Health diagnosis failed" if status == "failed" else None,
+        duration_ms=record.get("duration_ms") if completed else None,
+        created_at=record.get("gmt_create"),
+    )
+
+
+async def _authorize(
+    *,
+    relay: EngineRuntimeRelayProtocol,
+    bot_id: str,
+    actor_id: str,
+    owner_id: str,
+) -> str:
+    facts = await resolve_operable_bot(
+        relay,
+        bot_id,
+        caller_id=actor_id,
+        owner_id=owner_id,
+        stage="draft",
+        surface="diagnostics",
+    )
+    if (facts.active_engine or DEFAULT_ENGINE_TYPE) != DEFAULT_ENGINE_TYPE:
+        raise BotOperationNotAllowedError(
+            "health diagnosis is supported only by openclaw"
+        )
+    return facts.owner_id
+
+
+@router.get("/health", response_model=Envelope[BotHealth])
+@envelope_errors
+async def get_health(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    scan_id: ScanIdQuery = None,
+    relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
+    service: HealthDiagnosisServiceProtocol = Injected(HealthDiagnosisServiceProtocol),
+) -> Envelope[BotHealth]:
+    """Return a requested diagnosis, or the latest completed diagnosis."""
+    resolved_owner = await _authorize(
+        relay=relay,
+        bot_id=bot_id,
+        actor_id=actor_id,
+        owner_id=owner_id,
+    )
+    if scan_id is None:
+        record = await service.get_recent(bot_id=bot_id, owner_id=resolved_owner)
+    else:
+        record = await service.get_by_id(
+            scan_id=scan_id,
+            bot_id=bot_id,
+            owner_id=resolved_owner,
+        )
+    return envelope(_project(bot_id, record), request)
+
+
+@router.post(
+    "/health-check",
+    status_code=202,
+    response_model=Envelope[HealthCheckAccepted],
+)
+@envelope_errors
+async def start_health_check(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
+    service: HealthDiagnosisServiceProtocol = Injected(HealthDiagnosisServiceProtocol),
+) -> Envelope[HealthCheckAccepted]:
+    """Start an asynchronous health diagnosis for an OpenClaw cloud Bot."""
+    resolved_owner = await _authorize(
+        relay=relay,
+        bot_id=bot_id,
+        actor_id=actor_id,
+        owner_id=owner_id,
+    )
+    result = await service.start(
+        bot_id=bot_id,
+        owner_id=resolved_owner,
+        operator_id=actor_id,
+    )
+    return accepted(HealthCheckAccepted.model_validate(result), request)
+
+
+__all__ = ["get_health", "router", "start_health_check"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/diagnostics/schemas.py
@@ -1,0 +1,117 @@
+"""Public contracts for Bot health diagnosis."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+HealthDiagnosisStatus = Literal[
+    "not_run",
+    "scanning",
+    "scan_completed",
+    "patching",
+    "completed",
+    "failed",
+]
+
+
+class HealthCheckItem(BaseModel):
+    """Progress or result for one diagnosed configuration area."""
+
+    name: str = Field(description="Configuration area or diagnostic rule name.")
+    status: str = Field(description="Current state of this diagnostic item.")
+    result: str | None = Field(
+        default=None,
+        description="Result such as pass, warning, fail, or error when available.",
+    )
+    score: int | None = Field(
+        default=None, ge=0, le=100, description="Item score from 0 to 100."
+    )
+    duration_ms: int | None = Field(
+        default=None, ge=0, description="Time spent on this item in milliseconds."
+    )
+
+
+class HealthFindingDetail(BaseModel):
+    """One issue discovered by the health diagnosis."""
+
+    rule_id: str = Field(description="Stable diagnostic rule identifier.")
+    name: str = Field(description="Diagnostic rule name.")
+    message: str = Field(description="Description of the issue and suggested action.")
+    risk_level: str = Field(description="Finding severity level.")
+    result: str = Field(description="Finding result such as warning or fail.")
+    score: int = Field(ge=0, le=100, description="Finding score from 0 to 100.")
+
+
+class HealthFindingGroup(BaseModel):
+    """Findings grouped by the configuration area that was checked."""
+
+    check_item: str = Field(description="Configuration area that was checked.")
+    findings: list[HealthFindingDetail] = Field(
+        description="Issues found in this configuration area."
+    )
+
+
+class BotHealth(BaseModel):
+    """Latest or explicitly requested Bot health diagnosis state."""
+
+    found: bool = Field(description="Whether a matching diagnosis exists.")
+    bot_id: str = Field(description="Stable Bot identifier.")
+    scan_id: int | None = Field(
+        default=None, description="Diagnosis identifier used for polling."
+    )
+    status: HealthDiagnosisStatus = Field(description="Diagnosis lifecycle state.")
+    health_score: int | None = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description="Overall health score from 0 to 100 when completed.",
+    )
+    grade: str | None = Field(
+        default=None,
+        description="Overall grade: excellent, good, warning, or critical.",
+    )
+    summary: dict[str, int] = Field(
+        default_factory=dict,
+        description="Aggregated finding counts by result category.",
+    )
+    check_items: list[HealthCheckItem] = Field(
+        default_factory=list,
+        description="Progress and result for each diagnosed configuration area.",
+    )
+    findings: list[HealthFindingGroup] = Field(
+        default_factory=list,
+        description="Detailed findings grouped by configuration area.",
+    )
+    failed_reason: str | None = Field(
+        default=None, description="Public failure reason when the diagnosis failed."
+    )
+    duration_ms: int | None = Field(
+        default=None,
+        ge=0,
+        description="Total diagnosis duration in milliseconds when available.",
+    )
+    created_at: datetime | None = Field(
+        default=None, description="Creation timestamp of the diagnosis."
+    )
+
+
+class HealthCheckAccepted(BaseModel):
+    """Acknowledgement for an asynchronously started health diagnosis."""
+
+    bot_id: str = Field(description="Stable Bot identifier.")
+    scan_id: int = Field(description="Diagnosis identifier used for polling.")
+    status: Literal["scanning"] = Field(description="Initial diagnosis state.")
+
+
+__all__ = [
+    "BotHealth",
+    "HealthCheckAccepted",
+    "HealthCheckItem",
+    "HealthDiagnosisStatus",
+    "HealthFindingDetail",
+    "HealthFindingGroup",
+]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -99,6 +99,11 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineUpstreamError,
 )
 from agentclaw.community.core.gateway_principal import PrincipalVerificationError
+from agentclaw.community.core.harness.errors import (
+    HealthDiagnosisConflictError,
+    HealthDiagnosisNotFoundError,
+    HealthDiagnosisUnavailableError,
+)
 from agentclaw.community.core.mcp.errors import (
     McpConfigValueError,
     McpHeadersInvalidError,
@@ -141,6 +146,9 @@ from agentclaw.community.plugin_api.auth_relationship import (
 )
 from agentclaw.community.plugin_api.passport import PassportError
 from agentclaw.community.core.service_bot.errors import (
+    ServiceContainerConflictError,
+    ServiceContainerNotFoundError,
+    ServiceContainerUpstreamError,
     ServicePublicationConflictError,
     ServicePublicationLockedError,
     ServicePublicationNotFoundError,
@@ -243,6 +251,15 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
         "Another authorization for this bot id is already live",
     ),
     BotPermissionError: (404, "Not found"),
+    ServiceContainerNotFoundError: (404, "Not found"),
+    ServiceContainerConflictError: (
+        409,
+        "Container is not in a valid state for this operation",
+    ),
+    ServiceContainerUpstreamError: (502, "Container service error"),
+    HealthDiagnosisNotFoundError: (404, "Not found"),
+    HealthDiagnosisConflictError: (409, "A health diagnosis is already running"),
+    HealthDiagnosisUnavailableError: (502, "Health diagnosis service error"),
     ServicePublicationNotFoundError: (404, "Not found"),
     LockNotHeldError: (404, "Not found"),
     LockReleaseDeniedError: (404, "Not found"),

--- a/src/backend/src/agentclaw/community/api/device_service.py
+++ b/src/backend/src/agentclaw/community/api/device_service.py
@@ -1,4 +1,5 @@
 """Service API Protocol for device allocation/lifecycle/inspection."""
+
 from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
@@ -37,5 +38,7 @@ class DeviceServiceProtocol(Protocol):
     def get_instances_by_bot(self, *args: Any, **kwargs: Any) -> Any: ...
 
     def restart_device(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def restart_device_by_bot(self, *args: Any, **kwargs: Any) -> Any: ...
 
     def get_device_connection_by_bot(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/src/backend/src/agentclaw/community/api/health_diagnosis_service.py
+++ b/src/backend/src/agentclaw/community/api/health_diagnosis_service.py
@@ -1,0 +1,36 @@
+"""Service API for Bot health diagnosis."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class HealthDiagnosisServiceProtocol(Protocol):
+    """Start and query persisted Bot health diagnoses."""
+
+    async def start(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        operator_id: str,
+    ) -> dict[str, Any]: ...
+
+    async def get_recent(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def get_by_id(
+        self,
+        *,
+        scan_id: int,
+        bot_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]: ...
+
+
+__all__ = ["HealthDiagnosisServiceProtocol"]

--- a/src/backend/src/agentclaw/community/api/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/api/service_publication_facade.py
@@ -87,3 +87,16 @@ class ServicePublicationFacadeProtocol(Protocol):
     def steal_lock(self, bot_id: str, *, actor_id: str, owner_id: str) -> Any: ...
 
     def get_lock(self, bot_id: str, *, actor_id: str, owner_id: str) -> Any: ...
+
+    def list_containers(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> dict[str, Any]: ...
+
+    def restart_container(
+        self,
+        bot_id: str,
+        instance_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]: ...

--- a/src/backend/src/agentclaw/community/core/devices/services/device_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_instance_service.py
@@ -392,3 +392,18 @@ class DeviceInstanceService:
             request_id=request_id,
         )
         return {"publish_id": data.get("publish_id")}
+
+    def restart_device_by_bot(
+        self,
+        *,
+        bot_id: str,
+        device_uuid: str,
+        operator: OperatorContext,
+    ) -> dict[str, Any]:
+        """Resolve the live binding for ``bot_id`` and restart one instance."""
+        binding_id = self._resolve_binding_id_by_bot_id(bot_id)
+        return self.restart_device(
+            binding_id=binding_id,
+            device_uuid=device_uuid,
+            operator=operator,
+        )

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service_router.py
@@ -963,3 +963,18 @@ class DeviceServiceRouter(DeviceService):
             device_uuid=device_uuid,
             operator=operator,
         )
+
+    @override
+    def restart_device_by_bot(
+        self,
+        *,
+        bot_id: str,
+        device_uuid: str,
+        operator: OperatorContext,
+    ) -> dict[str, Any]:
+        """指定 Bot 的运行实例重启。委托 DeviceInstanceService。"""
+        return self._instance_service().restart_device_by_bot(
+            bot_id=bot_id,
+            device_uuid=device_uuid,
+            operator=operator,
+        )

--- a/src/backend/src/agentclaw/community/core/harness/README.md
+++ b/src/backend/src/agentclaw/community/core/harness/README.md
@@ -16,11 +16,14 @@ consumes:
   - "WorkspacePathFactory"
   - "MCPCenterPlugin"
 internal_dependencies:
+  - agentclaw.community.api.content_scanner_service
+  - agentclaw.community.api.health_diagnosis_service
   - agentclaw.community.core.repository.protocols.harness    # repository contracts consumed by this module
   - agentclaw.community.core.services
   - agentclaw.community.core.skill_center
   - agentclaw.community.core.workspace
   - agentclaw.community.di.config
+  - agentclaw.community.log
   - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.mcp_center
   - agentclaw.community.plugin_api.models

--- a/src/backend/src/agentclaw/community/core/harness/errors.py
+++ b/src/backend/src/agentclaw/community/core/harness/errors.py
@@ -1,0 +1,25 @@
+"""Domain errors for public health diagnosis orchestration."""
+
+
+class HealthDiagnosisError(Exception):
+    """Base class for health diagnosis failures."""
+
+
+class HealthDiagnosisConflictError(HealthDiagnosisError):
+    """A recent diagnosis is already running for the Bot."""
+
+
+class HealthDiagnosisNotFoundError(HealthDiagnosisError):
+    """The requested diagnosis is absent or outside the authorized Bot scope."""
+
+
+class HealthDiagnosisUnavailableError(HealthDiagnosisError):
+    """Diagnosis persistence is temporarily unavailable."""
+
+
+__all__ = [
+    "HealthDiagnosisConflictError",
+    "HealthDiagnosisError",
+    "HealthDiagnosisNotFoundError",
+    "HealthDiagnosisUnavailableError",
+]

--- a/src/backend/src/agentclaw/community/core/harness/services/health_diagnosis_service.py
+++ b/src/backend/src/agentclaw/community/core/harness/services/health_diagnosis_service.py
@@ -1,0 +1,173 @@
+"""Persisted asynchronous orchestration around the existing content scanner."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from injector import inject
+
+from agentclaw.community.api.content_scanner_service import ContentScannerProtocol
+from agentclaw.community.api.health_diagnosis_service import (
+    HealthDiagnosisServiceProtocol,
+)
+from agentclaw.community.core.harness.errors import (
+    HealthDiagnosisConflictError,
+    HealthDiagnosisNotFoundError,
+    HealthDiagnosisUnavailableError,
+)
+from agentclaw.community.core.harness.models import FindingsReport, Layer
+from agentclaw.community.core.repository.protocols.harness import (
+    HarnessScanRecordRepository,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+logger = get_logger()
+
+
+class HealthDiagnosisService(HealthDiagnosisServiceProtocol):
+    """Run the existing health scanner and persist its lifecycle."""
+
+    @inject
+    def __init__(
+        self,
+        scanner: ContentScannerProtocol,
+        scan_repo: HarnessScanRecordRepository,
+    ) -> None:
+        self._scanner = scanner
+        self._scan_repo = scan_repo
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    async def start(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        operator_id: str,
+    ) -> dict[str, Any]:
+        """Create a scan record and launch the existing scanner asynchronously."""
+        try:
+            active = await asyncio.to_thread(
+                self._scan_repo.has_active_scan,
+                bot_id,
+                owner_id,
+                5,
+            )
+            if active:
+                raise HealthDiagnosisConflictError(
+                    "a health diagnosis is already running"
+                )
+
+            initial = FindingsReport(
+                bot_id=bot_id,
+                entity_id=owner_id,
+                scan_type="full",
+                layer=Layer.L1,
+                trigger_source="openapi",
+                status="scanning",
+            )
+            scan_id = await asyncio.to_thread(self._scan_repo.create, initial)
+        except HealthDiagnosisConflictError:
+            raise
+        except Exception as exc:
+            raise HealthDiagnosisUnavailableError(
+                "health diagnosis storage is unavailable"
+            ) from exc
+
+        task = asyncio.create_task(
+            self._run(
+                scan_id=scan_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                operator_id=operator_id,
+            ),
+            name=f"health-diagnosis-{scan_id}",
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return {"scan_id": scan_id, "bot_id": bot_id, "status": "scanning"}
+
+    async def _run(
+        self,
+        *,
+        scan_id: int,
+        bot_id: str,
+        owner_id: str,
+        operator_id: str,
+    ) -> None:
+        try:
+            report = await self._scanner.scan(
+                entity_type="staff",
+                entity_id=owner_id,
+                bot_id=bot_id,
+                operator_id=operator_id,
+            )
+            report.status = "completed"
+            await asyncio.to_thread(self._scan_repo.complete, scan_id, report)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "health diagnosis failed for bot=%s scan_id=%s", bot_id, scan_id
+            )
+            try:
+                await asyncio.to_thread(
+                    self._scan_repo.update_status,
+                    scan_id,
+                    "failed",
+                    "Health diagnosis failed",
+                )
+            except Exception:
+                logger.exception(
+                    "failed to persist health diagnosis failure for scan_id=%s",
+                    scan_id,
+                )
+
+    async def get_recent(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> dict[str, Any] | None:
+        try:
+            return await asyncio.to_thread(
+                self._scan_repo.get_recent,
+                bot_id,
+                owner_id,
+                "full",
+                Layer.L1.value,
+            )
+        except Exception as exc:
+            raise HealthDiagnosisUnavailableError(
+                "health diagnosis storage is unavailable"
+            ) from exc
+
+    async def get_by_id(
+        self,
+        *,
+        scan_id: int,
+        bot_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]:
+        try:
+            record = await asyncio.to_thread(self._scan_repo.get_by_id, scan_id)
+        except Exception as exc:
+            raise HealthDiagnosisUnavailableError(
+                "health diagnosis storage is unavailable"
+            ) from exc
+
+        # COSEC: scan ids are globally enumerable. Bind the record to the Bot and
+        # resolved owner that already passed authorization before returning it.
+        if (
+            record is None
+            or str(record.get("bot_id") or "") != bot_id
+            or str(record.get("entity_id") or "") != owner_id
+            or str(record.get("env") or "") != get_current_env()
+        ):
+            raise HealthDiagnosisNotFoundError("health diagnosis not found")
+        return record
+
+
+__all__ = ["HealthDiagnosisService"]

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -22,6 +22,7 @@ consumes:
   - "SystemConfig"
   - "PassportPlugin"
 internal_dependencies:
+  - agentclaw.community.api.device_service    # device instance list and restart Service API used by the public lifecycle facade
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.devices    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.publishing    # repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/service_bot/errors.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/errors.py
@@ -19,3 +19,15 @@ class ServicePublicationLockedError(ServicePublicationError):
 
 class ServicePublicationUnsupportedError(ServicePublicationError):
     """The Bot cannot participate in the service publication lifecycle."""
+
+
+class ServiceContainerNotFoundError(ServicePublicationError):
+    """The addressed service-Bot container is absent or hidden."""
+
+
+class ServiceContainerConflictError(ServicePublicationError):
+    """The container operation conflicts with its current runtime state."""
+
+
+class ServiceContainerUpstreamError(ServicePublicationError):
+    """The runtime provider failed while serving a container operation."""

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
+from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
     CollaboratorLockService,
@@ -25,6 +26,16 @@ from agentclaw.community.core.bot_inventory.policies.combo_policy import (
     assert_service_upgrade,
 )
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.devices.errors import (
+    DeviceServiceError,
+    InvalidDeviceStatusError,
+)
+from agentclaw.community.core.devices.models import OperatorContext
+from agentclaw.community.core.devices.services.device_instance_service import (
+    BindingNotFoundError,
+    BotPublishNotFoundError,
+    InstanceHealthStatus,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.publishing import (
     BotPublishRepositoryProtocol,
@@ -34,6 +45,9 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.errors import (
+    ServiceContainerConflictError,
+    ServiceContainerNotFoundError,
+    ServiceContainerUpstreamError,
     ServicePublicationConflictError,
     ServicePublicationLockedError,
     ServicePublicationNotFoundError,
@@ -42,6 +56,7 @@ from agentclaw.community.core.service_bot.errors import (
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     BotPublishService,
 )
+from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 from agentclaw.community.core.service_bot.services.publish_approval_service import (
     PublishApprovalService,
 )
@@ -88,6 +103,7 @@ class ServicePublicationFacade:
         collaborator_service: CollaboratorService,
         lock_service: CollaboratorLockService,
         bot_service: BotService,
+        device_service: DeviceServiceProtocol,
     ) -> None:
         self._bot_repo = bot_repo
         self._publish_repo = publish_repo
@@ -97,6 +113,7 @@ class ServicePublicationFacade:
         self._collaborator_service = collaborator_service
         self._lock_service = lock_service
         self._bot_service = bot_service
+        self._device_service = device_service
 
     def _resolve_bot(
         self,
@@ -307,6 +324,82 @@ class ServicePublicationFacade:
             for record in self._visible_records(records)
         ]
         return {"bot_id": bot_id, "items": cards}
+
+    def list_containers(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> dict[str, Any]:
+        """Return live service-Bot instances after collaborator authorization."""
+        self._resolve_bot(bot_id, actor_id=actor_id, owner_id=owner_id)
+        try:
+            result = self._device_service.get_instances_by_bot(
+                bot_id=bot_id,
+                health_check=True,
+            )
+        except (BotPublishNotFoundError, BindingNotFoundError) as exc:
+            raise ServiceContainerConflictError("service runtime is not live") from exc
+        except (DeviceServiceError, BaasServiceError) as exc:
+            raise ServiceContainerUpstreamError("container provider failed") from exc
+        return {"bot_id": bot_id, "instances": result.get("devices", [])}
+
+    def restart_container(
+        self,
+        bot_id: str,
+        instance_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]:
+        """Restart one abnormal live instance; only the Bot owner may do so."""
+        self._resolve_bot(
+            bot_id,
+            actor_id=actor_id,
+            owner_id=owner_id,
+            required_level=PermissionLevel.OWNER,
+        )
+        current = self.list_containers(
+            bot_id,
+            actor_id=actor_id,
+            owner_id=owner_id,
+        )
+        instance = next(
+            (
+                item
+                for item in current["instances"]
+                if item.get("device_uuid") == instance_id
+            ),
+            None,
+        )
+        # COSEC: bind the path instance id to the authorized Bot's live device
+        # inventory before forwarding it to BaaS; an instance id is not authority.
+        if instance is None:
+            raise ServiceContainerNotFoundError("container not found")
+        if instance.get("health_status") != InstanceHealthStatus.ABNORMAL:
+            raise ServiceContainerConflictError("only abnormal containers may restart")
+
+        operator = OperatorContext(
+            staff_id=actor_id,
+            staff=actor_id,
+            nick_name=actor_id,
+            operator_name=actor_id,
+        )
+        try:
+            result = self._device_service.restart_device_by_bot(
+                bot_id=bot_id,
+                device_uuid=instance_id,
+                operator=operator,
+            )
+        except (BotPublishNotFoundError, BindingNotFoundError) as exc:
+            raise ServiceContainerConflictError("service runtime is not live") from exc
+        except InvalidDeviceStatusError as exc:
+            raise ServiceContainerNotFoundError("container not found") from exc
+        except (DeviceServiceError, BaasServiceError) as exc:
+            raise ServiceContainerUpstreamError("container provider failed") from exc
+        return {
+            "bot_id": bot_id,
+            "instance_id": instance_id,
+            "publish_id": result.get("publish_id"),
+            "accepted": True,
+        }
 
     def get_publication(
         self,

--- a/src/backend/src/agentclaw/community/di/modules/harness_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/harness_module.py
@@ -13,6 +13,9 @@ from typing import Annotated
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.content_scanner_service import ContentScannerProtocol
+from agentclaw.community.api.health_diagnosis_service import (
+    HealthDiagnosisServiceProtocol,
+)
 from agentclaw.community.api.patch_engine_service import PatchEngineProtocol
 from agentclaw.community.api.patch_library_service import PatchLibraryProtocol
 from agentclaw.community.api.patch_planner_service import PatchPlannerProtocol
@@ -22,6 +25,9 @@ from agentclaw.community.core.repository.protocols.harness import HarnessPatchRe
 from agentclaw.community.core.repository.protocols.harness import HarnessPatchRecordRepository
 from agentclaw.community.core.harness.services.bot_profile import BotProfile
 from agentclaw.community.core.harness.services.content_scanner import ContentScanner
+from agentclaw.community.core.harness.services.health_diagnosis_service import (
+    HealthDiagnosisService,
+)
 from agentclaw.community.core.harness.services.llm import LLM
 from agentclaw.community.di.config import BcsFuseConfig, KbConfig, LLMHarnessConfig
 from agentclaw.community.plugin_api.http_client import HttpClient, QUALIFIER_GENERAL
@@ -192,6 +198,15 @@ class HarnessModule(Module):
     @provider
     @inject
     def _content_scanner_protocol(self, svc: ContentScanner) -> ContentScannerProtocol:
+        return svc
+
+    @singleton
+    @provider
+    @inject
+    def _health_diagnosis_protocol(
+        self,
+        svc: HealthDiagnosisService,
+    ) -> HealthDiagnosisServiceProtocol:
         return svc
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -37,6 +37,7 @@ from agentclaw.community.api.bot_startup_script_service import (
 )
 from agentclaw.community.api.bot_publish_service import BotPublishServiceProtocol
 from agentclaw.community.api.channel_service import ChannelServiceProtocol
+from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.api.publish_flow_service import PublishFlowServiceProtocol
 from agentclaw.community.api.publish_approval import PublishApprovalServiceProtocol
 from agentclaw.community.api.service_publication_facade import (
@@ -602,6 +603,7 @@ class ServiceBotModule(Module):
         collaborator_service: CollaboratorServiceProtocol,
         lock_service: CollaboratorLockServiceProtocol,
         bot_service: BotService,
+        device_service: DeviceServiceProtocol,
     ) -> ServicePublicationFacade:
         """Construct the public publication facade from existing domain services."""
         return ServicePublicationFacade(
@@ -613,6 +615,7 @@ class ServiceBotModule(Module):
             collaborator_service=collaborator_service,
             lock_service=lock_service,
             bot_service=bot_service,
+            device_service=device_service,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -106,6 +106,10 @@ _OWNER_ADDRESSED_ELSEWHERE = {
     ("post", "/openapi/v1/bots/{bot_id}/edit-lock"),
     ("delete", "/openapi/v1/bots/{bot_id}/edit-lock"),
     ("post", "/openapi/v1/bots/{bot_id}/edit-lock/steal"),
+    ("get", "/openapi/v1/bots/{bot_id}/containers"),
+    ("post", "/openapi/v1/bots/{bot_id}/containers/{instance_id}/restart"),
+    ("get", "/openapi/v1/bots/{bot_id}/diagnostics/health"),
+    ("post", "/openapi/v1/bots/{bot_id}/diagnostics/health-check"),
 }
 
 
@@ -299,8 +303,8 @@ def test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations():
     assert sorted(carrying_owner) == sorted(
         set(engine_runtime) | _OWNER_ADDRESSED_ELSEWHERE
     ), (
-        "owner_id belongs to the engine-runtime operations, the three "
-        "authorization operations, and to nothing else by accident"
+        "owner_id belongs to engine-runtime and the explicitly listed "
+        "owner-addressed operations, and to nothing else by accident"
     )
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_container_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_container_endpoints.py
@@ -1,0 +1,104 @@
+"""Public service-Bot container endpoint contract tests."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.containers.router import (
+    list_containers,
+    restart_container,
+)
+
+
+def request(method: str = "GET") -> Request:
+    req = Request({"type": "http", "method": method, "path": "/"})
+    req.state.trace_id = "trace-1"
+    return req
+
+
+def instances() -> list[dict]:
+    return [
+        {
+            "device_uuid": "DEVICE-1",
+            "status": "ACTIVE",
+            "health_status": "ACTIVE",
+            "engine_type": "openclaw",
+            "provider_type": "arca",
+            "provider_device_id": "ARCA-1",
+            "gmt_create": "2026-08-18T09:00:00Z",
+        },
+        {
+            "device_uuid": "DEVICE-2",
+            "status": "FAILED",
+            "health_status": "ABNORMAL",
+            "engine_type": "hermes",
+        },
+        {
+            "device_uuid": "DEVICE-3",
+            "status": "UPDATING",
+            "health_status": "RESTARTING",
+            "engine_type": "claude-code",
+        },
+        {
+            "device_uuid": "DEVICE-4",
+            "status": "ACTIVE",
+            "health_status": "unexpected",
+            "engine_type": "openclaw",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_containers_projects_summary_and_nullable_metrics():
+    facade = Mock()
+    facade.list_containers.return_value = {
+        "bot_id": "bot-1",
+        "instances": instances(),
+    }
+
+    response = await list_containers(
+        "bot-1", request(), "member", "owner", facade
+    )
+
+    assert response.request_id == "trace-1"
+    assert response.data.summary.model_dump() == {
+        "total": 4,
+        "healthy": 1,
+        "abnormal": 1,
+        "restarting": 1,
+        "unknown": 1,
+    }
+    first = response.data.instances[0]
+    assert first.id == "DEVICE-1"
+    assert first.provider_instance_id == "ARCA-1"
+    assert first.node is None and first.cpu is None and first.memory is None
+    facade.list_containers.assert_called_once_with(
+        "bot-1", actor_id="member", owner_id="owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_container_returns_accepted_operation():
+    facade = Mock()
+    facade.restart_container.return_value = {
+        "bot_id": "bot-1",
+        "instance_id": "DEVICE-2",
+        "publish_id": 42,
+        "accepted": True,
+    }
+
+    response = await restart_container(
+        "bot-1", "DEVICE-2", request("POST"), "owner", "owner", facade
+    )
+
+    assert response.code == 202000
+    assert response.data.publish_id == 42
+    facade.restart_container.assert_called_once_with(
+        "bot-1",
+        "DEVICE-2",
+        actor_id="owner",
+        owner_id="owner",
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -318,9 +318,9 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #:
 #: The component-first service lifecycle and edit-lock surfaces add 14
 #: bot-addressed operations while leaving query and account-level operations
-#: unchanged. ``GET /{bot_id}/data-init`` adds one more — the status read
-#: sibling to the existing POST trigger.
-_BOT_ID_PLACEMENT = {"path": 77, "query": 1, "none": 21}
+#: unchanged. ``GET /{bot_id}/data-init`` adds one more, then the container and
+#: health-diagnosis surfaces add four more bot-addressed operations.
+_BOT_ID_PLACEMENT = {"path": 81, "query": 1, "none": 21}
 
 
 def _schema() -> dict:
@@ -399,14 +399,14 @@ def test_the_pinned_number_of_operations_take_it():
     POST /{bot_id}/data-init trigger, passport fields, /openapi/v1/bots/all).
     88 → 89 adds the GET /{bot_id}/data-init status read — the polling sibling
     to the POST trigger, also user-scoped.
+    89 → 93 adds the two container and two health-diagnosis operations.
     """
     taking = [
         1
         for path, method, operation in _current_operations(_schema())
         if _user_scoped(path, method) and _param(operation, USER_ID_QUERY)
     ]
-    # The service lifecycle and edit-lock surfaces add 14 user-scoped routes.
-    assert len(taking) == 89
+    assert len(taking) == 93
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_health_diagnostics_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_health_diagnostics_endpoints.py
@@ -1,0 +1,199 @@
+"""Public health diagnosis endpoint contract tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.diagnostics.router import (
+    get_health,
+    start_health_check,
+)
+from agentclaw.community.core.engine_runtime.models import BotFacts
+
+
+def request(method: str = "GET") -> Request:
+    req = Request({"type": "http", "method": method, "path": "/"})
+    req.state.trace_id = "trace-health"
+    return req
+
+
+def relay(engine: str = "openclaw") -> AsyncMock:
+    value = AsyncMock()
+    value.resolve_bot_off_loop.return_value = BotFacts(
+        bot_id="bot-1",
+        bot_type="service",
+        active_engine=engine,
+        owner_id="owner",
+    )
+    return value
+
+
+@pytest.mark.asyncio
+async def test_get_latest_health_projects_completed_result():
+    service = AsyncMock()
+    service.get_recent.return_value = {
+        "id": 17,
+        "status": "completed",
+        "health_score": 86,
+        "score_grade": "good",
+        "findings_summary": {"warning": 1},
+        "check_items": [
+            {"rule_id": "D-1", "rule_name": "Agent role", "severity": "warning"}
+        ],
+        "findings": [
+            {
+                "check_item": "AGENTS.md",
+                "finding_details": [
+                    {
+                        "rule_id": "D-1",
+                        "name": "Agent role",
+                        "message": "Role is incomplete",
+                        "risk_level": "warning",
+                        "result": "warning",
+                        "score": 86,
+                    }
+                ],
+            }
+        ],
+        "duration_ms": 1200,
+        "gmt_create": "2026-08-18T10:00:00",
+    }
+
+    response = await get_health(
+        "bot-1", request(), "member", "owner", None, relay(), service
+    )
+
+    assert response.request_id == "trace-health"
+    assert response.data.health_score == 86
+    assert response.data.grade == "good"
+    assert response.data.check_items[0].name == "Agent role"
+    assert response.data.findings[0].findings[0].rule_id == "D-1"
+    service.get_recent.assert_awaited_once_with(bot_id="bot-1", owner_id="owner")
+
+
+@pytest.mark.asyncio
+async def test_get_health_by_scan_id_supports_polling():
+    service = AsyncMock()
+    service.get_by_id.return_value = {
+        "id": 18,
+        "status": "scanning",
+        "findings_summary": {},
+        "check_items": [],
+        "findings": [],
+    }
+
+    response = await get_health(
+        "bot-1", request(), "member", "owner", 18, relay(), service
+    )
+
+    assert response.data.status == "scanning"
+    assert response.data.health_score is None
+    service.get_by_id.assert_awaited_once_with(
+        scan_id=18, bot_id="bot-1", owner_id="owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_health_check_does_not_publish_internal_failure_detail():
+    service = AsyncMock()
+    service.get_by_id.return_value = {
+        "id": 18,
+        "status": "failed",
+        "failed_reason": "database host and secret detail",
+    }
+
+    response = await get_health(
+        "bot-1", request(), "owner", "owner", 18, relay(), service
+    )
+
+    assert response.data.failed_reason == "Health diagnosis failed"
+
+
+@pytest.mark.asyncio
+async def test_system_finding_does_not_publish_upstream_exception_detail():
+    service = AsyncMock()
+    service.get_by_id.return_value = {
+        "id": 18,
+        "status": "completed",
+        "findings": [
+            {
+                "check_item": "_unknown",
+                "finding_details": [
+                    {
+                        "rule_id": "SYS02",
+                        "name": "Diagnostic failed",
+                        "message": "connection failed with secret=internal-value",
+                        "risk_level": "critical",
+                        "result": "fail",
+                        "score": 0,
+                    }
+                ],
+            }
+        ],
+    }
+
+    response = await get_health(
+        "bot-1", request(), "owner", "owner", 18, relay(), service
+    )
+
+    assert response.data.findings[0].findings[0].message == "Diagnostic item failed"
+
+
+@pytest.mark.asyncio
+async def test_get_health_returns_not_run_when_no_completed_result_exists():
+    service = AsyncMock()
+    service.get_recent.return_value = None
+
+    response = await get_health(
+        "bot-1", request(), "owner", "owner", None, relay(), service
+    )
+
+    assert response.data.model_dump() == {
+        "found": False,
+        "bot_id": "bot-1",
+        "scan_id": None,
+        "status": "not_run",
+        "health_score": None,
+        "grade": None,
+        "summary": {},
+        "check_items": [],
+        "findings": [],
+        "failed_reason": None,
+        "duration_ms": None,
+        "created_at": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_health_check_returns_accepted_scan():
+    service = AsyncMock()
+    service.start.return_value = {
+        "bot_id": "bot-1",
+        "scan_id": 19,
+        "status": "scanning",
+    }
+
+    response = await start_health_check(
+        "bot-1", request("POST"), "member", "owner", relay(), service
+    )
+
+    assert response.code == 202000
+    assert response.data.scan_id == 19
+    service.start.assert_awaited_once_with(
+        bot_id="bot-1", owner_id="owner", operator_id="member"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_openclaw_bot_is_refused_before_diagnosis_access():
+    service = AsyncMock()
+
+    response = await get_health(
+        "bot-1", request(), "owner", "owner", None, relay("hermes"), service
+    )
+
+    assert response.status_code == 409
+    service.get_recent.assert_not_awaited()

--- a/src/backend/tests/community/core/devices/services/test_multi_instance.py
+++ b/src/backend/tests/community/core/devices/services/test_multi_instance.py
@@ -487,6 +487,41 @@ def test_restart_device_no_baas_service_raises():
         )
 
 
+def test_restart_device_by_bot_resolves_live_binding_then_restarts():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _make_record(
+        id=1001, device_id="bot-uuid-abc", entity_id="owner-001"
+    )
+    publish_repo = MagicMock()
+    publish_repo.get_latest_success_by_source_bot_id.return_value = _make_publish_record(
+        ext={"binding": {"online": 1001}}
+    )
+    baas = MagicMock()
+    baas.restart_devices.return_value = {"publish_id": 43}
+    router = _make_router(
+        repo=repo,
+        baas_service=baas,
+        publish_repo=publish_repo,
+    )
+
+    result = router.restart_device_by_bot(
+        bot_id="bot-001",
+        device_uuid="DEVICE-001",
+        operator=_make_operator("owner-001"),
+    )
+
+    assert result == {"publish_id": 43}
+    publish_repo.get_latest_success_by_source_bot_id.assert_called_once_with(
+        "bot-001", "dev"
+    )
+    baas.restart_devices.assert_called_once_with(
+        "bot-uuid-abc",
+        device_uuids=["DEVICE-001"],
+        operator="owner-001",
+        request_id="restart_dev_b1001_DEVICE-001",
+    )
+
+
 # ---------------------------------------------------------------------------
 # get_device_connection_by_bot (bot_id entry, ext.binding.online) — §3
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/core/harness/test_health_diagnosis_service.py
+++ b/src/backend/tests/community/core/harness/test_health_diagnosis_service.py
@@ -1,0 +1,125 @@
+"""Health diagnosis orchestration tests."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agentclaw.community.core.harness.errors import (
+    HealthDiagnosisConflictError,
+    HealthDiagnosisNotFoundError,
+    HealthDiagnosisUnavailableError,
+)
+from agentclaw.community.core.harness.models import FindingsReport
+from agentclaw.community.core.harness.services.health_diagnosis_service import (
+    HealthDiagnosisService,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+@pytest.mark.asyncio
+async def test_start_persists_and_completes_existing_scanner_report():
+    scanner = AsyncMock()
+    scanner.scan.return_value = FindingsReport(
+        bot_id="bot-1",
+        entity_id="owner",
+        health_score=92,
+        score_grade="excellent",
+    )
+    repo = Mock()
+    repo.has_active_scan.return_value = False
+    repo.create.return_value = 7
+    service = HealthDiagnosisService(scanner, repo)
+
+    result = await service.start(bot_id="bot-1", owner_id="owner", operator_id="member")
+    await asyncio.gather(*tuple(service._tasks))
+
+    assert result == {"scan_id": 7, "bot_id": "bot-1", "status": "scanning"}
+    repo.create.assert_called_once()
+    scanner.scan.assert_awaited_once_with(
+        entity_type="staff",
+        entity_id="owner",
+        bot_id="bot-1",
+        operator_id="member",
+    )
+    completed = repo.complete.call_args.args[1]
+    assert completed.status == "completed"
+    assert completed.health_score == 92
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_recent_active_scan():
+    repo = Mock()
+    repo.has_active_scan.return_value = True
+    service = HealthDiagnosisService(AsyncMock(), repo)
+
+    with pytest.raises(HealthDiagnosisConflictError):
+        await service.start(bot_id="bot-1", owner_id="owner", operator_id="owner")
+
+    repo.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_normalizes_repository_failure():
+    repo = Mock()
+    repo.has_active_scan.side_effect = RuntimeError("database detail")
+    service = HealthDiagnosisService(AsyncMock(), repo)
+
+    with pytest.raises(HealthDiagnosisUnavailableError):
+        await service.start(bot_id="bot-1", owner_id="owner", operator_id="owner")
+
+
+@pytest.mark.asyncio
+async def test_failed_scan_is_persisted_without_leaking_exception_text():
+    scanner = AsyncMock()
+    scanner.scan.side_effect = RuntimeError("sensitive upstream detail")
+    repo = Mock()
+    service = HealthDiagnosisService(scanner, repo)
+
+    await service._run(scan_id=8, bot_id="bot-1", owner_id="owner", operator_id="owner")
+
+    repo.update_status.assert_called_once_with(8, "failed", "Health diagnosis failed")
+
+
+@pytest.mark.asyncio
+async def test_scan_id_is_bound_to_authorized_bot_and_owner():
+    repo = Mock()
+    repo.get_by_id.return_value = {
+        "id": 9,
+        "bot_id": "other-bot",
+        "entity_id": "owner",
+    }
+    service = HealthDiagnosisService(AsyncMock(), repo)
+
+    with pytest.raises(HealthDiagnosisNotFoundError):
+        await service.get_by_id(scan_id=9, bot_id="bot-1", owner_id="owner")
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_record_in_authorized_environment():
+    repo = Mock()
+    repo.get_by_id.return_value = {
+        "id": 9,
+        "bot_id": "bot-1",
+        "entity_id": "owner",
+        "env": get_current_env(),
+    }
+    service = HealthDiagnosisService(AsyncMock(), repo)
+
+    result = await service.get_by_id(scan_id=9, bot_id="bot-1", owner_id="owner")
+
+    assert result["id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_get_recent_uses_bot_owner_and_fixed_diagnosis_scope():
+    repo = Mock()
+    repo.get_recent.return_value = {"id": 10}
+    service = HealthDiagnosisService(AsyncMock(), repo)
+
+    result = await service.get_recent(bot_id="bot-1", owner_id="owner")
+
+    assert result == {"id": 10}
+    repo.get_recent.assert_called_once_with("bot-1", "owner", "full", "L1")

--- a/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
@@ -13,10 +13,20 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.service_bot.errors import (
+    ServiceContainerConflictError,
+    ServiceContainerNotFoundError,
+    ServiceContainerUpstreamError,
     ServicePublicationConflictError,
     ServicePublicationLockedError,
     ServicePublicationNotFoundError,
     ServicePublicationUnsupportedError,
+)
+from agentclaw.community.core.devices.errors import (
+    DeviceServiceError,
+    InvalidDeviceStatusError,
+)
+from agentclaw.community.core.devices.services.device_instance_service import (
+    BotPublishNotFoundError,
 )
 from agentclaw.community.core.service_bot.services.service_publication_facade import (
     ServicePublicationFacade,
@@ -64,6 +74,7 @@ def deps():
         collaborator_service=Mock(),
         lock_service=Mock(),
         bot_service=Mock(),
+        device_service=Mock(),
     )
     values.bot_repo.get_by_id_and_owner.return_value = {
         "id": 10,
@@ -91,6 +102,7 @@ def deps():
         collaborator_service=values.collaborator_service,
         lock_service=values.lock_service,
         bot_service=values.bot_service,
+        device_service=values.device_service,
     )
     return values
 
@@ -116,6 +128,134 @@ def test_list_projects_latest_two_and_deduplicates_released(deps, monkeypatch):
     assert result["items"][0]["live_version"] == 5
     assert result["items"][0]["card_id"] == "service:bot-1:5"
     assert result["items"][1]["available_actions"] == ["publish_staging"]
+
+
+def _container(health_status: str = "ABNORMAL") -> dict:
+    return {
+        "device_uuid": "DEVICE-001",
+        "status": "FAILED",
+        "health_status": health_status,
+        "engine_type": "openclaw",
+    }
+
+
+def test_list_containers_authorizes_and_requests_realtime_health(deps):
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.MEMBER
+    deps.device_service.get_instances_by_bot.return_value = {
+        "bot_uuid": "runtime-1",
+        "devices": [_container()],
+    }
+
+    result = deps.facade.list_containers("bot-1", actor_id="member", owner_id="owner")
+
+    assert result == {"bot_id": "bot-1", "instances": [_container()]}
+    deps.device_service.get_instances_by_bot.assert_called_once_with(
+        bot_id="bot-1", health_check=True
+    )
+
+
+def test_list_containers_masks_provider_failure(deps):
+    deps.device_service.get_instances_by_bot.side_effect = DeviceServiceError("secret")
+
+    with pytest.raises(ServiceContainerUpstreamError):
+        deps.facade.list_containers("bot-1", actor_id="owner", owner_id="owner")
+
+
+def test_list_containers_reports_missing_live_runtime_as_conflict(deps):
+    deps.device_service.get_instances_by_bot.side_effect = BotPublishNotFoundError(
+        "missing"
+    )
+
+    with pytest.raises(ServiceContainerConflictError):
+        deps.facade.list_containers("bot-1", actor_id="owner", owner_id="owner")
+
+
+def test_restart_container_accepts_owned_abnormal_instance(deps):
+    deps.device_service.get_instances_by_bot.return_value = {"devices": [_container()]}
+    deps.device_service.restart_device_by_bot.return_value = {"publish_id": 42}
+
+    result = deps.facade.restart_container(
+        "bot-1",
+        "DEVICE-001",
+        actor_id="owner",
+        owner_id="owner",
+    )
+
+    assert result == {
+        "bot_id": "bot-1",
+        "instance_id": "DEVICE-001",
+        "publish_id": 42,
+        "accepted": True,
+    }
+    call = deps.device_service.restart_device_by_bot.call_args
+    assert call.kwargs["bot_id"] == "bot-1"
+    assert call.kwargs["device_uuid"] == "DEVICE-001"
+    assert call.kwargs["operator"].staff_id == "owner"
+
+
+def test_restart_container_refuses_instance_from_another_bot(deps):
+    deps.device_service.get_instances_by_bot.return_value = {"devices": [_container()]}
+
+    with pytest.raises(ServiceContainerNotFoundError):
+        deps.facade.restart_container(
+            "bot-1",
+            "DEVICE-OTHER",
+            actor_id="owner",
+            owner_id="owner",
+        )
+
+    deps.device_service.restart_device_by_bot.assert_not_called()
+
+
+def test_restart_container_refuses_healthy_instance(deps):
+    deps.device_service.get_instances_by_bot.return_value = {
+        "devices": [_container("ACTIVE")]
+    }
+
+    with pytest.raises(ServiceContainerConflictError):
+        deps.facade.restart_container(
+            "bot-1",
+            "DEVICE-001",
+            actor_id="owner",
+            owner_id="owner",
+        )
+
+
+def test_restart_container_requires_owner(deps):
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.MEMBER
+
+    with pytest.raises(ServicePublicationNotFoundError):
+        deps.facade.restart_container(
+            "bot-1",
+            "DEVICE-001",
+            actor_id="member",
+            owner_id="owner",
+        )
+
+    deps.device_service.get_instances_by_bot.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (BotPublishNotFoundError("missing"), ServiceContainerConflictError),
+        (InvalidDeviceStatusError("mismatch"), ServiceContainerNotFoundError),
+        (DeviceServiceError("upstream"), ServiceContainerUpstreamError),
+    ],
+)
+def test_restart_container_normalizes_runtime_failures(deps, failure, expected):
+    deps.device_service.get_instances_by_bot.return_value = {
+        "devices": [_container()]
+    }
+    deps.device_service.restart_device_by_bot.side_effect = failure
+
+    with pytest.raises(expected):
+        deps.facade.restart_container(
+            "bot-1",
+            "DEVICE-001",
+            actor_id="owner",
+            owner_id="owner",
+        )
 
 
 @pytest.mark.parametrize(

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -439,6 +439,141 @@
         "title": "BotCreate",
         "type": "object"
       },
+      "BotHealth": {
+        "description": "Latest or explicitly requested Bot health diagnosis state.",
+        "properties": {
+          "bot_id": {
+            "description": "Stable Bot identifier.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "check_items": {
+            "description": "Progress and result for each diagnosed configuration area.",
+            "items": {
+              "$ref": "#/components/schemas/HealthCheckItem"
+            },
+            "title": "Check Items",
+            "type": "array"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Creation timestamp of the diagnosis.",
+            "title": "Created At"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Total diagnosis duration in milliseconds when available.",
+            "title": "Duration Ms"
+          },
+          "failed_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Public failure reason when the diagnosis failed.",
+            "title": "Failed Reason"
+          },
+          "findings": {
+            "description": "Detailed findings grouped by configuration area.",
+            "items": {
+              "$ref": "#/components/schemas/HealthFindingGroup"
+            },
+            "title": "Findings",
+            "type": "array"
+          },
+          "found": {
+            "description": "Whether a matching diagnosis exists.",
+            "title": "Found",
+            "type": "boolean"
+          },
+          "grade": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Overall grade: excellent, good, warning, or critical.",
+            "title": "Grade"
+          },
+          "health_score": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Overall health score from 0 to 100 when completed.",
+            "title": "Health Score"
+          },
+          "scan_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Diagnosis identifier used for polling.",
+            "title": "Scan Id"
+          },
+          "status": {
+            "description": "Diagnosis lifecycle state.",
+            "enum": [
+              "not_run",
+              "scanning",
+              "scan_completed",
+              "patching",
+              "completed",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "Aggregated finding counts by result category.",
+            "title": "Summary",
+            "type": "object"
+          }
+        },
+        "required": [
+          "found",
+          "bot_id",
+          "status"
+        ],
+        "title": "BotHealth",
+        "type": "object"
+      },
       "BotInventoryItem": {
         "description": "Unified card for a personal cloud, local, or service bot.",
         "properties": {
@@ -830,6 +965,231 @@
           "sockets"
         ],
         "title": "Connection",
+        "type": "object"
+      },
+      "ContainerInstance": {
+        "description": "One runtime instance backing a service Bot.",
+        "properties": {
+          "cpu": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "CPU usage or allocation; null until BaaS exposes metrics.",
+            "title": "Cpu"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Instance creation timestamp.",
+            "title": "Created At"
+          },
+          "engine": {
+            "description": "Engine running in this instance.",
+            "title": "Engine",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable instance identifier used by instance actions.",
+            "title": "Id",
+            "type": "string"
+          },
+          "internal_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Raw BaaS lifecycle state for diagnostics.",
+            "title": "Internal Status"
+          },
+          "memory": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Memory usage or allocation; null until BaaS exposes metrics.",
+            "title": "Memory"
+          },
+          "node": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Runtime node name; null until BaaS exposes this metric.",
+            "title": "Node"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Runtime provider type.",
+            "title": "Provider"
+          },
+          "provider_instance_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Provider-side instance identifier.",
+            "title": "Provider Instance Id"
+          },
+          "status": {
+            "description": "Stable product health state.",
+            "enum": [
+              "healthy",
+              "restarting",
+              "abnormal",
+              "unknown"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "engine"
+        ],
+        "title": "ContainerInstance",
+        "type": "object"
+      },
+      "ContainerList": {
+        "description": "Current service-Bot instance snapshot and derived summary.",
+        "properties": {
+          "bot_id": {
+            "description": "Stable Bot identifier.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "instances": {
+            "description": "Current runtime instances backing the service Bot.",
+            "items": {
+              "$ref": "#/components/schemas/ContainerInstance"
+            },
+            "title": "Instances",
+            "type": "array"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/ContainerSummary",
+            "description": "Counts derived from the same instance snapshot."
+          }
+        },
+        "required": [
+          "bot_id",
+          "summary",
+          "instances"
+        ],
+        "title": "ContainerList",
+        "type": "object"
+      },
+      "ContainerRestart": {
+        "description": "Acknowledgement for an asynchronous single-instance restart.",
+        "properties": {
+          "accepted": {
+            "description": "Whether the restart was accepted.",
+            "title": "Accepted",
+            "type": "boolean"
+          },
+          "bot_id": {
+            "description": "Stable Bot identifier.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "instance_id": {
+            "description": "Restarted instance identifier.",
+            "title": "Instance Id",
+            "type": "string"
+          },
+          "publish_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "BaaS publish workflow identifier.",
+            "title": "Publish Id"
+          }
+        },
+        "required": [
+          "bot_id",
+          "instance_id",
+          "accepted"
+        ],
+        "title": "ContainerRestart",
+        "type": "object"
+      },
+      "ContainerSummary": {
+        "description": "Counts derived from the current BaaS instance snapshot.",
+        "properties": {
+          "abnormal": {
+            "description": "Instances whose health probe is unhealthy.",
+            "title": "Abnormal",
+            "type": "integer"
+          },
+          "healthy": {
+            "description": "Instances whose health probe is healthy.",
+            "title": "Healthy",
+            "type": "integer"
+          },
+          "restarting": {
+            "description": "Instances currently pending or updating.",
+            "title": "Restarting",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Total live instances in the snapshot.",
+            "title": "Total",
+            "type": "integer"
+          },
+          "unknown": {
+            "description": "Instances without a usable health result.",
+            "title": "Unknown",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "healthy",
+          "abnormal",
+          "restarting",
+          "unknown"
+        ],
+        "title": "ContainerSummary",
         "type": "object"
       },
       "ConversationDetail": {
@@ -1864,6 +2224,48 @@
         "title": "Envelope[BotAuthStatus]",
         "type": "object"
       },
+      "Envelope_BotHealth_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BotHealth"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[BotHealth]",
+        "type": "object"
+      },
       "Envelope_BotStatus_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -2030,6 +2432,90 @@
           "request_id"
         ],
         "title": "Envelope[Connection]",
+        "type": "object"
+      },
+      "Envelope_ContainerList_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContainerList"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ContainerList]",
+        "type": "object"
+      },
+      "Envelope_ContainerRestart_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ContainerRestart"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[ContainerRestart]",
         "type": "object"
       },
       "Envelope_ConversationDetail_": {
@@ -2408,6 +2894,48 @@
           "request_id"
         ],
         "title": "Envelope[FileEntry]",
+        "type": "object"
+      },
+      "Envelope_HealthCheckAccepted_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HealthCheckAccepted"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[HealthCheckAccepted]",
         "type": "object"
       },
       "Envelope_HelloWorld_": {
@@ -4433,6 +4961,165 @@
           "type"
         ],
         "title": "FileEntry",
+        "type": "object"
+      },
+      "HealthCheckAccepted": {
+        "description": "Acknowledgement for an asynchronously started health diagnosis.",
+        "properties": {
+          "bot_id": {
+            "description": "Stable Bot identifier.",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "scan_id": {
+            "description": "Diagnosis identifier used for polling.",
+            "title": "Scan Id",
+            "type": "integer"
+          },
+          "status": {
+            "const": "scanning",
+            "description": "Initial diagnosis state.",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bot_id",
+          "scan_id",
+          "status"
+        ],
+        "title": "HealthCheckAccepted",
+        "type": "object"
+      },
+      "HealthCheckItem": {
+        "description": "Progress or result for one diagnosed configuration area.",
+        "properties": {
+          "duration_ms": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Time spent on this item in milliseconds.",
+            "title": "Duration Ms"
+          },
+          "name": {
+            "description": "Configuration area or diagnostic rule name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Result such as pass, warning, fail, or error when available.",
+            "title": "Result"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Item score from 0 to 100.",
+            "title": "Score"
+          },
+          "status": {
+            "description": "Current state of this diagnostic item.",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "status"
+        ],
+        "title": "HealthCheckItem",
+        "type": "object"
+      },
+      "HealthFindingDetail": {
+        "description": "One issue discovered by the health diagnosis.",
+        "properties": {
+          "message": {
+            "description": "Description of the issue and suggested action.",
+            "title": "Message",
+            "type": "string"
+          },
+          "name": {
+            "description": "Diagnostic rule name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "result": {
+            "description": "Finding result such as warning or fail.",
+            "title": "Result",
+            "type": "string"
+          },
+          "risk_level": {
+            "description": "Finding severity level.",
+            "title": "Risk Level",
+            "type": "string"
+          },
+          "rule_id": {
+            "description": "Stable diagnostic rule identifier.",
+            "title": "Rule Id",
+            "type": "string"
+          },
+          "score": {
+            "description": "Finding score from 0 to 100.",
+            "maximum": 100.0,
+            "minimum": 0.0,
+            "title": "Score",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "rule_id",
+          "name",
+          "message",
+          "risk_level",
+          "result",
+          "score"
+        ],
+        "title": "HealthFindingDetail",
+        "type": "object"
+      },
+      "HealthFindingGroup": {
+        "description": "Findings grouped by the configuration area that was checked.",
+        "properties": {
+          "check_item": {
+            "description": "Configuration area that was checked.",
+            "title": "Check Item",
+            "type": "string"
+          },
+          "findings": {
+            "description": "Issues found in this configuration area.",
+            "items": {
+              "$ref": "#/components/schemas/HealthFindingDetail"
+            },
+            "title": "Findings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "check_item",
+          "findings"
+        ],
+        "title": "HealthFindingGroup",
         "type": "object"
       },
       "HelloWorld": {
@@ -21877,6 +22564,385 @@
         ]
       }
     },
+    "/openapi/v1/bots/{bot_id}/containers": {
+      "get": {
+        "description": "Return the current online instance snapshot for a service Bot.",
+        "operationId": "list_containers_openapi_v1_bots__bot_id__containers_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContainerList_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Containers"
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/containers/{instance_id}/restart": {
+      "post": {
+        "description": "Restart one abnormal instance; service-Bot owner only.",
+        "operationId": "restart_container_openapi_v1_bots__bot_id__containers__instance_id__restart_post",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Stable instance identifier returned by the container list.",
+            "in": "path",
+            "name": "instance_id",
+            "required": true,
+            "schema": {
+              "description": "Stable instance identifier returned by the container list.",
+              "maxLength": 128,
+              "minLength": 1,
+              "title": "Instance Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ContainerRestart_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Restart Container"
+      }
+    },
     "/openapi/v1/bots/{bot_id}/data-init": {
       "get": {
         "description": "Read cold-start initialization state without exposing the bot ext bag.",
@@ -22216,6 +23282,397 @@
         "summary": "Trigger Bot Data Init",
         "tags": [
           "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/diagnostics/health": {
+      "get": {
+        "description": "Return a requested diagnosis, or the latest completed diagnosis.",
+        "operationId": "get_health_openapi_v1_bots__bot_id__diagnostics_health_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Diagnosis identifier returned by health-check; omit for the latest completed result.",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Diagnosis identifier returned by health-check; omit for the latest completed result.",
+              "title": "Scan Id"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_BotHealth_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Health",
+        "tags": [
+          "diagnostics"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/diagnostics/health-check": {
+      "post": {
+        "description": "Start an asynchronous health diagnosis for an OpenClaw cloud Bot.",
+        "operationId": "start_health_check_openapi_v1_bots__bot_id__diagnostics_health_check_post",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_HealthCheckAccepted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Start Health Check",
+        "tags": [
+          "diagnostics"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- add Bot-first OpenAPI endpoints for listing service Bot container instances and restarting a selected instance
- add asynchronous OpenClaw Bot health diagnosis, latest-result lookup, and `scan_id` polling by reusing the existing Harness scanner and scan-record repository
- wire admission, authorization, public error mapping, dependency injection, generated Gateway schema, API documentation, and architecture contract pins

## Public API

- `GET /openapi/v1/bots/{bot_id}/containers`
- `POST /openapi/v1/bots/{bot_id}/containers/{instance_id}/restart`
- `GET /openapi/v1/bots/{bot_id}/diagnostics/health`
- `POST /openapi/v1/bots/{bot_id}/diagnostics/health-check`

Health diagnosis currently supports cloud OpenClaw personal Bots and service Bot draft workspaces. Owner and Member-or-above collaborators are authorized through the existing Bot operator gate. Scan records are rebound to the authorized Bot, owner, and environment before being returned, and internal scanner failures are sanitized on the public surface.

## Validation

- Backend OpenAPI, service, Harness, and architecture tests: `1020 passed, 1 skipped`
- changed-line coverage: `95.70% (289/302)`
- Gateway contracts, unit, and architecture tests: `776 passed, 2 skipped`
- generated `bots.openapi.json` verified idempotent
- `git diff --check` passed
