### PR TITLE
fix(bcs): widen session add-participant eligibility to group driver/originator

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -417,22 +417,29 @@ impl SessionServiceImpl {
         Ok(session)
     }
 
-    /// VSN7B: Mirror `bcs-app-group`'s `ensure_collaboration_eligible`. A
-    /// caller may add a Bot to a session only when that Bot is
-    /// collaboration-eligible for the caller:
-    /// - the target must be a Bot Actor that is not Hidden; AND
-    /// - the caller IS the target bot; OR the target is `public`; OR (for a
-    ///   Human caller) the caller owns the target via `created_by` or a
-    ///   creator relation edge; OR the caller and target are friends.
+    /// VSN7B: A caller may add a Bot to a session only when that Bot is
+    /// collaboration-eligible from the caller OR from at least one of the
+    /// parent Group's management anchors (driver, originator). A Hidden bot is
+    /// rejected outright regardless of which anchor could sponsor it.
     ///
-    /// Called for the session driver, every participant in `create`, and in
-    /// `add_participant` so a manager cannot pull a hidden / protected Bot
-    /// into a session without the required relation.
+    /// Eligibility from an anchor actor (a Human `human_{id}` or a Bot uuid) is:
+    /// - the target must be a Bot Actor that is not Hidden; AND
+    /// - the anchor IS the target bot; OR the target is `public`; OR (for a
+    ///   Human anchor) the anchor owns the target via `created_by` or a creator
+    ///   relation edge; OR the anchor and target are friends.
+    ///
+    /// This widens the sibling `bcs-app-group::ensure_collaboration_eligible`
+    /// (caller-only) check for the session-add case: a group's existing
+    /// driver/originator may legitimately sponsor a participant that the caller
+    /// itself cannot reach (e.g. a protected Bot that is the driver's friend
+    /// but not the caller's), so a manager cannot be blocked from pulling a Bot
+    /// the group already collaborates with.
     async fn ensure_collaboration_eligible(
         &self,
         principal: &Principal,
         bot_uuid: &str,
         field_name: &str,
+        group: &DomainGroup,
     ) -> Result<(), ApplicationError> {
         let bot = self.load_bot(bot_uuid).await?;
         if bot.actor_kind != ActorKind::Bot {
@@ -446,37 +453,69 @@ impl SessionServiceImpl {
                 "Bot '{bot_uuid}' is hidden and cannot collaborate"
             )));
         }
-        let principal_actor_id = principal.actor_id();
-        if principal_actor_id == bot_uuid || bot.capabilities.visibility == "public" {
+        if bot.capabilities.visibility == "public" {
             return Ok(());
         }
 
-        if let Principal::Human(human) = principal {
-            if bot.created_by.as_deref() == Some(human.subject.id.as_str()) {
-                return Ok(());
-            }
-            let creator_edge = self
-                .relation
-                .get_edge(&principal_actor_id, bot_uuid, &self.config.relation_env)
-                .await
-                .map_err(map_service_error)?;
-            if creator_edge.is_some_and(|edge| edge.is_creator) {
-                return Ok(());
-            }
+        // Anchor set: the calling Principal plus the parent Group's driver and
+        // originator. Dedup so a Human originator that also equals the caller,
+        // or a driver that equals the originator, is not consulted twice.
+        let mut anchors = Vec::new();
+        anchors.push(principal.actor_id());
+        anchors.push(group.driver_bot.clone());
+        if let Some(originator) = group.originator.as_deref() {
+            anchors.push(originator.to_string());
         }
-
-        if self
-            .friends
-            .try_are_friends(&principal_actor_id, bot_uuid)
-            .await
-            .map_err(map_service_error)?
-        {
-            return Ok(());
+        let mut seen = HashSet::new();
+        for anchor in anchors {
+            if !seen.insert(anchor.clone()) {
+                continue;
+            }
+            if self.anchor_reaches_bot(&anchor, &bot).await? {
+                return Ok(());
+            }
         }
 
         Err(ApplicationError::forbidden(format!(
-            "Bot '{bot_uuid}' is not collaboration-eligible for this Principal"
+            "Bot '{bot_uuid}' is not collaboration-eligible for this Principal or the Group driver/originator"
         )))
+    }
+
+    /// Whether `bot` is collaboration-reachable from the anchor actor
+    /// `anchor_id`. An anchor is a `human_{id}` actor id or a Bot uuid; only a
+    /// Human anchor may sponsor via `created_by` or a creator relation edge
+    /// (ownership semantics), while any anchor may sponsor via self-identity or
+    /// direct friendship. The public/hidden gates are evaluated by the caller.
+    async fn anchor_reaches_bot(
+        &self,
+        anchor_id: &str,
+        bot: &RegisteredBot,
+    ) -> Result<bool, ApplicationError> {
+        if anchor_id == bot.bot_uuid {
+            return Ok(true);
+        }
+        if let Some(staff_no) = anchor_id.strip_prefix("human_") {
+            if bot.created_by.as_deref() == Some(staff_no) {
+                return Ok(true);
+            }
+            let creator_edge = self
+                .relation
+                .get_edge(anchor_id, &bot.bot_uuid, &self.config.relation_env)
+                .await
+                .map_err(map_service_error)?;
+            if creator_edge.is_some_and(|edge| edge.is_creator) {
+                return Ok(true);
+            }
+        }
+        if self
+            .friends
+            .try_are_friends(anchor_id, &bot.bot_uuid)
+            .await
+            .map_err(map_service_error)?
+        {
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     // ── projections ────────────────────────────────────────────────────
@@ -812,9 +851,10 @@ impl SessionService for SessionServiceImpl {
         let (session, group) = self
             .load_session_for_manage(&principal, &command.session_id)
             .await?;
-        // VSN7B: the added Bot must be collaboration-eligible for the caller
-        // (visible + friend/creator relation), not merely registered.
-        self.ensure_collaboration_eligible(&principal, &command.bot_uuid, "bot_uuid")
+        // VSN7B: the added Bot must be collaboration-eligible from the caller
+        // OR from the parent Group's driver/originator (visible + friend/creator
+        // relation), not merely registered.
+        self.ensure_collaboration_eligible(&principal, &command.bot_uuid, "bot_uuid", &group)
             .await?;
         // VfhG3: explicit 409 if the target Bot is already a session participant.
         // The legacy memory repo silently skipped duplicates (idempotent); the V1

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -30,9 +30,10 @@ use bcs_service_api::application::v1::{
 };
 use bcs_service_api::port::repo::{NewSessionParams, SessionRepoPort};
 use bcs_service_api::{
-    ActorKind, BotCapabilities, BotRegistryCoreService, CallerContext,
+    ActorKind, ActorStatus, BotCapabilities, BotRegistryCoreService, CallerContext,
     CancelStateMachineRunCommand, CollaborationDefinition, CollaborationRuntimeError,
-    CollaborationRuntimeService, ConfigureGroupRuntimeCommand, ConfigureGroupRuntimeOutcome, Group,
+    CollaborationRuntimeService, ConfigureGroupRuntimeCommand, ConfigureGroupRuntimeOutcome,
+    FriendCoreService, Group,
     GroupCoreService, GroupHistoryCommand, GroupHistoryResult, GroupMessage,
     GroupMessageHistoryService, GroupMessageType, GroupStrategy, GroupUseCaseError,
     HandleBotTerminalEventCommand, HandleBotTerminalEventOutcome, HumanActor, MessageRole,
@@ -217,6 +218,7 @@ struct Fixture {
     service: SessionServiceImpl,
     groups: Arc<GroupCore>,
     bots: Arc<BotCore>,
+    friends: Arc<FriendCore>,
     history: Arc<RecordingHistoryService>,
     runtime: Arc<RecordingRuntime>,
     session_repo: Arc<dyn SessionRepoPort>,
@@ -233,6 +235,7 @@ impl Fixture {
         let groups = Arc::new(GroupCore::with_repo(group_repo.clone()));
         let relation = Arc::new(RelationCore::memory());
         let friends = Arc::new(FriendCore::memory().with_relation(relation.clone()));
+        let friends_handle = friends.clone();
         let session_repo: Arc<dyn SessionRepoPort> = Arc::new(MemorySessionRepo::new());
         let history = Arc::new(RecordingHistoryService::default());
         let runtime = Arc::new(RecordingRuntime::default());
@@ -265,6 +268,7 @@ impl Fixture {
             service,
             groups,
             bots,
+            friends: friends_handle,
             history,
             runtime,
             session_repo,
@@ -287,6 +291,37 @@ impl Fixture {
             .save_created_by(bot_uuid, bot_uuid, true)
             .await
             .expect("assign test Bot owner");
+    }
+
+    /// Register a Bot with explicit `visibility` and `created_by` owner, for
+    /// collaboration-eligibility tests that need a non-public or non-caller-owned
+    /// actor (the default `add_bot` always registers a `public` Bot owned by
+    /// itself).
+    async fn add_bot_with(&self, bot_uuid: &str, visibility: &str, created_by: &str) {
+        self.bots
+            .register(
+                bot_uuid.to_string(),
+                BotCapabilities {
+                    name: Some(bot_uuid.to_string()),
+                    visibility: visibility.to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("register bot");
+        self.bots
+            .save_created_by(bot_uuid, created_by, true)
+            .await
+            .expect("assign test Bot owner");
+    }
+
+    /// Establish a bidirectional friendship between two Bots in the fixture's
+    /// shared in-memory friend repo.
+    async fn befriend(&self, bot_a: &str, bot_b: &str) {
+        self.friends
+            .add_friendship(bot_a, bot_b)
+            .await
+            .expect("establish friendship");
     }
 
     async fn store_group(&self, group_id: &str, driver: &str, context: Option<&str>) {
@@ -3236,4 +3271,208 @@ async fn add_participant_derives_worker_role_for_manager_worker() {
         "VfhG3: ManagerWorker Worker gains Worker role on add_participant, not Consultant"
     );
     assert_eq!(worker.mode, ParticipantMode::Auto);
+}
+
+// ── ensure_collaboration_eligible: session add-participant anchor set ──
+//
+// VSN7B (revised): an added Bot is admitted when collaboration-reachable from
+// the caller OR from the parent Group's driver/originator. These tests pin the
+// widened behavior so a manager is not blocked from pulling a Bot the group's
+// driver/originator already collaborates with.
+
+async fn eligibility_fixture(group_id: &str, driver: &str, originator: &str) -> Fixture {
+    let fixture = Fixture::new().await;
+    // The Human caller `manager` owns the public driver Bot, which grants group
+    // access for session creation and group-management authority.
+    fixture.add_bot_with(driver, "public", "manager").await;
+    fixture
+        .store_group_with_originator(group_id, driver, originator, None)
+        .await;
+    fixture
+}
+
+#[tokio::test]
+async fn add_participant_admits_protected_bot_reachable_from_driver_friend() {
+    // Protected Bot not owned by / friends with the caller, but friends with the
+    // group driver → admitted via the driver anchor.
+    let fixture = eligibility_fixture("g1", "driver-bot", "human_manager").await;
+    fixture
+        .add_bot_with("px", "protected", "other-owner")
+        .await;
+    fixture.befriend("driver-bot", "px").await;
+
+    let outcome = create_session(
+        &fixture,
+        human_principal("manager"),
+        "g1",
+        "driver-bot",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    let added = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("manager"),
+            session_id: session_id.clone(),
+            bot_uuid: "px".into(),
+        })
+        .await
+        .expect("driver-friend Bot should be admitted");
+    assert_eq!(added.actor_id, "px");
+}
+
+#[tokio::test]
+async fn add_participant_rejects_protected_bot_unreachable_from_all_anchors() {
+    // Protected Bot reachable from none of caller/driver/originator → 403.
+    let fixture = eligibility_fixture("g1", "driver-bot", "human_manager").await;
+    fixture
+        .add_bot_with("px", "protected", "other-owner")
+        .await;
+
+    let outcome = create_session(
+        &fixture,
+        human_principal("manager"),
+        "g1",
+        "driver-bot",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    let error = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("manager"),
+            session_id: session_id.clone(),
+            bot_uuid: "px".into(),
+        })
+        .await
+        .expect_err("unreachable Bot should be rejected");
+    assert!(
+        matches!(
+            error,
+            bcs_service_api::application::v1::ApplicationError::Forbidden(_)
+        ),
+        "expected Forbidden, got {error:?}",
+    );
+    assert_eq!(error.code(), "forbidden");
+}
+
+#[tokio::test]
+async fn add_participant_admits_protected_bot_owned_by_caller() {
+    // Protected Bot whose `created_by` matches the Human caller → admitted via
+    // the caller (Human) anchor's ownership rule.
+    let fixture = eligibility_fixture("g1", "driver-bot", "human_manager").await;
+    fixture.add_bot_with("px", "protected", "manager").await;
+
+    let outcome = create_session(
+        &fixture,
+        human_principal("manager"),
+        "g1",
+        "driver-bot",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    let added = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("manager"),
+            session_id: session_id.clone(),
+            bot_uuid: "px".into(),
+        })
+        .await
+        .expect("caller-owned protected Bot should be admitted");
+    assert_eq!(added.actor_id, "px");
+}
+
+#[tokio::test]
+async fn add_participant_admits_protected_bot_reachable_from_originator_friend() {
+    // Distinct Bot originator (not the driver) is the only anchor that reaches
+    // the target → admitted via the originator anchor, proving the anchor set is
+    // not collapsed to caller+driver only.
+    let fixture = eligibility_fixture("g1", "driver-bot", "originator-bot").await;
+    fixture
+        .add_bot_with("px", "protected", "other-owner")
+        .await;
+    fixture.befriend("originator-bot", "px").await;
+
+    let outcome = create_session(
+        &fixture,
+        human_principal("manager"),
+        "g1",
+        "driver-bot",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    let added = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("manager"),
+            session_id: session_id.clone(),
+            bot_uuid: "px".into(),
+        })
+        .await
+        .expect("originator-friend Bot should be admitted");
+    assert_eq!(added.actor_id, "px");
+}
+
+#[tokio::test]
+async fn add_participant_rejects_hidden_bot_regardless_of_anchors() {
+    // A Hidden Bot is rejected outright before any anchor is consulted, even when
+    // the driver is its friend.
+    let fixture = eligibility_fixture("g1", "driver-bot", "human_manager").await;
+    fixture
+        .add_bot_with("px", "protected", "other-owner")
+        .await;
+    fixture.befriend("driver-bot", "px").await;
+    fixture
+        .bots
+        .update_actor_status("px", ActorStatus::Hidden)
+        .await
+        .expect("hide bot");
+
+    let outcome = create_session(
+        &fixture,
+        human_principal("manager"),
+        "g1",
+        "driver-bot",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    let error = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: human_principal("manager"),
+            session_id: session_id.clone(),
+            bot_uuid: "px".into(),
+        })
+        .await
+        .expect_err("hidden Bot should be rejected");
+    assert!(
+        matches!(
+            error,
+            bcs_service_api::application::v1::ApplicationError::Forbidden(ref message)
+                if message.contains("hidden")
+        ),
+        "expected hidden-Bot Forbidden, got {error:?}",
+    );
+    assert_eq!(error.code(), "forbidden");
 }


### PR DESCRIPTION
## Problem

`POST /openapi/v1/collaboration/sessions/{session_id}/participants` rejected protected Bots that the calling Human Principal had no relation to, returning:

```json
{ "code": 40300, "message": "Bot '<bot>' is not collaboration-eligible for this Principal", "data": { "error_code": "forbidden" } }
```

This blocked legitimate operations: a group manager could not pull a Bot the group already collaborates with when that Bot was sponsored by the group's **driver** or **originator** rather than by the caller. The V1 facade's `ensure_collaboration_eligible` only checked Principal→Bot reachability, unlike the legacy `/sessions/{sid}/members` path which performed no such gate.

## Solution

Generalize the session-add eligibility check in `bcs-app-session` from a single caller anchor to an anchor set `{caller, group.driver_bot, group.originator}`. A Bot is admitted when collaboration-reachable from **any** anchor — self-identity, `public` visibility, human ownership (`created_by` / creator relation edge for a `human_{id}` anchor), or friendship.

- A new `anchor_reaches_bot` helper expresses single-anchor reachability for both Human and Bot anchors. Human-anchored ownership (`created_by` / creator edge) is preserved; Bot anchors (e.g. the driver) sponsor via self/friendship.
- `Hidden` Bots are still rejected outright, before any anchor is consulted.
- Anchors are deduplicated so a Human originator equal to the caller, or a driver equal to the originator, is not consulted twice.
- The sibling `bcs-app-group` facade is intentionally **unchanged**: its caller-only `ensure_collaboration_eligible` governs Group creation, where the driver/target itself is being authorized and no group yet exists to source additional anchors.

### Behavior change (session add-participant, protected target Bot)

| Scenario | Before | After |
| --- | :---: | :---: |
| Reachable from caller (friend/ownership) | ✅ | ✅ |
| **Not** reachable from caller, but friend of **driver** | ❌ 403 | ✅ |
| **Not** reachable from caller, but friend/owned by **originator** | ❌ 403 | ✅ |
| Reachable from none of caller/driver/originator | ❌ 403 | ❌ 403 |
| `Hidden` Bot | ❌ 403 | ❌ 403 (absolute) |
| `public` Bot | ✅ | ✅ |

## Validation

- Manual code review against `RegisteredBot` / `DomainGroup` field shapes and the existing `relation.get_edge` / `friends.try_are_friends` call signatures.
- No existing tests reference the old signature or the rejected message string; `ensure_collaboration_eligible` had a single call site (`add_participant`), updated.
- **Not run:** `cargo build -p bcs-app-session` and the module test gate were not executed in this environment (Rust toolchain was installed only at the end of the session and a clean build was not completed). Please run the module CI gate.

## Compatibility and risk

- Scope is the OpenAPI v1 session add-participant path only; legacy HTTP and Group-creation paths are untouched.
- The check is strictly **widened** (more Bots admitted), so existing 403s that were correct remain, while previously-over-rejected requests now succeed — no narrowing of access.
- Error message wording changed (`"... for this Principal or the Group driver/originator"`); clients matching on the literal message (not the stable `error_code: forbidden`) would need updating.
- Rollback: revert this single commit; the prior caller-only behavior is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)