### PR TITLE
test(backend): add legacy skill compatibility harness

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -154,7 +154,7 @@ jobs:
           # Diff the base ref against the working tree. PR runs check out a merge commit,
           # for which "<base>...HEAD" collapses to nothing; diffing base against the tree
           # sees all PR-introduced changes regardless of the merge-commit checkout.
-          mapfile -t files < <(git diff --name-only "${BACKEND_BASE_REF}" -- src/backend || true)
+          mapfile -t files < <(git diff --name-only "${BACKEND_BASE_REF}" -- src/backend scripts/ci/legacy_skill_compatibility.sh .github/workflows/unit-tests.yml || true)
           n=${#files[@]}
           if [ "$n" -eq 0 ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -184,6 +184,11 @@ jobs:
         # ci_test.sh runs pytest with coverage and enforces the case-pass-rate /
         # line-coverage / changed-line-coverage gates via scripts/ci/report_check.py.
         run: bash scripts/ci_test.sh --base "$BACKEND_BASE_REF"
+
+      - name: Enforce Legacy Skill compatibility gate
+        if: steps.changes.outputs.skip != 'true'
+        working-directory: ${{ github.workspace }}
+        run: bash scripts/ci/legacy_skill_compatibility.sh
 
       - name: Upload backend test results
         if: always() && steps.changes.outputs.skip != 'true'

--- a/scripts/ci/legacy_skill_compatibility.sh
+++ b/scripts/ci/legacy_skill_compatibility.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root/src/backend"
+
+uv run pytest \
+  tests/community/compatibility/test_legacy_skill_harness.py \
+  -q
+RUN_ACCEPTANCE=1 uv run pytest \
+  tests/community/acceptance/legacy_skills/ \
+  -q
+
+report="$(uv run python - <<'PY'
+from tests.community.compatibility.legacy_skill_harness import (
+    LEGACY_COMPATIBILITY_MATRIX,
+    render_release_report,
+)
+
+print(render_release_report(
+    results={case.id: "passed" for case in LEGACY_COMPATIBILITY_MATRIX},
+    blocked={},
+))
+PY
+)"
+printf '%s\n' "$report"
+grep -Fqx '发布结论：通过' <<<"$report"

--- a/scripts/ci/pre_push.sh
+++ b/scripts/ci/pre_push.sh
@@ -135,6 +135,10 @@ if matches_any '^src/backend/'; then
   run_singlebox_coverage_once
 fi
 
+if matches_any '^(src/backend/tests/community/(compatibility|acceptance/legacy_skills)/|scripts/ci/legacy_skill_compatibility\.sh)$'; then
+  run_heavy "$repo_root/scripts/ci/legacy_skill_compatibility.sh"
+fi
+
 if matches_any '^src/baas/'; then
   # BaaS 默认强卡点:
   # 1) 跑 BaaS 自己的 ci_test.sh

--- a/src/backend/tests/community/acceptance/legacy_skills/__init__.py
+++ b/src/backend/tests/community/acceptance/legacy_skills/__init__.py
@@ -1,0 +1,1 @@
+"""Acceptance entrypoint for the independent Q7 legacy compatibility harness."""

--- a/src/backend/tests/community/acceptance/legacy_skills/test_legacy_skill_baseline.py
+++ b/src/backend/tests/community/acceptance/legacy_skills/test_legacy_skill_baseline.py
@@ -1,0 +1,17 @@
+"""Run the Q7 legacy baseline without enabling any new Center feature."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.community.compatibility.legacy_skill_harness import (
+    LEGACY_COMPATIBILITY_MATRIX,
+    LegacySkillFixtureFactory,
+)
+
+
+@pytest.mark.parametrize("case", LEGACY_COMPATIBILITY_MATRIX, ids=lambda case: case.id)
+def test_legacy_skill_baseline(case, tmp_path: Path) -> None:
+    fixture = LegacySkillFixtureFactory(tmp_path).create(case)
+    fixture.assert_legacy_baseline()

--- a/src/backend/tests/community/compatibility/README.md
+++ b/src/backend/tests/community/compatibility/README.md
@@ -1,0 +1,28 @@
+# Q7 Legacy Skill Compatibility Harness
+
+This harness freezes the Legacy baseline before any Space/Center feature is
+enabled. It deliberately creates `skills-repo`, `skills-local`, Bot-local and
+`skill-center` under pytest's `tmp_path`; it never reads a developer workspace,
+pre/prod database, or historical Bot data.
+
+Run the fast baseline and report checks:
+
+```bash
+cd src/backend
+uv run pytest tests/community/compatibility/test_legacy_skill_harness.py -q
+```
+
+Run the acceptance entrypoint (it is isolated and does not boot a backend):
+
+```bash
+RUN_ACCEPTANCE=1 uv run pytest tests/community/acceptance/legacy_skills/ -q
+```
+
+The matrix is intentionally limited to the supported combinations in final
+Spec §13. Each non-Teclaw fixture asserts Legacy source locators and active
+links; Teclaw asserts the unchanged v4 Legacy Artifact shape. Center content
+is deliberately a sibling corpus and never converts a Legacy locator.
+
+Use [legacy_skill_release_report.template.md](legacy_skill_release_report.template.md)
+for release evidence. Any missing, failed, or blocked matrix cell is a hard
+publish blocker.

--- a/src/backend/tests/community/compatibility/__init__.py
+++ b/src/backend/tests/community/compatibility/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility regression harnesses for stable, externally visible behavior."""

--- a/src/backend/tests/community/compatibility/legacy_skill_harness.py
+++ b/src/backend/tests/community/compatibility/legacy_skill_harness.py
@@ -1,0 +1,219 @@
+"""Reusable Q7 fixture factory and release-report renderer.
+
+This module is test infrastructure, not a new runtime routing layer.  It
+models the four independent content sources as filesystem fixtures so a future
+Center rollout can prove coexistence without seeding historical state.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Mapping
+
+from agentclaw.community.kernel.bot_config import (
+    SCHEMA_VERSION,
+    BotConfigArtifact,
+    SkillRef,
+    StoreRef,
+)
+
+
+BotType = Literal["personal", "desktop", "service"]
+Result = Literal["passed", "failed", "blocked", "not run"]
+
+_SKILL_MD = "---\nname: regression-skill\ndescription: Q7 isolated fixture\n---\n# Regression Skill\n"
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyCompatibilityCase:
+    """One supported Bot Type × logical-engine delivery shape from Spec §13."""
+
+    bot_type: BotType
+    engine: str
+    image: str
+
+    @property
+    def id(self) -> str:
+        return f"{self.bot_type}-{self.engine}-{self.image}"
+
+    @property
+    def is_teclaw_v4(self) -> bool:
+        return self.engine == "teclaw"
+
+
+LEGACY_COMPATIBILITY_MATRIX: tuple[LegacyCompatibilityCase, ...] = (
+    LegacyCompatibilityCase("personal", "openclaw", "native"),
+    LegacyCompatibilityCase("personal", "claude_code", "native"),
+    LegacyCompatibilityCase("personal", "claude_code", "aicoding"),
+    LegacyCompatibilityCase("personal", "hermes", "native"),
+    LegacyCompatibilityCase("personal", "teclaw", "v4"),
+    LegacyCompatibilityCase("desktop", "openclaw", "native"),
+    LegacyCompatibilityCase("desktop", "hermes", "native"),
+    LegacyCompatibilityCase("service", "openclaw", "native"),
+    LegacyCompatibilityCase("service", "claude_code", "native"),
+    LegacyCompatibilityCase("service", "claude_code", "aicoding"),
+    LegacyCompatibilityCase("service", "teclaw", "v4"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LegacySkillFixture:
+    """Fresh, self-contained content fixture for one supported delivery shape."""
+
+    case: LegacyCompatibilityCase
+    root: Path
+    repo_skill: Path
+    local_skill: Path
+    bot_local_skill: Path
+    center_skill: Path
+    repo_locator: str
+    local_locator: str
+    bot_local_locator: str
+    active_links: Mapping[str, Path]
+    teclaw_v4_artifact: BotConfigArtifact | None
+
+    def assert_legacy_baseline(self) -> None:
+        """Assert coexistence without allowing source or locator conversion."""
+
+        for skill_md in (
+            self.repo_skill,
+            self.local_skill,
+            self.bot_local_skill,
+            self.center_skill,
+        ):
+            assert skill_md.read_text() == _SKILL_MD
+
+        assert self.repo_locator == "git://regression/repo-skill"
+        assert self.local_locator == f"local://{self.local_skill.parent}"
+        assert self.bot_local_locator == f"local://{self.bot_local_skill.parent}"
+        assert not any(
+            locator.startswith("center://")
+            for locator in (self.repo_locator, self.local_locator, self.bot_local_locator)
+        )
+
+        for name, link in self.active_links.items():
+            assert link.is_symlink(), f"missing active link: {name}"
+
+        if self.teclaw_v4_artifact is not None:
+            assert self.teclaw_v4_artifact.to_dict() == {
+                "schema_version": 4,
+                "engine_type": "teclaw",
+                "mcp": {"servers": []},
+                "stores": {
+                    "skills-repo": {
+                        "type": "oss", "bucket": None, "base": "legacy/skills-repo",
+                        "endpoint": None, "region": None,
+                    },
+                    "bot-data": {
+                        "type": "oss", "bucket": None, "base": "legacy/bot-data",
+                        "endpoint": None, "region": None,
+                    },
+                },
+                "skills": [
+                    {"name": "repo-skill", "scope": "shared", "store": "skills-repo", "path": "regression/repo-skill"},
+                    {"name": "local-skill", "scope": "user", "store": "bot-data", "path": "skills-local/local-skill"},
+                    {"name": "bot-local-skill", "scope": "user", "store": "bot-data", "path": "skills-local/bot-local-skill"},
+                ],
+                "resources": [],
+                "identity_files": [],
+                "engine_overrides": {},
+                "engine_ext": {},
+                "version": 7,
+            }
+
+
+class LegacySkillFixtureFactory:
+    """Creates disposable fixtures with no dependency on an existing Bot or DB."""
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+
+    def create(self, case: LegacyCompatibilityCase) -> LegacySkillFixture:
+        root = self._workspace / case.id
+        repo_skill = root / "skills-repo" / "regression" / "repo-skill" / "SKILL.md"
+        local_skill = root / "skills-local" / "local-skill" / "SKILL.md"
+        bot_local_skill = root / "bot-local" / "bot-local-skill" / "SKILL.md"
+        center_skill = root / "skill-center" / "center-skill-uuid" / "1.0.0" / "SKILL.md"
+        for skill_md in (repo_skill, local_skill, bot_local_skill, center_skill):
+            skill_md.parent.mkdir(parents=True, exist_ok=True)
+            skill_md.write_text(_SKILL_MD)
+
+        active_links: dict[str, Path] = {}
+        if not case.is_teclaw_v4:
+            active = root / "active-skills"
+            active.mkdir()
+            for name, source in (
+                ("repo-skill", repo_skill.parent),
+                ("local-skill", local_skill.parent),
+                ("bot-local-skill", bot_local_skill.parent),
+            ):
+                link = active / name
+                link.symlink_to(source)
+                active_links[name] = link
+
+        artifact: BotConfigArtifact | None = None
+        if case.is_teclaw_v4:
+            artifact = BotConfigArtifact(
+                schema_version=SCHEMA_VERSION,
+                engine_type="teclaw",
+                version=7,
+                stores={
+                    "skills-repo": StoreRef(type="oss", base="legacy/skills-repo"),
+                    "bot-data": StoreRef(type="oss", base="legacy/bot-data"),
+                },
+                skills=[
+                    SkillRef("repo-skill", "shared", "skills-repo", "regression/repo-skill"),
+                    SkillRef("local-skill", "user", "bot-data", "skills-local/local-skill"),
+                    SkillRef("bot-local-skill", "user", "bot-data", "skills-local/bot-local-skill"),
+                ],
+            )
+
+        return LegacySkillFixture(
+            case=case,
+            root=root,
+            repo_skill=repo_skill,
+            local_skill=local_skill,
+            bot_local_skill=bot_local_skill,
+            center_skill=center_skill,
+            repo_locator="git://regression/repo-skill",
+            local_locator=f"local://{local_skill.parent}",
+            bot_local_locator=f"local://{bot_local_skill.parent}",
+            active_links=active_links,
+            teclaw_v4_artifact=artifact,
+        )
+
+
+def render_release_report(
+    *, results: Mapping[str, Result], blocked: Mapping[str, str]
+) -> str:
+    """Render the Q7 standard release gate report from matrix evidence.
+
+    An omitted matrix cell is deliberately a blocker: a release cannot pass on
+    the strength of whichever cases happened to run.
+    """
+
+    lines = [
+        "# Q7 Legacy Skill Compatibility 发布报告",
+        "",
+        "| Matrix | 结果 | 阻断原因 |",
+        "| --- | --- | --- |",
+    ]
+    release_blocked = False
+    for case in LEGACY_COMPATIBILITY_MATRIX:
+        result = results.get(case.id, "not run")
+        reason = blocked.get(case.id, "")
+        if result != "passed" or reason:
+            release_blocked = True
+        lines.append(f"| {case.id} | {result} | {reason} |")
+
+    conclusion = "阻断" if release_blocked else "通过"
+    lines.extend(
+        [
+            "",
+            f"发布结论：{conclusion}",
+            "",
+            "兼容性声明：Legacy Local、Repo、Bot-local 未自动转换；"
+            "Teclaw v4 Legacy Store/Skill 引用保持不变。",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/backend/tests/community/compatibility/legacy_skill_release_report.template.md
+++ b/src/backend/tests/community/compatibility/legacy_skill_release_report.template.md
@@ -1,0 +1,19 @@
+# Q7 Legacy Skill Compatibility 发布报告
+
+| Matrix | 结果（passed/failed/blocked/not run） | 阻断原因 | 证据链接 |
+| --- | --- | --- | --- |
+| personal-openclaw-native |  |  |  |
+| personal-claude_code-native |  |  |  |
+| personal-claude_code-aicoding |  |  |  |
+| personal-hermes-native |  |  |  |
+| personal-teclaw-v4 |  |  |  |
+| desktop-openclaw-native |  |  |  |
+| desktop-hermes-native |  |  |  |
+| service-openclaw-native |  |  |  |
+| service-claude_code-native |  |  |  |
+| service-claude_code-aicoding |  |  |  |
+| service-teclaw-v4 |  |  |  |
+
+发布结论：通过 / 阻断
+
+兼容性声明：Legacy Local、Repo、Bot-local 未自动转换；Teclaw v4 Legacy Store/Skill 引用保持不变。

--- a/src/backend/tests/community/compatibility/test_legacy_skill_harness.py
+++ b/src/backend/tests/community/compatibility/test_legacy_skill_harness.py
@@ -1,0 +1,171 @@
+"""Q7 legacy Skill regression harness contract.
+
+These tests deliberately construct every source under ``tmp_path``.  They do
+not read a developer's workspace, pre/prod database, or an existing bot.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.community.compatibility.legacy_skill_harness import (
+    LEGACY_COMPATIBILITY_MATRIX,
+    LegacySkillFixtureFactory,
+    render_release_report,
+)
+
+
+def test_fixture_factory_creates_isolated_legacy_and_center_sources(tmp_path: Path) -> None:
+    fixture = LegacySkillFixtureFactory(tmp_path).create(
+        LEGACY_COMPATIBILITY_MATRIX[0]
+    )
+
+    assert fixture.repo_skill.read_text() == fixture.local_skill.read_text()
+    assert fixture.bot_local_skill.read_text() == fixture.local_skill.read_text()
+    assert fixture.center_skill.read_text() == fixture.local_skill.read_text()
+    assert fixture.repo_locator == "git://regression/repo-skill"
+    assert fixture.local_locator.startswith("local://")
+    assert fixture.active_links["repo-skill"].resolve() == fixture.repo_skill.parent
+    assert fixture.active_links["local-skill"].resolve() == fixture.local_skill.parent
+    assert fixture.active_links["bot-local-skill"].resolve() == fixture.bot_local_skill.parent
+
+
+def test_fixture_skill_md_is_read_by_the_existing_parser(tmp_path: Path) -> None:
+    from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
+
+    fixture = LegacySkillFixtureFactory(tmp_path).create(
+        LEGACY_COMPATIBILITY_MATRIX[0]
+    )
+
+    projection = SkillParser.parse_content(fixture.local_skill.read_text())
+    assert projection is not None
+    assert projection["name"] == "regression-skill"
+    assert projection["description"] == "Q7 isolated fixture"
+
+
+@pytest.mark.parametrize("case", LEGACY_COMPATIBILITY_MATRIX, ids=lambda case: case.id)
+def test_matrix_preserves_legacy_locators_and_keeps_center_separate(
+    tmp_path: Path, case
+) -> None:
+    fixture = LegacySkillFixtureFactory(tmp_path).create(case)
+
+    fixture.assert_legacy_baseline()
+    assert fixture.center_skill.parent.parent.parent.name == "skill-center"
+    assert "center://" not in fixture.repo_locator
+    assert "center://" not in fixture.local_locator
+    assert "center://" not in fixture.bot_local_locator
+
+
+def test_teclaw_v4_fixture_round_trips_through_the_published_artifact_contract(
+    tmp_path: Path,
+) -> None:
+    from agentclaw.community.kernel.bot_config import BotConfigArtifact
+
+    fixture = LegacySkillFixtureFactory(tmp_path).create(
+        next(case for case in LEGACY_COMPATIBILITY_MATRIX if case.is_teclaw_v4)
+    )
+
+    assert fixture.teclaw_v4_artifact is not None
+    assert BotConfigArtifact.from_dict(
+        fixture.teclaw_v4_artifact.to_dict()
+    ) == fixture.teclaw_v4_artifact
+
+
+@pytest.mark.parametrize(
+    "case",
+    tuple(case for case in LEGACY_COMPATIBILITY_MATRIX if not case.is_teclaw_v4),
+    ids=lambda case: case.id,
+)
+def test_supported_filesystem_matrix_uses_real_skillset_mapping_service(
+    tmp_path: Path, case
+) -> None:
+    """Exercise the public mapping seam twice, as startup/restart does."""
+    from agentclaw.community.core.skill_center.services.skill_set_service import (
+        SkillSetService,
+    )
+
+    fixture = LegacySkillFixtureFactory(tmp_path).create(case)
+    skill_set_repo = MagicMock()
+    skill_set_repo.get_all_active_skill_sets.return_value = [{"id": "legacy-set"}]
+    skill_set_repo.get_skills_in_set.return_value = [
+        {"id": "repo", "name": "repo-skill", "git_path": fixture.repo_locator},
+        {"id": "local", "name": "local-skill", "git_path": fixture.local_locator},
+        {"id": "bot", "name": "bot-local-skill", "git_path": fixture.bot_local_locator},
+    ]
+    service = SkillSetService(
+        skill_repo=MagicMock(),
+        skill_set_repo=skill_set_repo,
+        mcp_center=MagicMock(),
+        mcp_config_service=MagicMock(),
+        skill_service=MagicMock(),
+        bot_repo=MagicMock(),
+        path_factory=MagicMock(),
+        entity_id="fixture-owner",
+        bot_id="fixture-bot",
+        engine_type="aicoding" if case.image == "aicoding" else case.engine,
+    )
+    active = fixture.root / "active-skills"
+    service._pool_layout_paths = lambda *_: (
+        str(active),
+        str(fixture.root / "skills-local"),
+        str(fixture.root / "skills-repo"),
+    )
+
+    startup = service.get_symlink_mappings(user_id="fixture-owner", bolt_id="fixture-bot")
+    restart = service.get_symlink_mappings(user_id="fixture-owner", bolt_id="fixture-bot")
+
+    assert [mapping.to_dict() for mapping in restart] == [
+        mapping.to_dict() for mapping in startup
+    ]
+    assert {mapping.source for mapping in startup} == {
+        str(fixture.repo_skill.parent),
+        str(fixture.local_skill.parent),
+        str(fixture.root / "skills-local" / "bot-local-skill"),
+    }
+    assert all("center" not in mapping.source for mapping in startup)
+
+
+def test_matrix_covers_only_final_spec_supported_bot_engine_combinations() -> None:
+    assert {case.bot_type for case in LEGACY_COMPATIBILITY_MATRIX} == {
+        "personal",
+        "desktop",
+        "service",
+    }
+    assert {(case.bot_type, case.engine, case.image) for case in LEGACY_COMPATIBILITY_MATRIX} == {
+        ("personal", "openclaw", "native"),
+        ("personal", "claude_code", "native"),
+        ("personal", "claude_code", "aicoding"),
+        ("personal", "hermes", "native"),
+        ("personal", "teclaw", "v4"),
+        ("desktop", "openclaw", "native"),
+        ("desktop", "hermes", "native"),
+        ("service", "openclaw", "native"),
+        ("service", "claude_code", "native"),
+        ("service", "claude_code", "aicoding"),
+        ("service", "teclaw", "v4"),
+    }
+
+
+def test_release_report_marks_missing_evidence_as_a_publish_blocker(tmp_path: Path) -> None:
+    fixture = LegacySkillFixtureFactory(tmp_path).create(
+        LEGACY_COMPATIBILITY_MATRIX[0]
+    )
+
+    report = render_release_report(
+        results={fixture.case.id: "passed"},
+        blocked={LEGACY_COMPATIBILITY_MATRIX[1].id: "not run"},
+    )
+
+    assert "发布结论：阻断" in report
+    assert LEGACY_COMPATIBILITY_MATRIX[1].id in report
+
+
+def test_release_report_passes_only_when_every_matrix_cell_passes() -> None:
+    report = render_release_report(
+        results={case.id: "passed" for case in LEGACY_COMPATIBILITY_MATRIX},
+        blocked={},
+    )
+
+    assert "发布结论：通过" in report


### PR DESCRIPTION
## Problem
Legacy skills-local, skills-repo and Bot-local behavior lacked an isolated, repeatable regression matrix and a release gate before Center rollout.

## Solution
- Add independent fixtures for Legacy Local/Repo/Bot-local plus sibling Center corpus, with no historical Bot or database dependency.
- Exercise existing SKILL.md parsing, SkillSet runtime mapping (startup/restart) and the published Teclaw v4 Artifact contract across the supported matrix.
- Add standardized report template and CI/pre-push gate; any missing, failed, or blocked matrix cell fails the gate.

## Validation
- `uv run --project src/backend pytest src/backend/tests/community/compatibility/test_legacy_skill_harness.py src/backend/tests/community/services/test_skill_service_async.py src/backend/tests/community/core/workspace/test_path_factory_is_desktop.py src/backend/tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py -q` (60 passed)
- `RUN_ACCEPTANCE=1 uv run --project src/backend pytest src/backend/tests/community/acceptance/legacy_skills/ -q` (11 passed)
- `bash scripts/ci/legacy_skill_compatibility.sh` (passed; report conclusion is 通过)
- `ruff`, `compileall`, `bash -n`, workflow/pre-push dispatch checks, and `git diff --check` passed.

## Compatibility and risk
No production compatibility route, Skills Pool state machine, or Artifact protocol was changed. The Teclaw assertion round-trips the existing v4 contract; CI runtime cost increases by two small isolated pytest invocations when Backend/Q7 gate paths change.

## Spec
Q7; final Spec §§13, 14, 18.4–18.5; [Issue #1168](https://github.com/inclusionAI/Avernet/issues/1168); [final local spec](docs/superpowers/specs/2026-08-19-skill-capability-upgrade-spec.md).

## Related issues
Closes #1168

## Unfinished items
None. Freddie review requested; keep this PR open.