### PR TITLE
feat(backend): expose product bot chats through OpenAPI

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -199,6 +199,7 @@ from .identity import router as identity_router
 from .loadtest import router as loadtest_router
 from .mcp import router as mcp_router
 from .bot_logs import router as logs_router
+from .bot_chats import router as chats_router
 from .resources import router as resources_router
 from .routines import router as routines_router
 from .skills import router as skills_router
@@ -252,6 +253,10 @@ _SUBGROUPS = [
     # claiming it.
     authorized_apps_router,
     authorized_bots_router,
+    # Product Bot Chat reads are bot-first and use the product service's
+    # owner/collaborator adjudication. Their own route dependency checks an
+    # app-only caller's grant against the addressed owner.
+    chats_router,
     # Mixed, like `bots`: its two collection operations declare the grant check
     # per route, and its four `{skill_id}` operations resolve the bot's owner
     # from the skill record and check it themselves. A group-level dependency

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -337,6 +337,14 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "GET",
         "/openapi/v1/bots/{bot_id}/connection",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/chats",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/chats/{trace_id}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # ── B: returns a set of bots, narrowed to the granted ones ───────────────
     ("GET", "/openapi/v1/bots"): AdmissionMode.GRANT_FILTERED,
     # The application's own view, and the **complete** one: a granted bot the

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_chats/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_chats/__init__.py
@@ -1,0 +1,5 @@
+"""Product-compatible Bot Chat reads on the public API surface."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_chats/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_chats/router.py
@@ -1,0 +1,151 @@
+"""Thin public HTTP adapter for the product Bot Chat query service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    UserIdDep,
+    require_granted_addressed_bot,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.bot_chat_service import BotChatServiceProtocol
+from agentclaw.community.core.bot_chat.errors import (
+    InvalidBotLogQueryError,
+    SessionNotFoundError,
+)
+from agentclaw.community.core.bot_chat.schemas import (
+    ConversationDetail,
+    SessionListResponse,
+)
+from agentclaw.community.di import Injected
+
+router = APIRouter(
+    prefix="/openapi/v1/bots/{bot_id}/chats",
+    tags=["bot-chats"],
+)
+
+_GRANT_CHECKED_ADDRESSED_BOT = [Depends(require_granted_addressed_bot)]
+
+
+@router.get(
+    "",
+    response_model=Envelope[SessionListResponse],
+    dependencies=_GRANT_CHECKED_ADDRESSED_BOT,
+)
+@envelope_errors
+async def list_bot_chats(
+    request: Request,
+    bot_id: BotIdPath,
+    user_id: UserIdDep,
+    owner_id: str | None = Query(
+        default=None,
+        min_length=1,
+        description="Owner of the addressed bot; defaults to user_id. Name it "
+        "only when the bot is shared with the acting user.",
+    ),
+    trace_id: str | None = Query(default=None, description="Filter by trace id."),
+    session_id: str | None = Query(
+        default=None, description="Filter by the engine session id."
+    ),
+    session_key: str | None = Query(
+        default=None, description="Filter by the engine session key."
+    ),
+    query: str | None = Query(
+        default=None,
+        description="Fuzzy search over the chat name and user input.",
+    ),
+    biz_scene: str | None = Query(default=None, description="Business scene."),
+    biz_task_id: str | None = Query(default=None, description="Business task id."),
+    group_id: str | None = Query(default=None, description="BCS group id."),
+    match_mode: str = Query(default="exact", pattern="^(exact|contains)$"),
+    include_output_match: bool = Query(
+        default=False,
+        description="Include trace output when applying the keyword query.",
+    ),
+    time_scope: str = Query(default="default", pattern="^(default|all)$"),
+    from_date: datetime | None = Query(default=None, description="ISO 8601 start time."),
+    to_date: datetime | None = Query(default=None, description="ISO 8601 end time."),
+    page: int = Query(default=1, ge=1, description="1-based page number."),
+    limit: int = Query(default=20, ge=1, le=100, description="Chats per page."),
+    log_source: str | None = Query(
+        default=None,
+        description="Data source override: 'db' or 'langfuse'.",
+    ),
+    service: BotChatServiceProtocol = Injected(BotChatServiceProtocol),
+) -> Envelope[SessionListResponse]:
+    """List one addressed Bot's product chat records for the acting user."""
+    # ``owner_id`` is consumed by the addressed-bot grant dependency. Product
+    # chat visibility remains scoped to the acting user and is re-adjudicated
+    # by BotChatService (owner or collaborator), exactly like the product API.
+    del owner_id
+    try:
+        result = await service.list_sessions(
+            owner_id=user_id,
+            from_date=from_date,
+            to_date=to_date,
+            page=page,
+            limit=limit,
+            bot_id=bot_id,
+            trace_id=trace_id,
+            session_id=session_id,
+            session_key=session_key,
+            query=query,
+            biz_scene=biz_scene,
+            biz_task_id=biz_task_id,
+            group_id=group_id,
+            match_mode=match_mode,
+            include_output_match=include_output_match,
+            time_scope=time_scope,
+            log_source=log_source,
+        )
+    except ValueError as exc:
+        raise InvalidBotLogQueryError("invalid product chat query") from exc
+    return envelope(result, request)
+
+
+@router.get(
+    "/{trace_id}",
+    response_model=Envelope[ConversationDetail],
+    dependencies=_GRANT_CHECKED_ADDRESSED_BOT,
+)
+@envelope_errors
+async def get_bot_chat(
+    request: Request,
+    bot_id: BotIdPath,
+    trace_id: str,
+    user_id: UserIdDep,
+    owner_id: str | None = Query(
+        default=None,
+        min_length=1,
+        description="Owner of the addressed bot; defaults to user_id. Name it "
+        "only when the bot is shared with the acting user.",
+    ),
+    log_source: str | None = Query(
+        default=None,
+        description="Data source override: 'db' or 'langfuse'.",
+    ),
+    service: BotChatServiceProtocol = Injected(BotChatServiceProtocol),
+) -> Envelope[ConversationDetail]:
+    """Return one product chat Trace and its observation tree."""
+    del owner_id
+    result = await service.get_session(
+        trace_id=trace_id,
+        owner_id=user_id,
+        log_source=log_source,
+    )
+    # The grant is checked against the bot in the path. The fetched Trace must
+    # belong to that same bot, or a grant on one bot could authorize a Trace id
+    # from another bot the delegating user can reach.
+    if result.bot_id != bot_id:
+        raise SessionNotFoundError("trace does not belong to the addressed bot")
+    return envelope(result, request)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bot_chats_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bot_chats_router.py
@@ -1,0 +1,122 @@
+"""Focused tests for the product Bot Chats public adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.bot_chats.router import (
+    get_bot_chat,
+    list_bot_chats,
+)
+from agentclaw.community.core.bot_chat.schemas import (
+    ConversationDetail,
+    SessionListResponse,
+)
+
+
+def _request(path: str) -> Request:
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+    request.state.trace_id = "request-trace"
+    return request
+
+
+@pytest.mark.asyncio
+async def test_list_delegates_the_product_query_without_reinterpreting_it():
+    service = SimpleNamespace(
+        list_sessions=AsyncMock(
+            return_value=SessionListResponse(
+                sessions=[], total=0, page=3, limit=17, has_more=False
+            )
+        )
+    )
+    start = datetime(2026, 8, 11, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 14, tzinfo=timezone.utc)
+
+    result = await list_bot_chats(
+        request=_request("/openapi/v1/bots/bot-1/chats"),
+        bot_id="bot-1",
+        user_id="user-1",
+        owner_id="bot-owner",
+        trace_id="trace-1",
+        session_id="session-1",
+        session_key="session-key-1",
+        query="needle",
+        biz_scene="scene",
+        biz_task_id="task",
+        group_id="group",
+        match_mode="contains",
+        include_output_match=True,
+        time_scope="default",
+        from_date=start,
+        to_date=end,
+        page=3,
+        limit=17,
+        log_source="db",
+        service=service,
+    )
+
+    assert result.code == 200000
+    assert result.request_id == "request-trace"
+    service.list_sessions.assert_awaited_once_with(
+        owner_id="user-1",
+        from_date=start,
+        to_date=end,
+        page=3,
+        limit=17,
+        bot_id="bot-1",
+        trace_id="trace-1",
+        session_id="session-1",
+        session_key="session-key-1",
+        query="needle",
+        biz_scene="scene",
+        biz_task_id="task",
+        group_id="group",
+        match_mode="contains",
+        include_output_match=True,
+        time_scope="default",
+        log_source="db",
+    )
+
+
+@pytest.mark.asyncio
+async def test_detail_masks_a_trace_from_a_different_path_bot():
+    service = SimpleNamespace(
+        get_session=AsyncMock(
+            return_value=ConversationDetail(
+                id="trace-1",
+                bot_id="bot-2",
+                name="trace",
+                timestamp="2026-08-18T00:00:00Z",
+            )
+        )
+    )
+
+    result = await get_bot_chat(
+        request=_request("/openapi/v1/bots/bot-1/chats/trace-1"),
+        bot_id="bot-1",
+        trace_id="trace-1",
+        user_id="user-1",
+        owner_id=None,
+        log_source="db",
+        service=service,
+    )
+
+    assert result.status_code == 404
+    service.get_session.assert_awaited_once_with(
+        trace_id="trace-1", owner_id="user-1", log_source="db"
+    )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -319,7 +319,9 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: ``none`` then moved 16 → 35 when the 19 collaboration operations for Spaces,
 #: work orders and recipient notifications were added. None of those operations
 #: addresses a bot, so the path and query counts remain unchanged.
-_BOT_ID_PLACEMENT = {"path": 54, "query": 1, "none": 35}
+#:
+#: ``path`` then moved 54 → 56 when the two Bot Chats operations were added.
+_BOT_ID_PLACEMENT = {"path": 56, "query": 1, "none": 35}
 
 
 def _schema() -> dict:
@@ -398,8 +400,9 @@ def test_the_pinned_number_of_operations_take_it():
     # 60 on the merge base, +3 for the startup-script operations, +2 for the
     # resources file endpoints re-addressed by workspace path (#1000), then -4
     # for the files-only resources group, then +19 for Spaces, work orders and
-    # recipient-notification operations added by the collaboration API.
-    assert len(taking) == 80
+    # recipient-notification operations added by the collaboration API, then +2
+    # for the Bot Chats operations.
+    assert len(taking) == 82
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/endpoints/test_product_bot_chats.py
+++ b/src/backend/tests/community/endpoints/test_product_bot_chats.py
@@ -1,0 +1,164 @@
+"""Endpoint coverage for product-compatible Bot Chat reads."""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.core.repository.implementations.chat.db import (
+    BotChatDbRepository,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_LIST_PATH = "/openapi/v1/bots/{bot_id}/chats"
+_DETAIL_PATH = "/openapi/v1/bots/{bot_id}/chats/{trace_id}"
+_BOT_ID = "default"
+_TRACE_ID = "trace_product_chat_endpoint"
+_USER_ID = "product-chat-user"
+_SIGNING_KEY = "product-chat-endpoint-secret-at-least-32-bytes"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _SIGNING_KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal_headers() -> dict[str, str]:
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 60 * 60,
+            "principals": [
+                {
+                    "type": "user",
+                    "tenant": "product-chat-endpoint-test",
+                    "subject": {
+                        "id": _USER_ID,
+                        "username": "product-chat-user@example.com",
+                    },
+                }
+            ],
+        },
+        _SIGNING_KEY,
+        algorithm="HS256",
+    )
+    return {"X-Avernet-Principal": token}
+
+
+def _enable_public_auth(_world) -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+def _seed_trace(world) -> None:
+    _enable_public_auth(world)
+    BotChatDbRepository(world.get(DatabasePlugin)).upsert_ocb_trace(
+        {
+            "trace_id": _TRACE_ID,
+            "session_id": "session_product_chat_endpoint",
+            "session_key": "agent:main:session:product-chat:user:product-chat-user",
+            "user_id": _USER_ID,
+            "bot_id": _BOT_ID,
+            "name": "Product chat endpoint fixture",
+            "input": "synthetic input",
+            "output": "synthetic output",
+            "start_time_ms": 1_000,
+            "status": "SUCCESS",
+            "usage": {},
+        }
+    )
+
+
+@endpoint_test(
+    method="GET",
+    path=_LIST_PATH,
+    scenario="happy",
+    seed=_seed_trace,
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={
+            "user_id": _USER_ID,
+            "trace_id": _TRACE_ID,
+            "time_scope": "all",
+            "log_source": "db",
+        },
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {"total": 1, "sessions": [{"id": _TRACE_ID}]},
+        },
+    ),
+)
+def product_bot_chats_list_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_LIST_PATH,
+    scenario="wrong_user",
+    seed=_enable_public_auth,
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": "another-user"},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectError(status=403),
+)
+def product_bot_chats_list_wrong_user():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="happy",
+    seed=_seed_trace,
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "trace_id": _TRACE_ID},
+        query_params={"user_id": _USER_ID, "log_source": "db"},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"id": _TRACE_ID, "bot_id": _BOT_ID}},
+    ),
+)
+def product_bot_chat_detail_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="not_found",
+    seed=_enable_public_auth,
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "trace_id": "missing-trace"},
+        query_params={"user_id": _USER_ID, "log_source": "db"},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectError(status=404),
+)
+def product_bot_chat_detail_not_found():
+    """The framework owns invocation."""

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -20562,6 +20562,648 @@
         ]
       }
     },
+    "/openapi/v1/bots/{bot_id}/chats": {
+      "get": {
+        "description": "List one addressed Bot's product chat records for the acting user.",
+        "operationId": "list_bot_chats_openapi_v1_bots__bot_id__chats_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Owner of the addressed bot; defaults to user_id. Name it only when the bot is shared with the acting user.",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Owner of the addressed bot; defaults to user_id. Name it only when the bot is shared with the acting user.",
+              "title": "Owner Id"
+            }
+          },
+          {
+            "description": "Filter by trace id.",
+            "in": "query",
+            "name": "trace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by trace id.",
+              "title": "Trace Id"
+            }
+          },
+          {
+            "description": "Filter by the engine session id.",
+            "in": "query",
+            "name": "session_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by the engine session id.",
+              "title": "Session Id"
+            }
+          },
+          {
+            "description": "Filter by the engine session key.",
+            "in": "query",
+            "name": "session_key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by the engine session key.",
+              "title": "Session Key"
+            }
+          },
+          {
+            "description": "Fuzzy search over the chat name and user input.",
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Fuzzy search over the chat name and user input.",
+              "title": "Query"
+            }
+          },
+          {
+            "description": "Business scene.",
+            "in": "query",
+            "name": "biz_scene",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Business scene.",
+              "title": "Biz Scene"
+            }
+          },
+          {
+            "description": "Business task id.",
+            "in": "query",
+            "name": "biz_task_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Business task id.",
+              "title": "Biz Task Id"
+            }
+          },
+          {
+            "description": "BCS group id.",
+            "in": "query",
+            "name": "group_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "BCS group id.",
+              "title": "Group Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "match_mode",
+            "required": false,
+            "schema": {
+              "default": "exact",
+              "pattern": "^(exact|contains)$",
+              "title": "Match Mode",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include trace output when applying the keyword query.",
+            "in": "query",
+            "name": "include_output_match",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include trace output when applying the keyword query.",
+              "title": "Include Output Match",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "time_scope",
+            "required": false,
+            "schema": {
+              "default": "default",
+              "pattern": "^(default|all)$",
+              "title": "Time Scope",
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO 8601 start time.",
+            "in": "query",
+            "name": "from_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO 8601 start time.",
+              "title": "From Date"
+            }
+          },
+          {
+            "description": "ISO 8601 end time.",
+            "in": "query",
+            "name": "to_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO 8601 end time.",
+              "title": "To Date"
+            }
+          },
+          {
+            "description": "1-based page number.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "1-based page number.",
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Chats per page.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Chats per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Data source override: 'db' or 'langfuse'.",
+            "in": "query",
+            "name": "log_source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data source override: 'db' or 'langfuse'.",
+              "title": "Log Source"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SessionListResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Bot Chats",
+        "tags": [
+          "bot-chats"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/chats/{trace_id}": {
+      "get": {
+        "description": "Return one product chat Trace and its observation tree.",
+        "operationId": "get_bot_chat_openapi_v1_bots__bot_id__chats__trace_id__get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Owner of the addressed bot; defaults to user_id. Name it only when the bot is shared with the acting user.",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Owner of the addressed bot; defaults to user_id. Name it only when the bot is shared with the acting user.",
+              "title": "Owner Id"
+            }
+          },
+          {
+            "description": "Data source override: 'db' or 'langfuse'.",
+            "in": "query",
+            "name": "log_source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Data source override: 'db' or 'langfuse'.",
+              "title": "Log Source"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_ConversationDetail_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Bot Chat",
+        "tags": [
+          "bot-chats"
+        ]
+      }
+    },
     "/openapi/v1/bots/{bot_id}/connection": {
       "get": {
         "description": "Get usable socket connections for a bot.",


### PR DESCRIPTION
  - GET /openapi/v1/bots/{bot_id}/chats?user_id=...
  - GET /openapi/v1/bots/{bot_id}/chats/{trace_id}?user_id=...

  关键调整：

  - user_id 必须显式传入，支持 User 或 App 身份。
  - 接入 GRANT_CHECKED_ADDRESSED_BOT：
      - User 调用要求 user_id 与本人一致。
      - App-only 调用必须具有目标 Bot grant。
      - 共享 Bot 可通过可选 owner_id 定位授权，但不会改变实际数据查询用户。

  - 复用现有 BotChatServiceProtocol，未改产品 Core、Repository 和旧 /api/v1/bot-chats/**。
  - 详情结果额外校验 Trace 的 bot_id 与路径一致，避免跨 Bot 查询。
  - 未修改 Gateway application.yaml，继承现有 /openapi/v1/bots/** optional 配置。
  - 已更新 src/gateway/configs/schemas/bots.openapi.json。
