### PR TITLE
feat(bcs-interaction): enrich ask_user resolve answers with origin question

### DIFF
--- a/src/bcs/crates/services/bcs-interaction/src/management.rs
+++ b/src/bcs/crates/services/bcs-interaction/src/management.rs
@@ -298,7 +298,11 @@ impl InteractionService for InteractionManagement {
         validate_resolution(&record, &command.resolution)
             .map_err(InteractionServiceError::InvalidRequest)?;
 
-        let fingerprint = resolution_fingerprint(record.kind, &command.resolution);
+        // 前端 resolve 只发 values；BCS 用 requested 存储的原始 question 文本
+        // 按 questionId 补进每个 answer，fingerprint 与 Provider 转发均用补齐后的版本。
+        let resolution = augment_ask_user_resolution(&record, command.resolution);
+
+        let fingerprint = resolution_fingerprint(record.kind, &resolution);
         match self
             .store
             .claim_resolution(&key, &command.idempotency_key, &fingerprint)
@@ -337,7 +341,7 @@ impl InteractionService for InteractionManagement {
                         interaction_id: claimed.key.interaction_id.clone(),
                         kind: claimed.kind,
                         idempotency_key: command.idempotency_key.clone(),
-                        resolution: command.resolution,
+                        resolution,
                     })
                     .await;
 
@@ -730,6 +734,47 @@ fn validate_ask_user_resolution(
         }
     }
     Ok(())
+}
+
+/// AskUser submit 时，按 questionId（answers 对象的键）把 requested 阶段存储的
+/// 原始 question 文本补进每个 answer 对象，字段名 `question`，与 `values` 平级。
+/// 前端 resolve 只发 `values`，question 始终由 BCS 用权威存储文本补齐并覆盖前端
+/// 可能回传的同名字段。cancel / exec / mode_switch 原样返回。
+fn augment_ask_user_resolution(record: &InteractionRecord, mut resolution: Value) -> Value {
+    if record.kind != bcs_service_api::InteractionKind::AskUser {
+        return resolution;
+    }
+    if resolution.get("action").and_then(Value::as_str) != Some("submit") {
+        return resolution;
+    }
+    let Some(questions) = record
+        .requested_payload
+        .get("questions")
+        .and_then(Value::as_array)
+    else {
+        return resolution;
+    };
+    let Some(answers) = resolution
+        .get_mut("answers")
+        .and_then(Value::as_object_mut)
+    else {
+        return resolution;
+    };
+    for question in questions {
+        let Some(question_id) = question.get("questionId").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(question_text) = question.get("question").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(answer) = answers.get_mut(question_id).and_then(Value::as_object_mut) {
+            answer.insert(
+                "question".to_string(),
+                Value::String(question_text.to_string()),
+            );
+        }
+    }
+    resolution
 }
 
 fn require_non_empty_string<'a>(value: &'a Value, field: &str) -> Result<&'a str, String> {
@@ -1522,6 +1567,61 @@ mod tests {
             Err(InteractionServiceError::InvalidRequest(_))
         ));
         assert!(provider.calls.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ask_user_submit_augments_answers_with_origin_question() {
+        let (service, _store, provider, _frontend) = service(true);
+        let mut ask = requested("ask-1");
+        ask.kind = InteractionKind::AskUser;
+        ask.payload = json!({
+            "runId":"provider-run-1",
+            "phase":"requested",
+            "interactionId":"ask-1",
+            "kind":"ask_user",
+            "questions":[
+                {"questionId":"target","question":"Where should this be deployed?","options":[
+                    {"value":"staging","label":"Staging"},
+                    {"value":"prod","label":"Production"}
+                ]},
+                {"questionId":"components","question":"Which components?","multiSelect":true,"options":[
+                    {"value":"web","label":"Web"},
+                    {"value":"worker","label":"Worker"}
+                ]}
+            ]
+        });
+        service.on_provider_requested(ask).await.unwrap();
+
+        let mut command = resolve("ask-1", "idem-ask");
+        command.resolution = json!({
+            "action":"submit",
+            "answers":{
+                "target":{"values":["staging"]},
+                "components":{"values":["web","worker"]}
+            }
+        });
+        let result = service.resolve(command).await.unwrap();
+        assert!(result.accepted);
+
+        let calls = provider.calls.lock().await;
+        let resolution = &calls[0].resolution;
+        assert_eq!(resolution["action"], "submit");
+        assert_eq!(
+            resolution["answers"]["target"]["values"],
+            json!(["staging"])
+        );
+        assert_eq!(
+            resolution["answers"]["target"]["question"],
+            "Where should this be deployed?"
+        );
+        assert_eq!(
+            resolution["answers"]["components"]["values"],
+            json!(["web", "worker"])
+        );
+        assert_eq!(
+            resolution["answers"]["components"]["question"],
+            "Which components?"
+        );
     }
 
     #[tokio::test]

--- a/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+++ b/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
@@ -426,7 +426,7 @@ Requested：
 }
 ```
 
-Submit：
+Submit（前端回传，只发 `values`）：
 
 ```json
 {
@@ -435,6 +435,20 @@ Submit：
     "deploy_target": {"values": ["canary"]},
     "components": {"values": ["web", "worker"]},
     "release_notes": {"values": ["Deploy after 22:00"]}
+  }
+}
+```
+
+BCS 转发给 Provider 时，按 `questionId` 把 requested 存储的原始 `question` 文本
+补进每个 answer（与 `values` 平级），Provider 收到的 answers 形如：
+
+```json
+{
+  "action": "submit",
+  "answers": {
+    "deploy_target": {"values": ["canary"], "question": "Where should this be deployed?"},
+    "components": {"values": ["web", "worker"], "question": "Which components?"},
+    "release_notes": {"values": ["Deploy after 22:00"], "question": "Additional deployment instructions?"}
   }
 }
 ```
@@ -458,6 +472,9 @@ Cancel：
   option value 区分预定义值和自由文本，不引入第二套 custom 字段。
 - resolve 的 `action` 必须是 `submit/cancel`。submit 必须提供 answers，且
   questionId 集合与 requested 完全一致；本期所有问题都必须回答。
+- answers 的键是 `questionId`；每个 answer 只需 `values`，`question` 字段由 BCS
+  按 `questionId` 从 requested 存储的原始问题文本补齐后转发给 Provider，
+  前端 submit 不需要也不应自行回传 `question`。
 - cancel 的语义由 action 决定。BCS 不额外禁止携带 answers，但 Provider/Frontend
   应发送最小的 `{action:"cancel"}`，避免产生歧义。
 - 单选和纯文本恰好一个 value；多选一个或多个；每项都是非空字符串。


### PR DESCRIPTION
## Problem

For BCS `ask_user` interactions, the frontend `resolve` payload only carries the answer `values` keyed by `questionId`:

```json
"answers": { "deploy_target": {"values": ["staging"]} }
```

The original question text (`questions[].question`, supplied by the Provider in the `requested` frame) is not present. Downstream Providers that receive the resolve payload therefore cannot see which question each answer corresponds to without re-looking it up by `questionId`.

## Solution

Add a `question` field (parallel to `values`) to each answer, populated by BCS as the authoritative source of truth:

- New helper `augment_ask_user_resolution` in `crates/services/bcs-interaction/src/management.rs`. For `ask_user` resolutions with `action: "submit"`, it copies the stored `requested_payload.questions[].question` text into the matching answer by `questionId`.
- The enriched payload is used for both the idempotency fingerprint and the resolution forwarded to the Provider (replacing the previous `command.resolution`).
- `cancel` / `exec` / `mode_switch` resolutions pass through unchanged. Validation still runs against the raw frontend shape, so no validation logic changed.
- Frontend keeps sending only `values`; BCS enriches server-side. Single source of truth — avoids drift/tampering of question text and keeps the frontend wire contract stable.
- Idempotency is preserved: enrichment is deterministic from the immutable stored `questions`, so repeated resolves of the same answers yield the same fingerprint.

This was a deliberate design choice over having the frontend resend the question text, since BCS already holds the authoritative `requested_payload` (keyed by `questionId`) and the resolve validation path already iterates those stored questions.

**Field clarification:** `questionId` is the answers-object key; the `question` field added here is the full question text. The optional protocol `header` field (short title) is unrelated and untouched.

Updated `docs/bcs-provider-2.0-sse-protocol.md` §6.2 to document the frontend-submitted vs BCS-forwarded answer shapes and the new constraint.

## Validation

- New test `ask_user_submit_augments_answers_with_origin_question` (`crates/services/bcs-interaction/src/management.rs`): two-question `ask_user` requested → submit with only `values` → asserts the Provider receives each answer with the correct `question` and unchanged `values`.
- Full crate suite: `cargo test -p bcs-interaction` → 25 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)