### PR TITLE
fix(skill-center): fallback default skillsets for routed claude code

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
@@ -27,14 +27,20 @@ class AicodingDefaultSkillSetSelectionResolver:
         runtime_engine_type: str | None,
         normalized_persisted_engine_type: str,
         normalized_runtime_engine_type: str,
-    ) -> DefaultSkillSetSelection | None:
+    ) -> tuple[DefaultSkillSetSelection, ...] | None:
         if (
             normalized_persisted_engine_type == CLAUDE_CODE_ENGINE_TYPE
             and normalized_runtime_engine_type == AICODING_ENGINE_TYPE
         ):
-            return DefaultSkillSetSelection(
-                engine_type=runtime_engine_type,
-                bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+            return (
+                DefaultSkillSetSelection(
+                    engine_type=runtime_engine_type,
+                    bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                ),
+                DefaultSkillSetSelection(
+                    engine_type=persisted_engine_type,
+                    bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                ),
             )
         return None
 

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
@@ -40,8 +40,8 @@ class DefaultSkillSetSelectionResolver(Protocol):
         runtime_engine_type: str | None,
         normalized_persisted_engine_type: str,
         normalized_runtime_engine_type: str,
-    ) -> DefaultSkillSetSelection | None:
-        """Return default SkillSet lookup constraints, or ``None``."""
+    ) -> tuple[DefaultSkillSetSelection, ...] | DefaultSkillSetSelection | None:
+        """Return default SkillSet lookup candidates, or ``None``."""
 
 
 class DefaultSkillSetSelectionPolicy:
@@ -59,6 +59,17 @@ class DefaultSkillSetSelectionPolicy:
         persisted_engine_type: str | None,
         runtime_engine_type: str | None,
     ) -> DefaultSkillSetSelection:
+        return self.resolve_candidates(
+            persisted_engine_type=persisted_engine_type,
+            runtime_engine_type=runtime_engine_type,
+        )[0]
+
+    def resolve_candidates(
+        self,
+        *,
+        persisted_engine_type: str | None,
+        runtime_engine_type: str | None,
+    ) -> tuple[DefaultSkillSetSelection, ...]:
         normalized_persisted_engine = normalize_engine_for_default_skill_set(
             persisted_engine_type
         )
@@ -72,9 +83,11 @@ class DefaultSkillSetSelectionPolicy:
                 normalized_persisted_engine_type=normalized_persisted_engine,
                 normalized_runtime_engine_type=normalized_runtime_engine,
             )
+            if isinstance(selection, DefaultSkillSetSelection):
+                return (selection,)
             if selection is not None:
                 return selection
-        return DefaultSkillSetSelection(engine_type=persisted_engine_type)
+        return (DefaultSkillSetSelection(engine_type=persisted_engine_type),)
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -275,28 +275,126 @@ class SkillSetService:
     def _default_skill_set_selection(
         self, engine_type: str | None = None
     ) -> DefaultSkillSetSelection:
-        return self._default_skill_set_selection_policy.resolve(
+        return self._default_skill_set_selection_candidates(engine_type)[0]
+
+    def _default_skill_set_selection_candidates(
+        self, engine_type: str | None = None
+    ) -> tuple[DefaultSkillSetSelection, ...]:
+        return self._default_skill_set_selection_policy.resolve_candidates(
             persisted_engine_type=self.engine_type if engine_type is None else engine_type,
             runtime_engine_type=self.runtime_engine_type,
         )
 
     def _default_skill_set_query_kwargs(
-        self, engine_type: str | None = None
+        self,
+        engine_type: str | None = None,
+        selection: DefaultSkillSetSelection | None = None,
     ) -> dict[str, str | None]:
         """Return repository kwargs only when compatibility needs them.
 
         OpenClaw and ordinary Claude Code keep the exact historical query shape.
-        Routed Claude Code needs a different default SkillSet lookup key because
-        online global default rows were created under the runtime engine.
+        Routed Claude Code can provide ordered global default lookup candidates
+        through the default SkillSet selection policy.
         """
         persisted_engine = self.engine_type if engine_type is None else engine_type
-        selection = self._default_skill_set_selection(persisted_engine)
-        if selection.bolt_id is None and selection.engine_type == persisted_engine:
+        effective_selection = selection or self._default_skill_set_selection(persisted_engine)
+        if (
+            effective_selection.bolt_id is None
+            and effective_selection.engine_type == persisted_engine
+        ):
             return {}
         return {
-            "default_skill_set_bolt_id": selection.bolt_id,
-            "default_skill_set_engine_type": selection.engine_type,
+            "default_skill_set_bolt_id": effective_selection.bolt_id,
+            "default_skill_set_engine_type": effective_selection.engine_type,
         }
+
+    @staticmethod
+    def _has_default_skill_set(skill_sets: list[dict]) -> bool:
+        return any(skill_set.get("is_default") for skill_set in skill_sets)
+
+    def _ordered_active_default_selections(
+        self, *, bolt_id: str | None, engine_type: str | None
+    ) -> tuple[DefaultSkillSetSelection, ...] | None:
+        candidates = self._default_skill_set_selection_candidates(engine_type)
+        if (
+            len(candidates) == 1
+            and candidates[0].bolt_id is None
+            and candidates[0].engine_type == engine_type
+        ):
+            return None
+
+        # Compatibility-only path. Keep the generic repository query primitive
+        # unchanged, and express the lookup order in the service layer:
+        # bot-scoped persisted default -> resolver-provided global fallbacks.
+        return (
+            DefaultSkillSetSelection(engine_type=engine_type, bolt_id=bolt_id),
+            *candidates,
+        )
+
+    def _get_all_active_skill_sets_with_default_fallback(
+        self,
+        *,
+        user_id: str | None,
+        bolt_id: str | None,
+        engine_type: str | None,
+    ) -> list[dict]:
+        selections = self._ordered_active_default_selections(
+            bolt_id=bolt_id, engine_type=engine_type
+        )
+        if selections is None:
+            return self.skill_set_repo.get_all_active_skill_sets(
+                user_id=user_id,
+                bolt_id=bolt_id,
+                engine_type=engine_type,
+            )
+
+        first_result: list[dict] | None = None
+        for selection in selections:
+            result = self.skill_set_repo.get_all_active_skill_sets(
+                user_id=user_id,
+                bolt_id=bolt_id,
+                engine_type=engine_type,
+                **self._default_skill_set_query_kwargs(engine_type, selection),
+            )
+            if first_result is None:
+                first_result = result
+            if self._has_default_skill_set(result):
+                return result
+        return first_result or []
+
+    def _get_all_active_skill_sets_for_env_with_default_fallback(
+        self,
+        *,
+        user_id: str | None,
+        bolt_id: str | None,
+        engine_type: str | None,
+        env: str,
+    ) -> list[dict]:
+        selections = self._ordered_active_default_selections(
+            bolt_id=bolt_id, engine_type=engine_type
+        )
+        if selections is None:
+            return self.skill_set_repo.get_all_active_skill_sets_for_env(
+                user_id=user_id,
+                bolt_id=bolt_id,
+                engine_type=engine_type,
+                env=env,
+            )
+
+        first_result: list[dict] | None = None
+        for selection in selections:
+            result = self.skill_set_repo.get_all_active_skill_sets_for_env(
+                user_id=user_id,
+                bolt_id=bolt_id,
+                engine_type=engine_type,
+                env=env,
+                **self._default_skill_set_query_kwargs(engine_type, selection),
+            )
+            if first_result is None:
+                first_result = result
+            if self._has_default_skill_set(result):
+                return result
+        return first_result or []
 
     def _get_default_capabilities_ext_info(
         self,
@@ -525,7 +623,6 @@ class SkillSetService:
             user_id,
             bolt_id=effective_bolt_id,
             engine_type=self.engine_type,
-            **self._default_skill_set_query_kwargs(),
         )
 
     def update_skill_set(
@@ -989,11 +1086,10 @@ class SkillSetService:
         # 查当前 bot_id 下所有激活集，集合判断替换 LIMIT 1 单值比较
         current_active_ids = {
             str(s.get('id'))
-            for s in self.skill_set_repo.get_all_active_skill_sets(
+            for s in self._get_all_active_skill_sets_with_default_fallback(
                 user_id=self.entity_id,
                 bolt_id=self.bot_id,
                 engine_type=self.engine_type,
-                **self._default_skill_set_query_kwargs(),
             )
         }
         logger.info(
@@ -1158,7 +1254,6 @@ class SkillSetService:
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
             engine_type=self.engine_type,
-            **self._default_skill_set_query_kwargs(),
         )
 
         logger.info(f"[get_all_skill_sets_with_skills] 找到 {len(skill_sets)} 个能力集")
@@ -1224,7 +1319,6 @@ class SkillSetService:
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
             engine_type=self.engine_type,
-            **self._default_skill_set_query_kwargs(),
         )
 
         # 排序：默认能力集在前，然后按创建时间排序
@@ -1261,11 +1355,10 @@ class SkillSetService:
         effective_user_id = user_id if user_id is not None else self.entity_id
         effective_bolt_id = bolt_id if bolt_id is not None else self.bot_id
         effective_engine = engine_type if engine_type is not None else self.engine_type
-        return self.skill_set_repo.get_all_active_skill_sets(
+        return self._get_all_active_skill_sets_with_default_fallback(
             user_id=effective_user_id,
             bolt_id=effective_bolt_id,
             engine_type=effective_engine,
-            **self._default_skill_set_query_kwargs(effective_engine),
         )
 
     def get_active_skills(
@@ -1917,11 +2010,10 @@ class SkillSetService:
             bot_id,
         )
         effective_template_type = self._get_default_capabilities_template_type(bot_id)
-        active_skill_sets = self.skill_set_repo.get_all_active_skill_sets(
+        active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
-            **self._default_skill_set_query_kwargs(effective_engine),
         )
 
         active_mcps = []
@@ -2093,12 +2185,11 @@ class SkillSetService:
         if target_env not in {"pre", "prod"}:
             raise ValueError("target_env must be pre or prod")
         effective_engine = engine_type if engine_type is not None else self.engine_type
-        active_skill_sets = self.skill_set_repo.get_all_active_skill_sets_for_env(
+        active_skill_sets = self._get_all_active_skill_sets_for_env_with_default_fallback(
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
             env=target_env,
-            **self._default_skill_set_query_kwargs(effective_engine),
         )
 
         codes: list[str] = []
@@ -2151,11 +2242,10 @@ class SkillSetService:
             bot_id,
         )
         effective_template_type = self._get_default_capabilities_template_type(bot_id)
-        active_skill_sets = self.skill_set_repo.get_all_active_skill_sets(
+        active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
             user_id=entity_id,
             bolt_id=bot_id,
             engine_type=effective_engine,
-            **self._default_skill_set_query_kwargs(effective_engine),
         )
         active_skill_sets_info = []
         seen = set()

--- a/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
+++ b/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
@@ -54,3 +54,36 @@ def test_registered_policy_keeps_openclaw_unchanged():
 
     assert selection.engine_type == "openclaw"
     assert selection.bolt_id is None
+
+
+def test_registered_policy_orders_routed_claude_code_global_default_fallbacks():
+    plan = get_default_skill_set_selection_policy().resolve_candidates(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="aicoding",
+    )
+
+    assert [(item.engine_type, item.bolt_id) for item in plan] == [
+        ("aicoding", "default"),
+        ("claude_code", "default"),
+    ]
+
+
+def test_policy_accepts_single_selection_resolver_result():
+    from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
+        DefaultSkillSetSelection,
+    )
+
+    class SingleSelectionResolver:
+        def resolve_default_skill_set_selection(self, **_kwargs):
+            return DefaultSkillSetSelection(engine_type="runtime", bolt_id="default")
+
+    candidates = DefaultSkillSetSelectionPolicy(
+        resolvers=[SingleSelectionResolver()]
+    ).resolve_candidates(
+        persisted_engine_type="persisted",
+        runtime_engine_type="runtime",
+    )
+
+    assert [(item.engine_type, item.bolt_id) for item in candidates] == [
+        ("runtime", "default")
+    ]

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -246,3 +246,147 @@ def test_default_skill_set_query_kwargs_routes_claude_code_default_to_aicoding(t
         "default_skill_set_bolt_id": "default",
         "default_skill_set_engine_type": "aicoding",
     }
+
+
+def test_active_skill_sets_falls_back_from_bot_default_to_aicoding_then_claude_code_default(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    repo.get_all_active_skill_sets.side_effect = [
+        [{"id": "custom-1", "is_default": False}],
+        [{"id": "custom-1", "is_default": False}],
+        [{"id": "global-claude", "is_default": True}],
+    ]
+
+    result = service.list_active_skill_sets(user_id="owner", bolt_id="bot")
+
+    assert result == [{"id": "global-claude", "is_default": True}]
+    assert repo.get_all_active_skill_sets.call_count == 3
+    first_kwargs = repo.get_all_active_skill_sets.call_args_list[0].kwargs
+    second_kwargs = repo.get_all_active_skill_sets.call_args_list[1].kwargs
+    third_kwargs = repo.get_all_active_skill_sets.call_args_list[2].kwargs
+    assert first_kwargs["default_skill_set_bolt_id"] == "bot"
+    assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
+    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
+    assert third_kwargs["default_skill_set_bolt_id"] == "default"
+    assert third_kwargs["default_skill_set_engine_type"] == "claude_code"
+
+
+def test_active_skill_sets_stops_when_bot_default_exists(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    repo.get_all_active_skill_sets.return_value = [{"id": "bot-default", "is_default": True}]
+
+    result = service.list_active_skill_sets(user_id="owner", bolt_id="bot")
+
+    assert result == [{"id": "bot-default", "is_default": True}]
+    assert repo.get_all_active_skill_sets.call_count == 1
+
+
+def test_active_skill_sets_returns_first_result_when_no_default_candidate_exists(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    first = [{"id": "custom-1", "is_default": False}]
+    repo.get_all_active_skill_sets.side_effect = [
+        first,
+        [{"id": "custom-2", "is_default": False}],
+        [{"id": "custom-3", "is_default": False}],
+    ]
+
+    result = service.list_active_skill_sets(user_id="owner", bolt_id="bot")
+
+    assert result == first
+    assert repo.get_all_active_skill_sets.call_count == 3
+
+
+def test_env_active_skill_sets_fallback_stops_when_default_exists(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    repo.get_all_active_skill_sets_for_env.side_effect = [
+        [{"id": "custom-1", "is_default": False}],
+        [{"id": "global-aicoding", "is_default": True}],
+    ]
+
+    result = service._get_all_active_skill_sets_for_env_with_default_fallback(
+        user_id="owner",
+        bolt_id="bot",
+        engine_type="claude_code",
+        env="pre",
+    )
+
+    assert result == [{"id": "global-aicoding", "is_default": True}]
+    assert repo.get_all_active_skill_sets_for_env.call_count == 2
+    first_kwargs = repo.get_all_active_skill_sets_for_env.call_args_list[0].kwargs
+    second_kwargs = repo.get_all_active_skill_sets_for_env.call_args_list[1].kwargs
+    assert first_kwargs["default_skill_set_bolt_id"] == "bot"
+    assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
+    assert first_kwargs["env"] == "pre"
+    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
+    assert second_kwargs["env"] == "pre"
+
+
+def test_env_active_skill_sets_returns_first_result_when_no_default_candidate_exists(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    first = [{"id": "custom-1", "is_default": False}]
+    repo.get_all_active_skill_sets_for_env.side_effect = [
+        first,
+        [{"id": "custom-2", "is_default": False}],
+        [{"id": "custom-3", "is_default": False}],
+    ]
+
+    result = service._get_all_active_skill_sets_for_env_with_default_fallback(
+        user_id="owner",
+        bolt_id="bot",
+        engine_type="claude_code",
+        env="prod",
+    )
+
+    assert result == first
+    assert repo.get_all_active_skill_sets_for_env.call_count == 3


### PR DESCRIPTION
## Summary
- add ordered default SkillSet selection candidates for routed Claude Code runtime compatibility
- read active SkillSets in order: bot-scoped persisted default, historical aicoding global default, persisted global default
- keep repository query semantics engine-neutral and preserve historical query shape for OpenClaw / normal Claude Code

## Tests
- uv run pytest tests/community/core/skill_center/test_default_skill_set_selection_policy.py tests/community/services/test_skill_set_service_engine_type.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_identity_vendor_in_core.py -q --tb=short

## Compatibility and risk
- Routed Claude Code: compatible with existing online aicoding/default SkillSet rows and newer claude_code bot-scoped defaults.
- OpenClaw / normal Claude Code / other engines: resolver does not claim these cases, so active SkillSet repository calls keep the historical shape without compatibility kwargs.
- Repository remains engine-neutral; aicoding-specific fallback ordering stays in the engine resolver/policy path.