### PR TITLE
fix(bcs): support legacy group context updates

### DIFF
--- a/src/bcs/CLAUDE.md
+++ b/src/bcs/CLAUDE.md
@@ -387,7 +387,7 @@ export BOT_DATA_DIR=/path/to/bot/data
 | `/groups` | GET | List all groups |
 | `/groups/my` | GET | List formal groups for the authenticated human or bot |
 | `/groups/{id}` | GET | Get group details |
-| `/groups/{id}` | PATCH | Update mutable group properties (legacy compatibility route) |
+| `/groups/{id}` | PATCH | Update `name`, `context`, `visibility`, or delivery policy (legacy compatibility route) |
 | `/groups/{id}` | DELETE | Delete group |
 | `/groups/{id}/members` | POST | Add member to group |
 | `/groups/{id}/chat` | POST | Send group chat message |

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
@@ -248,6 +248,7 @@ impl From<UpdateGroupRequest> for GroupPatch {
     fn from(value: UpdateGroupRequest) -> Self {
         Self {
             name: value.name,
+            context: None,
             visibility: value.visibility,
             delivery_policy: value.delivery_policy.map(|policy| GroupDeliveryPolicy {
                 bot_final_delivery: policy.bot_final_delivery,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -146,6 +146,8 @@ pub struct LegacyUpdateGroupRequest {
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
+    pub context: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub visibility: Option<GroupVisibility>,
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub delivery_policy: Option<LegacyGroupDeliveryPolicyRequest>,
@@ -163,6 +165,7 @@ impl From<LegacyUpdateGroupRequest> for GroupPatch {
     fn from(value: LegacyUpdateGroupRequest) -> Self {
         Self {
             name: value.name,
+            context: value.context,
             visibility: value.visibility,
             delivery_policy: value.delivery_policy.map(|policy| GroupDeliveryPolicy {
                 bot_final_delivery: policy.bot_final_delivery,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
@@ -142,6 +142,7 @@ async fn patch_response(service: Arc<RecordingGroupService>) -> axum::response::
         .await
         .expect("response")
 }
+
 #[tokio::test]
 async fn legacy_patch_group_delegates_to_v1_group_application() {
     let service = Arc::new(RecordingGroupService::default());

--- a/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
@@ -142,7 +142,6 @@ async fn patch_response(service: Arc<RecordingGroupService>) -> axum::response::
         .await
         .expect("response")
 }
-
 #[tokio::test]
 async fn legacy_patch_group_delegates_to_v1_group_application() {
     let service = Arc::new(RecordingGroupService::default());

--- a/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
@@ -155,6 +155,7 @@ async fn legacy_patch_group_delegates_to_v1_group_application() {
                 .body(Body::from(
                     json!({
                         "name": "Renamed",
+                        "context": "测试1",
                         "visibility": "public",
                         "delivery_policy": {
                             "bot_final_delivery": "inject_observers"
@@ -186,6 +187,7 @@ async fn legacy_patch_group_delegates_to_v1_group_application() {
     assert_eq!(user.id, "staff-1");
     assert_eq!(user.display_name.as_deref(), Some("Ray"));
     assert_eq!(command.patch.name.as_deref(), Some("Renamed"));
+    assert_eq!(command.patch.context.as_deref(), Some("测试1"));
     assert_eq!(command.patch.visibility, Some(GroupVisibility::Public));
     assert_eq!(
         command

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -1234,6 +1234,10 @@ impl GroupService for GroupServiceImpl {
             group.label = Some(name.clone());
             persistence_patch.label = Some(name);
         }
+        if let Some(context) = patch.context {
+            group.context = Some(context.clone());
+            persistence_patch.context = Some(context);
+        }
         if let Some(visibility) = patch.visibility {
             if visibility == GroupVisibility::Public {
                 for participant in &group.participants {

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -2238,6 +2238,7 @@ async fn update_preserves_hidden_legacy_routing_fields() {
             group_id: "group-1".into(),
             patch: GroupPatch {
                 name: Some("Renamed".into()),
+                context: Some("测试1".into()),
                 delivery_policy: Some(GroupDeliveryPolicy {
                     bot_final_delivery: BotFinalDelivery::InjectObservers,
                 }),
@@ -2262,6 +2263,8 @@ async fn update_preserves_hidden_legacy_routing_fields() {
         DefaultDelivery::InjectObservers
     );
     assert_eq!(stored.label.as_deref(), Some("Renamed"));
+    assert_eq!(stored.context.as_deref(), Some("测试1"));
+    assert_eq!(detail.context.as_deref(), Some("测试1"));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
@@ -306,6 +306,7 @@ pub struct GetGroup {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GroupPatch {
     pub name: Option<String>,
+    pub context: Option<String>,
     pub visibility: Option<GroupVisibility>,
     pub delivery_policy: Option<GroupDeliveryPolicy>,
 }
@@ -313,6 +314,7 @@ pub struct GroupPatch {
 impl GroupPatch {
     pub fn is_empty(&self) -> bool {
         self.name.is_none()
+            && self.context.is_none()
             && self.visibility.is_none()
             && self.delivery_policy.is_none()
     }

--- a/src/bcs/scripts/e2e-test/group.sh
+++ b/src/bcs/scripts/e2e-test/group.sh
@@ -81,7 +81,7 @@ test_patch_group() {
     local group_id
     group_id=$(json_field "$RESPONSE" "id")
 
-    api_patch "/groups/$group_id" '{"name":"legacy-patch-e2e"}'
+    api_patch "/groups/$group_id" '{"name":"legacy-patch-e2e","context":"legacy-context-e2e"}'
     assert_eq "legacy group PATCH returns 200" "$HTTP_STATUS" "200"
     assert_eq "legacy group PATCH returns the new name" \
         "$(json_field "$RESPONSE" "name")" "legacy-patch-e2e"
@@ -89,6 +89,8 @@ test_patch_group() {
     api_get "/groups/$group_id"
     assert_eq "legacy group PATCH persists the label" \
         "$(json_field "$RESPONSE" "label")" "legacy-patch-e2e"
+    assert_eq "legacy group PATCH persists the context" \
+        "$(json_field "$RESPONSE" "context")" "legacy-context-e2e"
 }
 
 test_list_groups() {


### PR DESCRIPTION
## Problem
The legacy `PATCH /groups/{id}` route rejects `{"context":"测试1"}` as an unknown field even though group context already exists in the domain and persistence model.

## Solution
Extend only the legacy update request and the internal group patch command with `context`, then propagate it through the application service to the existing parameterized persistence patch. Keep the V1 update DTO unchanged by mapping its internal context field to `None`. Add HTTP contract, application persistence, and BCS E2E assertions.

## Validation
- `cargo test -p bcs-http --test legacy_group_patch_contract` — 4 passed
- `cargo test -p bcs-app-group update_preserves_hidden_legacy_routing_fields` — 1 passed
- `cargo test -p bcs-api-http --test group_routes` — 15 passed
- `cargo test -p bcs-http --test groups_contract` — 35 passed
- `cargo check -p bcs` — passed
- `bash -n scripts/e2e-test/group.sh scripts/e2e-test/stories.sh` — passed
- Local E2E was not run as requested; GitHub CI will run the online E2E/coverage gate.

## Compatibility and risk
This is a backward-compatible expansion of the legacy route only. Unknown fields and explicit null values remain rejected. The V1 HTTP contract is unchanged. Rollback is a revert of this PR.