### PR TITLE
feat(skills): add center mapping v3 consumer support

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -515,6 +515,8 @@ class SkillRepository(
                     skill_id=row.id,
                     name=row.name,
                     git_path=row.git_path,
+                    skill_uuid=getattr(row, "skill_uuid", None),
+                    sc_version_number=getattr(row, "sc_version_number", None),
                 )
                 for row in rows
             ]
@@ -570,6 +572,16 @@ class SkillRepository(
                         skill_id=int(row["id"]),
                         name=str(row["name"]),
                         git_path=git_path,
+                        skill_uuid=(
+                            str(row["skill_uuid"])
+                            if row.get("skill_uuid") is not None
+                            else None
+                        ),
+                        sc_version_number=(
+                            str(row["sc_version_number"])
+                            if row.get("sc_version_number") is not None
+                            else None
+                        ),
                     )
                 )
         return assets

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -25,6 +25,7 @@ from agentclaw.community.plugin_api.device_adapter_transport import (
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
 MAPPING_CONTRACT_VERSION = "skills-pool-mapping-v2"
+MAPPING_V3_CONTRACT_VERSION = "skills-pool-mapping-v3"
 CUTOVER_EVIDENCE_CONTRACT_VERSION = "quarantine-v1"
 
 
@@ -186,8 +187,7 @@ class CurrentRuntimeLayoutProbeService:
             return CurrentRuntimeLayoutProbeService._invalid_response(engine)
         if (
             data.status is RuntimeLayoutProbeStatus.READY
-            and data.evidence.get("mapping_contract_version")
-            != MAPPING_CONTRACT_VERSION
+            and not CurrentRuntimeLayoutProbeService._supports_v2(data.evidence)
         ):
             return CurrentRuntimeLayoutProbeService._not_capable(
                 engine,
@@ -199,6 +199,14 @@ class CurrentRuntimeLayoutProbeService:
             layout_contract_version=LAYOUT_CONTRACT_VERSION,
             preparation_id=data.preparation_id,
             evidence=data.evidence,
+        )
+
+    @staticmethod
+    def _supports_v2(evidence: dict[str, Any]) -> bool:
+        legacy = evidence.get("mapping_contract_version")
+        supported = evidence.get("supported_mapping_contract_versions")
+        return legacy == MAPPING_CONTRACT_VERSION or (
+            isinstance(supported, list) and MAPPING_CONTRACT_VERSION in supported
         )
 
     @staticmethod
@@ -260,6 +268,7 @@ __all__ = [
     "CurrentRuntimeLayoutProbeService",
     "LAYOUT_CONTRACT_VERSION",
     "MAPPING_CONTRACT_VERSION",
+    "MAPPING_V3_CONTRACT_VERSION",
     "CUTOVER_EVIDENCE_CONTRACT_VERSION",
     "RuntimeLayoutProbeResult",
     "RuntimeLayoutProbeStatus",

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -147,6 +147,8 @@ provides:
   - "SkillsPoolRolloutGate"
   - "SkillsPoolMigrationClaimService"
   - "SkillsPoolReconcileService"
+  - "SkillsPoolReconcileOutcome"
+  - "SkillsPoolReconcileResult"
   - "SkillsPoolReconcileTaskHandler"
   - "SkillsPoolReconcileWakeupListener"
   - "SkillsPoolRecoveryService"

--- a/src/backend/src/agentclaw/community/core/skills_pool/README.md
+++ b/src/backend/src/agentclaw/community/core/skills_pool/README.md
@@ -39,9 +39,10 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
 - 激活只处理当前仍可编辑、已经认领、引擎已显式接入且由当前 worker 持有
   lease 的 Bot；每次执行都重新读取 Bot 和当前 provider binding，并重新
   probe 对应引擎 marker。只有 probe evidence 明确声明
-  `skills-pool-mapping-v2` 后才发送 logical mapping；旧或缺失 capability
+  `skills-pool-mapping-v2`，并在含 Center mapping 时显式支持
+  `skills-pool-mapping-v3` 后才发送 logical mapping；旧或缺失 capability
   作为 `NOT_CAPABLE` 释放认领并保持 Legacy。OpenClaw、Claude Code 内置
-  consumer 直接广告 v2；AICoding、Hermes 只有在具体 composition root
+  consumer 直接广告 v2/v3；AICoding、Hermes 只有在具体 composition root
   已接入同一 resolver 后才显式广告，旧 consumer 继续保持
   `NOT_CAPABLE`/Legacy。未知引擎不回退到 OpenClaw。
 - Backend 发送的 v2 mapping 只包含
@@ -49,6 +50,11 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   descriptor 投影 source/active target，并返回 locator evidence。Backend
   只校验并持久化 evidence，不按引擎重建 activation/publish/verify/reconcile
   的物理路径。
+- v3 的 Center mapping 只包含 `skill_uuid + sc_version_number + link_name`，
+  Runtime 解析为唯一 canonical `pool_center` 路径。Center 与
+  `source_layout=legacy|pool` 中立：cutover、rollback、publish、verify 与
+  retired lifecycle 都携带它，但绝不迁移、删除或创建 `legacy_center`。每次完整
+  v3 publish/cutover 前先 ensure 所有精确 Center 版本；ensure 失败不发布部分集合。
 - 容器内先把 Legacy local 以 generation-scoped rename 移入隔离区，再执行
   best-effort 后置合并；随后发布并验证直接指向 canonical Pool 的 active
   mapping。持久化 `.pool-active` 的 `finalizing → active` 后，active root
@@ -89,7 +95,7 @@ Hermes；物理路径投影由 Engine Layout Descriptor 统一持有。
   编辑 fail closed。mapping 请求同时声明 `source_layout`：激活缺省为
   `pool`，显式回滚前后使用 `legacy`。显式回滚也必须在第一次 logical
   mapping 请求前重新 probe 当前 binding；若运行时已降级或缺少 v2
-  capability，则不发送 v2、不执行文件系统切换，并记录可重试失败。
+  capability，则不发送所需版本、不执行文件系统切换，并记录可重试失败。
 - 显式回滚不会读取迁移隔离副本，Pool 激活后产生的 local 新增和修改会被
   带入新的 Legacy；Pool 本身保留用于证据和后续恢复。
 - local 后置合并采用 best-effort、无覆盖的文件级收敛：一般的切换前修改、
@@ -165,7 +171,7 @@ consumes:
   - "DatabasePlugin (through Skills Pool layout, operational and rollout repositories)"
   - "SkillsPoolRuntimeProtocol"
   - "SkillsPoolSkillRepositoryProtocol"
-  - "skills-pool-mapping-v2 capability and Engine locator evidence"
+  - "skills-pool-mapping-v2/v3 capability and Engine locator evidence"
   - "DeviceBindingRepository"
   - "TaskQueueService and HandlerRegistry"
 internal_dependencies:

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
@@ -47,6 +47,7 @@ async def converge_post_cutover_mappings(
     engine: str,
     cutover_mappings: list[PoolSkillMapping],
     durable_retired_mappings: list[PoolSkillMapping],
+    mapping_contract_version: str,
 ) -> MappingConvergenceResult:
     """Publish until Engine state matches one stable product-state snapshot."""
 
@@ -99,6 +100,7 @@ async def converge_post_cutover_mappings(
             user_id=user_id,
             mappings=mappings,
             retired_mappings=retired_mappings,
+            mapping_contract_version=mapping_contract_version,
         ):
             return MappingConvergenceResult(
                 MappingConvergenceStatus.PUBLISH_FAILED,
@@ -109,6 +111,7 @@ async def converge_post_cutover_mappings(
             user_id=user_id,
             mappings=mappings,
             retired_mappings=retired_mappings,
+            mapping_contract_version=mapping_contract_version,
         ):
             return MappingConvergenceResult(
                 MappingConvergenceStatus.VERIFY_FAILED,

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -134,15 +134,41 @@ def logical_skill_mappings_from_evidence(
     parsed: list[PoolSkillMapping] = []
     targets: dict[str, PoolSkillMapping] = {}
     for raw in raw_mappings:
-        if not isinstance(raw, dict) or set(raw) != {
-            "corpus",
-            "relative_path",
-            "link_name",
-        }:
+        if not isinstance(raw, dict):
             raise ValueError("invalid retired mapping evidence")
         corpus = raw.get("corpus")
         relative_path = raw.get("relative_path")
         link_name = raw.get("link_name")
+        if corpus == "center":
+            if set(raw) != {
+                "corpus",
+                "skill_uuid",
+                "sc_version_number",
+                "link_name",
+            }:
+                raise ValueError("invalid retired mapping evidence")
+            skill_uuid = raw.get("skill_uuid")
+            sc_version_number = raw.get("sc_version_number")
+            if not all(
+                isinstance(value, str) and value
+                for value in (skill_uuid, sc_version_number, link_name)
+            ):
+                raise ValueError("invalid retired mapping evidence")
+            mapping = PoolSkillMapping(
+                corpus="center",
+                relative_path=None,
+                link_name=link_name,
+                skill_uuid=skill_uuid,
+                sc_version_number=sc_version_number,
+            )
+            if link_name in targets and targets[link_name] != mapping:
+                raise ValueError("ambiguous retired mapping evidence")
+            targets[link_name] = mapping
+            if mapping not in parsed:
+                parsed.append(mapping)
+            continue
+        if set(raw) != {"corpus", "relative_path", "link_name"}:
+            raise ValueError("invalid retired mapping evidence")
         if (
             corpus not in {"local", "repo"}
             or not isinstance(relative_path, str)

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -9,6 +9,22 @@ from agentclaw.community.core.skills_pool.models import (
     RegisteredSkillAsset,
 )
 
+MAPPING_CONTRACT_V2 = "skills-pool-mapping-v2"
+MAPPING_CONTRACT_V3 = "skills-pool-mapping-v3"
+
+
+def mapping_contract_for(
+    mappings: list[PoolSkillMapping],
+    supported_versions: object,
+) -> str:
+    """Select the newest contract required by a complete mapping snapshot."""
+
+    if not any(mapping.corpus == "center" for mapping in mappings):
+        return MAPPING_CONTRACT_V2
+    if not isinstance(supported_versions, list) or MAPPING_CONTRACT_V3 not in supported_versions:
+        raise ValueError("runtime does not explicitly support mapping v3")
+    return MAPPING_CONTRACT_V3
+
 
 def _source_tail(git_path: str, prefix: str) -> PurePosixPath:
     raw = git_path[len(prefix) :]
@@ -43,10 +59,19 @@ def build_logical_skill_mappings(
         elif asset.git_path.startswith("git://"):
             relative = _source_tail(asset.git_path, "git://")
             corpus = "repo"
+        elif asset.git_path.startswith("center://"):
+            if not asset.skill_uuid or not asset.sc_version_number:
+                raise ValueError("center mapping requires structured identity")
+            relative = None
+            corpus = "center"
         else:
             continue
-        link_name = relative.name
-        identity = f"{corpus}:{relative.as_posix()}"
+        link_name = asset.name if corpus == "center" else relative.name
+        identity = (
+            f"center:{asset.skill_uuid}:{asset.sc_version_number}"
+            if corpus == "center"
+            else f"{corpus}:{relative.as_posix()}"
+        )
         if targets.get(link_name) == identity:
             continue
         if link_name in targets:
@@ -55,8 +80,10 @@ def build_logical_skill_mappings(
         mappings.append(
             PoolSkillMapping(
                 corpus=corpus,
-                relative_path=relative.as_posix(),
+                relative_path=None if relative is None else relative.as_posix(),
                 link_name=link_name,
+                skill_uuid=asset.skill_uuid if corpus == "center" else None,
+                sc_version_number=(asset.sc_version_number if corpus == "center" else None),
             )
         )
     return mappings
@@ -178,6 +205,7 @@ __all__ = [
     "logical_skill_mappings_from_evidence",
     "local_locators_from_evidence",
     "local_skill_name",
+    "mapping_contract_for",
     "merge_retired_logical_skill_mappings",
     "retired_logical_skill_mappings",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -33,6 +33,8 @@ class RegisteredSkillAsset:
     skill_id: int
     name: str
     git_path: str
+    skill_uuid: str | None = None
+    sc_version_number: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,15 +42,27 @@ class PoolSkillMapping:
     """Backend-owned logical intent; Engine resolves filesystem paths."""
 
     corpus: str
-    relative_path: str
+    relative_path: str | None
     link_name: str
+    skill_uuid: str | None = None
+    sc_version_number: str | None = None
 
     def to_dict(self) -> dict[str, str]:
-        return {
+        result = {
             "corpus": self.corpus,
-            "relative_path": self.relative_path,
             "link_name": self.link_name,
         }
+        if self.corpus == "center":
+            if self.skill_uuid is None or self.sc_version_number is None:
+                raise ValueError("center mapping requires structured identity")
+            return {
+                **result,
+                "skill_uuid": self.skill_uuid,
+                "sc_version_number": self.sc_version_number,
+            }
+        if self.relative_path is None:
+            raise ValueError("mapping requires relative_path")
+        return {**result, "relative_path": self.relative_path}
 
 
 class SkillMappingSourceLayout(StrEnum):

--- a/src/backend/src/agentclaw/community/core/skills_pool/ports.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/ports.py
@@ -38,6 +38,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         preparation_id: str,
         registered_local_names: list[str],
         mappings: list[PoolSkillMapping],
+        mapping_contract_version: str = "skills-pool-mapping-v2",
     ) -> PoolCutoverResult: ...
 
     async def rollback_to_legacy(
@@ -66,6 +67,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         mappings: list[PoolSkillMapping],
         retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
+        mapping_contract_version: str = "skills-pool-mapping-v2",
     ) -> bool: ...
 
     async def verify_mappings(
@@ -76,6 +78,7 @@ class SkillsPoolRuntimeProtocol(Protocol):
         mappings: list[PoolSkillMapping],
         retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
+        mapping_contract_version: str = "skills-pool-mapping-v2",
     ) -> bool: ...
 
 

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_models.py
@@ -1,0 +1,37 @@
+"""Stable result types returned by Skills Pool reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class SkillsPoolReconcileOutcome(StrEnum):
+    POOL_ACTIVE = "pool_active"
+    ALREADY_ACTIVE = "already_active"
+    NOT_CLAIMED = "not_claimed"
+    LEASE_NOT_HELD = "lease_not_held"
+    BOT_NOT_FOUND = "bot_not_found"
+    BOT_CHANGED = "bot_changed"
+    NOT_CAPABLE = "not_capable"
+    TRANSIENT_ERROR = "transient_error"
+    INVALID = "invalid"
+    STATE_RACE_LOST = "state_race_lost"
+    DATA_INCONSISTENT = "data_inconsistent"
+    ACTIVE_ENTRY_CONFLICT = "active_entry_conflict"
+    CUTOVER_FAILED = "cutover_failed"
+    MAPPING_FAILED = "mapping_failed"
+    MAPPING_VERIFY_FAILED = "mapping_verify_failed"
+    DATABASE_COMMIT_FAILED = "database_commit_failed"
+    MANUAL_REPAIR_REQUIRED = "manual_repair_required"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillsPoolReconcileResult:
+    outcome: SkillsPoolReconcileOutcome
+    preparation_id: str | None = None
+    evidence: dict[str, object] | None = None
+    retryable: bool | None = None
+
+
+__all__ = ["SkillsPoolReconcileOutcome", "SkillsPoolReconcileResult"]

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import StrEnum
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -49,39 +47,15 @@ from agentclaw.community.core.skills_pool.types import (
     SkillLayoutPhase,
 )
 from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
+from agentclaw.community.core.skills_pool.reconcile_models import (
+    SkillsPoolReconcileOutcome,
+    SkillsPoolReconcileResult,
+)
 from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
 from agentclaw.community.log import get_logger
 
 
 logger = get_logger()
-
-
-class SkillsPoolReconcileOutcome(StrEnum):
-    POOL_ACTIVE = "pool_active"
-    ALREADY_ACTIVE = "already_active"
-    NOT_CLAIMED = "not_claimed"
-    LEASE_NOT_HELD = "lease_not_held"
-    BOT_NOT_FOUND = "bot_not_found"
-    BOT_CHANGED = "bot_changed"
-    NOT_CAPABLE = "not_capable"
-    TRANSIENT_ERROR = "transient_error"
-    INVALID = "invalid"
-    STATE_RACE_LOST = "state_race_lost"
-    DATA_INCONSISTENT = "data_inconsistent"
-    ACTIVE_ENTRY_CONFLICT = "active_entry_conflict"
-    CUTOVER_FAILED = "cutover_failed"
-    MAPPING_FAILED = "mapping_failed"
-    MAPPING_VERIFY_FAILED = "mapping_verify_failed"
-    DATABASE_COMMIT_FAILED = "database_commit_failed"
-    MANUAL_REPAIR_REQUIRED = "manual_repair_required"
-
-
-@dataclass(frozen=True, slots=True)
-class SkillsPoolReconcileResult:
-    outcome: SkillsPoolReconcileOutcome
-    preparation_id: str | None = None
-    evidence: dict[str, object] | None = None
-    retryable: bool | None = None
 
 
 class SkillsPoolReconcileService:

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -29,6 +29,7 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
     logical_skill_mappings_from_evidence,
     local_locators_from_evidence,
     local_skill_name,
+    mapping_contract_for,
 )
 from agentclaw.community.core.skills_pool.mapping_convergence import (
     MappingConvergenceStatus,
@@ -340,6 +341,10 @@ class SkillsPoolReconcileService:
         try:
             local_names = [local_skill_name(asset) for asset in local_assets]
             mappings = build_logical_skill_mappings(active_assets)
+            mapping_contract_version = mapping_contract_for(
+                mappings,
+                probe.evidence.get("supported_mapping_contract_versions"),
+            )
             durable_retired_mappings = logical_skill_mappings_from_evidence(
                 state.last_failure_evidence
             )
@@ -420,6 +425,7 @@ class SkillsPoolReconcileService:
                 preparation_id=probe.preparation_id,
                 registered_local_names=local_names,
                 mappings=mappings,
+                mapping_contract_version=mapping_contract_version,
             )
             if not cutover.committed:
                 evidence = cutover.to_dict()
@@ -652,6 +658,7 @@ class SkillsPoolReconcileService:
             engine=engine,
             cutover_mappings=mappings,
             durable_retired_mappings=durable_retired_mappings,
+            mapping_contract_version=mapping_contract_version,
         )
         if convergence.status is MappingConvergenceStatus.LEASE_NOT_HELD:
             return SkillsPoolReconcileResult(
@@ -859,6 +866,10 @@ class SkillsPoolReconcileService:
                         engine=engine,
                     )
                 )
+                mapping_contract_version = mapping_contract_for(
+                    mappings,
+                    probe.evidence.get("supported_mapping_contract_versions"),
+                )
             except ValueError as error:
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.INVALID,
@@ -870,6 +881,7 @@ class SkillsPoolReconcileService:
                 user_id=str(owner_id),
                 mappings=mappings,
                 retired_mappings=[],
+                mapping_contract_version=mapping_contract_version,
             ):
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.MAPPING_FAILED,
@@ -881,6 +893,7 @@ class SkillsPoolReconcileService:
                 user_id=str(owner_id),
                 mappings=mappings,
                 retired_mappings=[],
+                mapping_contract_version=mapping_contract_version,
             ):
                 return SkillsPoolReconcileResult(
                     SkillsPoolReconcileOutcome.MAPPING_VERIFY_FAILED,

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -23,6 +23,7 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
     local_locators_from_evidence,
     local_skill_name,
+    mapping_contract_for,
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
@@ -370,6 +371,10 @@ class SkillsPoolRollbackService:
         try:
             local_names = [local_skill_name(asset) for asset in local_assets]
             mappings = build_logical_skill_mappings(active_assets)
+            mapping_contract_version = mapping_contract_for(
+                mappings,
+                probe.evidence.get("supported_mapping_contract_versions"),
+            )
         except ValueError as error:
             return self._failure(
                 scope=scope,
@@ -428,6 +433,7 @@ class SkillsPoolRollbackService:
             scope=scope,
             user_id=user_id,
             mappings=mappings,
+            mapping_contract_version=mapping_contract_version,
             rollback_generation=rollback_generation,
             lease_owner=lease_owner,
         )
@@ -475,6 +481,7 @@ class SkillsPoolRollbackService:
         scope: BotSkillLayoutScope,
         user_id: str,
         mappings: list[PoolSkillMapping],
+        mapping_contract_version: str,
         rollback_generation: str,
         lease_owner: str,
     ) -> SkillsPoolRollbackResult | None:
@@ -484,6 +491,7 @@ class SkillsPoolRollbackService:
             mappings=mappings,
             retired_mappings=[],
             source_layout=SkillMappingSourceLayout.LEGACY,
+            mapping_contract_version=mapping_contract_version,
         ):
             return self._failure(
                 scope=scope,
@@ -501,6 +509,7 @@ class SkillsPoolRollbackService:
             mappings=mappings,
             retired_mappings=[],
             source_layout=SkillMappingSourceLayout.LEGACY,
+            mapping_contract_version=mapping_contract_version,
         ):
             return self._failure(
                 scope=scope,

--- a/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
@@ -78,7 +78,7 @@ class SkillsPoolRuntime:
         ):
             return PoolCutoverResult(
                 committed=False,
-                status=PoolCutoverStatus.INVALID,
+                status=PoolCutoverStatus.TRANSIENT_ERROR,
                 evidence={"reason": "center_ensure_failed_before_mapping_publish"},
             )
         try:

--- a/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
@@ -13,6 +13,7 @@ from agentclaw.community.core.devices.services.device_context_resolver import (
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CurrentRuntimeLayoutProbeService,
     MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -67,7 +68,19 @@ class SkillsPoolRuntime:
         preparation_id: str,
         registered_local_names: list[str],
         mappings: list[PoolSkillMapping],
+        mapping_contract_version: str = MAPPING_CONTRACT_VERSION,
     ) -> PoolCutoverResult:
+        if not await self._ensure_center_mappings(
+            bot_id=bot_id,
+            user_id=user_id,
+            mappings=mappings,
+            mapping_contract_version=mapping_contract_version,
+        ):
+            return PoolCutoverResult(
+                committed=False,
+                status=PoolCutoverStatus.INVALID,
+                evidence={"reason": "center_ensure_failed_before_mapping_publish"},
+            )
         try:
             response = await self._invoke(
                 bot_id=bot_id,
@@ -77,7 +90,7 @@ class SkillsPoolRuntime:
                     "migration_generation": migration_generation,
                     "preparation_id": preparation_id,
                     "registered_local_names": registered_local_names,
-                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+                    "mapping_contract_version": mapping_contract_version,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                 },
             )
@@ -131,14 +144,22 @@ class SkillsPoolRuntime:
         mappings: list[PoolSkillMapping],
         retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
+        mapping_contract_version: str = MAPPING_CONTRACT_VERSION,
     ) -> bool:
+        if not await self._ensure_center_mappings(
+            bot_id=bot_id,
+            user_id=user_id,
+            mappings=mappings,
+            mapping_contract_version=mapping_contract_version,
+        ):
+            return False
         try:
             response = await self._invoke(
                 bot_id=bot_id,
                 user_id=user_id,
                 path="/api/skills/layout/mappings/publish",
                 body={
-                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+                    "mapping_contract_version": mapping_contract_version,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                     "retired_mappings": [
                         mapping.to_dict() for mapping in retired_mappings
@@ -275,6 +296,7 @@ class SkillsPoolRuntime:
         mappings: list[PoolSkillMapping],
         retired_mappings: Sequence[PoolSkillMapping] = (),
         source_layout: SkillMappingSourceLayout = SkillMappingSourceLayout.POOL,
+        mapping_contract_version: str = MAPPING_CONTRACT_VERSION,
     ) -> bool:
         try:
             response = await self._invoke(
@@ -282,7 +304,7 @@ class SkillsPoolRuntime:
                 user_id=user_id,
                 path="/api/skills/layout/mappings/verify",
                 body={
-                    "mapping_contract_version": MAPPING_CONTRACT_VERSION,
+                    "mapping_contract_version": mapping_contract_version,
                     "mappings": [mapping.to_dict() for mapping in mappings],
                     "retired_mappings": [
                         mapping.to_dict() for mapping in retired_mappings
@@ -301,6 +323,46 @@ class SkillsPoolRuntime:
             response.get("success") is True
             and isinstance(data, dict)
             and data.get("valid") is True
+        )
+
+    async def _ensure_center_mappings(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        mappings: Sequence[PoolSkillMapping],
+        mapping_contract_version: str,
+    ) -> bool:
+        center = [mapping for mapping in mappings if mapping.corpus == "center"]
+        if not center:
+            return True
+        if mapping_contract_version != MAPPING_V3_CONTRACT_VERSION:
+            logger.error("[skills_pool.runtime] center mapping requires v3")
+            return False
+        items = [
+            {"skill_uuid": mapping.skill_uuid, "version": mapping.sc_version_number}
+            for mapping in center
+            if mapping.skill_uuid and mapping.sc_version_number
+        ]
+        if len(items) != len(center):
+            return False
+        try:
+            response = await self._invoke(
+                bot_id=bot_id,
+                user_id=user_id,
+                path="/api/skills/center/ensure",
+                body={"items": items},
+            )
+        except Exception:
+            logger.exception("[skills_pool.runtime] center ensure failed bot_id=%s", bot_id)
+            return False
+        data = response.get("data")
+        return (
+            response.get("success") is True
+            and isinstance(data, dict)
+            and data.get("failed") == []
+            and isinstance(data.get("ok"), list)
+            and len(data["ok"]) == len(items)
         )
 
     async def _invoke(

--- a/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
+++ b/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
@@ -3,6 +3,7 @@ import pytest
 from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
     local_locators_from_evidence,
+    mapping_contract_for,
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 
@@ -35,6 +36,64 @@ def test_builds_logical_intent_without_engine_paths() -> None:
             "link_name": "reviewer",
         },
     ]
+
+
+def test_builds_structured_center_intent_without_runtime_paths() -> None:
+    mappings = build_logical_skill_mappings(
+        [
+            RegisteredSkillAsset(
+                skill_id=3,
+                name="risk-review",
+                git_path="center://2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                sc_version_number="2026.8.19",
+            )
+        ]
+    )
+
+    assert [mapping.to_dict() for mapping in mappings] == [
+        {
+            "corpus": "center",
+            "skill_uuid": "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+            "sc_version_number": "2026.8.19",
+            "link_name": "risk-review",
+        }
+    ]
+
+
+def test_rejects_center_mapping_without_structured_exact_version() -> None:
+    with pytest.raises(ValueError, match="structured identity"):
+        build_logical_skill_mappings(
+            [
+                RegisteredSkillAsset(
+                    skill_id=3,
+                    name="risk-review",
+                    git_path="center://2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                )
+            ]
+        )
+
+
+def test_center_mapping_requires_explicit_runtime_v3_capability() -> None:
+    mappings = build_logical_skill_mappings(
+        [
+            RegisteredSkillAsset(
+                skill_id=3,
+                name="risk-review",
+                git_path="center://2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                sc_version_number="2026.8.19",
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="explicitly support mapping v3"):
+        mapping_contract_for(mappings, ["skills-pool-mapping-v2"])
+
+    assert mapping_contract_for(
+        mappings,
+        ["skills-pool-mapping-v2", "skills-pool-mapping-v3"],
+    ) == "skills-pool-mapping-v3"
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
+++ b/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
@@ -2,10 +2,14 @@ import pytest
 
 from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
+    logical_skill_mappings_from_evidence,
     local_locators_from_evidence,
     mapping_contract_for,
 )
-from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
 
 
 def test_builds_logical_intent_without_engine_paths() -> None:
@@ -94,6 +98,29 @@ def test_center_mapping_requires_explicit_runtime_v3_capability() -> None:
         mappings,
         ["skills-pool-mapping-v2", "skills-pool-mapping-v3"],
     ) == "skills-pool-mapping-v3"
+
+
+def test_restores_structured_center_retirement_for_retry() -> None:
+    assert logical_skill_mappings_from_evidence(
+        {
+            "retired_mappings": [
+                {
+                    "corpus": "center",
+                    "skill_uuid": "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                    "sc_version_number": "2026.8.19",
+                    "link_name": "risk-review",
+                }
+            ]
+        }
+    ) == [
+        PoolSkillMapping(
+            corpus="center",
+            relative_path=None,
+            link_name="risk-review",
+            skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+            sc_version_number="2026.8.19",
+        )
+    ]
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -12,6 +12,9 @@ from agentclaw.community.core.skills_pool.models import (
 )
 from agentclaw.community.core.skills_pool.quarantine import RuntimeQuarantineCleanupStatus
 from agentclaw.community.core.skills_pool.runtime import OpenClawSkillsPoolRuntime
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    MAPPING_V3_CONTRACT_VERSION,
+)
 
 
 class FakeResolver:
@@ -62,6 +65,16 @@ class FakeTransport:
 class FakeProbe:
     async def probe_bot(self, **kwargs):
         return kwargs
+
+
+class CenterEnsureTransport(FakeTransport):
+    async def invoke(self, conn_info, method, path, *, body, timeout):
+        if path.endswith("/center/ensure"):
+            self.calls.append(
+                {"conn_info": conn_info, "method": method, "path": path, "body": body, "timeout": timeout}
+            )
+            return {"success": True, "data": {"ok": body["items"], "failed": []}}
+        return await super().invoke(conn_info, method, path, body=body, timeout=timeout)
 
 
 class FutureStatusTransport(FakeTransport):
@@ -223,6 +236,34 @@ async def test_pool_runtime_returns_typed_quarantine_cleanup_result() -> None:
 
     assert result.status is RuntimeQuarantineCleanupStatus.CLEANED
     assert result.evidence == {"generation_scoped": True}
+
+
+@pytest.mark.asyncio
+async def test_center_mapping_is_ensured_before_full_v3_publish() -> None:
+    transport = CenterEnsureTransport()
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=FakeResolver(),
+        adapter_transport=transport,
+        probe_service=FakeProbe(),
+    )
+    mapping = PoolSkillMapping(
+        corpus="center",
+        relative_path=None,
+        link_name="risk-review",
+        skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+        sc_version_number="2026.8.19",
+    )
+
+    assert await runtime.publish_mappings(
+        bot_id="bot-1",
+        user_id="owner-1",
+        mappings=[mapping],
+        mapping_contract_version=MAPPING_V3_CONTRACT_VERSION,
+    )
+    assert [call["path"] for call in transport.calls] == [
+        "/api/skills/center/ensure",
+        "/api/skills/layout/mappings/publish",
+    ]
 
 
 @pytest.mark.asyncio

--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -1075,8 +1075,8 @@ class SkillExecutionResult:
 
 ### 7.3 Skills Pool mapping wire contract
 
-`SkillsService` 的 Pool activation、publish、verify 使用显式版本协商。当前
-新契约版本为 `skills-pool-mapping-v2`：
+`SkillsService` 的 Pool activation、publish、verify 使用显式版本协商。v2 保留
+给仅含 Local/Repo 的 mapping；v3 在同一完整 mapping 集合加入 Center 时使用：
 
 ```json
 {
@@ -1103,9 +1103,14 @@ class SkillExecutionResult:
 }
 ```
 
-- `corpus` 只允许 `local` 或 `repo`；`relative_path` 必须是规范化的相对
+- v2 的 `corpus` 只允许 `local` 或 `repo`；`relative_path` 必须是规范化的相对
   POSIX 路径；`link_name` 必须是单个规范化路径段。绝对路径、路径逃逸、
   重复 target、未知 corpus 和额外/混合字段全部 fail closed。
+- v3 仍可包含上述 v2 Local/Repo item，并额外允许严格的 Center item：
+  `{"corpus":"center","skill_uuid":"<UUIDv4>","sc_version_number":"<exact>","link_name":"<name>"}`。
+  Center item 不得携带 `relative_path`、裸物理 source/target 或 `current/latest`。
+  Runtime 唯一将其解析为 canonical `skills-pool/skill-center/<skill_uuid>/<sc_version_number>`；
+  `source_layout=legacy|pool` 只影响 Local/Repo，不能搬迁、删除或改写 Center。
 - Backend 不发送 engine-specific source/target。Engine 的
   `layout_planner.py` 使用当前 engine、layout state、repo delivery 与本地
   home 投影物理 source/active target；publish/verify 返回
@@ -1123,9 +1128,12 @@ class SkillExecutionResult:
   的 active layout 以及仍为 `finalizing` 的恢复窗口不适用或尚未完成该
   检查，必须省略此 key，不能用 `false` 或未经校验的 `true` 代替；
   preparation/Legacy evidence 仍按各 Engine 拓扑报告其必需 bridge 检查。
-- 新 Backend 只有在 `/api/skills/layout/probe` 的 READY evidence 明确包含
-  `"mapping_contract_version": "skills-pool-mapping-v2"` 后，才会在已通过
-  rollout gate 且 migration claim 成功的 reconcile 中发送 v2。缺失或旧
+- Probe 保留 `"mapping_contract_version": "skills-pool-mapping-v2"` 供旧 Backend
+  识别，并在新 Runtime 增加 `supported_mapping_contract_versions:[v2,v3]`。新 Backend
+  只有在 Center mapping 所需的 v3 出现在该数组时才发送 v3；否则失败关闭，绝不忽略
+  Center 或降级为物理路径。无 Center 的完整集合继续发送 v2。Backend 在 publish/cutover
+  前对 Center 精确版本执行 ensure；任一 ensure 失败则不发布任何部分 mapping，返回可重试失败。
+  所有请求仍须在已通过 rollout gate 且 migration claim 成功的 reconcile 中发送。缺失或旧
   capability 归类为 `NOT_CAPABLE`，保持 Legacy；probe 本身不能触发
   claim/cutover。已处于 Pool 的 Bot 发起显式 rollback 时也会重新 probe
   当前 binding；若 runtime 已降级或缺少 capability，则 Backend 在首个 v2
@@ -1142,7 +1150,7 @@ class SkillExecutionResult:
   `SkillsPoolReconcileService`、Engine `/api/skills` router 与
   `SkillsService`，以及 OpenClaw、Claude Code、AICoding、Hermes 的
   filesystem composition roots。OpenClaw/Claude Code 内置 consumer
-  直接广告 v2；AICoding/Hermes 由具体 composition root 在接入同一 resolver
+  直接广告 v2+v3；AICoding/Hermes 由具体 composition root 在接入同一 resolver
   后显式广告。旧 composition root 不广告，混部期间保持
   `NOT_CAPABLE`/Legacy。四个 consumer 使用相同 contract tests；Teclaw
   保持 artifact delivery，不消费文件系统 mapping。

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import logging
 
+from fastapi import APIRouter, HTTPException
+
 from engine.community.api.caps import check_capability
 from engine.community.api.response import ApiResponse
 from engine.community.api.skills.schemas import (
@@ -26,6 +28,9 @@ from engine.community.api.skills.schemas import (
     RuntimeLayoutProbeRequest,
     RuntimeLayoutProbeResponse,
     SyncSymlinkRequest,
+)
+from engine.community.api.skills.schemas import (
+    PoolCenterMappingIntent as PoolCenterMappingIntentSchema,
 )
 from engine.community.api.skills.schemas import (
     PoolPhysicalMapping as PoolPhysicalMappingSchema,
@@ -66,7 +71,6 @@ from engine.community.core.skills.models import (
 from engine.community.core.skills.models import (
     PoolQuarantineCleanupRequest as PoolQuarantineCleanupCommand,
 )
-from fastapi import APIRouter, HTTPException
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 log = logging.getLogger("api-skills")
@@ -79,8 +83,16 @@ def _skills_plugin():
 
 
 def _mapping_command(
-    item: PoolSkillMappingIntentSchema | PoolPhysicalMappingSchema,
+    item: PoolSkillMappingIntentSchema | PoolCenterMappingIntentSchema | PoolPhysicalMappingSchema,
 ) -> PoolSkillMappingIntent | SymlinkItem:
+    if isinstance(item, PoolCenterMappingIntentSchema):
+        return PoolSkillMappingIntent(
+            corpus=item.corpus,
+            relative_path=None,
+            link_name=item.link_name,
+            skill_uuid=item.skill_uuid,
+            sc_version_number=item.sc_version_number,
+        )
     if isinstance(item, PoolSkillMappingIntentSchema):
         return PoolSkillMappingIntent(
             corpus=item.corpus,

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -33,6 +33,17 @@ class PoolSkillMappingIntent(BaseModel):
     link_name: str
 
 
+class PoolCenterMappingIntent(BaseModel):
+    """Mapping-v3 Center identity; Runtime owns its physical projection."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    corpus: Literal["center"]
+    skill_uuid: str
+    sc_version_number: str
+    link_name: str
+
+
 class SyncSymlinkRequest(BaseModel):
     symlinks: list[SymlinkItem] | None = None
 
@@ -93,7 +104,9 @@ class PoolLayoutActivateRequest(BaseModel):
     preparation_id: str
     registered_local_names: list[str]
     mapping_contract_version: str | None = None
-    mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping]
+    mappings: list[
+        PoolSkillMappingIntent | PoolCenterMappingIntent | PoolPhysicalMapping
+    ]
 
 
 class PoolLayoutRollbackRequest(BaseModel):
@@ -127,8 +140,12 @@ class PoolLayoutActivateApiResponse(ApiResponse):
 
 class PoolMappingVerifyRequest(BaseModel):
     mapping_contract_version: str | None = None
-    mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping]
-    retired_mappings: list[PoolSkillMappingIntent | PoolPhysicalMapping] = Field(
+    mappings: list[
+        PoolSkillMappingIntent | PoolCenterMappingIntent | PoolPhysicalMapping
+    ]
+    retired_mappings: list[
+        PoolSkillMappingIntent | PoolCenterMappingIntent | PoolPhysicalMapping
+    ] = Field(
         default_factory=list
     )
     source_layout: Literal["pool", "legacy"] = "pool"
@@ -142,6 +159,7 @@ __all__ = [
     "CenterEnsureRequestSchema",
     "CenterEnsureResponseSchema",
     "CleanSymlinkRequest",
+    "PoolCenterMappingIntent",
     "PoolLayoutActivateApiResponse",
     "PoolLayoutActivateRequest",
     "PoolLayoutActivateResponse",

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from engine.community.api.skills.router import router as skills_router
+from engine.community.api.skills.router import (
+    _mapping_command,
+)
+from engine.community.api.skills.router import (
+    router as skills_router,
+)
+from engine.community.api.skills.schemas import PoolCenterMappingIntent
 from engine.community.core.adapters.openclaw.skills import (
     OpenClawSkillsAdapter,
 )
@@ -297,7 +303,21 @@ def test_runtime_layout_probe_rejects_unknown_engine_before_dispatch(
             "error_type": "SkillLayoutResolutionError",
         },
     }
-    plugin.probe_pool_layout.assert_not_awaited()
+
+
+def test_mapping_command_preserves_structured_center_identity() -> None:
+    command = _mapping_command(
+        PoolCenterMappingIntent(
+            corpus="center",
+            skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+            sc_version_number="2026.8.19",
+            link_name="risk-review",
+        )
+    )
+
+    assert command.corpus == "center"
+    assert command.relative_path is None
+    assert command.skill_uuid == "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
 
 
 def test_runtime_layout_probe_rejects_unknown_contract_before_dispatch(

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -75,6 +75,17 @@ def _serialize_pool_mapping(
     item: PoolSkillMappingIntent | SymlinkItem,
 ) -> dict[str, str]:
     if isinstance(item, PoolSkillMappingIntent):
+        if item.corpus == "center":
+            if item.skill_uuid is None or item.sc_version_number is None:
+                raise ValueError("center mapping requires structured identity")
+            return {
+                "corpus": "center",
+                "skill_uuid": item.skill_uuid,
+                "sc_version_number": item.sc_version_number,
+                "link_name": item.link_name,
+            }
+        if item.relative_path is None:
+            raise ValueError("logical mapping requires relative_path")
         return {
             "corpus": item.corpus,
             "relative_path": item.relative_path,

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -64,6 +64,17 @@ def _serialize_pool_mapping(
     item: PoolSkillMappingIntent | SymlinkItem,
 ) -> dict[str, str]:
     if isinstance(item, PoolSkillMappingIntent):
+        if item.corpus == "center":
+            if item.skill_uuid is None or item.sc_version_number is None:
+                raise ValueError("center mapping requires structured identity")
+            return {
+                "corpus": "center",
+                "skill_uuid": item.skill_uuid,
+                "sc_version_number": item.sc_version_number,
+                "link_name": item.link_name,
+            }
+        if item.relative_path is None:
+            raise ValueError("logical mapping requires relative_path")
         return {
             "corpus": item.corpus,
             "relative_path": item.relative_path,

--- a/src/engine/src/engine/community/core/skills/layout_planner.py
+++ b/src/engine/src/engine/community/core/skills/layout_planner.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path, PurePosixPath
+from uuid import UUID
 
 LAYOUT_CONTRACT_VERSION = "skills-pool-p3-v1"
 MAPPING_CONTRACT_VERSION = "skills-pool-mapping-v2"
+MAPPING_V3_CONTRACT_VERSION = "skills-pool-mapping-v3"
 
 
 class SkillLayoutCapability(StrEnum):
@@ -26,6 +28,7 @@ class SkillCorpus(StrEnum):
 
     LOCAL = "local"
     REPO = "repo"
+    CENTER = "center"
 
 
 class SkillLayoutResolutionError(ValueError):
@@ -56,8 +59,10 @@ class LogicalSkillMapping:
     """Engine-independent declaration of one active Skill."""
 
     corpus: SkillCorpus
-    relative_path: str
+    relative_path: str | None
     link_name: str
+    skill_uuid: str | None = None
+    sc_version_number: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,6 +107,7 @@ class _FilesystemTemplate:
             pool_root=pool_root,
             pool_local=pool_root / "skills-local",
             pool_repo=pool_root / "skills-repo",
+            pool_center=pool_root / "skill-center",
             ready_marker=pool_root / ".pool-ready",
             active_marker=pool_root / ".pool-active",
             local_bridge=path(self.local_bridge),
@@ -160,6 +166,7 @@ class ResolvedFilesystemLayoutPlan:
     pool_root: Path
     pool_local: Path
     pool_repo: Path
+    pool_center: Path
     ready_marker: Path
     active_marker: Path
     local_bridge: Path
@@ -228,6 +235,7 @@ def resolve_skill_mappings(
     active_root: Path,
     local_root: Path,
     repo_root: Path,
+    center_root: Path | None = None,
     mappings: list[LogicalSkillMapping],
 ) -> list[ResolvedSkillMapping]:
     """Resolve mappings from roots selected by the operation's protocol."""
@@ -235,17 +243,35 @@ def resolve_skill_mappings(
     resolved: list[ResolvedSkillMapping] = []
     seen_targets: set[Path] = set()
     for mapping in mappings:
-        relative_path = _normalize_relative_path(
-            mapping.relative_path,
-            field="relative_path",
-        )
         link_name = _normalize_link_name(mapping.link_name)
         if mapping.corpus is SkillCorpus.LOCAL:
+            if mapping.relative_path is None:
+                raise SkillLayoutResolutionError("local mapping requires relative_path")
+            relative_path = _normalize_relative_path(mapping.relative_path, field="relative_path")
             source_root = local_root
             locator_scheme = "local"
         elif mapping.corpus is SkillCorpus.REPO:
+            if mapping.relative_path is None:
+                raise SkillLayoutResolutionError("repo mapping requires relative_path")
+            relative_path = _normalize_relative_path(mapping.relative_path, field="relative_path")
             source_root = repo_root
             locator_scheme = "git"
+        elif mapping.corpus is SkillCorpus.CENTER:
+            if center_root is None:
+                raise SkillLayoutResolutionError("center mapping requires pool_center")
+            if mapping.relative_path is not None:
+                raise SkillLayoutResolutionError("center mapping must not carry relative_path")
+            skill_uuid = _normalize_link_name(mapping.skill_uuid or "")
+            sc_version_number = _normalize_link_name(mapping.sc_version_number or "")
+            try:
+                parsed_uuid = UUID(skill_uuid)
+            except ValueError as error:
+                raise SkillLayoutResolutionError("skill_uuid must be a UUID") from error
+            if parsed_uuid.version != 4:
+                raise SkillLayoutResolutionError("skill_uuid must be UUIDv4")
+            relative_path = f"{skill_uuid}/{sc_version_number}"
+            source_root = center_root
+            locator_scheme = "center"
         else:
             raise SkillLayoutResolutionError(
                 f"unknown Skill corpus: {mapping.corpus!r}"
@@ -258,11 +284,7 @@ def resolve_skill_mappings(
                 f"duplicate active Skill target: {link_name}"
             )
         seen_targets.add(target)
-        locator_value = (
-            str(source)
-            if mapping.corpus is SkillCorpus.LOCAL
-            else relative_path
-        )
+        locator_value = str(source) if mapping.corpus is SkillCorpus.LOCAL else relative_path
         resolved.append(
             ResolvedSkillMapping(
                 corpus=mapping.corpus,
@@ -413,6 +435,7 @@ __all__ = [
     "DESCRIPTORS",
     "LAYOUT_CONTRACT_VERSION",
     "MAPPING_CONTRACT_VERSION",
+    "MAPPING_V3_CONTRACT_VERSION",
     "EngineSkillLayoutDescriptor",
     "LayoutIdentity",
     "LogicalSkillMapping",

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -100,8 +100,10 @@ class PoolSkillMappingIntent:
     """Path-agnostic mapping resolved by the active Engine implementation."""
 
     corpus: str
-    relative_path: str
+    relative_path: str | None
     link_name: str
+    skill_uuid: str | None = None
+    sc_version_number: str | None = None
 
 
 @dataclass

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -56,7 +56,7 @@ class _SkillsPortMixin:
     _SKILLS_CENTER_LOCAL_ROOT_ENV = "SKILLS_CENTER_LOCAL_ROOT"
     _DEFAULT_SKILLS_CENTER_NAS_ROOT = "/home/admin/nfs/skills-center"
     _DEFAULT_SKILLS_CENTER_LOCAL_ROOT = str(
-        workspace_root() / "skills" / "skills-center"
+        workspace_root() / "skills-pool" / "skill-center"
     )
 
     @staticmethod
@@ -319,14 +319,12 @@ class _SkillsPortMixin:
         local_version_dir = local_uuid_dir / version_dir_name
 
         if local_version_dir.exists() and any(local_version_dir.iterdir()):
-            self._skills_ensure_current_symlink(local_uuid_dir, version_dir_name)
             return
 
         lock_key = f"{skill_uuid}/{version_dir_name}"
         lock = self._get_ensure_lock(lock_key)
         async with lock:
             if local_version_dir.exists() and any(local_version_dir.iterdir()):
-                self._skills_ensure_current_symlink(local_uuid_dir, version_dir_name)
                 return
 
             nas_version_dir = nas_root / skill_uuid / version_dir_name
@@ -337,7 +335,6 @@ class _SkillsPortMixin:
             await _asyncio.to_thread(
                 self._skills_rsync_dir, nas_version_dir, local_version_dir
             )
-            self._skills_ensure_current_symlink(local_uuid_dir, version_dir_name)
 
     async def ensure_center_skills(self, params: dict[str, Any]) -> dict[str, Any]:
         """Ensure each (skill_uuid, version) from ``params["items"]`` is present locally.

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -140,7 +140,8 @@ def mapping_sources_use_pool(
 
     layout = _Layout.for_engine(engine, Path(home))
     pool_roots = tuple(
-        Path(os.path.abspath(root)) for root in (layout.pool_local, layout.pool_repo)
+        Path(os.path.abspath(root))
+        for root in (layout.pool_local, layout.pool_repo, layout.pool_center)
     )
     legacy_roots = tuple(
         Path(os.path.abspath(root))
@@ -630,6 +631,7 @@ def _canonical_pool_source(layout: _Layout, source: Path) -> Path | None:
         (layout.legacy_repo, layout.pool_repo),
         (layout.repo_bridge, layout.pool_repo),
         (layout.pool_repo, layout.pool_repo),
+        (layout.pool_center, layout.pool_center),
     ):
         normalized_root = Path(os.path.abspath(root))
         if source.is_relative_to(normalized_root):
@@ -680,12 +682,12 @@ def _source_failure(
     if source_layout is MappingSourceLayout.LEGACY:
         return _managed_source_failure(
             source,
-            roots=(layout.legacy_local, layout.legacy_repo),
+        roots=(layout.legacy_local, layout.legacy_repo, layout.pool_center),
             outside_reason="source_outside_legacy",
         )
     return _managed_source_failure(
         source,
-        roots=(layout.pool_local, layout.pool_repo),
+        roots=(layout.pool_local, layout.pool_repo, layout.pool_center),
         outside_reason="source_outside_pool",
     )
 
@@ -934,9 +936,9 @@ def _mapping_source_outside_layout(
     source_layout: MappingSourceLayout,
 ) -> bool:
     roots = (
-        (layout.legacy_local, layout.legacy_repo)
+        (layout.legacy_local, layout.legacy_repo, layout.pool_center)
         if source_layout is MappingSourceLayout.LEGACY
-        else (layout.pool_local, layout.pool_repo)
+        else (layout.pool_local, layout.pool_repo, layout.pool_center)
     )
     normalized = Path(os.path.abspath(source))
     return not any(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -17,6 +17,7 @@ from engine.community.config import RepoDelivery, current_repo_delivery
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
     LayoutIdentity,
     RuntimeLayoutContext,
     resolve_filesystem_skill_layout,
@@ -77,6 +78,10 @@ def _ready_evidence(
         evidence.update(
             {
                 "mapping_contract_version": mapping_contract_version,
+                "supported_mapping_contract_versions": [
+                    MAPPING_CONTRACT_VERSION,
+                    MAPPING_V3_CONTRACT_VERSION,
+                ],
                 "resolved_layout": resolved_filesystem_layout_evidence(
                     layout,
                     local_root=layout.pool_local,

--- a/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/mapping_contract.py
@@ -12,6 +12,7 @@ from engine.community.core.skills.exceptions import (
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
     LayoutIdentity,
     LogicalSkillMapping,
     RuntimeLayoutContext,
@@ -27,6 +28,9 @@ from engine.community.plugins.skills_pool.layout_activation import (
 
 _LEGACY_PHYSICAL_FIELDS = frozenset({"source", "target"})
 _LOGICAL_V2_FIELDS = frozenset({"corpus", "relative_path", "link_name"})
+_LOGICAL_V3_CENTER_FIELDS = frozenset(
+    {"corpus", "skill_uuid", "sc_version_number", "link_name"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -87,29 +91,32 @@ def resolve_mapping_payload(
                 )
             physical.append(SkillMapping(source=source, target=target))
         return ResolvedMappingPayload(tuple(physical))
-    if mapping_contract_version != MAPPING_CONTRACT_VERSION:
+    if mapping_contract_version not in {
+        MAPPING_CONTRACT_VERSION,
+        MAPPING_V3_CONTRACT_VERSION,
+    }:
         raise InvalidPoolMappingRequestError(
             f"unsupported mapping contract: {mapping_contract_version}"
         )
 
     logical: list[LogicalSkillMapping] = []
     for raw_item in payload:
+        if not isinstance(raw_item, dict):
+            raise InvalidPoolMappingRequestError("each logical mapping must be an object")
+        fields = frozenset(raw_item)
+        is_center = fields == _LOGICAL_V3_CENTER_FIELDS
+        if is_center and mapping_contract_version != MAPPING_V3_CONTRACT_VERSION:
+            raise InvalidPoolMappingRequestError("v2 logical mapping must contain exactly corpus, link_name, relative_path")
         item = _require_mapping_fields(
             raw_item,
-            expected=_LOGICAL_V2_FIELDS,
+            expected=_LOGICAL_V3_CENTER_FIELDS if is_center else _LOGICAL_V2_FIELDS,
             contract_name="logical",
         )
         corpus = item["corpus"]
-        relative_path = item["relative_path"]
         link_name = item["link_name"]
-        if (
-            not isinstance(corpus, str)
-            or not isinstance(relative_path, str)
-            or not isinstance(link_name, str)
-        ):
+        if not isinstance(corpus, str) or not isinstance(link_name, str):
             raise InvalidPoolMappingRequestError(
-                "logical mapping corpus, relative_path and link_name "
-                "must be strings"
+                "logical mapping corpus and link_name must be strings"
             )
         try:
             resolved_corpus = SkillCorpus(corpus)
@@ -117,13 +124,38 @@ def resolve_mapping_payload(
             raise InvalidPoolMappingRequestError(
                 f"unknown Skill corpus: {corpus!r}"
             ) from error
-        logical.append(
-            LogicalSkillMapping(
+        if is_center:
+            skill_uuid = item["skill_uuid"]
+            sc_version_number = item["sc_version_number"]
+            if (
+                resolved_corpus is not SkillCorpus.CENTER
+                or not isinstance(skill_uuid, str)
+                or not isinstance(sc_version_number, str)
+            ):
+                raise InvalidPoolMappingRequestError(
+                    "center mapping requires structured skill_uuid and sc_version_number"
+                )
+            logical.append(LogicalSkillMapping(
                 corpus=resolved_corpus,
-                relative_path=relative_path,
+                relative_path=None,
                 link_name=link_name,
+                skill_uuid=skill_uuid,
+                sc_version_number=sc_version_number,
+            ))
+            continue
+        relative_path = item["relative_path"]
+        if (
+            resolved_corpus is SkillCorpus.CENTER
+            or not isinstance(relative_path, str)
+        ):
+            raise InvalidPoolMappingRequestError(
+                "logical mapping corpus, relative_path and link_name must be strings"
             )
-        )
+        logical.append(LogicalSkillMapping(
+            corpus=resolved_corpus,
+            relative_path=relative_path,
+            link_name=link_name,
+        ))
 
     plan = resolve_filesystem_skill_layout(
         LayoutIdentity(
@@ -151,6 +183,7 @@ def resolve_mapping_payload(
                 active_root=active_root,
                 local_root=local_root,
                 repo_root=repo_root,
+                center_root=plan.pool_center,
                 mappings=logical,
             )
         ]
@@ -163,12 +196,22 @@ def resolve_mapping_payload(
         ),
         resolved_locators=tuple(
             {
+                "corpus": "center",
+                "skill_uuid": logical[index % len(logical)].skill_uuid or "",
+                "sc_version_number": (
+                    logical[index % len(logical)].sc_version_number or ""
+                ),
+                "link_name": mapping.link_name,
+                "resolved_locator": mapping.resolved_locator,
+            }
+            if mapping.corpus is SkillCorpus.CENTER
+            else {
                 "corpus": mapping.corpus.value,
                 "relative_path": mapping.relative_path,
                 "link_name": mapping.link_name,
                 "resolved_locator": mapping.resolved_locator,
             }
-            for mapping in resolved
+            for index, mapping in enumerate(resolved)
         ),
     )
 

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
 from engine.community.core.adapters.claude_code.skills import (
     ClaudeCodeSkillsAdapter,
 )

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 from engine.community.core.adapters.claude_code.skills import (
     ClaudeCodeSkillsAdapter,
+    _serialize_pool_mapping,
 )
 from engine.community.core.skills.models import (
     PoolLayoutActivateRequest,
@@ -290,3 +291,18 @@ async def test_claude_code_adapter_unknown_rollback_fails_closed() -> None:
         "source": "newer-plugin",
         "raw_status": "FUTURE_STATUS",
     }
+
+
+@pytest.mark.parametrize(
+    "mapping,message",
+    [
+        (PoolSkillMappingIntent(corpus="center", relative_path=None, link_name="a"), "structured identity"),
+        (PoolSkillMappingIntent(corpus="repo", relative_path=None, link_name="a"), "relative_path"),
+    ],
+)
+def test_claude_mapping_serializer_rejects_incomplete_intent(
+    mapping: PoolSkillMappingIntent,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _serialize_pool_mapping(mapping)

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -220,6 +220,30 @@ async def test_claude_code_adapter_propagates_logical_mapping_version() -> None:
 
 
 @pytest.mark.asyncio
+async def test_claude_adapter_serializes_center_v3_for_full_lifecycle() -> None:
+    port = _port()
+    mapping = PoolSkillMappingIntent(
+        corpus="center", relative_path=None, link_name="risk-review",
+        skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a", sc_version_number="2026.8.19",
+    )
+    version = "skills-pool-mapping-v3"
+    adapter = ClaudeCodeSkillsAdapter(port)
+
+    await adapter.activate_pool_layout(PoolLayoutActivateRequest(
+        migration_generation="generation-1", preparation_id="prep-1",
+        mappings=[mapping], mapping_contract_version=version,
+    ))
+    await adapter.publish_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
+    await adapter.verify_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
+
+    expected = {"corpus": "center", "skill_uuid": mapping.skill_uuid, "sc_version_number": mapping.sc_version_number, "link_name": "risk-review"}
+    assert port.activate_pool_layout.await_args.args[0]["mappings"] == [expected]
+    assert port.publish_pool_mappings.await_args.args[0]["mappings"] == [expected]
+    assert port.publish_pool_mappings.await_args.args[0]["retired_mappings"] == [expected]
+    assert port.verify_pool_mappings.await_args.args[0]["mappings"] == [expected]
+
+
+@pytest.mark.asyncio
 async def test_claude_code_adapter_unknown_activation_fails_closed() -> None:
     port = _port()
     port.activate_pool_layout.return_value = {

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_skills_pool_contract.py
@@ -237,6 +237,9 @@ async def test_claude_adapter_serializes_center_v3_for_full_lifecycle() -> None:
     await adapter.verify_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
 
     expected = {"corpus": "center", "skill_uuid": mapping.skill_uuid, "sc_version_number": mapping.sc_version_number, "link_name": "risk-review"}
+    assert port.activate_pool_layout.await_args.args[0]["mapping_contract_version"] == version
+    assert port.publish_pool_mappings.await_args.args[0]["mapping_contract_version"] == version
+    assert port.verify_pool_mappings.await_args.args[0]["mapping_contract_version"] == version
     assert port.activate_pool_layout.await_args.args[0]["mappings"] == [expected]
     assert port.publish_pool_mappings.await_args.args[0]["mappings"] == [expected]
     assert port.publish_pool_mappings.await_args.args[0]["retired_mappings"] == [expected]

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -265,6 +265,9 @@ async def test_openclaw_adapter_serializes_center_v3_for_full_lifecycle() -> Non
     await adapter.verify_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
 
     expected = {"corpus": "center", "skill_uuid": mapping.skill_uuid, "sc_version_number": mapping.sc_version_number, "link_name": "risk-review"}
+    assert port.activate_pool_layout.await_args.args[0]["mapping_contract_version"] == version
+    assert port.publish_pool_mappings.await_args.args[0]["mapping_contract_version"] == version
+    assert port.verify_pool_mappings.await_args.args[0]["mapping_contract_version"] == version
     assert port.activate_pool_layout.await_args.args[0]["mappings"] == [expected]
     assert port.publish_pool_mappings.await_args.args[0]["mappings"] == [expected]
     assert port.publish_pool_mappings.await_args.args[0]["retired_mappings"] == [expected]

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -245,6 +245,33 @@ async def test_openclaw_adapter_propagates_logical_mapping_version() -> None:
 
 
 @pytest.mark.asyncio
+async def test_openclaw_adapter_serializes_center_v3_for_full_lifecycle() -> None:
+    port = MagicMock()
+    port.activate_pool_layout = AsyncMock(return_value={"committed": True, "status": "COMMITTED", "evidence": {}})
+    port.publish_pool_mappings = AsyncMock(return_value={"published": True, "evidence": {}})
+    port.verify_pool_mappings = AsyncMock(return_value={"valid": True, "evidence": {}})
+    mapping = PoolSkillMappingIntent(
+        corpus="center", relative_path=None, link_name="risk-review",
+        skill_uuid="2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a", sc_version_number="2026.8.19",
+    )
+    version = "skills-pool-mapping-v3"
+    adapter = OpenClawSkillsAdapter(port)
+
+    await adapter.activate_pool_layout(PoolLayoutActivateRequest(
+        migration_generation="generation-1", preparation_id="preparation-1",
+        mappings=[mapping], mapping_contract_version=version,
+    ))
+    await adapter.publish_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
+    await adapter.verify_pool_mappings([mapping], retired_mappings=[mapping], mapping_contract_version=version)
+
+    expected = {"corpus": "center", "skill_uuid": mapping.skill_uuid, "sc_version_number": mapping.sc_version_number, "link_name": "risk-review"}
+    assert port.activate_pool_layout.await_args.args[0]["mappings"] == [expected]
+    assert port.publish_pool_mappings.await_args.args[0]["mappings"] == [expected]
+    assert port.publish_pool_mappings.await_args.args[0]["retired_mappings"] == [expected]
+    assert port.verify_pool_mappings.await_args.args[0]["mappings"] == [expected]
+
+
+@pytest.mark.asyncio
 async def test_openclaw_adapter_keeps_unversioned_physical_mapping() -> None:
     port = MagicMock()
     port.publish_pool_mappings = AsyncMock(

--- a/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
+++ b/src/engine/src/engine/community/tests/contracts/test_openclaw_skills_pool_contract.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from engine.community.core.adapters.openclaw.skills import OpenClawSkillsAdapter
+from engine.community.core.adapters.openclaw.skills import (
+    OpenClawSkillsAdapter,
+    _serialize_pool_mapping,
+)
 from engine.community.core.skills.exceptions import (
     InvalidPoolMappingRequestError,
 )
@@ -272,6 +275,21 @@ async def test_openclaw_adapter_serializes_center_v3_for_full_lifecycle() -> Non
     assert port.publish_pool_mappings.await_args.args[0]["mappings"] == [expected]
     assert port.publish_pool_mappings.await_args.args[0]["retired_mappings"] == [expected]
     assert port.verify_pool_mappings.await_args.args[0]["mappings"] == [expected]
+
+
+@pytest.mark.parametrize(
+    "mapping,message",
+    [
+        (PoolSkillMappingIntent(corpus="center", relative_path=None, link_name="a"), "structured identity"),
+        (PoolSkillMappingIntent(corpus="repo", relative_path=None, link_name="a"), "relative_path"),
+    ],
+)
+def test_openclaw_mapping_serializer_rejects_incomplete_intent(
+    mapping: PoolSkillMappingIntent,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _serialize_pool_mapping(mapping)
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     LayoutIdentity,
@@ -197,6 +196,32 @@ def test_logical_mapping_rejects_unknown_corpus() -> None:
                     "writer",
                 )
             ],
+        )
+
+
+@pytest.mark.parametrize(
+    "mapping,error",
+    [
+        (LogicalSkillMapping(SkillCorpus.LOCAL, None, "writer"), "local mapping"),
+        (LogicalSkillMapping(SkillCorpus.REPO, None, "writer"), "repo mapping"),
+        (LogicalSkillMapping(SkillCorpus.CENTER, None, "writer"), "pool_center"),
+        (LogicalSkillMapping(SkillCorpus.CENTER, "unexpected", "writer"), "relative_path"),
+        (LogicalSkillMapping(SkillCorpus.CENTER, None, "writer", skill_uuid="not-a-uuid", sc_version_number="1"), "UUID"),
+        (LogicalSkillMapping(SkillCorpus.CENTER, None, "writer", skill_uuid="00000000-0000-1000-8000-000000000000", sc_version_number="1"), "UUIDv4"),
+    ],
+)
+def test_logical_mapping_rejects_incomplete_or_untrusted_center_identity(
+    mapping: LogicalSkillMapping,
+    error: str,
+) -> None:
+    plan = _plan()
+    with pytest.raises(SkillLayoutResolutionError, match=error):
+        resolve_skill_mappings(
+            active_root=plan.active_root,
+            local_root=plan.pool_local,
+            repo_root=plan.pool_repo,
+            center_root=(None if error == "pool_center" else plan.pool_center),
+            mappings=[mapping],
         )
 
 

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import pytest
-
 from engine.community.core.skills.exceptions import (
     InvalidPoolMappingRequestError,
 )
@@ -218,6 +217,31 @@ def test_invalid_contract_shape_has_no_filesystem_side_effect(
         )
 
     assert _snapshot(tmp_path) == before
+
+
+@pytest.mark.parametrize(
+    "version,payload,message",
+    [
+        (MAPPING_V3_CONTRACT_VERSION, ["not-an-object"], "must be an object"),
+        (MAPPING_CONTRACT_VERSION, [{"corpus": "center", "skill_uuid": "u", "sc_version_number": "1", "link_name": "a"}], "v2 logical"),
+        (MAPPING_V3_CONTRACT_VERSION, [{"corpus": "repo", "skill_uuid": "u", "sc_version_number": "1", "link_name": "a"}], "structured"),
+        (MAPPING_V3_CONTRACT_VERSION, [{"corpus": "center", "relative_path": "x", "link_name": "a"}], "logical mapping"),
+    ],
+)
+def test_mapping_contract_rejects_invalid_v3_shapes_before_resolution(
+    tmp_path: Path,
+    version: str,
+    payload: list[object],
+    message: str,
+) -> None:
+    with pytest.raises(InvalidPoolMappingRequestError, match=message):
+        resolve_mapping_payload(
+            engine="openclaw",
+            source_layout=MappingSourceLayout.POOL,
+            mapping_contract_version=version,
+            payload=payload,
+            home=tmp_path,
+        )
 
 
 def test_internal_layout_resolution_error_is_not_reclassified(

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -7,6 +7,7 @@ from engine.community.core.skills.exceptions import (
 )
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
     SkillLayoutResolutionError,
 )
 from engine.community.plugins.claude_code.layout_pool import (
@@ -105,6 +106,52 @@ def test_mapping_v2_resolves_for_every_filesystem_engine(
     assert (
         resolved.resolved_locators[0]["resolved_locator"]
         == "git://business/reviewer"
+    )
+
+
+@pytest.mark.parametrize(
+    ("engine", "active_root", "center_root"),
+    [
+        ("openclaw", ".openclaw/workspace/skills", ".openclaw/workspace/skills-pool/skill-center"),
+        ("claude_code", ".claude/skills", ".claude_code/workspace/skills-pool/skill-center"),
+        ("aicoding", ".claude/skills", ".aicoding/workspace/skills-pool/skill-center"),
+        ("hermes", ".hermes/skills", ".hermes/workspace/skills-pool/skill-center"),
+    ],
+)
+def test_mapping_v3_projects_structured_center_identity_for_every_runtime(
+    tmp_path: Path,
+    engine: str,
+    active_root: str,
+    center_root: str,
+) -> None:
+    skill_uuid = "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
+    resolved = resolve_mapping_payload(
+        engine=engine,
+        source_layout=MappingSourceLayout.LEGACY,
+        mapping_contract_version=MAPPING_V3_CONTRACT_VERSION,
+        payload=[
+            {
+                "corpus": "center",
+                "skill_uuid": skill_uuid,
+                "sc_version_number": "2026.8.19",
+                "link_name": "risk-review",
+            }
+        ],
+        home=tmp_path,
+    )
+
+    assert resolved.mappings[0].source == str(
+        tmp_path / center_root / skill_uuid / "2026.8.19"
+    )
+    assert resolved.mappings[0].target == str(tmp_path / active_root / "risk-review")
+    assert resolved.resolved_locators == (
+        {
+            "corpus": "center",
+            "skill_uuid": skill_uuid,
+            "sc_version_number": "2026.8.19",
+            "link_name": "risk-review",
+            "resolved_locator": f"center://{skill_uuid}/2026.8.19",
+        },
     )
 
 


### PR DESCRIPTION
## Problem

File-based runtimes could not consume a structured, exact Skill Center version while preserving v2 consumers and the Local/Repo layout lifecycle.

## Solution

- Add Mapping v3 Center identities with skill_uuid and sc_version_number, resolved only by Runtime into canonical pool_center.
- Advertise v2/v3 runtime capability, select v3 only when Center is present, and fail closed otherwise.
- Ensure Center versions before full publish/cutover; propagate complete mappings across cutover, rollback, verification, and retirement.
- Preserve Local/Repo source_layout semantics and prohibit current/latest or legacy_center.

## Validation

- Backend Skills Pool and repository suites: 346 passed.
- Engine mapping, API, layout, and contract suites: 303 passed.
- Targeted Mapping v3 and recovery suites plus Ruff checks passed.

## Compatibility and risk

v2 payloads remain unchanged for Local/Repo-only mappings. Center requires an explicit v3 runtime capability and exact-version materialization; otherwise publishing fails closed. Rollback preserves pool_center content and re-publishes complete mappings.

## Spec

Skill capability upgrade final spec sections 12.2, 15, and 18.4.

## Related issues

Closes #1167