### PR TITLE
fix(bot-service): catch CancelledError in aiohttp request retry loop

### DIFF
--- a/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/bot_service/real/_plugin.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from asyncio.exceptions import CancelledError
 from typing import Any
 
 import aiohttp
@@ -247,7 +248,7 @@ class AiohttpBotServicePlugin(BotServicePlugin):
                         resp.status,
                     )
                 return self._check_response_envelope(data)
-            except (TimeoutError, aiohttp.ClientError) as exc:
+            except (TimeoutError, CancelledError, aiohttp.ClientError) as exc:
                 retryable = isinstance(
                     exc, (TimeoutError, aiohttp.ClientConnectionError)
                 )


### PR DESCRIPTION
    fix(bot-service): catch CancelledError in aiohttp request retry loop
    
    When an asyncio task is cancelled mid-request, `CancelledError` propagates
    out of `aiohttp` and is not caught by the existing `except` clause (which
    only handles `TimeoutError` and `aiohttp.ClientError`). The uncaught
    `CancelledError` escapes the retry loop, surfacing as an unexpected
    error instead of a clean cancellation.
    
    Add `asyncio.CancelledError` to the `except` tuple so the error path
    handles cancellation gracefully alongside timeout and client errors.