### PR TITLE
feat(backend): add the caller-identity read to the public API

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -176,8 +176,8 @@ from fastapi import APIRouter, Depends
 from .authorized_apps import app_view_router as authorized_bots_router
 from .authorized_apps import router as authorized_apps_router
 from .bots import router as bots_router
-from .caller import router as caller_router
 from .bots.engine_config import router as engine_config_router
+from .caller import router as caller_router
 from .deprecated import (
     ENGINE_RUNTIME_GROUPS as _LEGACY_ENGINE_RUNTIME,
     GRANT_CHECKED_GROUPS as _LEGACY_GRANT_CHECKED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -176,6 +176,7 @@ from fastapi import APIRouter, Depends
 from .authorized_apps import app_view_router as authorized_bots_router
 from .authorized_apps import router as authorized_apps_router
 from .bots import router as bots_router
+from .caller import router as caller_router
 from .bots.engine_config import router as engine_config_router
 from .deprecated import (
     ENGINE_RUNTIME_GROUPS as _LEGACY_ENGINE_RUNTIME,
@@ -350,6 +351,15 @@ def build_public_router() -> APIRouter:
     user" above).
     """
     public = APIRouter()
+    # The caller's own identity — the one operation whose answer IS the user,
+    # so it takes no ``user_id`` and can answer no 403: it gets the base error
+    # table, not the user-scoped one. Top-level like ``spaces``, because the
+    # caller is not a bots resource.
+    public.include_router(
+        caller_router,
+        responses=ERROR_RESPONSES,
+        dependencies=_PUBLIC_AUTH,
+    )
     # Space APIs are user-only in the first phase. They are top-level
     # resources, so they intentionally do not inherit any bot grant gate.
     public.include_router(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -409,6 +409,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ): AdmissionMode.USER_GATED,
     ("POST", "/openapi/v1/work-order-notifications/read-all"): AdmissionMode.USER_GATED,
     # ── REFUSED — each for its own reason ────────────────────────────────────
+    # The caller's own identity. An app-only caller names no end user, so there
+    # is nothing to return — its scope question is answered by
+    # ``GET /openapi/v1/bots/authorized`` instead.
+    ("GET", "/openapi/v1/caller"): AdmissionMode.REFUSED,
     # No bot exists yet for a grant to cover, and creation spends the user's
     # quota. Auto-granting the new bot would invent consent nobody gave.
     ("POST", "/openapi/v1/bots"): AdmissionMode.REFUSED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/__init__.py
@@ -1,0 +1,5 @@
+"""caller public API group."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/router.py
@@ -1,0 +1,88 @@
+"""Caller group — ``GET /openapi/v1/caller``: who the verified caller is.
+
+The one operation whose *answer* is the end user, so it is also the one
+user-scoped read that takes no ``user_id`` parameter: a client calls it to
+*learn* that value, and requiring the parameter here would make the id a
+precondition of discovering it. Everything it returns is read off the verified
+principal the gateway signed — nothing comes from the request — so the answer
+cannot be steered by the caller.
+
+Who it is for: a browser client (Teamclaw) whose session credential is an
+http-only cookie. The cookie authenticates every request — the gateway resolves
+it into the signed principal — but the page's own code cannot read it, so the
+client has no way to know the id it must thread through the rest of the
+surface. It calls this once, caches the identity, and names it everywhere else;
+a stale cache fails closed, because ``require_user_id`` refuses a ``user_id``
+that no longer matches the credential with a 403.
+
+Why it is ``REFUSED`` for an application acting alone (``admission.py``): an
+app-only caller names no end user, so there is nothing to return — and its own
+identity question ("which bots may I reach?") is already answered by
+``GET /openapi/v1/bots/authorized``. The refusal is declared on the route with
+``refuse_app_only_caller``, as every ``REFUSED`` operation declares it.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+
+from agentclaw.community.adapters.http.openapi_v1.caller.schemas import CallerIdentity
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.dependencies import (
+    Principal,
+    require_principal,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    refuse_app_only_caller,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+
+router = APIRouter(prefix="/openapi/v1/caller", tags=["caller"])
+
+PrincipalDep = Annotated[Principal, Depends(require_principal)]
+
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+
+
+@router.get(
+    "",
+    response_model=Envelope[CallerIdentity],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def get_caller_identity(
+    request: Request,
+    principal: PrincipalDep,
+) -> Envelope[CallerIdentity]:
+    """Return the end user the caller's credential names.
+
+    The identity the gateway resolved and signed: the id to use as `user_id`
+    on every user-scoped operation, plus the profile attributes the identity
+    provider supplied. Call it once per session and cache the result — the
+    values only change when the session's credential does.
+    """
+    # ``getattr`` for the same reason ``principal.py``'s helpers read
+    # tolerantly: production always supplies a ``VerifiedCaller``, and a test
+    # stand-in that models no user must land in the fail-closed branch below
+    # rather than on an AttributeError.
+    user = getattr(principal, "user", None)
+    if user is None:
+        # Unreachable behind ``refuse_app_only_caller`` for a verified caller;
+        # kept as the fail-closed answer for a hand-constructed principal.
+        raise MissingPrincipalError("principal names no end user")
+    return envelope(
+        CallerIdentity(
+            user_id=user.id,
+            username=user.username,
+            display_name=user.display_name,
+            full_name=user.full_name,
+            tenant=principal.tenant,
+        ),
+        request,
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller/schemas.py
@@ -1,0 +1,51 @@
+"""Schemas for the caller group — the verified caller's own identity."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CallerIdentity(BaseModel):
+    """The end user the caller's credential names, as resolved at the gateway.
+
+    Every field is read off the verified principal — nothing is taken from the
+    request, so the answer cannot be steered. The display attributes are
+    optional because absence is a real state of the identity contract: an
+    identity provider may not supply them, and they are null rather than
+    invented when absent.
+    """
+
+    # The docstring above is published verbatim as the schema's description
+    # (see test_schema_docs), so it carries no RST markup and no internal
+    # names; rationale that needs either lives here instead.
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "user_id": "u-8f3a2c",
+                "username": "alice@example.com",
+                "display_name": "Alice",
+                "full_name": "Alice Zhang",
+                "tenant": "acme-tenant",
+            }
+        }
+    )
+
+    user_id: str = Field(
+        description="The caller's end-user id — the exact value to pass as the "
+        "`user_id` query parameter on every user-scoped operation of this API."
+    )
+    username: str = Field(
+        description="The login name the identity provider resolved for the "
+        "caller."
+    )
+    display_name: str | None = Field(
+        description="Short display name, when the identity provider supplied "
+        "one; null otherwise."
+    )
+    full_name: str | None = Field(
+        description="Full name, when the identity provider supplied one; null "
+        "otherwise."
+    )
+    tenant: str = Field(
+        description="The tenant this caller's requests are scoped to."
+    )

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -40,6 +40,7 @@ from agentclaw.community.core.gateway_principal.errors import (
 from agentclaw.community.core.gateway_principal.models import (
     AppPrincipal,
     GatewayPrincipal,
+    GatewayUser,
     UserPrincipal,
 )
 from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
@@ -212,6 +213,19 @@ class VerifiedCaller:
         """
         principal = _first_user_principal(self.principals)
         return principal.subject.id if principal is not None else ""
+
+    @property
+    def user(self) -> GatewayUser | None:
+        """The end user's verified subject, or ``None`` for a machine-only set.
+
+        The full profile the gateway resolved — ``username`` and the optional
+        display attributes — where :attr:`user_id` is only its id. Both read the
+        set through :func:`_first_user_principal`, so they cannot name different
+        people. ``None`` is the same state ``has_user`` answers ``False`` for:
+        an application acting alone, which has no subject to return.
+        """
+        principal = _first_user_principal(self.principals)
+        return principal.subject if principal is not None else None
 
     @property
     def has_user(self) -> bool:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
@@ -144,7 +144,7 @@ def _concrete(path: str) -> str:
     ("method", "path"), _refused_operations(), ids=lambda v: str(v)
 )
 def test_every_refused_operation_refuses_an_app_only_caller(client, method, path):
-    """All fourteen, by behaviour rather than by wiring.
+    """All fifteen, by behaviour rather than by wiring.
 
     ``401`` specifically: the surface's answer for "no caller we can act for",
     the same one an unauthenticated request gets. Not ``403`` — that would say

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_caller_identity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_caller_identity.py
@@ -1,0 +1,200 @@
+"""``GET /openapi/v1/caller`` — the caller-identity read, by behaviour.
+
+The one operation whose answer *is* the end user, so the properties worth
+pinning are about where that answer comes from and who gets one at all:
+
+- a caller naming an end user gets **the principal's** identity back — the
+  subject id, username and profile attributes the gateway signed, never
+  anything the request supplied;
+- the tenant in the answer is the tenant the request was scoped by: the
+  internal default for a first-party user-only set, the asserted one when a
+  machine principal rides along;
+- an application acting alone is refused with the same ``401`` an
+  unauthenticated caller gets (the sweep in ``test_app_only_refusals.py``
+  covers this operation too; the test here pins the byte-identity).
+
+Wiring-level properties — the ``REFUSED`` table entry, the
+``refuse_app_only_caller`` declaration, the absent ``user_id`` parameter —
+are held by ``test_admission_inventory.py`` and ``test_explicit_user_id.py``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.plugin_api.secret_resolver import SecretResolver
+from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+    reset_principal_verifier_config_cache,
+)
+
+KEY = "caller-test-shared-secret-at-least-32-bytes"
+TENANT = "acme-tenant"
+USER = "u-1"
+
+
+class _Secret:
+    secret_user = "gateway"
+
+    def __init__(self, value: str) -> None:
+        self.secret_value = value
+
+
+@pytest.fixture(autouse=True)
+def signing_key():
+    class _Resolver(SecretResolver):
+        def get_secret(self, secret_name: str) -> object | None:
+            return _Secret(KEY)
+
+    init_principal_verifier_config(
+        _Resolver(), "gateway_principal_signing_key", strict=False
+    )
+    yield
+    reset_principal_verifier_config_cache()
+
+
+def _token(
+    *,
+    user: dict | None,
+    include_app: bool = False,
+) -> str:
+    """A signed token; ``user`` is the ``user`` principal's subject, verbatim."""
+    now = int(time.time())
+    principals: list[dict] = []
+    if user is not None:
+        principals.append({"type": "user", "subject": user})
+    if include_app:
+        principals.append(
+            {
+                "type": "app",
+                "tenant": TENANT,
+                "app": {
+                    "app_id": 42,
+                    "app_name": "partner",
+                    "owners": "platform-team",
+                    "tenant": TENANT,
+                    "app_type": "integration",
+                },
+            }
+        )
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 60,
+            "principals": principals,
+        },
+        KEY,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+def client():
+    """The whole public surface, with no services bound.
+
+    Nothing needs binding: the caller-identity handler reads only the verified
+    principal. Mounting the full surface rather than the one group means the
+    route answers behind exactly the dependencies production mounts it behind.
+    """
+    from agentclaw.community.adapters.http.app import _unhandled_exception_handler
+
+    app = FastAPI()
+    app.add_middleware(AvernetTenantMiddleware)
+    app.include_router(build_public_router())
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_a_user_reads_the_identity_the_gateway_signed(client):
+    """The full subject comes back, off the principal and nothing else."""
+    token = _token(
+        user={
+            "id": USER,
+            "username": "alice@example.com",
+            "display_name": "Alice",
+            "full_name": "Alice Zhang",
+        }
+    )
+
+    response = client.get("/openapi/v1/caller", headers={PRINCIPAL_HEADER: token})
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data == {
+        "user_id": USER,
+        "username": "alice@example.com",
+        "display_name": "Alice",
+        "full_name": "Alice Zhang",
+        # A user-only set asserts no tenant and scopes to the internal default.
+        "tenant": DEFAULT_AVERNET_TENANT,
+    }
+
+
+def test_absent_profile_attributes_answer_null_not_invented(client):
+    """The optional fields are the contract's absence, not a fabrication."""
+    token = _token(user={"id": USER, "username": "alice@example.com"})
+
+    response = client.get("/openapi/v1/caller", headers={PRINCIPAL_HEADER: token})
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["display_name"] is None
+    assert data["full_name"] is None
+
+
+def test_an_app_riding_along_does_not_change_whose_identity_it_is(client):
+    """A human request with an App on the wire is still the human's whoami —
+    and it lands in the App's asserted tenant, like every request it rides."""
+    token = _token(
+        user={"id": USER, "username": "alice@example.com"}, include_app=True
+    )
+
+    response = client.get("/openapi/v1/caller", headers={PRINCIPAL_HEADER: token})
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["user_id"] == USER
+    assert data["tenant"] == TENANT
+
+
+def test_an_app_alone_is_refused_like_an_unauthenticated_caller(client):
+    """Byte for byte: no oracle for 'right credential, wrong identity type'."""
+    refused = client.get(
+        "/openapi/v1/caller",
+        headers={PRINCIPAL_HEADER: _token(user=None, include_app=True)},
+    )
+    unauthenticated = client.get("/openapi/v1/caller")
+
+    assert refused.status_code == 401, refused.text
+    assert unauthenticated.status_code == 401, unauthenticated.text
+    assert refused.json()["message"] == unauthenticated.json()["message"]
+    assert refused.json()["code"] == unauthenticated.json()["code"]
+
+
+def test_the_answer_ignores_a_user_id_smuggled_into_the_query(client):
+    """The operation takes no ``user_id`` — one supplied anyway changes nothing.
+
+    Not a 422: an undeclared query parameter is ignored on this surface, and
+    the identity comes off the signed principal either way.
+    """
+    token = _token(user={"id": USER, "username": "alice@example.com"})
+
+    response = client.get(
+        "/openapi/v1/caller",
+        headers={PRINCIPAL_HEADER: token},
+        params={"user_id": "someone-else"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["user_id"] == USER

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -263,11 +263,17 @@ def _without_request_id(response) -> dict:
 
 #: The operations that take no ``user_id``, and why each one cannot.
 #:
-#: Pinned by address rather than counted, so adding a fifth is a deliberate edit
+#: Pinned by address rather than counted, so adding another is a deliberate edit
 #: to this list with a reason attached — which is the only thing standing
 #: between "this operation has no user dimension" and "somebody found the
 #: parameter inconvenient".
 _NO_USER_DIMENSION = {
+    # The caller-identity read is how a client LEARNS the id it must thread
+    # everywhere else — requiring the parameter here would make the id a
+    # precondition of discovering it. The answer is read off the verified
+    # principal, so there is no caller-supplied user to compare against and no
+    # 403 to answer.
+    ("get", f"{PUBLIC_API_PREFIX}/caller"),
     # Name uniqueness is checked across the tenant, not within one user's bots.
     ("get", f"{PUBLIC_API_PREFIX}/bots/check-name"),
     # The marketplace catalogue is identical for every caller in the tenant.
@@ -321,7 +327,10 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: addresses a bot, so the path and query counts remain unchanged.
 #:
 #: ``path`` then moved 54 → 56 when the two Bot Chats operations were added.
-_BOT_ID_PLACEMENT = {"path": 56, "query": 1, "none": 35}
+#:
+#: ``none`` then moved 35 → 36 with the caller-identity read: it answers who
+#: the caller is and addresses no bot.
+_BOT_ID_PLACEMENT = {"path": 56, "query": 1, "none": 36}
 
 
 def _schema() -> dict:
@@ -406,7 +415,7 @@ def test_the_pinned_number_of_operations_take_it():
 
 
 def test_the_exempt_operations_take_none():
-    """The four with no user dimension ask for nothing they cannot use."""
+    """The exempt operations ask for nothing they cannot use."""
     schema = _schema()
     for method, path in _NO_USER_DIMENSION:
         operation = schema["paths"][path][method]

--- a/src/backend/tests/community/contracts/gateway/test_public_namespace.py
+++ b/src/backend/tests/community/contracts/gateway/test_public_namespace.py
@@ -18,6 +18,9 @@ from fastapi import FastAPI
 #: matching gateway domain + route_security entries, never alone.
 _DECLARED_PREFIXES = (
     "/openapi/v1/bots",
+    # The verified caller's own identity — the one operation whose answer is
+    # the user. Declared with its gateway domain + route_security entries.
+    "/openapi/v1/caller",
     "/openapi/v1/spaces",
     "/openapi/v1/work-orders",
     "/openapi/v1/work-order-notifications",

--- a/src/backend/tests/community/endpoints/test_openapi_caller_identity.py
+++ b/src/backend/tests/community/endpoints/test_openapi_caller_identity.py
@@ -1,0 +1,116 @@
+"""Endpoint-framework coverage for the caller-identity read.
+
+The framework owns invocation, so these two cases are what makes
+``GET /openapi/v1/caller`` *covered* rather than merely tested: the happy path
+— a verified user reads the identity the gateway signed — and the refusal the
+operation most needs pinned, because its whole answer is an identity: no
+signed principal, no answer.
+
+``test_caller_identity.py`` covers the same outcomes plus the app-only refusal
+and the tenant rules in the adapter's own suite. The duplication is the
+coverage gate's design: it reads this registry, not that file.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_PATH = "/openapi/v1/caller"
+_CALLER = "caller-identity-user"
+_KEY = "caller-identity-framework-signing-key-32b"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    """A user-only identity set — the caller shape this endpoint exists for."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": _CALLER,
+                        "username": "caller@example.test",
+                        "display_name": "Caller",
+                    },
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+def _boot_verifier(_world) -> None:
+    """Install the shared key both cases are judged against.
+
+    The refusal case needs it as much as the happy one: without a booted
+    verifier the 401 could come from an unconfigured seam rather than from the
+    missing header, and the case would pass for the wrong reason.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="returns_the_verified_identity",
+    input=CaseInput(headers={PRINCIPAL_HEADER: _principal()}),
+    seed=_boot_verifier,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "message": "OK",
+            "data": {
+                "user_id": _CALLER,
+                "username": "caller@example.test",
+                "display_name": "Caller",
+            },
+        },
+    ),
+)
+def caller_identity_ok():
+    """Body intentionally empty — the framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="unauthenticated",
+    input=CaseInput(),
+    seed=_boot_verifier,
+    expect=ExpectError(
+        status=401,
+        json_contains={"code": 401000, "message": "Unauthorized", "data": None},
+    ),
+)
+def caller_identity_requires_a_principal():
+    """No ``X-Avernet-Principal`` header — the surface's uniform refusal."""

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -148,6 +148,13 @@ user_config:
 
     # ── The refusals: operations that still require a human on the wire ──────
 
+    # The caller-identity read: its answer IS the end user, so a caller with no
+    # human on the wire has nothing to ask. Explicit even though /** already
+    # requires a user, for the same reason the spaces rules below are: when the
+    # broader policy evolves, this route must remain fail-closed.
+    "/openapi/v1/caller":
+      user: required
+
     # Space/member/favorite OpenAPI operations are user-only in the first
     # refactor phase. Keep this explicit even though /** also requires a user:
     # when the broader public API policy evolves, these routes must remain
@@ -394,6 +401,12 @@ user_config:
         #     source: object_store
         #     url: "${BOTS_OPENAPI_URL}"   # e.g. https://<bucket>/bots/openapi-latest.json
         #     refresh_seconds: 300
+        schema:
+          source: file
+          path: schemas/bots.openapi.json
+          refresh_seconds: 300
+      caller:
+        server: backend
         schema:
           source: file
           path: schemas/bots.openapi.json

--- a/src/gateway/configs/schemas/README.md
+++ b/src/gateway/configs/schemas/README.md
@@ -17,9 +17,9 @@ of a surface the upstream does not serve, and nothing downstream would catch it.
 - `bcsfuse-fusion.openapi.json` — bcsfuse group-fusion endpoint served under `/openapi/v1/bcsfuse/groups/**`
 - `bcsfuse-workers.openapi.json` — bcsfuse worker-config + fusable-query endpoints served under `/openapi/v1/bcsfuse/workers/**`
 - `bots.openapi.json` — Backend public OpenAPI spec (currently the
-  `/openapi/v1/bots`, `/openapi/v1/spaces`, `/openapi/v1/work-orders`, and
-  `/openapi/v1/work-order-notifications` surfaces, narrowed to public paths and
-  the components they reference)
+  `/openapi/v1/bots`, `/openapi/v1/caller`, `/openapi/v1/spaces`,
+  `/openapi/v1/work-orders`, and `/openapi/v1/work-order-notifications`
+  surfaces, narrowed to public paths and the components they reference)
 
 ## Future: build-time generation
 

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -475,6 +475,66 @@
         "title": "BotUpdate",
         "type": "object"
       },
+      "CallerIdentity": {
+        "description": "The end user the caller's credential names, as resolved at the gateway.\n\nEvery field is read off the verified principal — nothing is taken from the\nrequest, so the answer cannot be steered. The display attributes are\noptional because absence is a real state of the identity contract: an\nidentity provider may not supply them, and they are null rather than\ninvented when absent.",
+        "example": {
+          "display_name": "Alice",
+          "full_name": "Alice Zhang",
+          "tenant": "acme-tenant",
+          "user_id": "u-8f3a2c",
+          "username": "alice@example.com"
+        },
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Short display name, when the identity provider supplied one; null otherwise.",
+            "title": "Display Name"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Full name, when the identity provider supplied one; null otherwise.",
+            "title": "Full Name"
+          },
+          "tenant": {
+            "description": "The tenant this caller's requests are scoped to.",
+            "title": "Tenant",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "The caller's end-user id — the exact value to pass as the `user_id` query parameter on every user-scoped operation of this API.",
+            "title": "User Id",
+            "type": "string"
+          },
+          "username": {
+            "description": "The login name the identity provider resolved for the caller.",
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "username",
+          "display_name",
+          "full_name",
+          "tenant"
+        ],
+        "title": "CallerIdentity",
+        "type": "object"
+      },
       "Ceiling": {
         "description": "Per-user bot creation quota.",
         "example": {
@@ -1477,6 +1537,48 @@
           "request_id"
         ],
         "title": "Envelope[Bot]",
+        "type": "object"
+      },
+      "Envelope_CallerIdentity_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CallerIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[CallerIdentity]",
         "type": "object"
       },
       "Envelope_Ceiling_": {
@@ -20724,11 +20826,13 @@
             }
           },
           {
+            "description": "How the identifier filters and keyword query match: 'exact' compares whole values, 'contains' substring-matches.",
             "in": "query",
             "name": "match_mode",
             "required": false,
             "schema": {
               "default": "exact",
+              "description": "How the identifier filters and keyword query match: 'exact' compares whole values, 'contains' substring-matches.",
               "pattern": "^(exact|contains)$",
               "title": "Match Mode",
               "type": "string"
@@ -20747,11 +20851,13 @@
             }
           },
           {
+            "description": "'default' searches the recent window; 'all' searches the full history and requires match_mode='exact' plus an exact identifier filter.",
             "in": "query",
             "name": "time_scope",
             "required": false,
             "schema": {
               "default": "default",
+              "description": "'default' searches the recent window; 'all' searches the full history and requires match_mode='exact' plus an exact identifier filter.",
               "pattern": "^(default|all)$",
               "title": "Time Scope",
               "type": "string"
@@ -20823,7 +20929,7 @@
             }
           },
           {
-            "description": "Data source override: 'db' or 'langfuse'.",
+            "description": "Data source override: 'db' forces the primary chat store; unset lets the service choose.",
             "in": "query",
             "name": "log_source",
             "required": false,
@@ -20836,7 +20942,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Data source override: 'db' or 'langfuse'.",
+              "description": "Data source override: 'db' forces the primary chat store; unset lets the service choose.",
               "title": "Log Source"
             }
           },
@@ -21008,10 +21114,12 @@
             }
           },
           {
+            "description": "Trace identifier of the chat, as returned by the chats listing.",
             "in": "path",
             "name": "trace_id",
             "required": true,
             "schema": {
+              "description": "Trace identifier of the chat, as returned by the chats listing.",
               "title": "Trace Id",
               "type": "string"
             }
@@ -21036,7 +21144,7 @@
             }
           },
           {
-            "description": "Data source override: 'db' or 'langfuse'.",
+            "description": "Data source override: 'db' forces the primary chat store; unset lets the service choose.",
             "in": "query",
             "name": "log_source",
             "required": false,
@@ -21049,7 +21157,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Data source override: 'db' or 'langfuse'.",
+              "description": "Data source override: 'db' forces the primary chat store; unset lets the service choose.",
               "title": "Log Source"
             }
           },
@@ -30475,6 +30583,133 @@
         "summary": "Get Bot Status",
         "tags": [
           "bots"
+        ]
+      }
+    },
+    "/openapi/v1/caller": {
+      "get": {
+        "description": "Return the end user the caller's credential names.\n\nThe identity the gateway resolved and signed: the id to use as `user_id`\non every user-scoped operation, plus the profile attributes the identity\nprovider supplied. Call it once per session and cache the result — the\nvalues only change when the session's credential does.",
+        "operationId": "get_caller_identity_openapi_v1_caller_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_CallerIdentity_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Caller Identity",
+        "tags": [
+          "caller"
         ]
       }
     },

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -39,6 +39,7 @@ def test_shipped_config_admits_a_machine_caller_on_the_public_api() -> None:
 #: packages, so the agreement is kept by these tests plus the backend's own
 #: enumeration rather than by a shared import.
 _HUMAN_ONLY = [
+    ("GET", "/openapi/v1/caller"),
     ("GET", "/openapi/v1/spaces"),
     ("POST", "/openapi/v1/spaces/personal/initialize"),
     ("POST", "/openapi/v1/spaces/create"),


### PR DESCRIPTION
## Problem

Every user-scoped `/openapi/v1` operation requires a `user_id` query parameter naming the end user the request acts for (specs/2026-08-08-openapi-v1-explicit-user-id). A first-party browser client — Teamclaw, migrating to this surface — authenticates through the `IAM_TOKEN` http-only cookie, which the gateway resolves into the signed principal. The cookie authenticates every request, but the page's own code cannot read it, so the client has **no way to learn the id it must thread through the rest of the surface**. The surface had no caller-identity read: the `identity` group is bot identity files, and `/api/v1/token/iam` returns the token itself, not the identity.

## Solution

`GET /openapi/v1/caller` — the one operation whose *answer* is the end user:

- Returns the verified principal's subject — `user_id`, `username`, the optional `display_name` / `full_name`, and the request's `tenant`. Everything is read off the gateway-signed principal; nothing comes from the request, so the answer cannot be steered. A client calls it once per session, caches the identity, and names it everywhere else; a stale cache fails closed (`require_user_id` answers 403 on a mismatch).
- It is also the one user-scoped read that takes **no `user_id` parameter**: requiring it would make the id a precondition of discovering it. Accordingly it is mounted with the base error table (no 403 to advertise) and pinned in `_NO_USER_DIMENSION` with its reason.
- Admission mode **REFUSED** for an application acting alone: an app-only caller names no end user, so there is nothing to return — its own scope question is already answered by `GET /openapi/v1/bots/authorized`. The route declares `refuse_app_only_caller`, as every REFUSED operation does, and the refusal is byte-identical to an unauthenticated 401.
- `VerifiedCaller.user` now exposes the full `GatewayUser` subject beside `user_id` / `has_user`, reading through the same `_first_user_principal` seam so the three cannot name different people.
- `/openapi/v1/caller` joins `_DECLARED_PREFIXES` in the public-namespace contract, landing together with the matching gateway domain and `route_security` entries as that test requires.
- Endpoint-framework coverage cases (happy + unauthenticated) registered for the coverage gate.
- Gateway: a `caller` domain forwards `/openapi/v1/caller` to the backend (the `**` glob matches zero segments, so the bare path is served); an explicit `route_security` rule keeps the operation human-only at the edge, mirrored in the `_HUMAN_ONLY` pin; `bots.openapi.json` regenerated via `dump_openapi.py` + `gate_and_publish_openapi.py` (a semantic diff confirms the only operation-level change is the new endpoint; the gate reports compatible).

Rejected alternatives: making `user_id` optional surface-wide (forks the contract — an app-only caller still cannot omit it — and reintroduces the credential-derived user the 2026-08-08 spec removed); a `user_id=me` sentinel (a second spelling of identity, and it gives up the stale-session 403).

## Validation

- `src/backend`: the full openapi_v1 surface package, the endpoint-coverage gate, the gateway contracts package, and the new endpoint suites on the `dev_refactory_collaboration` base — **1033 passed, 0 failed** locally (the base's earlier gate debt was cleared by #1150; this PR adds no new gaps). New coverage: 5 behavior tests in `test_caller_identity.py` (identity comes off the signed principal, null profile fields answered as null, tenant follows the asserted/default rule, app-only refusal byte-identical to unauthenticated, smuggled `user_id` ignored) + 2 framework cases in `tests/community/endpoints/test_openapi_caller_identity.py`.
- The pinned inventory tests hold both directions: the REFUSED entry ↔ `refuse_app_only_caller` declaration (`test_admission_inventory.py`), surface ↔ table (`test_principal_seam.py`), exempt set + `bot_id` placement (`test_explicit_user_id.py`), and the app-only refusal sweep picks the new operation up by enumeration (`test_app_only_refusals.py`).
- `src/gateway`: `pytest tests/unit tests/integration/baseline/test_startup.py tests/e2e/asgi/baseline/test_served_openapi.py` — 645 passed; the one failure (`test_dump_and_publish_script.py::test_bcn_dump_uses_the_gateway_managed_python_environment`) is environment-dependent, unrelated to this diff, and green in CI.
- flake8 block rules (E999/E902/E117/F405/E712/E701/E702/F821/F822/F823/F831) clean on every changed file.
- Not run: Singlebox E2E and the full-module coverage gates (heavier CI-side gates; lint-only pre-push per AGENTS.md).

## Compatibility and risk

Purely additive: one new operation, no path, parameter, or response change to any existing one. The regenerated `bots.openapi.json` passed the compatibility gate; a semantic diff confirms the only operation-level change is the added `GET /openapi/v1/caller`. Rollback is reverting the commit; no schema/config migration.

## Spec

Follows the contract laid down by `src/backend/specs/2026-08-08-openapi-v1-explicit-user-id` (the `user_id` parameter this endpoint lets a browser client discover) and the admission machinery from `specs/2026-08-10-openapi-v1-app-only-caller`.