### PR TITLE
ci: skip architecture checks for refactory branch

### DIFF
--- a/.github/workflows/architecture-checks.yml
+++ b/.github/workflows/architecture-checks.yml
@@ -3,11 +3,9 @@ name: Architecture Checks
 on:
   pull_request:
     branches:
-      - dev_refactory_collaboration
       - main
   push:
     branches:
-      - dev_refactory_collaboration
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- stop triggering Architecture Checks for PRs targeting `dev_refactory_collaboration`
- stop triggering Architecture Checks on pushes to that branch
- keep the seven required checks from Unit Tests, E2E Tests, and Singlebox Coverage

## Verification
- `git diff --check`
- parsed workflow branch filters and confirmed only `unit-tests.yml`, `e2e-tests.yml`, and `singlebox-coverage.yml` target `dev_refactory_collaboration`
- confirmed the branch ruleset lists exactly the seven expected required check contexts