### PR TITLE
docs(bcs): document add-session-participant sponsorship eligibility

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/sessions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/sessions.yaml
@@ -672,14 +672,21 @@ AddSessionParticipantPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Principal cannot manage the session. A Human Principal may manage
-          when it can act as the Session creator or at least one parent Group
-          management actor: the driver, originator, or ManagerWorker manager participant.
+          The Principal may not manage the Session, or the added Bot is not
+          collaboration-eligible. A Human Principal may manage when it can act
+          as the Session creator or at least one parent Group management actor:
+          the driver, originator, or ManagerWorker manager participant.
           Human-to-actor authority is checked only against these target actors:
           direct human_{user.id}, a Bot whose created_by equals the Human user
           id, or a creator relation edge from human_{user.id} to that Bot. The
           server does not enumerate every Bot created by the Human for this
-          authorization decision.
+          authorization decision. Separately, the added Bot must be
+          collaboration-eligible from at least one of the following anchor
+          actors: the calling Principal, the parent Group driver, or the parent
+          Group originator. A Bot is eligible when it is public, equals an
+          anchor, or (for a Human anchor) is owned by that Human via created_by
+          or a creator relation edge, or is a friend of an anchor. A Hidden Bot
+          is rejected outright regardless of any anchor.
         x-error-codes:
           - forbidden
         content:
@@ -687,7 +694,7 @@ AddSessionParticipantPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "404":
-        description: Session or referenced Bot is missing or hidden.
+        description: Session or referenced Bot is missing.
         x-error-codes:
           - session_not_found
           - bot_not_found

--- a/src/bcs/tests/openapi/test_session_v1_contract.py
+++ b/src/bcs/tests/openapi/test_session_v1_contract.py
@@ -277,6 +277,49 @@ def test_add_session_participant_accepts_only_bot_uuid() -> None:
     }
 
 
+def test_add_session_participant_forbidden_documents_management_and_eligibility() -> None:
+    # The add-participant 403 governs two independent gates: Session-management
+    # authority and the added-Bot collaboration-eligibility sponsorship set
+    # {caller, parent Group driver, parent Group originator}. The contract must
+    # document both so other implementations do not regress to caller-only
+    # eligibility semantics.
+    contract = load_contract(CONTRACT_ROOT)
+    operation = contract["paths"][
+        "/openapi/v1/collaboration/sessions/{session_id}/participants"
+    ]["post"]
+
+    forbidden = operation["responses"]["403"]
+    assert forbidden["x-error-codes"] == ["forbidden"]
+    description = forbidden["description"]
+
+    # Session-management authority gate.
+    assert "manage" in description
+    assert "parent Group management actor" in description
+    assert "driver" in description
+    assert "originator" in description
+
+    # Added-Bot collaboration-eligibility sponsorship gate.
+    assert "collaboration-eligible" in description
+    assert "anchor" in description
+    assert "parent Group driver" in description
+    assert "parent Group originator" in description
+    assert "friend of an anchor" in description
+    assert "Hidden Bot is rejected outright" in description
+
+
+def test_add_session_participant_not_found_does_not_classify_hidden_as_missing() -> None:
+    # A Hidden Bot is a 403, not a 404; the not-found response must describe
+    # only a missing Session or Bot.
+    contract = load_contract(CONTRACT_ROOT)
+    operation = contract["paths"][
+        "/openapi/v1/collaboration/sessions/{session_id}/participants"
+    ]["post"]
+
+    not_found = operation["responses"]["404"]
+    assert not_found["x-error-codes"] == ["session_not_found", "bot_not_found"]
+    assert "hidden" not in not_found["description"].lower()
+
+
 def test_update_session_participant_accepts_bot_and_human_modes() -> None:
     contract = load_contract(CONTRACT_ROOT)
     operation = contract["paths"][


### PR DESCRIPTION
## Problem

Follow-up to #1164 (merged as `8e15fce9`). That change widened the V1 session facade's `ensure_collaboration_eligible` so a protected Bot is admitted to a session when reachable from the caller **or** the parent Group's driver/originator — changing `POST /openapi/v1/collaboration/sessions/{session_id}/participants` from 403 to success in the driver/originator-sponsored case.

The authoritative OpenAPI contract was not updated: `AddSessionParticipantPath` 403 still documented only the Session-management authorization gate and was silent on the added-Bot collaboration-eligibility sponsorship semantics. Per `AGENTS.md` (\"Contract changes require matching docs and conformance or compatibility tests\"), a public-API behavior change must be reflected in the contract so other implementations and clients do not keep using caller-only eligibility semantics. Raised as a P1 by an automated review on #1164.

## Solution

- `api-contracts/v1/openapi/sessions.yaml` — `AddSessionParticipantPath`:
  - **403 description**: now documents both gates — the existing Session-management authority (caller acts as session creator or a parent Group management actor: driver/originator/ManagerWorker manager), **and** the new collaboration-eligibility sponsorship from the anchor set `{caller, parent Group driver, parent Group originator}`. A Bot is eligible when it is public, equals an anchor, or (for a Human anchor) is owned via `created_by`/creator edge, or is a friend of an anchor; a Hidden Bot is rejected outright regardless of any anchor.
  - **404 description**: no longer classifies a Hidden Bot as \"missing or hidden\" — Hidden is a 403, so 404 now describes only a missing Session or Bot.
- `tests/openapi/test_session_v1_contract.py` — two conformance tests pinning the documented 403/404 wording so the sponsorship semantics cannot silently regress to caller-only eligibility.

No production code changed.

## Validation

Locally:
```
python3 -m pytest tests/openapi/test_session_v1_contract.py -q
# 22 passed
```
including the two new tests
(`test_add_session_participant_forbidden_documents_management_and_eligibility`,
`test_add_session_participant_not_found_does_not_classify_hidden_as_missing`).

## Compatibility and risk

- Contract-documentation-only change plus conformance tests; no runtime behavior change, no schema/transport change.
- 403 `x-error-codes` stays `["forbidden"]`; 404 `x-error-codes` stays `["session_not_found", "bot_not_found"]`. Only human-readable descriptions changed.

## Note for reviewers (pre-existing, out of scope)

On the `dev` base, `tests/openapi/test_contract.py` has two failures unrelated to this PR (verified by stashing my changes and re-running on clean `inclusionAI/dev`):
- `test_operations_use_the_approved_gateway_security_boundary` — `POST /openapi/v1/collaboration/groups/{group_id}/sessions` deliberately uses `{user: optional, app: optional, bot: optional}` with `x-bcn-identity-policy: human_or_owned_bot`, but the test blanket-asserts `user/app required`.
- `test_contract_contains_exactly_the_34_approved_operations` — the approved-operations inventory no longer matches the actual contract.

Both appear to be a stale test-vs-contract mismatch from the `create_session` identity-policy change, not introduced by this PR. Flagging for visibility; happy to address in a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)