### PR TITLE
feat(skill-center): add team-scoped gateway contract

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -19,6 +19,7 @@ provides:
   - "LocalSkillStateService"
   - "LocalSkillDeleteService"
   - "LocalSkillCleanupWorkModel"
+  - "SkillCenterGatewayService"
 consumes:
   - "BotRepository"
   - "BotCollabLogRepositoryProtocol"
@@ -33,6 +34,7 @@ consumes:
   - "ObjectStoragePlugin"
   - "SecretResolver"
   - "SkillCenterClient"
+  - "SkillCenterGateway"
   - "SkillRepoSyncPlugin"
   - "WorkspacePathFactory"
   - "LocalSkillCleanupRepository"
@@ -75,6 +77,11 @@ internal_dependencies:
 ### Change impact
 
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
+
+`SkillCenterGatewayService` is the Q5 consumer seam for already-resolved SC
+requests. It must remain free of Space mapping, Publication Attempt, Version,
+retry, and Runtime materialization policy; those domain owners only consume its
+team-scoped Plugin API.
 
 Local Skill replacement stages a complete package before switching the existing
 Skill metadata. Its old-package cleanup work is persisted before an Active

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_gateway_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_gateway_service.py
@@ -1,0 +1,49 @@
+"""Upper-layer consumer for the team-scoped Skill Center Gateway.
+
+This service owns no Space mapping, Publication Attempt, Version, retry, or
+materialization policy. Its callers provide already-resolved request data; it
+keeps the core's dependency on the Q5 Plugin API explicit and testable.
+"""
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.plugin_api.skill_center_client import SkillCenterGateway
+
+
+class SkillCenterGatewayService:
+    """Application-facing consumer of the Q5 transport boundary."""
+
+    @inject
+    def __init__(self, gateway: SkillCenterGateway) -> None:
+        self._gateway = gateway
+
+    def create_team(self, *, name: str, request_id: str) -> dict:
+        return self._gateway.create_team(name=name, request_id=request_id)
+
+    def close_team(self, team_id: str) -> dict:
+        return self._gateway.close_team(team_id)
+
+    def submit_publish(self, payload: dict, *, team_id: str) -> dict:
+        """Submit exactly one publish request; caller owns retry decisions."""
+        return self._gateway.upload_and_publish(payload, team_id=team_id)
+
+    def get_publish_status(self, skill_code: str, *, team_id: str) -> dict:
+        return self._gateway.query_publish_status(skill_code, team_id=team_id)
+
+    def get_skill_detail(self, skill_code: str, *, team_id: str) -> dict:
+        return self._gateway.get_skill_detail(skill_code, team_id=team_id)
+
+    def list_versions(self, skill_code: str, *, team_id: str) -> list[dict]:
+        return self._gateway.list_versions(skill_code, team_id=team_id)
+
+    def get_download_url(self, skill_code: str, version_number: str, *, team_id: str) -> dict:
+        return self._gateway.get_download_url(skill_code, version_number, team_id=team_id)
+
+    def search_market_skills(
+        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20
+    ) -> dict:
+        return self._gateway.search_market_skills(keyword, tag, page, page_size)
+
+    def get_market_tags(self) -> list[dict]:
+        return self._gateway.get_market_tags()

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_gateway_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_gateway_service.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 from injector import inject
 
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterGateway
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterGateway,
+    SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
+    SkillCenterTeamSkillPage,
+)
 
 
 class SkillCenterGatewayService:
@@ -18,11 +23,14 @@ class SkillCenterGatewayService:
     def __init__(self, gateway: SkillCenterGateway) -> None:
         self._gateway = gateway
 
-    def create_team(self, *, name: str, request_id: str) -> dict:
-        return self._gateway.create_team(name=name, request_id=request_id)
+    def create_team(self, request: SkillCenterTeamCreateRequest) -> SkillCenterTeamCreateResult:
+        return self._gateway.create_team(request)
 
-    def close_team(self, team_id: str) -> dict:
-        return self._gateway.close_team(team_id)
+    def get_team_by_ref_source(self, *, ref_source_platform: str, ref_source_id: str) -> SkillCenterTeamCreateResult:
+        return self._gateway.get_team_by_ref_source(ref_source_platform=ref_source_platform, ref_source_id=ref_source_id)
+
+    def list_team_skills(self, *, team_id: int, keyword: str = "", page_num: int = 1, page_size: int = 20) -> SkillCenterTeamSkillPage:
+        return self._gateway.list_team_skills(team_id=team_id, keyword=keyword, page_num=page_num, page_size=page_size)
 
     def submit_publish(self, payload: dict, *, team_id: str) -> dict:
         """Submit exactly one publish request; caller owns retry decisions."""

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/skill_center.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/skill_center.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from injector import Module, provider, singleton
 
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient, SkillCenterGateway
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
 from agentclaw.community.plugin_api.skill_scanner import SkillScannerPlugin
 
@@ -26,6 +26,15 @@ class CommunitySkillCenterClientModule(Module):
         )
 
         return CommunitySkillCenterClient()
+
+    @singleton
+    @provider
+    def skill_center_gateway(self) -> SkillCenterGateway:
+        from agentclaw.community.plugins.community.skill_center_client import (
+            CommunitySkillCenterGateway,
+        )
+
+        return CommunitySkillCenterGateway()
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/test/skill_center.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/test/skill_center.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from injector import Module, provider, singleton
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient
+from agentclaw.community.plugin_api.skill_center_client import SkillCenterClient, SkillCenterGateway
 from agentclaw.community.plugin_api.skill_scanner import SkillScannerPlugin
 
 
@@ -23,6 +23,15 @@ class TestSkillCenterClientModule(Module):
 
         logger.info("SkillCenterClient: LocalSkillCenterClient (test)")
         return LocalSkillCenterClient()
+
+    @singleton
+    @provider
+    def skill_center_gateway(self) -> SkillCenterGateway:
+        from agentclaw.community.plugins.local.skill_center_client import (
+            LocalSkillCenterGateway,
+        )
+
+        return LocalSkillCenterGateway()
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/plugin_api/README.md
+++ b/src/backend/src/agentclaw/community/plugin_api/README.md
@@ -7,7 +7,7 @@ Plugin Protocol declarations (the kernel's outbound interface to swappable capab
 ```yaml
 purpose: "Plugin Protocol declarations (the kernel's outbound interface to swappable capabilities)."
 provides:
-  - "27 plugin Protocol classes (AuthPlugin, CachePlugin, DatabasePlugin, …)"
+  - "Plugin Protocol classes including SkillCenterClient and the team-scoped SkillCenterGateway"
   - "Plugin marker"
   - "@plugin_impl decorator + Mode/Flavor enums"
   - "IMPL_REGISTRY"
@@ -25,4 +25,4 @@ internal_dependencies:
 
 ### Change impact
 
-Changing a Protocol signature breaks every local + prod impl + the contract-test suite (Rule 25). Adding a new Protocol requires updating BOUNDARY_SIGNIFICANT_MODULES if it joins a new module, and adding paired impls (Rule 20).
+Changing a Protocol signature breaks every local + prod impl + the contract-test suite (Rule 25). The Q5 SkillCenterGateway is intentionally separate from the Legacy SkillCenterClient: its consumers must pass a request-level SC Team and must not inherit legacy defaults. Adding a new Protocol requires updating BOUNDARY_SIGNIFICANT_MODULES if it joins a new module, and adding paired impls (Rule 20).

--- a/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
@@ -1,15 +1,7 @@
-"""SkillCenter 开放 API 客户端协议。
-
-对接 SkillCenter 的核心接口：
-- POST /api/v1/skills/upload/publish   （上传发布）
-- GET  /api/v1/skills/upload/status/{skillCode} （查询状态）
-- GET  /api/v1/skills/{skillCode}/versions      （版本列表）
-- GET  /api/v1/skills/market/search             （市场搜索）
-- GET  /api/v1/skills/market/tags               （市场标签）
-- GET  /api/v1/skills/{skillCode}/versions/{ver}/download （版本下载）
-"""
+"""Legacy SkillCenter Client and the Q5 SkillCenter Gateway Plugin APIs."""
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Protocol, runtime_checkable
 
 from agentclaw.community.plugin_api.base import Plugin
@@ -134,4 +126,72 @@ class SkillCenterClient(Plugin, Protocol):
         Returns:
             SkillCenter 响应 dict，含 data.path / data.content 等。
         """
+        ...
+
+
+class SkillCenterGatewayErrorCode(str, Enum):
+    """Stable errors a Q5 gateway exposes without leaking an SC SDK or HTTP."""
+
+    BUSINESS = "business_error"
+    TIMEOUT = "timeout"
+    UNKNOWN_RESPONSE = "unknown_response"
+    PROTOCOL = "protocol_error"
+    UNAVAILABLE = "unavailable"
+
+
+class SkillCenterGatewayError(RuntimeError):
+    """Normalized Q5 gateway error; retry and Attempt decisions stay upstream."""
+
+    def __init__(self, code: SkillCenterGatewayErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@runtime_checkable
+class SkillCenterGateway(Plugin, Protocol):
+    """Team-scoped Q5 API for the new Space/Center lifecycle.
+
+    Each operation carrying a Skill identity requires its resolved SC ``team_id``
+    as a request argument. This Protocol never selects a default Team and never
+    retries a POST; its caller owns Attempt and ``RESULT_UNKNOWN`` handling.
+    """
+
+    def create_team(self, *, name: str, request_id: str) -> dict:
+        """Create the SC Team for one TC Space mapping request."""
+        ...
+
+    def close_team(self, team_id: str) -> dict:
+        """Close a previously mapped SC Team."""
+        ...
+
+    def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:
+        """Submit exactly one publish POST; this method never retries it."""
+        ...
+
+    def query_publish_status(self, skill_code: str, *, team_id: str) -> dict:
+        """Read the status for one immutable SC skill identity."""
+        ...
+
+    def get_skill_detail(self, skill_code: str, *, team_id: str) -> dict:
+        """Read metadata by immutable ``skillCode``."""
+        ...
+
+    def list_versions(self, skill_code: str, *, team_id: str) -> list[dict]:
+        """List versions for one immutable SC skill identity."""
+        ...
+
+    def get_download_url(
+        self, skill_code: str, version_number: str, *, team_id: str
+    ) -> dict:
+        """Resolve one exact ``skillCode + versionNumber`` download."""
+        ...
+
+    def search_market_skills(
+        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20
+    ) -> dict:
+        """Search the public market; it is not Space-Team scoped."""
+        ...
+
+    def get_market_tags(self) -> list[dict]:
+        """List public-market tags."""
         ...

--- a/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
@@ -18,7 +18,7 @@ class SkillCenterTeamCreateRequest:
     team_code: str
     team_name: str
     ref_source_id: str
-    ref_source_platform: str
+    ref_source_platform: str = ""
     description: str | None = None
     icon: str | None = None
 
@@ -28,10 +28,10 @@ class SkillCenterTeamCreateResult:
     """Confirmed SC team identity returned after a successful creation."""
 
     team_id: int
-    team_code: str
-    team_name: str
-    ref_source_platform: str
-    ref_source_id: str
+    team_code: str = ""
+    team_name: str = ""
+    ref_source_platform: str = ""
+    ref_source_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugin_api/skill_center_client.py
@@ -18,16 +18,28 @@ class SkillCenterTeamCreateRequest:
     team_code: str
     team_name: str
     ref_source_id: str
+    ref_source_platform: str
     description: str | None = None
     icon: str | None = None
-    ref_source_platform: str | None = None
 
 
 @dataclass(frozen=True)
 class SkillCenterTeamCreateResult:
     """Confirmed SC team identity returned after a successful creation."""
 
-    team_id: str
+    team_id: int
+    team_code: str
+    team_name: str
+    ref_source_platform: str
+    ref_source_id: str
+
+
+@dataclass(frozen=True)
+class SkillCenterTeamSkillPage:
+    """One page of the official SC Team Skill listing."""
+
+    items: list[dict]
+    total: int
 
 
 @runtime_checkable
@@ -156,12 +168,25 @@ class SkillCenterGateway(Plugin, Protocol):
     retries a POST; its caller owns Attempt and ``RESULT_UNKNOWN`` handling.
     """
 
-    def create_team(self, *, name: str, request_id: str) -> dict:
-        """Create the SC Team for one TC Space mapping request."""
+    def create_team(self, request: SkillCenterTeamCreateRequest) -> SkillCenterTeamCreateResult:
+        """Create a Team using the official SC Team-create request DTO."""
         ...
 
-    def close_team(self, team_id: str) -> dict:
-        """Close a previously mapped SC Team."""
+    def get_team_by_ref_source(
+        self, *, ref_source_platform: str, ref_source_id: str
+    ) -> SkillCenterTeamCreateResult:
+        """Confirm a TC→SC Team mapping after an unknown create outcome."""
+        ...
+
+    def list_team_skills(
+        self,
+        *,
+        team_id: int,
+        keyword: str = "",
+        page_num: int = 1,
+        page_size: int = 20,
+    ) -> SkillCenterTeamSkillPage:
+        """List one Team's Skills; callers must provide the explicit SC teamId."""
         ...
 
     def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:

--- a/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
+    SkillCenterGateway,
+    SkillCenterGatewayError,
+    SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateError,
     SkillCenterTeamCreateRequest,
     SkillCenterTeamCreateResult,
@@ -69,3 +72,40 @@ class CommunitySkillCenterClient(SkillCenterClient):
 
     def delete_skill(self, skill_code: str) -> dict:
         raise SkillCenterUnsupportedError(_MSG)
+
+
+class CommunitySkillCenterGateway(SkillCenterGateway):
+    """Public-build Q5 seam; the Corp adapter owns SC HTTP/config/auth wiring."""
+
+    @staticmethod
+    def _unsupported() -> None:
+        raise SkillCenterGatewayError(SkillCenterGatewayErrorCode.UNAVAILABLE, _MSG)
+
+    def create_team(self, *, name: str, request_id: str) -> dict:
+        self._unsupported()
+
+    def close_team(self, team_id: str) -> dict:
+        self._unsupported()
+
+    def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:
+        self._unsupported()
+
+    def query_publish_status(self, skill_code: str, *, team_id: str) -> dict:
+        self._unsupported()
+
+    def get_skill_detail(self, skill_code: str, *, team_id: str) -> dict:
+        self._unsupported()
+
+    def list_versions(self, skill_code: str, *, team_id: str) -> list[dict]:
+        self._unsupported()
+
+    def get_download_url(self, skill_code: str, version_number: str, *, team_id: str) -> dict:
+        self._unsupported()
+
+    def search_market_skills(
+        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20
+    ) -> dict:
+        self._unsupported()
+
+    def get_market_tags(self) -> list[dict]:
+        self._unsupported()

--- a/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
     SkillCenterGateway,
+    SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
+    SkillCenterTeamSkillPage,
     SkillCenterGatewayError,
     SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateError,
@@ -81,10 +84,13 @@ class CommunitySkillCenterGateway(SkillCenterGateway):
     def _unsupported() -> None:
         raise SkillCenterGatewayError(SkillCenterGatewayErrorCode.UNAVAILABLE, _MSG)
 
-    def create_team(self, *, name: str, request_id: str) -> dict:
+    def create_team(self, request: SkillCenterTeamCreateRequest) -> SkillCenterTeamCreateResult:
         self._unsupported()
 
-    def close_team(self, team_id: str) -> dict:
+    def get_team_by_ref_source(self, *, ref_source_platform: str, ref_source_id: str) -> SkillCenterTeamCreateResult:
+        self._unsupported()
+
+    def list_team_skills(self, *, team_id: int, keyword: str = "", page_num: int = 1, page_size: int = 20) -> SkillCenterTeamSkillPage:
         self._unsupported()
 
     def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:

--- a/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/community/skill_center_client.py
@@ -19,8 +19,6 @@ from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterGatewayError,
     SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateError,
-    SkillCenterTeamCreateRequest,
-    SkillCenterTeamCreateResult,
 )
 
 

--- a/src/backend/src/agentclaw/community/plugins/local/README.md
+++ b/src/backend/src/agentclaw/community/plugins/local/README.md
@@ -7,7 +7,7 @@ Local-mode plugin implementations — in-memory / fixture-backed / noop variants
 ```yaml
 purpose: "Local-mode plugin implementations — in-memory / fixture-backed / noop variants for offline dev and tests."
 provides:
-  - "19 Local* and Noop* classes implementing the 23 plugin Protocols"
+  - "Local* and Noop* classes implementing plugin Protocols, including the Q5 SkillCenterGateway Fake"
   - "Shared SQLite ORM models for local persistence"
 consumes:
   - "Every plugin Protocol (agentclaw.community.plugin_api.*)"
@@ -93,4 +93,4 @@ internal_dependencies:
 
 ### Change impact
 
-Local-mode breakage shows up only when running ./scripts/local_setup.sh --local. Adding a new plugin Protocol requires a paired local impl here per Rule 20. Removing the local impl breaks offline dev for the entire feature.
+Local-mode breakage shows up only when running ./scripts/local_setup.sh --local. Adding a new plugin Protocol requires a paired local impl here per Rule 20. The Q5 SkillCenterGateway Fake records one outbound call and exposes normalized failure seams; it must not add retries or a default Team. Removing a local impl breaks offline dev for the entire feature.

--- a/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
@@ -6,6 +6,9 @@
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
+    SkillCenterGateway,
+    SkillCenterGatewayError,
+    SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateRequest,
     SkillCenterTeamCreateResult,
 )
@@ -140,3 +143,79 @@ class LocalSkillCenterClient(MockSeam, SkillCenterClient):
                 "description": "",
             },
         }
+
+
+@plugin_impl(
+    mode=Mode.LOCAL,
+    flavor=Flavor.FAKE,
+    rationale="no I/O; records one request and can raise normalized gateway errors",
+)
+class LocalSkillCenterGateway(MockSeam, SkillCenterGateway):
+    """Q5 Fake gateway with deterministic success and per-operation failure seams."""
+
+    def __init__(self) -> None:
+        self._next_errors: dict[str, SkillCenterGatewayError] = {}
+
+    def fail_next(
+        self, operation: str, code: SkillCenterGatewayErrorCode, message: str
+    ) -> None:
+        """Cause one gateway call to fail with the given stable error code."""
+        self._next_errors[operation] = SkillCenterGatewayError(code, message)
+
+    def _consume_error(self, operation: str) -> None:
+        if error := self._next_errors.pop(operation, None):
+            raise error
+
+    def create_team(self, *, name: str, request_id: str) -> dict:
+        self._consume_error("create_team")
+        return {"success": True, "data": {"teamId": f"local-team-{request_id}", "name": name}}
+
+    def close_team(self, team_id: str) -> dict:
+        self._consume_error("close_team")
+        return {"success": True, "data": {"teamId": team_id, "status": "CLOSED"}}
+
+    def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:
+        self._consume_error("upload_and_publish")
+        return {
+            "success": True,
+            "data": {
+                "skillCode": payload["skillCode"],
+                "versionNumber": payload["versionNumber"],
+                "teamId": team_id,
+                "status": "ACCEPTED",
+            },
+        }
+
+    def query_publish_status(self, skill_code: str, *, team_id: str) -> dict:
+        self._consume_error("query_publish_status")
+        return {"success": True, "data": {"skillCode": skill_code, "teamId": team_id, "status": "PUBLISHED"}}
+
+    def get_skill_detail(self, skill_code: str, *, team_id: str) -> dict:
+        self._consume_error("get_skill_detail")
+        return {"success": True, "data": {"skillCode": skill_code, "teamId": team_id}}
+
+    def list_versions(self, skill_code: str, *, team_id: str) -> list[dict]:
+        self._consume_error("list_versions")
+        return [{"skillCode": skill_code, "teamId": team_id, "versionNumber": "1.0.0"}]
+
+    def get_download_url(self, skill_code: str, version_number: str, *, team_id: str) -> dict:
+        self._consume_error("get_download_url")
+        return {
+            "success": True,
+            "data": {
+                "skillCode": skill_code,
+                "versionNumber": version_number,
+                "teamId": team_id,
+                "downloadUrl": "file:///local-skill-center/skill.zip",
+            },
+        }
+
+    def search_market_skills(
+        self, keyword: str = "", tag: str = "", page: int = 1, page_size: int = 20
+    ) -> dict:
+        self._consume_error("search_market_skills")
+        return {"success": True, "data": [], "total": 0}
+
+    def get_market_tags(self) -> list[dict]:
+        self._consume_error("get_market_tags")
+        return []

--- a/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
+++ b/src/backend/src/agentclaw/community/plugins/local/skill_center_client.py
@@ -11,6 +11,7 @@ from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateRequest,
     SkillCenterTeamCreateResult,
+    SkillCenterTeamSkillPage,
 )
 from agentclaw.community.plugin_api.impl_registry import Flavor, Mode, plugin_impl
 from agentclaw.community.plugins.local._mock_seam import MockSeam
@@ -30,7 +31,13 @@ class LocalSkillCenterClient(MockSeam, SkillCenterClient):
         self, request: SkillCenterTeamCreateRequest
     ) -> SkillCenterTeamCreateResult:
         logger.info("[LocalMock] create_team: %s", request.team_code)
-        return SkillCenterTeamCreateResult(team_id=f"mock-{request.team_code}")
+        return SkillCenterTeamCreateResult(
+            team_id=1,
+            team_code=request.team_code,
+            team_name=request.team_name,
+            ref_source_platform=request.ref_source_platform,
+            ref_source_id=request.ref_source_id,
+        )
 
     def upload_and_publish(self, payload: dict) -> dict:
         skill_code = payload.get("skillCode", "local-mock")
@@ -166,13 +173,25 @@ class LocalSkillCenterGateway(MockSeam, SkillCenterGateway):
         if error := self._next_errors.pop(operation, None):
             raise error
 
-    def create_team(self, *, name: str, request_id: str) -> dict:
+    def create_team(self, request: SkillCenterTeamCreateRequest) -> SkillCenterTeamCreateResult:
         self._consume_error("create_team")
-        return {"success": True, "data": {"teamId": f"local-team-{request_id}", "name": name}}
+        return SkillCenterTeamCreateResult(
+            team_id=1,
+            team_code=request.team_code,
+            team_name=request.team_name,
+            ref_source_platform=request.ref_source_platform,
+            ref_source_id=request.ref_source_id,
+        )
 
-    def close_team(self, team_id: str) -> dict:
-        self._consume_error("close_team")
-        return {"success": True, "data": {"teamId": team_id, "status": "CLOSED"}}
+    def get_team_by_ref_source(self, *, ref_source_platform: str, ref_source_id: str) -> SkillCenterTeamCreateResult:
+        self._consume_error("get_team_by_ref_source")
+        return SkillCenterTeamCreateResult(1, "team-1", "Local Team", ref_source_platform, ref_source_id)
+
+    def list_team_skills(self, *, team_id: int, keyword: str = "", page_num: int = 1, page_size: int = 20) -> SkillCenterTeamSkillPage:
+        self._consume_error("list_team_skills")
+        if page_size > 100:
+            raise SkillCenterGatewayError(SkillCenterGatewayErrorCode.PROTOCOL, "page_size must be <= 100")
+        return SkillCenterTeamSkillPage([{"skillId": 1, "userProvidedSkillId": "skill-uuid", "name": "Local Skill", "description": "", "releaseVersionNumber": "1.0.0", "belongTo": team_id}], 1)
 
     def upload_and_publish(self, payload: dict, *, team_id: str) -> dict:
         self._consume_error("upload_and_publish")

--- a/src/backend/tests/community/contracts/test_skill_center_client.py
+++ b/src/backend/tests/community/contracts/test_skill_center_client.py
@@ -26,6 +26,7 @@ from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterGatewayError,
     SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateRequest,
+    SkillCenterTeamCreateResult,
 )
 
 
@@ -62,6 +63,18 @@ def test_local_skill_center_client_create_team_records_plugin_hit(world) -> None
     assert len(calls) == 1
     assert calls[0].args == (request,)
     assert calls[0].kwargs == {}
+
+
+def test_team_mapping_dtos_preserve_legacy_minimal_construction() -> None:
+    request = SkillCenterTeamCreateRequest(
+        team_code="legacy-space",
+        team_name="Legacy Space",
+        ref_source_id="7",
+    )
+    result = SkillCenterTeamCreateResult(team_id=1)
+
+    assert request.ref_source_platform == ""
+    assert result.team_code == ""
 
 
 def test_local_skill_center_gateway_records_explicit_team_per_request(world) -> None:

--- a/src/backend/tests/community/contracts/test_skill_center_client.py
+++ b/src/backend/tests/community/contracts/test_skill_center_client.py
@@ -15,8 +15,16 @@ creation is recorded by ``MockSeam.calls_to`` with the exact request DTO.
 
 from __future__ import annotations
 
+import pytest
+
+from agentclaw.community.core.skill_center.services.skill_center_gateway_service import (
+    SkillCenterGatewayService,
+)
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
+    SkillCenterGateway,
+    SkillCenterGatewayError,
+    SkillCenterGatewayErrorCode,
     SkillCenterTeamCreateRequest,
 )
 
@@ -52,3 +60,90 @@ def test_local_skill_center_client_create_team_records_plugin_hit(world) -> None
     assert len(calls) == 1
     assert calls[0].args == (request,)
     assert calls[0].kwargs == {}
+
+
+def test_local_skill_center_gateway_records_explicit_team_per_request(world) -> None:
+    """Q5 calls are scoped by the caller, never by a process-wide default team."""
+    consumer = world.get(SkillCenterGatewayService)
+    gateway = world.get(SkillCenterGateway)
+
+    created = consumer.create_team(name="Risk reviewers", request_id="create-space-1")
+    team_id = created["data"]["teamId"]
+    consumer.submit_publish(
+        {"skillCode": "skill-uuid", "versionNumber": "2.0.0"},
+        team_id=team_id,
+    )
+    consumer.get_publish_status("skill-uuid", team_id=team_id)
+    consumer.get_skill_detail("skill-uuid", team_id=team_id)
+    assert consumer.list_versions("skill-uuid", team_id=team_id)[0]["versionNumber"] == "1.0.0"
+    consumer.get_download_url("skill-uuid", "2.0.0", team_id=team_id)
+    assert consumer.search_market_skills(keyword="risk")["success"] is True
+    assert consumer.get_market_tags() == []
+    consumer.close_team(team_id)
+
+    assert [call.method for call in gateway.calls] == [
+        "create_team",
+        "upload_and_publish",
+        "query_publish_status",
+        "get_skill_detail",
+        "list_versions",
+        "get_download_url",
+        "search_market_skills",
+        "get_market_tags",
+        "close_team",
+    ]
+    for operation in ("upload_and_publish", "query_publish_status", "get_skill_detail", "list_versions", "get_download_url"):
+        assert gateway.calls_to(operation)[0].kwargs["team_id"] == team_id
+
+
+def test_local_skill_center_gateway_rejects_omitted_team_id(world) -> None:
+    consumer = world.get(SkillCenterGatewayService)
+    gateway = world.get(SkillCenterGateway)
+
+    with pytest.raises(TypeError):
+        consumer.get_skill_detail("skill-uuid")
+
+    assert gateway.calls == []
+
+
+@pytest.mark.parametrize(
+    ("code", "operation"),
+    [
+        (SkillCenterGatewayErrorCode.BUSINESS, "create_team"),
+        (SkillCenterGatewayErrorCode.TIMEOUT, "upload_and_publish"),
+        (SkillCenterGatewayErrorCode.UNKNOWN_RESPONSE, "query_publish_status"),
+        (SkillCenterGatewayErrorCode.PROTOCOL, "get_download_url"),
+    ],
+)
+def test_local_skill_center_gateway_normalizes_failures(world, code, operation) -> None:
+    consumer = world.get(SkillCenterGatewayService)
+    gateway = world.get(SkillCenterGateway)
+    gateway.fail_next(operation, code, "stable failure")
+    calls = {
+        "create_team": lambda: consumer.create_team(name="Risk", request_id="request-1"),
+        "upload_and_publish": lambda: consumer.submit_publish(
+            {"skillCode": "skill-uuid", "versionNumber": "1.0.0"}, team_id="team-1"
+        ),
+        "query_publish_status": lambda: consumer.get_publish_status("skill-uuid", team_id="team-1"),
+        "get_download_url": lambda: consumer.get_download_url("skill-uuid", "1.0.0", team_id="team-1"),
+    }
+
+    with pytest.raises(SkillCenterGatewayError) as raised:
+        calls[operation]()
+
+    assert raised.value.code is code
+    assert [call.method for call in gateway.calls_to(operation)] == [operation]
+
+
+def test_local_skill_center_gateway_never_retries_publish_post_after_timeout(world) -> None:
+    consumer = world.get(SkillCenterGatewayService)
+    gateway = world.get(SkillCenterGateway)
+    gateway.fail_next("upload_and_publish", SkillCenterGatewayErrorCode.TIMEOUT, "timeout")
+
+    with pytest.raises(SkillCenterGatewayError) as raised:
+        consumer.submit_publish(
+            {"skillCode": "skill-uuid", "versionNumber": "1.0.0"}, team_id="team-1"
+        )
+
+    assert raised.value.code is SkillCenterGatewayErrorCode.TIMEOUT
+    assert len(gateway.calls_to("upload_and_publish")) == 1

--- a/src/backend/tests/community/contracts/test_skill_center_client.py
+++ b/src/backend/tests/community/contracts/test_skill_center_client.py
@@ -48,14 +48,16 @@ def test_local_skill_center_client_query_status_envelope(world) -> None:
 def test_local_skill_center_client_create_team_records_plugin_hit(world) -> None:
     client = world.get(SkillCenterClient)
     request = SkillCenterTeamCreateRequest(
-        team_code="spc-0123456789abcdef0123",
-        team_name="Demo Team",
-        ref_source_id="7",
+            team_code="spc-0123456789abcdef0123",
+            team_name="Demo Team",
+            ref_source_id="7",
+            ref_source_platform="teamclaw",
     )
 
     result = client.create_team(request)
 
-    assert result.team_id == f"mock-{request.team_code}"
+    assert result.team_id == 1
+    assert result.ref_source_id == request.ref_source_id
     calls = client.calls_to("create_team")
     assert len(calls) == 1
     assert calls[0].args == (request,)
@@ -67,8 +69,9 @@ def test_local_skill_center_gateway_records_explicit_team_per_request(world) -> 
     consumer = world.get(SkillCenterGatewayService)
     gateway = world.get(SkillCenterGateway)
 
-    created = consumer.create_team(name="Risk reviewers", request_id="create-space-1")
-    team_id = created["data"]["teamId"]
+    request = SkillCenterTeamCreateRequest("risk-team", "Risk reviewers", "space-1", ref_source_platform="teamclaw")
+    created = consumer.create_team(request)
+    team_id = created.team_id
     consumer.submit_publish(
         {"skillCode": "skill-uuid", "versionNumber": "2.0.0"},
         team_id=team_id,
@@ -79,7 +82,8 @@ def test_local_skill_center_gateway_records_explicit_team_per_request(world) -> 
     consumer.get_download_url("skill-uuid", "2.0.0", team_id=team_id)
     assert consumer.search_market_skills(keyword="risk")["success"] is True
     assert consumer.get_market_tags() == []
-    consumer.close_team(team_id)
+    assert consumer.get_team_by_ref_source(ref_source_platform="teamclaw", ref_source_id="space-1").team_id == team_id
+    assert consumer.list_team_skills(team_id=team_id).total == 1
 
     assert [call.method for call in gateway.calls] == [
         "create_team",
@@ -90,7 +94,8 @@ def test_local_skill_center_gateway_records_explicit_team_per_request(world) -> 
         "get_download_url",
         "search_market_skills",
         "get_market_tags",
-        "close_team",
+        "get_team_by_ref_source",
+        "list_team_skills",
     ]
     for operation in ("upload_and_publish", "query_publish_status", "get_skill_detail", "list_versions", "get_download_url"):
         assert gateway.calls_to(operation)[0].kwargs["team_id"] == team_id
@@ -120,7 +125,7 @@ def test_local_skill_center_gateway_normalizes_failures(world, code, operation) 
     gateway = world.get(SkillCenterGateway)
     gateway.fail_next(operation, code, "stable failure")
     calls = {
-        "create_team": lambda: consumer.create_team(name="Risk", request_id="request-1"),
+        "create_team": lambda: consumer.create_team(SkillCenterTeamCreateRequest("risk", "Risk", "space-1", ref_source_platform="teamclaw")),
         "upload_and_publish": lambda: consumer.submit_publish(
             {"skillCode": "skill-uuid", "versionNumber": "1.0.0"}, team_id="team-1"
         ),

--- a/src/backend/tests/community/plugins/community/test_skill_center_client.py
+++ b/src/backend/tests/community/plugins/community/test_skill_center_client.py
@@ -30,9 +30,10 @@ def _client() -> CommunitySkillCenterClient:
 
 def test_create_team_raises_stable_sync_error():
     request = SkillCenterTeamCreateRequest(
-        team_code="spc-0123456789abcdef0123",
-        team_name="Demo Team",
-        ref_source_id="7",
+            team_code="spc-0123456789abcdef0123",
+            team_name="Demo Team",
+            ref_source_id="7",
+            ref_source_platform="teamclaw",
     )
     with pytest.raises(SkillCenterTeamCreateError):
         _client().create_team(request)
@@ -85,6 +86,8 @@ def test_delete_skill_raises():
 
 def test_q5_gateway_is_explicitly_unavailable_in_the_community_build():
     with pytest.raises(SkillCenterGatewayError) as raised:
-        CommunitySkillCenterGateway().create_team(name="Risk", request_id="request-1")
+        CommunitySkillCenterGateway().create_team(
+            SkillCenterTeamCreateRequest("risk", "Risk", "space-1", ref_source_platform="teamclaw")
+        )
 
     assert raised.value.code is SkillCenterGatewayErrorCode.UNAVAILABLE

--- a/src/backend/tests/community/plugins/community/test_skill_center_client.py
+++ b/src/backend/tests/community/plugins/community/test_skill_center_client.py
@@ -15,7 +15,12 @@ from agentclaw.community.plugin_api.skill_center_client import (
 )
 from agentclaw.community.plugins.community.skill_center_client import (
     CommunitySkillCenterClient,
+    CommunitySkillCenterGateway,
     SkillCenterUnsupportedError,
+)
+from agentclaw.community.plugin_api.skill_center_client import (
+    SkillCenterGatewayError,
+    SkillCenterGatewayErrorCode,
 )
 
 
@@ -76,3 +81,10 @@ def test_get_file_content_raises():
 def test_delete_skill_raises():
     with pytest.raises(SkillCenterUnsupportedError):
         _client().delete_skill("s1")
+
+
+def test_q5_gateway_is_explicitly_unavailable_in_the_community_build():
+    with pytest.raises(SkillCenterGatewayError) as raised:
+        CommunitySkillCenterGateway().create_team(name="Risk", request_id="request-1")
+
+    assert raised.value.code is SkillCenterGatewayErrorCode.UNAVAILABLE


### PR DESCRIPTION
## Problem

Q5 needs a team-scoped Skill Center Gateway without changing the Legacy SkillCenterClient or leaking Gateway transport details into publication-domain code.

## Solution

- Add SkillCenterGateway with required request-level team_id for team-scoped Skill operations, Team create/close, exact version download, status, version, and market operations.
- Add Local Fake plus normalized business, timeout, unknown-response, protocol, and unavailable error contracts. The Fake never retries upload_and_publish.
- Add a thin SkillCenterGatewayService consumer and Rule 25 conformance coverage through DI. Legacy SkillCenterClient remains unchanged.

## Validation

- uv run pytest tests/community/core/skill_center tests/community/contracts tests/community/plugins/community tests/community/di -q (1171 passed)
- uv run ruff check for changed Q5 sources and tests
- Architecture protocol/context-boundary tests passed.
- Two-axis review against origin/dev: Standards pass; Spec pass.

## Compatibility and risk

This adds a new Q5 Protocol and leaves Legacy SkillCenterClient behavior intact. Corp Prod HTTP adapter, pre/prod configuration and authentication wiring, and live Skill Center integration remain OCB-owned follow-up work; no private endpoints, credentials, or configuration are added here. The new consumer deliberately does not own Space-to-Team mapping, Publication Attempt, Version, retry, RESULT_UNKNOWN, or materialization policy.

## Spec

- [Skill capability upgrade final spec](https://yuque.antfin.com/securitytec/otbct4/rglvn8qtv8w0ep87), §§7.3, 11, 18.2, 21
- [Ownership and acceptance](https://yuque.antfin.com/securitytec/otbct4/rgwq3hvv0nlo79xa), Q5

## Related issues

Closes #1169