### PR TITLE
fix(bcs): clean up channel bindings when deleting provider bot

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -377,6 +377,12 @@ impl ChannelBindingCleanupPort for FailingChannelBindingCleanup {
             "channel binding cleanup failed".to_string(),
         ))
     }
+
+    async fn delete_bindings_for_bot(&self, _bot_id: &str) -> ServiceResult<u64> {
+        Err(ServiceError::InternalError(
+            "channel binding cleanup failed".to_string(),
+        ))
+    }
 }
 
 #[derive(Default)]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -506,6 +506,18 @@ impl ChannelBindingCleanupPort for DeferredChannelBindingCleanupPort {
         })?;
         service.delete_bindings_for_group(group_id).await
     }
+
+    async fn delete_bindings_for_bot(
+        &self,
+        bot_id: &str,
+    ) -> bcs_service_api::ServiceResult<u64> {
+        let service = self.service.get().ok_or_else(|| {
+            bcs_service_api::ServiceError::InternalError(
+                "channel binding cleanup port is not initialized".to_string(),
+            )
+        })?;
+        service.delete_bindings_for_bot(bot_id).await
+    }
 }
 
 type ChannelRepos = (
@@ -1157,6 +1169,7 @@ fn build_provider_services_with_webhook_url_guard(
     relation: Arc<dyn bcs_service_api::RelationCoreService>,
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
     webhook_url_guard: OutboundUrlGuard,
+    channel_binding_cleanup: Arc<dyn ChannelBindingCleanupPort>,
 ) -> (
     Arc<dyn ProviderCoreService>,
     Arc<dyn ProviderBotCoreService>,
@@ -1176,7 +1189,8 @@ fn build_provider_services_with_webhook_url_guard(
         provider_bot_core.clone(),
         registry,
         relation,
-    );
+    )
+    .with_channel_binding_cleanup(channel_binding_cleanup);
     if let Some(user_directory) = user_directory {
         provider_management = provider_management.with_user_directory(user_directory);
     }
@@ -1693,6 +1707,7 @@ impl Default for BcsServerState {
         let relation_store: Arc<RelationCore> = Arc::new(RelationCore::memory());
         let user_directory =
             create_user_directory_plugin(&config).expect("default user directory config is valid");
+        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let (provider_core, provider_bot_core, provider_management) =
             build_provider_services_with_webhook_url_guard(
                 &provider_repos,
@@ -1700,6 +1715,7 @@ impl Default for BcsServerState {
                 relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>,
                 user_directory.clone(),
                 outbound_url_guard.clone(),
+                channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = memory_organization_services(
             &provider_repos,
@@ -1877,7 +1893,6 @@ impl Default for BcsServerState {
             provider_stream_gray_list.clone(),
             state_machine_terminal_observer.clone(),
         );
-        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let group_management_impl = Arc::new(GroupManagement::new(
             sessions.clone(),
             bot_registry.clone(),
@@ -3124,6 +3139,7 @@ impl BcsServer {
         let relation_store: Arc<RelationCore> = Arc::new(RelationCore::memory());
         let user_directory = create_user_directory_plugin(&config)
             .expect("user directory config is valid for in-memory server");
+        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let (provider_core, provider_bot_core, provider_management) =
             build_provider_services_with_webhook_url_guard(
                 &provider_repos,
@@ -3131,6 +3147,7 @@ impl BcsServer {
                 relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>,
                 user_directory.clone(),
                 provider_webhook_url_guard,
+                channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = memory_organization_services(
             &provider_repos,
@@ -3260,7 +3277,6 @@ impl BcsServer {
         let a2a_chat_runs: Arc<dyn A2aChatRunService> = a2a_chat_impl.clone();
         let a2a_chat_runs = maybe_wrap_a2a_chat_runs(&config, a2a_chat_runs);
         let direct_chat_run_snapshot: Arc<dyn DirectChatRunSnapshotPort> = a2a_chat_impl;
-        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let use_cases = build_use_case_bundle(
             &config,
             bot_registry.clone(),
@@ -3671,6 +3687,7 @@ impl BcsServer {
         let relation_svc: Arc<dyn bcs_service_api::RelationCoreService> =
             Arc::new(RelationCore::with_repo(relation_repo));
 
+        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let (provider_core, provider_bot_core, provider_management) =
             build_provider_services_with_webhook_url_guard(
                 &provider_repos,
@@ -3678,6 +3695,7 @@ impl BcsServer {
                 relation_svc.clone(),
                 user_directory.clone(),
                 outbound_url_guard.clone(),
+                channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = db_organization_services(
             db_plugin.clone(),
@@ -3861,7 +3879,6 @@ impl BcsServer {
         let a2a_chat_runs: Arc<dyn A2aChatRunService> = a2a_chat_impl.clone();
         let a2a_chat_runs = maybe_wrap_a2a_chat_runs(&config, a2a_chat_runs);
         let direct_chat_run_snapshot: Arc<dyn DirectChatRunSnapshotPort> = a2a_chat_impl;
-        let channel_binding_cleanup = Arc::new(DeferredChannelBindingCleanupPort::default());
         let use_cases = build_use_case_bundle(
             &config,
             bot_registry.clone(),
@@ -4721,6 +4738,99 @@ mod tests {
     #[derive(Default)]
     struct RecordingSessionChannelOutbound {
         events: tokio::sync::Mutex<Vec<HumanInputReadyEvent>>,
+    }
+
+    #[derive(Default)]
+    struct RecordingChannelBindingCleanup {
+        deleted_bot_ids: tokio::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ChannelBindingCleanupPort for RecordingChannelBindingCleanup {
+        async fn delete_bindings_for_group(
+            &self,
+            _group_id: &str,
+        ) -> bcs_service_api::ServiceResult<u64> {
+            Ok(0)
+        }
+
+        async fn delete_bindings_for_bot(
+            &self,
+            bot_id: &str,
+        ) -> bcs_service_api::ServiceResult<u64> {
+            self.deleted_bot_ids.lock().await.push(bot_id.to_string());
+            Ok(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_management_deletes_channel_bindings_when_provider_bot_is_deleted() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let provider_repos = memory_provider_repos();
+        let bot_repo = Arc::new(MemoryBotRepo::with_base_dir(temp_dir.path().to_path_buf()));
+        let bot_registry: Arc<dyn BotRegistryCoreService> = Arc::new(BotCore::with_provider_repos(
+            bot_repo,
+            provider_repos.provider_repo.clone(),
+            provider_repos.provider_credentials.clone(),
+            provider_repos.provider_bindings.clone(),
+        ));
+        let relation: Arc<dyn bcs_service_api::RelationCoreService> =
+            Arc::new(RelationCore::memory());
+        let cleanup = Arc::new(RecordingChannelBindingCleanup::default());
+        let (_provider_core, _provider_bot_core, provider_management) =
+            build_provider_services_with_webhook_url_guard(
+                &provider_repos,
+                bot_registry,
+                relation,
+                None,
+                OutboundUrlGuard::allowing_private_networks_for_tests(),
+                cleanup.clone(),
+            );
+
+        let registered = provider_management
+            .register_provider(RegisterProviderCommand {
+                name: "Provider".to_string(),
+                webhook_url: "https://provider.example.com/bcs/webhook".to_string(),
+                admin_callback_url: None,
+                auth_mode: bcs_domain::ProviderAuthMode::StaticBearer,
+                created_by: "11111111".to_string(),
+                protocol_version: None,
+                coordination: None,
+            })
+            .await
+            .expect("register provider");
+        let bot = provider_management
+            .register_provider_bot(bcs_service_api::RegisterProviderBotCommand {
+                provider_id: registered.provider_id.clone(),
+                provider_admin_token: registered.provider_admin_token.clone(),
+                name: "Bot".to_string(),
+                summary: None,
+                owners: vec!["11111111".to_string()],
+                provider_bot_ref: "bot-ref-1".to_string(),
+                domains: Vec::new(),
+                skills: Vec::new(),
+                scopes: Vec::new(),
+                bot_uuid: None,
+                reject_existing_bot_uuid: false,
+            })
+            .await
+            .expect("register provider bot");
+
+        let outcome = provider_management
+            .delete_provider_bot(bcs_service_api::DeleteProviderBotCommand {
+                provider_id: registered.provider_id,
+                provider_admin_token: registered.provider_admin_token,
+                provider_bot_ref: "bot-ref-1".to_string(),
+                allow_unbound_owner_suffixed_bot: false,
+            })
+            .await
+            .expect("delete provider bot");
+
+        assert!(outcome.deleted);
+        assert_eq!(
+            cleanup.deleted_bot_ids.lock().await.as_slice(),
+            &[bot.bot_uuid]
+        );
     }
 
     #[tokio::test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/channel_binding_cleanup.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/channel_binding_cleanup.rs
@@ -1,14 +1,16 @@
-//! Channel-binding cleanup used by group lifecycle orchestration.
+//! Channel-binding cleanup used by group and bot lifecycle orchestration.
 
 use async_trait::async_trait;
 
 use crate::types::ServiceResult;
 
-/// Removes channel bindings that would otherwise reference a deleted group.
+/// Removes channel bindings that would otherwise reference a deleted group or bot.
 #[async_trait]
 pub trait ChannelBindingCleanupPort: Send + Sync {
     /// Delete every channel binding whose target is the given group.
     async fn delete_bindings_for_group(&self, group_id: &str) -> ServiceResult<u64>;
+    /// Delete every channel binding whose target is the given bot.
+    async fn delete_bindings_for_bot(&self, bot_id: &str) -> ServiceResult<u64>;
 }
 
 /// Default implementation for runtimes where the channel bridge is unavailable.
@@ -18,6 +20,10 @@ pub struct NoopChannelBindingCleanupPort;
 #[async_trait]
 impl ChannelBindingCleanupPort for NoopChannelBindingCleanupPort {
     async fn delete_bindings_for_group(&self, _group_id: &str) -> ServiceResult<u64> {
+        Ok(0)
+    }
+
+    async fn delete_bindings_for_bot(&self, _bot_id: &str) -> ServiceResult<u64> {
         Ok(0)
     }
 }
@@ -33,6 +39,13 @@ mod tests {
         assert_eq!(
             cleanup
                 .delete_bindings_for_group("group_1")
+                .await
+                .expect("noop cleanup should succeed"),
+            0
+        );
+        assert_eq!(
+            cleanup
+                .delete_bindings_for_bot("bot_1")
                 .await
                 .expect("noop cleanup should succeed"),
             0

--- a/src/bcs/crates/services/bcs-bot/src/application/provider.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::{
-    BotRegistryCoreService, DeleteProviderBotCommand, DeleteProviderBotOutcome, ProviderBotBinding,
+    BotRegistryCoreService, ChannelBindingCleanupPort, DeleteProviderBotCommand,
+    DeleteProviderBotOutcome, NoopChannelBindingCleanupPort, ProviderBotBinding,
     ProviderBotCoreService, ProviderCoreService, ProviderManagementService, ProviderRecord,
     RegisterProviderBotCommand, RegisterProviderBotOutcome, RegisterProviderBotParams,
     RegisterProviderCommand, RegisterProviderOutcome, RelationCoreService, ServiceError,
@@ -16,6 +17,7 @@ pub struct ProviderManagement {
     provider_bot_core: Arc<dyn ProviderBotCoreService>,
     registry: Arc<dyn BotRegistryCoreService>,
     relation: Arc<dyn RelationCoreService>,
+    channel_binding_cleanup: Arc<dyn ChannelBindingCleanupPort>,
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
 }
 
@@ -31,8 +33,17 @@ impl ProviderManagement {
             provider_bot_core,
             registry,
             relation,
+            channel_binding_cleanup: Arc::new(NoopChannelBindingCleanupPort),
             user_directory: None,
         }
+    }
+
+    pub fn with_channel_binding_cleanup(
+        mut self,
+        channel_binding_cleanup: Arc<dyn ChannelBindingCleanupPort>,
+    ) -> Self {
+        self.channel_binding_cleanup = channel_binding_cleanup;
+        self
     }
 
     pub fn with_user_directory(mut self, user_directory: Arc<dyn UserDirectoryPlugin>) -> Self {
@@ -308,7 +319,14 @@ impl ProviderManagementService for ProviderManagement {
             }
         };
 
+        // Soft-delete the bot first so concurrent channel binding creation can no
+        // longer validate this bot as a target, then remove its channel bindings.
+        // Cleanup failure is returned as an error; re-deleting is idempotent for
+        // binding-backed bots because the provider binding row still resolves bot_uuid.
         let deleted = self.registry.soft_delete(&bot_uuid).await;
+        self.channel_binding_cleanup
+            .delete_bindings_for_bot(&bot_uuid)
+            .await?;
         Ok(DeleteProviderBotOutcome {
             bot_uuid,
             provider_id: command.provider_id,

--- a/src/bcs/crates/services/bcs-bot/tests/provider_management.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/provider_management.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bcs_bot::application::ProviderManagement;
+use bcs_bot::core::{BotCore, ProviderCore};
+use bcs_bot_store::MemoryBotRepo;
+use bcs_bot_store::provider::MemoryProviderStore;
+use bcs_service_api::{
+    BotRegistryCoreService, ChannelBindingCleanupPort, DeleteProviderBotCommand,
+    ProviderAuthMode, ProviderBotBindingRepoPort, ProviderBotCoreService,
+    ProviderCredentialRepoPort, ProviderManagementService, ProviderRepoPort,
+    RegisterProviderBotCommand, RegisterProviderCommand, ServiceError, ServiceResult,
+};
+use bcs_test_support::NoopRelationCoreService;
+use tokio::sync::Mutex;
+
+struct TestContext {
+    management: ProviderManagement,
+    provider_core: Arc<ProviderCore>,
+    cleanup: Arc<RecordingCleanup>,
+    _temp_dir: tempfile::TempDir,
+}
+
+#[derive(Default)]
+struct RecordingCleanup {
+    deleted_bot_ids: Mutex<Vec<String>>,
+    fail: Mutex<bool>,
+}
+
+#[async_trait]
+impl ChannelBindingCleanupPort for RecordingCleanup {
+    async fn delete_bindings_for_group(&self, _group_id: &str) -> ServiceResult<u64> {
+        Ok(0)
+    }
+
+    async fn delete_bindings_for_bot(&self, bot_id: &str) -> ServiceResult<u64> {
+        if *self.fail.lock().await {
+            return Err(ServiceError::InternalError(
+                "cleanup failure injected by test".to_string(),
+            ));
+        }
+        self.deleted_bot_ids.lock().await.push(bot_id.to_string());
+        Ok(1)
+    }
+}
+
+fn test_context() -> TestContext {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let provider_store = Arc::new(MemoryProviderStore::new());
+    let provider_repo: Arc<dyn ProviderRepoPort> = provider_store.clone();
+    let provider_credentials: Arc<dyn ProviderCredentialRepoPort> = provider_store.clone();
+    let provider_bindings: Arc<dyn ProviderBotBindingRepoPort> = provider_store.clone();
+    let bot_repo = Arc::new(MemoryBotRepo::with_base_dir(temp_dir.path().to_path_buf()));
+    let registry: Arc<dyn BotRegistryCoreService> = Arc::new(BotCore::with_provider_repos(
+        bot_repo,
+        provider_repo.clone(),
+        provider_credentials.clone(),
+        provider_bindings.clone(),
+    ));
+    let provider_core = Arc::new(ProviderCore::new(
+        provider_repo,
+        provider_credentials,
+        provider_bindings,
+        registry.clone(),
+    ));
+    let provider_bot_core: Arc<dyn ProviderBotCoreService> = provider_core.clone();
+    let cleanup = Arc::new(RecordingCleanup::default());
+    let management = ProviderManagement::new(
+        provider_core.clone(),
+        provider_bot_core,
+        registry,
+        Arc::new(NoopRelationCoreService),
+    )
+    .with_channel_binding_cleanup(cleanup.clone());
+    TestContext {
+        management,
+        provider_core,
+        cleanup,
+        _temp_dir: temp_dir,
+    }
+}
+
+async fn register_provider(ctx: &TestContext) -> (String, String) {
+    let registered = ctx
+        .management
+        .register_provider(RegisterProviderCommand {
+            name: "Provider".to_string(),
+            webhook_url: "https://provider.example.com/bcs/webhook".to_string(),
+            admin_callback_url: None,
+            auth_mode: ProviderAuthMode::StaticBearer,
+            created_by: "11111111".to_string(),
+            protocol_version: None,
+            coordination: None,
+        })
+        .await
+        .expect("register provider");
+    (registered.provider_id, registered.provider_admin_token)
+}
+
+async fn register_provider_bot(
+    ctx: &TestContext,
+    provider_id: &str,
+    admin_token: &str,
+    provider_bot_ref: &str,
+) -> String {
+    let outcome = ctx
+        .management
+        .register_provider_bot(RegisterProviderBotCommand {
+            provider_id: provider_id.to_string(),
+            provider_admin_token: admin_token.to_string(),
+            name: "Bot".to_string(),
+            summary: None,
+            owners: vec!["11111111".to_string()],
+            provider_bot_ref: provider_bot_ref.to_string(),
+            domains: Vec::new(),
+            skills: Vec::new(),
+            scopes: Vec::new(),
+            bot_uuid: None,
+            reject_existing_bot_uuid: false,
+        })
+        .await
+        .expect("register provider bot");
+    outcome.bot_uuid
+}
+
+fn delete_command(provider_id: &str, admin_token: &str, provider_bot_ref: &str) -> DeleteProviderBotCommand {
+    DeleteProviderBotCommand {
+        provider_id: provider_id.to_string(),
+        provider_admin_token: admin_token.to_string(),
+        provider_bot_ref: provider_bot_ref.to_string(),
+        allow_unbound_owner_suffixed_bot: false,
+    }
+}
+
+#[tokio::test]
+async fn delete_provider_bot_cleans_channel_bindings_for_deleted_bot() {
+    let ctx = test_context();
+    let (provider_id, admin_token) = register_provider(&ctx).await;
+    let bot_uuid = register_provider_bot(&ctx, &provider_id, &admin_token, "bot-ref-1").await;
+
+    let outcome = ctx
+        .management
+        .delete_provider_bot(delete_command(&provider_id, &admin_token, "bot-ref-1"))
+        .await
+        .expect("delete provider bot");
+
+    assert!(outcome.deleted);
+    assert_eq!(outcome.bot_uuid, bot_uuid);
+    assert_eq!(
+        ctx.cleanup.deleted_bot_ids.lock().await.as_slice(),
+        &[bot_uuid]
+    );
+}
+
+#[tokio::test]
+async fn delete_provider_bot_returns_error_when_channel_binding_cleanup_fails() {
+    let ctx = test_context();
+    let (provider_id, admin_token) = register_provider(&ctx).await;
+    register_provider_bot(&ctx, &provider_id, &admin_token, "bot-ref-1").await;
+    *ctx.cleanup.fail.lock().await = true;
+
+    let result = ctx
+        .management
+        .delete_provider_bot(delete_command(&provider_id, &admin_token, "bot-ref-1"))
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn delete_provider_bot_keeps_bindings_for_other_bots() {
+    let ctx = test_context();
+    let (provider_id, admin_token) = register_provider(&ctx).await;
+    let bot_uuid_1 = register_provider_bot(&ctx, &provider_id, &admin_token, "bot-ref-1").await;
+    let bot_uuid_2 = register_provider_bot(&ctx, &provider_id, &admin_token, "bot-ref-2").await;
+    assert_ne!(bot_uuid_1, bot_uuid_2);
+
+    ctx.management
+        .delete_provider_bot(delete_command(&provider_id, &admin_token, "bot-ref-1"))
+        .await
+        .expect("delete provider bot");
+
+    assert_eq!(
+        ctx.cleanup.deleted_bot_ids.lock().await.as_slice(),
+        &[bot_uuid_1]
+    );
+}

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -1578,6 +1578,28 @@ impl ChannelBindingCleanupPort for BcsChannelService {
         }
         Ok(deleted)
     }
+
+    async fn delete_bindings_for_bot(
+        &self,
+        bot_id: &str,
+    ) -> ServiceResult<u64> {
+        let _guard = self.binding_admin_lock.lock().await;
+        let bindings = self
+            .bindings
+            .list_by_target(
+                &BindingTarget::Bot {
+                bot_id: bot_id.to_string(),
+                },
+                None,
+            )
+            .await?;
+        let mut deleted = 0;
+        for binding in bindings {
+            self.delete_binding_locked(&binding).await?;
+            deleted += 1;
+        }
+        Ok(deleted)
+    }
 }
 
 impl BcsChannelService {
@@ -2905,6 +2927,81 @@ mod tests {
             1
         );
         assert_eq!(harness.binding_repo.list_by_target(&bot, None).await?.len(), 1);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn bot_binding_cleanup_removes_only_bindings_for_requested_bot() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        let bot_1 = BindingTarget::Bot {
+            bot_id: "bot_1".to_string(),
+        };
+        let bot_2 = BindingTarget::Bot {
+            bot_id: "bot_2".to_string(),
+        };
+        let group = BindingTarget::Group {
+            group_id: "group_1".to_string(),
+        };
+
+        harness
+            .binding_repo
+            .create(active_binding(
+                "bot_1_dingtalk",
+                "robot_1",
+                bot_1.clone(),
+                Visibility::FullTranscript,
+            ))
+            .await?;
+        let mut bot_1_other_channel = active_binding(
+            "bot_1_other_channel",
+            "account_2",
+            bot_1.clone(),
+            Visibility::FullTranscript,
+        );
+        bot_1_other_channel.channel_type = "test_im".to_string();
+        harness.binding_repo.create(bot_1_other_channel).await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "bot_2_dingtalk",
+                "robot_2",
+                bot_2.clone(),
+                Visibility::FullTranscript,
+            ))
+            .await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "group_dingtalk",
+                "robot_3",
+                group.clone(),
+                Visibility::FullTranscript,
+            ))
+            .await?;
+
+        let removed = harness.service.delete_bindings_for_bot("bot_1").await?;
+
+        assert_eq!(removed, 2);
+        assert!(
+            harness
+                .binding_repo
+                .list_by_target(&bot_1, None)
+                .await?
+                .is_empty()
+        );
+        assert_eq!(
+            harness
+                .binding_repo
+                .list_by_target(&bot_2, None)
+                .await?
+                .len(),
+            1
+        );
+        assert_eq!(
+            harness.binding_repo.list_by_target(&group, None).await?.len(),
+            1
+        );
 
         Ok(())
     }

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -122,6 +122,7 @@ use tokio::sync::Mutex;
 #[derive(Default)]
 struct RecordingChannelBindingCleanup {
     deleted_group_ids: Mutex<Vec<String>>,
+    deleted_bot_ids: Mutex<Vec<String>>,
     fail: bool,
 }
 
@@ -129,6 +130,7 @@ impl RecordingChannelBindingCleanup {
     fn failing() -> Self {
         Self {
             deleted_group_ids: Mutex::new(Vec::new()),
+            deleted_bot_ids: Mutex::new(Vec::new()),
             fail: true,
         }
     }
@@ -138,6 +140,16 @@ impl RecordingChannelBindingCleanup {
 impl ChannelBindingCleanupPort for RecordingChannelBindingCleanup {
     async fn delete_bindings_for_group(&self, group_id: &str) -> ServiceResult<u64> {
         self.deleted_group_ids.lock().await.push(group_id.to_string());
+        if self.fail {
+            return Err(ServiceError::InternalError(
+                "channel binding cleanup failed".to_string(),
+            ));
+        }
+        Ok(1)
+    }
+
+    async fn delete_bindings_for_bot(&self, bot_id: &str) -> ServiceResult<u64> {
+        self.deleted_bot_ids.lock().await.push(bot_id.to_string());
         if self.fail {
             return Err(ServiceError::InternalError(
                 "channel binding cleanup failed".to_string(),


### PR DESCRIPTION
## Problem

The provider bot logical delete interface (`ProviderManagement::delete_provider_bot`) only disabled the provider binding and soft-deleted the bot; channel bindings targeting the bot (`BindingTarget::Bot`) were left behind as dirty data, together with their conversation session mappings.

## Solution

Extend `ChannelBindingCleanupPort` with `delete_bindings_for_bot(bot_id)`, mirroring the existing group-deletion cleanup path, and call it from `delete_provider_bot` after the soft-delete. Cleanup reuses `delete_binding_locked`, so it cascades: disable binding → cancel runs → complete sessions → drop conversation mappings → delete binding.

Ordering: soft-delete runs first so concurrent binding creation can no longer validate the bot as a target (`create_binding` validates via `registry.get`), matching the group-delete race rationale. Cleanup failure fails the delete; re-deleting binding-backed bots is idempotent because the provider binding row still resolves bot_uuid. Rejected alternatives: injecting `ChannelBindingRepoPort` directly (skips session/run cascade) and injecting the full `ChannelService` (application→application coupling the cleanup port exists to avoid).

Wiring: the composition root's three build paths now create the shared `DeferredChannelBindingCleanupPort` before provider services and inject it into `ProviderManagement` via the new `with_channel_binding_cleanup` builder (defaults to Noop, preserving behavior when the channel bridge is disabled).

## Validation

- New tests (TDD, red first): Noop port unit test; `bcs-channel` bot-target cleanup test; new `bcs-bot/tests/provider_management.rs` (cleanup invoked with the deleted bot_uuid only, cleanup failure returns error); `server.rs` wiring test proving provider delete reaches the injected cleanup port.
- Existing test doubles in `bcs-group` / `bcs-app-group` updated for the new trait method.
- `cargo check --workspace --all-targets` clean; full suites pass for bcs-service-api, bcs-channel, bcs-bot, bcs-group, bcs-app-group, bcs-http, and bootstrap lib (165 tests).
- Pre-push gates skipped per request (`--no-verify`); pre-existing clippy deny errors in untouched `bcs-domain` left as-is.

## Compatibility and risk

No API or schema changes. Known limitation (pre-existing shape, not a regression): on the legacy owner-suffixed branch (no provider binding row), a cleanup failure followed by a retry returns `BotNotFound` and bindings remain — the same end state as before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)