### PR TITLE
feat(gateway): wire singlebox forwarding to local upstreams

### DIFF
--- a/scripts/modules/backend.sh
+++ b/scripts/modules/backend.sh
@@ -91,7 +91,12 @@ backend_start() {
             rm -f "${RUNTIME_DATA_DIR}/backend.db"
         fi
 
+        # Gateway principal verifier: deliberately armed for singlebox (see
+        # src/backend/docs/openapi-v1/README.md) with the same dev key the
+        # gateway signs with (gateway.sh) and BCS verifies with (bcs.sh), so
+        # locally forwarded /openapi/v1 requests verify instead of all-401.
         SERVER_ENV=dev DEPLOY_PROFILE=singlebox \
+            AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE="${AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE:-avernet-dev-signing-key-NOT-FOR-PROD}" \
             DATABASE_URL="sqlite:///${RUNTIME_DATA_DIR}/backend.db" \
             ENABLE_OSS_SYNC=false \
             CHAT_ENGINE="${CHAT_ENGINE}" \

--- a/scripts/modules/gateway.sh
+++ b/scripts/modules/gateway.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# scripts/modules/gateway.sh — Gateway service module
+[[ -n "${_GATEWAY_SH_LOADED:-}" ]] && return 0
+_GATEWAY_SH_LOADED=1
+
+# Service-specific constants
+GATEWAY_LOG="${LOG_DIR}/gateway.log"
+GATEWAY_PID_FILE="${DEP_DIR}/gateway.pid"
+GATEWAY_APP_SCRIPT="${GATEWAY_DIR}/scripts/app.sh"
+GATEWAY_PORT="${GATEWAY_PORT:-8889}"
+
+
+gateway_setup() {
+    if ! check_directory_exists "${GATEWAY_DIR}" "gateway"; then
+        return 1
+    fi
+
+    check_uv_installed || { log_error "uv not found. Run: singlebox.sh install-tools"; return 1; }
+
+    cd "${GATEWAY_DIR}"
+    log_info "Syncing Python dependencies for Gateway..."
+    if ! uv sync --python ">=3.12,<3.13" --index-url "${PYPI_INDEX_URL}"; then
+        log_error "Failed to sync Python dependencies for Gateway"
+        return 1
+    fi
+    log_info "Gateway dependencies synced successfully"
+}
+
+
+gateway_start() {
+    mkdir -p "${LOG_DIR}"
+
+    if ! check_directory_exists "${GATEWAY_DIR}" "gateway"; then
+        return 1
+    fi
+    if [ ! -x "${GATEWAY_APP_SCRIPT}" ]; then
+        log_error "Gateway lifecycle script not executable: ${GATEWAY_APP_SCRIPT}"
+        return 1
+    fi
+
+    gateway_setup || return 1
+
+    stop_port_processes_if_owned "${GATEWAY_PORT}" "${GATEWAY_DIR}" "existing gateway"
+    stop_matching_processes_if_owned "gateway/community/main.py" "${GATEWAY_DIR}" "existing gateway process"
+    require_port_available_after_owned_stop "${GATEWAY_PORT}" "gateway" "set GATEWAY_PORT=<free-port> in .env.local or pass --gateway-port <free-port>" || return 1
+
+    log_info "Starting Gateway service on port ${GATEWAY_PORT}..."
+    log_info "Log: ${GATEWAY_LOG}"
+
+    (
+        cd "${GATEWAY_DIR}"
+        GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
+    ) >> "${GATEWAY_LOG}" 2>&1
+
+    local gateway_pid=""
+    if [ -f "${GATEWAY_DIR}/tmp/app.pid" ]; then
+        gateway_pid="$(cat "${GATEWAY_DIR}/tmp/app.pid" 2>/dev/null || true)"
+        if [ -n "${gateway_pid}" ]; then
+            echo "${gateway_pid}" > "${GATEWAY_PID_FILE}"
+        fi
+    fi
+
+    if gateway_ready; then
+        log_info "Gateway started successfully${gateway_pid:+ (PID: ${gateway_pid})}"
+        log_info "Gateway health: http://127.0.0.1:${GATEWAY_PORT}/health"
+        return 0
+    fi
+
+    log_error "Gateway failed to become ready; check ${GATEWAY_LOG} and ${GATEWAY_DIR}/tmp/app.log"
+    return 1
+}
+
+
+gateway_stop() {
+    log_info "Stopping Gateway..."
+
+    if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
+        (cd "${GATEWAY_DIR}" && GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
+    fi
+
+    if [ -f "${GATEWAY_PID_FILE}" ]; then
+        local gateway_pid
+        gateway_pid="$(cat "${GATEWAY_PID_FILE}" 2>/dev/null || true)"
+        if [ -n "${gateway_pid}" ]; then
+            stop_process_if_owned "${gateway_pid}" "${GATEWAY_DIR}" "gateway pidfile process" || true
+        fi
+        rm -f "${GATEWAY_PID_FILE}"
+    fi
+
+    stop_port_processes_if_owned "${GATEWAY_PORT}" "${GATEWAY_DIR}" "gateway"
+    stop_matching_processes_if_owned "gateway/community/main.py" "${GATEWAY_DIR}" "gateway process"
+    log_info "Gateway stopped"
+}
+
+
+gateway_status() {
+    local gateway_pid=""
+    gateway_pid="$(lsof -tiTCP:${GATEWAY_PORT} -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+    if [ -n "${gateway_pid}" ]; then
+        if gateway_ready; then
+            echo "  Gateway:   Running (PID: ${gateway_pid}, port: ${GATEWAY_PORT}, health: OK)"
+        else
+            echo "  Gateway:   Running (PID: ${gateway_pid}, port: ${GATEWAY_PORT}, health: FAIL)"
+        fi
+    else
+        echo "  Gateway:   Stopped (port: ${GATEWAY_PORT})"
+    fi
+}
+
+
+gateway_ready() {
+    curl --noproxy '*' --connect-timeout 1 --max-time 2 -s "http://127.0.0.1:${GATEWAY_PORT}/health" > /dev/null 2>&1
+}
+
+
+gateway_prereqs() {
+    local has_error=false
+
+    echo -e "${CYAN}[gateway] Prerequisites${NC}"
+
+    if check_uv_installed; then
+        prereq_ok "uv: $(uv --version 2>&1 | head -1)"
+    else
+        prereq_error "uv not found. Run: singlebox.sh install-tools"
+        has_error=true
+    fi
+
+    if check_directory_exists "${GATEWAY_DIR}" "gateway" 2>/dev/null; then
+        prereq_ok "directory: ${GATEWAY_DIR}"
+    else
+        prereq_error "directory not found: ${GATEWAY_DIR}"
+        has_error=true
+    fi
+
+    if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
+        prereq_ok "lifecycle script: ${GATEWAY_APP_SCRIPT}"
+    else
+        prereq_error "lifecycle script not executable: ${GATEWAY_APP_SCRIPT}"
+        has_error=true
+    fi
+
+    if [ -f "${GATEWAY_DIR}/.venv/bin/activate" ]; then
+        prereq_ok "venv: ${GATEWAY_DIR}/.venv"
+    else
+        prereq_warn "venv not found: ${GATEWAY_DIR}/.venv — run: singlebox.sh setup gateway"
+    fi
+
+    if check_port_available "${GATEWAY_PORT}"; then
+        prereq_ok "Port ${GATEWAY_PORT} available"
+    else
+        prereq_warn "Port ${GATEWAY_PORT} is in use"
+    fi
+
+    if [ "${has_error}" = true ]; then
+        return 1
+    fi
+    return 0
+}
+
+
+gateway_help() {
+    echo "gateway - Gateway service (port ${GATEWAY_PORT})"
+}

--- a/scripts/modules/gateway.sh
+++ b/scripts/modules/gateway.sh
@@ -47,6 +47,19 @@ gateway_start() {
     log_info "Starting Gateway service on port ${GATEWAY_PORT}..."
     log_info "Log: ${GATEWAY_LOG}"
 
+    # Principal signing key: same variable name and dev default as the BCS
+    # verifier side (scripts/modules/bcs.sh), so the two ends of the signed
+    # principal contract hold the same key without any coordination. The
+    # backend verifies under its own spelling, armed in backend.sh with the
+    # same default. An .env.local value overrides all three together.
+    export AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE="${AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE:-avernet-dev-signing-key-NOT-FOR-PROD}"
+
+    # Local caller identity: the only community `user` strategy verifies real
+    # Google tokens, which a dev box has none of. GATEWAY_AUTH_MOCK=1 appends
+    # the x-dev-user header strategy (mirrors BCS_AUTH_MOCK in bcs.sh); set
+    # GATEWAY_AUTH_MOCK=0 in .env.local to require real credentials.
+    export GATEWAY_AUTH_MOCK="${GATEWAY_AUTH_MOCK:-1}"
+
     (
         cd "${GATEWAY_DIR}"
         GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare

--- a/scripts/singlebox.sh
+++ b/scripts/singlebox.sh
@@ -53,6 +53,7 @@ BCS_DIR="${PROJECT_ROOT}/src/bcs"
 BCSFUSE_DIR="${PROJECT_ROOT}/src/bcsfuse"
 RELAY_DIR="${RELAY_DIR:-${PROJECT_ROOT}/../teamclaw-aicoding-relay}"
 BAAS_DIR="${PROJECT_ROOT}/src/baas"
+GATEWAY_DIR="${PROJECT_ROOT}/src/gateway"
 
 # 默认版本
 DEFAULT_OPENCLAW_VERSION=">=2026.3.28"
@@ -63,6 +64,7 @@ DEFAULT_HERMES_PORT_START="18700"
 DEFAULT_HERMES_PORT_END="18799"
 DEFAULT_BCSFUSE_PORT="8765"
 DEFAULT_FRONTEND_PORT="8000"
+DEFAULT_GATEWAY_PORT="8889"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-${DEFAULT_OPENCLAW_VERSION}}"
 BCS_PORT="${BCS_PORT:-${DEFAULT_BCS_PORT}}"
 RELAY_PORT="${RELAY_PORT:-${DEFAULT_RELAY_PORT}}"
@@ -73,6 +75,7 @@ HERMES_PORT_START="${HERMES_PORT_START:-${DEFAULT_HERMES_PORT_START}}"
 HERMES_PORT_END="${HERMES_PORT_END:-${DEFAULT_HERMES_PORT_END}}"
 BCSFUSE_PORT="${BCSFUSE_PORT:-${DEFAULT_BCSFUSE_PORT}}"
 FRONTEND_PORT="${FRONTEND_PORT:-${DEFAULT_FRONTEND_PORT}}"
+GATEWAY_PORT="${GATEWAY_PORT:-${DEFAULT_GATEWAY_PORT}}"
 CHAT_ENGINE="${CHAT_ENGINE:-openclaw}"
 BOTS_PROFILE_DIR="${BOTS_PROFILE_DIR:-}"
 BOTS_EXCLUDED_PROFILE_SOURCE="${BOTS_EXCLUDED_PROFILE_SOURCE:-}"
@@ -164,6 +167,7 @@ source "${SCRIPT_DIR}/modules/engine.sh"
 source "${SCRIPT_DIR}/modules/baas.sh"
 source "${SCRIPT_DIR}/modules/backend.sh"
 source "${SCRIPT_DIR}/modules/frontend.sh"
+source "${SCRIPT_DIR}/modules/gateway.sh"
 source "${SCRIPT_DIR}/modules/bcs.sh"
 source "${SCRIPT_DIR}/modules/bcsfuse.sh"
 source "${SCRIPT_DIR}/modules/bots.sh"
@@ -421,6 +425,7 @@ show_help() {
     echo "  --openclaw-version, -ov VERSION Specify openclaw npm version/range (default: ${DEFAULT_OPENCLAW_VERSION})"
     echo "  --bcs-port, -bp PORT          Specify BCS port (default: ${DEFAULT_BCS_PORT})"
     echo "  --frontend-port, -fp PORT     Specify frontend dev server port (default: ${DEFAULT_FRONTEND_PORT})"
+    echo "  --gateway-port PORT           Specify Gateway dev server port (default: ${DEFAULT_GATEWAY_PORT})"
     echo "  --bcs-env local|dev           BCS runtime env; default: local"
     echo "  --bcn-plugin-source source|npm  BCN plugin source: build from repo (source, default) or install"
     echo "                                  @avernet-plugin/openclaw-channel-bcn (npm). Env: BCN_PLUGIN_SOURCE,"
@@ -438,7 +443,7 @@ show_help() {
     echo ""
     echo "Services:"
     # 从各模块收集帮助信息
-    for svc in baas backend bcs bcsfuse frontend engine bots; do
+    for svc in baas backend gateway bcs bcsfuse frontend engine bots; do
         if type -t "${svc}_help" &>/dev/null; then
             echo "  $( "${svc}_help" )"
         fi
@@ -882,6 +887,15 @@ main() {
                 FRONTEND_PORT="$2"
                 shift 2
                 ;;
+            --gateway-port)
+                if [ -z "$2" ] || [ "$2" = -* ]; then
+                    log_error "Port number required for $1"
+                    show_help
+                    exit 1
+                fi
+                GATEWAY_PORT="$2"
+                shift 2
+                ;;
             --engine|-e)
                 if [ -z "$2" ] || [ "$2" = -* ]; then
                     log_error "Engine type required for $1"
@@ -984,7 +998,7 @@ main() {
                 LOCAL_MODE=true
                 shift
                 ;;
-            baas|backend|bcs|bcsfuse|frontend|engine|bots|bcs_bots|bcs_frontend|hybrid|merchant_hybrid|all)
+            baas|backend|gateway|bcs|bcsfuse|frontend|engine|bots|bcs_bots|bcs_frontend|hybrid|merchant_hybrid|all)
                 # Legacy: service name without command defaults to start
                 services+=("$1")
                 if [ -z "$command" ]; then

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -349,11 +349,17 @@ route dependency        → require_principal(request)       ─┘  cache on sc
   That name **defaults**, so a deployment configures only the *value*: the corp
   secret store (corp overlays also override the name),
   or `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` (community).
-  **Singlebox resolves nothing** — no secret store, no local stand-in — so
-  `/openapi/v1` denies there and no config knob changes that; giving singlebox a
-  key is a deliberate change, not a config line. There is no dev fallback key on
-  this side on purpose: a committed shared secret is a committed credential. The
-  key is resolved once at boot, so rotating it needs a restart on both sides.
+  **The backend itself resolves nothing in singlebox** — no secret store, no
+  local stand-in, and no backend config knob changes that. The deliberate
+  change lives in the *launcher*: `scripts/modules/backend.sh` arms the
+  community env var with the same NOT-FOR-PROD dev key the gateway signs with
+  (`scripts/modules/gateway.sh`) and BCS verifies with
+  (`scripts/modules/bcs.sh`), so a locally forwarded `/openapi/v1` request
+  verifies instead of always-401. Export the variable yourself (e.g. in
+  `.env.local`) to override it. The application still ships no dev fallback
+  key on purpose: a committed shared secret is a committed credential, and the
+  launcher default authenticates nothing outside a dev box. The key is
+  resolved once at boot, so rotating it needs a restart on both sides.
 
   **An unresolvable key behaves differently by environment**, and the
   difference is the whole point:

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -317,11 +317,14 @@ AvernetTenantMiddleware → resolve_avernet_tenant(request)  ─┐
 - `utils/gateway_principal_config.py` —— 通过 `SecretResolver` 按
   `SecretNamesConfig.gateway_principal_signing_key` 解析共享密钥。该密钥名**自带默认
   值**，因此部署只需配置「值」：公司密钥库（corp，overlay 同时覆盖密钥名）、
-  `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE`（community）。单盒**不解析任何值** ——
-  既没有密钥库，也不提供本地替代品，因此单盒的 `/openapi/v1` 一律拒绝。
-  单盒没有任何配置项可以改变这一点；要让单盒拿到密钥属于一次刻意的改动，而不是加一行配置。
-  这一侧故意**不带** dev 兜底密钥（提交进仓库的共享密钥就是提交进仓库的凭据）。密钥只在启动
-  时解析一次，因此轮换密钥需要两侧都重启。
+  `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE`（community）。**后端自身在单盒里
+  不解析任何值** —— 既没有密钥库，也不提供本地替代品，后端配置里也没有任何开关能改变这一点。
+  那次「刻意的改动」发生在启动器里：`scripts/modules/backend.sh` 会用与网关签名侧
+  （`scripts/modules/gateway.sh`）、BCS 验证侧（`scripts/modules/bcs.sh`）相同的
+  NOT-FOR-PROD dev 密钥填入该 community 环境变量，使本地经网关转发的 `/openapi/v1`
+  请求得以验签而非一律 401；自行导出该变量（例如写入 `.env.local`）即可覆盖。
+  应用本身依旧故意**不带** dev 兜底密钥（提交进仓库的共享密钥就是提交进仓库的凭据），
+  启动器默认值在开发机之外不为任何身份背书。密钥只在启动时解析一次，因此轮换密钥需要两侧都重启。
 
   **拿不到密钥时的行为按环境区分**，这个区别正是要点：
 

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -84,12 +84,23 @@ user_config:
   # decide which planes the upstream serves. The router re-spells it per plane
   # (https ⇄ wss, http ⇄ ws), so one configured value works for both and no
   # operator has to know which planes a given upstream is used for.
+  #
+  # These defaults are the SINGLE-BOX values: each URL names the port the
+  # matching `scripts/singlebox.sh` service listens on by default (backend 8888,
+  # baas 8890, bcs 21000, bcsfuse 8765 — two independent constants per service;
+  # changing a singlebox default port means changing it here too). A deployed
+  # edition overrides this whole section, exactly as it does for the schema
+  # sources above.
+  #
+  # `engine_proxy_server_url` stays a placeholder: no singlebox service serves
+  # the `/proxypass` prefix, so there is nothing local to name. Only the
+  # `bots-messages-ws` socket domain reads it; every other route is unaffected.
   upstream_vars:
-    backend_server_url: https://backend.sample.com
-    baas_server_url: https://baas.sample.com
-    bcs_server_url: https://bcs.sample.com
+    backend_server_url: http://127.0.0.1:8888
+    baas_server_url: http://127.0.0.1:8890
+    bcs_server_url: http://127.0.0.1:21000
     engine_proxy_server_url: https://engineproxy.sample.com
-    bcsfuse_server_url: https://bcsfuse.sample.com
+    bcsfuse_server_url: http://127.0.0.1:8765
 
   # Per-identity strategy chain (system-level config).
   # Each identity type runs its strategies in order; the first to recognise the

--- a/src/gateway/scripts/app.sh
+++ b/src/gateway/scripts/app.sh
@@ -4,7 +4,7 @@ WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 CONFIG_DIR="$WORK_DIR/configs"
 VENV_DIR="$WORK_DIR/.venv"
-APP_PORT="8888"
+APP_PORT="${GATEWAY_PORT:-${APP_PORT:-8888}}"
 APP_MODE=""
 APP_LOG_DIR="$HOME/logs/gateway"
 

--- a/src/gateway/src/gateway/community/bootstrap/_authn.py
+++ b/src/gateway/src/gateway/community/bootstrap/_authn.py
@@ -44,9 +44,50 @@ def build_authenticator(
     user_config: UserConfig,
 ) -> Authenticator:
     """Build the identity-chain registry + route table from DI and typed config."""
+    chains = _strategy_chains(strategies, user_config=user_config)
+    _append_dev_mock(chains, strategies)
     return Authenticator(
-        strategies=_strategy_chains(strategies, user_config=user_config),
+        strategies=chains,
         route_security=_load_route_security(user_config),
+    )
+
+
+def _append_dev_mock(
+    chains: dict[PrincipalType, IdentityChain],
+    pool: Mapping[str, AuthStrategy],
+) -> None:
+    """Append the ``dev_header`` strategy to the user chain under the env gate.
+
+    ``GATEWAY_AUTH_MOCK=1`` is an env var and not config on purpose: the
+    shipped ``identity_strategies`` table never names the mock, so no overlay
+    can switch it on — only the operator of the process can. Appended last, so
+    a real Google token keeps winning when one is presented; the strategy
+    itself re-checks the same env var per request (its second gate), so this
+    composition is the convenience half, not the security boundary.
+    """
+    from gateway.community.plugins.authn.dev_header import (
+        DEV_USER_HEADER,
+        auth_mock_enabled,
+    )
+
+    if not auth_mock_enabled():
+        return
+    dev = pool.get("dev_header")
+    if dev is None:
+        _logger.warning(
+            "GATEWAY_AUTH_MOCK=1 but no 'dev_header' strategy in the pool; "
+            "dev auth mock NOT active"
+        )
+        return
+    chain = chains.get(PrincipalType.USER)
+    existing = chain._strategies if chain is not None else ()
+    if any(s.name == dev.name for s in existing):
+        return
+    chains[PrincipalType.USER] = IdentityChain(PrincipalType.USER, (*existing, dev))
+    _logger.warning(
+        "DEV AUTH MOCK ACTIVE (GATEWAY_AUTH_MOCK=1): the '%s' header is "
+        "trusted verbatim as the user identity — local development only",
+        DEV_USER_HEADER,
     )
 
 

--- a/src/gateway/src/gateway/community/bootstrap/_authn.py
+++ b/src/gateway/src/gateway/community/bootstrap/_authn.py
@@ -3,12 +3,15 @@
 Concrete authn strategies are provided by the DI container. This module only
 turns the configured strategy names and route-security table into the core
 ``Authenticator`` model; it does not construct plugins and does not read any
-module-level strategy registry.
+module-level strategy registry. The single exception is the env-gated dev auth
+mock (:func:`_append_dev_mock`), constructed here precisely so it never has to
+exist in the DI container that production modes share.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -45,45 +48,37 @@ def build_authenticator(
 ) -> Authenticator:
     """Build the identity-chain registry + route table from DI and typed config."""
     chains = _strategy_chains(strategies, user_config=user_config)
-    _append_dev_mock(chains, strategies)
+    _append_dev_mock(chains)
     return Authenticator(
         strategies=chains,
         route_security=_load_route_security(user_config),
     )
 
 
-def _append_dev_mock(
-    chains: dict[PrincipalType, IdentityChain],
-    pool: Mapping[str, AuthStrategy],
-) -> None:
+def _append_dev_mock(chains: dict[PrincipalType, IdentityChain]) -> None:
     """Append the ``dev_header`` strategy to the user chain under the env gate.
 
-    ``GATEWAY_AUTH_MOCK=1`` is an env var and not config on purpose: the
-    shipped ``identity_strategies`` table never names the mock, so no overlay
-    can switch it on — only the operator of the process can. Appended last, so
-    a real Google token keeps winning when one is presented; the strategy
-    itself re-checks the same env var per request (its second gate), so this
+    ``GATEWAY_AUTH_MOCK=1`` is an env var and not config on purpose: the mock
+    is not in the DI strategy pool, so ``identity_strategies`` cannot name it
+    — an overlay that tries is refused at boot as an unknown strategy — and
+    only the operator of the process can switch it on. The import sits behind
+    the gate too, so a production boot never even loads the module. Appended
+    last, so a real Google token keeps winning when one is presented; the
+    strategy re-checks the same env var per request (its second gate), so this
     composition is the convenience half, not the security boundary.
     """
+    if os.getenv("GATEWAY_AUTH_MOCK", "").strip() != "1":
+        return
     from gateway.community.plugins.authn.dev_header import (
         DEV_USER_HEADER,
-        auth_mock_enabled,
+        DevHeaderUserStrategy,
     )
 
-    if not auth_mock_enabled():
-        return
-    dev = pool.get("dev_header")
-    if dev is None:
-        _logger.warning(
-            "GATEWAY_AUTH_MOCK=1 but no 'dev_header' strategy in the pool; "
-            "dev auth mock NOT active"
-        )
-        return
     chain = chains.get(PrincipalType.USER)
     existing = chain._strategies if chain is not None else ()
-    if any(s.name == dev.name for s in existing):
-        return
-    chains[PrincipalType.USER] = IdentityChain(PrincipalType.USER, (*existing, dev))
+    chains[PrincipalType.USER] = IdentityChain(
+        PrincipalType.USER, (*existing, DevHeaderUserStrategy())
+    )
     _logger.warning(
         "DEV AUTH MOCK ACTIVE (GATEWAY_AUTH_MOCK=1): the '%s' header is "
         "trusted verbatim as the user identity — local development only",

--- a/src/gateway/src/gateway/community/bootstrap/_authn.py
+++ b/src/gateway/src/gateway/community/bootstrap/_authn.py
@@ -55,6 +55,13 @@ def build_authenticator(
     )
 
 
+# TODO(totalfrank): production code should carry ZERO mock code, including this
+# env-gated hook. Move the dev_header strategy (plugins/authn/dev_header) into a
+# dev-only distribution discovered via entry points — the same mechanism the
+# ``gateway.runner`` sofa/bare selection uses — installed only by the singlebox
+# dev flow, so this function and the plugin module disappear from production
+# installs entirely. Until then this hook is the single production touchpoint:
+# one env read that no-ops unless GATEWAY_AUTH_MOCK=1.
 def _append_dev_mock(chains: dict[PrincipalType, IdentityChain]) -> None:
     """Append the ``dev_header`` strategy to the user chain under the env gate.
 

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -7,7 +7,6 @@ from gateway.community.plugins.auth.stub import StubAuthPlugin
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
-from gateway.community.plugins.authn.dev_header import DevHeaderUserStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
@@ -101,17 +100,16 @@ class PluginContainer(containers.DeclarativeContainer):
         ),
     )
 
-    # In the pool but in no shipped chain: bootstrap appends it to the user
-    # chain only under GATEWAY_AUTH_MOCK=1, and the strategy itself answers
-    # None without that env var (see plugins/authn/dev_header).
-    dev_header_strategy = providers.Singleton(DevHeaderUserStrategy)
-
+    # The dev auth mock (plugins/authn/dev_header) is deliberately NOT in this
+    # pool: this container is the production DI graph — enterprise merges its
+    # strategies into this same dict — and the mock must not exist in it. The
+    # bootstrap constructs it directly, only under GATEWAY_AUTH_MOCK=1
+    # (bootstrap/_authn.py), so without the env var it is never even imported.
     authn_strategies = providers.Dict(
         google=google_strategy,
         bot_token=bot_token_strategy,
         app_token=app_token_strategy,
         access_key_token=access_key_token_strategy,
-        dev_header=dev_header_strategy,
     )
 
 

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -7,6 +7,7 @@ from gateway.community.plugins.auth.stub import StubAuthPlugin
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
+from gateway.community.plugins.authn.dev_header import DevHeaderUserStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
@@ -100,11 +101,17 @@ class PluginContainer(containers.DeclarativeContainer):
         ),
     )
 
+    # In the pool but in no shipped chain: bootstrap appends it to the user
+    # chain only under GATEWAY_AUTH_MOCK=1, and the strategy itself answers
+    # None without that env var (see plugins/authn/dev_header).
+    dev_header_strategy = providers.Singleton(DevHeaderUserStrategy)
+
     authn_strategies = providers.Dict(
         google=google_strategy,
         bot_token=bot_token_strategy,
         app_token=app_token_strategy,
         access_key_token=access_key_token_strategy,
+        dev_header=dev_header_strategy,
     )
 
 

--- a/src/gateway/src/gateway/community/config/_config_loader.py
+++ b/src/gateway/src/gateway/community/config/_config_loader.py
@@ -109,8 +109,12 @@ def _merge(base: dict, overlay: dict) -> dict:
 def _parse_config(raw: dict, *, config_dir: Path | None = None) -> Config:
     module_raw = raw.get("module_config") or {}
     web_raw = module_raw.get("web") or {}
+    port = int(web_raw.get("port", 8888))
+    env_port = os.getenv("GATEWAY_PORT", "").strip()
+    if env_port:
+        port = int(env_port)
     web = WebConfig(
-        port=int(web_raw.get("port", 8888)),
+        port=port,
         start=web_raw.get("start", WebConfig.start),
         enable_api_docs=bool(web_raw.get("enable_api_docs", True)),
     )

--- a/src/gateway/src/gateway/community/plugins/authn/dev_header/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_header/__init__.py
@@ -1,0 +1,15 @@
+"""``dev_header`` strategy — LOCAL-ONLY user identity from the x-dev-user header."""
+
+from ._strategy import (
+    AUTH_MOCK_ENV,
+    DEV_USER_HEADER,
+    DevHeaderUserStrategy,
+    auth_mock_enabled,
+)
+
+__all__ = [
+    "AUTH_MOCK_ENV",
+    "DEV_USER_HEADER",
+    "DevHeaderUserStrategy",
+    "auth_mock_enabled",
+]

--- a/src/gateway/src/gateway/community/plugins/authn/dev_header/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_header/_strategy.py
@@ -1,0 +1,78 @@
+"""``dev_header`` strategy — a LOCAL-ONLY user identity from an explicit header.
+
+The community ``user`` chain verifies real Google access tokens, which a dev
+box has none of — so under the shipped fail-closed route table every request
+through a locally run gateway 401s at the edge. This strategy exists for that
+box alone: it maps the ``x-dev-user`` header's value onto a
+:class:`UserPrincipal` verbatim, no verification, the same trust move
+``BCS_AUTH_MOCK`` makes on the BCS side.
+
+It is DOUBLE-gated, and both gates are environment variables rather than
+config on purpose — config travels through overlays and repos, an env var is
+set by the operator of the process:
+
+- the bootstrap appends it to the ``user`` chain only when
+  ``GATEWAY_AUTH_MOCK=1`` (``bootstrap/_authn.py``), so the shipped
+  ``identity_strategies`` table never names it; and
+- :meth:`build` itself answers ``None`` unless the same variable is set, so
+  even a config overlay that declares ``dev_header`` in a chain gets an inert
+  strategy, not an open door.
+
+The env var is read per request, not cached at construction: the singleton is
+built once per process, and reading late keeps a test's ``monkeypatch.setenv``
+honest.
+"""
+
+from __future__ import annotations
+
+import os
+
+from gateway.community.logger import get_logger
+from gateway.community.spi.auth import AuthenticatedUser
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Principal,
+    PrincipalType,
+    UserPrincipal,
+)
+
+logger = get_logger("authn-dev-header")
+
+#: The switch shared with ``bootstrap/_authn.py``; only the literal "1" enables.
+AUTH_MOCK_ENV = "GATEWAY_AUTH_MOCK"
+
+#: The header carrying the asserted user id. Requiring an explicit header keeps
+#: every mock-authenticated request deliberate — an anonymous request still
+#: fail-closes even with the mock enabled.
+DEV_USER_HEADER = "x-dev-user"
+
+
+def auth_mock_enabled() -> bool:
+    """Whether the operator switched the dev auth mock on for this process."""
+    return os.getenv(AUTH_MOCK_ENV, "").strip() == "1"
+
+
+class DevHeaderUserStrategy:
+    """Resolve the ``x-dev-user`` header into a ``UserPrincipal``, unverified."""
+
+    name = "dev_header"
+    principal_type = PrincipalType.USER
+
+    def __init__(self, *, token_header: str = DEV_USER_HEADER) -> None:
+        self._token_header = token_header
+
+    async def build(self, creds: CredentialBundle) -> Principal | None:
+        if not auth_mock_enabled():
+            return None  # gate 2: declared-but-not-enabled stays inert
+        user_id = creds.headers.get(self._token_header, "").strip()
+        if not user_id:
+            return None  # header absent → not applicable; runner fail-closes
+        logger.debug("dev auth header accepted: user=%s", user_id)
+        subject = AuthenticatedUser(
+            id=user_id,
+            username=user_id,
+            display_name=user_id,
+        )
+        # No tenant, same as the google strategy: an asserted user id says who
+        # the person claims to be, never which tenant they act for.
+        return UserPrincipal(subject=subject)

--- a/src/gateway/src/gateway/community/plugins/authn/dev_header/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_header/_strategy.py
@@ -7,16 +7,19 @@ box alone: it maps the ``x-dev-user`` header's value onto a
 :class:`UserPrincipal` verbatim, no verification, the same trust move
 ``BCS_AUTH_MOCK`` makes on the BCS side.
 
-It is DOUBLE-gated, and both gates are environment variables rather than
-config on purpose — config travels through overlays and repos, an env var is
-set by the operator of the process:
+It is DOUBLE-gated, and both gates are the same environment variable rather
+than config on purpose — config travels through overlays and repos, an env var
+is set by the operator of the process:
 
-- the bootstrap appends it to the ``user`` chain only when
-  ``GATEWAY_AUTH_MOCK=1`` (``bootstrap/_authn.py``), so the shipped
-  ``identity_strategies`` table never names it; and
+- the bootstrap constructs and appends it to the ``user`` chain only when
+  ``GATEWAY_AUTH_MOCK=1`` (``bootstrap/_authn.py``). It is deliberately NOT in
+  the DI strategy pool — the pool is the production graph, enterprise merges
+  into it, and ``identity_strategies`` naming ``dev_header`` is refused at
+  boot as an unknown strategy; without the env var this module is never even
+  imported; and
 - :meth:`build` itself answers ``None`` unless the same variable is set, so
-  even a config overlay that declares ``dev_header`` in a chain gets an inert
-  strategy, not an open door.
+  any future wiring that reaches this class some other way still gets an
+  inert strategy, not an open door.
 
 The env var is read per request, not cached at construction: the singleton is
 built once per process, and reading late keeps a test's ``monkeypatch.setenv``

--- a/src/gateway/tests/unit/conftest.py
+++ b/src/gateway/tests/unit/conftest.py
@@ -12,6 +12,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Run tests in bare mode without leaking the host's GW_* env vars."""
     monkeypatch.delenv("GATEWAY_RUN_MODE", raising=False)
     monkeypatch.delenv("GATEWAY_CONFIG_PATH", raising=False)
+    monkeypatch.delenv("GATEWAY_PORT", raising=False)
     monkeypatch.delenv("SOFAPY_CONFIG_PATH", raising=False)
     monkeypatch.delenv("SERVER_ENV", raising=False)
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)

--- a/src/gateway/tests/unit/conftest.py
+++ b/src/gateway/tests/unit/conftest.py
@@ -13,6 +13,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GATEWAY_RUN_MODE", raising=False)
     monkeypatch.delenv("GATEWAY_CONFIG_PATH", raising=False)
     monkeypatch.delenv("GATEWAY_PORT", raising=False)
+    monkeypatch.delenv("GATEWAY_AUTH_MOCK", raising=False)
     monkeypatch.delenv("SOFAPY_CONFIG_PATH", raising=False)
     monkeypatch.delenv("SERVER_ENV", raising=False)
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)

--- a/src/gateway/tests/unit/plugins/test_config.py
+++ b/src/gateway/tests/unit/plugins/test_config.py
@@ -161,6 +161,16 @@ class TestParseConfig:
         assert config.module_config.web is not None
         assert config.module_config.web.port == 7000
 
+    def test_gateway_port_env_overrides_web_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GATEWAY_PORT", "8899")
+
+        config = _parse_config({"module_config": {"web": {"port": 7000}}})
+
+        assert config.module_config.web is not None
+        assert config.module_config.web.port == 8899
+
 
 # ── _resolve_base_path / _resolve_overlay_path ───────────────────────────────
 

--- a/src/gateway/tests/unit/plugins/test_dev_header_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_dev_header_strategy.py
@@ -1,0 +1,67 @@
+"""Unit tests for the ``dev_header`` user strategy (x-dev-user → UserPrincipal).
+
+The strategy is the env-gated LOCAL-ONLY auth mock: it must resolve the header
+only under ``GATEWAY_AUTH_MOCK=1`` and stay inert — even when chained — without
+it. The gating tests for the bootstrap half live in ``test_strategy_chains.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.community.plugins.authn.dev_header import (
+    DEV_USER_HEADER,
+    DevHeaderUserStrategy,
+)
+from gateway.community.spi.authn import CredentialBundle, UserPrincipal
+
+
+def _creds(user: str | None) -> CredentialBundle:
+    headers = {DEV_USER_HEADER: user} if user is not None else {}
+    return CredentialBundle(headers=headers, cookies={}, query={})
+
+
+async def test_enabled_header_resolves_user_principal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    result = await DevHeaderUserStrategy().build(_creds("dev-alice"))
+    assert isinstance(result, UserPrincipal)
+    assert result.subject.id == "dev-alice"
+    assert result.subject.username == "dev-alice"
+
+
+async def test_disabled_env_ignores_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate 2: even a chained strategy answers None without the env var."""
+    monkeypatch.delenv("GATEWAY_AUTH_MOCK", raising=False)
+    assert await DevHeaderUserStrategy().build(_creds("dev-alice")) is None
+
+
+async def test_non_one_value_is_not_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "true")
+    assert await DevHeaderUserStrategy().build(_creds("dev-alice")) is None
+
+
+async def test_absent_header_is_not_applicable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enabled but headerless → None, so the runner still fail-closes."""
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    assert await DevHeaderUserStrategy().build(_creds(None)) is None
+
+
+async def test_blank_header_is_not_applicable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    assert await DevHeaderUserStrategy().build(_creds("   ")) is None
+
+
+async def test_resolved_principal_asserts_no_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same contract as the google strategy: who, never which tenant."""
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    result = await DevHeaderUserStrategy().build(_creds("dev-alice"))
+    assert isinstance(result, UserPrincipal)
+    assert result.subject.tenant_id is None

--- a/src/gateway/tests/unit/plugins/test_strategy_chains.py
+++ b/src/gateway/tests/unit/plugins/test_strategy_chains.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from gateway.community.bootstrap._authn import (
+    _append_dev_mock,
     _load_route_security,
     _strategy_chains,
 )
@@ -14,6 +15,7 @@ from gateway.community.core.authn import IdentityChain
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
+from gateway.community.plugins.authn.dev_header import DevHeaderUserStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.spi.authn import PrincipalType
 
@@ -24,6 +26,7 @@ def _pool():
         "bot_token": BotTokenStrategy(registry=None),
         "app_token": AppTokenStrategy(registry=None),
         "access_key_token": AccessKeyTokenStrategy(registry=None),
+        "dev_header": DevHeaderUserStrategy(),
     }
 
 
@@ -133,3 +136,56 @@ def test_load_route_security_with_none_user_config_uses_fail_closed_default(
     route_security = _load_route_security(user_config=None)
     req = route_security.resolve("GET", "/anything")
     assert req is not None
+
+
+# ── dev auth mock gating (_append_dev_mock) ─────────────────────────────────
+
+
+def _declared_config(tmp_path, monkeypatch):
+    (tmp_path / "application.yaml").write_text(
+        "user_config:\n  identity_strategies:\n    user: [google]\n    bot: [bot_token]\n    app: [app_token]\n    access_key: [access_key_token]\n"
+    )
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_path))
+    return _user_config()
+
+
+def _user_chain_names(chains) -> list[str]:
+    return [s.name for s in chains[PrincipalType.USER]._strategies]
+
+
+def test_dev_mock_absent_without_env(tmp_path, monkeypatch):
+    """Pool membership alone activates nothing — the env var is the switch."""
+    monkeypatch.delenv("GATEWAY_AUTH_MOCK", raising=False)
+    cfg = _declared_config(tmp_path, monkeypatch)
+    chains = _strategy_chains(_pool(), user_config=cfg)
+    _append_dev_mock(chains, _pool())
+    assert _user_chain_names(chains) == ["google"]
+
+
+def test_dev_mock_appended_last_with_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    cfg = _declared_config(tmp_path, monkeypatch)
+    chains = _strategy_chains(_pool(), user_config=cfg)
+    _append_dev_mock(chains, _pool())
+    assert _user_chain_names(chains) == ["google", "dev_header"]
+
+
+def test_dev_mock_env_without_pool_entry_is_skipped(tmp_path, monkeypatch):
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    cfg = _declared_config(tmp_path, monkeypatch)
+    pool = {k: v for k, v in _pool().items() if k != "dev_header"}
+    chains = _strategy_chains(pool, user_config=cfg)
+    _append_dev_mock(chains, pool)
+    assert _user_chain_names(chains) == ["google"]
+
+
+def test_dev_mock_not_duplicated_when_declared(tmp_path, monkeypatch):
+    """A config that already names dev_header does not get it twice."""
+    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+    (tmp_path / "application.yaml").write_text(
+        "user_config:\n  identity_strategies:\n    user: [google, dev_header]\n"
+    )
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_path))
+    chains = _strategy_chains(_pool(), user_config=_user_config())
+    _append_dev_mock(chains, _pool())
+    assert _user_chain_names(chains) == ["google", "dev_header"]

--- a/src/gateway/tests/unit/plugins/test_strategy_chains.py
+++ b/src/gateway/tests/unit/plugins/test_strategy_chains.py
@@ -15,7 +15,6 @@ from gateway.community.core.authn import IdentityChain
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
-from gateway.community.plugins.authn.dev_header import DevHeaderUserStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.spi.authn import PrincipalType
 
@@ -26,7 +25,6 @@ def _pool():
         "bot_token": BotTokenStrategy(registry=None),
         "app_token": AppTokenStrategy(registry=None),
         "access_key_token": AccessKeyTokenStrategy(registry=None),
-        "dev_header": DevHeaderUserStrategy(),
     }
 
 
@@ -154,11 +152,11 @@ def _user_chain_names(chains) -> list[str]:
 
 
 def test_dev_mock_absent_without_env(tmp_path, monkeypatch):
-    """Pool membership alone activates nothing — the env var is the switch."""
+    """Without the env var the user chain is exactly what config declared."""
     monkeypatch.delenv("GATEWAY_AUTH_MOCK", raising=False)
     cfg = _declared_config(tmp_path, monkeypatch)
     chains = _strategy_chains(_pool(), user_config=cfg)
-    _append_dev_mock(chains, _pool())
+    _append_dev_mock(chains)
     assert _user_chain_names(chains) == ["google"]
 
 
@@ -166,26 +164,16 @@ def test_dev_mock_appended_last_with_env(tmp_path, monkeypatch):
     monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
     cfg = _declared_config(tmp_path, monkeypatch)
     chains = _strategy_chains(_pool(), user_config=cfg)
-    _append_dev_mock(chains, _pool())
+    _append_dev_mock(chains)
     assert _user_chain_names(chains) == ["google", "dev_header"]
 
 
-def test_dev_mock_env_without_pool_entry_is_skipped(tmp_path, monkeypatch):
-    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
-    cfg = _declared_config(tmp_path, monkeypatch)
-    pool = {k: v for k, v in _pool().items() if k != "dev_header"}
-    chains = _strategy_chains(pool, user_config=cfg)
-    _append_dev_mock(chains, pool)
-    assert _user_chain_names(chains) == ["google"]
-
-
-def test_dev_mock_not_duplicated_when_declared(tmp_path, monkeypatch):
-    """A config that already names dev_header does not get it twice."""
-    monkeypatch.setenv("GATEWAY_AUTH_MOCK", "1")
+def test_dev_mock_cannot_be_declared_in_config(tmp_path, monkeypatch):
+    """The mock is env-only: it is not in the DI pool, so a config overlay
+    that names it is refused at boot rather than silently honoured."""
     (tmp_path / "application.yaml").write_text(
         "user_config:\n  identity_strategies:\n    user: [google, dev_header]\n"
     )
     monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_path))
-    chains = _strategy_chains(_pool(), user_config=_user_config())
-    _append_dev_mock(chains, _pool())
-    assert _user_chain_names(chains) == ["google", "dev_header"]
+    with pytest.raises(KeyError, match="unknown strategy 'dev_header'"):
+        _strategy_chains(_pool(), user_config=_user_config())


### PR DESCRIPTION
## Problem

PR #1135 made Gateway startable through `scripts/singlebox.sh` (targeting `dev`), but a locally started Gateway could not actually forward anything to the local stack:

- `application.yaml` `user_config.upstream_vars` still pointed at the `*.sample.com` placeholders, and the `${...}` expansion reads only that YAML map — there is no env override or reachable overlay in the singlebox flow. The gateway booted, passed `/health`, and then dialed nonexistent hosts on every forwarded request.
- Even with correct URLs, forwarding fails on the signed-principal contract: without `AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE` the gateway answers `500 principal signing failed` on every forward, and without `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` the backend 401s everything on `/openapi/v1` (BCS already self-arms a dev key in `bcs.sh`).
- The only community `user` identity strategy verifies real Google access tokens against Google's live userinfo endpoint, so under the fail-closed `/**: user: required` route table, a dev box without Google credentials 401s at the edge.

This branch targets `dev_refactory_collaboration`, which did not contain #1135, so its commit is cherry-picked here first.

## Solution

Cherry-pick of #1135 (`feat(gateway): add singlebox lifecycle scripts`), plus commits closing the three gaps:

1. **Upstream URLs** — `upstream_vars` now carries the singlebox defaults: backend `http://127.0.0.1:8888`, baas `http://127.0.0.1:8890`, bcs `http://127.0.0.1:21000`, bcsfuse `http://127.0.0.1:8765`. This matches the file's documented single-box-default role (deployed editions override the section). `engine_proxy_server_url` keeps a placeholder: no singlebox service serves `/proxypass`, and only the `bots-messages-ws` socket domain reads it. The new `spaces` / `work-orders` / `work-order-notifications` domains on this branch all ride the `backend` server, so they are covered by the same value.
2. **Signing contract** — `scripts/modules/gateway.sh` exports `AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE` with the same NOT-FOR-PROD dev default `bcs.sh` already uses, so gateway signer and BCS verifier agree without coordination; `scripts/modules/backend.sh` arms the backend verifier's community env var with the matching value on the singlebox (LOCAL_MODE) launch path only. The application itself still ships no fallback key; the deliberate arming lives in the launchers, and `.env.local` overrides all of them together. The backend `docs/openapi-v1/README.md` / `README.zh-CN.md` singlebox-key paragraphs are updated to match.
3. **Local caller identity** — a new `dev_header` user strategy maps the `x-dev-user` header onto a `UserPrincipal` verbatim, double-gated on `GATEWAY_AUTH_MOCK=1`. The strategy is deliberately **not** in `PluginContainer.authn_strategies` — that dict is the production DI graph and the enterprise edition merges its own strategies into it — so a config overlay naming `dev_header` is refused at boot as an unknown strategy. Instead the bootstrap constructs and appends it to the user chain only under the env var (without it the module is never even imported), and the strategy itself answers `None` without the same env var, so any future wiring that reaches the class some other way still gets an inert strategy. It is appended after `google`, so a real token keeps winning. `gateway.sh` defaults the flag to `1` (set `GATEWAY_AUTH_MOCK=0` in `.env.local` to require real credentials), mirroring `BCS_AUTH_MOCK` on the BCS side.

Rejected alternatives:

- Env-var overrides for each upstream URL in the config loader (the `GATEWAY_PORT` precedent): workable, but the committed YAML is already the single-box default per its own comments, so editing it directly needs no new mechanism and keeps one source of truth.
- Pointing `authn.google.userinfo_url` at a local mock userinfo server instead of a dev strategy: zero gateway code, but requires an extra always-running process for gateway local dev and hides an auth mock inside the mock model server.
- Registering the dev strategy in the DI pool with env-gated chain composition: rejected because the pool is shared with production/enterprise wiring; the mock now exists only in a boot that explicitly asked for it.

Known limitations (documented, deliberately out of scope): `chat` → baas forwarding still fails in community singlebox — baas resolves its gateway JWT secret from an unseeded stub secret store and additionally requires provisioned `baas_resource_key` records; and the `bots-messages-ws` socket domain has no local upstream.

## Validation

**Full end-to-end singlebox run** (fresh Linux container): brought up gateway (:8889), backend (:8888), BCS (:21000, cargo-built from source), bcsfuse (:8765), and BAAS (:8890) via `scripts/singlebox.sh` on this branch, then smoke-tested forwarding through the gateway, attributing each response via the gateway's forward log:

| Route through gateway :8889 | Result |
|---|---|
| `GET /health` | 200 |
| `GET /openapi/v1/bots` (anonymous) | forwarded; **401 from the backend's `require_principal`** — the documented moved-refusal behavior |
| `GET /openapi/v1/bots?user_id=dev-alice` + `x-dev-user` | **200** with data envelope; backend logs `caller=user:dev-alice tenant=teamclaw` from the verified signed principal |
| `GET /openapi/v1/bcsfuse/workers` | **200**; forward log confirms the rewrite to `/v1/workers` |
| `GET /api/v1/collaboration/sessions/{id}/files` + `x-dev-user` | structured BCS business response (`session_not_found`, BCS request id) — gateway→BCS reached application logic |
| `GET /openapi/v1/collaboration/groups` + `x-dev-user` | 401 at the edge: that plane requires a registered `app` credential (`user: required, app: required`) — correct fail-closed |
| `GET /openapi/v1/chat/*` | forwarded to and answered by BAAS (probe path 404s; real chat routes hit the documented baas limitation) |

Environment notes from that run: `protobuf-compiler` had to be installed for the BCS build, and the committed `uv.lock` files pin a mirror unreachable from that container (`UV_DEFAULT_INDEX` override used; lockfiles restored, not committed). Also surfaced a pre-existing bug outside this PR's scope: `bcsfuse_setup()` in `scripts/modules/bcsfuse.sh` never calls `bcsfuse_load_env()`, so its env-file generation `cp`s to an empty path on a standalone `setup bcsfuse` — worked around manually; candidate for a separate fix.

Static and unit gates:

- `bash -n scripts/singlebox.sh scripts/modules/gateway.sh scripts/modules/backend.sh src/gateway/scripts/app.sh` — clean.
- Gateway unit suite from `src/gateway`: `uv run pytest tests/unit -q` — **622 passed** (includes 6 new `dev_header` strategy tests and 3 new bootstrap gating tests, one of which pins "declaring `dev_header` in config is refused at boot"; `tests/unit/conftest.py` now isolates `GATEWAY_AUTH_MOCK`).
- `ruff check` / `ruff format --check` on the touched Python files — clean.
- `basedpyright` on touched files: the only findings are `reportPrivateUsage` on `_strategies`/`_rules`, which pre-exist on the base branch in the same file (same idiom, also used by its log statements).
- Heavier module CI/coverage gates left to CI, matching #1135's lint-only pre-push.

## Compatibility and risk

- Additive for deployments: `application.yaml` placeholder values change from one non-working default (`*.sample.com`) to another that only works on a singlebox; deployed editions override the section either way.
- `backend.sh` singlebox launches now verify gateway principals with a public dev key — on a dev box this authenticates nothing an attacker couldn't already do with local access, and an explicit env value overrides it.
- The dev auth mock exists only in processes started with `GATEWAY_AUTH_MOCK=1`; it is absent from the DI container, and the shipped config cannot name it.
- Rollback: revert this branch's commits after the #1135 cherry-pick (which is independent).