### PR TITLE
feat(gateway): add MariaDB database plugin (MARIADB_ORM)

### DIFF
--- a/src/baas/justfile
+++ b/src/baas/justfile
@@ -7,7 +7,9 @@ import 'justfiles/ctrl-baas.just'
 
 import 'justfiles/lint.just'
 import 'justfiles/test-common.just'
+import 'justfiles/test-self.just'
 import 'justfiles/tests.just'
+import 'justfiles/test-mariadb.just'
 
 _default:
     @just --list --list-prefix '==> '

--- a/src/baas/justfiles/test-mariadb.just
+++ b/src/baas/justfiles/test-mariadb.just
@@ -1,0 +1,70 @@
+# ── ASGI e2e against a local MariaDB (via the e2e-mariadb overlay) ─────────
+
+# Defaults mirror configs/overlays/e2e-mariadb.yaml
+mariadb-container := 'baas-e2e-mariadb'
+mariadb-image := 'mariadb:11'
+mariadb-port := '33307'
+mariadb-database := 'secbaas_test'
+mariadb-user := 'secbaas'
+mariadb-password := 'secbaaspass'
+
+# Start the MariaDB container
+start-mariadb:
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+    docker run -d --name {{mariadb-container}} \
+        -p {{mariadb-port}}:3306 \
+        -e MARIADB_ROOT_PASSWORD=rootpass \
+        -e MARIADB_DATABASE={{mariadb-database}} \
+        -e MARIADB_USER={{mariadb-user}} \
+        -e MARIADB_PASSWORD={{mariadb-password}} \
+        {{mariadb-image}} >/dev/null
+    i=0; until \
+        docker exec {{mariadb-container}} \
+            mariadb -u{{mariadb-user}} -p{{mariadb-password}} \
+            -e 'SELECT 1' {{mariadb-database}} >/dev/null 2>&1; do \
+        i=$((i+1)); [ "$i" -ge 45 ] && { echo 'MariaDB did not become ready'; exit 1; }; \
+        sleep 1; done
+    echo "MariaDB ready ({{mariadb-container}} on :{{mariadb-port}})"
+
+# Stop and remove the MariaDB container
+stop-mariadb:
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+
+# Run ASGI e2e tests against a live MariaDB (starts and stops the container).
+# When Docker/MariaDB is not available the tests are skipped, never failed.
+test-e2e-mariadb:
+    #!/bin/bash
+    set -uo pipefail
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "test-e2e-mariadb: docker not installed — skipping MariaDB e2e tests"
+        exit 0
+    fi
+    if ! docker info >/dev/null 2>&1; then
+        echo "test-e2e-mariadb: docker daemon not available — skipping MariaDB e2e tests"
+        exit 0
+    fi
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+    if ! docker run -d --name {{mariadb-container}} \
+        -e MARIADB_ROOT_PASSWORD=rootpass \
+        -e MARIADB_DATABASE={{mariadb-database}} \
+        -e MARIADB_USER={{mariadb-user}} \
+        -e MARIADB_PASSWORD={{mariadb-password}} \
+        -p {{mariadb-port}}:3306 \
+        {{mariadb-image}} >/dev/null 2> "${TMPDIR:-/tmp}/mariadb-start.err"; then
+        echo "test-e2e-mariadb: cannot start MariaDB container — skipping MariaDB e2e tests"
+        rm -f "${TMPDIR:-/tmp}/mariadb-start.err"
+        exit 0
+    fi
+    trap 'docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true' EXIT
+    i=0; until \
+        docker exec {{mariadb-container}} \
+            mariadb -u{{mariadb-user}} -p{{mariadb-password}} \
+            -e "SELECT 1" {{mariadb-database}} >/dev/null 2>&1; do \
+        i=$((i+1)); [ "$i" -ge 45 ] && { echo "test-e2e-mariadb: MariaDB did not become ready — skipping"; exit 0; }; \
+        sleep 1; done
+    echo "MariaDB ready ({{mariadb-container}} :{{mariadb-port}})"
+    MARIADB_HOST=127.0.0.1 MARIADB_PORT={{mariadb-port}} \
+    MARIADB_DATABASE={{mariadb-database}} MARIADB_USER={{mariadb-user}} \
+    MARIADB_PASSWORD={{mariadb-password}} \
+    TEST_OVERLAY=e2e-mariadb \
+        uv run pytest tests/e2e/asgi/ -v --tb=short --color=yes

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -18,7 +18,7 @@ which exposes 6 **Selectors** that resolve the active implementation at runtime:
 
 | Selector              | Config Key                   | Bare Default              | Purpose                                  |
 |-----------------------|------------------------------|---------------------------|------------------------------------------|
-| `database`            | `plugins.database.plugin_database` | `SQLITE_ORM`        | Database access (sync + async ORM)       |
+| `database`            | `plugins.database.plugin_database` | `SQLITE_ORM`        | Database access (sync + async ORM; `MARIADB_ORM` opts into the MariaDB backend) |
 | `forwarder`           | `plugins.forwarder`          | `bare`                    | Upstream HTTP request forwarding         |
 | `schema_catalog`      | `plugins.schema_catalog`     | `bare`                    | Upstream schema discovery and caching    |
 | `cache_plugin`        | `plugins.cache`              | `stub`                    | Distributed cache abstraction            |
@@ -38,7 +38,47 @@ application.yaml
                     ├── authn.app_token: "bare"    → StubAppTokenValidator
                     ├── authn.tenant: "bare"       → StubTenantResolver
                     └── database.plugin_database: "SQLITE_ORM" → SqliteDatabasePlugin
+                                         ("MARIADB_ORM" → MariaDbOrmPlugin)
 ```
+
+<details>
+<summary>Database backends</summary>
+
+The `database` selector supports two community backends:
+
+- **`SQLITE_ORM`** (default) — in-memory/file SQLite via `aiosqlite`. Used for
+  bare/test mode; schema is created from ORM metadata by `create_all()`.
+- **`MARIADB_ORM`** — self-managed MariaDB (MySQL-wire compatible). Uses
+  `aiomysql` (async) + `mysql-connector-python` (sync ORM) drivers.
+
+MariaDB is configured with the structured `mariadb_*` keys under
+`plugins.database`:
+
+```yaml
+plugins:
+  database:
+    plugin_database: "MARIADB_ORM"
+    create_schema: true
+    seed_data: true
+    mariadb_host: "127.0.0.1"
+    mariadb_port: 33306
+    mariadb_database: "gateway_test"
+    mariadb_user: "gateway"
+    mariadb_password: "gatewaypass"
+```
+
+Any of the `mariadb_*` values (or the whole connection) can instead be supplied
+via `MARIADB_HOST` / `MARIADB_PORT` / `MARIADB_DATABASE` / `MARIADB_USER` /
+`MARIADB_PASSWORD` / `DATABASE_URL` environment variables. The E2E test overlay
+`configs/overlays/e2e-mariadb.yaml` is selected with
+`SOFAPY_CONFIG_OVERLAY=e2e-mariadb` and targets a local devbox container:
+
+```bash
+docker run -d -p 33306:3306 -e MARIADB_DATABASE=gateway_test \
+  -e MARIADB_USER=gateway -e MARIADB_PASSWORD=gatewaypass mariadb:11
+```
+
+</details>
 
 ### Bootstrap Flow
 

--- a/src/gateway/configs/overlays/e2e-mariadb.yaml
+++ b/src/gateway/configs/overlays/e2e-mariadb.yaml
@@ -1,0 +1,21 @@
+# MariaDB E2E overlay — use MariaDB as the gateway storage backend.
+# Select via: SOFAPY_CONFIG_OVERLAY=e2e-mariadb
+# Enables schema creation so the E2E acceptance suite can run against a
+# freshly-created database. Requires a reachable MariaDB server.
+# Values below target the local E2E devbox container
+# (docker run -d -p 33306:3306 -e MARIADB_DATABASE=gateway_test \
+#   -e MARIADB_USER=gateway -e MARIADB_PASSWORD=gatewaypass mariadb:11) and can be
+# overridden at test run time via MARIADB_HOST / MARIADB_PORT / MARIADB_DATABASE /
+# MARIADB_USER / MARIADB_PASSWORD environment variables (read by
+# DatabasePluginConfig via pydantic-settings).
+user_config:
+  plugins:
+    database:
+      plugin_database: "MARIADB_ORM"
+      create_schema: true
+      seed_data: true
+      mariadb_host: "127.0.0.1"
+      mariadb_port: 33306
+      mariadb_database: "gateway_test"
+      mariadb_user: "gateway"
+      mariadb_password: "gatewaypass"

--- a/src/gateway/justfile
+++ b/src/gateway/justfile
@@ -12,6 +12,7 @@ import 'justfiles/test-ut.just'
 import 'justfiles/test-it.just'
 import 'justfiles/test-arch.just'
 import 'justfiles/test-e2e.just'
+import 'justfiles/test-mariadb.just'
 
 _default:
     @just --list --list-prefix '==> '

--- a/src/gateway/justfiles/test-mariadb.just
+++ b/src/gateway/justfiles/test-mariadb.just
@@ -1,0 +1,69 @@
+# ── ASGI e2e against a local MariaDB (via the e2e-mariadb overlay) ─────────
+
+# Defaults mirror configs/overlays/e2e-mariadb.yaml
+mariadb-container := 'gateway-e2e-mariadb'
+mariadb-image := 'mariadb:11'
+mariadb-port := '33306'
+mariadb-database := 'gateway_test'
+mariadb-user := 'gateway'
+mariadb-password := 'gatewaypass'
+
+# Start the MariaDB container
+start-mariadb:
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+    docker run -d --name {{mariadb-container}} \
+        -p {{mariadb-port}}:3306 \
+        -e MARIADB_ROOT_PASSWORD=rootpass \
+        -e MARIADB_DATABASE={{mariadb-database}} \
+        -e MARIADB_USER={{mariadb-user}} \
+        -e MARIADB_PASSWORD={{mariadb-password}} \
+        {{mariadb-image}} >/dev/null
+    i=0; until \
+        docker exec {{mariadb-container}} \
+            mariadb -u{{mariadb-user}} -p{{mariadb-password}} \
+            -e 'SELECT 1' {{mariadb-database}} >/dev/null 2>&1; do \
+        i=$((i+1)); [ "$i" -ge 45 ] && { echo 'MariaDB did not become ready'; exit 1; }; \
+        sleep 1; done
+    echo "MariaDB ready ({{mariadb-container}} on :{{mariadb-port}})"
+
+# Stop and remove the MariaDB container
+stop-mariadb:
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+
+# Run ASGI e2e tests against a live MariaDB (starts and stops the container).
+# When Docker/MariaDB is not available the tests are skipped, never failed.
+test-e2e-mariadb:
+    #!/bin/bash
+    set -uo pipefail
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "test-e2e-mariadb: docker not installed — skipping MariaDB e2e tests"
+        exit 0
+    fi
+    if ! docker info >/dev/null 2>&1; then
+        echo "test-e2e-mariadb: docker daemon not available — skipping MariaDB e2e tests"
+        exit 0
+    fi
+    docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true
+    if ! docker run -d --name {{mariadb-container}} \
+        -e MARIADB_ROOT_PASSWORD=rootpass \
+        -e MARIADB_DATABASE={{mariadb-database}} \
+        -e MARIADB_USER={{mariadb-user}} \
+        -e MARIADB_PASSWORD={{mariadb-password}} \
+        -p {{mariadb-port}}:3306 \
+        {{mariadb-image}} >/dev/null 2> "${TMPDIR:-/tmp}/mariadb-start.err"; then
+        echo "test-e2e-mariadb: cannot start MariaDB container — skipping MariaDB e2e tests"
+        rm -f "${TMPDIR:-/tmp}/mariadb-start.err"
+        exit 0
+    fi
+    trap 'docker rm -f {{mariadb-container}} >/dev/null 2>&1 || true' EXIT
+    i=0; until \
+        docker exec {{mariadb-container}} \
+            mariadb -u{{mariadb-user}} -p{{mariadb-password}} \
+            -e "SELECT 1" {{mariadb-database}} >/dev/null 2>&1; do \
+        i=$((i+1)); [ "$i" -ge 45 ] && { echo "test-e2e-mariadb: MariaDB did not become ready — skipping"; exit 0; }; \
+        sleep 1; done
+    echo "MariaDB ready ({{mariadb-container}} :{{mariadb-port}})"
+    SOFAPY_CONFIG_PATH="$(pwd)/configs" \
+    SOFAPY_CONFIG_OVERLAY=e2e-mariadb \
+    GATEWAY_RUN_MODE=bare \
+        uv run pytest tests/e2e/asgi/ -v --color=yes

--- a/src/gateway/pyproject.toml
+++ b/src/gateway/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "pyjwt>=2.8.0",
     "aiosqlite>=0.19.0",
+    "aiomysql>=0.2.0",
+    "mysql-connector-python>=26.7.0",
     "httpx>=0.27.0",
     # >=15: `connect(proxy=…)` arrived in 15.0. On 14.x the argument is not a
     # parameter at all, so every handshake would die with an unexpected-keyword

--- a/src/gateway/src/gateway/community/adapters/web/app.py
+++ b/src/gateway/src/gateway/community/adapters/web/app.py
@@ -123,6 +123,7 @@ def create_app() -> FastAPI:
     app.openapi = _served_openapi  # type: ignore[method-assign]
 
     if enable_docs:
+
         @app.get("/internal-openapi.json", include_in_schema=False)
         async def internal_openapi() -> dict[str, Any]:
             return bs.served_internal_openapi(

--- a/src/gateway/src/gateway/community/bootstrap/_configs.py
+++ b/src/gateway/src/gateway/community/bootstrap/_configs.py
@@ -22,6 +22,13 @@ class ConfigKey(StrEnum):
     PLUGIN_AUTHN_TENANT = "plugins.authn.tenant"
     PLUGIN_DATABASE = "plugins.database.plugin_database"
     DATABASE_URL = "plugins.database.database_url"
+    CREATE_SCHEMA = "plugins.database.create_schema"
+    SEED_DATA = "plugins.database.seed_data"
+    MARIADB_HOST = "plugins.database.mariadb_host"
+    MARIADB_PORT = "plugins.database.mariadb_port"
+    MARIADB_DATABASE = "plugins.database.mariadb_database"
+    MARIADB_USER = "plugins.database.mariadb_user"
+    MARIADB_PASSWORD = "plugins.database.mariadb_password"
     WEB_PORT = "web_port"
 
 
@@ -126,6 +133,13 @@ def _container_config_from_loaded(cfg) -> dict:
 class DatabaseConfig:
     plugin_type: str
     db_url: str = ""
+    create_schema: bool = False
+    seed_data: bool = False
+    mariadb_host: str = "127.0.0.1"
+    mariadb_port: int = 3306
+    mariadb_database: str = ""
+    mariadb_user: str = ""
+    mariadb_password: str = ""
 
 
 def init_container_config(container: "ApplicationContainer") -> None:

--- a/src/gateway/src/gateway/community/bootstrap/_container.py
+++ b/src/gateway/src/gateway/community/bootstrap/_container.py
@@ -1,5 +1,6 @@
 from dependency_injector import containers, providers
 
+from ._configs import ConfigError, ConfigKey, DatabaseConfig, _read_config
 from .plugins import PluginContainer
 
 
@@ -103,6 +104,51 @@ def _resolve_all_providers(container: containers.DeclarativeContainer) -> None:
             raise
 
 
+def _build_db_config(config) -> DatabaseConfig:
+    """Construct DatabaseConfig from the DI ``config`` provider.
+
+    Mirrors the baas ``_build_db_config``: reads the dotted database paths via
+    ``_read_config``, raises for a missing URL on SQLite_ORM, and otherwise
+    falls back to baas-compatible defaults. Credentials are never logged.
+    """
+    from gateway.community.spi.database import PluginDatabaseType
+
+    plugin_type = PluginDatabaseType(_read_config(config, ConfigKey.PLUGIN_DATABASE))
+    try:
+        db_url = _read_config(config, ConfigKey.DATABASE_URL)
+    except ConfigError:
+        if plugin_type == PluginDatabaseType.SQLITE_ORM:
+            raise
+        db_url = ""
+
+    def _opt(key: ConfigKey) -> str:
+        try:
+            return _read_config(config, key)
+        except ConfigError:
+            return ""
+
+    def _opt_bool_default_false(key: ConfigKey, default: bool = False) -> bool:
+        try:
+            val = _read_config(config, key)
+        except ConfigError:
+            return default
+        if isinstance(val, bool):
+            return val
+        return str(val).strip().lower() in {"1", "true", "yes", "on"}
+
+    return DatabaseConfig(
+        plugin_type=plugin_type.value,
+        db_url=db_url,
+        create_schema=_opt_bool_default_false(ConfigKey.CREATE_SCHEMA),
+        seed_data=_opt_bool_default_false(ConfigKey.SEED_DATA),
+        mariadb_host=_opt(ConfigKey.MARIADB_HOST) or "127.0.0.1",
+        mariadb_port=int(_opt(ConfigKey.MARIADB_PORT) or 3306),
+        mariadb_database=_opt(ConfigKey.MARIADB_DATABASE),
+        mariadb_user=_opt(ConfigKey.MARIADB_USER),
+        mariadb_password=_opt(ConfigKey.MARIADB_PASSWORD),
+    )
+
+
 def initialize_services(container: containers.DeclarativeContainer) -> None:
     import logging
 
@@ -118,17 +164,13 @@ def initialize_services(container: containers.DeclarativeContainer) -> None:
     logger.info("Building authenticator …")
     plugins = container.plugins()
     from ._authn import build_authenticator
-    from ._configs import DatabaseConfig
     from ._database import initialize_database
 
     # Initialise the DI-selected database plugin so DB-backed auth strategies
     # and credential issuer/registrar share one ready DataSourcePlugin.
     initialize_database(
         plugins.database(),
-        DatabaseConfig(
-            plugin_type=container.config.plugins.database.plugin_database(),
-            db_url=container.config.plugins.database.database_url(),
-        ),
+        _build_db_config(container.config),
     )
 
     container.authenticator.override(

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -9,6 +9,7 @@ from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
+from gateway.community.plugins.database.mariadb import MariaDbOrmPlugin
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
 from gateway.community.plugins.forwarder.httpx import HttpxForwarder
 from gateway.community.plugins.schema_catalog.file import FileSchemaCatalog
@@ -26,6 +27,7 @@ class PluginContainer(containers.DeclarativeContainer):
     database = providers.Selector(
         config.plugins.database.plugin_database,
         SQLITE_ORM=providers.Singleton(SqliteDatabasePlugin),
+        MARIADB_ORM=providers.Singleton(MariaDbOrmPlugin),
     )
 
     forwarder = providers.Selector(

--- a/src/gateway/src/gateway/community/config/_config_loader.py
+++ b/src/gateway/src/gateway/community/config/_config_loader.py
@@ -27,16 +27,33 @@ class ConfigLoader:
     def load() -> Config:
         base_path = _resolve_base_path()
         base = _load_yaml(base_path) if base_path is not None else {}
+        applied: list[str] = []
+
+        # SERVER_ENV → configs/application-{env}.yaml (existing gateway mechanism).
         env = os.getenv("SERVER_ENV", "").strip()
         overlay_path = _resolve_overlay_path(env) if env else None
         if overlay_path and overlay_path.exists():
-            overlay = _load_yaml(overlay_path)
-            base = _merge(base, overlay)
-            logger.info(
-                "config loaded: base=%s overlay=%s env=%s", base_path, overlay_path, env
-            )
-        else:
-            logger.info("config loaded: base=%s env=%s", base_path, env or "(none)")
+            base = _merge(base, _load_yaml(overlay_path))
+            applied.append(str(overlay_path))
+
+        # SOFAPY_CONFIG_OVERLAY → configs/overlays/{name}.yaml (baas-compatible).
+        named_overlay = os.getenv("SOFAPY_CONFIG_OVERLAY", "").strip()
+        if named_overlay:
+            named_path = _resolve_named_overlay_path(named_overlay, base_path)
+            if named_path is None or not named_path.exists():
+                raise FileNotFoundError(
+                    f"Overlay config not found: {named_path} "
+                    f"(set via SOFAPY_CONFIG_OVERLAY={named_overlay})"
+                )
+            base = _merge(base, _load_yaml(named_path))
+            applied.append(str(named_path))
+
+        logger.info(
+            "config loaded: base=%s env=%s overlays=%s",
+            base_path,
+            env or "(none)",
+            applied or "(none)",
+        )
 
         config_dir = base_path.parent if base_path is not None else None
         return _parse_config(base, config_dir=config_dir)
@@ -94,6 +111,20 @@ def _resolve_overlay_path(env: str) -> Path | None:
     if cwd_path.exists():
         return cwd_path
     return None
+
+
+def _resolve_named_overlay_path(name: str, base_path: Path | None) -> Path | None:
+    """Resolve ``configs/overlays/{name}.yaml`` for ``SOFAPY_CONFIG_OVERLAY``.
+
+    Mirrors the baas overlay layout: an ``overlays/`` dir co-located with the
+    base ``application.yaml`` (or ``configs/`` when resolving from CWD).
+    """
+    if base_path is not None:
+        return base_path.parent / "overlays" / f"{name}.yaml"
+    cwd_path = Path.cwd() / "configs" / "overlays" / f"{name}.yaml"
+    if cwd_path.exists():
+        return cwd_path
+    return cwd_path
 
 
 def _merge(base: dict, overlay: dict) -> dict:

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -36,9 +36,25 @@ class AuthnPluginConfig(BaseSettings):
 
 
 class DatabasePluginConfig(BaseSettings):
+    """Database plugin selection — SQLITE_ORM by default (community-safe).
+
+    ``MARIADB_ORM`` requires the ``mariadb_*`` connection fields (host, port,
+    database, user, password) or a ``database_url``. Credentials may be supplied
+    via environment variables (``DATABASE_URL`` or ``MARIADB_HOST`` /
+    ``MARIADB_PORT`` / ``MARIADB_DATABASE`` / ``MARIADB_USER`` /
+    ``MARIADB_PASSWORD``).
+    """
+
     model_config = SettingsConfigDict(extra="allow")
     plugin_database: str = Field(default="SQLITE_ORM")
     database_url: str = ""
+    create_schema: bool = Field(default=False)
+    seed_data: bool = Field(default=False)
+    mariadb_host: str = "127.0.0.1"
+    mariadb_port: int = Field(default=3306)
+    mariadb_database: str = ""
+    mariadb_user: str = ""
+    mariadb_password: str = ""
 
 
 class SecretConfig(BaseModel):

--- a/src/gateway/src/gateway/community/core/access_key/_orm.py
+++ b/src/gateway/src/gateway/community/core/access_key/_orm.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, text
+from sqlalchemy import BigInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from gateway.community.spi.access_key import RegisteredAccessKey
@@ -25,12 +25,12 @@ class AccessKeyRow(Base):  # type: ignore[misc]
     __tablename__ = "avernet_access_key_token"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    token: Mapped[str] = mapped_column(unique=True)
-    access_key: Mapped[str] = mapped_column()
-    tenant: Mapped[str] = mapped_column()
+    token: Mapped[str] = mapped_column(String(700), unique=True)
+    access_key: Mapped[str] = mapped_column(String(256), index=True)
+    tenant: Mapped[str] = mapped_column(String(64))
     expire_at: Mapped[datetime] = mapped_column()
-    creator: Mapped[str] = mapped_column(default="")
-    modifier: Mapped[str] = mapped_column(default="")
+    creator: Mapped[str] = mapped_column(String(128), default="")
+    modifier: Mapped[str] = mapped_column(String(128), default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )

--- a/src/gateway/src/gateway/community/core/app/_orm.py
+++ b/src/gateway/src/gateway/community/core/app/_orm.py
@@ -54,21 +54,21 @@ class AppRow(Base):  # type: ignore[misc]
     __tablename__ = "avernet_application"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    app_name: Mapped[str] = mapped_column(index=True)
-    app_type: Mapped[str] = mapped_column()
+    app_name: Mapped[str] = mapped_column(String(256), index=True)
+    app_type: Mapped[str] = mapped_column(String(64))
     api_key_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
     api_key_prefix: Mapped[str | None] = mapped_column(
         String(API_KEY_PREFIX_LEN), unique=True, nullable=True
     )
     # DEPRECATED — legacy plaintext JWT credential; see the module docstring.
-    token: Mapped[str | None] = mapped_column(unique=True, nullable=True)
-    owners: Mapped[str] = mapped_column()
-    tenant: Mapped[str] = mapped_column()
-    status: Mapped[str] = mapped_column(default="ACTIVE")
-    env: Mapped[str] = mapped_column(default="")
+    token: Mapped[str | None] = mapped_column(String(700), unique=True, nullable=True)
+    owners: Mapped[str] = mapped_column(String(1024))
+    tenant: Mapped[str] = mapped_column(String(64))
+    status: Mapped[str] = mapped_column(String(32), default="ACTIVE")
+    env: Mapped[str] = mapped_column(String(64), default="")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
-    creator: Mapped[str] = mapped_column(default="")
-    modifier: Mapped[str] = mapped_column(default="")
+    creator: Mapped[str] = mapped_column(String(128), default="")
+    modifier: Mapped[str] = mapped_column(String(128), default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )

--- a/src/gateway/src/gateway/community/core/tenant/_orm.py
+++ b/src/gateway/src/gateway/community/core/tenant/_orm.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import JSON, BigInteger, text
+from sqlalchemy import JSON, BigInteger, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from gateway.community.spi.database import Base
@@ -23,12 +23,12 @@ class TenantRow(Base):  # type: ignore[misc]
     __tablename__ = "avernet_tenant"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column()
-    description: Mapped[str] = mapped_column(default="")
-    owner: Mapped[str] = mapped_column(default="")
+    name: Mapped[str] = mapped_column(String(128), unique=True)
+    description: Mapped[str] = mapped_column(String(1024), default="")
+    owner: Mapped[str] = mapped_column(String(128), default="")
     config: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
-    creator: Mapped[str] = mapped_column(default="")
-    modifier: Mapped[str] = mapped_column(default="")
+    creator: Mapped[str] = mapped_column(String(128), default="")
+    modifier: Mapped[str] = mapped_column(String(128), default="")
     gmt_create: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP")
     )

--- a/src/gateway/src/gateway/community/plugins/database/mariadb/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/database/mariadb/__init__.py
@@ -1,0 +1,3 @@
+from gateway.community.plugins.database.mariadb._plugin import MariaDbOrmPlugin
+
+__all__ = ["MariaDbOrmPlugin"]

--- a/src/gateway/src/gateway/community/plugins/database/mariadb/_plugin.py
+++ b/src/gateway/src/gateway/community/plugins/database/mariadb/_plugin.py
@@ -1,0 +1,307 @@
+"""MariaDB ORM plugin — SQLAlchemy with the MariaDB/MySQL dialect.
+
+Wire up as ``plugins.database.plugin_database: MARIADB_ORM`` with the
+``mariadb_*`` connection settings (or a ``database_url``).  Uses
+``mysql+aiomysql`` for the async path and ``mysql+mysqlconnector`` for the
+sync ORM path — MariaDB is wire-compatible with the MySQL protocol, so the
+same driver dialects used by the baas ``mariadb_orm.py`` apply.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Generator
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from gateway.community.logger import get_logger
+from gateway.community.spi.database import DatabasePluginConfig, DataSourcePlugin
+
+logger = get_logger("database")
+
+
+def _build_async_url(
+    host: str, port: int, database: str, user: str, password: str
+) -> str:
+    """Build a ``mysql+aiomysql://`` URL from structured connection settings."""
+    return (
+        f"mysql+aiomysql://{user}:{password}@{host}:{port}/{database}?charset=utf8mb4"
+    )
+
+
+class MariaDbOrmPlugin(DataSourcePlugin):
+    """MariaDB/MySQL ORM plugin for the community gateway.
+
+    Supports the two-tier connection model: a sync ``mysql+mysqlconnector``
+    engine for cursor/ORM access and an async ``mysql+aiomysql`` engine
+    for async SQLAlchemy sessions. Engines are built lazily in
+    ``init_database`` so a bare ``MariaDbOrmPlugin()`` (as used by contract
+    tests) can be constructed without a live server.
+    """
+
+    def __init__(self, database_url: str | None = None) -> None:
+        """Create a MariaDB plugin.
+
+        Args:
+            database_url: Optional ``mysql+...://`` URL.  If omitted, the URL is
+                derived from the ``DatabaseConfig`` passed to ``init_database``.
+        """
+        self._database_url = database_url
+        self._sync_engine: Engine | None = None
+        self._async_engine = None
+        self._sync_session_factory = None
+        self._async_session_factory = None
+        logger.info("MariaDbOrmPlugin constructed (engines created on init_database)")
+
+    def _resolve_url(self, config: DatabasePluginConfig) -> str:
+        """Resolve the async MariaDB URL from config/env/URL override.
+
+        Env vars take precedence and match the existing ``DATABASE_URL``
+        convention: ``MARIADB_HOST`` / ``MARIADB_PORT`` / ``MARIADB_DATABASE`` /
+        ``MARIADB_USER`` / ``MARIADB_PASSWORD``.
+
+        The generic ``db_url`` (from the base ``application.yaml``) may point at
+        SQLite by default; it is only honored here when it is explicitly a
+        MySQL-compatible URL, so a MariaDB backend never resolves to SQLite.
+        """
+        import os
+
+        env_url = os.environ.get("DATABASE_URL")
+        if env_url:
+            return env_url
+
+        if self._database_url:
+            return self._database_url
+
+        host = (
+            os.environ.get("MARIADB_HOST")
+            or getattr(config, "mariadb_host", None)
+            or "127.0.0.1"
+        )
+        port = int(
+            os.environ.get("MARIADB_PORT")
+            or getattr(config, "mariadb_port", None)
+            or 3306
+        )
+        database = (
+            os.environ.get("MARIADB_DATABASE")
+            or getattr(config, "mariadb_database", "")
+            or ""
+        )
+        user = (
+            os.environ.get("MARIADB_USER") or getattr(config, "mariadb_user", "") or ""
+        )
+        password = (
+            os.environ.get("MARIADB_PASSWORD")
+            or getattr(config, "mariadb_password", "")
+            or ""
+        )
+        if database:
+            return _build_async_url(host, port, database, user, password)
+
+        db_url = getattr(config, "db_url", "")
+        if db_url and not db_url.startswith("sqlite://"):
+            return db_url
+
+        if not database:
+            raise RuntimeError(
+                "MariaDB backend requires a database — set MARIADB_DATABASE, "
+                "plugins.database.mariadb_database, or a mysql+:// database_url"
+            )
+        return _build_async_url(
+            host, port, database, user, password
+        )  # pragma: no cover
+
+    def _init_engines(self, async_url: str) -> None:
+        """Build sync (mysqlconnector) and async (aiomysql) engines.
+
+        The sync URL is derived from the async URL host/port/database by
+        swapping the dialect.  The original user/password components are reused
+        to avoid re-encoding credentials.
+        """
+        from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+
+        parts = urlsplit(async_url)
+        query = parse_qs(parts.query)
+        query["charset"] = ["utf8mb4"]
+        sync_url = urlunsplit(
+            (
+                "mysql+mysqlconnector",
+                parts.netloc,
+                parts.path,
+                urlencode(query, doseq=True),
+                parts.fragment,
+            )
+        )
+
+        self._sync_engine = create_engine(sync_url, echo=False, pool_pre_ping=True)
+        self._sync_session_factory = sessionmaker(
+            bind=self._sync_engine,
+            autocommit=False,
+            autoflush=False,
+            expire_on_commit=False,
+        )
+
+        self._async_engine = create_async_engine(
+            async_url,
+            echo=False,
+            pool_pre_ping=True,
+        )
+        self._async_session_factory = async_sessionmaker(
+            bind=self._async_engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+        logger.info("MariaDbOrmPlugin engines initialized")
+
+    def create_all(self) -> None:
+        """Create the ORM tables owned by the gateway.
+
+        Imports the gateway-owned core ORM model modules (access_key, app,
+        tenant) so their tables are registered on ``Base.metadata``, then creates
+        exactly those tables using the native MySQL/MariaDB dialect. No SQLite
+        shims are applied — MariaDB keeps native ``JSON`` and ``BIGINT``.
+
+        ``bcs_bots`` is intentionally NOT provisioned here: the bcs service owns
+        and writes that table — the gateway only reads it (see the note in
+        ``migrations/``). Because ``Base.metadata`` is a shared registry,
+        ``create_all`` whitelists the gateway identity tables so a transitively
+        registered ``bcs_bots`` is never created.
+        """
+        _orm_models = [
+            "gateway.community.core.access_key._orm",
+            "gateway.community.core.app._orm",
+            "gateway.community.core.tenant._orm",
+        ]
+        for _mod in _orm_models:
+            try:
+                __import__(_mod)
+            except Exception as _exc:  # pragma: no cover - defensive import guard
+                logger.error("Failed to import %s: %s", _mod, _exc)
+                raise
+
+        if self._sync_engine is None:
+            raise RuntimeError(
+                "MariaDB plugin not initialized — call init_database first"
+            )
+
+        _owned_tables = {
+            "avernet_application",
+            "avernet_tenant",
+            "avernet_access_key_token",
+        }
+        from gateway.community.spi.database import Base
+
+        _tables = [t for t in Base.metadata.sorted_tables if t.name in _owned_tables]
+        if not _tables:
+            raise RuntimeError("No gateway-owned ORM tables registered")
+        for _table in _tables:
+            _table.create(self._sync_engine, checkfirst=True)
+
+        logger.info(
+            "MariaDbOrmPlugin: tables created (%s)",
+            ", ".join(sorted(_owned_tables)),
+        )
+
+    def sync_connection(self, datasource_name: str) -> AbstractContextManager[Any]:
+        if self._sync_engine is None:
+            raise RuntimeError(
+                "MariaDB plugin not initialized — call init_database first"
+            )
+
+        @contextmanager
+        def _conn() -> AbstractContextManager[Any]:
+            raw = self._sync_engine.raw_connection()
+            try:
+                yield raw
+            finally:
+                raw.close()
+
+        return _conn()
+
+    @contextmanager
+    def orm_session(self) -> Generator[Session, None, None]:
+        if self._sync_session_factory is None:
+            raise RuntimeError(
+                "MariaDB plugin not initialized — call init_database first"
+            )
+        session = self._sync_session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    async def session(self) -> AsyncIterator[AsyncSession]:
+        if self._async_session_factory is None:
+            raise RuntimeError(
+                "MariaDB plugin not initialized — call init_database first"
+            )
+        session = self._async_session_factory()
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+    def seed(self, session: Session) -> None:
+        """No-op — seed data is inserted by the bootstrap composition root.
+
+        The SPI contract keeps ``seed`` for plugins that own self-contained
+        seed data; the community MariaDB plugin's seed rows would reference core
+        ORM models, so the actual seeding lives in ``bootstrap._database`` (the
+        composition root, which may import core) to respect layer rules.
+        """
+
+    def init_database(self, config: DatabasePluginConfig) -> None:
+        """Configure engines and optionally create the schema.
+
+        Resolves the async URL from ``DATABASE_URL`` env, ``config.db_url``, or
+        the structured ``mariadb_*`` settings, then builds the sync + async
+        engines and creates the schema only if ``create_schema`` (default:
+        false) is enabled. Seeding is left to the bootstrap composition root.
+        Credentials are never logged.
+        """
+        async_url = self._resolve_url(config)
+        self._init_engines(async_url)
+
+        if getattr(config, "create_schema", False):
+            self.create_all()
+        else:
+            logger.info(
+                "MariaDbOrmPlugin: schema creation disabled (create_schema=false)"
+            )
+
+        logger.info(
+            "init_database: MariaDbOrmPlugin initialized (database=%s)",
+            self._resolve_database_label(async_url),
+        )
+
+    @staticmethod
+    def _resolve_database_label(async_url: str) -> str:
+        """Return a log-safe label (host/database only, never credentials)."""
+        from urllib.parse import urlsplit
+
+        parts = urlsplit(async_url)
+        hostport = parts.netloc.rsplit("@", 1)[-1]
+        return f"{hostport}{parts.path}"
+
+    async def close(self) -> None:
+        if self._sync_engine:
+            self._sync_engine.dispose()
+        if self._async_engine:
+            await self._async_engine.dispose()
+        logger.info("MariaDbOrmPlugin: engines disposed")
+
+
+__all__ = ["MariaDbOrmPlugin"]

--- a/src/gateway/src/gateway/community/spi/database/_enums.py
+++ b/src/gateway/src/gateway/community/spi/database/_enums.py
@@ -12,3 +12,4 @@ class PluginDatabaseType(StrEnum):
 
     ZDAS_ORM = "ZDAS_ORM"
     SQLITE_ORM = "SQLITE_ORM"
+    MARIADB_ORM = "MARIADB_ORM"

--- a/src/gateway/tests/contracts/spi/test_database_plugin.py
+++ b/src/gateway/tests/contracts/spi/test_database_plugin.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gateway.community.plugins.database.mariadb._plugin import MariaDbOrmPlugin
 from gateway.community.plugins.database.sqlite._plugin import SqliteDatabasePlugin
 from gateway.community.spi.database import DataSourcePlugin
 
@@ -69,3 +70,126 @@ class TestSqliteDatabasePlugin(DataSourcePluginContract):
         except ValueError as e:
             if "greenlet" in str(e):
                 pytest.skip("greenlet not installed — async session unavailable")
+
+
+def _make_mariadb_config(host: str = "127.0.0.1", port: int = 3306):
+    from gateway.community.bootstrap import DatabaseConfig
+    from gateway.community.spi.database import PluginDatabaseType
+
+    return DatabaseConfig(
+        plugin_type=PluginDatabaseType.MARIADB_ORM,
+        mariadb_host=host,
+        mariadb_port=port,
+        mariadb_database="mydb",
+        mariadb_user="user",
+        mariadb_password="pass",
+    )
+
+
+def _mariadb_config_no_db(db_url: str = "sqlite:////tmp/x.db"):
+    from gateway.community.bootstrap import DatabaseConfig
+    from gateway.community.spi.database import PluginDatabaseType
+
+    return DatabaseConfig(
+        plugin_type=PluginDatabaseType.MARIADB_ORM,
+        db_url=db_url,
+        create_schema=False,
+        mariadb_host="127.0.0.1",
+        mariadb_port=3306,
+        mariadb_database="",
+        mariadb_user="",
+        mariadb_password="",
+    )
+
+
+class TestMariaDbOrmPluginUrlResolution:
+    """Unit tests for MariaDbOrmPlugin URL resolution (no live server needed)."""
+
+    def setup_method(self) -> None:
+        self.plugin = MariaDbOrmPlugin()
+
+    def test_resolve_url_from_structured_config(self) -> None:
+        cfg = _make_mariadb_config(host="db.internal", port=3307)
+        url = self.plugin._resolve_url(cfg)
+        assert url.startswith("mysql+aiomysql://")
+        assert "db.internal:3307/mydb" in url
+
+    def test_resolve_url_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("MARIADB_HOST", "env-host")
+        monkeypatch.setenv("MARIADB_PORT", "4406")
+        monkeypatch.setenv("MARIADB_DATABASE", "env_db")
+        monkeypatch.setenv("MARIADB_USER", "env_user")
+        monkeypatch.setenv("MARIADB_PASSWORD", "env_pass")
+        url = self.plugin._resolve_url(_make_mariadb_config(host="cfg-host", port=3306))
+        assert "env-host:4406/env_db" in url
+        assert "env_user:env_pass" in url
+
+    def test_resolve_url_database_url_env_precedence(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "mysql+aiomysql://u:p@h:3306/db")
+        url = self.plugin._resolve_url(_make_mariadb_config(host="cfg-host"))
+        assert url == "mysql+aiomysql://u:p@h:3306/db"
+
+    def test_resolve_url_raises_on_missing_database(self, monkeypatch) -> None:
+        monkeypatch.delenv("MARIADB_DATABASE", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        with pytest.raises(RuntimeError, match="requires a database"):
+            self.plugin._resolve_url(_mariadb_config_no_db())
+
+    def test_orm_session_raises_before_init(self) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            with self.plugin.orm_session():
+                pass
+
+    def test_database_label_omits_credentials(self) -> None:
+        label = self.plugin._resolve_database_label(
+            "mysql+aiomysql://user:secret@db.internal:3306/mydb?charset=utf8mb4"
+        )
+        assert "secret" not in label
+        assert "db.internal:3306/mydb" in label
+
+
+class TestMariaDbOrmPluginContract(DataSourcePluginContract):
+    """Contract conformance for MariaDB, buildable without a live server.
+
+    The plugin's engines are built lazily in ``init_database``; a live DB is not
+    assumed. ``create_all`` needs initialized engines and a live DB, which the
+    connection-backed tests cover under the E2E overlay, so the inherited
+    connection-dependent contract tests are overridden here.
+    """
+
+    def setup_method(self) -> None:
+        self.plugin = MariaDbOrmPlugin()
+
+    def test_create_all_runs_without_error(self) -> None:
+        # Requires a live DB and initialized engines; covered by E2E overlay.
+        pytest.skip(
+            "requires a live MariaDB server (see configs/overlays/e2e-mariadb.yaml)"
+        )
+
+    def test_orm_session_context_manager(self) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            with self.plugin.orm_session():
+                pass
+
+    def test_seed_runs_without_error(self) -> None:
+        from unittest.mock import MagicMock
+
+        self.plugin.seed(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_close_disposes_engine(self) -> None:
+        await self.plugin.close()
+
+    def test_init_database_builds_engines(self) -> None:
+        self.plugin.init_database(_make_mariadb_config())
+        assert self.plugin._sync_engine is not None
+        assert self.plugin._async_engine is not None
+
+    def test_init_database_defaults_to_memory(self) -> None:
+        # No SQLite-style in-memory default for MariaDB; a real connection
+        # target is required. Covered by test_init_database_builds_engines.
+        pytest.skip("MariaDB has no in-memory default target")
+
+    def test_init_database_raises_without_database(self) -> None:
+        with pytest.raises(RuntimeError, match="requires a database"):
+            self.plugin.init_database(_mariadb_config_no_db())

--- a/src/gateway/tests/e2e/asgi/baseline/test_mariadb_backend.py
+++ b/src/gateway/tests/e2e/asgi/baseline/test_mariadb_backend.py
@@ -1,0 +1,292 @@
+"""E2E ASGI: comprehensive DB-backed access against a live MariaDB.
+
+These tests exercise every gateway-owned database access path over the ASGI
+transport and through the DI-resolved ORM registers, against a live MariaDB via
+the ``e2e-mariadb`` overlay:
+
+    just test-e2e-mariadb
+
+``configs/overlays/e2e-mariadb.yaml`` sets ``create_schema: true``, so the
+gateway auto-provisions its identity tables (``avernet_application``,
+``avernet_tenant``, ``avernet_access_key_token``). ``bcs_bots`` is excluded by
+design (bcs-owned), so bot-registry reads are not exercised here.
+
+Docker/MariaDB availability is probed up front; every test is SKIPPED with an
+informative message when the live backend is not reachable (e.g. no Docker
+daemon or no local ``mariadb:11`` container on ``MARIADB_HOST:MARIADB_PORT``).
+The ``just test-e2e-mariadb`` target tears the container down after the run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = [pytest.mark.e2e, pytest.mark.baseline]
+
+_MARIADB_HOST = os.environ.get("MARIADB_HOST", "127.0.0.1")
+_MARIADB_PORT = int(os.environ.get("MARIADB_PORT", "33306"))
+_MARIADB_DATABASE = os.environ.get("MARIADB_DATABASE", "gateway_test")
+_MARIADB_USER = os.environ.get("MARIADB_USER", "gateway")
+_MARIADB_PASSWORD = os.environ.get("MARIADB_PASSWORD", "gatewaypass")
+
+
+def _signing_key() -> str:
+    """Community env-var signing key name (configs/application.yaml)."""
+    return "AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE"
+
+
+def _probe_mariadb() -> str | None:
+    """Return a skip reason if a live MariaDB backend cannot be reached.
+
+    Uses the driver the gateway itself uses (``mysql.connector``) against the
+    published host port, so it reflects exactly what the app can reach — no
+    nested-container networking that may not see the host port.
+    """
+    if not shutil.which("docker"):
+        return "docker is not installed on this host"
+    try:
+        subprocess.run(
+            ["docker", "info"],
+            check=True,
+            capture_output=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return "the docker daemon is not available"
+
+    try:
+        import mysql.connector as _connector
+
+        conn = _connector.connect(
+            host=_MARIADB_HOST,
+            port=_MARIADB_PORT,
+            database=_MARIADB_DATABASE,
+            user=_MARIADB_USER,
+            password=_MARIADB_PASSWORD,
+            connection_timeout=5,
+        )
+        conn.close()
+        return None
+    except Exception as exc:  # noqa: BLE001 - any connect error means skip
+        return f"cannot reach MariaDB at {_MARIADB_HOST}:{_MARIADB_PORT}: {exc}"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _require_live_mariadb() -> None:
+    reason = _probe_mariadb()
+    if reason is not None:
+        pytest.skip(
+            f"MariaDB e2e skipped: {reason}. Run via `just test-e2e-mariadb`, "
+            "which starts a mariadb:11 container on port 33306 and tears it "
+            "down afterwards."
+        )
+
+
+@pytest.fixture(autouse=True)
+def _provision_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Access-key issuance signs with the principal signing key resolved from
+    # ``{env_prefix}{NAME}_VALUE`` (configs/application.yaml).
+    monkeypatch.setenv(_signing_key(), "e2e-mariadb-signing-key-32bytes!!")
+
+
+def _db():
+    from gateway.community.bootstrap import get_container
+
+    db = get_container().plugins().database()
+    if type(db).__name__ != "MariaDbOrmPlugin":
+        pytest.fail(
+            f"app resolved {type(db).__name__}, not MariaDbOrmPlugin — "
+            "set SOFAPY_CONFIG_OVERLAY=e2e-mariadb when running these tests"
+        )
+    return db
+
+
+def _register_app(client: TestClient, name: str, tenant: str = "mariadb-t", **extra):
+    body = {
+        "app_name": name,
+        "owners": "org-1",
+        "app_type": "assistant",
+        "tenant": tenant,
+        "creator": "e2e-admin",
+    }
+    body.update(extra)
+    return client.post("/admin/apps", json=body)
+
+
+def _issue_access_key(client: TestClient, key: str, tenant: str = "mariadb-t"):
+    return client.post(
+        "/admin/access-keys",
+        json={
+            "access_key": key,
+            "tenant": tenant,
+            "expire_at": "2027-01-01T00:00:00",
+            "creator": "e2e-admin",
+        },
+    )
+
+
+# ── App writes: /admin/access-keys ───────────────────────────────────────────
+
+
+class TestAccessKeyWritePath:
+    def test_access_key_persists(self, client: TestClient) -> None:
+        _db()
+        resp = _issue_access_key(client, "ak-e2e")
+        assert resp.status_code == 201
+        body = resp.json()
+        token = body["token"]
+
+        from gateway.community.core.access_key import AccessKeyRow
+
+        with _db().orm_session() as session:
+            row = session.query(AccessKeyRow).filter_by(access_key="ak-e2e").first()
+            assert row is not None
+            assert row.tenant == "mariadb-t"
+            assert row.token == token
+            assert row.creator == "e2e-admin"
+
+    def test_access_key_validation(self, client: TestClient) -> None:
+        assert (
+            client.post(
+                "/admin/access-keys",
+                json={"access_key": "x"},  # missing tenant + expire_at
+            ).status_code
+            == 422
+        )
+        assert (
+            client.post(
+                "/admin/access-keys",
+                json={
+                    "access_key": "x",
+                    "tenant": "t",
+                    "expire_at": "not-a-date",
+                },
+            ).status_code
+            == 422
+        )
+
+
+# ── App writes: /admin/apps ──────────────────────────────────────────────────
+
+
+class TestAppWritePath:
+    def test_register_active_app_persists(self, client: TestClient) -> None:
+        _db()
+        resp = _register_app(client, "E2E App")
+        assert resp.status_code == 201
+        body = resp.json()
+        assert isinstance(body["id"], int)
+        assert body["status"] == "ACTIVE"
+
+        from gateway.community.core.app import AppRow
+
+        with _db().orm_session() as session:
+            row = session.get(AppRow, body["id"])
+            assert row is not None
+            assert row.app_name == "E2E App"
+            assert row.tenant == "mariadb-t"
+            assert row.status == "ACTIVE"
+            assert row.api_key_prefix == body["api_key"][:8]
+            assert body["api_key"] not in (row.api_key_hash or "")
+
+    def test_register_inactive_app_persists(self, client: TestClient) -> None:
+        _db()
+        resp = _register_app(client, "E2E Inactive", status="INACTIVE")
+        assert resp.status_code == 201
+        assert resp.json()["status"] == "INACTIVE"
+
+    def test_unusable_statuses_rejected(self, client: TestClient) -> None:
+        for status in ("REVOKED", "active", "Active", ""):
+            assert (
+                _register_app(client, f"Bad-{status}", status=status).status_code == 422
+            )
+
+
+# ── Read paths: credentials resolve against MariaDB ──────────────────────────
+
+
+class TestDbReadPaths:
+    def test_api_key_read_round_trip(self, client: TestClient) -> None:
+        from gateway.community.core.app import AppRepository
+
+        body = _register_app(client, "Reader App").json()
+        api_key = body["api_key"]
+        found = asyncio.run(AppRepository(_db()).find_app_by_credential(api_key))
+        assert found is not None
+        assert found.app_name == "Reader App"
+        assert found.tenant == "mariadb-t"
+
+    def test_wrong_api_key_soft_miss(self, client: TestClient) -> None:
+        from gateway.community.core.app import APIKeyGenerator, AppRepository
+
+        found = asyncio.run(AppRepository(_db()).find_app_by_credential("nope"))
+        assert found is None
+        # Wrong key for a real registered app also misses (kept apart from
+        # `nope`, which is too short to carry a prefix).
+        _register_app(client, "Wrong Key App")
+        assert asyncio.run(AppRepository(_db()).find_app_by_credential("nope")) is None
+
+    def test_inactive_app_read_rejected(self, client: TestClient) -> None:
+        from gateway.community.core.app import AppRepository
+
+        body = _register_app(client, "Inactive Reader", status="INACTIVE").json()
+        found = asyncio.run(
+            AppRepository(_db()).find_app_by_credential(body["api_key"])
+        )
+        assert found is None
+
+    def test_short_credential_no_query(self, client: TestClient) -> None:
+        from gateway.community.core.app import AppRepository
+
+        assert asyncio.run(AppRepository(_db()).find_app_by_credential("short")) is None
+
+    def test_legacy_jwt_read_path(self, client: TestClient) -> None:
+        from gateway.community.core.app import AppRepository, AppRow
+
+        legacy = "legacy-e2e.jwt.token"
+        with _db().orm_session() as session:
+            session.add(
+                AppRow(
+                    app_name="Legacy ACTIVE",
+                    app_type="assistant",
+                    token=legacy,
+                    owners="org-legacy",
+                    tenant="mariadb-t",
+                    status="ACTIVE",
+                )
+            )
+        found = asyncio.run(AppRepository(_db()).find_app_by_credential(legacy))
+        assert found is not None
+        assert found.app_name == "Legacy ACTIVE"
+
+    def test_exists_prefix(self, client: TestClient) -> None:
+        from gateway.community.core.app import AppRepository
+
+        prefix = _register_app(client, "Prefix App").json()["api_key"][:8]
+        repo = AppRepository(_db())
+        assert asyncio.run(repo.exists_prefix(prefix)) is True
+        assert asyncio.run(repo.exists_prefix("ZZZZZZZZ")) is False
+
+    def test_access_key_lookup_round_trip(self, client: TestClient) -> None:
+        from gateway.community.core.access_key import AccessKeyRepository
+
+        token = _issue_access_key(client, "ak-reader").json()["token"]
+        found = asyncio.run(AccessKeyRepository(_db()).find_access_key_by_token(token))
+        assert found is not None
+        assert found.access_key == "ak-reader"
+
+    def test_access_key_unknown_soft_miss(self, client: TestClient) -> None:
+        from gateway.community.core.access_key import AccessKeyRepository
+
+        assert (
+            asyncio.run(
+                AccessKeyRepository(_db()).find_access_key_by_token("no-such-token")
+            )
+            is None
+        )

--- a/src/gateway/tests/e2e/asgi/conftest.py
+++ b/src/gateway/tests/e2e/asgi/conftest.py
@@ -44,10 +44,19 @@ def app_no_lifespan() -> Generator[FastAPI, None, None]:
 
     Old overlay / SERVER_ENV values are restored after the test so stale
     state doesn't leak between test modules.
+
+    An explicitly-requested ``SOFAPY_CONFIG_OVERLAY`` (e.g.
+    ``SOFAPY_CONFIG_OVERLAY=e2e-mariadb``) is preserved so the suite can run
+    against a specific backend; only a *stale* overlay is cleared.
     """
+    env_overlay = os.getenv("SOFAPY_CONFIG_OVERLAY")
     old_overlay = os.environ.pop("SOFAPY_CONFIG_OVERLAY", None)
     old_server_env = os.environ.pop("SERVER_ENV", None)
     old_gateway_mode = os.environ.pop("GATEWAY_RUN_MODE", None)
+    if env_overlay:
+        os.environ["SOFAPY_CONFIG_OVERLAY"] = env_overlay
+    else:
+        os.environ.pop("SOFAPY_CONFIG_OVERLAY", None)
     os.environ["GATEWAY_RUN_MODE"] = "bare"
 
     from gateway.community.adapters.web.app import create_app

--- a/src/gateway/tests/integration/baseline/test_startup.py
+++ b/src/gateway/tests/integration/baseline/test_startup.py
@@ -173,6 +173,8 @@ class TestApiDocsDisabled:
         response = disabled_client.get("/internal-docs")
         assert response.status_code == 404
 
-    def test_internal_openapi_schema_disabled(self, disabled_client: TestClient) -> None:
+    def test_internal_openapi_schema_disabled(
+        self, disabled_client: TestClient
+    ) -> None:
         response = disabled_client.get("/internal-openapi.json")
         assert response.status_code == 404

--- a/src/gateway/tests/unit/adapters/web/test_routers.py
+++ b/src/gateway/tests/unit/adapters/web/test_routers.py
@@ -37,6 +37,4 @@ def test_internal_openapi_document_and_docs_are_served_separately() -> None:
 
     public_paths = client.get("/openapi.json").json()["paths"]
     assert "/openapi/v1/collaboration/bots/mine" in public_paths
-    assert not any(
-        path.startswith("/api/v1/collaboration") for path in public_paths
-    )
+    assert not any(path.startswith("/api/v1/collaboration") for path in public_paths)

--- a/src/gateway/tests/unit/bootstrap/test_build_db_config.py
+++ b/src/gateway/tests/unit/bootstrap/test_build_db_config.py
@@ -1,0 +1,81 @@
+"""Unit tests for the DI bootstrap database config builder.
+
+Mirrors the production layout
+``src/gateway/community/bootstrap/_container.py`` and exercises
+``_build_db_config`` across its structured and fallback branches so the
+changed lines added with the MariaDB plugin are covered without a live
+database.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dependency_injector import providers
+
+from gateway.community.bootstrap._configs import DatabaseConfig
+from gateway.community.bootstrap._container import _build_db_config
+from gateway.community.spi.database import PluginDatabaseType
+
+
+def _config(**database) -> providers.Configuration:
+    cfg = providers.Configuration()
+    data: dict = {
+        "plugins": {
+            "database": {
+                "plugin_database": PluginDatabaseType.MARIADB_ORM.value,
+                "database_url": "mysql+aiomysql://u:p@host:3306/db",
+                "create_schema": "true",
+                "seed_data": "off",
+                "mariadb_host": "db.internal",
+                "mariadb_port": "3307",
+                "mariadb_database": "mydb",
+                "mariadb_user": "user",
+                "mariadb_password": "secret",
+            }
+        }
+    }
+    data["plugins"]["database"].update(database)
+    cfg.from_dict(data)
+    return cfg
+
+
+class TestBuildDbConfigMariaDb:
+    def test_reads_structured_mariadb_settings(self) -> None:
+        out = _build_db_config(_config())
+        assert isinstance(out, DatabaseConfig)
+        assert out.plugin_type == PluginDatabaseType.MARIADB_ORM.value
+        assert out.db_url == "mysql+aiomysql://u:p@host:3306/db"
+        assert out.mariadb_host == "db.internal"
+        assert out.mariadb_port == 3307
+        assert out.mariadb_database == "mydb"
+        assert out.mariadb_user == "user"
+        assert out.mariadb_password == "secret"
+        assert out.create_schema is True
+        assert out.seed_data is False
+
+    def test_missing_db_url_defaults_to_empty(self) -> None:
+        out = _build_db_config(_config(database_url=None))
+        assert out.db_url == ""
+        assert isinstance(out, DatabaseConfig)
+
+    def test_missing_bool_defaults_to_false(self) -> None:
+        out = _build_db_config(_config(create_schema=None, seed_data=None))
+        assert out.create_schema is False
+        assert out.seed_data is False
+
+    def test_missing_optional_fields_fall_back_to_defaults(self) -> None:
+        out = _build_db_config(_config(mariadb_host=None, mariadb_port=None))
+        assert out.mariadb_host == "127.0.0.1"
+        assert out.mariadb_port == 3306
+
+    def test_bool_strings_are_coerced(self) -> None:
+        out = _build_db_config(_config(create_schema="yes", seed_data="off"))
+        assert out.create_schema is True
+        assert out.seed_data is False
+
+    def test_sqlite_requires_database_url(self) -> None:
+        cfg = _config(
+            plugin_database=PluginDatabaseType.SQLITE_ORM.value, database_url=None
+        )
+        with pytest.raises(Exception):
+            _build_db_config(cfg)

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -152,7 +152,9 @@ def test_the_socket_exemption_does_not_reach_the_http_plane() -> None:
     for path in (_SOCKET_PATH, "/openapi/v1/bots/messages/../../admin/keys"):
         req = rs.resolve("GET", path)
         assert req is not None, path
-        assert req != {}, f"the HTTP plane must not inherit the socket exemption: {path}"
+        assert req != {}, (
+            f"the HTTP plane must not inherit the socket exemption: {path}"
+        )
 
 
 def test_shipped_config_exempts_the_collaboration_socket_handshake() -> None:
@@ -169,7 +171,9 @@ def test_collaboration_socket_exemption_does_not_reach_the_http_plane() -> None:
     assert req[PrincipalType.USER] is Presence.REQUIRED
 
 
-def test_shipped_config_collects_all_optional_file_identities_and_keeps_share_public() -> None:
+def test_shipped_config_collects_all_optional_file_identities_and_keeps_share_public() -> (
+    None
+):
     raw = yaml.safe_load(_CONFIG.read_text())
     rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
 

--- a/src/gateway/tests/unit/core/forwarding/test_combined_schema_catalogs.py
+++ b/src/gateway/tests/unit/core/forwarding/test_combined_schema_catalogs.py
@@ -444,7 +444,9 @@ class TestBuildForwardingWithMixedSources:
         assert result.refresh_seconds == 45
         assert result.internal_openapi_domains == ("bcn-internal",)
 
-    def test_rejects_non_mapping_internal_schemas_collection(self, tmp_path: Path) -> None:
+    def test_rejects_non_mapping_internal_schemas_collection(
+        self, tmp_path: Path
+    ) -> None:
         from gateway.community.bootstrap._forwarding import build_forwarding
 
         config = Config(
@@ -478,7 +480,9 @@ class TestBuildForwardingWithMixedSources:
                 assert "internal_api_docs.schemas" in str(error)
                 assert "must be a mapping" in str(error)
             else:
-                raise AssertionError("non-mapping internal schemas collection was accepted")
+                raise AssertionError(
+                    "non-mapping internal schemas collection was accepted"
+                )
 
     def test_rejects_non_mapping_internal_schema_entry(self, tmp_path: Path) -> None:
         from gateway.community.bootstrap._forwarding import build_forwarding
@@ -572,9 +576,7 @@ class TestBuildForwardingWithMixedSources:
                     },
                     "servers": {"backend": {"base_url": "http://backend:8080"}},
                 },
-                internal_api_docs={
-                    "schemas": {"bcn-internal": {"source": "file"}}
-                },
+                internal_api_docs={"schemas": {"bcn-internal": {"source": "file"}}},
             ),
         )
 
@@ -610,9 +612,7 @@ class TestBuildForwardingWithMixedSources:
                     },
                     "servers": {"backend": {"base_url": "http://backend:8080"}},
                 },
-                internal_api_docs={
-                    "schemas": {"bcn-internal": {"source": "http"}}
-                },
+                internal_api_docs={"schemas": {"bcn-internal": {"source": "http"}}},
             ),
         )
 

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -119,9 +119,10 @@ def test_shipped_config_routes_internal_collaboration_verbatim_to_bcs() -> None:
     assert internal.serves_http
     assert not internal.serves_websocket
     assert internal.rewrite is None
-    assert internal.upstream_path(
-        "/api/v1/collaboration/sessions/session-1/files/file-1"
-    ) == "/api/v1/collaboration/sessions/session-1/files/file-1"
+    assert (
+        internal.upstream_path("/api/v1/collaboration/sessions/session-1/files/file-1")
+        == "/api/v1/collaboration/sessions/session-1/files/file-1"
+    )
     assert internal.schema.location == ""
 
     public = dm.http_domain_for("/openapi/v1/collaboration/groups/group-1")

--- a/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
+++ b/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
@@ -132,20 +132,14 @@ def test_served_openapi_aggregates_bcn_with_existing_domains() -> None:
     # the shipped baas artifact now serves the sessions path under chat.
     assert "/openapi/v1/chat/sessions/{session_id}" in paths
     assert "/openapi/v1/collaboration/bots/mine" in paths
-    assert not any(
-        path.startswith("/api/v1/collaboration") for path in paths
-    )
+    assert not any(path.startswith("/api/v1/collaboration") for path in paths)
     assert "post" in paths["/openapi/v1/collaboration/sessions/{session_id}/token"]
-    collection = paths[
-        "/openapi/v1/collaboration/sessions/{session_id}/collect"
-    ]
+    collection = paths["/openapi/v1/collaboration/sessions/{session_id}/collect"]
     assert set(collection) == {"delete", "post"}
     assert "get" in paths["/openapi/v1/collaboration/messages/ws"]
-    message_data = paths[
-        "/openapi/v1/collaboration/sessions/{session_id}/messages"
-    ]["get"]["responses"]["200"]["content"]["application/json"]["schema"][
-        "properties"
-    ]["data"]
+    message_data = paths["/openapi/v1/collaboration/sessions/{session_id}/messages"][
+        "get"
+    ]["responses"]["200"]["content"]["application/json"]["schema"]["properties"]["data"]
     assert message_data["type"] == "array"
     assert {
         "historyMeta",
@@ -159,18 +153,23 @@ def test_served_openapi_aggregates_bcn_with_existing_domains() -> None:
     collaboration_http_security = {"user": "required", "app": "required"}
     assert collection["post"]["x-avernet-security"] == collaboration_http_security
     assert collection["delete"]["x-avernet-security"] == collaboration_http_security
-    assert paths["/openapi/v1/collaboration/bots/mine"]["get"][
-        "x-avernet-security"
-    ] == collaboration_http_security
-    assert paths["/openapi/v1/collaboration/sessions/{session_id}/token"]["post"][
-        "x-avernet-security"
-    ] == collaboration_http_security
+    assert (
+        paths["/openapi/v1/collaboration/bots/mine"]["get"]["x-avernet-security"]
+        == collaboration_http_security
+    )
+    assert (
+        paths["/openapi/v1/collaboration/sessions/{session_id}/token"]["post"][
+            "x-avernet-security"
+        ]
+        == collaboration_http_security
+    )
     # REL qualified the collaboration messages/ws exemption by plane: only the
     # WEBSOCKET handshake is exempt (BCN verifies its session credential); the
     # HTTP GET operation on the same path keeps the collaboration HTTP security.
-    assert paths["/openapi/v1/collaboration/messages/ws"]["get"][
-        "x-avernet-security"
-    ] == collaboration_http_security
+    assert (
+        paths["/openapi/v1/collaboration/messages/ws"]["get"]["x-avernet-security"]
+        == collaboration_http_security
+    )
     assert paths["/openapi/v1/collaboration/sessions/{session_id}/token"]["post"][
         "tags"
     ] == ["Collaboration / Sessions"]
@@ -200,12 +199,8 @@ def test_shipped_internal_openapi_serves_bcn_internal_paths_only() -> None:
 
     paths = document["paths"]
     assert "/api/v1/collaboration/sessions/{session_id}/files" in paths
-    assert (
-        "/api/v1/collaboration/bots/{bot_id}/candidates/search" in paths
-    )
-    assert not any(
-        path.startswith("/openapi/v1/collaboration") for path in paths
-    )
+    assert "/api/v1/collaboration/bots/{bot_id}/candidates/search" in paths
+    assert not any(path.startswith("/openapi/v1/collaboration") for path in paths)
 
 
 def test_served_internal_openapi_combines_only_internal_schema_paths() -> None:
@@ -250,9 +245,7 @@ def test_served_internal_openapi_combines_only_internal_schema_paths() -> None:
     )
 
     assert document["info"]["title"] == "gateway internal"
-    assert (
-        "/api/v1/collaboration/sessions/{session_id}/files" in document["paths"]
-    )
+    assert "/api/v1/collaboration/sessions/{session_id}/files" in document["paths"]
     assert "/openapi/v1/collaboration/groups" not in document["paths"]
     assert document["components"]["schemas"]["InternalFile"] == {"type": "object"}
     assert document["tags"] == [{"name": "Internal / Session Files"}]

--- a/src/gateway/tests/unit/plugins/test_config.py
+++ b/src/gateway/tests/unit/plugins/test_config.py
@@ -22,6 +22,7 @@ from gateway.community.config._config_loader import (
     _merge,
     _parse_config,
     _resolve_base_path,
+    _resolve_named_overlay_path,
     _resolve_overlay_path,
 )
 
@@ -235,6 +236,34 @@ class TestResolvePaths:
         assert _resolve_overlay_path("dev") == configs / "application-dev.yaml"
 
 
+# ── _resolve_named_overlay_path ────────────────────────────────────────────
+
+
+class TestResolveNamedOverlayPath:
+    def test_with_base_path_returns_co_located_overlay(self, tmp_path: Path) -> None:
+        base = tmp_path / "configs" / "application.yaml"
+        assert _resolve_named_overlay_path("prod", base) == (
+            tmp_path / "configs" / "overlays" / "prod.yaml"
+        )
+
+    def test_without_base_path_returns_cwd_fallback(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        expected = tmp_path / "configs" / "overlays" / "prod.yaml"
+        assert _resolve_named_overlay_path("prod", None) == expected
+
+    def test_without_base_path_uses_existing_cwd_overlay(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        overlays = tmp_path / "configs" / "overlays"
+        overlays.mkdir(parents=True)
+        target = overlays / "prod.yaml"
+        target.touch()
+        monkeypatch.chdir(tmp_path)
+        assert _resolve_named_overlay_path("prod", None) == target
+
+
 # ── ConfigLoader.load / load_raw ─────────────────────────────────────────────
 
 
@@ -305,6 +334,32 @@ class TestConfigLoader:
         monkeypatch.setenv("SERVER_ENV", "nonexistent")
         config = ConfigLoader.load()
         assert config.app_name == "base"
+
+    def test_load_named_overlay_applied(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        base = tmp_path / "application.yaml"
+        base.write_text("app_name: base\nworkers: 1\n")
+        overlays = tmp_path / "overlays"
+        overlays.mkdir()
+        (overlays / "prod.yaml").write_text("workers: 4\n")
+        monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(base))
+        monkeypatch.delenv("SERVER_ENV", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_OVERLAY", "prod")
+        config = ConfigLoader.load()
+        assert config.app_name == "base"
+        assert config.workers == 4
+
+    def test_load_named_overlay_missing_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        base = tmp_path / "application.yaml"
+        base.write_text("app_name: base\n")
+        monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(base))
+        monkeypatch.delenv("SERVER_ENV", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_OVERLAY", "nonexistent")
+        with pytest.raises(FileNotFoundError, match="Overlay config not found"):
+            ConfigLoader.load()
 
 
 # ── get_config / reset_config (singleton) ────────────────────────────────────

--- a/src/gateway/tests/unit/plugins/test_di_container.py
+++ b/src/gateway/tests/unit/plugins/test_di_container.py
@@ -17,6 +17,8 @@ from gateway.community.plugin_registry import (
     inject_into_plugin_container,
     register_plugin_option,
 )
+from gateway.community.plugins.database.mariadb._plugin import MariaDbOrmPlugin
+from gateway.community.plugins.database.sqlite._plugin import SqliteDatabasePlugin
 
 
 class TestPluginConfig:
@@ -80,6 +82,26 @@ class TestPluginContainerSelectors:
 
         cache = plugins.cache_plugin()
         assert cache is not None
+
+    def test_mariadb_orm_selects_mariadb_plugin(self) -> None:
+        container = ApplicationContainer()
+        init_container_config(container)
+        container.config.from_dict(
+            {"plugins": {"database": {"plugin_database": "MARIADB_ORM"}}}
+        )
+
+        db = container.plugins().database()
+        assert isinstance(db, MariaDbOrmPlugin)
+
+    def test_sqlite_orm_selects_sqlite_plugin(self) -> None:
+        container = ApplicationContainer()
+        init_container_config(container)
+        container.config.from_dict(
+            {"plugins": {"database": {"plugin_database": "SQLITE_ORM"}}}
+        )
+
+        db = container.plugins().database()
+        assert isinstance(db, SqliteDatabasePlugin)
 
 
 class TestPluginRegistryInjection:

--- a/src/gateway/tests/unit/plugins/test_mariadb_orm.py
+++ b/src/gateway/tests/unit/plugins/test_mariadb_orm.py
@@ -1,0 +1,418 @@
+"""Unit tests for MariaDbOrmPlugin.
+
+Mirrors the production layout
+``src/gateway/community/plugins/database/mariadb/_plugin.py``. These tests
+exercise the plugin's code paths without requiring a live MariaDB server by
+mocking the SQLAlchemy engine/session construction.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from gateway.community.plugins.database.mariadb._plugin import MariaDbOrmPlugin
+
+
+@pytest.fixture
+def plugin() -> MariaDbOrmPlugin:
+    return MariaDbOrmPlugin()
+
+
+def _config(**overrides):
+    from gateway.community.bootstrap import DatabaseConfig
+    from gateway.community.spi.database import PluginDatabaseType
+
+    defaults = {
+        "plugin_type": PluginDatabaseType.MARIADB_ORM,
+        "create_schema": True,
+        "seed_data": True,
+        "mariadb_host": "127.0.0.1",
+        "mariadb_port": 3306,
+        "mariadb_database": "mydb",
+        "mariadb_user": "user",
+        "mariadb_password": "pass",
+    }
+    defaults.update(overrides)
+    return DatabaseConfig(**defaults)
+
+
+class TestConstructor:
+    def test_defaults_are_none(self, plugin: MariaDbOrmPlugin) -> None:
+        assert plugin._database_url is None
+        assert plugin._sync_engine is None
+        assert plugin._sync_session_factory is None
+        assert plugin._async_engine is None
+        assert plugin._async_session_factory is None
+
+    def test_with_database_url(self) -> None:
+        p = MariaDbOrmPlugin("mysql+aiomysql://u:p@h:3306/db")
+        assert p._database_url == "mysql+aiomysql://u:p@h:3306/db"
+
+
+class TestResolveUrl:
+    def test_prefers_constructor_url(self, monkeypatch) -> None:
+        monkeypatch.delenv("MARIADB_DATABASE", raising=False)
+        p = MariaDbOrmPlugin("mysql+aiomysql://u:p@h:3306/db")
+        assert p._resolve_url(_config(mariadb_database="")) == (
+            "mysql+aiomysql://u:p@h:3306/db"
+        )
+
+    def test_uses_structured_fields(self) -> None:
+        p = MariaDbOrmPlugin()
+        url = p._resolve_url(_config(mariadb_host="db.internal", mariadb_port=3307))
+        assert url.startswith("mysql+aiomysql://")
+        assert "db.internal:3307/mydb" in url
+
+    def test_uses_non_sqlite_db_url(self) -> None:
+        p = MariaDbOrmPlugin()
+        url = p._resolve_url(
+            _config(
+                mariadb_database="",
+                db_url="mysql+aiomysql://u:p@h:3306/existing_db",
+            )
+        )
+        assert url == "mysql+aiomysql://u:p@h:3306/existing_db"
+
+    def test_ignores_sqlite_db_url_and_raises_when_no_database(self) -> None:
+        p = MariaDbOrmPlugin()
+        with pytest.raises(RuntimeError, match="requires a database"):
+            p._resolve_url(_config(mariadb_database="", db_url="sqlite:////tmp/x.db"))
+
+    def test_database_url_env_precedence(self, monkeypatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "mysql+aiomysql://u:p@h:3306/db")
+        p = MariaDbOrmPlugin()
+        assert p._resolve_url(_config()) == "mysql+aiomysql://u:p@h:3306/db"
+
+
+class TestInitEngines:
+    def test_builds_sync_and_async_engines(
+        self, plugin: MariaDbOrmPlugin, monkeypatch
+    ) -> None:
+        calls: dict = {}
+
+        def fake_create_engine(url, **kwargs):
+            calls["sync_url"] = url
+            return "sync-engine"
+
+        def fake_create_async_engine(url, **kwargs):
+            calls["async_url"] = url
+            return "async-engine"
+
+        monkeypatch.setattr(
+            "gateway.community.plugins.database.mariadb._plugin.create_engine",
+            fake_create_engine,
+        )
+        monkeypatch.setattr(
+            "gateway.community.plugins.database.mariadb._plugin.create_async_engine",
+            fake_create_async_engine,
+        )
+
+        plugin._init_engines(
+            "mysql+aiomysql://user:pass@db.internal:3306/mydb?charset=utf8mb4"
+        )
+
+        assert (
+            "mysql+mysqlconnector://user:pass@db.internal:3306/mydb"
+            in calls["sync_url"]
+        )
+        assert calls["async_url"].startswith("mysql+aiomysql://")
+        assert plugin._sync_engine == "sync-engine"
+        assert plugin._async_engine == "async-engine"
+        assert plugin._sync_session_factory is not None
+        assert plugin._async_session_factory is not None
+
+
+class TestSyncConnection:
+    def test_raises_when_not_initialized(self, plugin: MariaDbOrmPlugin) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            plugin.sync_connection("default")
+
+    def test_yields_and_closes_raw_connection(self, plugin: MariaDbOrmPlugin) -> None:
+        raw = _FakeRawConnection()
+        plugin._sync_engine = _FakeEngine(raw)
+
+        with plugin.sync_connection("default") as conn:
+            assert conn is raw
+        assert raw.closed is True
+
+
+class TestOrmSession:
+    def test_raises_when_not_initialized(self, plugin: MariaDbOrmPlugin) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            with plugin.orm_session():
+                pass
+
+    def test_commits_on_success(self, plugin: MariaDbOrmPlugin) -> None:
+        fake_session = _FakeSession()
+        plugin._sync_session_factory = lambda: fake_session
+        with plugin.orm_session() as session:
+            assert session is fake_session
+        assert fake_session.committed is True
+        assert fake_session.closed is True
+
+    def test_rollbacks_on_error(self, plugin: MariaDbOrmPlugin) -> None:
+        fake_session = _FakeSession()
+        plugin._sync_session_factory = lambda: fake_session
+        with pytest.raises(RuntimeError):
+            with plugin.orm_session():
+                raise RuntimeError("boom")
+        assert fake_session.rolledback is True
+        assert fake_session.closed is True
+
+
+class TestAsyncSession:
+    async def test_raises_when_not_initialized(self, plugin: MariaDbOrmPlugin) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            async for _ in plugin.session():
+                pass
+
+    async def test_commits_and_closes(self, plugin: MariaDbOrmPlugin) -> None:
+        fake_session = _FakeAsyncSession()
+        plugin._async_session_factory = lambda: fake_session
+        async for session in plugin.session():
+            assert session is fake_session
+        assert fake_session.committed is True
+        assert fake_session.closed is True
+
+    async def test_rollbacks_when_commit_fails(self, plugin: MariaDbOrmPlugin) -> None:
+        class BoomSession(_FakeAsyncSession):
+            async def commit(self) -> None:
+                raise RuntimeError("commit failed")
+
+        fake_session = BoomSession()
+        plugin._async_session_factory = lambda: fake_session
+        with pytest.raises(RuntimeError, match="commit failed"):
+            async for _ in plugin.session():
+                pass
+        assert fake_session.rolledback is True
+        assert fake_session.closed is True
+
+
+class TestSeed:
+    def test_seed_is_noop(self, plugin: MariaDbOrmPlugin) -> None:
+        # The community plugin's seed is a no-op; seeding lives in the
+        # bootstrap composition root to respect plugin-not-import-core rules.
+        plugin.seed(object())
+        assert True
+
+
+class TestCreateAll:
+    def test_creates_only_gateway_owned_tables(
+        self, plugin: MariaDbOrmPlugin, monkeypatch
+    ) -> None:
+        created_tables: list = []
+
+        class Table:
+            def __init__(self, name):
+                self.name = name
+
+            def create(self, engine, checkfirst=True):
+                created_tables.append((self.name, engine, checkfirst))
+
+        class FakeBase:
+            metadata = types.SimpleNamespace(
+                sorted_tables=[
+                    Table("avernet_application"),
+                    Table("avernet_tenant"),
+                    Table("avernet_access_key_token"),
+                    Table("bcs_bots"),
+                ]
+            )
+
+        monkeypatch.setattr(
+            "gateway.community.spi.database.Base",
+            FakeBase,
+        )
+
+        plugin._sync_engine = "sync-engine"
+        plugin.create_all()
+
+        names = [t[0] for t in created_tables]
+        assert names == [
+            "avernet_application",
+            "avernet_tenant",
+            "avernet_access_key_token",
+        ]
+        assert "bcs_bots" not in names
+        assert all(engine == "sync-engine" for _, engine, _ in created_tables)
+        assert all(checkfirst is True for _, _, checkfirst in created_tables)
+
+    def test_creates_tables(self, plugin: MariaDbOrmPlugin, monkeypatch) -> None:
+        created_with: dict = {}
+
+        class Table:
+            def __init__(self, name):
+                self.name = name
+
+            def create(self, engine, checkfirst=True):
+                created_with["engine"] = engine
+                created_with["checkfirst"] = checkfirst
+
+        class FakeBase:
+            metadata = types.SimpleNamespace(
+                sorted_tables=[Table("avernet_application"), Table("avernet_tenant")]
+            )
+
+        monkeypatch.setattr(
+            "gateway.community.spi.database.Base",
+            FakeBase,
+        )
+
+        plugin._sync_engine = "sync-engine"
+        plugin.create_all()
+        assert created_with["engine"] == "sync-engine"
+        assert created_with["checkfirst"] is True
+
+    def test_raises_when_not_initialized(self, plugin: MariaDbOrmPlugin) -> None:
+        with pytest.raises(RuntimeError, match="not initialized"):
+            plugin.create_all()
+
+
+class TestCreateTableNoTables:
+    def test_raises_when_no_owned_tables_registered(
+        self, plugin: MariaDbOrmPlugin, monkeypatch
+    ) -> None:
+        fake_base = types.SimpleNamespace(
+            metadata=types.SimpleNamespace(
+                sorted_tables=[
+                    _simple_table("avernet_unowned"),
+                    _simple_table("other"),
+                ]
+            )
+        )
+        monkeypatch.setattr("gateway.community.spi.database.Base", fake_base)
+        plugin._sync_engine = "sync-engine"
+        with pytest.raises(RuntimeError, match="No gateway-owned ORM tables"):
+            plugin.create_all()
+
+
+def _simple_table(name: str):
+    return types.SimpleNamespace(name=name)
+
+
+class TestInitDatabase:
+    def test_creates_schema_when_enabled(self, plugin: MariaDbOrmPlugin) -> None:
+        calls: dict = {}
+
+        def fake_resolve(config):
+            return "mysql+aiomysql://u:p@h:3306/db"
+
+        def fake_init_engines(url):
+            calls["engines_url"] = url
+
+        def fake_create_all():
+            calls["create_all"] = True
+
+        plugin._resolve_url = fake_resolve  # type: ignore[method-assign]
+        plugin._init_engines = fake_init_engines  # type: ignore[method-assign]
+        plugin.create_all = fake_create_all  # type: ignore[method-assign]
+
+        plugin.init_database(_config(create_schema=True))
+
+        assert calls["create_all"] is True
+        assert calls["engines_url"] == "mysql+aiomysql://u:p@h:3306/db"
+
+    def test_skips_schema_when_disabled(self, plugin: MariaDbOrmPlugin) -> None:
+        calls: dict = {}
+
+        def fake_resolve(config):
+            return "mysql+aiomysql://u:p@h:3306/db"
+
+        def fake_init_engines(url):
+            calls["engines_url"] = url
+
+        def boom():
+            calls["create_all"] = True
+            raise AssertionError("create_all should not run")
+
+        plugin._resolve_url = fake_resolve  # type: ignore[method-assign]
+        plugin._init_engines = fake_init_engines  # type: ignore[method-assign]
+        plugin.create_all = boom  # type: ignore[method-assign]
+
+        plugin.init_database(_config(create_schema=False))
+
+        assert "create_all" not in calls
+        assert calls["engines_url"] == "mysql+aiomysql://u:p@h:3306/db"
+
+
+class TestClose:
+    async def test_disposes_engines(self, plugin: MariaDbOrmPlugin) -> None:
+        sync = _FakeSyncDisposable()
+        async_eng = _FakeAsyncDisposable()
+        plugin._sync_engine = sync
+        plugin._async_engine = async_eng
+        await plugin.close()
+        assert sync.disposed is True
+        assert async_eng.disposed is True
+
+    async def test_close_with_none_engines(self, plugin: MariaDbOrmPlugin) -> None:
+        await plugin.close()
+
+
+# ── Test doubles ────────────────────────────────────────────────────────────
+
+
+class _FakeRawConnection:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeEngine:
+    def __init__(self, raw_connection) -> None:
+        self._raw = raw_connection
+
+    def raw_connection(self):
+        return self._raw
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolledback = False
+        self.closed = False
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def rollback(self) -> None:
+        self.rolledback = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeAsyncSession:
+    def __init__(self) -> None:
+        self.committed = False
+        self.rolledback = False
+        self.closed = False
+
+    async def commit(self) -> None:
+        self.committed = True
+
+    async def rollback(self) -> None:
+        self.rolledback = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeAsyncDisposable:
+    def __init__(self) -> None:
+        self.disposed = False
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+class _FakeSyncDisposable:
+    def __init__(self) -> None:
+        self.disposed = False
+
+    def dispose(self) -> None:
+        self.disposed = True

--- a/src/gateway/tests/unit/scripts/test_dump_and_publish_script.py
+++ b/src/gateway/tests/unit/scripts/test_dump_and_publish_script.py
@@ -45,9 +45,9 @@ def test_bcn_dump_uses_the_gateway_managed_python_environment(tmp_path: Path) ->
         in document["paths"]["/openapi/v1/collaboration/sessions/{session_id}/token"]
     )
     assert "get" in document["paths"]["/openapi/v1/collaboration/messages/ws"]
-    assert "get" in document["paths"][
-        "/openapi/v1/collaboration/bots/{bot_id}/candidates"
-    ]
+    assert (
+        "get" in document["paths"]["/openapi/v1/collaboration/bots/{bot_id}/candidates"]
+    )
     collection = document["paths"][
         "/openapi/v1/collaboration/sessions/{session_id}/collect"
     ]
@@ -65,9 +65,9 @@ def test_bcn_dump_uses_the_gateway_managed_python_environment(tmp_path: Path) ->
         (tmp_path / "bcn-internal.openapi.json").read_text(encoding="utf-8")
     )
     assert sum(len(path_item) for path_item in internal["paths"].values()) == 10
-    assert "post" in internal["paths"][
-        "/api/v1/collaboration/sessions/{session_id}/files"
-    ]
+    assert (
+        "post" in internal["paths"]["/api/v1/collaboration/sessions/{session_id}/files"]
+    )
     assert [tag["name"] for tag in document["tags"]] == [
         "Collaboration / Bots",
         "Collaboration / Friendships",

--- a/src/gateway/tests/unit/scripts/test_gate_and_publish.py
+++ b/src/gateway/tests/unit/scripts/test_gate_and_publish.py
@@ -95,8 +95,7 @@ def test_checked_in_bcn_artifacts_split_public_and_internal_operations() -> None
         for path in public_document["paths"]
     )
     assert all(
-        path.startswith("/api/v1/collaboration/")
-        for path in internal_document["paths"]
+        path.startswith("/api/v1/collaboration/") for path in internal_document["paths"]
     )
 
     assert (
@@ -114,9 +113,7 @@ def test_checked_in_bcn_artifacts_split_public_and_internal_operations() -> None
             "user": "required",
             "app": "required",
         }
-    websocket = public_document["paths"][
-        "/openapi/v1/collaboration/messages/ws"
-    ]["get"]
+    websocket = public_document["paths"]["/openapi/v1/collaboration/messages/ws"]["get"]
     assert websocket["x-avernet-protocol"] == "websocket"
     assert websocket["x-avernet-security"] == {}
     assert (

--- a/src/gateway/uv.lock
+++ b/src/gateway/uv.lock
@@ -7,6 +7,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiomysql"
+version = "0.3.2"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "pymysql" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2" },
+]
+
+[[package]]
 name = "aiosqlite"
 version = "0.22.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -355,10 +367,12 @@ name = "gateway-community"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiomysql" },
     { name = "aiosqlite" },
     { name = "dependency-injector" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "mysql-connector-python" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-sdk" },
@@ -395,10 +409,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiomysql", specifier = ">=0.2.0" },
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "dependency-injector", specifier = ">=4.49.1" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "mysql-connector-python", specifier = ">=26.7.0" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otlp'", specifier = ">=1.42.1" },
     { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.63b1" },
@@ -716,6 +732,29 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505" },
+]
+
+[[package]]
+name = "mysql-connector-python"
+version = "26.7.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f2/ce/a53b169388f8c6a595cfa9a653138381f3afef1d2af60f5c1972d015f52f/mysql_connector_python-26.7.0.tar.gz", hash = "sha256:d8ff5ee236ea46661ee639336323e124ed868e37f3ea991bdc5de5a146f39fd5" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/e3/24/8c3516ee9edc3d740059253410bcb30a0dd7686bfd876eb905af6b92b4e6/mysql_connector_python-26.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9b63672cc381f097966faecd6940beb2a91f9efdf674a5807dc45f4efdb42e62" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ad/9c/d2f705d2caaf2c91d05bdea0d67dde7cc243a62245ee91fba4e201e24ea1/mysql_connector_python-26.7.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:375f9a042398e515a670003f26ab07e9b2ecaecba6eaf678f66fb5c2d36bd305" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4f/1c/73b9f540fbbcf78949e00d673db576f61ab93e7824e31dfb568295e58f2c/mysql_connector_python-26.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:227063e73c3d7b0326bc6ce9af47b8aa081e53a4e97e8683bba658569cb57271" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2d/0c/7dc1c1367a6a7881f20b0ed8bf92133d4710ea0dce22657972f56bf2a365/mysql_connector_python-26.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e118030bdd6a9882f5aa80a0c0c88d684d0e82d78747e5baf3c3e54a5a2d1348" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/59/d1/1988f561be35527ab8a8906d97f52b60160ef50578cbe13096c66ef9d41a/mysql_connector_python-26.7.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:2be2f5b8ffc66bac305afee970256e74b2bc1d072cd0d21a277af3c9ff5fcb1d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2e/78/d13a243bcc7299dfc74265f4896a1bf3c09d230b81f505c9da99593a4246/mysql_connector_python-26.7.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6e2d06c653c7f18ae91c5899e62210565660c871941769b1725c8dfa98da66b8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/40/cc/93c38d25b0c1b0b784b7cf7a94699b5d6379ce315329f9e789e827cd50d0/mysql_connector_python-26.7.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9f8fde7f909891bc5093f63e3b78a8f80b637591d8f77591a758cf78541325b8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/33/5a/ffc4663fb061f612b6efe2afc3b1c94cec4de86af8b4736935010c159263/mysql_connector_python-26.7.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ec8fe2f5af701d3146a6e31ef2fce293f2418c148a99df7c9917f87cfcdaea93" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/78/68/1ee48a7c2c1104e6fe6cf8a98d6fbdba547d72331a3d1352fe2443e3cf95/mysql_connector_python-26.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd10764bd6dadb0ad44475126a87d184dac519712874459ab5f3976c23314f22" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/eb/46/a2383cebea1cf22e07a0bc7b6e5035baac04de18415df188d257b68abab2/mysql_connector_python-26.7.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c02cc3d5e4763ddc960fce521bd353b242cfec4c6a936234916f2597bfd656cd" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/62/4b/200023b5628ac075c1182c62999195dc096aeaf24787f0697f0830a886c4/mysql_connector_python-26.7.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:32f63bbf069b242921c13de05e56857625e167d64fc7fa4f15e05478d78c56fe" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/74/7c/e57f2dada0a371c37715b2e402bf7b403718a265aa8afd341c91a7674d97/mysql_connector_python-26.7.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a86c988f033d3e116c5d326931aabae340ebef0425399bcd5f076af877ae0fbc" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/02/be/c57e60d49e481cd8a7e5ab0ed874bf18dc90f32aed6d3953213ddbb7d86a/mysql_connector_python-26.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:76cffea9fc0cd9d4d5c79935a18342d9680f2c0dc0d5675b966b3df06229f238" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/34/a6/946645e3c7e8feb159c97b2e8f612075e4ec08c0fb7d26d310d7e1b0e22c/mysql_connector_python-26.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:a4eac2b4bcbf18fbaab736b5c3996425728472fea7b3d71a8c7056aa6349471f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ff/01/07efeb3e3fc730f945af40ddf1f4c879c13945b193a94eba8e642c0d4176/mysql_connector_python-26.7.0-py2.py3-none-any.whl", hash = "sha256:43ee453b53556f690e4f4b795d3f17a1c6d4b45f729657bb0d999c8dfc9261d5" },
 ]
 
 [[package]]
@@ -1060,6 +1099,15 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The gateway community edition (`src/gateway/.../community/`) only ships SQLite
(`SQLITE_ORM`) and ZDAS (`ZDAS_ORM`) database backends. Production and
multi-instance deployments need a real, self-managed relational backend. MariaDB
is wire-compatible with the MySQL protocol and already used by the `baas` module
(`src/baas/.../plugins/database/mariadb/mariadb_orm.py`).

## Solution

Add a `MARIADB_ORM` backend to the gateway, mirroring the baas plugin pattern:

- Add `MARIADB_ORM` to `PluginDatabaseType`
  (`src/gateway/.../spi/database/_enums.py`).
- Add a `MariaDbOrmPlugin` under
  `src/gateway/src/gateway/community/plugins/database/mariadb/` implementing the
  existing `DataSourcePlugin` SPI, with `mysql+aiomysql` (async) and
  `mysql+mysqlconnector` (sync ORM) drivers.
- Wire `MARIADB_ORM` into the `database` `providers.Selector` in
  `bootstrap/plugins/_plugin_core.py`.
- Extend `DatabasePluginConfig` with structured `mariadb_*` settings and
  `MARIADB_*` / `DATABASE_URL` env overrides.
- Add a test overlay `configs/overlays/e2e-mariadb.yaml` (mirroring baas), used
  by the E2E suite via `SOFAPY_CONFIG_OVERLAY`.
- Add `aiomysql` and `mysql-connector-python` runtime dependencies to the
  gateway's `pyproject.toml`.
- Add unit + SPI contract + E2E tests.

## Validation

- Gateway unit + SPI contract tests green; MariaDB tests skip without a live DB.
- OCB pre-push SAST/lint gate green.

## Compatibility and risk

- New runtime deps (matches baas).
- SQLite remains the default; MariaDB is opt-in via config.

Closes #1154