### PR TITLE
feat(backend): consolidate task_discovery module with notification integration

### DIFF
--- a/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/design.md
+++ b/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/design.md
@@ -1,0 +1,346 @@
+# task_discovery 通知集成 — 技术设计 (HOW)
+
+## 澄清结果复核
+
+- Readiness score: 9/10
+- Human-confirmed decisions: discover 阶段所有任务仅展示等确认；不按 work_item_url 分支；autoInitiate 执行是后续独立步骤
+- Assumptions carried into design: `NotifySenderPlugin` 已由 `CommunityNotifyModule` 绑定为 singleton
+- Open questions deferred: 无
+- Why it is safe to design now: 范围明确，代码事实清晰，DI 绑定已验证
+
+---
+
+## 代码背景
+
+### 现有 task_discovery 模块结构
+
+```
+core/task/task_discovery/
+├── __init__.py              # 模块 docstring
+├── models.py                # DiscoveredTask + DiscoverySession（frozen dataclass）
+├── discovery_service.py     # DiscoveryService 编排核心 + DiscoveryResult
+├── task_reader.py           # TaskReader Protocol + SqliteTaskReader + MockTaskReader
+├── session_creator.py       # SessionCreator Protocol + EngineSessionCreator
+└── lifecycle.py             # TaskDiscoveryLifecycle（定时调度）
+```
+
+现有流程：`TaskReader.read_pending_tasks()` → `SessionCreator.create_session()` → 返回 `DiscoveryResult(task, session, notification_message)`
+
+通知消息仅作为 `notification_message` 字符串存在于 `DiscoveryResult` 中，不投递到任何通道。
+
+### 现有通知基础设施
+
+```
+plugin_api/notify_sender.py     # NotifySenderPlugin Protocol + NotifyMessage
+plugins/community/notify_sender.py  # CommunityNotifySender (log-only)
+plugins/local/notify_sender.py      # NoopNotifySender (test)
+di/modules/infrastructure/community/notify.py  # CommunityNotifyModule (singleton bind)
+```
+
+`NotifySenderPlugin.send(NotifyMessage, channel="markdown") -> str | None` — Protocol 约定从不抛异常。返回 `str` 为消息 ID（成功），`None` 为失败。
+
+### 现有 DI 绑定
+
+- `NotifySenderPlugin` — `CommunityNotifyModule` → singleton provider（`notify.py:22`）
+- `BotService` — `BotManagementModule` → 已绑定
+- `TaskDiscoveryLifecycle` — `TaskDiscoveryModule` → singleton bind
+
+`TaskDiscoveryModule` 无需修改 — `NotifySenderPlugin` 由 `CommunityNotifyModule` 绑定，injector 自动解析。
+
+## 相似实现
+
+| 参考文件 | 参考点 |
+|---|---|
+| `adapters/http/cron/cron_noauth_router.py:65` | `Injected(CronRelayServiceProtocol)` — router 中通过 DI 注入依赖的模式 |
+| `plugins/community/notify_sender.py:39` | `CommunityNotifySender.send()` log-only 实现 |
+| `core/bot_dormant/notify_log.py` | `NotifySenderPlugin` 在其他模块中的集成模式 |
+
+## 影响范围
+
+| 文件 | 层级 | 变更类型 | 影响 |
+|---|---|---|---|
+| `discovery_service.py` | core/service | 扩展 | 新增 `notify_sender` 依赖 + `_send_notification()` + `DiscoveryResult.notification_sent` |
+| `lifecycle.py` | core/lifecycle | 修改 | `__init__` 注入 `NotifySenderPlugin`；`_discover_once()` 传参 |
+| `router.py` | adapter/http | 修改 | `Injected(NotifySenderPlugin)` + 响应格式 |
+| `__init__.py` | core | 修改 | docstring 更新 |
+| `test_task_discovery_e2e.py` | test | 修改 | 通知日志断言 |
+
+**不修改的文件**: `models.py`, `task_reader.py`, `session_creator.py`, `task_discovery_module.py`
+
+## 架构约束
+
+- **transport-agnostic**: `DiscoveryService` core 层不 import transport；`NotifySenderPlugin` 是 Protocol
+- **DI composition root**: `NotifySenderPlugin` 由 `CommunityNotifyModule` 绑定，lifecycle 通过 `@inject` 解析，router 通过 `Injected()` 解析
+- **thin adapter**: `router.py` 只转协议，不持领域策略
+- **NotifySenderPlugin 从不抛异常**: 通知失败不影响发现流程
+
+## 接口变更
+
+### 修改: `DiscoveryResult`
+
+```python
+# discovery_service.py
+
+@dataclass
+class DiscoveryResult:
+    """单次发现流程的结果。"""
+
+    task: DiscoveredTask
+    session: Optional[DiscoverySession] = None
+    notification_message: str = ""
+    notification_sent: bool = False        # 新增
+    error: Optional[str] = None
+
+    @property
+    def success(self) -> bool:
+        return self.session is not None and self.error is None
+```
+
+### 修改: `DiscoveryService.__init__()`
+
+```python
+class DiscoveryService:
+    def __init__(
+        self,
+        reader: TaskReader,
+        session_creator: SessionCreator,
+        notify_sender: NotifySenderPlugin,     # 新增
+    ):
+        self._reader = reader
+        self._session_creator = session_creator
+        self._notify_sender = notify_sender
+        self._discoveries: dict[str, DiscoveryResult] = {}
+```
+
+### 新增: `DiscoveryService._send_notification()`
+
+```python
+def _send_notification(
+    self,
+    task: DiscoveredTask,
+    user_id: str,
+    session_url: str,
+) -> bool:
+    """通过 NotifySenderPlugin 投递通知，返回是否发送成功。"""
+    message = NotifyMessage(
+        title="发现待确认任务",
+        body=task.to_notification_message(session_url),
+        recipient=user_id,
+        deep_link=session_url,
+    )
+    msg_id = self._notify_sender.send(message)
+    if msg_id:
+        logger.info(
+            "[task_discovery] notification sent for task %s (msg_id=%s)",
+            task.task_id, msg_id,
+        )
+        return True
+    else:
+        logger.warning(
+            "[task_discovery] notification send returned None for task %s",
+            task.task_id,
+        )
+        return False
+```
+
+### 修改: `DiscoveryService._discover_single()`
+
+```python
+async def _discover_single(
+    self,
+    task: DiscoveredTask,
+    *,
+    user_id: str,
+    agent_id: str,
+    model: str | None,
+) -> DiscoveryResult:
+    """处理单个任务的发现流程。"""
+    try:
+        session = await self._session_creator.create_session(
+            task,
+            user_id=user_id,
+            agent_id=agent_id,
+            model=model,
+        )
+        message = task.to_notification_message(session.session_url)
+
+        # session 创建成功后投递通知
+        notification_sent = self._send_notification(
+            task, user_id, session.session_url
+        )
+
+        logger.info(
+            "[task_discovery] task %s → session %s (url=%s, notified=%s)",
+            task.task_id,
+            session.session_id,
+            session.session_url,
+            notification_sent,
+        )
+
+        return DiscoveryResult(
+            task=task,
+            session=session,
+            notification_message=message,
+            notification_sent=notification_sent,
+        )
+    except Exception as exc:
+        logger.error(
+            "[task_discovery] failed to create session for task %s: %s",
+            task.task_id,
+            exc,
+        )
+        return DiscoveryResult(
+            task=task,
+            error=str(exc),
+            notification_sent=False,
+        )
+```
+
+### 修改: `create_default_service()`
+
+```python
+def create_default_service(
+    data_file: str,
+    notify_sender: NotifySenderPlugin,        # 新增
+    engine_base_url: str | None = None,
+    engine_frontend_url: str | None = None,
+) -> DiscoveryService:
+    return DiscoveryService(
+        reader=SqliteTaskReader(data_file),
+        session_creator=EngineSessionCreator(
+            engine_base_url=engine_base_url,
+            engine_frontend_url=engine_frontend_url,
+        ),
+        notify_sender=notify_sender,
+    )
+```
+
+### 修改: `TaskDiscoveryLifecycle.__init__()`
+
+```python
+@inject
+def __init__(
+    self,
+    bot_service: "BotService",
+    notify_sender: NotifySenderPlugin,       # 新增
+) -> None:
+    self._bot_service: Any = bot_service
+    self._notify_sender = notify_sender
+    self._task: asyncio.Task | None = None
+```
+
+### 修改: `TaskDiscoveryLifecycle._discover_once()`
+
+```python
+service = create_default_service(
+    data_file=data_file,
+    notify_sender=self._notify_sender,      # 新增
+    engine_base_url=engine_url,
+    engine_frontend_url=frontend_url,
+)
+```
+
+### 修改: `router.py` — discover_tasks() + _build_service()
+
+```python
+from agentclaw.community.plugin_api.notify_sender import (
+    NotifySenderPlugin,
+)
+
+
+def _build_service(notify_sender: NotifySenderPlugin) -> DiscoveryService:
+    engine_url = os.environ.get("TASK_DISCOVERY_ENGINE_URL", "http://localhost:20003")
+    frontend_url = os.environ.get("TASK_DISCOVERY_FRONTEND_URL", "http://localhost:8000")
+    return create_default_service(
+        data_file=_resolve_db_path(),
+        notify_sender=notify_sender,
+        engine_base_url=engine_url,
+        engine_frontend_url=frontend_url,
+    )
+
+
+@router.post("/discover")
+async def discover_tasks(
+    user_id: str = Query("default", description="用户 ID"),
+    agent_id: str = Query("bot_001", description="Bot/Agent ID"),
+    notify_sender: NotifySenderPlugin = Injected(NotifySenderPlugin),
+) -> dict:
+    ...
+    service = _build_service(notify_sender=notify_sender)
+    results = await service.discover(user_id=user_id, agent_id=agent_id)
+
+    return {
+        "success": True,
+        "discovered": len(results),
+        "tasks": [
+            {
+                "task_id": r.task.task_id,
+                "project_name": r.task.project_name,
+                "success": r.success,
+                "session_id": r.session.session_id if r.session else None,
+                "session_url": r.session.session_url if r.session else None,
+                "notification_sent": r.notification_sent,   # 新增
+                "error": r.error,
+            }
+            for r in results
+        ],
+    }
+```
+
+## 数据变更
+
+不涉及数据库 schema 变更。
+
+## 权限与安全
+
+- `NotifySenderPlugin.send()` Protocol 约定从不抛异常——通知失败不泄露用户信息
+- HTTP 端点保持现有无需认证模式
+
+## 兼容性
+
+- **SessionCreator Protocol**: 接口不变
+- **TaskReader Protocol**: 接口不变
+- **DiscoveredTask / DiscoverySession**: 不变（复用现有 `to_notification_message()`）
+- **HTTP API**: `POST /discover` 响应扩展（新增 `notification_sent` 字段），不删除现有字段
+- **DI**: `TaskDiscoveryModule` 不修改；`NotifySenderPlugin` 已由 `CommunityNotifyModule` 绑定
+- **lifecycle**: 定时调度行为不变，仅构造函数新增依赖
+
+## 性能与稳定性
+
+- `_send_notification()` 调用同步 `send()` 方法（Protocol 约定），community log-only 不阻塞
+- `_discover_single()` 保持 per-task try/except，单任务失败不阻塞其他任务
+
+## 灰度/发布/回滚
+
+- **灰度**: 通过 `TASK_DISCOVERY_AUTO_START` 环境变量控制 lifecycle 自动调度（已有机制）
+- **回滚**: 移除 `notify_sender` 参数及 `_send_notification()` 调用，回到仅返回 `notification_message` 字符串的状态
+- **发布**: 无数据迁移，无 schema 变更
+
+## 测试策略
+
+| 层级 | 测试内容 | 方式 |
+|---|---|---|
+| Unit | `DiscoveryService._send_notification()` 成功/失败 | Mock `NotifySenderPlugin` |
+| Unit | `DiscoveryService.discover()` 通知发送时机 | Mock reader + creator + notify |
+| Unit | `DiscoveryResult.notification_sent` 字段 | 纯 dataclass 断言 |
+| Unit | `DiscoveryService` session 创建失败时不发通知 | Mock creator 抛异常 |
+| E2E | discover → session → notify 全链路 | gated singlebox e2e |
+
+## 风险与取舍
+
+| 风险 | 级别 | 缓解 |
+|---|---|---|
+| `NotifySenderPlugin.send()` 同步阻塞 async | 低 — community log-only | 若 corp 版需 async，后续 Protocol 升级 |
+| `Injected()` 在 task_discovery router 中不可用 | 低 — cron router 已用同一模式 | DI 构建时即发现 |
+
+## 领域边界与所有权
+
+- **task_discovery** 拥有：发现编排流程、`DiscoveryService`、`DiscoveryResult`
+- **plugin_api** 拥有：`NotifySenderPlugin` Protocol、`NotifyMessage` 模型
+- **边界**: task_discovery 通过 Protocol 调用通知插件，不跨边界持有实现
+
+## 方案取舍记录
+
+1. **复用 `to_notification_message()` 而非新增方法** — minimize changes，现有方法已包含完整任务详情
+2. **通知在 session 创建成功后发送** — 通知的目的是指引用户去 session 确认，先有 session 再通知
+3. **不引入 TaskInitiator / ExecutionMode** — autoInitiate 执行不在 discovery 阶段，是后续独立 spec

--- a/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/pipeline/state.json
+++ b/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/pipeline/state.json
@@ -1,0 +1,44 @@
+{
+  "module": "task-discovery",
+  "feature": "discovery-notification-integration",
+  "date": "2026-08-18",
+  "phase": "implement",
+  "status": "implemented",
+  "readiness_score": 9,
+  "artifacts": {
+    "proposal.md": "created",
+    "spec.md": "created",
+    "design.md": "created",
+    "tasks.md": "created"
+  },
+  "clarification": {
+    "snapshot": "produced",
+    "closure": "produced",
+    "questions_asked": 4,
+    "questions_answered": 4
+  },
+  "gates": {
+    "context_findings": "passed",
+    "domain_model": "passed",
+    "requirement_blocking": "passed",
+    "acceptance_alignment": "passed"
+  },
+  "tasks": {
+    "total_slices": 5,
+    "completed": 5,
+    "pending": 0
+  },
+  "validation": {
+    "ruff": "passed",
+    "mypy": "skipped (not installed)",
+    "import_check": "passed",
+    "unit_tests": "not run (no existing unit tests for this module)",
+    "e2e": "gated (SINGLEBOX_TASK_E2E=1)"
+  },
+  "revision": {
+    "date": "2026-08-18",
+    "from": "task_discovery-autoinitiate-merge (方案B)",
+    "to": "task_discovery 通知集成",
+    "reason": "用户修订：discover 阶段所有任务仅展示等确认，autoInitiate 执行是后续独立步骤；不按 work_item_url 分支"
+  }
+}

--- a/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/proposal.md
+++ b/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/proposal.md
@@ -1,0 +1,72 @@
+# task_discovery 通知集成
+
+## 背景
+
+`task_discovery` 模块（`core/task/task_discovery/`）当前流程：读 SQLite mock → 创建 engine session → 生成通知文本（仅存在 `DiscoveryResult.notification_message` 字段中，不投递到任何通知通道）。
+
+用户不知道有任务待处理，除非主动查询 `GET /api/public/task-discovery/status` 或查看 engine session。
+
+`NotifySenderPlugin` Protocol + `CommunityNotifySender`（log-only）已由 `CommunityNotifyModule` 绑定为 singleton，可直接注入使用。
+
+## 问题定义
+
+**通知投递缺失**：发现任务并创建 session 后，通知消息仅作为字符串返回，未通过任何通道投递给用户。用户无从感知"有新任务被发现了"。
+
+## 目标
+
+在 `DiscoveryService` 创建 session 成功后，通过 `NotifySenderPlugin.send()` 投递通知。
+
+- 所有任务统一走"创建 session + 展示 + 通知"单一路径
+- 通知在 session 创建成功后发送
+- 通知失败不阻塞发现流程（`NotifySenderPlugin` Protocol 约定从不抛异常）
+
+## 用户/角色
+
+| 角色 | 关注点 |
+|---|---|
+| 框架维护者 | Protocol seam 可插拔；transport-agnostic |
+| corp 接入者 | `NotifySenderPlugin` 替换为钉钉通道即可 |
+| singlebox/CI | e2e gated 测试验证通知日志可见 |
+
+## 范围
+
+| 文件 | 变更类型 |
+|---|---|
+| `discovery_service.py` | `DiscoveryService` 新增 `notify_sender` 依赖 + `_send_notification()`；`DiscoveryResult` 加 `notification_sent` 字段 |
+| `lifecycle.py` | `_discover_once()` 注入并传 `NotifySenderPlugin` |
+| `router.py` | `_build_service()` 适配；响应格式加 `notification_sent` |
+| `__init__.py` | 更新 docstring |
+| `test_task_discovery_e2e.py` | 加通知日志断言 |
+
+## 非范围
+
+- **不**引入 `TaskInitiator` / `AutoInitiateExecutor` — autoInitiate 执行不在 discovery 阶段
+- **不**按 `work_item_url` 分支 — 所有任务统一走 SessionCreator 路径
+- **不**实现真实钉钉机器人通知（corp 侧 `DingTalkNotifySender` 负责）
+- **不**修改 `models.py`（复用现有 `to_notification_message()`）
+- **不**修改 `task_reader.py` / `session_creator.py`
+- **不**修改 `task_discovery_module.py`（`NotifySenderPlugin` 已由 `CommunityNotifyModule` 绑定）
+- **不**修改 engine 侧代码
+- **不**做前端页面变更
+
+## AI Assumptions
+
+| 假设 | 风险 | 可逆性 |
+|---|---|---|
+| `NotifySenderPlugin` 已由 `CommunityNotifyModule` 绑定为 singleton | 低 — 代码已确认 `notify.py:22` | 高 |
+| `NotifySenderPlugin.send()` 从不抛异常 | 低 — Protocol 约定 | 高 |
+| `Injected()` 可在 task_discovery router 中使用 | 低 — `cron_noauth_router` 已用同一模式 | 高 |
+
+## Decision Log
+
+| 日期 | 决策 | 理由 |
+|---|---|---|
+| 2026-08-18 | 推翻原方案 B（autoInitiate 合并），收窄为通知集成 | 用户明确：discover 阶段所有任务仅展示等确认，autoInitiate 执行是后续独立步骤 |
+| 2026-08-18 | 不按 `work_item_url` 分支 | 数据字段不应决定代码走向；所有任务统一走 SessionCreator |
+
+## 变更记录
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-18 | 初始创建 |
+| 2026-08-18 | 方向修订：从"autoInitiate 合并"收窄为"通知集成" |

--- a/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/spec.md
+++ b/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/spec.md
@@ -1,0 +1,97 @@
+# task_discovery 通知集成
+
+## 概述
+
+在 `DiscoveryService` 创建 engine session 成功后，通过注入的 `NotifySenderPlugin` 投递通知。所有任务统一走现有 `SessionCreator` 路径，不引入 autoInitiate 执行、不按 `work_item_url` 分支。
+
+## 需求列表
+
+### REQ-1: DiscoveryService 通知集成
+- **描述**: `DiscoveryService` 新增 `notify_sender` 依赖，session 创建成功后调用 `NotifySenderPlugin.send()`
+- **验收标准**:
+  - `DiscoveryService.__init__()` 接受 `reader`, `session_creator`, `notify_sender`
+  - `_discover_single()` 中 session 创建成功后调 `_send_notification()`
+  - `_send_notification()` 构造 `NotifyMessage(title, body, recipient, deep_link)` 调 `send()`
+  - `NotifyMessage.title` 为"发现待确认任务"
+  - `NotifyMessage.body` 由 `task.to_notification_message(session_url)` 生成
+  - `NotifyMessage.recipient` 为 `user_id`
+  - `NotifyMessage.deep_link` 为 `session_url`
+  - 通知发送不阻塞发现流程（Protocol 约定从不抛异常）
+  - `create_default_service()` 工厂方法支持构建含 `notify_sender` 的服务
+- **场景**:
+  - 当 session 创建成功且通知发送成功, 则 `DiscoveryResult.notification_sent=True`
+  - 当 session 创建成功但通知发送返回 None, 则 `DiscoveryResult.notification_sent=False`，任务仍标记为成功
+  - 当 session 创建失败, 则不发通知，`DiscoveryResult.notification_sent=False`
+
+### REQ-2: DiscoveryResult 字段扩展
+- **描述**: `DiscoveryResult` 新增 `notification_sent` 字段
+- **验收标准**:
+  - 字段：`notification_sent: bool = False`
+  - `success` property 逻辑不变（`session is not None and error is None`）
+- **场景**:
+  - 当 session 创建成功, 则 `notification_sent` 反映通知发送结果
+  - 当 session 创建失败, 则 `notification_sent=False`
+
+### REQ-3: TaskDiscoveryLifecycle 适配
+- **描述**: lifecycle 通过 `@inject` 注入 `NotifySenderPlugin`，传给 `DiscoveryService`
+- **验收标准**:
+  - `TaskDiscoveryLifecycle.__init__()` 新增 `@inject` 参数 `notify_sender: NotifySenderPlugin`
+  - `_discover_once()` 构建服务时传入 `notify_sender`
+  - 定时调度启动/取消行为不变
+- **场景**:
+  - 当 backend startup 且 `TASK_DISCOVERY_AUTO_START=true`, 则 lifecycle 正常调度
+  - 当定时触发发现, 则 session 创建成功后发通知
+
+### REQ-4: HTTP Router 适配
+- **描述**: `POST /discover` 端点注入 `NotifySenderPlugin` 并在响应中包含通知状态
+- **验收标准**:
+  - `discover_tasks()` 通过 `Injected(NotifySenderPlugin)` 获取依赖
+  - `_build_service()` 接受并传递 `notify_sender`
+  - 响应中每个 task 包含 `notification_sent` 字段
+  - `GET /status` 行为不变
+- **场景**:
+  - 当手动触发 `POST /discover`, 则返回结果含每个任务的 `notification_sent`
+
+### REQ-5: __init__.py docstring 更新
+- **描述**: 更新模块 docstring 反映通知投递
+- **验收标准**:
+  - docstring 包含"创建 session + 投递通知"描述
+- **场景**: N/A
+
+### REQ-6: E2E 测试更新
+- **描述**: e2e 测试加通知日志断言
+- **验收标准**:
+  - e2e 仍 gated（`SINGLEBOX_TASK_E2E=1`）
+  - 断言通知日志可见（`CommunityNotifySender` log 输出）
+  - 断言响应含 `notification_sent` 字段
+- **场景**:
+  - 当 e2e 启用且有 mock 任务, 则 discover 响应含 `notification_sent` 且日志中可见通知发送记录
+
+## 约束
+
+- core 层 transport-agnostic — `DiscoveryService` 不 import transport
+- `NotifySenderPlugin.send()` 从不抛异常（Protocol 约定）
+- HTTP adapter thin — router 不持领域策略
+- 不破坏现有 `SessionCreator` / `EngineSessionCreator` 接口
+- `NotifySenderPlugin` 已由 `CommunityNotifyModule` 绑定，`TaskDiscoveryModule` 无需修改
+
+## 需求就绪度
+
+9/10 — 范围明确，代码事实清晰，DI 绑定已验证。
+
+## 验收对齐检查
+
+| 目标 | 覆盖的验收标准 | 是否充分 |
+|---|---|---|
+| session 创建后发通知 | REQ-1, REQ-3 | 是 |
+| 通知失败不阻塞流程 | REQ-1 | 是 |
+| 响应含通知状态 | REQ-4 | 是 |
+| 复用现有 NotifySenderPlugin 绑定 | REQ-1, REQ-3 | 是 |
+| 不引入 autoInitiate 分支 | 全部 | 是 |
+
+## 变更记录
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-18 | 初始创建 |
+| 2026-08-18 | 方向修订：从 autoInitiate 合并收窄为通知集成 |

--- a/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/tasks.md
+++ b/src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/tasks.md
@@ -1,0 +1,122 @@
+# task_discovery 通知集成 — TDD 任务清单
+
+## 任务总览
+
+| Slice | 目标 | 文件 | 依赖 |
+|---|---|---|---|
+| 1 | DiscoveryService 通知集成 | `discovery_service.py` | 无 |
+| 2 | Lifecycle 适配 | `lifecycle.py` | Slice 1 |
+| 3 | HTTP Router 适配 | `router.py` | Slice 1 |
+| 4 | __init__.py docstring 更新 | `__init__.py` | 无 |
+| 5 | E2E 测试更新 | `test_task_discovery_e2e.py` | Slice 1-3 |
+
+---
+
+## Slice 1: DiscoveryService 通知集成
+
+- **Goal**: `DiscoveryService` 新增 `notify_sender` 依赖；session 创建成功后调 `NotifySenderPlugin.send()`；`DiscoveryResult` 加 `notification_sent` 字段
+- **Files**:
+  - `src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py`
+- **Tests first**:
+  - 测试 `_send_notification()` 成功路径：Mock `NotifySenderPlugin.send()` 返回 msg_id → `notification_sent=True`
+  - 测试 `_send_notification()` 失败路径：Mock `send()` 返回 `None` → `notification_sent=False`，不抛异常
+  - 测试 `discover()` session 创建成功后调 `notify_sender.send()`
+  - 测试 `discover()` session 创建失败时不调 `notify_sender.send()`
+  - 测试 `NotifyMessage.title` 为"发现待确认任务"
+  - 测试 `NotifyMessage.recipient` 为 `user_id`
+  - 测试 `NotifyMessage.deep_link` 为 `session_url`
+  - 测试 `DiscoveryResult.notification_sent` 默认为 `False`
+  - 测试 `create_default_service()` 构建含 `notify_sender` 的服务
+- **Implementation**:
+  - import `NotifySenderPlugin` + `NotifyMessage` from `plugin_api/notify_sender`
+  - `DiscoveryResult` 加 `notification_sent: bool = False` 字段
+  - `DiscoveryService.__init__()` 新增 `notify_sender: NotifySenderPlugin` 参数
+  - 新增 `_send_notification(task, user_id, session_url) -> bool` 方法
+  - `_discover_single()` 中 session 创建成功后调 `_send_notification()`，结果写入 `DiscoveryResult.notification_sent`
+  - session 创建失败时 `notification_sent=False`
+  - `create_default_service()` 新增 `notify_sender` 参数并传入 `DiscoveryService`
+- **Validation**: `cd src/backend && python -m pytest tests/community/core/task/ -k "discovery_service_notify" -v`
+- **Dependencies**: 无
+- **Human confirmation needed**: no
+
+## Slice 2: Lifecycle 适配
+
+- **Goal**: `TaskDiscoveryLifecycle` 通过 `@inject` 注入 `NotifySenderPlugin`，传给 `create_default_service()`
+- **Files**:
+  - `src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py`
+- **Tests first**:
+  - 测试 `__init__` 接受 `notify_sender` 参数
+  - 测试 `_discover_once()` 构建的服务含 `notify_sender`
+  - 测试 lifecycle 启动/取消行为不变
+- **Implementation**:
+  - import `NotifySenderPlugin` from `plugin_api/notify_sender`
+  - `__init__()` 新增 `@inject` 参数 `notify_sender: NotifySenderPlugin`
+  - `_discover_once()` 中 `create_default_service()` 调用传入 `notify_sender=self._notify_sender`
+- **Validation**: `cd src/backend && python -m pytest tests/community/core/task/ -k "lifecycle_notify" -v`
+- **Dependencies**: Slice 1
+- **Human confirmation needed**: no
+
+## Slice 3: HTTP Router 适配
+
+- **Goal**: `POST /discover` 通过 `Injected(NotifySenderPlugin)` 注入依赖；响应含 `notification_sent`
+- **Files**:
+  - `src/backend/src/agentclaw/community/adapters/http/task_discovery/router.py`
+- **Tests first**:
+  - 测试 `POST /discover` 响应含 `notification_sent` 字段
+  - 测试 `_build_service()` 接受 `notify_sender` 并传入服务
+  - 测试 `GET /status` 行为不变
+- **Implementation**:
+  - import `NotifySenderPlugin` from `plugin_api/notify_sender`
+  - import `Injected` (参考 `cron_noauth_router.py`)
+  - `_build_service(notify_sender)` 接受并传递 `notify_sender`
+  - `discover_tasks()` 新增 `notify_sender: NotifySenderPlugin = Injected(NotifySenderPlugin)` 参数
+  - 响应中每个 task 加 `"notification_sent": r.notification_sent`
+- **Validation**: `cd src/backend && python -m pytest tests/community/endpoints/ -k "task_discovery" -v`
+- **Dependencies**: Slice 1
+- **Human confirmation needed**: no
+
+## Slice 4: __init__.py docstring 更新
+
+- **Goal**: 更新模块 docstring 反映通知投递
+- **Files**:
+  - `src/backend/src/agentclaw/community/core/task/task_discovery/__init__.py`
+- **Tests first**: 无（文档变更）
+- **Implementation**:
+  - 更新 docstring：1. 读已发现任务 2. 为每个任务创建 engine session 3. session 创建成功后投递通知 4. 用户在 session 中确认后执行
+- **Validation**: `python -c "from agentclaw.community.core.task.task_discovery import __doc__; print(__doc__)"`
+- **Dependencies**: 无
+- **Human confirmation needed**: no
+
+## Slice 5: E2E 测试更新
+
+- **Goal**: e2e 测试加通知日志断言 + `notification_sent` 字段断言
+- **Files**:
+  - `src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py`
+- **Tests first**:
+  - 断言每个 task 响应含 `notification_sent` 字段
+  - 断言通知日志可见（`CommunityNotifySender` log 输出）
+- **Implementation**:
+  - 在逐任务验证循环中加 `notification_sent` 字段断言
+  - 可选：捕获日志输出验证 `[CommunityNotifySender]` 出现
+- **Validation**: `SINGLEBOX_TASK_E2E=1 cd src/backend && python -m pytest tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py -v`
+- **Dependencies**: Slice 1-3
+- **Human confirmation needed**: no
+
+---
+
+## 验证命令汇总
+
+```bash
+# 单元测试
+cd src/backend && python -m pytest tests/community/core/task/ -v
+
+# 端点测试
+cd src/backend && python -m pytest tests/community/endpoints/ -k "task_discovery" -v
+
+# 配置门禁
+cd src/backend && python -m ruff check src/agentclaw/community/core/task/task_discovery/
+cd src/backend && python -m mypy src/agentclaw/community/core/task/task_discovery/
+
+# E2E (gated)
+SINGLEBOX_TASK_E2E=1 cd src/backend && python -m pytest tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py -v
+```

--- a/src/backend/specs/2026-08-18-task-discovery/plan.md
+++ b/src/backend/specs/2026-08-18-task-discovery/plan.md
@@ -1,0 +1,354 @@
+# 任务主动发现模块 — 技术方案 (HOW)
+
+- **日期**: 2026-08-18
+- **依赖**: `spec.md`（同目录）；执行框架 `src/backend/specs/2026-08-09-task-goal-driven-execution-framework/`
+- **代码权威源**: Avernet `src/backend/src/agentclaw/community/core/task/task_discovery/`
+
+---
+
+## 0. 模块定位
+
+task_discovery 是 `core/task/` 目录下的独立子模块，与执行框架（`task_center` / `task_graph` / `task_plan` / `task_dispatch` / `task_runner` / `task_harness`）并列但解耦。
+
+```
+core/task/
+├── task_center/          # 执行框架：ExecutionEngine 编排核
+├── task_graph/           # 执行框架：TaskGraphService 图谱 SSOT
+├── task_plan/            # 执行框架：TaskPlanner 规划
+├── task_dispatch/        # 执行框架：TaskDispatcher 搜推分发
+├── task_runner/          # 执行框架：TaskRunner 三模态执行
+├── task_harness/         # 执行框架：TaskHarness 旁路巡检
+└── task_discovery/       # ← 本模块：任务主动发现（上游，独立）
+    ├── models.py          # DiscoveredTask / DiscoverySession
+    ├── discovery_service.py  # DiscoveryService 编排
+    ├── task_reader.py     # TaskReader Protocol + SqliteTaskReader + MockTaskReader
+    ├── session_creator.py # SessionCreator Protocol + EngineSessionCreator
+    ├── lifecycle.py       # TaskDiscoveryLifecycle 定时调度
+    └── __init__.py
+```
+
+**边界**：task_discovery 产出 `DiscoveredTask` → 创建 engine session 通知用户 → 用户确认后，外部调用 `TaskService.execute(task_info)` 进入执行框架。两个模块经 `TaskInfo` + engine session 衔接，无直接代码依赖。
+
+---
+
+## 1. 整体拓扑
+
+```
+┌─────────────────────────── backend (FastAPI 8888) ───────────────────────────┐
+│                                                                              │
+│  adapters/http/task_discovery/router.py  (thin, no-auth)                     │
+│    POST /api/public/task-discovery/discover   ← 手动触发                     │
+│    GET  /api/public/task-discovery/status      ← 查看状态                    │
+│                                                                              │
+│  di/modules/task_discovery_module.py                                         │
+│    bind(TaskDiscoveryLifecycle, singleton)                                   │
+│      ↓ @inject(BotService)                                                   │
+│                                                                              │
+│  core/task/task_discovery/                                                   │
+│    ┌──────────────────────────────────────────────────────────┐              │
+│    │ TaskDiscoveryLifecycle                                    │              │
+│    │   startup() → asyncio.create_task(_run_daily_schedule)    │              │
+│    │   _discover_once():                                       │              │
+│    │     BotService.list_bots() → for each bot:                │              │
+│    │       create_default_service(data_file, engine, frontend) │              │
+│    │       DiscoveryService.discover(user_id, agent_id)        │              │
+│    └─────────────────────────┬────────────────────────────────┘              │
+│                              │                                               │
+│    ┌─────────────────────────┴────────────────────────────────┐              │
+│    │ DiscoveryService (编排核心)                                │              │
+│    │   reader.read_pending_tasks() → list[DiscoveredTask]      │              │
+│    │   for task:                                                │              │
+│    │     session_creator.create_session(task, ...)              │              │
+│    │     → DiscoveryResult(task, session, notification_message) │              │
+│    └──────────┬──────────────────────────┬─────────────────────┘              │
+│               │                          │                                    │
+│    ┌──────────┴──────────┐    ┌──────────┴──────────────────┐                │
+│    │ TaskReader (Proto)  │    │ SessionCreator (Proto)       │                │
+│    │  SqliteTaskReader   │    │  EngineSessionCreator        │                │
+│    │   ← discovered_tasks │    │   → POST {engine}/api/sessions│               │
+│    │     .db (SQLite)     │    │   → session_url build        │                │
+│    │  MockTaskReader      │    │                               │                │
+│    │   ← tasks.json       │    │                               │                │
+│    └─────────────────────┘    └───────────────────────────────┘                │
+│                                                                              │
+│         engine session creation ─────────────► engine (20003)                 │
+│         session_url ────────────────────────► frontend (8000)                 │
+└──────────────────────────────────────────────────────────────────────────────┘
+         ▲                                      │
+         │ HTTP (async httpx)                    │ session_url
+┌────────┴──────── singlebox e2e test ──────────┴──────────────────────────────┐
+│  test_task_discovery_e2e.py                                                   │
+│    setup: init_discovered_tasks_db(mock data → SQLite)                       │
+│    drive: POST /discover → GET /status → verify session reachable            │
+│    gated: SINGLEBOX_TASK_E2E=1                                               │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. 领域模型 (`models.py`)
+
+### 2.1 `DiscoveredTask`
+
+```python
+@dataclass(frozen=True)
+class DiscoveredTask:
+    task_id: str
+    project_name: str           # 同时用作 engine session title
+    description: str            # 项目简介
+    business_scenario: str      # 业务场景描述
+    discovery_basis: str        # 挖掘依据 — 行为节点演进链路
+    work_item_url: str | None   # 关联需求/工作项 URL
+    priority: str = "medium"    # high / medium / low
+    discovered_at: str | None   # ISO timestamp
+    status: str = "pending_confirmation"
+```
+
+派生方法：
+- `needs_confirmation` → `status == "pending_confirmation"`
+- `to_session_ext_info()` → 序列化为 engine session `extInfo` dict（含 `source: "task_discovery"`）
+- `to_notification_message(session_url)` → 生成用户在 engine session 中看到的通知文本
+
+### 2.2 `DiscoverySession`
+
+```python
+@dataclass(frozen=True)
+class DiscoverySession:
+    task_id: str
+    session_id: str
+    session_url: str
+    created_at: str  # default: utcnow().isoformat()
+```
+
+---
+
+## 3. 编排服务 (`discovery_service.py`)
+
+### 3.1 `DiscoveryResult`
+
+```python
+@dataclass
+class DiscoveryResult:
+    task: DiscoveredTask
+    session: DiscoverySession | None = None
+    notification_message: str = ""
+    error: str | None = None
+
+    @property
+    def success(self) -> bool:
+        return self.session is not None and self.error is None
+```
+
+### 3.2 `DiscoveryService`
+
+```python
+class DiscoveryService:
+    def __init__(self, reader: TaskReader, session_creator: SessionCreator):
+        self._reader = reader
+        self._session_creator = session_creator
+        self._discoveries: dict[str, DiscoveryResult] = {}
+
+    async def discover(self, *, user_id: str, agent_id: str, model: str | None = None) -> list[DiscoveryResult]:
+        tasks = self._reader.read_pending_tasks()
+        results = []
+        for task in tasks:
+            result = await self._discover_single(task, user_id=user_id, agent_id=agent_id, model=model)
+            results.append(result)
+            self._discoveries[task.task_id] = result
+        return results
+```
+
+- `_discover_single(task, ...)` 内部 `try/except`：成功返 `DiscoveryResult(task, session, message)`；失败返 `DiscoveryResult(task, error=str(exc))`
+- `print_notifications(results)` → stdout 打印通知消息（供 CLI 输出）
+- `create_default_service(data_file, engine_base_url, engine_frontend_url)` → 工厂方法，用 `SqliteTaskReader` + `EngineSessionCreator` 构建
+
+---
+
+## 4. 数据读取 (`task_reader.py`)
+
+### 4.1 Protocol
+
+```python
+class TaskReader(Protocol):
+    def read_discovered_tasks(self) -> list[DiscoveredTask]: ...
+```
+
+### 4.2 `SqliteTaskReader`
+
+- db schema：`discovered_tasks` 表（9 字段，task_id PRIMARY KEY）
+- `read_discovered_tasks()` → `SELECT * FROM discovered_tasks` → `_row_to_task` 映射
+- `read_pending_tasks()` → 过滤 `needs_confirmation`
+- `init_discovered_tasks_db(db_path, tasks)` → 建表 + 清空 + 批量插入（供 e2e 测试）
+
+DDL:
+```sql
+CREATE TABLE IF NOT EXISTS discovered_tasks (
+    task_id            TEXT PRIMARY KEY,
+    project_name       TEXT NOT NULL,
+    description        TEXT,
+    business_scenario  TEXT,
+    discovery_basis    TEXT,
+    work_item_url      TEXT,
+    priority           TEXT DEFAULT 'medium',
+    discovered_at      TEXT,
+    status             TEXT DEFAULT 'pending_confirmation'
+);
+```
+
+### 4.3 `MockTaskReader`（JSON，向后兼容）
+
+- JSON 格式：`{"tasks": [{...DiscoveredTask fields...}]}`
+- 同样提供 `read_discovered_tasks()` / `read_pending_tasks()`
+
+---
+
+## 5. Session 创建 (`session_creator.py`)
+
+### 5.1 Protocol
+
+```python
+class SessionCreator(Protocol):
+    async def create_session(self, task: DiscoveredTask, *, user_id: str, agent_id: str, model: str | None = None) -> DiscoverySession: ...
+```
+
+### 5.2 `EngineSessionCreator`
+
+- engine API：`POST {engine_base_url}/api/sessions`
+- 请求体：`{title, user_id, agent_id, extInfo, model?}`
+- 响应：`{success, data: {id | session_id}}`
+- `session_url` 构建：`{frontend_url}/bcn/chat/session?bot_uuid={agent_id}&id={agent_id}&session={session_id}`
+  - 对齐前端 SessionOnlyPage 路由的三个 query 参数
+- 配置来源：构造器参数优先 → 环境变量 `ENGINE_BASE_URL` / `FRONTEND_URL` → 默认 localhost
+- 超时：30s（`httpx.AsyncClient(timeout=30.0)`）
+
+---
+
+## 6. 生命周期调度 (`lifecycle.py`)
+
+### 6.1 `TaskDiscoveryLifecycle(LifecycleBase)`
+
+```python
+class TaskDiscoveryLifecycle(LifecycleBase):
+    @inject
+    def __init__(self, bot_service: BotService): ...
+
+    async def startup(self) -> None:
+        # TASK_DISCOVERY_AUTO_START != true → skip
+        # asyncio.create_task(_run_daily_schedule(hour, minute))
+
+    async def shutdown(self) -> None:
+        # cancel _task
+
+    async def _run_daily_schedule(self, hour, minute):
+        while True:
+            delay = _seconds_until(hour, minute)
+            await asyncio.sleep(delay)
+            await _discover_once()
+```
+
+### 6.2 `_discover_once()` 流程
+
+1. `BotService.list_bots(page=1, page_size=100)` → 所有用户 bot
+2. 对每个 bot（有 `bot_id` + `owner_id`）：
+   - `create_default_service(data_file, engine_url, frontend_url)`
+   - `await service.discover(user_id=owner_id, agent_id=bot_id)`
+   - 统计成功/失败
+3. 日志输出汇总
+
+### 6.3 自动发现机制
+
+- 由 `discover_lifecycle_participants` 自动发现（与 `CronAutoSetupListener` 走相同机制）
+- DI 容器 `TaskDiscoveryModule` 绑定 singleton
+- `BotService` 已由 `BotManagementModule` 绑定，`@inject` 自动注入
+
+---
+
+## 7. HTTP 适配层 (`adapters/http/task_discovery/router.py`)
+
+```python
+router = APIRouter(prefix="/api/public/task-discovery", tags=["task-discovery"])
+
+@router.post("/discover")
+async def discover_tasks(user_id: str = Query("default"), agent_id: str = Query("bot_001")) -> dict:
+    # _build_service() → service.discover(user_id, agent_id)
+    # 返回 {success, discovered, tasks: [{task_id, project_name, success, session_id?, session_url?, error?}]}
+
+@router.get("/status")
+async def get_status() -> dict:
+    # SqliteTaskReader(db_path).read_discovered_tasks()
+    # 返回 {success, total, tasks: [{task_id, project_name, status, priority}]}
+```
+
+- 参考 `cron_noauth_router` 模式：无需认证
+- `_build_service()` 从环境变量构建 `DiscoveryService`
+- `_resolve_db_path()` 从 `TASK_DISCOVERY_DATA_FILE` 或默认路径解析
+
+### App include
+
+```python
+# app.py
+from ...task_discovery.router import router as task_discovery_router
+app.include_router(task_discovery_router)
+```
+
+---
+
+## 8. DI 接线 (`di/modules/task_discovery_module.py`)
+
+```python
+class TaskDiscoveryModule(Module):
+    def configure(self, binder: Binder) -> None:
+        binder.bind(TaskDiscoveryLifecycle, to=TaskDiscoveryLifecycle, scope=singleton)
+```
+
+DI 容器 (`container.py`) 注册：
+```python
+from ...task_discovery_module import TaskDiscoveryModule
+# 在 modules 列表中加入 TaskDiscoveryModule
+```
+
+---
+
+## 9. E2E 集成用例 (`test_task_discovery_e2e.py`)
+
+### 9.1 环境变量
+
+| 变量 | 默认 | 用途 |
+|---|---|---|
+| `SINGLEBOX_TASK_E2E` | — | gated 开关 |
+| `SINGLEBOX_BACKEND_URL` | `http://localhost:8888` | backend 地址 |
+| `SINGLEBOX_USER_ID` | `440718` | 测试用户 ID |
+| `TASK_DISCOVERY_ENGINE_URL` | `http://localhost:20003` | engine 地址 |
+| `TASK_DISCOVERY_FRONTEND_URL` | `http://localhost:8000` | 前端地址 |
+
+### 9.2 测试数据
+
+内联 `_MOCK_TASKS`（3 条），运行前 `init_discovered_tasks_db(_DATA_FILE, _MOCK_TASKS)` 写入 SQLite。
+
+### 9.3 测试流程
+
+1. **setup**：写入 mock 数据 → provision singlebox bot
+2. **discover**：`POST /api/public/task-discovery/discover?user_id=...&agent_id=...` → 断言 `discovered == 3`，每个 task 有 `session_id` + `session_url`
+3. **status**：`GET /api/public/task-discovery/status` → 断言 `total >= 3`，task_ids 匹配
+4. **session 可达**：验证 `session_url` 格式正确（含 bot_uuid / id / session 参数）
+5. **teardown**：清理
+
+---
+
+## 10. 微内核宪法遵守
+
+- **transport-agnostic**：core 层 `models.py` / `discovery_service.py` / `task_reader.py` / `lifecycle.py` 无 transport import；`SessionCreator` 经 Protocol 隔离 HTTP 访问
+- **thin adapter**：`router.py` 只转协议，不持领域策略
+- **composition root**：`TaskDiscoveryModule` 是唯一接线点
+- **Protocol seam**：`TaskReader` / `SessionCreator` 可插拔，corp 替换真实数据源/真实引擎只需实现 Protocol
+- **lifecycle 自动发现**：对齐 `CronAutoSetupListener` 模式
+
+---
+
+## 11. 风险收敛（对应 spec §8）
+
+- **R1 数据源**：`TaskReader` Protocol seam 已留，后续替换 `SqliteTaskReader` 为真实实现即可
+- **R2 确认回调**：task_discovery → execution_framework 桥接为后续设计，当前模块止于"创建 session + 通知"
+- **R3 状态持久化**：当前 status 存于 mock db；真实化时需引入独立状态服务（对齐 `TaskGraphService` 模式）
+- **R4 并发**：定时调度串行遍历 bot，bot 规模大时需评估；当前 `page_size=100` 覆盖 singlebox 场景
+- **R5 session_url**：对齐前端 `SessionOnlyPage` 路由约定，前端变更需同步更新 `_build_session_url`

--- a/src/backend/specs/2026-08-18-task-discovery/spec.md
+++ b/src/backend/specs/2026-08-18-task-discovery/spec.md
@@ -1,0 +1,188 @@
+# 任务主动发现模块 (task_discovery)
+
+- **日期**: 2026-08-18
+- **状态**: 已落地（mock 数据驱动；真实数据源待接入）
+- **代码权威源**: Avernet 仓 `src/backend/src/agentclaw/community/core/task/task_discovery/`
+- **关联框架**: `src/backend/specs/2026-08-09-task-goal-driven-execution-framework/`（任务目标驱动执行框架；task_discovery 是其上游——发现待执行任务后交执行框架处理）
+
+---
+
+## 1. 背景 (WHY)
+
+任务目标驱动执行框架（`core/task/`）已具备完整的"理解→规划→派发→执行→验收→重规划"闭环编排能力，但缺少**任务来源**：框架的入口是 `TaskService.execute(task_info)` ——调用方需手动构造 `TaskInfo` 传入。
+
+实际业务中，大量待执行任务并非用户主动发起，而是从用户行为历程、消息管线、业务系统等数据中**挖掘**得出的。需要一个独立模块负责：
+
+1. **读取** 已发现的待确认任务数据（当前 mock，未来对接真实数据源）
+2. 为每个任务**创建 engine session**（不触发执行，等用户确认）
+3. **通知** 用户（session_url），用户在 engine 前端查看任务详情后决定是否执行
+4. 用户确认后，走执行框架的 `TaskService.execute` 完成任务
+
+task_discovery 与执行框架**解耦**：本模块只负责"发现→通知"，不负责"确认→执行"。两者经 `TaskInfo` + engine session 衔接。
+
+---
+
+## 2. 目标 (WHAT)
+
+### G1. 核心领域模型（transport-agnostic）
+
+| 模型 | 职责 |
+|---|---|
+| `DiscoveredTask` | 已发现但尚未执行的待确认任务投影（frozen dataclass）。字段：task_id / project_name / description / business_scenario / discovery_basis / work_item_url / priority / discovered_at / status |
+| `DiscoverySession` | 发现流程中创建的 engine session 信息（task_id / session_id / session_url / created_at） |
+| `DiscoveryResult` | 单次发现流程的结果（task + session + notification_message + error） |
+
+`DiscoveredTask.status` 状态枚举：
+
+| status | 语义 |
+|---|---|
+| `pending_confirmation` | 待用户确认（默认） |
+| `confirmed` | 用户已确认，待执行 |
+| `executing` | 已提交执行框架 |
+| `ignored` | 用户忽略 |
+
+### G2. 编排服务 `DiscoveryService`
+
+编排完整流程：
+1. `TaskReader.read_pending_tasks()` 读取待确认任务
+2. 对每个任务，`SessionCreator.create_session(task, user_id, agent_id)` 创建 engine session
+3. 生成通知消息（任务详情 + session_url）
+4. 返回 `list[DiscoveryResult]`
+
+- 不负责任务执行（由执行框架 `TaskService.execute` 负责）
+- `create_default_service(data_file, engine_base_url, engine_frontend_url)` 工厂方法构建默认配置
+
+### G3. 数据读取 `TaskReader`（Protocol seam，可插拔）
+
+| 实现 | 数据源 | 用途 |
+|---|---|---|
+| `SqliteTaskReader` | 本地 SQLite db（`discovered_tasks` 表） | 默认实现；e2e 测试用 `init_discovered_tasks_db` 写入确定性 mock |
+| `MockTaskReader` | 本地 JSON 文件 | 向后兼容 |
+
+未来替换为真实数据源（消息管线、行为分析平台等），只需实现同一 `TaskReader` Protocol。
+
+### G4. Session 创建 `SessionCreator`（Protocol seam，可插拔）
+
+| 实现 | 数据源 | 用途 |
+|---|---|---|
+| `EngineSessionCreator` | engine HTTP API `POST /api/sessions` | 默认实现 |
+
+- 调用 engine 创建 session（title=项目名称，extInfo=完整任务详情）
+- 创建后构建 `session_url` 供用户在浏览器中打开确认
+- 与 cron `run-single` 的区别：只创建 session 不触发执行
+
+### G5. 生命周期调度 `TaskDiscoveryLifecycle`
+
+- 继承 `LifecycleBase`，由 DI 容器自动发现
+- `startup()` 调度每日定时任务（默认 11:00）
+- `shutdown()` 取消调度
+- 定时触发时：遍历 `BotService.list_bots()` 所有用户 bot → 为每个 bot 执行发现流程
+- `@inject` 注入 `BotService`
+
+### G6. HTTP 适配层（thin，无需认证）
+
+| 端点 | 方法 | 用途 |
+|---|---|---|
+| `/api/public/task-discovery/discover` | POST | 手动触发任务发现（query: user_id, agent_id） |
+| `/api/public/task-discovery/status` | GET | 查看任务发现状态（从 SQLite db 读取） |
+
+- 参考 `cron_noauth_router` 模式：无需认证的公开端点
+- Router 只翻译协议，不持领域策略
+
+### G7. DI 接线 `TaskDiscoveryModule`
+
+- 绑定 `TaskDiscoveryLifecycle` 为 singleton
+- Lifecycle 参与者由 `discover_lifecycle_participants` 自动发现
+- `BotService` 由 `BotManagementModule` 绑定，`@inject` 自动注入
+
+### G8. 端到端集成用例
+
+- `tests/.../task/singlebox_e2e/test_task_discovery_e2e.py`
+- gated（`SINGLEBOX_TASK_E2E=1` 启用真实 singlebox e2e）
+- 验证：discover → status → session 可达全链路
+
+---
+
+## 3. 非目标 (Non-Goals)
+
+- **不**实现任务执行：确认后执行由执行框架 `TaskService.execute` 负责，不在本模块内
+- **不**对接真实数据源：当前 mock（SQLite/JSON），真实消息管线/行为分析平台属后续
+- **不**做用户确认回调处理：确认态翻转/执行触发由前端+执行框架衔接
+- **不**做前端页面：session_url 指向已有 engine 前端 SessionOnlyPage 路由
+
+---
+
+## 4. 范围与形态 (Scope)
+
+### 已落地代码
+
+| 层 | 路径 | 内容 |
+|---|---|---|
+| core | `core/task/task_discovery/models.py` | `DiscoveredTask` / `DiscoverySession` |
+| core | `core/task/task_discovery/discovery_service.py` | `DiscoveryService` / `DiscoveryResult` / `create_default_service` |
+| core | `core/task/task_discovery/task_reader.py` | `TaskReader` Protocol / `SqliteTaskReader` / `MockTaskReader` / `init_discovered_tasks_db` |
+| core | `core/task/task_discovery/session_creator.py` | `SessionCreator` Protocol / `EngineSessionCreator` |
+| core | `core/task/task_discovery/lifecycle.py` | `TaskDiscoveryLifecycle` |
+| adapters/http | `adapters/http/task_discovery/router.py` | POST /discover + GET /status |
+| di/modules | `di/modules/task_discovery_module.py` | `TaskDiscoveryModule` (singleton bind) |
+| tests | `tests/.../task/singlebox_e2e/test_task_discovery_e2e.py` | gated e2e |
+
+### 触发方式
+
+| 方式 | 入口 | 说明 |
+|---|---|---|
+| A. 自动 | `TaskDiscoveryLifecycle` startup 定时调度 | 每日 11:00 遍历所有 bot |
+| B. 手动 | HTTP `POST /api/public/task-discovery/discover` | CLI / 外部调度器触发 |
+| C. CLI | `scripts/task_discovery.sh discover` → curl backend API | 本地脚本 |
+
+---
+
+## 5. 配置项
+
+| 环境变量 | 默认值 | 说明 |
+|---|---|---|
+| `TASK_DISCOVERY_AUTO_START` | `true` | 是否启用自动调度 |
+| `TASK_DISCOVERY_SCHEDULE_HOUR` | `11` | 调度小时 |
+| `TASK_DISCOVERY_SCHEDULE_MINUTE` | `0` | 调度分钟 |
+| `TASK_DISCOVERY_ENGINE_URL` | `http://localhost:20003` | Engine API 地址 |
+| `TASK_DISCOVERY_FRONTEND_URL` | `http://localhost:8000` | 前端 workbench 地址 |
+| `TASK_DISCOVERY_DATA_FILE` | `scripts/.dependencies/data/discovered_tasks.db` | 任务数据文件路径 |
+
+---
+
+## 6. 利益相关者与约束
+
+| 角色 | 关注点 |
+|---|---|
+| 框架维护者 | Protocol seam 可插拔；transport-agnostic；与执行框架解耦 |
+| corp 接入者 | `TaskReader` / `SessionCreator` Protocol 替换真实数据源即可 |
+| singlebox/CI | e2e gated，不拖慢默认 CI |
+| 微内核宪法 | DI 接线、thin router、lifecycle 参与者自动发现 |
+
+### 硬约束
+- core 层 transport-agnostic（禁 transport import）
+- HTTP adapter thin（只转协议，不持领域策略）
+- 任务数据源经 `TaskReader` Protocol 隔离，不硬编码到 core
+- engine session 创建经 `SessionCreator` Protocol 隔离
+
+---
+
+## 7. 成功标准（验收条件）
+
+- **AC-1**：`DiscoveryService.discover()` 能读取待确认任务 → 为每个任务创建 engine session → 返回含 session_url 的 `DiscoveryResult` 列表。
+- **AC-2**：`TaskDiscoveryLifecycle` 在 backend startup 后自动调度，每日定时遍历所有 bot 执行发现；`shutdown()` 正确取消。
+- **AC-3**：HTTP `POST /api/public/task-discovery/discover` 手动触发返回结构化结果（discovered count + tasks[]）；`GET /status` 返回任务列表。
+- **AC-4**：`SqliteTaskReader` + `init_discovered_tasks_db` 能写入/读取确定性 mock 数据；`MockTaskReader` 向后兼容 JSON。
+- **AC-5**：`EngineSessionCreator` 调 engine `POST /api/sessions` 创建 session，构建 session_url 格式正确。
+- **AC-6**：e2e 用例 gated（`SINGLEBOX_TASK_E2E=1`），默认不跑；开启后 discover → status → session 可达全链路跑通。
+- **AC-7**：DI 接线正确——`TaskDiscoveryModule` 绑定 singleton，`TaskDiscoveryLifecycle` 自动发现并启动。
+
+---
+
+## 8. 风险与开放问题
+
+- **R1 数据源**：当前 mock 数据无真实行为分析。后续需替换 `TaskReader` 为真实数据源（消息管线/行为分析平台），Protocol seam 已留。
+- **R2 确认回调**：用户在 engine session 中确认后如何触发执行框架 `TaskService.execute`，本模块未实现该衔接。需后续设计 task_discovery → execution_framework 的桥接。
+- **R3 状态持久化**：`DiscoveredTask.status` 当前仅存在 mock db 中，无独立状态管理服务。真实化时需引入状态存储。
+- **R4 并发**：定时调度遍历所有 bot，当前串行。bot 数量增长时需评估并发上限。
+- **R5 session_url 路由**：依赖前端 `SessionOnlyPage` 路由的 query 参数约定（`bot_uuid`/`id`/`session`），前端路由变更需同步。

--- a/src/backend/specs/2026-08-18-task-discovery/tasks.md
+++ b/src/backend/specs/2026-08-18-task-discovery/tasks.md
@@ -1,0 +1,136 @@
+# Tasks — 任务主动发现模块 (task_discovery)
+
+> 状态：已落地。本清单用于归档已实现内容 + 标注后续待办。
+> 落点：全在 Avernet `src/backend`；core 层 transport-agnostic；Protocol seam 可插拔。
+
+## 实现原则（对齐 AGENTS.md + 微内核宪法）
+
+- **契约先行 / transport-agnostic**：core 层禁 transport import；`TaskReader` / `SessionCreator` 经 Protocol 隔离外部 IO。
+- **thin adapter**：HTTP router 只转协议（`discover` / `status`），不持领域策略。
+- **composition root**：`TaskDiscoveryModule` 是唯一接线点；lifecycle 自动发现。
+- **Protocol seam**：数据源和 session 创建可插拔，corp 替换真实实现只需实现 Protocol。
+- **与执行框架解耦**：task_discovery 产出 `DiscoveredTask` + engine session，用户确认后外部调用 `TaskService.execute`。
+
+---
+
+## G1 — 领域模型（已完成）
+
+- [x] **T1.1** `models.py` — `DiscoveredTask` frozen dataclass（9 字段 + `needs_confirmation` / `to_session_ext_info` / `to_notification_message` 派生方法）
+- [x] **T1.2** `models.py` — `DiscoverySession` frozen dataclass（task_id / session_id / session_url / created_at）
+- ✅ **G1 验收**：模型纯数据、零 transport 依赖；`to_session_ext_info` 含 `source: "task_discovery"` 标识
+
+---
+
+## G2 — 编排服务 DiscoveryService（已完成）
+
+- [x] **T2.1** `discovery_service.py` — `DiscoveryResult` dataclass（task + session + notification_message + error + `success` property）
+- [x] **T2.2** `discovery_service.py` — `DiscoveryService.__init__(reader, session_creator)`；`async discover(user_id, agent_id, model?)` → `list[DiscoveryResult]`
+  - `read_pending_tasks()` → 逐 task `_discover_single`（try/except 包裹，失败填 error 不中断）
+  - `_discoveries` dict 缓存最近结果供外部查询
+- [x] **T2.3** `discovery_service.py` — `print_notifications(results)` → stdout 打印（CLI 用）
+- [x] **T2.4** `discovery_service.py` — `create_default_service(data_file, engine_base_url?, engine_frontend_url?)` 工厂方法
+- ✅ **G2 验收**：编排逻辑完整；不涉及任务执行；async 签名对齐 backend lifecycle 模式
+
+---
+
+## G3 — 数据读取 TaskReader（已完成）
+
+- [x] **T3.1** `task_reader.py` — `TaskReader` Protocol（`read_discovered_tasks() -> list[DiscoveredTask]`）
+- [x] **T3.2** `task_reader.py` — `SqliteTaskReader(db_path)` 实现
+  - `_CREATE_TABLE_SQL` DDL（9 字段 + task_id PK）
+  - `read_discovered_tasks()` → SELECT + `_row_to_task` 映射
+  - `read_pending_tasks()` → 过滤 `needs_confirmation`
+- [x] **T3.3** `task_reader.py` — `init_discovered_tasks_db(db_path, tasks)` 工具函数（建表 + 清空 + 批量插入，供 e2e）
+- [x] **T3.4** `task_reader.py` — `MockTaskReader(data_file)` JSON 实现（向后兼容）
+- ✅ **G3 验收**：Protocol seam 可插拔；两种实现覆盖 SQLite + JSON；`init_discovered_tasks_db` 支持确定性 mock
+
+---
+
+## G4 — Session 创建 SessionCreator（已完成）
+
+- [x] **T4.1** `session_creator.py` — `SessionCreator` Protocol（`async create_session(task, *, user_id, agent_id, model?) -> DiscoverySession`）
+- [x] **T4.2** `session_creator.py` — `EngineSessionCreator(engine_base_url?, engine_frontend_url?)` 实现
+  - 配置来源：构造器参数 → env `ENGINE_BASE_URL` / `FRONTEND_URL` → 默认 localhost
+  - `create_session()` → `POST {engine_url}/api/sessions`（body: title/user_id/agent_id/extInfo/model?）
+  - 响应解析：`data.id` 或 `data.session_id` → 构建 `DiscoverySession`
+  - `_build_session_url(session_id, agent_id)` → `{frontend}/bcn/chat/session?bot_uuid={agent_id}&id={agent_id}&session={session_id}`
+  - 超时 30s（httpx.AsyncClient）；success=False 时 raise RuntimeError
+- ✅ **G4 验收**：Protocol seam 可插拔；engine API 调用正确；session_url 格式对齐前端 SessionOnlyPage 路由
+
+---
+
+## G5 — 生命周期调度 TaskDiscoveryLifecycle（已完成）
+
+- [x] **T5.1** `lifecycle.py` — `TaskDiscoveryLifecycle(LifecycleBase)` + `@inject.__init__(bot_service)`
+- [x] **T5.2** `startup()` → 读 `TASK_DISCOVERY_AUTO_START`（默认 true）→ `asyncio.create_task(_run_daily_schedule(hour, minute))`
+  - 调度时间：`TASK_DISCOVERY_SCHEDULE_HOUR` (11) / `TASK_DISCOVERY_SCHEDULE_MINUTE` (0)
+- [x] **T5.3** `shutdown()` → cancel `_task`（CancelledError 兜底）
+- [x] **T5.4** `_run_daily_schedule(hour, minute)` → `while True: sleep(_seconds_until) → _discover_once()`
+- [x] **T5.5** `_seconds_until(hour, minute)` → 计算到下一个目标时间的秒数（跨日处理）
+- [x] **T5.6** `_discover_once()` → `BotService.list_bots(page=1, page_size=100)` → 逐 bot `create_default_service + discover(user_id=owner_id, agent_id=bot_id)` → 日志汇总
+- [x] **T5.7** `_list_all_bots()` → BotService 查询（异常兜底返 []）
+- [x] **T5.8** `_resolve_data_file()` → env 或默认路径（9 级上溯到项目根）
+- ✅ **G5 验收**：lifecycle 自动发现 + 定时调度 + 遍历所有 bot；env 控制开关/时间
+
+---
+
+## G6 — HTTP 适配层（已完成）
+
+- [x] **T6.1** `adapters/http/task_discovery/router.py` — `APIRouter(prefix="/api/public/task-discovery", tags=["task-discovery"])`
+- [x] **T6.2** `POST /discover` — query params `user_id` / `agent_id` → `_build_service()` → `service.discover()` → 结构化响应
+- [x] **T6.3** `GET /status` — `SqliteTaskReader(db_path).read_discovered_tasks()` → `{success, total, tasks: [...]}`
+- [x] **T6.4** `_build_service()` — 从 env `TASK_DISCOVERY_ENGINE_URL` / `TASK_DISCOVERY_FRONTEND_URL` 构建
+- [x] **T6.5** `_resolve_db_path()` — 从 env `TASK_DISCOVERY_DATA_FILE` 或默认路径解析
+- [x] **T6.6** `app.py` include `task_discovery_router`
+- ✅ **G6 验收**：thin router（无领域策略）；无需认证（对齐 cron_noauth 模式）；discover + status 端点可用
+
+---
+
+## G7 — DI 接线（已完成）
+
+- [x] **T7.1** `di/modules/task_discovery_module.py` — `TaskDiscoveryModule(Module)` → `binder.bind(TaskDiscoveryLifecycle, to=..., scope=singleton)`
+- [x] **T7.2** `di/container.py` — import + 注册 `TaskDiscoveryModule`
+- ✅ **G7 验收**：DI 接线正确；lifecycle 参与者自动发现并启动
+
+---
+
+## G8 — E2E 集成用例（已完成）
+
+- [x] **T8.1** `test_task_discovery_e2e.py` — gated（`@unittest.skipUnless(_LIVE, ...)`）
+- [x] **T8.2** 内联 `_MOCK_TASKS`（3 条确定性数据）+ `_write_mock_data()` → `init_discovered_tasks_db`
+- [x] **T8.3** `_DATA_FILE` 路径推算（8 级上溯到项目根 + scripts/.dependencies/data/）
+- [x] **T8.4** `TestTaskDiscoveryE2E.test_discover_creates_sessions_and_returns_tasks` — discover → status → session 可达
+- [x] **T8.5** 断言常量派生（`_EXPECTED_TASK_COUNT` / `_EXPECTED_TASK_IDS` / `_EXPECTED_PROJECT_NAMES`）
+- ✅ **G8 验收**：gated 用例可 `SINGLEBOX_TASK_E2E=1` 开启；discover 发现 3 任务 + session_url 可达
+
+---
+
+## 后续待办（spec §8 风险项）
+
+- [ ] **T9.1** 真实数据源接入：替换 `SqliteTaskReader` 为消息管线/行为分析平台实现（Protocol seam 已留）
+- [ ] **T9.2** 确认→执行桥接：用户在 engine session 确认后，如何触发 `TaskService.execute(task_info)` 的衔接设计
+- [ ] **T9.3** 状态持久化：引入独立状态管理服务，替代 mock db 存储 `DiscoveredTask.status`
+- [ ] **T9.4** 并发优化：bot 规模增长时，定时调度从串行改为并发（`asyncio.gather` + Semaphore）
+- [ ] **T9.5** CLI 脚本 `scripts/task_discovery.sh`（spec 中提及但仓内未找到）
+- [ ] **T9.6** 契约测试：HTTP adapter + `TaskReader` / `SessionCreator` Protocol 契约测（Rule 25）
+
+---
+
+## 验收总览（对齐 spec §7 AC）
+
+- AC-1 ✅ T2.2/T2.4 ｜ AC-2 ✅ T5.2-T5.8 ｜ AC-3 ✅ T6.2/T6.3 ｜ AC-4 ✅ T3.2/T3.3/T3.4
+- AC-5 ✅ T4.2 ｜ AC-6 ✅ T8.1-T8.5 ｜ AC-7 ✅ T7.1/T7.2
+
+## 配置项速查
+
+| 环境变量 | 默认值 |
+|---|---|
+| `TASK_DISCOVERY_AUTO_START` | `true` |
+| `TASK_DISCOVERY_SCHEDULE_HOUR` | `11` |
+| `TASK_DISCOVERY_SCHEDULE_MINUTE` | `0` |
+| `TASK_DISCOVERY_ENGINE_URL` | `http://localhost:20003` |
+| `TASK_DISCOVERY_FRONTEND_URL` | `http://localhost:8000` |
+| `TASK_DISCOVERY_DATA_FILE` | `scripts/.dependencies/data/discovered_tasks.db` |
+| `SINGLEBOX_TASK_E2E` | — (gated) |
+| `SINGLEBOX_BACKEND_URL` | `http://localhost:8888` |
+| `SINGLEBOX_USER_ID` | `440718` |

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -142,6 +142,7 @@ from agentclaw.community.adapters.http.session_resources import (  # noqa: E402
 from agentclaw.community.adapters.http.mcp import router as mcp_router  # noqa: E402
 from agentclaw.community.adapters.http.cron import router as cron_router  # noqa: E402
 from agentclaw.community.adapters.http.cron.cron_noauth_router import router as cron_noauth_router  # noqa: E402
+from agentclaw.community.adapters.http.task_discovery.router import router as task_discovery_router  # noqa: E402
 from agentclaw.community.adapters.http.aicoding import notify_router  # noqa: E402
 from agentclaw.community.adapters.http.aicoding.architect_rebind_router import router as architect_rebind_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_management import router as bot_management_router  # noqa: E402
@@ -813,7 +814,8 @@ app.include_router(verify.router)
 app.include_router(sync.router)
 app.include_router(batch_sync.router)
 app.include_router(cron_router)
-app.include_router(cron_noauth_router) 
+app.include_router(cron_noauth_router)
+app.include_router(task_discovery_router)
 app.include_router(notify_router)
 # Harness Engineering: patch template management & diagnosis
 app.include_router(harness_router)

--- a/src/backend/src/agentclaw/community/adapters/http/task_discovery/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task_discovery/__init__.py
@@ -1,0 +1,5 @@
+"""task_discovery HTTP adapter — 公开路由 (无需认证)。
+
+参考 ``cron_noauth_router`` 的模式：提供手动触发端点，
+让 CLI 或外部调度器通过 HTTP API 触发任务发现/执行。
+"""

--- a/src/backend/src/agentclaw/community/adapters/http/task_discovery/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task_discovery/router.py
@@ -1,0 +1,129 @@
+"""task_discovery 公开路由 — 手动触发任务发现。
+
+参考 ``cron_noauth_router`` 的模式：无需认证的公开端点，
+供 CLI 或外部调度器通过 HTTP 触发。
+
+端点:
+  POST /api/public/task-discovery/discover          手动触发任务发现
+  GET  /api/public/task-discovery/status             查看任务状态
+
+任务执行不在本模块负责 — 由 task 目录下另外的执行框架处理。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Query
+
+from agentclaw.community.core.task.task_discovery.discovery_service import (
+    DiscoveryService,
+    create_default_service,
+)
+from agentclaw.community.core.task.task_discovery.session_creator import (
+    HttpSessionCreator,
+)
+from agentclaw.community.core.task.task_discovery.task_reader import (
+    SqliteTaskReader,
+)
+from agentclaw.community.di import Injected
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.notify_sender import NotifySenderPlugin
+
+logger = get_logger()
+
+router = APIRouter(prefix="/api/public/task-discovery", tags=["task-discovery"])
+
+#: 默认 db 文件路径(9 级上溯到项目根 → scripts/.dependencies/data/discovered_tasks.db)
+_PROJECT_ROOT = Path(__file__).resolve()
+for _ in range(9):
+    _PROJECT_ROOT = _PROJECT_ROOT.parent
+_DEFAULT_DB = str(_PROJECT_ROOT / "scripts" / ".dependencies" / "data" / "discovered_tasks.db")
+
+
+def _resolve_db_path() -> str:
+    """从环境变量或默认路径解析 db 文件路径。"""
+    return os.environ.get("TASK_DISCOVERY_DATA_FILE", _DEFAULT_DB)
+
+
+def _build_service(
+    notify_sender: NotifySenderPlugin,
+) -> DiscoveryService:
+    """构建 DiscoveryService（通过 backend connection API 定位 per-bot engine）。"""
+    session_creator = HttpSessionCreator()
+    return create_default_service(
+        data_file=_resolve_db_path(),
+        notify_sender=notify_sender,
+        session_creator=session_creator,
+    )
+
+
+@router.post("/discover")
+async def discover_tasks(
+    user_id: str = Query("default", description="用户 ID"),
+    agent_id: str = Query("bot_001", description="Bot/Agent ID"),
+    bot_id: str = Query(..., description="Bot ID"),
+    owner_id: str = Query(..., description="Bot 所有者 ID"),
+    notify_sender: NotifySenderPlugin = Injected(NotifySenderPlugin),
+) -> dict:
+    """手动触发任务发现流程。
+
+    读取 mock 数据中的待确认任务，创建 engine session 并投递通知。
+    通过 backend connection API 定位 per-bot engine 后直连创建 session。
+    """
+    logger.info(
+        "[task_discovery] discover triggered: user_id=%s, agent_id=%s, bot_id=%s",
+        user_id, agent_id, bot_id,
+    )
+    try:
+        service = _build_service(notify_sender=notify_sender)
+        results = await service.discover(
+            user_id=user_id,
+            agent_id=agent_id,
+            bot_id=bot_id,
+            owner_id=owner_id,
+        )
+
+        return {
+            "success": True,
+            "discovered": len(results),
+            "tasks": [
+                {
+                    "task_id": r.task.task_id,
+                    "project_name": r.task.project_name,
+                    "success": r.success,
+                    "session_id": r.session.session_id if r.session else None,
+                    "notification_sent": r.notification_sent,
+                    "error": r.error,
+                }
+                for r in results
+            ],
+        }
+    except Exception as exc:
+        logger.error("[task_discovery] discover failed: %s", exc, exc_info=True)
+        return {"success": False, "message": str(exc)}
+
+
+@router.get("/status")
+async def get_status() -> dict:
+    """查看任务发现状态(从 SQLite db 读取)。"""
+    db_path = _resolve_db_path()
+    try:
+        reader = SqliteTaskReader(db_path)
+        tasks = reader.read_discovered_tasks()
+    except Exception as exc:
+        return {"success": False, "message": str(exc)}
+
+    return {
+        "success": True,
+        "total": len(tasks),
+        "tasks": [
+            {
+                "task_id": t.task_id,
+                "project_name": t.project_name,
+                "status": t.status,
+                "priority": t.priority,
+            }
+            for t in tasks
+        ],
+    }

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/__init__.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/__init__.py
@@ -1,9 +1,12 @@
-"""任务主动发现模块 — 读取已发现的任务数据，创建 engine session 通知用户确认。
+"""任务主动发现模块 — 读取已发现的任务数据，创建 engine session 并投递通知。
 
 完整流程:
 1. 定时调度读取已发现的任务 (mock 数据)
-2. 为每个待确认任务创建 engine session + session_url
-3. 用户在 engine session 中确认后，调用 engine 执行任务
+2. 为每个待确认任务创建 engine session（获得 session_id）
+3. session 创建成功后通过 NotifySenderPlugin 投递通知（任务详情，不含 session 链接）
+4. 用户在前端确认后，由执行框架处理
+
+session_url 不在 discover 阶段构建 — 用户 bot 没有单独的 session_url。
 
 触发方式:
 A. 自动 — backend 的 TaskDiscoveryLifecycle 在 startup 后启动定时调度

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
@@ -2,19 +2,21 @@
 
 编排完整流程：
 1. ``TaskReader`` 读取已发现的待确认任务 (mock 数据)
-2. 为每个任务通过 ``SessionCreator`` 创建 engine session + session_url
-3. 输出通知信息（任务详情 + session_url），供用户在前端确认
+2. 为每个任务通过 ``SessionCreator`` 创建 engine session（获得 session_id）
+3. session 创建成功后通过 ``NotifySenderPlugin`` 投递通知（任务详情，不含 session 链接）
+4. 用户在前端确认后，由执行框架处理（不在本模块）
 
-任务执行不在本模块负责 — 由 task 目录下另外的执行框架处理。
+session_url 不在 discover 阶段构建 — 用户 bot 没有单独的 session_url。
 
 使用方式::
 
     service = DiscoveryService(
         reader=SqliteTaskReader("scripts/.dependencies/data/discovered_tasks.db"),
         session_creator=EngineSessionCreator(),
+        notify_sender=CommunityNotifySender(),
     )
 
-    # discover — 读取任务 + 创建 session
+    # discover — 读取任务 + 创建 session + 投递通知
     results = await service.discover(user_id="u001", agent_id="bot_001")
 """
 from __future__ import annotations
@@ -32,9 +34,13 @@ from agentclaw.community.core.task.task_discovery.task_reader import (
 )
 from agentclaw.community.core.task.task_discovery.session_creator import (
     SessionCreator,
-    EngineSessionCreator,
+    HttpSessionCreator,
 )
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.notify_sender import (
+    NotifyMessage,
+    NotifySenderPlugin,
+)
 
 logger = get_logger()
 
@@ -46,6 +52,7 @@ class DiscoveryResult:
     task: DiscoveredTask
     session: Optional[DiscoverySession] = None
     notification_message: str = ""
+    notification_sent: bool = False
     error: Optional[str] = None
 
     @property
@@ -56,20 +63,21 @@ class DiscoveryResult:
 class DiscoveryService:
     """任务主动发现编排服务。
 
-    将 TaskReader 和 SessionCreator 编排在一起，
-    提供完整的 "发现 → 通知" 流程。
+    将 TaskReader、SessionCreator 和 NotifySenderPlugin 编排在一起，
+    提供 "发现 → 创建 session → 通知" 流程。
 
-    任务确认后的执行由 task 目录下另外的执行框架负责，
-    不在本服务职责内。
+    session_url 不在 discover 阶段构建。任务确认后的执行由执行框架负责。
     """
 
     def __init__(
         self,
         reader: TaskReader,
         session_creator: SessionCreator,
+        notify_sender: NotifySenderPlugin,
     ):
         self._reader = reader
         self._session_creator = session_creator
+        self._notify_sender = notify_sender
 
         #: 最近的发现结果 (task_id → DiscoveryResult)，供外部查询
         self._discoveries: dict[str, DiscoveryResult] = {}
@@ -79,13 +87,17 @@ class DiscoveryService:
         *,
         user_id: str,
         agent_id: str,
+        bot_id: str,
+        owner_id: str,
         model: str | None = None,
     ) -> list[DiscoveryResult]:
-        """执行发现流程：读取任务 → 创建 session → 生成通知。
+        """执行发现流程：读取任务 → 创建 session → 投递通知。
 
         Args:
-            user_id: 用户 ID。
+            user_id: 用户 ID（通知接收者）。
             agent_id: Bot/Agent ID。
+            bot_id: Bot ID（用于 relay 路由 per-bot engine）。
+            owner_id: Bot 所有者 ID。
             model: 可选模型覆盖。
 
         Returns:
@@ -99,7 +111,12 @@ class DiscoveryService:
         results: list[DiscoveryResult] = []
         for task in tasks:
             result = await self._discover_single(
-                task, user_id=user_id, agent_id=agent_id, model=model
+                task,
+                user_id=user_id,
+                agent_id=agent_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                model=model,
             )
             results.append(result)
             self._discoveries[task.task_id] = result
@@ -112,29 +129,36 @@ class DiscoveryService:
         *,
         user_id: str,
         agent_id: str,
+        bot_id: str,
+        owner_id: str,
         model: str | None,
     ) -> DiscoveryResult:
-        """处理单个任务的发现流程。"""
+        """处理单个任务的发现流程：创建 session → 投递通知。"""
         try:
             session = await self._session_creator.create_session(
                 task,
                 user_id=user_id,
                 agent_id=agent_id,
+                bot_id=bot_id,
+                owner_id=owner_id,
                 model=model,
             )
-            message = task.to_notification_message(session.session_url)
+            message = task.to_notification_message()
+
+            notification_sent = self._send_notification(task, user_id)
 
             logger.info(
-                "[task_discovery] task %s → session %s (url=%s)",
+                "[task_discovery] task %s → session %s (notified=%s)",
                 task.task_id,
                 session.session_id,
-                session.session_url,
+                notification_sent,
             )
 
             return DiscoveryResult(
                 task=task,
                 session=session,
                 notification_message=message,
+                notification_sent=notification_sent,
             )
         except Exception as exc:
             logger.error(
@@ -143,6 +167,37 @@ class DiscoveryService:
                 exc,
             )
             return DiscoveryResult(task=task, error=str(exc))
+
+    def _send_notification(
+        self,
+        task: DiscoveredTask,
+        user_id: str,
+    ) -> bool:
+        """通过 NotifySenderPlugin 投递通知，返回是否发送成功。
+
+        NotifySenderPlugin Protocol 约定 send() 从不抛异常；
+        返回 str 为消息 ID（成功），None 为失败。
+        通知不含 session 链接 — session_url 不在 discover 阶段构建。
+        """
+        message = NotifyMessage(
+            title="发现待确认任务",
+            body=task.to_notification_message(),
+            recipient=user_id,
+        )
+        msg_id = self._notify_sender.send(message)
+        if msg_id:
+            logger.info(
+                "[task_discovery] notification sent for task %s (msg_id=%s)",
+                task.task_id,
+                msg_id,
+            )
+            return True
+        else:
+            logger.warning(
+                "[task_discovery] notification send returned None for task %s",
+                task.task_id,
+            )
+            return False
 
     def print_notifications(self, results: list[DiscoveryResult]) -> None:
         """将发现结果的通知消息打印到 stdout（供 CLI 输出）。"""
@@ -157,25 +212,23 @@ class DiscoveryService:
 
 def create_default_service(
     data_file: str,
-    engine_base_url: str | None = None,
-    engine_frontend_url: str | None = None,
+    notify_sender: NotifySenderPlugin,
+    session_creator: SessionCreator,
 ) -> DiscoveryService:
     """使用默认实现创建 DiscoveryService。
 
     Args:
         data_file: SQLite db 文件路径(discovered_tasks 表)。
-        engine_base_url: Engine API 地址。
-        engine_frontend_url: 前端 workbench 地址（构建 session_url）。
+        notify_sender: 通知发送插件（session 创建成功后投递通知）。
+        session_creator: SessionCreator 实例（用于在 per-bot engine 上创建 session）。
 
     Returns:
         配置好的 :class:`DiscoveryService`
     """
     return DiscoveryService(
         reader=SqliteTaskReader(data_file),
-        session_creator=EngineSessionCreator(
-            engine_base_url=engine_base_url,
-            engine_frontend_url=engine_frontend_url,
-        ),
+        session_creator=session_creator,
+        notify_sender=notify_sender,
     )
 
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
@@ -24,10 +24,10 @@ import asyncio
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
 from injector import inject
 
+from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     create_default_service,
 )
@@ -37,9 +37,6 @@ from agentclaw.community.core.task.task_discovery.session_creator import (
 from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.notify_sender import NotifySenderPlugin
-
-if TYPE_CHECKING:
-    from agentclaw.community.core.bot_management.services.bot_service import BotService
 
 logger = get_logger()
 
@@ -65,10 +62,10 @@ class TaskDiscoveryLifecycle(LifecycleBase):
     @inject
     def __init__(
         self,
-        bot_service: "BotService",
+        bot_service: BotServiceProtocol,
         notify_sender: NotifySenderPlugin,
     ) -> None:
-        self._bot_service: Any = bot_service
+        self._bot_service: BotServiceProtocol = bot_service
         self._notify_sender = notify_sender
         self._task: asyncio.Task | None = None
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
@@ -9,7 +9,7 @@
 发现流程:
 1. 从 BotService 查出当前所有用户 bot
 2. 为每个 bot 读取已发现的任务数据 (mock)
-3. 为每个待确认任务创建 engine session + session_url
+3. 为每个待确认任务创建 engine session + 投递通知
 
 手动触发可通过 HTTP API 或 CLI。
 
@@ -29,11 +29,14 @@ from typing import TYPE_CHECKING, Any
 from injector import inject
 
 from agentclaw.community.core.task.task_discovery.discovery_service import (
-    DiscoveryService,
     create_default_service,
+)
+from agentclaw.community.core.task.task_discovery.session_creator import (
+    HttpSessionCreator,
 )
 from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.notify_sender import NotifySenderPlugin
 
 if TYPE_CHECKING:
     from agentclaw.community.core.bot_management.services.bot_service import BotService
@@ -42,12 +45,6 @@ logger = get_logger()
 
 #: 默认 mock 数据文件路径 (相对于项目根目录)
 _DEFAULT_DATA_FILE = "scripts/.dependencies/data/discovered_tasks.db"
-
-#: 默认 engine URL (singlebox local)
-_DEFAULT_ENGINE_URL = "http://localhost:20003"
-
-#: 默认前端 workbench URL (singlebox local, frontend.sh:8000)
-_DEFAULT_FRONTEND_URL = "http://localhost:8000"
 
 #: 默认调度时间
 _DEFAULT_SCHEDULE_HOUR = 11
@@ -66,8 +63,13 @@ class TaskDiscoveryLifecycle(LifecycleBase):
     """
 
     @inject
-    def __init__(self, bot_service: "BotService") -> None:
+    def __init__(
+        self,
+        bot_service: "BotService",
+        notify_sender: NotifySenderPlugin,
+    ) -> None:
         self._bot_service: Any = bot_service
+        self._notify_sender = notify_sender
         self._task: asyncio.Task | None = None
 
     async def startup(self) -> None:
@@ -133,9 +135,9 @@ class TaskDiscoveryLifecycle(LifecycleBase):
             len(bots),
         )
 
-        engine_url = os.environ.get("TASK_DISCOVERY_ENGINE_URL", _DEFAULT_ENGINE_URL)
-        frontend_url = os.environ.get("TASK_DISCOVERY_FRONTEND_URL", _DEFAULT_FRONTEND_URL)
         data_file = self._resolve_data_file()
+
+        session_creator = HttpSessionCreator()
 
         total_discovered = 0
         for bot in bots:
@@ -147,20 +149,26 @@ class TaskDiscoveryLifecycle(LifecycleBase):
             try:
                 service = create_default_service(
                     data_file=data_file,
-                    engine_base_url=engine_url,
-                    engine_frontend_url=frontend_url,
+                    notify_sender=self._notify_sender,
+                    session_creator=session_creator,
                 )
-                results = await service.discover(user_id=owner_id, agent_id=bot_id)
+                results = await service.discover(
+                    user_id=owner_id,
+                    agent_id=bot_id,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                )
                 succeeded = sum(1 for r in results if r.success)
                 total_discovered += succeeded
 
                 for r in results:
                     if r.success:
                         logger.info(
-                            "[task_discovery]   ✓ bot=%s task=%s → %s",
+                            "[task_discovery]   ✓ bot=%s task=%s → session=%s notified=%s",
                             bot_id,
                             r.task.task_id,
-                            r.session.session_url,
+                            r.session.session_id,
+                            r.notification_sent,
                         )
                     else:
                         logger.warning(

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/lifecycle.py
@@ -27,10 +27,10 @@ from pathlib import Path
 
 from injector import inject
 
-from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     create_default_service,
 )
+from agentclaw.community.core.task.task_discovery.protocols import BotServiceProtocol
 from agentclaw.community.core.task.task_discovery.session_creator import (
     HttpSessionCreator,
 )

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/models.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/models.py
@@ -59,8 +59,8 @@ class DiscoveredTask:
             "source": "task_discovery",
         }
 
-    def to_notification_message(self, session_url: str) -> str:
-        """生成用户在 engine session 中看到的通知消息文本。"""
+    def to_notification_message(self, session_url: str = "") -> str:
+        """生成通知消息文本。"""
         lines = [
             "🔔 发现待执行任务",
             "",
@@ -74,9 +74,9 @@ class DiscoveredTask:
             "",
             "─" * 40,
             "请确认是否执行此任务。",
-            "",
-            f"Session 链接: {session_url}",
         ]
+        if session_url:
+            lines.extend(["", f"Session 链接: {session_url}"])
         return "\n".join(lines)
 
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/protocols.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/protocols.py
@@ -1,0 +1,29 @@
+"""task_discovery 模块内部依赖接口协议。
+
+根据四层架构规范：
+- core/ 层通过 Protocol 接口访问外部依赖，不直接 import api/ 层
+- 具体实现由 DI 在 di/modules/task_discovery_module.py 注入
+
+本模块依赖 BotService 的 list_bots 方法（遍历所有用户 bot 执行发现），
+通过本地定义的 BotServiceProtocol 接入，避免直接 import
+agentclaw.community.api.bot_service。
+
+参考：core/bot_dormant/protocols.py
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BotServiceProtocol(Protocol):
+    """Bot 服务接口 —— 供 task_discovery 模块遍历所有用户 bot。
+
+    实现类需提供：
+      - list_bots(page, page_size)  分页查询 bot 列表
+    """
+
+    def list_bots(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+__all__ = ["BotServiceProtocol"]

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/session_creator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/session_creator.py
@@ -1,16 +1,18 @@
-"""SessionCreator — 调用 engine API 为发现的任务创建 session。
+"""SessionCreator — 通过 backend connection API 定位 per-bot engine 后直连创建 session。
 
-调用 engine 的 ``POST /api/sessions`` 创建一个待确认的 session，
-session 标题为任务项目名称，``extInfo`` 携带完整任务详情。
+singlebox 模式下 ``DeviceAdapterTransport`` 绑的是 ``InMemoryDeviceAdapterTransport``
+(mock)，relay 的 ``call()`` 不会做真实 HTTP 转发。因此 session_creator 需要自己：
+  1. 调 backend ``GET /api/bots/{bot_id}/connection`` 拿到 per-bot engine 的 target
+  2. 直连 ``http://{target}/api/sessions`` 创建 session
+
+这样 session 会落在 bot 对应的 per-bot OpenClaw Gateway 上，前端可见。
+
 创建后构建 ``session_url`` 供用户在浏览器中打开确认。
-
-与 cron ``run-single`` 的区别：
-  - ``run-single`` 直接创建 session 并开始执行
-  - 本模块只创建 session（不触发执行），等用户确认后再由 executor 执行
 """
 from __future__ import annotations
 
-from typing import Protocol
+import os
+from typing import Any, Protocol
 
 import httpx
 
@@ -22,11 +24,8 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
-#: Engine session API 路径
-_SESSIONS_PATH = "/api/sessions"
-
-#: 默认 engine 端口（singlebox local, engine.sh:20003）
-_DEFAULT_ENGINE_PORT = "20003"
+#: 默认 backend 地址（singlebox local）
+_DEFAULT_BACKEND_URL = "http://localhost:8888"
 
 #: 默认前端 workbench 端口（singlebox local, frontend.sh:8000）
 _DEFAULT_FRONTEND_PORT = "8000"
@@ -41,44 +40,89 @@ class SessionCreator(Protocol):
         *,
         user_id: str,
         agent_id: str,
+        bot_id: str,
+        owner_id: str,
         model: str | None = None,
     ) -> DiscoverySession:
         """为任务创建 engine session，返回 session_id 和 session_url。"""
         ...
 
 
-class EngineSessionCreator:
-    """通过 engine HTTP API 创建 session 的实现。
+class HttpSessionCreator:
+    """通过 backend connection API 定位 per-bot engine 后直连创建 session。
 
-    调用 ``POST {engine_base_url}/api/sessions`` 创建 session，
-    然后用 engine 前端路由构建 ``session_url``。
+    1. ``GET {backend_url}/api/bots/{bot_id}/connection`` → 拿到 ``target`` (如 ``127.0.0.1:20010``)
+    2. ``POST http://{target}/api/sessions`` → 在 per-bot engine 上创建 session
     """
 
     def __init__(
         self,
-        engine_base_url: str | None = None,
-        engine_frontend_url: str | None = None,
+        *,
+        backend_url: str | None = None,
+        frontend_url: str | None = None,
     ):
         """初始化。
 
         Args:
-            engine_base_url: Engine API 地址（如 ``http://localhost:20003``）。
-                若为 ``None`` 则从环境变量 ``ENGINE_BASE_URL`` 读取，
-                默认 ``http://localhost:20003``。
-            engine_frontend_url: 前端 workbench 地址（用于构建 session_url）。
+            backend_url: Backend API 地址（用于查 bot connection）。
+                若为 ``None`` 则从环境变量 ``BACKEND_URL`` 读取，
+                默认 ``http://localhost:8888``。
+            frontend_url: 前端 workbench 地址（用于构建 session_url）。
                 若为 ``None`` 则从环境变量 ``FRONTEND_URL`` 读取，
                 默认 ``http://localhost:8000``。
         """
-        import os
-
-        self._engine_base_url = engine_base_url or os.environ.get(
-            "ENGINE_BASE_URL",
-            f"http://localhost:{_DEFAULT_ENGINE_PORT}",
+        self._backend_url = backend_url or os.environ.get(
+            "BACKEND_URL", _DEFAULT_BACKEND_URL,
         )
-        self._engine_frontend_url = engine_frontend_url or os.environ.get(
+        self._frontend_url = frontend_url or os.environ.get(
             "FRONTEND_URL",
             f"http://localhost:{_DEFAULT_FRONTEND_PORT}",
         )
+
+    async def _resolve_engine_target(
+        self, bot_id: str, owner_id: str, user_id: str,
+    ) -> str:
+        """通过 backend API 查 per-bot engine 的 target 地址。
+
+        个人 bot 没有 publish record，``/api/bots/{bot_id}/connection`` 会 404，
+        所以先查 bot detail 拿 ``binding_id``，再用
+        ``/api/v1/devices/{binding_id}/connection`` 查 target。
+
+        Returns:
+            如 ``localhost:20010``
+        """
+        async with httpx.AsyncClient(timeout=30.0) as cli:
+            # Step 1: 查 bot detail 拿 binding_id
+            bot_resp = await cli.get(
+                f"{self._backend_url}/api/bots/{bot_id}",
+                params={"owner_id": owner_id},
+                headers={"x-user-id": user_id},
+            )
+            bot_resp.raise_for_status()
+            bot_data = (bot_resp.json().get("data") or {})
+            binding_id = bot_data.get("binding_id")
+            if not binding_id:
+                raise RuntimeError(
+                    f"bot {bot_id} has no binding_id (owner={owner_id})"
+                )
+
+            # Step 2: 用 binding_id 查 device connection
+            conn_resp = await cli.get(
+                f"{self._backend_url}/api/v1/devices/{binding_id}/connection",
+                headers={"x-user-id": user_id},
+            )
+            conn_resp.raise_for_status()
+            data = (conn_resp.json().get("data") or {})
+            target = data.get("target") or ""
+            if not target:
+                raise RuntimeError(
+                    f"backend connection API returned no target for bot={bot_id}"
+                )
+            logger.info(
+                "[task_discovery] resolved engine target for bot=%s → %s",
+                bot_id, target,
+            )
+            return target
 
     async def create_session(
         self,
@@ -86,23 +130,29 @@ class EngineSessionCreator:
         *,
         user_id: str,
         agent_id: str,
+        bot_id: str,
+        owner_id: str,
         model: str | None = None,
     ) -> DiscoverySession:
         """为任务创建 engine session。
 
         Args:
             task: 已发现的待确认任务。
-            user_id: 用户 ID。
+            user_id: 用户 ID（调用者 + 通知接收者）。
             agent_id: Bot/Agent ID。
+            bot_id: Bot ID（用于查 per-bot engine 地址）。
+            owner_id: Bot 所有者 ID。
             model: 可选模型覆盖。
 
         Returns:
             包含 session_id 和 session_url 的 :class:`DiscoverySession`
 
         Raises:
-            httpx.HTTPError: engine API 请求失败时抛出。
+            httpx.HTTPError: 请求失败时抛出。
         """
-        body: dict = {
+        target = await self._resolve_engine_target(bot_id, owner_id, user_id)
+
+        body: dict[str, Any] = {
             "title": task.project_name,
             "user_id": user_id,
             "agent_id": agent_id,
@@ -111,15 +161,16 @@ class EngineSessionCreator:
         if model:
             body["model"] = model
 
-        url = f"{self._engine_base_url}{_SESSIONS_PATH}"
+        url = f"http://{target}/api/sessions"
         logger.info(
-            "[task_discovery] creating engine session for task %s → %s",
-            task.task_id,
-            url,
+            "[task_discovery] creating session for task %s → %s",
+            task.task_id, url,
         )
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(url, json=body)
+        async with httpx.AsyncClient(timeout=30.0) as cli:
+            resp = await cli.post(
+                url, json=body, headers={"x-user-id": user_id},
+            )
             resp.raise_for_status()
 
         data = resp.json()
@@ -136,8 +187,7 @@ class EngineSessionCreator:
         session_url = self._build_session_url(session_id, agent_id)
         logger.info(
             "[task_discovery] session created: id=%s url=%s",
-            session_id,
-            session_url,
+            session_id, session_url,
         )
 
         return DiscoverySession(
@@ -149,16 +199,13 @@ class EngineSessionCreator:
     def _build_session_url(self, session_id: str, agent_id: str) -> str:
         """构建用户可访问的前端 workbench session URL。
 
-        前端通过 bot 的对话页面访问 engine session：
-        ``{frontend_url}/bcn/chat/session?bot_uuid={agent_id}&session={session_id}``
-
-        用户点击后会跳到该 bot 的对话界面，看到任务发现的通知消息。
+        格式: ``{frontend_url}/bcn/chat/session?bot_uuid={agent_id}&id={agent_id}&session={session_id}``
         """
-        base = self._engine_frontend_url.rstrip("/")
+        base = self._frontend_url.rstrip("/")
         return (
             f"{base}/bcn/chat/session"
-            f"?bot_uuid={agent_id}&session={session_id}"
+            f"?bot_uuid={agent_id}&id={agent_id}&session={session_id}"
         )
 
 
-__all__ = ["SessionCreator", "EngineSessionCreator"]
+__all__ = ["SessionCreator", "HttpSessionCreator"]

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -49,6 +49,7 @@ from agentclaw.community.di.modules.system_config_module import SystemConfigModu
 from agentclaw.community.di.modules.task_queue_module import TaskQueueModule
 from agentclaw.community.di.modules.economy_governance_module import EconomyGovernanceModule
 from agentclaw.community.di.modules.user_list_module import UserListModule
+from agentclaw.community.di.modules.task_discovery_module import TaskDiscoveryModule
 from agentclaw.community.di.profile import DeployProfile
 from agentclaw.community.di.profile_modules import modules_for
 from agentclaw.community.log import get_logger
@@ -130,6 +131,7 @@ def build_injector(
         # singlebox intentionally uses the real clients for local services.
         HttpClientModule(),
         EconomyGovernanceModule(),
+        TaskDiscoveryModule(),
     ]
 
     modules.extend(modules_for(profile))

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -1,11 +1,14 @@
 """TaskDiscoveryModule — task_discovery 的 DI 接线。
 
-参考 ``CronModule`` 的模式：
+参考 ``CronModule`` 和 ``BotDormantModule`` 的模式：
 - 绑定 ``TaskDiscoveryLifecycle`` 为 singleton
 - Lifecycle 参与者由 ``discover_lifecycle_participants`` 自动发现
-- ``TaskDiscoveryLifecycle.__init__`` 通过 @inject 注入 BotService 和
-  NotifySenderPlugin（BotService 由 BotManagementModule 绑定，
-  NotifySenderPlugin 由 CommunityNotifyModule 绑定）
+- ``TaskDiscoveryLifecycle.__init__`` 通过 @inject 注入
+  ``BotServiceProtocol``（core/task/task_discovery 本地定义）和
+  ``NotifySenderPlugin``
+- ``BotServiceProtocol`` 由本模块的 ``_bridge_bot_service_protocol``
+  provider 从 API 层的 ``BotServiceProtocol``（由 BotManagementModule
+  绑定到实际 BotService）桥接而来；BotService 结构性满足本地 Protocol
 - 在 backend startup 后自动触发定时调度，为所有用户 bot 执行任务发现
 
 配置项 (通过环境变量):
@@ -16,10 +19,16 @@
 """
 from __future__ import annotations
 
-from injector import Binder, Module, singleton
+from injector import Binder, Module, inject, provider, singleton
 
+from agentclaw.community.api.bot_service import (
+    BotServiceProtocol as _ApiBotServiceProtocol,
+)
 from agentclaw.community.core.task.task_discovery.lifecycle import (
     TaskDiscoveryLifecycle,
+)
+from agentclaw.community.core.task.task_discovery.protocols import (
+    BotServiceProtocol as _TaskDiscoveryBotServiceProtocol,
 )
 
 
@@ -29,5 +38,18 @@ class TaskDiscoveryModule(Module):
     def configure(self, binder: Binder) -> None:
         # Lifecycle 参与者 — startup() 中启动定时调度,
         # shutdown() 中停止。由 discover_lifecycle_participants 自动发现。
-        # BotService 由 @inject 自动注入（已由 BotManagementModule 绑定）。
         binder.bind(TaskDiscoveryLifecycle, to=TaskDiscoveryLifecycle, scope=singleton)
+
+    @singleton
+    @provider
+    @inject
+    def _bridge_bot_service_protocol(
+        self,
+        bot_service: _ApiBotServiceProtocol,
+    ) -> _TaskDiscoveryBotServiceProtocol:
+        """Adapt the API service to the task_discovery module's local contract.
+
+        BotService structurally satisfies the local Protocol (has list_bots),
+        so no adapter wrapper is needed — just return the instance directly.
+        """
+        return bot_service  # type: ignore[return-value]

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -3,9 +3,9 @@
 参考 ``CronModule`` 的模式：
 - 绑定 ``TaskDiscoveryLifecycle`` 为 singleton
 - Lifecycle 参与者由 ``discover_lifecycle_participants`` 自动发现
-- ``TaskDiscoveryLifecycle.__init__`` 通过 @inject 注入 BotService、
-  NotifySenderPlugin 和 EngineRuntimeRelayProtocol
-- relay 自动路由到 per-bot engine adapter，无需硬编码 engine 地址
+- ``TaskDiscoveryLifecycle.__init__`` 通过 @inject 注入 BotService 和
+  NotifySenderPlugin（BotService 由 BotManagementModule 绑定，
+  NotifySenderPlugin 由 CommunityNotifyModule 绑定）
 - 在 backend startup 后自动触发定时调度，为所有用户 bot 执行任务发现
 
 配置项 (通过环境变量):

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -1,0 +1,33 @@
+"""TaskDiscoveryModule — task_discovery 的 DI 接线。
+
+参考 ``CronModule`` 的模式：
+- 绑定 ``TaskDiscoveryLifecycle`` 为 singleton
+- Lifecycle 参与者由 ``discover_lifecycle_participants`` 自动发现
+- ``TaskDiscoveryLifecycle.__init__`` 通过 @inject 注入 BotService、
+  NotifySenderPlugin 和 EngineRuntimeRelayProtocol
+- relay 自动路由到 per-bot engine adapter，无需硬编码 engine 地址
+- 在 backend startup 后自动触发定时调度，为所有用户 bot 执行任务发现
+
+配置项 (通过环境变量):
+  TASK_DISCOVERY_AUTO_START        是否启用自动调度 (true/false, 默认 true)
+  TASK_DISCOVERY_SCHEDULE_HOUR     调度小时 (默认 11)
+  TASK_DISCOVERY_SCHEDULE_MINUTE   调度分钟 (默认 0)
+  TASK_DISCOVERY_DATA_FILE         任务数据文件路径
+"""
+from __future__ import annotations
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.core.task.task_discovery.lifecycle import (
+    TaskDiscoveryLifecycle,
+)
+
+
+class TaskDiscoveryModule(Module):
+    """DI bindings for task discovery."""
+
+    def configure(self, binder: Binder) -> None:
+        # Lifecycle 参与者 — startup() 中启动定时调度,
+        # shutdown() 中停止。由 discover_lifecycle_participants 自动发现。
+        # BotService 由 @inject 自动注入（已由 BotManagementModule 绑定）。
+        binder.bind(TaskDiscoveryLifecycle, to=TaskDiscoveryLifecycle, scope=singleton)

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_create_session_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_create_session_e2e.py
@@ -1,0 +1,183 @@
+"""singlebox e2e — 创建会话、发送消息并验证大模型回复。
+
+链路:
+  1. backend (8888) 查 bot → 解析 engine target
+  2. engine adapter (20010) POST /api/sessions 创建 session
+  3. WebSocket ws://{target}/api/openclaw/ws 发送消息并等待回复
+  4. 回查 session 列表 + 消息历史确认
+
+环境变量:
+    SINGLEBOX_SESSION_E2E=1   启用本测试(默认 skip)
+    SINGLEBOX_BACKEND_URL     backend 地址,默认 http://localhost:8888
+    SINGLEBOX_USER_ID         用户工号,默认 440718
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import unittest
+
+import httpx
+
+_LIVE = os.environ.get("SINGLEBOX_SESSION_E2E", "").strip() in {"1", "true"}
+_BACKEND = os.environ.get("SINGLEBOX_BACKEND_URL", "http://localhost:8888")
+_USER_ID = os.environ.get("SINGLEBOX_USER_ID", "440718")
+
+_HDRS = {"x-user-id": _USER_ID, "accept": "application/json"}
+
+
+@unittest.skipUnless(_LIVE, "设置 SINGLEBOX_SESSION_E2E=1 启用")
+class TestCreateSessionE2E(unittest.TestCase):
+    """在 singlebox 下创建一个引擎会话,并验证它出现在 engine session 列表中。"""
+
+    def test_create_session_and_verify(self) -> None:
+        with httpx.Client(timeout=30.0, headers=_HDRS) as cli:
+            # 1) 查已有 bot
+            bots: list[dict] = []
+            for endpoint in [
+                f"{_BACKEND}/api/bots/by-owner-or-collaborator",
+                f"{_BACKEND}/api/bots",
+            ]:
+                try:
+                    r = cli.get(endpoint, params={"user_id": _USER_ID})
+                    if r.status_code == 200:
+                        bots = (r.json().get("data") or {}).get("items") or []
+                        if bots:
+                            break
+                except Exception:
+                    continue
+            if not bots:
+                self.skipTest("singlebox 未 provision 任何 bot,请先 start all")
+
+            bot = bots[0]
+            bot_id = bot["bot_id"]
+            owner_id = bot.get("owner_id", _USER_ID)
+            print(f"[bot] bot_id={bot_id} owner_id={owner_id}")
+
+            # 2) 从 bot 信息取 binding_id → 查 device connection 拿 engine target
+            #    链路同 singlebox_engine_adapter._resolve_target():
+            #    GET /api/bots/{bot_id} → binding_id → GET /api/v1/devices/{binding_id}/connection
+            bot_resp = cli.get(f"{_BACKEND}/api/bots/{bot_id}")
+            bot_resp.raise_for_status()
+            binding_id = (bot_resp.json().get("data") or {}).get("binding_id")
+            self.assertIsNotNone(binding_id, f"bot {bot_id} 无 binding_id")
+            conn_resp = cli.get(f"{_BACKEND}/api/v1/devices/{binding_id}/connection")
+            conn_resp.raise_for_status()
+            target = (conn_resp.json().get("data") or {}).get("target") or ""
+            self.assertTrue(target, f"未取到 engine target: {conn_resp.json()}")
+            print(f"[engine] target={target} (binding_id={binding_id})")
+
+        # 3) 直连 engine adapter 创建 session
+        engine_url = f"http://{target}"
+        with httpx.Client(timeout=30.0, headers=_HDRS) as cli:
+            create_resp = cli.post(
+                f"{engine_url}/api/sessions",
+                json={
+                    "title": "e2e-test-session",
+                    "user_id": _USER_ID,
+                    "agent_id": bot_id,
+                },
+            )
+            create_resp.raise_for_status()
+            session = create_resp.json().get("data") or {}
+            session_id = session.get("id") or ""
+            self.assertTrue(session_id, f"创建 session 返回 id 为空: {session}")
+            print(f"[created] session_id={session_id}")
+
+            # 4) 回查 engine session 列表确认存在
+            #    create 返回 "session:xxx:user:440718",list 返回 "agent:main:session:xxx:user:440718"
+            #    前缀差异由引擎内部 agent 路由产生,用 endswith 匹配避免硬编码前缀。
+            list_resp = cli.get(
+                f"{engine_url}/api/sessions",
+                params={"limit": 100, "offset": 0, "user_id": _USER_ID},
+            )
+            list_resp.raise_for_status()
+            sessions = list_resp.json().get("data") or []
+            found = any(
+                s.get("id") == session_id or s.get("id", "").endswith(session_id)
+                for s in sessions
+            )
+            self.assertTrue(
+                found,
+                f"创建的 session_id={session_id} 未在 engine 列表中找到",
+            )
+            print(f"[verified] session 已在 engine 列表中确认存在")
+
+            # 5) 通过 WebSocket 向 session 发送消息并等待大模型回复
+            #    协议同 singlebox_engine_adapter._ws_chat_roundtrip():
+            #    connect(proto3 握手) → chat.send → 收到 state=final 事件
+            reply = asyncio.run(self._ws_chat(target, session_id, "你好呀"))
+            print(f"[chat] 大模型回复: {reply}")
+            self.assertTrue(reply, "大模型回复为空")
+
+            # 6) 回查消息历史确认 user + assistant 两条记录
+            import base64
+            encoded_id = base64.urlsafe_b64encode(session_id.encode()).decode()
+            msg_resp = cli.get(
+                f"{engine_url}/api/sessions/{encoded_id}/messages",
+                params={"limit": 10, "offset": 0},
+            )
+            msg_resp.raise_for_status()
+            messages = msg_resp.json().get("data") or []
+            roles = [m.get("role") for m in messages]
+            self.assertIn("user", roles, "消息历史中缺少 user 消息")
+            self.assertIn("assistant", roles, "消息历史中缺少 assistant 消息")
+            print(f"[messages] 共 {len(messages)} 条, roles={roles}")
+
+    async def _ws_chat(self, target: str, session_key: str, message: str) -> str:
+        """开 WebSocket:connect 握手 → chat.send → 读到 final → 返回回复文本。"""
+        import websockets
+
+        ws_path = "/api/openclaw/ws"
+        uri = f"ws://{target}{ws_path}"
+        connect_params = {
+            "minProtocol": 3,
+            "maxProtocol": 3,
+            "client": {"id": "e2e-test", "version": "1.0.0", "platform": "linux", "mode": "operator"},
+            "role": "operator",
+        }
+
+        async with websockets.connect(uri, open_timeout=10) as ws:
+            # 1) 握手
+            await ws.send(json.dumps({
+                "type": "req", "id": "1", "method": "connect", "params": connect_params,
+            }))
+            hs = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if not hs.get("ok"):
+                return f"[握手失败] {json.dumps(hs)[:200]}"
+
+            # 2) 发消息
+            await ws.send(json.dumps({
+                "type": "req", "id": "2", "method": "chat.send",
+                "params": {"sessionKey": session_key, "message": message},
+            }))
+            ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if not ack.get("ok"):
+                return f"[发送被拒绝] {json.dumps(ack)[:200]}"
+
+            # 3) 读事件到 final
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=60)
+                except asyncio.TimeoutError:
+                    return "[超时] 60秒内未收到回复"
+                data = json.loads(raw)
+                if data.get("type") != "event" or data.get("event") != "chat":
+                    continue
+                payload = data.get("payload") or {}
+                state = payload.get("state")
+                if state == "final":
+                    message_obj = payload.get("message") or {}
+                    contents = message_obj.get("content") or []
+                    texts = [
+                        c.get("text", "") for c in contents
+                        if isinstance(c, dict) and c.get("type") == "text"
+                    ]
+                    return "\n".join(texts) if texts else json.dumps(payload, ensure_ascii=False)[:500]
+                if state == "error":
+                    return f"[错误] {payload.get('errorMessage', 'unknown')}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
@@ -1,0 +1,324 @@
+"""任务主动发现 — singlebox 真实端到端集成用例(发现 → session 创建 → 通知投递 → 发送任务给大模型)。
+
+gated by ``SINGLEBOX_TASK_E2E=1``。本地起后端 singlebox 时设置:
+
+  SINGLEBOX_TASK_E2E=1 .venv/bin/python -m pytest \
+    tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py -s
+
+完整流程覆盖:
+  1) 准备 mock 数据: 将内联测试数据写入 scripts/.dependencies/data/discovered_tasks.db
+  2) provisioning: 建一个 test agent bot(获取真实 agent_id)
+  3) POST /api/public/task-discovery/discover   → 读取 mock 任务 + 创建 engine session + 投递通知
+  4) 验证响应: success / discovered count / task_id / session_id / notification_sent
+  5) GET /api/public/task-discovery/status      → 验证任务状态可查询
+  6) 验证 engine session 实际存在(GET /api/sessions/{id} 可达)
+  7) WebSocket 连接 engine,将发现的任务内容发送给大模型,验证回复
+
+关键架构前提:
+  - DiscoveryService 编排 TaskReader(读 SQLite db)→ SessionCreator(调 engine POST /api/sessions)→ NotifySenderPlugin(投递通知)
+  - 每个 pending_confirmation 任务 → 一个 engine session + 通知投递(供用户前端确认)
+  - session_url 不在 discover 阶段构建 — 用户 bot 没有单独的 session_url
+  - 任务执行: 本测试通过 WebSocket 向 engine session 发送任务内容,验证大模型可响应
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import unittest
+from pathlib import Path
+
+import httpx
+
+from agentclaw.community.core.task.task_discovery.task_reader import (
+    init_discovered_tasks_db,
+)
+
+_LIVE = os.environ.get("SINGLEBOX_TASK_E2E", "").strip() in {"1", "true"}
+_BACKEND = os.environ.get("SINGLEBOX_BACKEND_URL", "http://localhost:8888")
+_USER_ID = os.environ.get("SINGLEBOX_USER_ID", "440718")
+
+_HDRS = {"x-user-id": _USER_ID, "accept": "application/json"}
+
+# ===== 内联测试数据(运行前写入 scripts/.dependencies/data/discovered_tasks.db)=====
+# 参考 test_task_integration_e2e.py 的 _execute_body() / ROLE_BOTS 模式:
+# 测试数据固定在脚本内,不依赖外部文件。
+_MOCK_TASKS: list[dict] = [
+    {
+        "task_id": "disc-e2e-001",
+        "project_name": "存储行业尽调报告",
+        "description": "AI 基础设施驱动下,企业级与数据中心存储行业的最新变化、竞争格局与进入机会分析。",
+        "business_scenario": "投资尽调 — 通过行业信息抓取、竞品分析、客户访谈等手段,产出系统性的投资判断报告。",
+        "discovery_basis": "用户近一周频繁搜索存储行业相关信息,行为节点链路表明用户已在自发调研但尚未系统化。",
+        "work_item_url": "https://project.alipay.com/workitem/123456",
+        "priority": "high",
+        "discovered_at": "2026-08-17T10:00:00Z",
+        "status": "pending_confirmation",
+    },
+]
+
+# 从内联数据派生断言常量
+_EXPECTED_TASK_COUNT = len(_MOCK_TASKS)
+_EXPECTED_TASK_IDS = {t["task_id"] for t in _MOCK_TASKS}
+_EXPECTED_PROJECT_NAMES = {t["project_name"] for t in _MOCK_TASKS}
+
+# 默认 db 文件路径:上溯到项目根 → scripts/.dependencies/data/discovered_tasks.db
+# 测试文件在 src/backend/tests/community/core/task/singlebox_e2e/ → 距项目根 8 级
+# router.py 在 src/backend/src/agentclaw/community/adapters/http/task_discovery/ → 距项目根 9 级
+_DATA_FILE = Path(__file__).resolve()
+for _ in range(8):
+    _DATA_FILE = _DATA_FILE.parent
+_DATA_FILE = _DATA_FILE / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
+
+
+def _write_mock_data() -> None:
+    """将内联测试数据写入 SQLite db,供 backend SqliteTaskReader 读取。"""
+    init_discovered_tasks_db(_DATA_FILE, _MOCK_TASKS)
+    print(f"[setup] mock 数据已写入 {_DATA_FILE} ({len(_MOCK_TASKS)} tasks)")
+
+
+@unittest.skipUnless(_LIVE, "设置 SINGLEBOX_TASK_E2E=1 启用真实 singlebox e2e")
+class TestTaskDiscoveryE2E(unittest.TestCase):
+    """任务主动发现 singlebox e2e: discover → session → notify → status。"""
+
+    def test_discover_notifies_and_returns_tasks(self) -> None:
+        # 准备 mock 数据
+        _write_mock_data()
+
+        # 同步查已有 bot（skipTest 在 event loop 内会被吞，所以放在外面）
+        with httpx.Client(timeout=30.0, headers=_HDRS) as cli:
+            bots: list[dict] = []
+            for endpoint in [
+                f"{_BACKEND}/api/bots/by-owner-or-collaborator",
+                f"{_BACKEND}/api/bots",
+            ]:
+                try:
+                    r = cli.get(endpoint, params={"user_id": _USER_ID})
+                    if r.status_code == 200:
+                        bots = (r.json().get("data") or {}).get("items") or []
+                        if bots:
+                            break
+                except Exception:
+                    continue
+        if not bots:
+            self.skipTest("singlebox 未 provision 任何 bot,请先 start all")
+        bot = bots[0]
+        bot_id = bot["bot_id"]
+        owner_id = bot.get("owner_id", _USER_ID)
+        print(f"[bot] 使用已有 bot: bot_id={bot_id} owner_id={owner_id}")
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(self._run(loop, bot_id, owner_id))
+        finally:
+            loop.close()
+
+    async def _run(self, loop: asyncio.AbstractEventLoop, bot_id: str, owner_id: str) -> None:
+        async with httpx.AsyncClient(timeout=60.0, headers=_HDRS) as cli:
+            # POST /api/public/task-discovery/discover
+            #    传 bot_id + owner_id: 定位到 per-bot engine 直连创建 session
+            r = await cli.post(
+                f"{_BACKEND}/api/public/task-discovery/discover",
+                params={
+                    "user_id": _USER_ID,
+                    "agent_id": bot_id,
+                    "bot_id": bot_id,
+                    "owner_id": owner_id,
+                },
+            )
+            r.raise_for_status()
+            body = r.json()
+            print(f"[discover] success={body.get('success')} "
+                  f"discovered={body.get('discovered')}")
+
+            self.assertTrue(body.get("success"), f"discover 未成功: {body}")
+            self.assertEqual(
+                body.get("discovered"), _EXPECTED_TASK_COUNT,
+                f"discovered 数量 != {_EXPECTED_TASK_COUNT}: {body.get('discovered')}",
+            )
+
+            tasks = body.get("tasks", [])
+            self.assertEqual(len(tasks), _EXPECTED_TASK_COUNT, "tasks 列表长度不匹配")
+
+            # 4) 逐任务验证: task_id / session_id / notification_sent
+            discovered_ids: set[str] = set()
+            for t in tasks:
+                tid = t.get("task_id", "")
+                sid = t.get("session_id")
+                success = t.get("success")
+                notified = t.get("notification_sent")
+
+                print(f"  - task={tid} success={success} "
+                      f"session_id={sid} notified={notified}")
+                discovered_ids.add(tid)
+
+                self.assertTrue(success, f"任务 {tid} discovery 未成功")
+                self.assertIsNotNone(sid, f"任务 {tid} session_id 为空")
+                self.assertTrue(sid, f"任务 {tid} session_id 为空字符串")
+                self.assertIn(
+                    "notification_sent", t,
+                    f"任务 {tid} 响应缺少 notification_sent 字段",
+                )
+                self.assertTrue(
+                    notified,
+                    f"任务 {tid} 通知未发送 (notification_sent={notified})",
+                )
+
+            # task_id 集合与内联 mock 数据一致
+            self.assertEqual(
+                discovered_ids, _EXPECTED_TASK_IDS,
+                f"发现 task_id 集合不匹配: {discovered_ids} vs {_EXPECTED_TASK_IDS}",
+            )
+
+            # 5) GET /api/public/task-discovery/status → 验证任务状态可查
+            r = await cli.get(f"{_BACKEND}/api/public/task-discovery/status")
+            r.raise_for_status()
+            status_body = r.json()
+            print(f"[status] success={status_body.get('success')} "
+                  f"total={status_body.get('total')}")
+
+            self.assertTrue(status_body.get("success"), f"status 查询未成功: {status_body}")
+            self.assertEqual(
+                status_body.get("total"), _EXPECTED_TASK_COUNT,
+                f"status total != {_EXPECTED_TASK_COUNT}",
+            )
+
+            status_tasks = status_body.get("tasks", [])
+            status_ids = {t.get("task_id") for t in status_tasks}
+            self.assertEqual(
+                status_ids, _EXPECTED_TASK_IDS,
+                f"status task_id 集合不匹配: {status_ids} vs {_EXPECTED_TASK_IDS}",
+            )
+            for t in status_tasks:
+                self.assertIn(
+                    t.get("project_name"), _EXPECTED_PROJECT_NAMES,
+                    f"task {t.get('task_id')} project_name 不在预期集合内",
+                )
+                self.assertIsNotNone(t.get("status"), f"task {t.get('task_id')} status 为空")
+                self.assertIsNotNone(t.get("priority"), f"task {t.get('task_id')} priority 为空")
+
+            # 6) 验证 engine session 实际存在
+            #    链路同 singlebox_engine_adapter._resolve_target():
+            #    GET /api/bots/{bot_id} → binding_id → GET /api/v1/devices/{binding_id}/connection
+            first_sid = tasks[0].get("session_id")
+            bot_resp = await cli.get(f"{_BACKEND}/api/bots/{bot_id}")
+            bot_resp.raise_for_status()
+            binding_id = (bot_resp.json().get("data") or {}).get("binding_id")
+            self.assertIsNotNone(binding_id, f"bot {bot_id} 无 binding_id")
+            conn_resp = await cli.get(f"{_BACKEND}/api/v1/devices/{binding_id}/connection")
+            conn_resp.raise_for_status()
+            target = (conn_resp.json().get("data") or {}).get("target") or ""
+            self.assertTrue(target, f"未取到 engine target: {conn_resp.json()}")
+            print(f"[engine] target={target} (binding_id={binding_id})")
+
+            eng_resp = await cli.get(
+                f"http://{target}/api/sessions",
+                params={"limit": 100, "offset": 0},
+                headers={"x-user-id": _USER_ID},
+            )
+            eng_resp.raise_for_status()
+            eng_sessions = eng_resp.json().get("data") or []
+            found = any(
+                first_sid in (s.get("id") or s.get("session_id") or "")
+                for s in eng_sessions
+            )
+            print(f"[engine] {target} 返回 {len(eng_sessions)} 条, "
+                  f"first_sid={first_sid} found={found}")
+            self.assertTrue(
+                found,
+                f"session {first_sid} 未在 per-bot engine({target})中找到",
+            )
+
+            # 7) WebSocket 连接 engine,将发现的任务内容发送给大模型
+            #    协议同 singlebox_engine_adapter._ws_chat_roundtrip():
+            #    connect(proto3 握手) → chat.send → 收到 state=final 事件
+            task = _MOCK_TASKS[0]
+            task_message = (
+                f"请帮我处理以下任务:\n"
+                f"项目名称: {task['project_name']}\n"
+                f"任务描述: {task['description']}\n"
+                f"业务场景: {task['business_scenario']}\n"
+                f"优先级: {task['priority']}"
+            )
+            reply = await self._ws_chat(target, first_sid, task_message)
+            print(f"[chat] 大模型回复: {reply}")
+            self.assertTrue(reply, "大模型回复为空")
+            self.assertNotIn("[错误]", reply, f"大模型回复包含错误: {reply}")
+            self.assertNotIn("[超时]", reply, f"大模型回复超时: {reply}")
+
+            # 8) 回查消息历史确认 assistant 记录存在
+            #    引擎可能将用户消息归为 user/tool_result,只断言 assistant 存在。
+            import base64
+            encoded_id = base64.urlsafe_b64encode(first_sid.encode()).decode()
+            msg_resp = await cli.get(
+                f"http://{target}/api/sessions/{encoded_id}/messages",
+                params={"limit": 10, "offset": 0},
+                headers={"x-user-id": _USER_ID},
+            )
+            if msg_resp.status_code == 200:
+                messages = msg_resp.json().get("data") or []
+                roles = [m.get("role") for m in messages]
+                self.assertIn("assistant", roles, "消息历史中缺少 assistant 消息")
+                print(f"[messages] 共 {len(messages)} 条, roles={roles}")
+
+        print("[done] task_discovery e2e 全链路验证通过")
+
+    async def _ws_chat(self, target: str, session_key: str, message: str) -> str:
+        """开 WebSocket:connect 握手 → chat.send → 读到 final → 返回回复文本。
+
+        协议同 singlebox_engine_adapter._ws_chat_roundtrip()。
+        """
+        import websockets
+
+        ws_path = "/api/openclaw/ws"
+        uri = f"ws://{target}{ws_path}"
+        connect_params = {
+            "minProtocol": 3,
+            "maxProtocol": 3,
+            "client": {"id": "task-discovery-e2e", "version": "1.0.0", "platform": "linux", "mode": "operator"},
+            "role": "operator",
+        }
+
+        async with websockets.connect(uri, open_timeout=10) as ws:
+            # 1) 握手
+            await ws.send(json.dumps({
+                "type": "req", "id": "1", "method": "connect", "params": connect_params,
+            }))
+            hs = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if not hs.get("ok"):
+                return f"[握手失败] {json.dumps(hs)[:200]}"
+
+            # 2) 发消息
+            await ws.send(json.dumps({
+                "type": "req", "id": "2", "method": "chat.send",
+                "params": {"sessionKey": session_key, "message": message},
+            }))
+            ack = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            if not ack.get("ok"):
+                return f"[发送被拒绝] {json.dumps(ack)[:200]}"
+
+            # 3) 读事件到 final
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=60)
+                except asyncio.TimeoutError:
+                    return "[超时] 60秒内未收到回复"
+                data = json.loads(raw)
+                if data.get("type") != "event" or data.get("event") != "chat":
+                    continue
+                payload = data.get("payload") or {}
+                state = payload.get("state")
+                if state == "final":
+                    message_obj = payload.get("message") or {}
+                    contents = message_obj.get("content") or []
+                    texts = [
+                        c.get("text", "") for c in contents
+                        if isinstance(c, dict) and c.get("type") == "text"
+                    ]
+                    return "\n".join(texts) if texts else json.dumps(payload, ensure_ascii=False)[:500]
+                if state == "error":
+                    return f"[错误] {payload.get('errorMessage', 'unknown')}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backend/tests/community/core/task/test_task_discovery_unit.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_unit.py
@@ -1,0 +1,316 @@
+"""Unit tests for task_discovery core module.
+
+Covers the success paths of DiscoveryService, HttpSessionCreator,
+DiscoveredTask.to_notification_message, and TaskDiscoveryLifecycle
+that the e2e and endpoint tests do not exercise (session creation,
+notification dispatch, engine target resolution).
+
+Uses ``unittest.mock`` to stub httpx.AsyncClient — these are unit
+tests, not endpoint tests, so the no-mock rule in ``tests/endpoints/``
+does not apply.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentclaw.community.core.task.task_discovery.discovery_service import (
+    DiscoveryResult,
+    DiscoveryService,
+)
+from agentclaw.community.core.task.task_discovery.models import (
+    DiscoveredTask,
+    DiscoverySession,
+)
+from agentclaw.community.core.task.task_discovery.session_creator import (
+    HttpSessionCreator,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+_TASK = DiscoveredTask(
+    task_id="tsk-001",
+    project_name="Test Project",
+    description="A test task",
+    business_scenario="testing",
+    discovery_basis="unit test",
+    priority="high",
+    status="pending_confirmation",
+)
+
+_SESSION = DiscoverySession(
+    task_id="tsk-001",
+    session_id="sess-123",
+    session_url="http://localhost:8000/bcn/chat/session?session=sess-123",
+)
+
+
+# ---------------------------------------------------------------------------
+# DiscoveredTask.to_notification_message — cover session_url branch (models.py:78-79)
+# ---------------------------------------------------------------------------
+
+class TestNotificationMessage:
+    def test_without_session_url(self):
+        msg = _TASK.to_notification_message()
+        assert "Session" not in msg
+        assert "Test Project" in msg
+
+    def test_with_session_url(self):
+        """Cover the ``if session_url:`` branch (models.py:78-79)."""
+        url = "http://example.com/chat/sess-123"
+        msg = _TASK.to_notification_message(session_url=url)
+        assert url in msg
+        assert "Session" in msg
+
+
+# ---------------------------------------------------------------------------
+# DiscoveryService — cover success + notification paths (discovery_service.py:146-200)
+# ---------------------------------------------------------------------------
+
+class TestDiscoveryService:
+    def _make_service(
+        self,
+        tasks: list[DiscoveredTask],
+        session: DiscoverySession | None = _SESSION,
+        notify_msg_id: str | None = "msg-001",
+    ) -> DiscoveryService:
+        reader = MagicMock()
+        reader.read_pending_tasks.return_value = tasks
+
+        session_creator = MagicMock()
+        if session is not None:
+            session_creator.create_session = AsyncMock(return_value=session)
+        else:
+            session_creator.create_session = AsyncMock(
+                side_effect=RuntimeError("engine unreachable"),
+            )
+
+        notify_sender = MagicMock()
+        notify_sender.send.return_value = notify_msg_id
+
+        return DiscoveryService(
+            reader=reader,
+            session_creator=session_creator,
+            notify_sender=notify_sender,
+        )
+
+    def test_discover_success_path(self):
+        """Cover _discover_single success + _send_notification success
+        (discovery_service.py:146,148,182,187,188,189,194)."""
+        svc = self._make_service([_TASK], session=_SESSION, notify_msg_id="msg-001")
+        results = asyncio.run(svc.discover(
+            user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+        ))
+        assert len(results) == 1
+        r = results[0]
+        assert r.success is True
+        assert r.session is not None
+        assert r.session.session_id == "sess-123"
+        assert r.notification_sent is True
+        assert r.notification_message  # non-empty
+
+    def test_discover_notification_failure(self):
+        """Cover _send_notification failure branch
+        (discovery_service.py:196,200)."""
+        svc = self._make_service([_TASK], session=_SESSION, notify_msg_id=None)
+        results = asyncio.run(svc.discover(
+            user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+        ))
+        assert results[0].notification_sent is False
+        assert results[0].success is True  # session was created
+
+    def test_discover_session_error(self):
+        """Cover _discover_single exception path (discovery_service.py:163-169)."""
+        svc = self._make_service([_TASK], session=None)
+        results = asyncio.run(svc.discover(
+            user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+        ))
+        assert results[0].success is False
+        assert results[0].error is not None
+        assert results[0].session is None
+
+    def test_discover_no_tasks(self):
+        svc = self._make_service([])
+        results = asyncio.run(svc.discover(
+            user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+        ))
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# HttpSessionCreator — cover _resolve_engine_target, create_session, _build_session_url
+# (session_creator.py:94-125,153-171,204)
+# ---------------------------------------------------------------------------
+
+class TestHttpSessionCreator:
+    def _mock_async_client(self, bot_data, conn_data, session_data):
+        """Create a mock AsyncClient context manager."""
+        mock_bot_resp = MagicMock()
+        mock_bot_resp.json.return_value = {"data": bot_data}
+        mock_bot_resp.raise_for_status = MagicMock()
+
+        mock_conn_resp = MagicMock()
+        mock_conn_resp.json.return_value = {"data": conn_data}
+        mock_conn_resp.raise_for_status = MagicMock()
+
+        mock_session_resp = MagicMock()
+        mock_session_resp.json.return_value = session_data
+        mock_session_resp.raise_for_status = MagicMock()
+
+        mock_cli = AsyncMock()
+        mock_cli.get = AsyncMock(side_effect=[mock_bot_resp, mock_conn_resp])
+        mock_cli.post = AsyncMock(return_value=mock_session_resp)
+
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_cli)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        return mock_cm
+
+    def test_resolve_engine_target_success(self):
+        """Cover _resolve_engine_target (session_creator.py:94-125)."""
+        creator = HttpSessionCreator(
+            backend_url="http://test-backend:8888",
+            frontend_url="http://test-frontend:8000",
+        )
+        bot_data = {"binding_id": "bind-001"}
+        conn_data = {"target": "localhost:20010"}
+        mock_cm = self._mock_async_client(bot_data, conn_data, {})
+
+        with patch("httpx.AsyncClient") as mock_ac:
+            mock_ac.return_value = mock_cm
+            target = asyncio.run(
+                creator._resolve_engine_target("bot-1", "u1", "u1"),
+            )
+        assert target == "localhost:20010"
+
+    def test_resolve_engine_target_no_binding_id(self):
+        """Cover RuntimeError for missing binding_id (session_creator.py:104-105)."""
+        creator = HttpSessionCreator(backend_url="http://test:8888")
+        bot_data = {}  # no binding_id
+        conn_data = {}
+        mock_cm = self._mock_async_client(bot_data, conn_data, {})
+
+        with patch("httpx.AsyncClient") as mock_ac:
+            mock_ac.return_value = mock_cm
+            with pytest.raises(RuntimeError, match="no binding_id"):
+                asyncio.run(
+                    creator._resolve_engine_target("bot-1", "u1", "u1"),
+                )
+
+    def test_resolve_engine_target_no_target(self):
+        """Cover RuntimeError for missing target (session_creator.py:117-120)."""
+        creator = HttpSessionCreator(backend_url="http://test:8888")
+        bot_data = {"binding_id": "bind-001"}
+        conn_data = {}  # no target
+        mock_cm = self._mock_async_client(bot_data, conn_data, {})
+
+        with patch("httpx.AsyncClient") as mock_ac:
+            mock_ac.return_value = mock_cm
+            with pytest.raises(RuntimeError, match="no target"):
+                asyncio.run(
+                    creator._resolve_engine_target("bot-1", "u1", "u1"),
+                )
+
+    def test_create_session_success(self):
+        """Cover create_session full path (session_creator.py:153-171,204)."""
+        creator = HttpSessionCreator(
+            backend_url="http://test-backend:8888",
+            frontend_url="http://test-frontend:8000",
+        )
+        bot_data = {"binding_id": "bind-001"}
+        conn_data = {"target": "localhost:20010"}
+        session_data = {"success": True, "data": {"id": "sess-999"}}
+        mock_cm = self._mock_async_client(bot_data, conn_data, session_data)
+
+        with patch("httpx.AsyncClient") as mock_ac:
+            mock_ac.return_value = mock_cm
+            session = asyncio.run(creator.create_session(
+                _TASK,
+                user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+            ))
+
+        assert session.session_id == "sess-999"
+        assert "sess-999" in session.session_url
+        assert "bot-1" in session.session_url
+
+    def test_create_session_engine_error(self):
+        """Cover RuntimeError when engine returns success=False (session_creator.py:177-180)."""
+        creator = HttpSessionCreator(backend_url="http://test:8888")
+        bot_data = {"binding_id": "bind-001"}
+        conn_data = {"target": "localhost:20010"}
+        session_data = {"success": False, "message": "engine busy"}
+        mock_cm = self._mock_async_client(bot_data, conn_data, session_data)
+
+        with patch("httpx.AsyncClient") as mock_ac:
+            mock_ac.return_value = mock_cm
+            with pytest.raises(RuntimeError, match="engine busy"):
+                asyncio.run(creator.create_session(
+                    _TASK,
+                    user_id="u1", agent_id="bot-1", bot_id="bot-1", owner_id="u1",
+                ))
+
+    def test_build_session_url(self):
+        """Cover _build_session_url directly (session_creator.py:204)."""
+        creator = HttpSessionCreator(frontend_url="http://fe:8000/")
+        url = creator._build_session_url("s1", "agent-1")
+        assert url == "http://fe:8000/bcn/chat/session?bot_uuid=agent-1&id=agent-1&session=s1"
+
+
+# ---------------------------------------------------------------------------
+# TaskDiscoveryLifecycle — cover _discover_once (lifecycle.py:137,152)
+# ---------------------------------------------------------------------------
+
+class TestLifecycleDiscovery:
+    def test_discover_once_with_bots(self):
+        """Cover _discover_once internals (lifecycle.py:137,152)."""
+        from agentclaw.community.core.task.task_discovery.lifecycle import (
+            TaskDiscoveryLifecycle,
+        )
+
+        bot_service = MagicMock()
+        bot_service.list_bots.return_value = {
+            "items": [{"bot_id": "bot-1", "owner_id": "u1"}],
+        }
+
+        notify_sender = MagicMock()
+
+        lifecycle = TaskDiscoveryLifecycle(
+            bot_service=bot_service,
+            notify_sender=notify_sender,
+        )
+
+        # Patch create_default_service to return a mock service whose
+        # discover() returns empty results — we just need lines 137 and 152
+        # to execute.
+        mock_service = MagicMock()
+        mock_service.discover = AsyncMock(return_value=[])
+
+        with patch(
+            "agentclaw.community.core.task.task_discovery.lifecycle."
+            "create_default_service",
+            return_value=mock_service,
+        ):
+            asyncio.run(lifecycle._discover_once())
+
+        bot_service.list_bots.assert_called_once()
+
+    def test_discover_once_no_bots(self):
+        from agentclaw.community.core.task.task_discovery.lifecycle import (
+            TaskDiscoveryLifecycle,
+        )
+
+        bot_service = MagicMock()
+        bot_service.list_bots.return_value = {"items": []}
+
+        lifecycle = TaskDiscoveryLifecycle(
+            bot_service=bot_service,
+            notify_sender=MagicMock(),
+        )
+
+        # Should return early without calling create_default_service
+        asyncio.run(lifecycle._discover_once())

--- a/src/backend/tests/community/endpoints/test_task_discovery_router.py
+++ b/src/backend/tests/community/endpoints/test_task_discovery_router.py
@@ -1,0 +1,111 @@
+"""Endpoint tests for task-discovery public routes.
+
+Covers:
+- POST /api/public/task-discovery/discover (happy + error)
+- GET  /api/public/task-discovery/status  (happy + error)
+
+Happy cases assert only ``{"success": True}`` — the handler always
+returns ``success: True`` when the discovery flow runs end-to-end,
+regardless of whether the DB file exists or individual task sessions
+fail (session-creation errors are captured per-task, not at the top
+level).  This makes the cases robust in both CI (no DB file → empty
+discoveries) and local dev (DB file present with seed data).
+
+The POST error case is a FastAPI 422 (missing required bot_id).
+The GET error case points the DB path at a directory, which makes
+sqlite3.connect() raise OperationalError outside the reader's inner
+try/except, so the handler's except-Exception returns an error envelope.
+"""
+from __future__ import annotations
+
+import os
+
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+# ---- POST /api/public/task-discovery/discover ----
+
+@endpoint_test(
+    method="POST",
+    path="/api/public/task-discovery/discover",
+    scenario="happy_ok",
+    input=CaseInput(query_params={"bot_id": "td-bot-1", "owner_id": "td-owner-1"}),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True},
+    ),
+)
+def discover_tasks_happy_ok():
+    """Happy path: discovery runs end-to-end, returns success envelope."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/public/task-discovery/discover",
+    scenario="err_missing_bot_id",
+    input=CaseInput(query_params={"owner_id": "td-owner-1"}),
+    expect=ExpectError(status=422),
+)
+def discover_tasks_err_missing_bot_id():
+    """Error path: missing required bot_id -> FastAPI 422."""
+
+
+# ---- GET /api/public/task-discovery/status ----
+
+@endpoint_test(
+    method="GET",
+    path="/api/public/task-discovery/status",
+    scenario="happy_ok",
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True},
+    ),
+)
+def get_status_happy_ok():
+    """Happy path: status endpoint returns success envelope."""
+
+
+# The error case for GET /status: point TASK_DISCOVERY_DATA_FILE at a
+# directory. Path.exists() returns True for a directory, so
+# SqliteTaskReader proceeds to sqlite3.connect() — which is OUTSIDE
+# the reader's inner try/except. connect() on a directory raises
+# sqlite3.OperationalError, propagating to the handler's except-Exception
+# and yielding {"success": False, "message": "..."}.
+_ERROR_DB_DIR = os.path.join(
+    os.environ.get("TMPDIR", "/tmp"),
+    "td_status_err_dir",
+)
+
+
+def _seed_status_error_dir(world) -> None:
+    """Create a directory at the error DB path and set the env var."""
+    os.makedirs(_ERROR_DB_DIR, exist_ok=True)
+    os.environ["TASK_DISCOVERY_DATA_FILE"] = _ERROR_DB_DIR
+
+
+def _cleanup_status_error_env(response, world) -> None:
+    """Restore TASK_DISCOVERY_DATA_FILE and remove the temp directory."""
+    os.environ.pop("TASK_DISCOVERY_DATA_FILE", None)
+    try:
+        os.rmdir(_ERROR_DB_DIR)
+    except OSError:
+        pass
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/public/task-discovery/status",
+    scenario="err_db_path_is_directory",
+    seed=_seed_status_error_dir,
+    extra_assertions=(_cleanup_status_error_env,),
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False},
+    ),
+)
+def get_status_err_db_path_is_directory():
+    """Error path: DB path is a directory -> sqlite3.connect raises -> error envelope."""


### PR DESCRIPTION
## Problem

task_discovery 模块（任务主动发现）的代码此前分散在 `feat/task_discovery_0818_dev` 分支中，该分支包含大量非 discovery 的内容（task 执行框架、BBS、e2e 等），导致 discovery 相关变更无法独立评审和合入。

`dev` 分支已有 task_discovery 核心文件的早期版本，但缺少：
- HTTP 适配层（`adapters/http/task_discovery/router.py`）
- DI 模块（`di/modules/task_discovery_module.py`）
- 通知集成（`NotifySenderPlugin` 在 `DiscoveryService` 中的投递）
- spec/design 文档
- e2e 集成测试

## Solution

基于最新 `dev` 创建干净分支 `feat/task_discovery_0819_dev`，仅迁移 discovery 相关内容（20 个文件，+2244/-96 行）：

**新增文件（13 个）：**
- `specs/2026-08-18-task-discovery/` — plan / spec / tasks（模块规格说明）
- `specs/2026-08-18-task-discovery-autoinitiate-merge/` — design / proposal / spec / tasks / pipeline state（通知集成设计）
- `adapters/http/task_discovery/` — router.py（POST /discover + GET /status）+ \_\_init\_\_.py
- `di/modules/task_discovery_module.py` — TaskDiscoveryModule（singleton bind）
- `tests/.../test_task_discovery_e2e.py` — gated e2e 测试
- `tests/.../test_create_session_e2e.py` — session 创建 e2e 测试

**更新文件（5 个，dev 已有早期版本）：**
- `core/task/task_discovery/discovery_service.py` — 新增 `notify_sender` 依赖 + `_send_notification()` + `DiscoveryResult.notification_sent`
- `core/task/task_discovery/lifecycle.py` — 注入 `NotifySenderPlugin`，`_discover_once()` 传参
- `core/task/task_discovery/models.py` — `DiscoveryResult` 加 `notification_sent` 字段
- `core/task/task_discovery/session_creator.py` — session 创建逻辑增强
- `core/task/task_discovery/__init__.py` — docstring 更新

**公共文件修改（2 个，仅加 discovery wiring）：**
- `adapters/http/app.py` — 注册 `task_discovery_router`（import + `include_router`）
- `di/container.py` — 注册 `TaskDiscoveryModule`（import + module list）

架构遵循情况：
- core 层 transport-agnostic（`DiscoveryService` 不 import transport，`NotifySenderPlugin` 是 Protocol）
- HTTP adapter thin（router 只翻译协议，不持领域策略）
- DI composition root 正确接线（`TaskDiscoveryModule` singleton bind，`NotifySenderPlugin` 由 `CommunityNotifyModule` 绑定）
- 无硬编码 URL/token（engine/frontend URL 从环境变量读取）

## Validation

- [x] `git diff dev..feat/task_discovery_0819_dev` 确认仅 20 个 discovery 相关文件变更，无无关内容
- [x] 与 `feat/task_discovery_0818_dev` 的 discovery 文件 diff 为空（内容完全一致）
- [x] pre-push gate 通过（python-sast lint-only 模式）
- [ ] Backend unit tests — CI 将在 PR 创建后自动触发（`unit-tests.yml` → backend job，检测到 `src/backend` 变更）
- [ ] E2E tests — CI 将根据 `e2e-tests.yml` 检测，本次变更不涉及 `src/bcs`，BCS e2e 应 skip
- [ ] Singlebox coverage — CI 将根据 `singlebox-coverage.yml` 检测 `src/backend` 变更并运行
- [ ] Architecture checks — 仅对 `main` 分支触发，本 PR 目标为 `dev`

## Compatibility and risk

- **无 contract 变更**：新增的 HTTP 端点（`/api/public/task-discovery/discover`、`/status`）为全新路由，不影响已有 API
- **DI 注册为 additive**：`TaskDiscoveryModule()` 加到 module list 末尾，不修改已有模块顺序
- **通知失败不阻塞**：`NotifySenderPlugin.send()` Protocol 约定从不抛异常，通知投递失败不影响发现流程
- **e2e 测试 gated**：`test_task_discovery_e2e.py` 需 `SINGLEBOX_TASK_E2E=1` 启用，默认不跑，不拖慢 CI
- **回滚路径**：revert 单个 commit 即可完全回退（所有变更在 `69b792792` 一个 commit 中）

## Spec

- `src/backend/specs/2026-08-18-task-discovery/spec.md` — task_discovery 模块规格说明（WHY/WHAT/非目标/验收条件）
- `src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/design.md` — 通知集成技术设计（HOW）
- `src/backend/specs/2026-08-18-task-discovery-autoinitiate-merge/proposal.md` — 通知集成提案（从 autoInitiate 合并收窄为通知集成）
