### PR TITLE
feat(backend): add additive Space Skill persistence schema

### DIFF
--- a/src/backend/src/agentclaw/community/core/models/__init__.py
+++ b/src/backend/src/agentclaw/community/core/models/__init__.py
@@ -17,3 +17,12 @@ from agentclaw.community.core.models.mcp import (  # noqa: F401
 )
 from agentclaw.community.core.models.skill_propagation_log import SkillPropagationLog  # noqa: F401
 from agentclaw.community.core.models.skill_center_sync_log import SkillCenterSyncLog  # noqa: F401
+from agentclaw.community.core.models.space_skill import (  # noqa: F401
+    SkillDraftEditLease,
+    SkillGrant,
+    SkillPublicationAttempt,
+    SkillSpaceBinding,
+    SkillVersion,
+    Space,
+    SpaceMember,
+)

--- a/src/backend/src/agentclaw/community/core/models/skill.py
+++ b/src/backend/src/agentclaw/community/core/models/skill.py
@@ -94,14 +94,30 @@ class Skill(Base):
     category_path = Column(String(256), nullable=True, comment="类目完整路径(ac_skill_category.code)")
     package_url = Column(String(1028), nullable=True, comment="上传到oss上的可访问的url")
     zip_url = Column(String(1028), nullable=True, comment="用户上传的url")
+    # Additive Space Skill identity fields.  The existing name/description/
+    # status/version columns remain Legacy projections; their write paths stay
+    # untouched while the Space Skill feature flag is off.
+    draft_target_version = Column(Integer, nullable=True)
+    draft_status = Column(String(16), nullable=True)
+    retired_at = Column(DateTime, nullable=True)
+    retired_by = Column(String(128), nullable=True)
+    source_repo_url = Column(String(2048), nullable=True)
+    source_branch = Column(String(512), nullable=True)
+    source_subdir = Column(String(1024), nullable=True)
+    source_commit_sha = Column(String(64), nullable=True)
     # Deliberately absent from to_dict(): tenant is persistence metadata, not
     # part of the established internal Skills response contract.
     avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
 
-    # uix_skill_link_name_env_version was dropped with link_name, and prod has
-    # no replacement unique key on these fields. Keep SQLite create_all aligned
-    # with that production DDL rather than inventing a source-only constraint.
-    __table_args__ = {"extend_existing": True}
+    # ``link_name`` remains derived and has no stored uniqueness rule.  The
+    # additive F01 migration instead makes the non-null stable Skill UUID
+    # unique within its tenant and environment.
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_uuid", name="uk_skill_uuid"
+        ),
+        {"extend_existing": True},
+    )
 
     skill_sets = relationship("SkillSetSkill", back_populates="skill", cascade="all, delete-orphan")
 
@@ -156,7 +172,13 @@ register_avernet_tenant_guard(Skill)
 class SkillSetSkill(Base):
     """Association table between SkillSet and Skill."""
     __tablename__ = "ac_skill_set_skill"
-    __table_args__ = {"extend_existing": True}
+    __table_args__ = (
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_set_id", "skill_id",
+            name="uk_skill_set_skill",
+        ),
+        {"extend_existing": True},
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     skill_set_id = Column(Integer, ForeignKey("ac_skill_set.id"), nullable=False, index=True)

--- a/src/backend/src/agentclaw/community/core/models/skill_center_sync_log.py
+++ b/src/backend/src/agentclaw/community/core/models/skill_center_sync_log.py
@@ -2,9 +2,11 @@
 
 记录每次 force_sync 的结果：pending → success / failed。
 """
-from sqlalchemy import Column, Index, Integer, String, Text, func
+from sqlalchemy import BigInteger, Column, Index, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects import mysql
 
 from agentclaw.community.core.base import Base
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
 
 
 class SkillCenterSyncLog(Base):
@@ -12,6 +14,10 @@ class SkillCenterSyncLog(Base):
     __tablename__ = "ac_skill_center_sync_log"
     __table_args__ = (
         Index("idx_sync_skill_env_created", "skill_uuid", "env", "gmt_created"),
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_version_id",
+            name="uk_center_version_materialization",
+        ),
         {"extend_existing": True},
     )
 
@@ -23,6 +29,11 @@ class SkillCenterSyncLog(Base):
     checksum = Column(String(128), nullable=True)
     error_msg = Column(String(500), nullable=True)
     extra = Column(Text, default="{}", nullable=False)
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    skill_version_id = Column(
+        BigInteger().with_variant(mysql.BIGINT(unsigned=True), "mysql"),
+        nullable=True,
+    )
     # Production stores these as varchar(64) DB-clock strings, not
     # DATETIME — see specs/2026-05-17-unified-repository-round-2/
     # ddl-parity-ac_skill_center_sync_log.md (same drift the pilot found
@@ -33,3 +44,6 @@ class SkillCenterSyncLog(Base):
     gmt_modified = Column(
         String(64), server_default=func.now(), onupdate=func.now(), nullable=False,
     )
+
+
+register_avernet_tenant_guard(SkillCenterSyncLog)

--- a/src/backend/src/agentclaw/community/core/models/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/models/space_skill.py
@@ -23,6 +23,10 @@ from sqlalchemy import (
 from sqlalchemy.dialects import mysql
 
 from agentclaw.community.core.base import Base
+from agentclaw.community.core.spaces.repository.models import (
+    SpaceMemberModel as SpaceMember,
+    SpaceModel as Space,
+)
 from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
 
 
@@ -55,59 +59,6 @@ class _ScopedDomainFact:
     gmt_modified = Column(
         DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
     )
-
-
-class Space(_ScopedDomainFact, Base):
-    __tablename__ = "ac_space"
-    __table_args__ = _scoped_table_args(
-        UniqueConstraint("avernet_tenant", "env", "space_code", name="uk_space_code"),
-        UniqueConstraint(
-            "avernet_tenant", "env", "personal_owner_id", name="uk_personal_space"
-        ),
-        Index("idx_space_sc_team", "avernet_tenant", "env", "sc_team_id"),
-        CheckConstraint("space_type IN ('PERSONAL', 'TEAM')", name="ck_space_type"),
-        CheckConstraint(
-            "sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')",
-            name="ck_space_mapping_status",
-        ),
-    )
-
-    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
-    space_code = Column(String(128), nullable=False)
-    space_type = Column(String(16), nullable=False)
-    name = Column(String(256), nullable=False)
-    description = Column(Text, nullable=True)
-    personal_owner_id = Column(String(128), nullable=True)
-    sc_team_id = Column(BigInteger, nullable=True)
-    sc_mapping_status = Column(String(24), nullable=False, server_default="PENDING")
-    created_by = Column(String(128), nullable=False)
-    deleted_at = Column(DateTime, nullable=True)
-    deleted_by = Column(String(128), nullable=True)
-
-
-class SpaceMember(_ScopedDomainFact, Base):
-    __tablename__ = "ac_space_member"
-    __table_args__ = _scoped_table_args(
-        UniqueConstraint(
-            "avernet_tenant", "env", "space_id", "user_id", name="uk_space_member"
-        ),
-        Index("idx_space_member_user", "avernet_tenant", "env", "user_id", "status"),
-        CheckConstraint(
-            "role IN ('ADMINISTRATOR', 'MEMBER')", name="ck_space_member_role"
-        ),
-        CheckConstraint(
-            "status IN ('ACTIVE', 'INACTIVE')", name="ck_space_member_status"
-        ),
-    )
-
-    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
-    space_id = Column(UnsignedBigInteger, nullable=False)
-    user_id = Column(String(128), nullable=False)
-    role = Column(String(24), nullable=False)
-    status = Column(String(16), nullable=False, server_default="ACTIVE")
-    created_by = Column(String(128), nullable=False)
-    removed_at = Column(DateTime, nullable=True)
-    removed_by = Column(String(128), nullable=True)
 
 
 class SkillSpaceBinding(_ScopedDomainFact, Base):
@@ -269,8 +220,6 @@ class SkillPublicationAttempt(_ScopedDomainFact, Base):
 
 
 for _model in (
-    Space,
-    SpaceMember,
     SkillSpaceBinding,
     SkillGrant,
     SkillDraftEditLease,

--- a/src/backend/src/agentclaw/community/core/models/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/models/space_skill.py
@@ -1,0 +1,291 @@
+"""Additive ORM facts for the Space Skill domain.
+
+These tables deliberately contain persistence facts only.  Draft command
+validation, publication state transitions and runtime delivery belong to later
+domain slices; modelling them here would make the migration itself a second
+source of domain policy.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects import mysql
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.utils.avernet_tenant_guard import register_avernet_tenant_guard
+
+
+UnsignedBigInteger = (
+    BigInteger()
+    .with_variant(mysql.BIGINT(unsigned=True), "mysql")
+    .with_variant(Integer, "sqlite")
+)
+UnsignedInteger = (
+    Integer()
+    .with_variant(mysql.INTEGER(unsigned=True), "mysql")
+    .with_variant(Integer, "sqlite")
+)
+TinyInteger = Integer().with_variant(mysql.TINYINT(), "mysql")
+MediumText = Text().with_variant(mysql.MEDIUMTEXT(), "mysql")
+AutoIncrementBigInteger = UnsignedBigInteger
+
+
+def _scoped_table_args(*constraints):
+    """Add the non-empty environment invariant shared by new domain tables."""
+    return (*constraints, CheckConstraint("env <> ''", name="ck_env_not_empty"))
+
+
+class _ScopedDomainFact:
+    """Column mixin for new tenant- and environment-scoped facts."""
+
+    avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
+    env = Column(String(20), nullable=False)
+    gmt_created = Column(DateTime, server_default=func.now(), nullable=False)
+    gmt_modified = Column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class Space(_ScopedDomainFact, Base):
+    __tablename__ = "ac_space"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint("avernet_tenant", "env", "space_code", name="uk_space_code"),
+        UniqueConstraint(
+            "avernet_tenant", "env", "personal_owner_id", name="uk_personal_space"
+        ),
+        Index("idx_space_sc_team", "avernet_tenant", "env", "sc_team_id"),
+        CheckConstraint("space_type IN ('PERSONAL', 'TEAM')", name="ck_space_type"),
+        CheckConstraint(
+            "sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')",
+            name="ck_space_mapping_status",
+        ),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    space_code = Column(String(128), nullable=False)
+    space_type = Column(String(16), nullable=False)
+    name = Column(String(256), nullable=False)
+    description = Column(Text, nullable=True)
+    personal_owner_id = Column(String(128), nullable=True)
+    sc_team_id = Column(BigInteger, nullable=True)
+    sc_mapping_status = Column(String(24), nullable=False, server_default="PENDING")
+    created_by = Column(String(128), nullable=False)
+    deleted_at = Column(DateTime, nullable=True)
+    deleted_by = Column(String(128), nullable=True)
+
+
+class SpaceMember(_ScopedDomainFact, Base):
+    __tablename__ = "ac_space_member"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant", "env", "space_id", "user_id", name="uk_space_member"
+        ),
+        Index("idx_space_member_user", "avernet_tenant", "env", "user_id", "status"),
+        CheckConstraint(
+            "role IN ('ADMINISTRATOR', 'MEMBER')", name="ck_space_member_role"
+        ),
+        CheckConstraint(
+            "status IN ('ACTIVE', 'INACTIVE')", name="ck_space_member_status"
+        ),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    space_id = Column(UnsignedBigInteger, nullable=False)
+    user_id = Column(String(128), nullable=False)
+    role = Column(String(24), nullable=False)
+    status = Column(String(16), nullable=False, server_default="ACTIVE")
+    created_by = Column(String(128), nullable=False)
+    removed_at = Column(DateTime, nullable=True)
+    removed_by = Column(String(128), nullable=True)
+
+
+class SkillSpaceBinding(_ScopedDomainFact, Base):
+    __tablename__ = "ac_skill_space_binding"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_id", name="uk_skill_ownership"
+        ),
+        Index("idx_space_skills", "avernet_tenant", "env", "space_id"),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    skill_id = Column(UnsignedBigInteger, nullable=False)
+    space_id = Column(UnsignedBigInteger, nullable=False)
+    created_by = Column(String(128), nullable=False)
+
+
+class SkillGrant(_ScopedDomainFact, Base):
+    __tablename__ = "ac_skill_grant"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_id", "user_id", name="uk_skill_grant_user"
+        ),
+        UniqueConstraint(
+            "avernet_tenant",
+            "env",
+            "skill_id",
+            "owner_slot",
+            name="uk_skill_active_owner",
+        ),
+        Index("idx_skill_grant_user", "avernet_tenant", "env", "user_id", "status"),
+        CheckConstraint("role IN ('OWNER', 'MANAGER')", name="ck_skill_grant_role"),
+        CheckConstraint(
+            "status IN ('ACTIVE', 'REVOKED')", name="ck_skill_grant_status"
+        ),
+        CheckConstraint(
+            "owner_slot IS NULL OR (owner_slot = 1 AND role = 'OWNER' AND status = 'ACTIVE')",
+            name="ck_skill_active_owner_slot",
+        ),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    skill_id = Column(UnsignedBigInteger, nullable=False)
+    user_id = Column(String(128), nullable=False)
+    role = Column(String(16), nullable=False)
+    status = Column(String(16), nullable=False, server_default="ACTIVE")
+    owner_slot = Column(TinyInteger, nullable=True)
+    granted_by = Column(String(128), nullable=False)
+    revoked_at = Column(DateTime, nullable=True)
+    revoked_by = Column(String(128), nullable=True)
+
+
+class SkillDraftEditLease(_ScopedDomainFact, Base):
+    __tablename__ = "ac_skill_draft_edit_lease"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_id", name="uk_skill_edit_lease"
+        ),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    skill_id = Column(UnsignedBigInteger, nullable=False)
+    holder_user_id = Column(String(128), nullable=True)
+    fencing_token = Column(UnsignedBigInteger, nullable=False, server_default="0")
+    expires_at = Column(DateTime, nullable=True)
+    acquired_at = Column(DateTime, nullable=True)
+    renewed_at = Column(DateTime, nullable=True)
+    last_takeover_by = Column(String(128), nullable=True)
+
+
+class SkillVersion(_ScopedDomainFact, Base):
+    __tablename__ = "ac_skill_version"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant",
+            "env",
+            "skill_id",
+            "version_ordinal",
+            name="uk_skill_version_ordinal",
+        ),
+        UniqueConstraint(
+            "avernet_tenant",
+            "env",
+            "skill_id",
+            "sc_version_number",
+            name="uk_skill_sc_version",
+        ),
+        UniqueConstraint(
+            "avernet_tenant", "env", "publication_attempt_id", name="uk_version_attempt"
+        ),
+        Index(
+            "idx_skill_latest",
+            "avernet_tenant",
+            "env",
+            "skill_id",
+            "status",
+            "version_ordinal",
+        ),
+        CheckConstraint(
+            "status IN ('MATERIALIZING', 'PUBLISHED')", name="ck_skill_version_status"
+        ),
+        CheckConstraint("version_ordinal >= 1", name="ck_skill_version_ordinal"),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    skill_id = Column(UnsignedBigInteger, nullable=False)
+    publication_attempt_id = Column(UnsignedBigInteger, nullable=False)
+    version_ordinal = Column(UnsignedInteger, nullable=False)
+    status = Column(String(24), nullable=False)
+    sc_version_number = Column(String(128), nullable=False)
+    sc_skill_id = Column(BigInteger, nullable=True)
+    sc_version_id = Column(BigInteger, nullable=True)
+    sc_sha256 = Column(String(128), nullable=True)
+    name = Column(String(256), nullable=False)
+    description = Column(Text, nullable=True)
+    metadata_json = Column(MediumText, nullable=True)
+    published_at = Column(DateTime, nullable=True)
+    created_by = Column(String(128), nullable=False)
+
+
+class SkillPublicationAttempt(_ScopedDomainFact, Base):
+    __tablename__ = "ac_skill_publication_attempt"
+    __table_args__ = _scoped_table_args(
+        UniqueConstraint(
+            "avernet_tenant", "env", "skill_id", "request_id", name="uk_publish_request"
+        ),
+        UniqueConstraint("active_skill_key", name="uk_active_skill_publish"),
+        Index(
+            "idx_publish_skill_history",
+            "avernet_tenant",
+            "env",
+            "skill_id",
+            "gmt_created",
+        ),
+        CheckConstraint(
+            "status IN ('PREPARING', 'VALIDATING', 'SCANNING', 'SC_SUBMITTING', "
+            "'WAITING_SC', 'RESULT_UNKNOWN', 'MATERIALIZING', 'SUCCEEDED', "
+            "'FAILED', 'MANUAL_RECONCILIATION')",
+            name="ck_skill_publication_attempt_status",
+        ),
+        CheckConstraint(
+            "target_version_ordinal >= 1", name="ck_attempt_target_ordinal"
+        ),
+    )
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    skill_id = Column(UnsignedBigInteger, nullable=False)
+    request_id = Column(String(128), nullable=False)
+    active_skill_key = Column(String(256), nullable=True)
+    target_version_ordinal = Column(UnsignedInteger, nullable=False)
+    sc_version_number = Column(String(128), nullable=False)
+    status = Column(String(32), nullable=False)
+    failure_code = Column(String(128), nullable=True)
+    error_message = Column(Text, nullable=True)
+    sc_post_started_at = Column(DateTime, nullable=True)
+    sc_accepted_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    created_by = Column(String(128), nullable=False)
+
+
+for _model in (
+    Space,
+    SpaceMember,
+    SkillSpaceBinding,
+    SkillGrant,
+    SkillDraftEditLease,
+    SkillVersion,
+    SkillPublicationAttempt,
+):
+    register_avernet_tenant_guard(_model)
+
+
+__all__ = [
+    "SkillDraftEditLease",
+    "SkillGrant",
+    "SkillPublicationAttempt",
+    "SkillSpaceBinding",
+    "SkillVersion",
+    "Space",
+    "SpaceMember",
+]

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -140,6 +140,7 @@ provides:
   - SkillMemberRepository
   - SkillPropagationLogRepository
   - SkillRepository
+  - SpaceSkillRepository
   - SkillSetRepository
   # skills_pool
   - QuarantineRepositoryProtocol
@@ -184,6 +185,7 @@ provides:
   - BotPublishRepository
   - OrmPublishOperationRepository
   # skill_center
+  - SpaceSkillRepository
   - SqlLocalSkillCleanupRepository
   # skills_pool
   - SkillsPoolLayoutRepository

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -1438,6 +1438,21 @@ class SkillSetRepository(
             )
             if skill_set is None or skill is None:
                 return False
+            # The F01 uniqueness migration makes an existing relation the
+            # successful, idempotent result required by the new control-plane
+            # contract.  Checking after both tenant-guarded parent lookups
+            # preserves the old cross-tenant false result.
+            if (
+                db.query(self.SkillSetSkill)
+                .filter(
+                    self.SkillSetSkill.skill_set_id == int(skill_set_id),
+                    self.SkillSetSkill.skill_id == int(skill_id),
+                    self.SkillSetSkill.env == get_current_env(),
+                )
+                .first()
+                is not None
+            ):
+                return True
             db.add(
                 self.SkillSetSkill(
                     skill_set_id=int(skill_set_id),

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
@@ -10,9 +10,8 @@ from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.models.space_skill import (
     SkillGrant,
     SkillSpaceBinding,
-    Space,
-    SpaceMember,
 )
+from agentclaw.community.core.spaces.repository.models import SpaceMemberModel, SpaceModel
 from agentclaw.community.core.repository.protocols.skill_center import (
     SpaceSkillRepository as SpaceSkillRepositoryProtocol,
 )
@@ -44,7 +43,8 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
 
     def create_space(self, data: SpaceCreateData) -> SpaceRecord:
         with self._db.orm_session() as session:
-            space = Space(**data)
+            payload = {**data, "updated_by": data["created_by"]}
+            space = SpaceModel(**payload)
             session.add(space)
             session.flush()
             session.refresh(space)
@@ -53,8 +53,12 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
     def get_space(self, space_id: int, *, env: str) -> SpaceRecord | None:
         with self._db.orm_session() as session:
             space = (
-                session.query(Space)
-                .filter(Space.id == space_id, Space.env == env)
+                session.query(SpaceModel)
+                .filter(
+                    SpaceModel.id == space_id,
+                    SpaceModel.env == env,
+                    SpaceModel.deleted_at.is_(None),
+                )
                 .first()
             )
             return self._space_to_dict(space) if space else None
@@ -79,11 +83,11 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
 
         with self._db.orm_session() as session:
             space = (
-                session.query(Space)
+                session.query(SpaceModel)
                 .filter(
-                    Space.id == ownership_data["space_id"],
-                    Space.env == env,
-                    Space.deleted_at.is_(None),
+                    SpaceModel.id == ownership_data["space_id"],
+                    SpaceModel.env == env,
+                    SpaceModel.deleted_at.is_(None),
                 )
                 .one_or_none()
             )
@@ -91,12 +95,12 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
                 raise ValueError("Space Skill ownership requires an active Space")
 
             member = (
-                session.query(SpaceMember)
+                session.query(SpaceMemberModel)
                 .filter(
-                    SpaceMember.space_id == space.id,
-                    SpaceMember.user_id == owner_grant_data["user_id"],
-                    SpaceMember.status == "ACTIVE",
-                    SpaceMember.env == env,
+                    SpaceMemberModel.space_id == space.id,
+                    SpaceMemberModel.user_id == owner_grant_data["user_id"],
+                    SpaceMemberModel.status == "ACTIVE",
+                    SpaceMemberModel.env == env,
                 )
                 .one_or_none()
             )
@@ -131,7 +135,7 @@ class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
             }
 
     @staticmethod
-    def _space_to_dict(space: Space) -> SpaceRecord:
+    def _space_to_dict(space: SpaceModel) -> SpaceRecord:
         return {
             "id": space.id,
             "space_code": space.space_code,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill.py
@@ -1,0 +1,181 @@
+"""Persistence implementation for additive Space Skill facts."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from injector import inject
+
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.models.space_skill import (
+    SkillGrant,
+    SkillSpaceBinding,
+    Space,
+    SpaceMember,
+)
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SpaceSkillRepository as SpaceSkillRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skill_center_types import (
+    SpaceCreateData,
+    SpaceRecord,
+    SpaceSkillCreateData,
+    SpaceSkillCreationRecord,
+    SpaceSkillGrantRecord,
+    SpaceSkillIdentityRecord,
+    SpaceSkillOwnerGrantData,
+    SpaceSkillOwnershipData,
+    SpaceSkillOwnershipRecord,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class SpaceSkillRepository(SpaceSkillRepositoryProtocol):
+    """Small public seam for the additive Space table.
+
+    No existing Legacy service injects this repository.  That keeps feature-off
+    traffic on its established Local/Repo/Bot-local paths while giving later
+    Space Skill slices one tenant-scoped persistence entry point.
+    """
+
+    @inject
+    def __init__(self, db: DatabasePlugin):
+        self._db = db
+
+    def create_space(self, data: SpaceCreateData) -> SpaceRecord:
+        with self._db.orm_session() as session:
+            space = Space(**data)
+            session.add(space)
+            session.flush()
+            session.refresh(space)
+            return self._space_to_dict(space)
+
+    def get_space(self, space_id: int, *, env: str) -> SpaceRecord | None:
+        with self._db.orm_session() as session:
+            space = (
+                session.query(Space)
+                .filter(Space.id == space_id, Space.env == env)
+                .first()
+            )
+            return self._space_to_dict(space) if space else None
+
+    def create_space_skill(
+        self,
+        *,
+        skill_data: SpaceSkillCreateData,
+        ownership_data: SpaceSkillOwnershipData,
+        owner_grant_data: SpaceSkillOwnerGrantData,
+    ) -> SpaceSkillCreationRecord:
+        """Commit a new Space Skill's inseparable initial persistence facts.
+
+        The caller supplies command fields, while this repository supplies the
+        server-generated UUID and the initial Draft/Owner invariants. The
+        ownership Space and Owner membership are checked in the same current
+        tenant/env transaction to reject orphan or cross-tenant facts.
+        """
+        env = skill_data["env"]
+        if ownership_data["env"] != env or owner_grant_data["env"] != env:
+            raise ValueError("Space Skill facts must share one env")
+
+        with self._db.orm_session() as session:
+            space = (
+                session.query(Space)
+                .filter(
+                    Space.id == ownership_data["space_id"],
+                    Space.env == env,
+                    Space.deleted_at.is_(None),
+                )
+                .one_or_none()
+            )
+            if space is None:
+                raise ValueError("Space Skill ownership requires an active Space")
+
+            member = (
+                session.query(SpaceMember)
+                .filter(
+                    SpaceMember.space_id == space.id,
+                    SpaceMember.user_id == owner_grant_data["user_id"],
+                    SpaceMember.status == "ACTIVE",
+                    SpaceMember.env == env,
+                )
+                .one_or_none()
+            )
+            if member is None:
+                raise ValueError("Space Skill Owner must be an active Space Member")
+
+            skill_payload = dict(skill_data)
+            skill_payload.update(
+                skill_uuid=str(uuid4()),
+                draft_target_version=1,
+                draft_status="EDITING",
+            )
+            skill = Skill(**skill_payload)
+            session.add(skill)
+            session.flush()
+
+            ownership = SkillSpaceBinding(**{**ownership_data, "skill_id": skill.id})
+            owner_grant_payload = dict(owner_grant_data)
+            owner_grant_payload.update(
+                skill_id=skill.id,
+                role="OWNER",
+                status="ACTIVE",
+                owner_slot=1,
+            )
+            owner_grant = SkillGrant(**owner_grant_payload)
+            session.add_all((ownership, owner_grant))
+            session.flush()
+            return {
+                "skill": self._skill_to_dict(skill),
+                "ownership": self._ownership_to_dict(ownership),
+                "owner_grant": self._grant_to_dict(owner_grant),
+            }
+
+    @staticmethod
+    def _space_to_dict(space: Space) -> SpaceRecord:
+        return {
+            "id": space.id,
+            "space_code": space.space_code,
+            "space_type": space.space_type,
+            "name": space.name,
+            "description": space.description,
+            "personal_owner_id": space.personal_owner_id,
+            "sc_team_id": space.sc_team_id,
+            "sc_mapping_status": space.sc_mapping_status,
+            "created_by": space.created_by,
+            "deleted_at": space.deleted_at,
+            "deleted_by": space.deleted_by,
+            "env": space.env,
+        }
+
+    @staticmethod
+    def _skill_to_dict(skill: Skill) -> SpaceSkillIdentityRecord:
+        return {
+            "id": skill.id,
+            "skill_uuid": skill.skill_uuid,
+            "draft_target_version": skill.draft_target_version,
+            "draft_status": skill.draft_status,
+            "env": skill.env,
+        }
+
+    @staticmethod
+    def _ownership_to_dict(
+        ownership: SkillSpaceBinding,
+    ) -> SpaceSkillOwnershipRecord:
+        return {
+            "id": ownership.id,
+            "skill_id": ownership.skill_id,
+            "space_id": ownership.space_id,
+            "env": ownership.env,
+        }
+
+    @staticmethod
+    def _grant_to_dict(grant: SkillGrant) -> SpaceSkillGrantRecord:
+        return {
+            "id": grant.id,
+            "skill_id": grant.skill_id,
+            "user_id": grant.user_id,
+            "role": grant.role,
+            "status": grant.status,
+            "owner_slot": grant.owner_slot,
+            "env": grant.env,
+        }

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -40,6 +40,11 @@ class SpaceRepository(SpaceRepositoryProtocol):
     def _new_code() -> str:
         return f"spc-{uuid4().hex[:20]}"
 
+    @staticmethod
+    def _stored_role(role: SpaceRole) -> str:
+        """Keep the existing OWNER projection over the final ADMINISTRATOR row."""
+        return "ADMINISTRATOR" if role is SpaceRole.OWNER else SpaceRole.MEMBER.value
+
     def initialize_personal(self, *, user_id: str, env: str):
         try:
             with self._db.transactional_orm_session() as db:
@@ -69,7 +74,7 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Member(
                         space_id=space.id,
                         user_id=user_id,
-                        role=SpaceRole.OWNER.value,
+                    role=self._stored_role(SpaceRole.OWNER),
                         env=env,
                         created_by=user_id,
                     )
@@ -112,7 +117,7 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Member(
                         space_id=space.id,
                         user_id=creator_id,
-                        role=SpaceRole.OWNER.value,
+                    role=self._stored_role(SpaceRole.OWNER),
                         env=env,
                         created_by=creator_id,
                     )
@@ -135,7 +140,11 @@ class SpaceRepository(SpaceRepositoryProtocol):
         with self._db.orm_session() as db:
             row = (
                 db.query(self._Space)
-                .filter(self._Space.id == space_id, self._Space.env == env)
+                .filter(
+                    self._Space.id == space_id,
+                    self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
+                )
                 .one_or_none()
             )
             return row.to_record() if row is not None else None
@@ -150,6 +159,7 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Space.personal_owner_id.in_(user_ids),
                     self._Space.space_type == SpaceType.PERSONAL.value,
                     self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
                 )
                 .all()
             )
@@ -176,6 +186,7 @@ class SpaceRepository(SpaceRepositoryProtocol):
         with self._db.orm_session() as db:
             query = db.query(self._Space).filter(
                 self._Space.env == env,
+                self._Space.deleted_at.is_(None),
                 or_(
                     self._Space.space_type != SpaceType.PERSONAL.value,
                     self._Space.personal_owner_id == user_id,
@@ -200,12 +211,17 @@ class SpaceRepository(SpaceRepositoryProtocol):
                         self._Member.space_id == row.id,
                         self._Member.user_id == user_id,
                         self._Member.env == env,
+                        self._Member.status == "ACTIVE",
                     )
                     .one_or_none()
                 )
                 member_count = (
                     db.query(func.count(self._Member.id))
-                    .filter(self._Member.space_id == row.id, self._Member.env == env)
+                    .filter(
+                        self._Member.space_id == row.id,
+                        self._Member.env == env,
+                        self._Member.status == "ACTIVE",
+                    )
                     .scalar()
                     or 0
                 )
@@ -213,13 +229,14 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     db.query(func.count(self._Member.id))
                     .filter(
                         self._Member.space_id == row.id,
-                        self._Member.role == SpaceRole.OWNER.value,
+                        self._Member.role == self._stored_role(SpaceRole.OWNER),
                         self._Member.env == env,
+                        self._Member.status == "ACTIVE",
                     )
                     .scalar()
                     or 0
                 )
-                role = SpaceRole(current.role) if current is not None else None
+                role = current.to_record().role if current is not None else None
                 items.append(
                     SpaceSummaryRecord(
                         space=row.to_record(),
@@ -243,6 +260,7 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Member.space_id == space_id,
                     self._Member.user_id == user_id,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .one_or_none()
             )
@@ -259,7 +277,9 @@ class SpaceRepository(SpaceRepositoryProtocol):
     ):
         with self._db.orm_session() as db:
             query = db.query(self._Member).filter(
-                self._Member.space_id == space_id, self._Member.env == env
+                self._Member.space_id == space_id,
+                self._Member.env == env,
+                self._Member.status == "ACTIVE",
             )
             if keyword:
                 query = query.filter(self._Member.user_id.ilike(f"%{keyword}%"))
@@ -272,7 +292,11 @@ class SpaceRepository(SpaceRepositoryProtocol):
             )
             space = (
                 db.query(self._Space)
-                .filter(self._Space.id == space_id, self._Space.env == env)
+                .filter(
+                    self._Space.id == space_id,
+                    self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
+                )
                 .one_or_none()
             )
             creator_id = space.created_by if space is not None else ""
@@ -294,14 +318,31 @@ class SpaceRepository(SpaceRepositoryProtocol):
     ):
         try:
             with self._db.orm_session() as db:
-                row = self._Member(
-                    space_id=space_id,
-                    user_id=user_id,
-                    role=role.value,
-                    env=env,
-                    created_by=creator_id,
+                row = (
+                    db.query(self._Member)
+                    .filter(
+                        self._Member.space_id == space_id,
+                        self._Member.user_id == user_id,
+                        self._Member.env == env,
+                    )
+                    .one_or_none()
                 )
-                db.add(row)
+                if row is not None and row.status == "ACTIVE":
+                    raise SpaceMemberAlreadyExistsError("space member already exists")
+                if row is None:
+                    row = self._Member(
+                        space_id=space_id,
+                        user_id=user_id,
+                        role=self._stored_role(role),
+                        env=env,
+                        created_by=creator_id,
+                    )
+                    db.add(row)
+                else:
+                    row.role = self._stored_role(role)
+                    row.status = "ACTIVE"
+                    row.removed_at = None
+                    row.removed_by = None
                 db.flush()
                 db.refresh(row)
                 return row.to_record()
@@ -316,8 +357,17 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Member.space_id == space_id,
                     self._Member.user_id == user_id,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
-                .delete(synchronize_session=False)
+                .update(
+                    {
+                        self._Member.status: "INACTIVE",
+                        self._Member.removed_at: func.now(),
+                        self._Member.removed_by: user_id,
+                        self._Member.gmt_modified: func.now(),
+                    },
+                    synchronize_session=False,
+                )
             )
             return deleted > 0
 
@@ -331,12 +381,13 @@ class SpaceRepository(SpaceRepositoryProtocol):
                     self._Member.space_id == space_id,
                     self._Member.user_id == user_id,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .one_or_none()
             )
             if row is None:
                 return None
-            row.role = role.value
+            row.role = self._stored_role(role)
             row.gmt_modified = func.now()
             db.flush()
             db.refresh(row)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -47,6 +47,9 @@ from agentclaw.community.core.work_orders.repository.models import (
 from agentclaw.community.plugin_api.database import DatabasePlugin
 
 
+_ADMINISTRATOR_ROLE = "ADMINISTRATOR"
+
+
 class WorkOrderRepository(WorkOrderRepositoryProtocol):
     @inject
     def __init__(self, db: DatabasePlugin) -> None:
@@ -100,8 +103,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 db.query(self._Member.user_id)
                 .filter(
                     self._Member.space_id == space_id,
-                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.role == _ADMINISTRATOR_ROLE,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .all()
             )
@@ -157,8 +161,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 for (space_id,) in db.query(self._Member.space_id)
                 .filter(
                     self._Member.user_id == actor_id,
-                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.role == _ADMINISTRATOR_ROLE,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .all()
             }
@@ -297,8 +302,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 .filter(
                     self._Member.space_id == space.id,
                     self._Member.user_id == actor_id,
-                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.role == _ADMINISTRATOR_ROLE,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .first()
                 is not None
@@ -354,8 +360,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 .filter(
                     self._Member.space_id == int(work_order.biz_id),
                     self._Member.user_id == reviewer_user_id,
-                    self._Member.role == SpaceRole.OWNER.value,
+                    self._Member.role == _ADMINISTRATOR_ROLE,
                     self._Member.env == env,
+                    self._Member.status == "ACTIVE",
                 )
                 .first()
             )
@@ -498,8 +505,9 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                         .filter(
                             self._Member.space_id == int(work_order.biz_id),
                             self._Member.user_id == recipient_user_id,
-                            self._Member.role == SpaceRole.OWNER.value,
+                            self._Member.role == _ADMINISTRATOR_ROLE,
                             self._Member.env == env,
+                            self._Member.status == "ACTIVE",
                         )
                         .first()
                         is not None

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -11,6 +11,39 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import List, Optional, Protocol, runtime_checkable
 
+from .skill_center_types import (
+    SpaceCreateData,
+    SpaceRecord,
+    SpaceSkillCreateData,
+    SpaceSkillCreationRecord,
+    SpaceSkillOwnerGrantData,
+    SpaceSkillOwnershipData,
+)
+
+
+@runtime_checkable
+class SpaceSkillRepository(Protocol):
+    """Tenant-scoped persistence seam for additive Space Skill facts."""
+
+    @abstractmethod
+    def create_space(self, data: SpaceCreateData) -> SpaceRecord:
+        ...
+
+    @abstractmethod
+    def get_space(self, space_id: int, *, env: str) -> SpaceRecord | None:
+        ...
+
+    @abstractmethod
+    def create_space_skill(
+        self,
+        *,
+        skill_data: SpaceSkillCreateData,
+        ownership_data: SpaceSkillOwnershipData,
+        owner_grant_data: SpaceSkillOwnerGrantData,
+    ) -> SpaceSkillCreationRecord:
+        """Atomically persist the initial identity, ownership and owner grant."""
+        ...
+
 
 @runtime_checkable
 class SkillRepository(Protocol):

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
@@ -1,0 +1,85 @@
+"""Typed data contracts for the Skill Center repository Protocols."""
+
+from __future__ import annotations
+
+from typing import Literal, NotRequired, TypedDict
+
+
+class SpaceCreateData(TypedDict):
+    space_code: str
+    space_type: Literal["PERSONAL", "TEAM"]
+    name: str
+    created_by: str
+    env: str
+    description: NotRequired[str | None]
+    personal_owner_id: NotRequired[str | None]
+    sc_team_id: NotRequired[int | None]
+
+
+class SpaceRecord(TypedDict):
+    id: int
+    space_code: str
+    space_type: str
+    name: str
+    description: str | None
+    personal_owner_id: str | None
+    sc_team_id: int | None
+    sc_mapping_status: str
+    created_by: str
+    deleted_at: object | None
+    deleted_by: str | None
+    env: str
+
+
+class SpaceSkillCreateData(TypedDict):
+    name: str
+    env: str
+    description: NotRequired[str | None]
+    source_type: NotRequired[str | None]
+    source_repo_url: NotRequired[str | None]
+    source_branch: NotRequired[str | None]
+    source_subdir: NotRequired[str | None]
+    source_commit_sha: NotRequired[str | None]
+
+
+class SpaceSkillOwnershipData(TypedDict):
+    space_id: int
+    created_by: str
+    env: str
+
+
+class SpaceSkillOwnerGrantData(TypedDict):
+    user_id: str
+    granted_by: str
+    env: str
+
+
+class SpaceSkillIdentityRecord(TypedDict):
+    id: int
+    skill_uuid: str
+    draft_target_version: int
+    draft_status: str
+    env: str
+
+
+class SpaceSkillOwnershipRecord(TypedDict):
+    id: int
+    skill_id: int
+    space_id: int
+    env: str
+
+
+class SpaceSkillGrantRecord(TypedDict):
+    id: int
+    skill_id: int
+    user_id: str
+    role: str
+    status: str
+    owner_slot: int | None
+    env: str
+
+
+class SpaceSkillCreationRecord(TypedDict):
+    skill: SpaceSkillIdentityRecord
+    ownership: SpaceSkillOwnershipRecord
+    owner_grant: SpaceSkillGrantRecord

--- a/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/feature_flags.py
@@ -14,6 +14,7 @@ class SkillCenterFlags:
     propagation_enabled: bool
     symlink_verify_auto_fix: bool
     write_skill_uuid: bool  # 双写控制，不关
+    space_skill_enabled: bool = False
 
     @classmethod
     def from_env(cls) -> "SkillCenterFlags":
@@ -24,11 +25,17 @@ class SkillCenterFlags:
             propagation_enabled=os.environ.get("SC_PROPAGATION_ENABLED", "false").lower() == "true",
             symlink_verify_auto_fix=os.environ.get("SC_SYMLINK_AUTO_FIX", "false").lower() == "true",
             write_skill_uuid=os.environ.get("SC_WRITE_SKILL_UUID", "true").lower() == "true",
+            space_skill_enabled=os.environ.get("SC_SPACE_SKILL_ENABLED", "false").lower() == "true",
         )
 
     def any_blocking_enabled(self) -> bool:
         """任一核心 flag 开启（用于日志采样等）。"""
-        return self.nas_sync_enabled or self.center_uri_enabled or self.propagation_enabled
+        return (
+            self.nas_sync_enabled
+            or self.center_uri_enabled
+            or self.propagation_enabled
+            or self.space_skill_enabled
+        )
 
 
 # 全局单例（延迟初始化）

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
@@ -23,51 +23,8 @@ ALTER TABLE ac_skill
 CREATE UNIQUE INDEX IF NOT EXISTS uk_skill_uuid
   ON ac_skill (avernet_tenant, env, skill_uuid);
 
-CREATE TABLE IF NOT EXISTS ac_space (
-  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  space_code VARCHAR(128) NOT NULL,
-  space_type VARCHAR(16) NOT NULL COMMENT 'PERSONAL/TEAM',
-  name VARCHAR(256) NOT NULL,
-  description TEXT NULL,
-  personal_owner_id VARCHAR(128) NULL,
-  sc_team_id BIGINT NULL,
-  sc_mapping_status VARCHAR(24) NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING/ACTIVE/INACTIVE/CLEANUP_FAILED',
-  created_by VARCHAR(128) NOT NULL,
-  deleted_at TIMESTAMP NULL,
-  deleted_by VARCHAR(128) NULL,
-  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
-  env VARCHAR(20) NOT NULL,
-  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
-  UNIQUE KEY uk_space_code (avernet_tenant, env, space_code),
-  UNIQUE KEY uk_personal_space (avernet_tenant, env, personal_owner_id),
-  KEY idx_space_sc_team (avernet_tenant, env, sc_team_id),
-  CONSTRAINT ck_space_type CHECK (space_type IN ('PERSONAL', 'TEAM')),
-  CONSTRAINT ck_space_mapping_status CHECK (sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')),
-  CONSTRAINT ck_space_env_not_empty CHECK (env <> '')
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-CREATE TABLE IF NOT EXISTS ac_space_member (
-  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  space_id BIGINT UNSIGNED NOT NULL,
-  user_id VARCHAR(128) NOT NULL,
-  role VARCHAR(24) NOT NULL COMMENT 'ADMINISTRATOR/MEMBER',
-  status VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/INACTIVE',
-  created_by VARCHAR(128) NOT NULL,
-  removed_at TIMESTAMP NULL,
-  removed_by VARCHAR(128) NULL,
-  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
-  env VARCHAR(20) NOT NULL,
-  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (id),
-  UNIQUE KEY uk_space_member (avernet_tenant, env, space_id, user_id),
-  KEY idx_space_member_user (avernet_tenant, env, user_id, status),
-  CONSTRAINT ck_space_member_role CHECK (role IN ('ADMINISTRATOR', 'MEMBER')),
-  CONSTRAINT ck_space_member_status CHECK (status IN ('ACTIVE', 'INACTIVE')),
-  CONSTRAINT ck_space_member_env_not_empty CHECK (env <> '')
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- ac_space and ac_space_member are owned by the unified Space migration:
+-- core/spaces/sql/2026_08_17_spaces.sql. Apply that file before this F01 DDL.
 
 CREATE TABLE IF NOT EXISTS ac_skill_space_binding (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
@@ -1,0 +1,194 @@
+-- F01 / compatibility baseline A: additive Space Skill persistence only.
+--
+-- Run the paired verify script before and after this file.  It intentionally
+-- does not delete duplicate ac_skill_set_skill rows: production rollout must
+-- provide the reviewed three primary keys from the ODC preflight (§15.1) before
+-- the unique key below is added.  This prevents a broad, irreversible cleanup.
+--
+-- The IF NOT EXISTS clauses make re-running this additive stage safe after an
+-- interrupted deployment.  They require the OceanBase MySQL-compatible DDL
+-- profile used by this service; run on a staging clone before production.
+
+ALTER TABLE ac_skill
+  MODIFY COLUMN env VARCHAR(20) NOT NULL,
+  ADD COLUMN IF NOT EXISTS draft_target_version INT NULL COMMENT '活动草稿目标 Version Ordinal',
+  ADD COLUMN IF NOT EXISTS draft_status VARCHAR(16) NULL COMMENT 'NULL/EDITING/FROZEN',
+  ADD COLUMN IF NOT EXISTS retired_at TIMESTAMP NULL COMMENT 'Skill 整体退役时间',
+  ADD COLUMN IF NOT EXISTS retired_by VARCHAR(128) NULL COMMENT 'Skill 整体退役操作者',
+  ADD COLUMN IF NOT EXISTS source_repo_url VARCHAR(2048) NULL COMMENT 'Git 导入仓库 URL',
+  ADD COLUMN IF NOT EXISTS source_branch VARCHAR(512) NULL COMMENT '首次导入解析的固定分支',
+  ADD COLUMN IF NOT EXISTS source_subdir VARCHAR(1024) NULL COMMENT '仓库内 Skill 子目录',
+  ADD COLUMN IF NOT EXISTS source_commit_sha VARCHAR(64) NULL COMMENT '最近一次成功 Source Snapshot commit';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_skill_uuid
+  ON ac_skill (avernet_tenant, env, skill_uuid);
+
+CREATE TABLE IF NOT EXISTS ac_space (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  space_code VARCHAR(128) NOT NULL,
+  space_type VARCHAR(16) NOT NULL COMMENT 'PERSONAL/TEAM',
+  name VARCHAR(256) NOT NULL,
+  description TEXT NULL,
+  personal_owner_id VARCHAR(128) NULL,
+  sc_team_id BIGINT NULL,
+  sc_mapping_status VARCHAR(24) NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING/ACTIVE/INACTIVE/CLEANUP_FAILED',
+  created_by VARCHAR(128) NOT NULL,
+  deleted_at TIMESTAMP NULL,
+  deleted_by VARCHAR(128) NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_space_code (avernet_tenant, env, space_code),
+  UNIQUE KEY uk_personal_space (avernet_tenant, env, personal_owner_id),
+  KEY idx_space_sc_team (avernet_tenant, env, sc_team_id),
+  CONSTRAINT ck_space_type CHECK (space_type IN ('PERSONAL', 'TEAM')),
+  CONSTRAINT ck_space_mapping_status CHECK (sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')),
+  CONSTRAINT ck_space_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_space_member (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  space_id BIGINT UNSIGNED NOT NULL,
+  user_id VARCHAR(128) NOT NULL,
+  role VARCHAR(24) NOT NULL COMMENT 'ADMINISTRATOR/MEMBER',
+  status VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/INACTIVE',
+  created_by VARCHAR(128) NOT NULL,
+  removed_at TIMESTAMP NULL,
+  removed_by VARCHAR(128) NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_space_member (avernet_tenant, env, space_id, user_id),
+  KEY idx_space_member_user (avernet_tenant, env, user_id, status),
+  CONSTRAINT ck_space_member_role CHECK (role IN ('ADMINISTRATOR', 'MEMBER')),
+  CONSTRAINT ck_space_member_status CHECK (status IN ('ACTIVE', 'INACTIVE')),
+  CONSTRAINT ck_space_member_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_skill_space_binding (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  skill_id BIGINT UNSIGNED NOT NULL,
+  space_id BIGINT UNSIGNED NOT NULL,
+  created_by VARCHAR(128) NOT NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skill_ownership (avernet_tenant, env, skill_id),
+  KEY idx_space_skills (avernet_tenant, env, space_id),
+  CONSTRAINT ck_skill_ownership_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_skill_grant (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  skill_id BIGINT UNSIGNED NOT NULL,
+  user_id VARCHAR(128) NOT NULL,
+  role VARCHAR(16) NOT NULL COMMENT 'OWNER/MANAGER',
+  status VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/REVOKED',
+  owner_slot TINYINT NULL COMMENT 'ACTIVE OWNER 固定为 1，其余 NULL',
+  granted_by VARCHAR(128) NOT NULL,
+  revoked_at TIMESTAMP NULL,
+  revoked_by VARCHAR(128) NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skill_grant_user (avernet_tenant, env, skill_id, user_id),
+  UNIQUE KEY uk_skill_active_owner (avernet_tenant, env, skill_id, owner_slot),
+  KEY idx_skill_grant_user (avernet_tenant, env, user_id, status),
+  CONSTRAINT ck_skill_grant_role CHECK (role IN ('OWNER', 'MANAGER')),
+  CONSTRAINT ck_skill_grant_status CHECK (status IN ('ACTIVE', 'REVOKED')),
+  CONSTRAINT ck_skill_active_owner_slot CHECK (owner_slot IS NULL OR (owner_slot = 1 AND role = 'OWNER' AND status = 'ACTIVE')),
+  CONSTRAINT ck_skill_grant_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_skill_draft_edit_lease (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  skill_id BIGINT UNSIGNED NOT NULL,
+  holder_user_id VARCHAR(128) NULL,
+  fencing_token BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  expires_at TIMESTAMP NULL,
+  acquired_at TIMESTAMP NULL,
+  renewed_at TIMESTAMP NULL,
+  last_takeover_by VARCHAR(128) NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skill_edit_lease (avernet_tenant, env, skill_id),
+  CONSTRAINT ck_skill_edit_lease_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_skill_version (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  skill_id BIGINT UNSIGNED NOT NULL,
+  publication_attempt_id BIGINT UNSIGNED NOT NULL,
+  version_ordinal INT UNSIGNED NOT NULL,
+  status VARCHAR(24) NOT NULL COMMENT 'MATERIALIZING/PUBLISHED',
+  sc_version_number VARCHAR(128) NOT NULL,
+  sc_skill_id BIGINT NULL,
+  sc_version_id BIGINT NULL,
+  sc_sha256 VARCHAR(128) NULL,
+  name VARCHAR(256) NOT NULL,
+  description TEXT NULL,
+  metadata_json MEDIUMTEXT NULL,
+  published_at TIMESTAMP NULL,
+  created_by VARCHAR(128) NOT NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_skill_version_ordinal (avernet_tenant, env, skill_id, version_ordinal),
+  UNIQUE KEY uk_skill_sc_version (avernet_tenant, env, skill_id, sc_version_number),
+  UNIQUE KEY uk_version_attempt (avernet_tenant, env, publication_attempt_id),
+  KEY idx_skill_latest (avernet_tenant, env, skill_id, status, version_ordinal),
+  CONSTRAINT ck_skill_version_status CHECK (status IN ('MATERIALIZING', 'PUBLISHED')),
+  CONSTRAINT ck_skill_version_ordinal CHECK (version_ordinal >= 1),
+  CONSTRAINT ck_skill_version_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ac_skill_publication_attempt (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  skill_id BIGINT UNSIGNED NOT NULL,
+  request_id VARCHAR(128) NOT NULL,
+  active_skill_key VARCHAR(256) NULL,
+  target_version_ordinal INT UNSIGNED NOT NULL,
+  sc_version_number VARCHAR(128) NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  failure_code VARCHAR(128) NULL,
+  error_message TEXT NULL,
+  sc_post_started_at TIMESTAMP NULL,
+  sc_accepted_at TIMESTAMP NULL,
+  completed_at TIMESTAMP NULL,
+  created_by VARCHAR(128) NOT NULL,
+  avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  env VARCHAR(20) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_publish_request (avernet_tenant, env, skill_id, request_id),
+  UNIQUE KEY uk_active_skill_publish (active_skill_key),
+  KEY idx_publish_skill_history (avernet_tenant, env, skill_id, gmt_created),
+  CONSTRAINT ck_skill_publication_attempt_status CHECK (status IN ('PREPARING', 'VALIDATING', 'SCANNING', 'SC_SUBMITTING', 'WAITING_SC', 'RESULT_UNKNOWN', 'MATERIALIZING', 'SUCCEEDED', 'FAILED', 'MANUAL_RECONCILIATION')),
+  CONSTRAINT ck_attempt_target_ordinal CHECK (target_version_ordinal >= 1),
+  CONSTRAINT ck_skill_publication_attempt_env_not_empty CHECK (env <> '')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE ac_skill_set_skill
+  MODIFY COLUMN env VARCHAR(20) NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_skill_set_skill
+  ON ac_skill_set_skill (avernet_tenant, env, skill_set_id, skill_id);
+
+ALTER TABLE ac_skill_center_sync_log
+  ADD COLUMN IF NOT EXISTS avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+  ADD COLUMN IF NOT EXISTS skill_version_id BIGINT UNSIGNED NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_center_version_materialization
+  ON ac_skill_center_sync_log (avernet_tenant, env, skill_version_id);

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
@@ -14,6 +14,9 @@ SELECT 'ac_skill_set_skill orphan skill' AS check_name, COUNT(*) AS count
 SELECT 'ac_skill_set_skill orphan set' AS check_name, COUNT(*) AS count
   FROM ac_skill_set_skill rel LEFT JOIN ac_skill_set skill_set ON skill_set.id = rel.skill_set_id
  WHERE skill_set.id IS NULL;
+SELECT 'ac_space non-numeric sc team id' AS check_name, COUNT(*) AS count
+  FROM ac_space
+ WHERE sc_team_id IS NOT NULL AND CAST(sc_team_id AS CHAR) REGEXP '[^0-9]';
 
 -- Apply the separately reviewed, exact three-row duplicate cleanup here.
 -- This script deliberately contains no broad DELETE/window-function cleanup.

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
@@ -1,0 +1,41 @@
+-- F01 pre/post verification.  Save every result with the deployment record.
+-- PRE: all must be zero before tightening constraints.
+SELECT 'ac_skill missing/empty env' AS check_name, COUNT(*) AS count
+  FROM ac_skill WHERE env IS NULL OR env = '';
+SELECT 'ac_skill duplicate uuid' AS check_name, avernet_tenant, env, skill_uuid, COUNT(*) AS count
+  FROM ac_skill WHERE skill_uuid IS NOT NULL
+ GROUP BY avernet_tenant, env, skill_uuid HAVING COUNT(*) > 1;
+SELECT 'ac_skill_set_skill duplicate' AS check_name, avernet_tenant, env, skill_set_id, skill_id, COUNT(*) AS count
+  FROM ac_skill_set_skill
+ GROUP BY avernet_tenant, env, skill_set_id, skill_id HAVING COUNT(*) > 1;
+SELECT 'ac_skill_set_skill orphan skill' AS check_name, COUNT(*) AS count
+  FROM ac_skill_set_skill rel LEFT JOIN ac_skill skill ON skill.id = rel.skill_id
+ WHERE skill.id IS NULL;
+SELECT 'ac_skill_set_skill orphan set' AS check_name, COUNT(*) AS count
+  FROM ac_skill_set_skill rel LEFT JOIN ac_skill_set skill_set ON skill_set.id = rel.skill_set_id
+ WHERE skill_set.id IS NULL;
+
+-- Apply the separately reviewed, exact three-row duplicate cleanup here.
+-- This script deliberately contains no broad DELETE/window-function cleanup.
+
+-- POST: confirm all new facts and required keys exist; repeat these queries
+-- after re-running the additive DDL to prove idempotence.
+SELECT table_name, table_rows
+  FROM information_schema.tables
+ WHERE table_schema = DATABASE()
+   AND table_name IN ('ac_space', 'ac_space_member', 'ac_skill_space_binding',
+                      'ac_skill_grant', 'ac_skill_draft_edit_lease',
+                      'ac_skill_version', 'ac_skill_publication_attempt');
+SELECT table_name, index_name
+  FROM information_schema.statistics
+ WHERE table_schema = DATABASE()
+   AND index_name IN ('uk_skill_uuid', 'uk_skill_set_skill',
+                      'uk_center_version_materialization', 'uk_space_code',
+                      'uk_skill_ownership', 'uk_skill_active_owner',
+                      'uk_skill_version_ordinal', 'uk_publish_request');
+SELECT table_name, column_name, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema = DATABASE() AND column_name = 'env'
+   AND table_name IN ('ac_space', 'ac_space_member', 'ac_skill_space_binding',
+                      'ac_skill_grant', 'ac_skill_draft_edit_lease',
+                      'ac_skill_version', 'ac_skill_publication_attempt');

--- a/src/backend/src/agentclaw/community/core/spaces/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/spaces/repository/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy import Column, DateTime, Index, String, UniqueConstraint
+from sqlalchemy import BigInteger, CheckConstraint, Column, DateTime, Index, String, Text, UniqueConstraint
 from sqlalchemy.sql import func
 
 from agentclaw.community.core.base import Base
@@ -21,32 +21,39 @@ class SpaceModel(Base):
     __tablename__ = "ac_space"
 
     id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
-    space_code = Column(String(64), nullable=False)
-    space_type = Column(String(32), nullable=False)
-    name = Column(String(128), nullable=False)
-    personal_owner_id = Column(String(256), nullable=True)
-    sc_team_id = Column(String(64), nullable=True)
+    space_code = Column(String(128), nullable=False)
+    space_type = Column(String(16), nullable=False)
+    name = Column(String(256), nullable=False)
+    description = Column(Text, nullable=True)
+    personal_owner_id = Column(String(128), nullable=True)
+    sc_team_id = Column(BigInteger, nullable=True)
+    sc_mapping_status = Column(String(24), nullable=False, server_default="PENDING")
     env = Column(String(20), nullable=False, default=get_current_env)
     avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
-    created_by = Column(String(256), nullable=False)
+    created_by = Column(String(128), nullable=False)
     updated_by = Column(String(256), nullable=False)
+    deleted_at = Column(DateTime, nullable=True)
+    deleted_by = Column(String(128), nullable=True)
     gmt_created = Column(DateTime, nullable=False, server_default=func.now())
     gmt_modified = Column(
         DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
     __table_args__ = (
-        UniqueConstraint(
-            "avernet_tenant", "space_code", "env", name="uk_space_code_env"
-        ),
+        UniqueConstraint("avernet_tenant", "env", "space_code", name="uk_space_code"),
         UniqueConstraint(
             "avernet_tenant",
-            "personal_owner_id",
             "env",
-            name="uk_space_personal_owner_env",
+            "personal_owner_id",
+            name="uk_personal_space",
         ),
-        UniqueConstraint("sc_team_id", "env", name="uk_sc_team_id_env"),
-        Index("idx_space_type_env", "avernet_tenant", "space_type", "env"),
+        Index("idx_space_sc_team", "avernet_tenant", "env", "sc_team_id"),
+        CheckConstraint("space_type IN ('PERSONAL', 'TEAM')", name="ck_space_type"),
+        CheckConstraint(
+            "sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')",
+            name="ck_space_mapping_status",
+        ),
+        CheckConstraint("env <> ''", name="ck_space_env_not_empty"),
     )
 
     def to_record(self) -> SpaceRecord:
@@ -56,7 +63,7 @@ class SpaceModel(Base):
             space_type=SpaceType(self.space_type),
             name=self.name,
             personal_owner_id=self.personal_owner_id,
-            sc_team_id=self.sc_team_id,
+            sc_team_id=str(self.sc_team_id) if self.sc_team_id is not None else None,
             env=self.env,
             created_by=self.created_by,
             updated_by=self.updated_by,
@@ -70,32 +77,25 @@ class SpaceMemberModel(Base):
 
     id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
     space_id = Column(AutoIncrementBigInteger, nullable=False)
-    user_id = Column(String(256), nullable=False)
-    role = Column(String(32), nullable=False)
+    user_id = Column(String(128), nullable=False)
+    role = Column(String(24), nullable=False)
+    status = Column(String(16), nullable=False, server_default="ACTIVE")
     env = Column(String(20), nullable=False, default=get_current_env)
     avernet_tenant = Column(String(64), nullable=False, server_default="teamclaw")
-    created_by = Column(String(256), nullable=False)
+    created_by = Column(String(128), nullable=False)
+    removed_at = Column(DateTime, nullable=True)
+    removed_by = Column(String(128), nullable=True)
     gmt_created = Column(DateTime, nullable=False, server_default=func.now())
     gmt_modified = Column(
         DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
     __table_args__ = (
-        UniqueConstraint(
-            "avernet_tenant",
-            "space_id",
-            "user_id",
-            "env",
-            name="uk_space_member_user_env",
-        ),
-        Index("idx_space_member_user", "avernet_tenant", "user_id", "env"),
-        Index(
-            "idx_space_member_role",
-            "avernet_tenant",
-            "space_id",
-            "role",
-            "env",
-        ),
+        UniqueConstraint("avernet_tenant", "env", "space_id", "user_id", name="uk_space_member"),
+        Index("idx_space_member_user", "avernet_tenant", "env", "user_id", "status"),
+        CheckConstraint("role IN ('ADMINISTRATOR', 'MEMBER')", name="ck_space_member_role"),
+        CheckConstraint("status IN ('ACTIVE', 'INACTIVE')", name="ck_space_member_status"),
+        CheckConstraint("env <> ''", name="ck_space_member_env_not_empty"),
     )
 
     def to_record(self) -> SpaceMemberRecord:
@@ -103,7 +103,11 @@ class SpaceMemberModel(Base):
             id=self.id,
             space_id=self.space_id,
             user_id=self.user_id,
-            role=SpaceRole(self.role),
+            role=(
+                SpaceRole.OWNER
+                if self.role == "ADMINISTRATOR"
+                else SpaceRole.MEMBER
+            ),
             env=self.env,
             created_by=self.created_by,
             gmt_created=self.gmt_created,

--- a/src/backend/src/agentclaw/community/core/spaces/sql/2026_08_17_spaces.sql
+++ b/src/backend/src/agentclaw/community/core/spaces/sql/2026_08_17_spaces.sql
@@ -1,34 +1,100 @@
--- Space and member foundation for the Skill Space refactor.
+-- Space foundation plus F01 final-schema upgrade.
+--
+-- Existing installations may already have the original 2026-08-17 tables.
+-- Therefore CREATE TABLE is followed by explicit additive ALTER statements:
+-- CREATE TABLE IF NOT EXISTS alone is not a migration and must not be relied
+-- upon to supply F01 columns. Before converting sc_team_id to BIGINT, run the
+-- paired F01 verification query; any non-numeric existing mapping is a
+-- fail-closed release blocker rather than data to coerce silently.
+
 CREATE TABLE IF NOT EXISTS ac_space (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    space_code VARCHAR(64) NOT NULL,
-    space_type VARCHAR(32) NOT NULL COMMENT 'PERSONAL | TEAM',
-    name VARCHAR(128) NOT NULL,
-    personal_owner_id VARCHAR(256) NULL,
-    env VARCHAR(20) NOT NULL,
-    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
-    created_by VARCHAR(256) NOT NULL,
+    space_code VARCHAR(128) NOT NULL,
+    space_type VARCHAR(16) NOT NULL COMMENT 'PERSONAL/TEAM',
+    name VARCHAR(256) NOT NULL,
+    description TEXT NULL,
+    personal_owner_id VARCHAR(128) NULL,
+    sc_team_id BIGINT NULL,
+    sc_mapping_status VARCHAR(24) NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING/ACTIVE/INACTIVE/CLEANUP_FAILED',
+    created_by VARCHAR(128) NOT NULL,
     updated_by VARCHAR(256) NOT NULL,
-    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL,
+    deleted_by VARCHAR(128) NULL,
+    avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
+    env VARCHAR(20) NOT NULL,
+    gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_space_code_env (avernet_tenant, space_code, env),
-    UNIQUE KEY uk_space_personal_owner_env (avernet_tenant, personal_owner_id, env),
-    KEY idx_space_type_env (avernet_tenant, space_type, env)
+    UNIQUE KEY uk_space_code (avernet_tenant, env, space_code),
+    UNIQUE KEY uk_personal_space (avernet_tenant, env, personal_owner_id),
+    KEY idx_space_sc_team (avernet_tenant, env, sc_team_id),
+    CONSTRAINT ck_space_type CHECK (space_type IN ('PERSONAL', 'TEAM')),
+    CONSTRAINT ck_space_mapping_status CHECK (sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')),
+    CONSTRAINT ck_space_env_not_empty CHECK (env <> '')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE ac_space
+    MODIFY COLUMN space_code VARCHAR(128) NOT NULL,
+    MODIFY COLUMN space_type VARCHAR(16) NOT NULL,
+    MODIFY COLUMN name VARCHAR(256) NOT NULL,
+    MODIFY COLUMN personal_owner_id VARCHAR(128) NULL,
+    ADD COLUMN IF NOT EXISTS description TEXT NULL,
+    ADD COLUMN IF NOT EXISTS sc_mapping_status VARCHAR(24) NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS deleted_by VARCHAR(128) NULL,
+    ADD COLUMN IF NOT EXISTS updated_by VARCHAR(256) NOT NULL DEFAULT '',
+    MODIFY COLUMN env VARCHAR(20) NOT NULL;
+
+-- Run only after the paired verification query proves every existing value is
+-- numeric. The engine must stop when that query reports a nonzero count.
+ALTER TABLE ac_space MODIFY COLUMN sc_team_id BIGINT NULL;
+UPDATE ac_space SET sc_mapping_status = 'PENDING' WHERE sc_mapping_status IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_space_code
+    ON ac_space (avernet_tenant, env, space_code);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_personal_space
+    ON ac_space (avernet_tenant, env, personal_owner_id);
+CREATE INDEX IF NOT EXISTS idx_space_sc_team
+    ON ac_space (avernet_tenant, env, sc_team_id);
+ALTER TABLE ac_space
+    ADD CONSTRAINT IF NOT EXISTS ck_space_type CHECK (space_type IN ('PERSONAL', 'TEAM')),
+    ADD CONSTRAINT IF NOT EXISTS ck_space_mapping_status CHECK (sc_mapping_status IN ('PENDING', 'ACTIVE', 'INACTIVE', 'CLEANUP_FAILED')),
+    ADD CONSTRAINT IF NOT EXISTS ck_space_env_not_empty CHECK (env <> '');
 
 CREATE TABLE IF NOT EXISTS ac_space_member (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     space_id BIGINT UNSIGNED NOT NULL,
-    user_id VARCHAR(256) NOT NULL,
-    role VARCHAR(32) NOT NULL COMMENT 'OWNER | MEMBER',
-    env VARCHAR(20) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
+    role VARCHAR(24) NOT NULL COMMENT 'ADMINISTRATOR/MEMBER',
+    status VARCHAR(16) NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/INACTIVE',
+    created_by VARCHAR(128) NOT NULL,
+    removed_at TIMESTAMP NULL,
+    removed_by VARCHAR(128) NULL,
     avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
-    created_by VARCHAR(256) NOT NULL,
-    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    env VARCHAR(20) NOT NULL,
+    gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_space_member_user_env (avernet_tenant, space_id, user_id, env),
-    KEY idx_space_member_user (avernet_tenant, user_id, env),
-    KEY idx_space_member_role (avernet_tenant, space_id, role, env)
+    UNIQUE KEY uk_space_member (avernet_tenant, env, space_id, user_id),
+    KEY idx_space_member_user (avernet_tenant, env, user_id, status),
+    CONSTRAINT ck_space_member_role CHECK (role IN ('ADMINISTRATOR', 'MEMBER')),
+    CONSTRAINT ck_space_member_status CHECK (status IN ('ACTIVE', 'INACTIVE')),
+    CONSTRAINT ck_space_member_env_not_empty CHECK (env <> '')
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE ac_space_member
+    MODIFY COLUMN user_id VARCHAR(128) NOT NULL,
+    MODIFY COLUMN role VARCHAR(24) NOT NULL,
+    ADD COLUMN IF NOT EXISTS status VARCHAR(16) NOT NULL DEFAULT 'ACTIVE',
+    ADD COLUMN IF NOT EXISTS removed_at TIMESTAMP NULL,
+    ADD COLUMN IF NOT EXISTS removed_by VARCHAR(128) NULL,
+    MODIFY COLUMN env VARCHAR(20) NOT NULL;
+UPDATE ac_space_member SET role = 'ADMINISTRATOR' WHERE role = 'OWNER';
+UPDATE ac_space_member SET status = 'ACTIVE' WHERE status IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS uk_space_member
+    ON ac_space_member (avernet_tenant, env, space_id, user_id);
+CREATE INDEX IF NOT EXISTS idx_space_member_user
+    ON ac_space_member (avernet_tenant, env, user_id, status);
+ALTER TABLE ac_space_member
+    ADD CONSTRAINT IF NOT EXISTS ck_space_member_role CHECK (role IN ('ADMINISTRATOR', 'MEMBER')),
+    ADD CONSTRAINT IF NOT EXISTS ck_space_member_status CHECK (status IN ('ACTIVE', 'INACTIVE')),
+    ADD CONSTRAINT IF NOT EXISTS ck_space_member_env_not_empty CHECK (env <> '');

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -89,6 +89,7 @@ from agentclaw.community.core.repository.protocols.skill_center import SkillSetR
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillMemberRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillCategoryRepository
+from agentclaw.community.core.repository.protocols.skill_center import SpaceSkillRepository
 from agentclaw.community.core.skill_center.services.skill_auth_service import (
     SkillAuthService,
 )
@@ -177,6 +178,7 @@ from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
 from agentclaw.community.core.repository.implementations.skill_center.sync_log import SkillCenterSyncLogRepository as UnifiedSkillCenterSyncLogRepository
+from agentclaw.community.core.repository.implementations.skill_center.space_skill import SpaceSkillRepository as UnifiedSpaceSkillRepository
 from agentclaw.community.core.repository.implementations.skill_center.propagation_log import SkillPropagationLogRepository as UnifiedSkillPropagationLogRepository
 from agentclaw.community.core.repository.implementations.skill_center.local_skill_cleanup import SqlLocalSkillCleanupRepository
 
@@ -258,6 +260,11 @@ class SkillCenterModule(Module):
         binder.bind(
             SkillCenterSyncLogRepository,
             to=UnifiedSkillCenterSyncLogRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SpaceSkillRepository,
+            to=UnifiedSpaceSkillRepository,
             scope=singleton,
         )
         binder.bind(

--- a/src/backend/tests/community/architecture/test_repository_contracts.py
+++ b/src/backend/tests/community/architecture/test_repository_contracts.py
@@ -139,7 +139,7 @@ def test_protocols_hold_no_implementations() -> None:
         f"{_rel(p)}:{c.lineno} {c.name}"
         for p in _py_files(_PROTOCOLS) for c in _classes(p)
         if not _is_protocol(c) and not c.name.endswith(("Error", "Exception"))
-        and not any(isinstance(b, ast.Name) and b.id in {"ABC", "StrEnum", "Enum"}
+        and not any(isinstance(b, ast.Name) and b.id in {"ABC", "StrEnum", "Enum", "TypedDict"}
                     for b in c.bases)
     ]
     assert not offenders, (

--- a/src/backend/tests/community/core/skill_center/test_feature_flags.py
+++ b/src/backend/tests/community/core/skill_center/test_feature_flags.py
@@ -14,6 +14,7 @@ class TestSkillCenterFlags:
         )
         assert flags.write_skill_uuid is True
         assert flags.nas_sync_enabled is False
+        assert flags.space_skill_enabled is False
 
     def test_from_env_reads_env_vars(self):
         os.environ["SC_NAS_SYNC_ENABLED"] = "true"
@@ -23,6 +24,7 @@ class TestSkillCenterFlags:
             assert flags.nas_sync_enabled is True
             assert flags.propagation_enabled is True
             assert flags.center_uri_enabled is False
+            assert flags.space_skill_enabled is False
         finally:
             del os.environ["SC_NAS_SYNC_ENABLED"]
             del os.environ["SC_PROPAGATION_ENABLED"]

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 
 import pytest
 from sqlalchemy import create_engine, event
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.models import Skill, SkillSet, SkillSetSkill
@@ -419,20 +420,19 @@ def test_public_local_delete_rechecks_active_custom_set_in_delete_transaction(
             assert session.query(LocalSkillCleanupWorkModel).one().status == "preparing"
 
 
-def test_skill_create_is_plain_insert_not_upsert(skills):
-    # Distinct versions → two independent rows (plain INSERT, not an
-    # upsert that would update-in-place).
-    a = skills.create({"name": "dup", "skill_uuid": "x", "version": 1})
-    b = skills.create({"name": "dup", "skill_uuid": "x", "version": 2})
-    assert a["id"] != b["id"]
-    assert len(skills.list_skills()) == 2
+def test_skill_identity_rejects_a_second_row_for_the_same_uuid(skills):
+    skills.create({"name": "dup", "skill_uuid": "x", "version": 1})
+    with pytest.raises(IntegrityError, match="UNIQUE constraint failed"):
+        skills.create({"name": "dup", "skill_uuid": "x", "version": 2})
 
 
-def test_skill_create_matches_prod_without_a_source_only_unique_constraint(skills):
-    """Prod accepts duplicate legacy skill identity fields; SQLite must too."""
-    first = skills.create({"name": "d", "skill_uuid": "x", "version": 1})
-    duplicate = skills.create({"name": "d", "skill_uuid": "x", "version": 1})
-    assert duplicate["id"] != first["id"]
+def test_skill_uuid_constraint_is_scoped_by_tenant_and_env(skills):
+    skills.create({"name": "d", "skill_uuid": "x", "version": 1})
+    with avernet_tenant_scope("tenant-b"):
+        other_tenant = skills.create(
+            {"name": "d", "skill_uuid": "x", "version": 1}
+        )
+    assert other_tenant["skill_uuid"] == "x"
 
 
 def test_skill_user_id_anonymous_coercion(skills):
@@ -700,22 +700,17 @@ def test_add_remove_skill_to_set(skills, sets):
     assert sets.get_skills_in_set(ss["id"]) == []
 
 
-def test_get_skills_in_set_center_max_version(skills, sets):
-    ss = sets.create({"name": "cset"})
+def test_legacy_center_version_rows_are_rejected_by_stable_uuid_constraint(skills, sets):
+    sets.create({"name": "cset"})
     skills.create(
         {"name": "cv1", "git_path": "center://c", "skill_uuid": "cu",
          "status": "PUBLISHED", "version": 1}
     )
-    skills.create(
-        {"name": "cv2", "git_path": "center://c", "skill_uuid": "cu",
-         "status": "PUBLISHED", "version": 2}
-    )
-    with skills._db.orm_session() as s:
-        s.add(SkillSetSkill(skill_set_id=int(ss["id"]),
-                            skill_id=0, skill_uuid="cu"))
-    res = sets.get_skills_in_set(ss["id"])
-    assert len(res) == 1
-    assert res[0]["version"] == 2  # MAX(version) PUBLISHED
+    with pytest.raises(IntegrityError, match="UNIQUE constraint failed"):
+        skills.create(
+            {"name": "cv2", "git_path": "center://c", "skill_uuid": "cu",
+             "status": "PUBLISHED", "version": 2}
+        )
 
 
 def test_get_all_active_skill_sets_preserves_global_and_bot_scoped_defaults(sets):

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
@@ -1,0 +1,283 @@
+"""F01 additive Space Skill persistence contract tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.repository.implementations.skill_center.space_skill import (
+    SpaceSkillRepository,
+)
+from agentclaw.community.core.models.space_skill import (
+    SkillGrant,
+    SkillPublicationAttempt,
+    SkillSpaceBinding,
+    SkillVersion,
+    Space,
+    SpaceMember,
+)
+from agentclaw.community.core.models.skill import Skill, SkillSetSkill
+from agentclaw.community.core.models.skill_center_sync_log import SkillCenterSyncLog
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+
+class _Database:
+    def __init__(self):
+        self.engine = create_engine("sqlite://")
+        Base.metadata.create_all(self.engine)
+        self._factory = sessionmaker(bind=self.engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+@pytest.fixture
+def db() -> _Database:
+    return _Database()
+
+
+def test_additive_schema_registers_every_space_skill_fact_with_tenant_env_scope(db):
+    tables = set(inspect(db.engine).get_table_names())
+
+    assert {
+        "ac_space",
+        "ac_space_member",
+        "ac_skill_space_binding",
+        "ac_skill_grant",
+        "ac_skill_draft_edit_lease",
+        "ac_skill_version",
+        "ac_skill_publication_attempt",
+    } <= tables
+
+    for model in (
+        Space,
+        SpaceMember,
+        SkillSpaceBinding,
+        SkillGrant,
+        SkillVersion,
+        SkillPublicationAttempt,
+    ):
+        columns = {column.name: column for column in model.__table__.columns}
+        assert columns["avernet_tenant"].nullable is False
+        assert columns["env"].nullable is False
+
+
+def test_additive_orm_contract_extends_only_the_documented_legacy_tables(db):
+    assert {
+        "draft_target_version",
+        "draft_status",
+        "retired_at",
+        "retired_by",
+        "source_repo_url",
+        "source_branch",
+        "source_subdir",
+        "source_commit_sha",
+    } <= {column.name for column in Skill.__table__.columns}
+    assert {"avernet_tenant", "skill_version_id"} <= {
+        column.name for column in SkillCenterSyncLog.__table__.columns
+    }
+
+    unique_names = {
+        constraint.name
+        for constraint in SkillSetSkill.__table__.constraints
+        if getattr(constraint, "unique", False)
+        or constraint.__class__.__name__ == "UniqueConstraint"
+    }
+    assert "uk_skill_set_skill" in unique_names
+
+
+def test_space_repository_is_tenant_env_scoped_and_unique(db):
+    repo = SpaceSkillRepository(db)
+    created = repo.create_space(
+        {
+            "space_code": "team-a",
+            "space_type": "TEAM",
+            "name": "Team A",
+            "created_by": "u-1",
+            "env": "dev",
+        }
+    )
+
+    assert created["space_code"] == "team-a"
+    assert repo.get_space(created["id"], env="dev")["name"] == "Team A"
+    assert repo.get_space(created["id"], env="prod") is None
+
+    with pytest.raises(IntegrityError):
+        repo.create_space(
+            {
+                "space_code": "team-a",
+                "space_type": "TEAM",
+                "name": "A duplicate",
+                "created_by": "u-1",
+                "env": "dev",
+            }
+        )
+
+
+def test_space_repository_never_reads_another_tenant_row(db):
+    repo = SpaceSkillRepository(db)
+    with avernet_tenant_scope("tenant-a"):
+        created = repo.create_space(
+            {
+                "space_code": "isolated",
+                "space_type": "TEAM",
+                "name": "Tenant A",
+                "created_by": "u-1",
+                "env": "dev",
+            }
+        )
+
+    with avernet_tenant_scope("tenant-b"):
+        assert repo.get_space(created["id"], env="dev") is None
+
+    with avernet_tenant_scope("tenant-a"):
+        assert repo.get_space(created["id"], env="dev")["space_code"] == "isolated"
+
+
+def test_schema_rejects_empty_env_and_duplicate_active_owner(db):
+    with db.orm_session() as session:
+        session.add(
+            Space(
+                space_code="invalid",
+                space_type="TEAM",
+                name="Invalid",
+                created_by="u-1",
+                env="",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.flush()
+        session.rollback()
+
+    with db.orm_session() as session:
+        session.add_all(
+            [
+                SkillGrant(
+                    skill_id=7,
+                    user_id="owner-1",
+                    role="OWNER",
+                    owner_slot=1,
+                    granted_by="owner-1",
+                    env="dev",
+                ),
+                SkillGrant(
+                    skill_id=7,
+                    user_id="owner-2",
+                    role="OWNER",
+                    owner_slot=1,
+                    granted_by="owner-1",
+                    env="dev",
+                ),
+            ]
+        )
+        with pytest.raises(IntegrityError):
+            session.flush()
+        session.rollback()
+
+
+def test_repository_creates_stable_identity_ownership_and_owner_grant_atomically(db):
+    repo = SpaceSkillRepository(db)
+    space = repo.create_space(
+        {
+            "space_code": "team-b",
+            "space_type": "TEAM",
+            "name": "Team B",
+            "created_by": "owner-1",
+            "env": "dev",
+        }
+    )
+    with db.orm_session() as session:
+        session.add(
+            SpaceMember(
+                space_id=space["id"],
+                user_id="owner-1",
+                role="ADMINISTRATOR",
+                created_by="owner-1",
+                env="dev",
+            )
+        )
+
+    created = repo.create_space_skill(
+        skill_data={
+            "name": "risk-review",
+            "env": "dev",
+        },
+        ownership_data={"space_id": space["id"], "created_by": "owner-1", "env": "dev"},
+        owner_grant_data={
+            "user_id": "owner-1",
+            "role": "OWNER",
+            "status": "ACTIVE",
+            "owner_slot": 1,
+            "granted_by": "owner-1",
+            "env": "dev",
+        },
+    )
+
+    assert created["skill"]["id"] is not None
+    assert UUID(created["skill"]["skill_uuid"]).version == 4
+    assert created["ownership"]["skill_id"] == created["skill"]["id"]
+    assert created["owner_grant"]["owner_slot"] == 1
+
+
+def test_repository_rejects_space_skill_without_an_active_owner_membership(db):
+    repo = SpaceSkillRepository(db)
+    space = repo.create_space(
+        {
+            "space_code": "team-c",
+            "space_type": "TEAM",
+            "name": "Team C",
+            "created_by": "creator",
+            "env": "dev",
+        }
+    )
+
+    with pytest.raises(ValueError, match="active Space Member"):
+        repo.create_space_skill(
+            skill_data={"name": "unowned", "env": "dev"},
+            ownership_data={
+                "space_id": space["id"],
+                "created_by": "creator",
+                "env": "dev",
+            },
+            owner_grant_data={
+                "user_id": "missing-member",
+                "granted_by": "creator",
+                "env": "dev",
+            },
+        )
+
+
+def test_additive_migration_is_repeat_safe_and_requires_reviewed_duplicate_cleanup():
+    sql_dir = (
+        Path(__file__).parents[4]
+        / "src"
+        / "agentclaw"
+        / "community"
+        / "core"
+        / "skill_center"
+        / "sql"
+    )
+    ddl = (sql_dir / "2026_08_19_additive_space_skill_schema.sql").read_text()
+    verify = (sql_dir / "2026_08_19_additive_space_skill_schema_verify.sql").read_text()
+
+    assert ddl.count("CREATE TABLE IF NOT EXISTS") == 7
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uk_skill_set_skill" in ddl
+    assert "DELETE FROM" not in ddl
+    assert "ac_skill_set_skill duplicate" in verify
+    assert "ac_skill_set_skill orphan skill" in verify

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
@@ -25,6 +25,10 @@ from agentclaw.community.core.models.space_skill import (
 )
 from agentclaw.community.core.models.skill import Skill, SkillSetSkill
 from agentclaw.community.core.models.skill_center_sync_log import SkillCenterSyncLog
+from agentclaw.community.core.spaces.repository.models import (
+    SpaceMemberModel,
+    SpaceModel,
+)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
@@ -64,6 +68,8 @@ def test_additive_schema_registers_every_space_skill_fact_with_tenant_env_scope(
         "ac_skill_version",
         "ac_skill_publication_attempt",
     } <= tables
+    assert Space is SpaceModel
+    assert SpaceMember is SpaceMemberModel
 
     for model in (
         Space,
@@ -76,6 +82,17 @@ def test_additive_schema_registers_every_space_skill_fact_with_tenant_env_scope(
         columns = {column.name: column for column in model.__table__.columns}
         assert columns["avernet_tenant"].nullable is False
         assert columns["env"].nullable is False
+
+    assert {
+        "description",
+        "sc_mapping_status",
+        "updated_by",
+        "deleted_at",
+        "deleted_by",
+    } <= {column.name for column in SpaceModel.__table__.columns}
+    assert {"status", "removed_at", "removed_by"} <= {
+        column.name for column in SpaceMemberModel.__table__.columns
+    }
 
 
 def test_additive_orm_contract_extends_only_the_documented_legacy_tables(db):
@@ -158,6 +175,7 @@ def test_schema_rejects_empty_env_and_duplicate_active_owner(db):
                 space_type="TEAM",
                 name="Invalid",
                 created_by="u-1",
+                updated_by="u-1",
                 env="",
             )
         )
@@ -275,8 +293,21 @@ def test_additive_migration_is_repeat_safe_and_requires_reviewed_duplicate_clean
     )
     ddl = (sql_dir / "2026_08_19_additive_space_skill_schema.sql").read_text()
     verify = (sql_dir / "2026_08_19_additive_space_skill_schema_verify.sql").read_text()
+    spaces_sql = (
+        Path(__file__).parents[4]
+        / "src"
+        / "agentclaw"
+        / "community"
+        / "core"
+        / "spaces"
+        / "sql"
+        / "2026_08_17_spaces.sql"
+    ).read_text()
 
-    assert ddl.count("CREATE TABLE IF NOT EXISTS") == 7
+    assert ddl.count("CREATE TABLE IF NOT EXISTS") == 5
+    assert "CREATE TABLE IF NOT EXISTS ac_space" not in ddl
+    assert "ALTER TABLE ac_space" in spaces_sql
+    assert "ALTER TABLE ac_space_member" in spaces_sql
     assert "CREATE UNIQUE INDEX IF NOT EXISTS uk_skill_set_skill" in ddl
     assert "DELETE FROM" not in ddl
     assert "ac_skill_set_skill duplicate" in verify


### PR DESCRIPTION
## Problem

Issue #1165 requires the additive persistence foundation for the new Space Skill model while keeping the feature disabled and Legacy Local/Repo/Bot-local paths unchanged.

## Solution

- Add Space, Membership, Ownership, Grant, Edit Lease, Version, and Publication Attempt ORM/DDL facts with tenant/env isolation and constraints.
- Extend existing Skill, Binding, and Sync Log tables with the specified additive fields and unique keys.
- Add an explicit typed Space Skill Repository seam, atomic initial identity/ownership/owner creation, and a default-off `SC_SPACE_SKILL_ENABLED` flag.
- Add repeat-safe migration DDL plus pre/post duplicate, count, and orphan verification queries.

## Validation

- `uv run --project src/backend pytest src/backend/tests/community/architecture src/backend/tests/community/plugins/test_avernet_tenant_guard.py src/backend/tests/community/plugins/local/test_database_bootstrap_skills_pool.py src/backend/tests/community/core/skill_center/test_feature_flags.py src/backend/tests/community/repository/skill_center -q` (270 passed)
- `uv run --project src/backend ruff check ...` (passed)
- `scripts/ci/python_sast_local.sh src/backend 1 --base origin/dev --head HEAD` (passed)

## Compatibility and risk

`SC_SPACE_SKILL_ENABLED` defaults to false and this PR does not route Legacy Local/Repo/Bot-local traffic through Space Skill code. The additive unique binding key requires the reviewed ODC cleanup of two duplicate groups (three redundant rows) before deployment; the migration intentionally fails closed rather than deleting unspecified rows.

## Spec

- [Skill capability upgrade final spec](https://yuque.antfin.com/securitytec/otbct4/rglvn8qtv8w0ep87)
- [Ownership and acceptance boundaries](https://yuque.antfin.com/securitytec/otbct4/rgwq3hvv0nlo79xa)

## Related issues

Closes #1165

## Uncompleted items

Production ODC execution remains blocked until the approved three duplicate `ac_skill_set_skill` primary keys and pre/post evidence are attached to the release runbook.