### PR TITLE
feat(backend): restore teclaw's default MCP roster

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -46,7 +46,23 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "hitl"},
     ],
     "moltis": [],
-    "teclaw": [],
+    "teclaw": [
+        {"server_code": "mcp.ant.lwawchat.cogmessagemcp", "name": "蚂蚁钉协作群消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver", "name": "蚂蚁钉日志服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver", "name": "蚂蚁钉群服务"},
+        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp", "name": "蚂蚁钉协作群文档相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver", "name": "蚂蚁钉日程相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver", "name": "蚂蚁钉机器人相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver", "name": "蚂蚁钉消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver", "name": "蚂蚁钉待办服务"},
+        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver", "name": "语雀 MCP"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima-MCP服务"},
+        {"server_code": "mcp.ant.homistudio.recordmcp", "name": "会中会话记录查询服务"},
+        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
+        # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
+        # last to match the other engines' lists.
+        {"server_code": "hitl", "name": "HITL"},
+    ],
     "claude_code": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp", "name": "任务中心MCP", "description": "任务中心待办任务，已办任务等相关任务查询MCP"},
         {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima MCP", "description": "Dima MCP"},

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -547,16 +547,38 @@ def test_template_config_cli_presets_are_aicoding_specific():
     ) == []
 
 
-def test_teclaw_default_roster_is_empty():
-    """teclaw ships no default MCPs — its roster is intentionally empty.
+# The teclaw roster, spelled out independently of the source list. The publish
+# suite's ``_install_default_mcp_catalog`` derives its mock *from*
+# ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so it proves only that a build
+# resolves whatever the roster happens to hold — a typo'd or duplicated
+# ``server_code`` would sail straight through it. This second, independent copy
+# is what makes such an edit fail loudly.
+TECLAW_DEFAULT_MCP_CODES = (
+    "mcp.ant.lwawchat.cogmessagemcp",
+    "mcp.ant.antdingopenapi.antdingreportmcpserver",
+    "mcp.ant.antdingopenapi.antdinggroupmcpserver",
+    "mcp.ant.lwawchat.cogdocumentmcp",
+    "mcp.ant.antdingopenapi.antdingeventmcpserver",
+    "mcp.ant.antdingopenapi.antdingrobotmcpserver",
+    "mcp.ant.antdingopenapi.antdingmessagemcpserver",
+    "mcp.ant.antdingopenapi.antdingtodomcpserver",
+    "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver",
+    "mcp.ant.arkai.dimamcpserver",
+    "mcp.ant.homistudio.recordmcp",
+    "mcp.ant.rpc.dcanttouch.adminservice",
+    "hitl",
+)
 
-    The publish suite's ``_install_default_mcp_catalog`` derives its mock *from*
-    ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so a server added there would
-    be resolved silently. This independent pin makes such an edit fail loudly.
-    """
-    assert get_default_mcp_servers("teclaw") == []
-    assert get_default_mcp_server_codes("teclaw") == []
-    assert "hitl" not in get_default_mcp_server_codes("teclaw")
+
+def test_teclaw_default_roster_shape():
+    """teclaw's roster: exact codes, exact order, no dupes, local entry last."""
+    codes = [s["server_code"] for s in get_default_mcp_servers("teclaw")]
+    assert codes == list(TECLAW_DEFAULT_MCP_CODES)
+    assert len(codes) == len(set(codes)), "duplicate server_code in the teclaw roster"
+    # ``hitl`` is the only local/stdio entry and stays last, matching how the
+    # other engines list it. The artifact path resolves its launch instruction
+    # through LocalMCPRegistry, not MCP Center — see ``_stdio_launch_for``.
+    assert codes[-1] == "hitl"
 
 
 def test_teclaw_roster_is_its_own_bucket():
@@ -564,8 +586,10 @@ def test_teclaw_roster_is_its_own_bucket():
 
     ``_resolve_default_mcp_engine_bucket`` normalizes case and delegates bucket
     overrides to the engine registry; an alias onto ``openclaw`` would silently
-    swap in that engine's whole roster, so pin both the normalization and the
-    distinctness.
+    swap the whole roster, so pin both the normalization and the distinctness.
     """
-    assert get_default_mcp_servers("TECLAW") == []
-    assert get_default_mcp_servers("openclaw") != []
+    assert [s["server_code"] for s in get_default_mcp_servers("TECLAW")] == list(
+        TECLAW_DEFAULT_MCP_CODES
+    )
+    openclaw_codes = {s["server_code"] for s in get_default_mcp_servers("openclaw")}
+    assert "mcp.ant.lwawchat.cogmessagemcp" not in openclaw_codes


### PR DESCRIPTION
## Problem

#1155 set `_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]` to `[]`, so every newly created teclaw bot ships with no default MCP config at all — including the local `hitl` entry. That roster is wanted back.

## Solution

Revert #1155. The 13-entry teclaw bucket in `src/backend/src/agentclaw/community/core/mcp/services/_defaults.py` is restored verbatim from history:

- the 蚂蚁钉 collaboration set — `cogmessagemcp`, `antdingreportmcpserver`, `antdinggroupmcpserver`, `cogdocumentmcp`, `antdingeventmcpserver`, `antdingrobotmcpserver`, `antdingmessagemcpserver`, `antdingtodomcpserver`
- `skylarkmcpserver` (语雀), `dimamcpserver` (Dima), `recordmcp` (会中会话记录查询), `dcanttouch.adminservice` (行政小宝)
- the local/stdio `hitl` entry, kept last to match the other engines' lists

No other code changes are needed: `get_default_mcp_servers`, `get_default_mcp_server_codes`, `get_default_mcp_config`, and the publish suite's roster-derived `_install_default_mcp_catalog` all read the bucket directly.

`tests/community/core/mcp/test_defaults_per_engine.py` goes back to pinning the roster independently of the source list. `TECLAW_DEFAULT_MCP_CODES` plus `test_teclaw_default_roster_shape` (exact codes, exact order, no duplicates, `hitl` last) replace `test_teclaw_default_roster_is_empty`, and `test_teclaw_roster_is_its_own_bucket` again asserts the full roster resolves under case normalization rather than aliasing onto openclaw's bucket. The independent copy is what makes a typo'd or duplicated `server_code` fail loudly — the publish suite's mock is derived from the roster, so it would resolve whatever the roster happens to hold.

A grep over the tree found no other code or test that assumed the empty teclaw roster.

## Validation

- `pytest tests/community/core/mcp/test_defaults_per_engine.py` — 36 passed
- `pytest tests/community/core/mcp/ tests/community/endpoints/test_service_bot_publish_flow.py tests/community/core/config_compose/test_mcporter_composer.py tests/community/kernel/test_bot_config_artifact.py` — 221 passed
- `pytest tests/community/core/service_bot/services/test_publish_flow_service.py tests/community/contracts/test_bot_config_artifact_schema.py` — 181 passed

## Compatibility and risk

Newly created teclaw bots get the roster again; existing bots' stored MCP configs are untouched, since the defaults are only applied at creation time. No schema, contract, or migration impact. Rollback is reverting this commit.

## Related issues

Reverts #1155.

---
_Generated by [Claude Code](https://claude.ai/code/session_016DjPdTLYnE3jcN2xDMPjVz)_