### PR TITLE
fix: omit bot type env for service publish

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -193,8 +193,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
 
         # Historical template types expose stable legacy bot-type values, while
         # template-factory templates expose their template_type verbatim so new
-        # template types do not require backend enum/map changes.
-        if template_type:
+        # template types do not require backend enum/map changes. Service bots
+        # already convey their service identity through the startup command, so
+        # skip this legacy template-kind env for that domain.
+        if template_type and ctx.bot_type != "service":
             envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(template_type, template_type)
 
         devflow_workflow = template_config.get("devflow_workflow", "")

--- a/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
+++ b/src/backend/tests/community/core/bot_management/test_engine_provisioning_strategy.py
@@ -331,7 +331,7 @@ def test_resolve_provisioning_routes_legacy_template_only_context():
     assert strategy.should_encrypt_template_token(ctx) is True
 
 
-def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
+def test_template_factory_service_normal_cc_consumes_model_runtime_repos_without_bot_type():
     strategy = AicodingProvisioningStrategy("claude_code")
     ctx = BotProvisioningContext(
         active_engine="claude_code",
@@ -361,7 +361,7 @@ def test_template_factory_normal_cc_consumes_model_runtime_repos_and_token():
         "https://code/repo1",
         "https://code/repo2",
     ]
-    assert envs["BOT_TYPE"] == "normalCC"
+    assert "BOT_TYPE" not in envs
     assert strategy.should_encrypt_template_token(ctx) is True
     assert strategy.extract_runtime_token(ctx) == "tok-normal"
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -272,7 +272,7 @@ def test_bot_build_service_upgrade_raises_for_other_errors():
 
 
 @pytest.mark.asyncio
-async def test_verify_first_release_injects_engine_extra_envs_for_service_coding_bot():
+async def test_verify_first_release_injects_engine_extra_envs_without_bot_type_for_service_coding_bot():
     publish_service = Mock()
     publish_service.create_device_binding.return_value = 55
     build_service = Mock()
@@ -307,7 +307,6 @@ async def test_verify_first_release_injects_engine_extra_envs_for_service_coding
 
     assert build_service.release_async.await_args.kwargs["extra_envs"] == {
         "AGENTCLAW_SKILLS_LAYOUT": "legacy",
-        "BOT_TYPE": "application",
         "AIX_DEVFLOW_INFO": "devflow/app.yaml",
         "GIT_ADDRESSES": '["git@x/y.git"]',
         "RELAY_DEFAULT_MODEL": "antchat/Ling-2.6-1T",
@@ -316,7 +315,7 @@ async def test_verify_first_release_injects_engine_extra_envs_for_service_coding
 
 
 @pytest.mark.asyncio
-async def test_verify_upgrade_preserves_skills_env_and_injects_engine_extra_envs():
+async def test_verify_upgrade_preserves_skills_env_and_injects_engine_extra_envs_without_bot_type():
     publish_service = Mock()
     build_service = Mock()
     build_service.upgrade_async = AsyncMock(return_value={"publish_id": 9})
@@ -365,7 +364,6 @@ async def test_verify_upgrade_preserves_skills_env_and_injects_engine_extra_envs
     assert build_service.upgrade_async.await_args.kwargs["extra_envs"] == {
         "AGENTCLAW_SKILLS_LAYOUT": "pool",
         "AGENTCLAW_SKILLS_LAYOUT_CONTRACT_VERSION": "skills-pool-p3-v1",
-        "BOT_TYPE": "application",
         "RELAY_DEFAULT_MODEL": "m1",
     }
 


### PR DESCRIPTION
## Summary\n- omit legacy BOT_TYPE from service-bot publish engine extra envs\n- keep other engine-owned envs for service publish/restart/rollback\n- update publish flow tests to assert service publish extra_envs no longer carries BOT_TYPE\n\n## Test\n- cd src/backend && uv run pytest tests/community/core/service_bot/services/test_publish_flow_service.py -q