### PR TITLE
ci: run checks for refactory collaboration branch

### DIFF
--- a/.github/workflows/architecture-checks.yml
+++ b/.github/workflows/architecture-checks.yml
@@ -3,9 +3,11 @@ name: Architecture Checks
 on:
   pull_request:
     branches:
+      - dev_refactory_collaboration
       - main
   push:
     branches:
+      - dev_refactory_collaboration
       - main
   workflow_dispatch:
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
       - 'REL*'
   push:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
   workflow_dispatch:
 

--- a/.github/workflows/singlebox-coverage.yml
+++ b/.github/workflows/singlebox-coverage.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
       - 'REL*'
   push:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
   workflow_dispatch:
     inputs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
       - 'REL*'
   push:
     branches:
       - dev
+      - dev_refactory_collaboration
       - main
   workflow_dispatch:
 

--- a/scripts/ci/tests/test_refactory_collaboration_workflow_triggers.py
+++ b/scripts/ci/tests/test_refactory_collaboration_workflow_triggers.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TARGET_BRANCH = "dev_refactory_collaboration"
+WORKFLOW_PATHS = (
+    REPO_ROOT / ".github/workflows/unit-tests.yml",
+    REPO_ROOT / ".github/workflows/singlebox-coverage.yml",
+    REPO_ROOT / ".github/workflows/architecture-checks.yml",
+    REPO_ROOT / ".github/workflows/e2e-tests.yml",
+)
+
+
+def _event_branches(workflow_path: Path, event: str) -> list[str]:
+    lines = workflow_path.read_text(encoding="utf-8").splitlines()
+    event_index = lines.index(f"  {event}:")
+    branches_index = lines.index("    branches:", event_index + 1)
+
+    branches: list[str] = []
+    for line in lines[branches_index + 1 :]:
+        if not line.startswith("      - "):
+            break
+        branches.append(line.removeprefix("      - ").strip("'\""))
+    return branches
+
+
+def test_refactory_collaboration_branch_triggers_required_workflows() -> None:
+    for workflow_path in WORKFLOW_PATHS:
+        for event in ("pull_request", "push"):
+            assert TARGET_BRANCH in _event_branches(workflow_path, event), (
+                f"{workflow_path.name} must run on {event} for {TARGET_BRANCH}"
+            )


### PR DESCRIPTION
## What changed

- run Unit Tests, Singlebox Coverage, Architecture Checks, and E2E Tests for pull requests targeting `dev_refactory_collaboration`
- run the same workflows on pushes to `dev_refactory_collaboration`
- add a focused structural test that prevents the branch trigger from being removed accidentally

## Why

The Skill refactor PRs target `dev_refactory_collaboration`, but the existing workflow branch filters do not include it, so those PRs currently receive no CI checks.

## Validation

- `uv run --with pytest pytest -q scripts/ci/tests/test_refactory_collaboration_workflow_triggers.py scripts/ci/tests/test_unit_test_workflow_diff.py` — 2 passed
- `uvx ruff check scripts/ci/tests/test_refactory_collaboration_workflow_triggers.py` — passed
- all four edited workflow files parse successfully with PyYAML BaseLoader
- `git diff --check` — passed

## Known baseline issue

`test_singlebox_coverage_workflow.py` currently fails on the target branch because it still requires two `src/bcs/**` path-filter entries while the target branch workflow has no `paths` filter. This pre-existing mismatch is not changed by this PR.
