### PR TITLE
fix(backend): keep bot-config artifact schema_version at 4

### DIFF
--- a/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
+++ b/src/backend/src/agentclaw/community/kernel/bot_config/artifact.py
@@ -41,10 +41,11 @@ from typing import Any
 # engine could observe. Distinct from the per-bot content ``version`` below.
 # v4: MCP credentials are inlined into the server entry; the ``auth_ref``
 # secret-by-reference field was removed (no container-side secret broker).
-# v5: the local (stdio) MCP launch instruction is flattened onto the server
-# entry — top-level ``command``/``args``/``env`` replace the nested ``stdio``
-# object, matching the flat shape MCP clients themselves consume.
-SCHEMA_VERSION = 5
+# The local (stdio) MCP launch instruction rides flat on the server entry —
+# top-level ``command``/``args``/``env``, the shape MCP clients themselves
+# consume (an early v4 iteration nested it under a ``stdio`` object;
+# ``from_dict`` still re-flattens that form on read).
+SCHEMA_VERSION = 4
 
 
 @dataclass(frozen=True)
@@ -159,9 +160,9 @@ def _mcp_server_from_dict(data: dict[str, Any]) -> McpServerRef:
 
     A remote entry omits ``command``/``args``/``env`` entirely, so the dataclass
     defaults apply — and artifacts published before the local form existed
-    deserialize unchanged. A pre-v5 local entry (nested ``{"stdio": {...}}``,
-    as pinned by schema_version 4 snapshots) is re-flattened on read so stored
-    artifacts stay loadable across the contract bump.
+    deserialize unchanged. A legacy local entry (nested ``{"stdio": {...}}``,
+    as pinned by snapshots from before the flat form) is re-flattened on read
+    so stored artifacts stay loadable.
     """
     legacy_stdio = data.get("stdio")
     fields = {k: v for k, v in data.items() if k != "stdio"}

--- a/src/backend/tests/community/kernel/test_bot_config_artifact.py
+++ b/src/backend/tests/community/kernel/test_bot_config_artifact.py
@@ -81,9 +81,9 @@ def test_local_entry_carries_its_launch_instruction_flat() -> None:
     }
 
 
-def test_from_dict_reflattens_a_pre_v5_nested_stdio_entry() -> None:
-    """A pinned schema_version-4 artifact (nested ``{"stdio": {...}}``) still
-    loads — its launch instruction lands on the flat fields."""
+def test_from_dict_reflattens_a_legacy_nested_stdio_entry() -> None:
+    """An artifact pinned before the flat local form (nested ``{"stdio":
+    {...}}``) still loads — its launch instruction lands on the flat fields."""
     restored = BotConfigArtifact.from_dict(
         {
             "schema_version": 4,


### PR DESCRIPTION
## Problem

#1136 shipped the flat local-MCP launch shape (top-level `command`/`args`/`env` on the artifact's server entry) together with a `SCHEMA_VERSION` bump from 4 to 5. The contract version must stay at 4.

## Solution

Revert `SCHEMA_VERSION` to 4 in `kernel/bot_config/artifact.py`. The flat entry shape itself is unchanged, as is the `from_dict` re-flatten of the legacy nested `{"stdio": {...}}` form — the version-header comment now describes the flatten as part of v4 rather than a v5 transition, and the kernel test named after "pre_v5" is renamed to `test_from_dict_reflattens_a_legacy_nested_stdio_entry` with matching wording. No other `v5` references remain in code, tests, or the schema.

## Validation

- `pytest tests/community/kernel tests/community/contracts tests/community/core/config_compose tests/community/core/mcp` — 516 passed (these suites assert against the `SCHEMA_VERSION` constant and the schema oracle, so they cover the revert directly).
- `scripts/ci/python_sast_local.sh src/backend 1 --base HEAD~1` — clean (exit 0).

## Compatibility and risk

Artifacts produced after #1136 but before this fix carry `schema_version: 5` with the same shape v4 now describes; nothing in the backend branches on the number, and pinned artifacts are re-composed on the next publish, so no migration is needed. Rollback is a revert of this one-constant change.


---
_Generated by [Claude Code](https://claude.ai/code/session_019sSzYR6CNANS2XuZifiMC2)_