### PR TITLE
fix(skill-center): select compatible default skillset

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -96,7 +96,6 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditPausedError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.di import Injected
@@ -997,7 +996,7 @@ async def get_active_skill_sets(
     engine_type: str | None = Query(None, description="Engine type override; defaults to bot's active_engine"),
     ctx: RequestContext = Depends(get_request_context),
     bot_repo: BotRepository = Injected(BotRepository),
-    repo: SkillSetRepository = Injected(SkillSetRepository),
+    skill_set_service_factory: SkillSetServiceFactoryProtocol = Injected(SkillSetServiceFactoryProtocol),
 ) -> ActiveSkillSetsResponse:
     """获取当前 bot 的所有激活能力集列表
 
@@ -1006,12 +1005,20 @@ async def get_active_skill_sets(
     # Get effective path parameters
     effective_entity_id, effective_bot_id, effective_engine, runtime_engine, effective_entity_type, is_desktop = _get_path_params(ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo)
 
-    # 使用 repository 直接获取所有激活的能力集
-    # 注意：使用 effective_entity_id 而不是 ctx.user_id，以保持一致性
-    # ctx.user_id 可能带有前缀（如 staff_xxx），而数据库存储的是纯 ID
-    active_sets = repo.get_all_active_skill_sets(
+    # 使用 service 获取所有激活的能力集，默认能力集兼容查询策略统一收口在 core service。
+    # 注意：使用 effective_entity_id 而不是 ctx.user_id，以保持一致性；
+    # ctx.user_id 可能带有前缀（如 staff_xxx），而数据库存储的是纯 ID。
+    skill_set_service = skill_set_service_factory.create(
+        entity_id=effective_entity_id,
+        bot_id=effective_bot_id,
+        engine_type=effective_engine,
+        runtime_engine_type=runtime_engine,
+        entity_type=effective_entity_type,
+    )
+    active_sets = skill_set_service.list_active_skill_sets(
         user_id=effective_entity_id,
-        bolt_id=effective_bot_id
+        bolt_id=effective_bot_id,
+        engine_type=effective_engine,
     )
 
     # 处理返回数据，移除 skills 字段

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
@@ -1,0 +1,42 @@
+"""Default SkillSet compatibility contributed by the aicoding engine."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
+    DefaultSkillSetSelection,
+)
+
+from .strategy import AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE
+
+
+class AicodingDefaultSkillSetSelectionResolver:
+    """Route non-normal Claude Code default SkillSet reads to aicoding rows.
+
+    Existing online global default SkillSet rows for routed Claude Code were
+    created under the aicoding runtime engine and ``bolt_id='default'``.  Only
+    this engine relationship needs the compatibility lookup; all unclaimed
+    inputs fall back to the persisted engine in the neutral policy.
+    """
+
+    _GLOBAL_DEFAULT_BOLT_ID = "default"
+
+    def resolve_default_skill_set_selection(
+        self,
+        *,
+        persisted_engine_type: str | None,
+        runtime_engine_type: str | None,
+        normalized_persisted_engine_type: str,
+        normalized_runtime_engine_type: str,
+    ) -> DefaultSkillSetSelection | None:
+        if (
+            normalized_persisted_engine_type == CLAUDE_CODE_ENGINE_TYPE
+            and normalized_runtime_engine_type == AICODING_ENGINE_TYPE
+        ):
+            return DefaultSkillSetSelection(
+                engine_type=runtime_engine_type,
+                bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+            )
+        return None
+
+
+__all__ = ["AicodingDefaultSkillSetSelectionResolver"]

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -13,8 +13,13 @@ from .aicoding.strategy import (
 )
 from .aicoding.cli_defaults import AicodingCliDefaultsResolver
 from .aicoding.mcp_defaults import AicodingMcpDefaultsResolver
+from .aicoding.default_skill_set_selection import AicodingDefaultSkillSetSelectionResolver
 from .default import DefaultProvisioningStrategy
 from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
+from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
+    DefaultSkillSetSelectionPolicy,
+    DefaultSkillSetSelectionResolver,
+)
 
 from agentclaw.community.log import get_logger
 
@@ -150,6 +155,21 @@ class McpDefaultsResolverRegistry(DefaultItemsResolverRegistry):
 
     def __init__(self) -> None:
         super().__init__("MCP")
+
+
+
+
+class DefaultSkillSetSelectionResolverRegistry:
+    """Registry for engine-contributed default SkillSet selection resolvers."""
+
+    def __init__(self) -> None:
+        self._resolvers: list[DefaultSkillSetSelectionResolver] = []
+
+    def register(self, resolver: DefaultSkillSetSelectionResolver) -> None:
+        self._resolvers.append(resolver)
+
+    def build_policy(self) -> DefaultSkillSetSelectionPolicy:
+        return DefaultSkillSetSelectionPolicy(self._resolvers)
 
 
 class EngineProvisioningRegistry:
@@ -307,6 +327,27 @@ def resolve_default_capabilities_engine_bucket(
         engine_type=engine_type,
         template_type=template_type,
     )
+
+
+
+
+def _build_default_skill_set_selection_resolver_registry() -> (
+    DefaultSkillSetSelectionResolverRegistry
+):
+    """Assemble the process-wide default SkillSet selection resolver registry."""
+    registry = DefaultSkillSetSelectionResolverRegistry()
+    registry.register(AicodingDefaultSkillSetSelectionResolver())
+    return registry
+
+
+_DEFAULT_SKILL_SET_SELECTION_RESOLVER_REGISTRY = (
+    _build_default_skill_set_selection_resolver_registry()
+)
+
+
+def get_default_skill_set_selection_policy() -> DefaultSkillSetSelectionPolicy:
+    """Return the process-wide default SkillSet selection policy."""
+    return _DEFAULT_SKILL_SET_SELECTION_RESOLVER_REGISTRY.build_policy()
 
 
 def _build_mcp_defaults_resolver_registry() -> McpDefaultsResolverRegistry:
@@ -513,10 +554,12 @@ __all__ = [
     "BotProvisioningContext",
     "DefaultCapabilitiesEngineBucketResolver",
     "DefaultCapabilitiesEngineBucketResolverRegistry",
+    "DefaultSkillSetSelectionResolverRegistry",
     "EngineProvisioningRegistry",
     "get_baas_engine_bucket_resolver_registry",
     "get_cli_defaults_resolver_registry",
     "get_default_capabilities_engine_bucket_resolver_registry",
+    "get_default_skill_set_selection_policy",
     "get_mcp_defaults_resolver_registry",
     "get_engine_provisioning_registry",
     "normalize_engine_type",

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -1217,8 +1217,27 @@ class SkillSetRepository(
             ss = query.limit(1).first()
             return _skill_set_to_dict(ss) if ss else None
 
+    def _default_skill_set_filter(
+        self,
+        engine_type: Optional[str],
+        default_skill_set_bolt_id: Optional[str],
+    ):
+        conditions = [
+            self.SkillSet.is_default == True,  # noqa: E712
+            self.SkillSet.engine_type == engine_type,
+        ]
+        if default_skill_set_bolt_id is not None:
+            conditions.append(self.SkillSet.bolt_id == default_skill_set_bolt_id)
+        return and_(*conditions)
+
     def _list_all_query(
-        self, db, user_id, bolt_id, engine_type
+        self,
+        db,
+        user_id,
+        bolt_id,
+        engine_type,
+        default_skill_set_bolt_id=None,
+        default_skill_set_engine_type=None,
     ):
         query = db.query(self.SkillSet).filter(
             or_(
@@ -1227,6 +1246,11 @@ class SkillSetRepository(
             )
         )
         effective_bolt_id = bolt_id if bolt_id else "default"
+        effective_default_engine = (
+            engine_type
+            if default_skill_set_engine_type is None
+            else default_skill_set_engine_type
+        )
         if engine_type is not None:
             query = query.filter(
                 or_(
@@ -1234,9 +1258,9 @@ class SkillSetRepository(
                         self.SkillSet.is_default == False,  # noqa: E712
                         self.SkillSet.bolt_id == effective_bolt_id,
                     ),
-                    and_(
-                        self.SkillSet.is_default == True,  # noqa: E712
-                        self.SkillSet.engine_type == engine_type,
+                    self._default_skill_set_filter(
+                        effective_default_engine,
+                        default_skill_set_bolt_id,
                     ),
                 )
             )
@@ -1263,10 +1287,17 @@ class SkillSetRepository(
         user_id: Optional[str] = None,
         bolt_id: Optional[str] = None,
         engine_type: Optional[str] = None,
+        default_skill_set_bolt_id: Optional[str] = None,
+        default_skill_set_engine_type: Optional[str] = None,
     ) -> List[dict]:
         with self._db.orm_session() as db:
             rows = self._list_all_query(
-                db, user_id, bolt_id, engine_type
+                db,
+                user_id,
+                bolt_id,
+                engine_type,
+                default_skill_set_bolt_id,
+                default_skill_set_engine_type,
             ).all()
             return [_skill_set_to_dict(s) for s in rows]
 
@@ -1275,6 +1306,8 @@ class SkillSetRepository(
         user_id: Optional[str] = None,
         bolt_id: Optional[str] = None,
         engine_type: Optional[str] = None,
+        default_skill_set_bolt_id: Optional[str] = None,
+        default_skill_set_engine_type: Optional[str] = None,
     ) -> List[dict]:
         from agentclaw.community.plugin_api.models import BotModel
 
@@ -1301,6 +1334,11 @@ class SkillSetRepository(
                 )
             )
             effective_bolt_id = bolt_id if bolt_id else "default"
+            effective_default_engine = (
+                engine_type
+                if default_skill_set_engine_type is None
+                else default_skill_set_engine_type
+            )
             if engine_type is not None:
                 query = query.filter(
                     or_(
@@ -1308,9 +1346,9 @@ class SkillSetRepository(
                             self.SkillSet.is_default == False,  # noqa: E712
                             self.SkillSet.bolt_id == effective_bolt_id,
                         ),
-                        and_(
-                            self.SkillSet.is_default == True,  # noqa: E712
-                            self.SkillSet.engine_type == engine_type,
+                        self._default_skill_set_filter(
+                            effective_default_engine,
+                            default_skill_set_bolt_id,
                         ),
                     )
                 )
@@ -1325,15 +1363,12 @@ class SkillSetRepository(
             if user_id:
                 query = query.filter(
                     or_(
-                        self.SkillSet.user_id
-                        == _normalize_user_id(user_id),
+                        self.SkillSet.user_id == _normalize_user_id(user_id),
                         self.SkillSet.is_default == True,  # noqa: E712
                         self.SkillSet.is_builtin == True,  # noqa: E712
                     )
                 )
-            rows = query.order_by(
-                self.SkillSet.gmt_created.desc()
-            ).all()
+            rows = query.order_by(self.SkillSet.gmt_created.desc()).all()
             return [_skill_set_to_dict(s) for s in rows]
 
     def get_skill_set_by_name_include_deleted(
@@ -2124,6 +2159,8 @@ class SkillSetRepository(
         user_id: Optional[str] = None,
         bolt_id: Optional[str] = None,
         engine_type: Optional[str] = None,
+        default_skill_set_bolt_id: Optional[str] = None,
+        default_skill_set_engine_type: Optional[str] = None,
     ) -> List[dict]:
         effective_bolt_id = bolt_id if bolt_id else "default"
         parsed = _normalize_user_id(user_id)
@@ -2136,23 +2173,29 @@ class SkillSetRepository(
                 self.SkillSet.bolt_id == effective_bolt_id,
             )
             if engine_type is not None:
-                query = query.filter(
-                    self.SkillSet.engine_type == engine_type
-                )
+                query = query.filter(self.SkillSet.engine_type == engine_type)
             if user_id:
-                query = query.filter(
-                    self.SkillSet.user_id == parsed
-                )
+                query = query.filter(self.SkillSet.user_id == parsed)
             else:
                 query = query.filter(self.SkillSet.user_id.is_(None))
             for ss in query.all():
                 active_sets.append(_skill_set_to_dict(ss))
 
-        default_set = self.get_default(
-            user_id=parsed if user_id is not None and bolt_id is not None else None,
-            bolt_id=effective_bolt_id if user_id is not None and bolt_id is not None else None,
-            engine_type=engine_type,
+        effective_default_engine = (
+            engine_type
+            if default_skill_set_engine_type is None
+            else default_skill_set_engine_type
         )
+        default_set = None
+        if (
+            default_skill_set_bolt_id is None
+            or effective_bolt_id == default_skill_set_bolt_id
+        ):
+            default_set = self.get_default(
+                user_id=parsed if user_id is not None and bolt_id is not None else None,
+                bolt_id=effective_bolt_id if user_id is not None and bolt_id is not None else None,
+                engine_type=effective_default_engine,
+            )
         if default_set:
             enabled = self._get_user_default_enabled(
                 user_id, effective_bolt_id, engine_type=engine_type
@@ -2161,12 +2204,11 @@ class SkillSetRepository(
                 active_sets.append(default_set)
         global_default = self.get_default(
             user_id=None,
-            bolt_id=None,
-            engine_type=engine_type,
+            bolt_id=default_skill_set_bolt_id,
+            engine_type=effective_default_engine,
         )
         if global_default and all(
-            skill_set["id"] != global_default["id"]
-            for skill_set in active_sets
+            skill_set["id"] != global_default["id"] for skill_set in active_sets
         ):
             active_sets.append(global_default)
         return active_sets
@@ -2178,6 +2220,8 @@ class SkillSetRepository(
         bolt_id: Optional[str] = None,
         engine_type: Optional[str] = None,
         env: str,
+        default_skill_set_bolt_id: Optional[str] = None,
+        default_skill_set_engine_type: Optional[str] = None,
     ) -> List[dict]:
         effective_bolt_id = bolt_id if bolt_id else "default"
         parsed = _normalize_user_id(user_id)
@@ -2197,23 +2241,32 @@ class SkillSetRepository(
                 query = query.filter(self.SkillSet.user_id.is_(None))
             active_sets.extend(_skill_set_to_dict(ss) for ss in query.all())
 
-        bot_default = self.get_default(
-            user_id=parsed if user_id is not None and bolt_id is not None else None,
-            bolt_id=effective_bolt_id if user_id is not None and bolt_id is not None else None,
-            engine_type=engine_type,
-            env=env,
+        effective_default_engine = (
+            engine_type
+            if default_skill_set_engine_type is None
+            else default_skill_set_engine_type
         )
+        bot_default = None
+        if (
+            default_skill_set_bolt_id is None
+            or effective_bolt_id == default_skill_set_bolt_id
+        ):
+            bot_default = self.get_default(
+                user_id=parsed if user_id is not None and bolt_id is not None else None,
+                bolt_id=effective_bolt_id if user_id is not None and bolt_id is not None else None,
+                engine_type=effective_default_engine,
+                env=env,
+            )
         if bot_default:
             active_sets.append(bot_default)
         global_default = self.get_default(
             user_id=None,
-            bolt_id=None,
-            engine_type=engine_type,
+            bolt_id=default_skill_set_bolt_id,
+            engine_type=effective_default_engine,
             env=env,
         )
         if global_default and all(
-            skill_set["id"] != global_default["id"]
-            for skill_set in active_sets
+            skill_set["id"] != global_default["id"] for skill_set in active_sets
         ):
             active_sets.append(global_default)
         return active_sets

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -211,6 +211,8 @@ class SkillSetRepository(Protocol):
         user_id: str | None = None,
         bolt_id: str | None = None,
         engine_type: str | None = None,
+        default_skill_set_bolt_id: str | None = None,
+        default_skill_set_engine_type: str | None = None,
     ) -> list[dict]:
         ...
 
@@ -329,6 +331,8 @@ class SkillSetRepository(Protocol):
         user_id: str | None = None,
         bolt_id: str | None = None,
         engine_type: str | None = None,
+        default_skill_set_bolt_id: str | None = None,
+        default_skill_set_engine_type: str | None = None,
     ) -> list[dict]:
         ...
 
@@ -340,6 +344,8 @@ class SkillSetRepository(Protocol):
         bolt_id: str | None = None,
         engine_type: str | None = None,
         env: str,
+        default_skill_set_bolt_id: str | None = None,
+        default_skill_set_engine_type: str | None = None,
     ) -> list[dict]:
         """Return active sets using an explicit environment, never runtime env."""
         ...
@@ -374,6 +380,8 @@ class SkillSetRepository(Protocol):
         user_id: str | None = None,
         bolt_id: str | None = None,
         engine_type: str | None = None,
+        default_skill_set_bolt_id: str | None = None,
+        default_skill_set_engine_type: str | None = None,
     ) -> list[dict]:
         """列出所有技能集（排除已删除 Bot 的），用于重名检查避免误判。"""
         ...

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -42,6 +42,7 @@ from agentclaw.community.core.skill_center.services.skill_set_service import (
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.bot_management.services.engine_resolver import resolve_runtime_engine_for_bot
+from agentclaw.community.core.bot_management.engines.registry import get_default_skill_set_selection_policy
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.plugin_api.skill_repo_sync import SkillRepoSyncPlugin
@@ -584,6 +585,7 @@ class SkillSetServiceFactory:
             mcp_sync_service=self._mcp_sync_service,
             device_plugin=self._device_plugin,
             ext_info_provider=self._ext_info_provider,
+            default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
             path_factory=self._path_factory,
             pool_layout_paths=self._pool_layout_paths,
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
@@ -1,0 +1,85 @@
+"""Default SkillSet selection contracts.
+
+Skill Center owns the neutral query shape for default SkillSets, but concrete
+engine compatibility quirks are contributed through resolvers registered by the
+engine composition root.  This keeps ``core/skill_center`` free from engine-name
+branching while still allowing existing data-layout compatibility rules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class DefaultSkillSetSelection:
+    """Neutral constraints used when querying default SkillSets."""
+
+    engine_type: str | None
+    bolt_id: str | None = None
+
+
+def normalize_engine_for_default_skill_set(engine_type: str | None) -> str:
+    """Normalize public engine spelling for resolver matching."""
+
+    return (engine_type or "").strip().lower().replace("-", "_")
+
+
+class DefaultSkillSetSelectionResolver(Protocol):
+    """Engine-contributed default SkillSet compatibility hook.
+
+    Return ``None`` when the resolver does not own the input.  The policy then
+    tries the next resolver and finally falls back to the persisted engine.
+    """
+
+    def resolve_default_skill_set_selection(
+        self,
+        *,
+        persisted_engine_type: str | None,
+        runtime_engine_type: str | None,
+        normalized_persisted_engine_type: str,
+        normalized_runtime_engine_type: str,
+    ) -> DefaultSkillSetSelection | None:
+        """Return default SkillSet lookup constraints, or ``None``."""
+
+
+class DefaultSkillSetSelectionPolicy:
+    """Resolve default SkillSet query constraints through registered hooks."""
+
+    def __init__(
+        self,
+        resolvers: Iterable[DefaultSkillSetSelectionResolver] | None = None,
+    ) -> None:
+        self._resolvers = tuple(resolvers or ())
+
+    def resolve(
+        self,
+        *,
+        persisted_engine_type: str | None,
+        runtime_engine_type: str | None,
+    ) -> DefaultSkillSetSelection:
+        normalized_persisted_engine = normalize_engine_for_default_skill_set(
+            persisted_engine_type
+        )
+        normalized_runtime_engine = normalize_engine_for_default_skill_set(
+            runtime_engine_type
+        )
+        for resolver in self._resolvers:
+            selection = resolver.resolve_default_skill_set_selection(
+                persisted_engine_type=persisted_engine_type,
+                runtime_engine_type=runtime_engine_type,
+                normalized_persisted_engine_type=normalized_persisted_engine,
+                normalized_runtime_engine_type=normalized_runtime_engine,
+            )
+            if selection is not None:
+                return selection
+        return DefaultSkillSetSelection(engine_type=persisted_engine_type)
+
+
+__all__ = [
+    "DefaultSkillSetSelection",
+    "DefaultSkillSetSelectionPolicy",
+    "DefaultSkillSetSelectionResolver",
+    "normalize_engine_for_default_skill_set",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -32,6 +32,10 @@ from agentclaw.community.core.mcp.services.config_service import MCPConfigServic
 from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.core.skill_center.services.skill_service import SkillService
+from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
+    DefaultSkillSetSelection,
+    DefaultSkillSetSelectionPolicy,
+)
 from agentclaw.community.core.skill_center.path_resolution import (
     canonical_pool_local_path,
 )
@@ -158,6 +162,7 @@ class SkillSetService:
         mcp_sync_service=None,
         device_plugin: DeviceAccessor | None = None,
         ext_info_provider: Callable[[str], Mapping[str, Any] | None] | None = None,
+        default_skill_set_selection_policy: DefaultSkillSetSelectionPolicy | None = None,
         *,
         path_factory: WorkspacePathFactory,
         pool_layout_paths: Callable[
@@ -263,6 +268,35 @@ class SkillSetService:
         self._resolver = resolver
         self._device_sync_dispatcher = device_sync_dispatcher
         self._mcp_sync_service = mcp_sync_service
+        self._default_skill_set_selection_policy = (
+            default_skill_set_selection_policy or DefaultSkillSetSelectionPolicy()
+        )
+
+    def _default_skill_set_selection(
+        self, engine_type: str | None = None
+    ) -> DefaultSkillSetSelection:
+        return self._default_skill_set_selection_policy.resolve(
+            persisted_engine_type=self.engine_type if engine_type is None else engine_type,
+            runtime_engine_type=self.runtime_engine_type,
+        )
+
+    def _default_skill_set_query_kwargs(
+        self, engine_type: str | None = None
+    ) -> dict[str, str | None]:
+        """Return repository kwargs only when compatibility needs them.
+
+        OpenClaw and ordinary Claude Code keep the exact historical query shape.
+        Routed Claude Code needs a different default SkillSet lookup key because
+        online global default rows were created under the runtime engine.
+        """
+        persisted_engine = self.engine_type if engine_type is None else engine_type
+        selection = self._default_skill_set_selection(persisted_engine)
+        if selection.bolt_id is None and selection.engine_type == persisted_engine:
+            return {}
+        return {
+            "default_skill_set_bolt_id": selection.bolt_id,
+            "default_skill_set_engine_type": selection.engine_type,
+        }
 
     def _get_default_capabilities_ext_info(
         self,
@@ -487,7 +521,12 @@ class SkillSetService:
             List of SkillSet dicts
         """
         effective_bolt_id = bolt_id if bolt_id else self.bot_id
-        return self.skill_set_repo.list_all(user_id, bolt_id=effective_bolt_id, engine_type=self.engine_type)
+        return self.skill_set_repo.list_all(
+            user_id,
+            bolt_id=effective_bolt_id,
+            engine_type=self.engine_type,
+            **self._default_skill_set_query_kwargs(),
+        )
 
     def update_skill_set(
         self,
@@ -951,7 +990,10 @@ class SkillSetService:
         current_active_ids = {
             str(s.get('id'))
             for s in self.skill_set_repo.get_all_active_skill_sets(
-                user_id=self.entity_id, bolt_id=self.bot_id, engine_type=self.engine_type
+                user_id=self.entity_id,
+                bolt_id=self.bot_id,
+                engine_type=self.engine_type,
+                **self._default_skill_set_query_kwargs(),
             )
         }
         logger.info(
@@ -1115,7 +1157,8 @@ class SkillSetService:
         skill_sets = self.skill_set_repo.list_all(
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
-            engine_type=self.engine_type
+            engine_type=self.engine_type,
+            **self._default_skill_set_query_kwargs(),
         )
 
         logger.info(f"[get_all_skill_sets_with_skills] 找到 {len(skill_sets)} 个能力集")
@@ -1180,7 +1223,8 @@ class SkillSetService:
         skill_sets = self.skill_set_repo.list_all(
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
-            engine_type=self.engine_type
+            engine_type=self.engine_type,
+            **self._default_skill_set_query_kwargs(),
         )
 
         # 排序：默认能力集在前，然后按创建时间排序
@@ -1199,6 +1243,30 @@ class SkillSetService:
             logger.debug(f"[get_all_skill_sets_with_mcps] 能力集 {skill_set.get('name')} 包含 {len(mcps)} 个 MCP")
 
         return skill_sets
+
+
+    def list_active_skill_sets(
+        self,
+        *,
+        user_id: str | None = None,
+        bolt_id: str | None = None,
+        engine_type: str | None = None,
+    ) -> list[dict]:
+        """Return active SkillSets using the service-owned default lookup policy.
+
+        This keeps delivery adapters from re-deriving default SkillSet
+        compatibility kwargs while preserving historical query shape for engines
+        that do not need a compatibility override.
+        """
+        effective_user_id = user_id if user_id is not None else self.entity_id
+        effective_bolt_id = bolt_id if bolt_id is not None else self.bot_id
+        effective_engine = engine_type if engine_type is not None else self.engine_type
+        return self.skill_set_repo.get_all_active_skill_sets(
+            user_id=effective_user_id,
+            bolt_id=effective_bolt_id,
+            engine_type=effective_engine,
+            **self._default_skill_set_query_kwargs(effective_engine),
+        )
 
     def get_active_skills(
         self,
@@ -1221,10 +1289,9 @@ class SkillSetService:
         effective_user_id = user_id if user_id else self.entity_id
 
         # 1. 查询所有激活的技能集（包含默认能力集）
-        active_skill_sets = self.skill_set_repo.get_all_active_skill_sets(
+        active_skill_sets = self.list_active_skill_sets(
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
-            engine_type=self.engine_type
         )
         if not active_skill_sets:
             logger.warning(f"[get_active_skills] 未找到激活的技能集: user_id={effective_user_id}, bolt_id={effective_bolt_id}")
@@ -1854,6 +1921,7 @@ class SkillSetService:
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
+            **self._default_skill_set_query_kwargs(effective_engine),
         )
 
         active_mcps = []
@@ -2030,6 +2098,7 @@ class SkillSetService:
             bolt_id=bot_id,
             engine_type=effective_engine,
             env=target_env,
+            **self._default_skill_set_query_kwargs(effective_engine),
         )
 
         codes: list[str] = []
@@ -2086,6 +2155,7 @@ class SkillSetService:
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
+            **self._default_skill_set_query_kwargs(effective_engine),
         )
         active_skill_sets_info = []
         seen = set()

--- a/src/backend/tests/community/architecture/test_skill_center_engine_boundaries.py
+++ b/src/backend/tests/community/architecture/test_skill_center_engine_boundaries.py
@@ -1,0 +1,57 @@
+"""Architecture guards for Skill Center engine variability seams."""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+
+_THIS_FILE = pathlib.Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[3]
+_SKILL_CENTER_POLICIES = (
+    _BACKEND_ROOT
+    / "src"
+    / "agentclaw"
+    / "community"
+    / "core"
+    / "skill_center"
+    / "policies"
+)
+_ENGINE_POLICY_LITERALS = frozenset({"aicoding", "claude_code", "normalcc"})
+
+
+def _parse(path: pathlib.Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _string_constants(node: ast.AST) -> set[str]:
+    return {
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant) and isinstance(child.value, str)
+    }
+
+
+def test_skill_center_policies_do_not_branch_on_engine_literals() -> None:
+    failures: list[str] = []
+    for path in sorted(_SKILL_CENTER_POLICIES.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = _parse(path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            literals = _string_constants(node) & _ENGINE_POLICY_LITERALS
+            if literals:
+                failures.append(
+                    f"{path.relative_to(_BACKEND_ROOT)}:{node.lineno} "
+                    f"compares engine policy literal(s): {sorted(literals)}"
+                )
+
+    if failures:
+        pytest.fail(
+            "Skill Center policies must delegate engine-specific default "
+            "SkillSet compatibility to registered engine resolvers, not branch "
+            "on engine-name strings:\n  " + "\n  ".join(failures)
+        )

--- a/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
+++ b/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
@@ -1,0 +1,56 @@
+from agentclaw.community.core.bot_management.engines.registry import (
+    get_default_skill_set_selection_policy,
+)
+from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
+    DefaultSkillSetSelectionPolicy,
+)
+
+
+def test_default_policy_keeps_openclaw_unchanged():
+    selection = DefaultSkillSetSelectionPolicy().resolve(
+        persisted_engine_type="openclaw",
+        runtime_engine_type="openclaw",
+    )
+
+    assert selection.engine_type == "openclaw"
+    assert selection.bolt_id is None
+
+
+def test_default_policy_keeps_normal_claude_code_unchanged():
+    selection = DefaultSkillSetSelectionPolicy().resolve(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="claude_code",
+    )
+
+    assert selection.engine_type == "claude_code"
+    assert selection.bolt_id is None
+
+
+def test_default_policy_has_no_engine_specific_runtime_routing():
+    selection = DefaultSkillSetSelectionPolicy().resolve(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="aicoding",
+    )
+
+    assert selection.engine_type == "claude_code"
+    assert selection.bolt_id is None
+
+
+def test_registered_policy_uses_aicoding_global_default_for_routed_claude_code():
+    selection = get_default_skill_set_selection_policy().resolve(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="aicoding",
+    )
+
+    assert selection.engine_type == "aicoding"
+    assert selection.bolt_id == "default"
+
+
+def test_registered_policy_keeps_openclaw_unchanged():
+    selection = get_default_skill_set_selection_policy().resolve(
+        persisted_engine_type="openclaw",
+        runtime_engine_type="openclaw",
+    )
+
+    assert selection.engine_type == "openclaw"
+    assert selection.bolt_id is None

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -939,3 +939,151 @@ def test_skillset_delete_by_bot_id_cascade(sets, db):
         assert s.query(SkillSet).count() == 0
         assert s.query(SkillSetSkill).count() == 0
         assert s.query(SkillSetMCPServer).count() == 0
+
+
+def test_list_all_default_constraint_only_includes_requested_default_bot(sets):
+    bot_default = sets.create(
+        {
+            "name": "bot defaults",
+            "user_id": "owner-x",
+            "bolt_id": "bot-x",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    global_default = sets.create(
+        {
+            "name": "global defaults",
+            "bolt_id": "default",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    custom = sets.create(
+        {
+            "name": "custom",
+            "user_id": "owner-x",
+            "bolt_id": "bot-x",
+            "engine_type": "claude_code",
+            "is_default": False,
+            "is_active": True,
+        }
+    )
+
+    rows = sets.list_all(
+        user_id="owner-x",
+        bolt_id="bot-x",
+        engine_type="claude_code",
+        default_skill_set_bolt_id="default",
+    )
+
+    ids = {row["id"] for row in rows}
+    assert global_default["id"] in ids
+    assert custom["id"] in ids
+    assert bot_default["id"] not in ids
+
+
+def test_get_all_active_skill_sets_default_constraint_skips_bot_scoped_default(sets):
+    bot_default = sets.create(
+        {
+            "name": "bot defaults",
+            "user_id": "owner-x",
+            "bolt_id": "bot-x",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    global_default = sets.create(
+        {
+            "name": "global defaults",
+            "bolt_id": "default",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+
+    active = sets.get_all_active_skill_sets(
+        user_id="owner-x",
+        bolt_id="bot-x",
+        engine_type="claude_code",
+        default_skill_set_bolt_id="default",
+    )
+
+    assert [row["id"] for row in active] == [global_default["id"]]
+    assert bot_default["id"] not in {row["id"] for row in active}
+
+
+def test_list_all_preserves_bot_scoped_defaults_without_constraint(sets):
+    bot_default = sets.create(
+        {
+            "name": "bot defaults compat",
+            "user_id": "owner-y",
+            "bolt_id": "bot-y",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    global_default = sets.create(
+        {
+            "name": "global defaults compat",
+            "bolt_id": "default",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+
+    rows = sets.list_all(
+        user_id="owner-y", bolt_id="bot-y", engine_type="claude_code"
+    )
+
+    ids = {row["id"] for row in rows}
+    assert bot_default["id"] in ids
+    assert global_default["id"] in ids
+
+
+def test_list_all_can_use_runtime_default_engine_for_global_default(sets):
+    sets.create(
+        {
+            "name": "claude bot defaults",
+            "user_id": "owner-z",
+            "bolt_id": "bot-z",
+            "engine_type": "claude_code",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    aicoding_global = sets.create(
+        {
+            "name": "aicoding global defaults",
+            "bolt_id": "default",
+            "engine_type": "aicoding",
+            "is_default": True,
+            "is_active": True,
+        }
+    )
+    custom = sets.create(
+        {
+            "name": "claude custom",
+            "user_id": "owner-z",
+            "bolt_id": "bot-z",
+            "engine_type": "claude_code",
+            "is_default": False,
+            "is_active": True,
+        }
+    )
+
+    rows = sets.list_all(
+        user_id="owner-z",
+        bolt_id="bot-z",
+        engine_type="claude_code",
+        default_skill_set_bolt_id="default",
+        default_skill_set_engine_type="aicoding",
+    )
+
+    assert {row["id"] for row in rows} == {aicoding_global["id"], custom["id"]}

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -186,3 +186,63 @@ class TestSkillSetServiceEngineTypeThreading:
         mock_skill_set_repo.get_all_active_skill_sets.assert_called_once()
         call_kwargs = mock_skill_set_repo.get_all_active_skill_sets.call_args.kwargs
         assert call_kwargs.get("engine_type") == "claude-code"
+
+
+def _make_skill_set_service_for_default_selection(
+    tmp_path, *, engine_type, runtime_engine_type, default_skill_set_selection_policy=None
+):
+    from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
+
+    return SkillSetService(
+        skill_repo=MagicMock(),
+        skill_set_repo=MagicMock(),
+        mcp_center=MagicMock(),
+        mcp_config_service=MagicMock(),
+        skill_service=MagicMock(),
+        skills_dir=tmp_path / "skills",
+        repo_dir=tmp_path / "skills-repo",
+        local_dir=tmp_path / "skills-local",
+        engine_type=engine_type,
+        runtime_engine_type=runtime_engine_type,
+        bot_repo=MagicMock(),
+        default_skill_set_selection_policy=default_skill_set_selection_policy,
+        path_factory=MagicMock(),
+    )
+
+
+def test_default_skill_set_query_kwargs_keeps_openclaw_query_shape(tmp_path):
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="openclaw",
+        runtime_engine_type="openclaw",
+    )
+
+    assert service._default_skill_set_query_kwargs() == {}
+
+
+def test_default_skill_set_query_kwargs_keeps_normal_claude_code_query_shape(tmp_path):
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="claude_code",
+    )
+
+    assert service._default_skill_set_query_kwargs() == {}
+
+
+def test_default_skill_set_query_kwargs_routes_claude_code_default_to_aicoding(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+
+    assert service._default_skill_set_query_kwargs() == {
+        "default_skill_set_bolt_id": "default",
+        "default_skill_set_engine_type": "aicoding",
+    }


### PR DESCRIPTION
## Summary
- add a default SkillSet selection policy for routed Claude Code runtime compatibility
- query routed Claude Code default SkillSets from the existing aicoding global default row while keeping custom SkillSets under claude_code
- keep OpenClaw and ordinary Claude Code query behavior unchanged

## Tests
- uv run pytest tests/community/core/skill_center/test_default_skill_set_selection_policy.py tests/community/repository/skill_center/test_skill_repository_unified.py tests/community/services/test_skill_set_service_engine_type.py tests/community/core/skill_center/services/test_skill_set_service.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_identity_vendor_in_core.py
- uv run pytest tests/community/api/skill_center/test_get_path_params.py tests/community/api/skill_center/test_skillsets_engine_type.py tests/community/api/skill_center/test_skills_router_is_desktop.py