### PR TITLE
feat(bcs-app-session): emit participant-mode-changed system message on openapi path

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::application::session::{SessionManagementService, SessionUseCaseError};
+use bcs_service_api::application::system_message::SystemMessageService;
 use bcs_service_api::application::v1::{
     ApplicationError, AuthenticatedCaller, DeleteResult, HumanPrincipal, Page, Principal,
     message::{ListSessionMessages, SessionMessageService},
@@ -40,7 +41,8 @@ use bcs_service_api::{
     HumanActor, Participant, ParticipantMode, ParticipantRole, RegisteredBot, RelationCoreService,
     RequestedSessionRole, ServiceError, Session, SessionHistoryCommand, SessionKind,
     SessionLaunchError, SessionLaunchRequest, SessionLaunchService,
-    SessionStatus as DomainSessionStatus, StateMachineRunView, backfill_participant_names,
+    SessionStatus as DomainSessionStatus, StateMachineRunView, SystemMessageEvent,
+    backfill_participant_names,
 };
 
 #[derive(Debug, Clone)]
@@ -66,6 +68,7 @@ pub struct SessionServiceImpl {
     session_repo: Arc<dyn SessionRepoPort>,
     history: Arc<dyn GroupMessageHistoryService>,
     collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
+    system_message: Arc<dyn SystemMessageService>,
     config: SessionServiceConfig,
 }
 
@@ -81,6 +84,7 @@ impl SessionServiceImpl {
         session_repo: Arc<dyn SessionRepoPort>,
         history: Arc<dyn GroupMessageHistoryService>,
         collaboration_runtime: Arc<dyn CollaborationRuntimeService>,
+        system_message: Arc<dyn SystemMessageService>,
         config: SessionServiceConfig,
     ) -> Self {
         Self {
@@ -93,6 +97,7 @@ impl SessionServiceImpl {
             session_repo,
             history,
             collaboration_runtime,
+            system_message,
             config,
         }
     }
@@ -912,6 +917,34 @@ impl SessionService for SessionServiceImpl {
         let principal = require_human(&command.caller)?;
         let session = self.load_session(&command.session_id).await?;
         let group = self.load_group(&session.group_id).await?;
+        // Capture the participant's pre-update identity so a
+        // `ParticipantModeChanged` system message can be emitted when the
+        // mode actually changes — mirroring the legacy
+        // `bcs_http::routes::sessions::update_session_participant_mode` path
+        // (the OpenAPI route previously had no such notification).
+        let existing = session
+            .participants
+            .iter()
+            .find(|participant| participant.bot_uuid == command.bot_uuid)
+            .cloned();
+        let old_mode = existing.as_ref().and_then(|p| p.mode);
+        let actor_kind = existing
+            .as_ref()
+            .map(|p| p.actor_kind)
+            .unwrap_or_else(|| {
+                if command.bot_uuid.starts_with("human_") {
+                    ActorKind::Human
+                } else {
+                    ActorKind::Bot
+                }
+            });
+        let actor_name = self
+            .registry
+            .try_get(&command.bot_uuid)
+            .await
+            .map_err(map_service_error)?
+            .and_then(|bot| bot.capabilities.name)
+            .unwrap_or_else(|| command.bot_uuid.clone());
         if let Some(actor_kind) = session
             .participants
             .iter()
@@ -978,6 +1011,36 @@ impl SessionService for SessionServiceImpl {
             .update_participant_mode(&command.session_id, &command.bot_uuid, command.mode)
             .await
             .map_err(map_session_error)?;
+        // Emit the participant-mode-changed system message only when the mode
+        // actually changed (same gating as the legacy endpoint). Best-effort:
+        // a dispatch failure is logged and never surfaces to the caller.
+        if old_mode != Some(command.mode) {
+            let event = SystemMessageEvent::ParticipantModeChanged {
+                group_id: updated.group_id.clone(),
+                actor_id: command.bot_uuid.clone(),
+                actor_name: actor_name.clone(),
+                actor_kind,
+                from: old_mode,
+                to: command.mode,
+            };
+            if let Err(error) = self
+                .system_message
+                .notify(
+                    &updated.group_id,
+                    event,
+                    &command.session_id,
+                    &updated.participants,
+                )
+                .await
+            {
+                tracing::warn!(
+                    session_id = %command.session_id,
+                    bot_uuid = %command.bot_uuid,
+                    error = %error,
+                    "notify participant mode changed failed"
+                );
+            }
+        }
         match self
             .backfill_and_project_participant(&mut updated.participants, &command.bot_uuid)
             .await

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -21,6 +21,7 @@ use bcs_domain::{AttachmentType, MessageAttachment};
 use bcs_friend::FriendCore;
 use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_relation::RelationCore;
+use bcs_service_api::application::system_message::SystemMessageService;
 use bcs_service_api::application::v1::{
     AddSessionParticipant, AuthenticatedAppIdentity, AuthenticatedBotIdentity, AuthenticatedCaller,
     AuthenticatedUserIdentity, CollectSession, CompleteSession, CreateSession, DeleteSession,
@@ -37,9 +38,10 @@ use bcs_service_api::{
     GroupCoreService, GroupHistoryCommand, GroupHistoryResult, GroupMessage,
     GroupMessageHistoryService, GroupMessageType, GroupStrategy, GroupUseCaseError,
     HandleBotTerminalEventCommand, HandleBotTerminalEventOutcome, HumanActor, MessageRole,
-    Participant, ParticipantMode, ParticipantRole, SessionCaller, SessionHistoryCommand,
-    SessionHistoryResult, SessionKind, StartStateMachineRunCommand, StartStateMachineRunOutcome,
-    StateMachineDeliveryCorrelation, StateMachineRun, StateMachineRunStatus, StateMachineRunView,
+    Participant, ParticipantMode, ParticipantRole, ServiceResult, SessionCaller,
+    SessionHistoryCommand, SessionHistoryResult, SessionKind, StartStateMachineRunCommand,
+    StartStateMachineRunOutcome, StateMachineDeliveryCorrelation, StateMachineRun,
+    StateMachineRunStatus, StateMachineRunView, SystemMessageEvent,
 };
 use bcs_session::{SessionLaunchApplication, SessionManagementServiceImpl};
 use bcs_session_store::MemorySessionRepo;
@@ -49,6 +51,41 @@ use bcs_test_support::NoopSystemMessageService;
 struct RecordingHistoryService {
     session_calls: Mutex<Vec<SessionHistoryCommand>>,
     messages: Mutex<Vec<GroupMessage>>,
+}
+
+/// Records every `SystemMessageService::notify` call so tests can assert that
+/// `SessionServiceImpl::update_participant` emits `ParticipantModeChanged`.
+#[derive(Default)]
+struct RecordingSystemMessageService {
+    events: Mutex<Vec<RecordedSystemMessage>>,
+}
+
+struct RecordedSystemMessage {
+    #[allow(dead_code)]
+    group_id: String,
+    session_id: String,
+    event: SystemMessageEvent,
+}
+
+#[async_trait]
+impl SystemMessageService for RecordingSystemMessageService {
+    async fn notify(
+        &self,
+        group_id: &str,
+        event: SystemMessageEvent,
+        session_id: &str,
+        _participants: &[Participant],
+    ) -> ServiceResult<usize> {
+        self.events
+            .lock()
+            .expect("sysmsg lock")
+            .push(RecordedSystemMessage {
+                group_id: group_id.to_string(),
+                session_id: session_id.to_string(),
+                event,
+            });
+        Ok(0)
+    }
 }
 
 #[async_trait]
@@ -221,6 +258,7 @@ struct Fixture {
     friends: Arc<FriendCore>,
     history: Arc<RecordingHistoryService>,
     runtime: Arc<RecordingRuntime>,
+    system_messages: Arc<RecordingSystemMessageService>,
     session_repo: Arc<dyn SessionRepoPort>,
 }
 
@@ -239,6 +277,7 @@ impl Fixture {
         let session_repo: Arc<dyn SessionRepoPort> = Arc::new(MemorySessionRepo::new());
         let history = Arc::new(RecordingHistoryService::default());
         let runtime = Arc::new(RecordingRuntime::default());
+        let system_messages = Arc::new(RecordingSystemMessageService::default());
         let sessions = Arc::new(SessionManagementServiceImpl::new(
             session_repo.clone(),
             group_repo,
@@ -260,6 +299,7 @@ impl Fixture {
             session_repo.clone(),
             history.clone(),
             runtime.clone(),
+            system_messages.clone(),
             SessionServiceConfig {
                 relation_env: "dev".to_string(),
             },
@@ -271,6 +311,7 @@ impl Fixture {
             friends: friends_handle,
             history,
             runtime,
+            system_messages,
             session_repo,
         }
     }
@@ -1861,6 +1902,103 @@ async fn participant_add_update_remove_lifecycle() {
         .await
         .expect("idempotent delete participant");
     assert!(!again.deleted);
+}
+
+#[tokio::test]
+async fn update_participant_emits_mode_changed_system_message_only_on_change() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture.store_group("g1", "driver", None).await;
+    let outcome = create_session(
+        &fixture,
+        bot_principal("driver"),
+        "g1",
+        "driver",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    // Add expert (defaults to Auto) so its mode can be updated.
+    let added = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect("add expert");
+    assert_eq!(added.mode, ParticipantMode::Auto);
+
+    // Changing expert Auto -> Muted must emit ParticipantModeChanged.
+    fixture
+        .service
+        .update_participant(UpdateSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+            mode: ParticipantMode::Muted,
+        })
+        .await
+        .expect("mute expert");
+
+    let mode_changes = recorded_mode_changes(&fixture, &session_id);
+    assert_eq!(mode_changes.len(), 1, "exactly one mode-change event");
+    assert_eq!(mode_changes[0].0, "expert");
+    assert_eq!(mode_changes[0].1, Some(ParticipantMode::Auto));
+    assert_eq!(mode_changes[0].2, ParticipantMode::Muted);
+
+    // Re-applying the same mode is a no-op and must NOT emit another event.
+    fixture
+        .service
+        .update_participant(UpdateSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+            mode: ParticipantMode::Muted,
+        })
+        .await
+        .expect("re-mute expert is idempotent");
+
+    let mode_changes = recorded_mode_changes(&fixture, &session_id);
+    assert_eq!(
+        mode_changes.len(),
+        1,
+        "no new event when the mode is unchanged"
+    );
+}
+
+/// Collect `ParticipantModeChanged` events recorded for `session_id`.
+fn recorded_mode_changes(
+    fixture: &Fixture,
+    session_id: &str,
+) -> Vec<(String, Option<ParticipantMode>, ParticipantMode)> {
+    fixture
+        .system_messages
+        .events
+        .lock()
+        .expect("sysmsg lock")
+        .iter()
+        .filter(|recorded| recorded.session_id == session_id)
+        .filter_map(|recorded| {
+            if let SystemMessageEvent::ParticipantModeChanged {
+                actor_id,
+                from,
+                to,
+                ..
+            } = &recorded.event
+            {
+                Some((actor_id.clone(), *from, *to))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1468,6 +1468,7 @@ fn build_openapi_v1_state(
         session_repo,
         group_message_history,
         collaboration_runtime,
+        system_message.clone(),
         SessionServiceConfig { relation_env },
     ));
     let session_file_service = Arc::new(SessionFileApplicationServiceImpl::new(


### PR DESCRIPTION
## Problem

BCS exposes two HTTP entry points for updating a session participant's mode:
- legacy `bcs_http::routes::sessions::update_session_participant_mode`
- OpenAPI v1 `bcs_api_http::v1::openapi::routes::session::update_session_participant`

Only the legacy path emits the `ParticipantModeChanged` system message, so participants are not notified when a mode change is performed through the OpenAPI surface.

## Solution

Emit `SystemMessageEvent::ParticipantModeChanged` from the OpenAPI path, placing it in the application facade (`SessionServiceImpl::update_participant`) rather than the thin delivery adapter — system-message dispatch is use-case orchestration, not protocol translation.

- `crates/application/v1/bcs-app-session/src/lib.rs`: add a `system_message: Arc<dyn SystemMessageService>` dependency to `SessionServiceImpl`. In `update_participant`, capture the participant's pre-update identity (old mode, actor kind, actor name resolved via the registry) from the already-loaded session, then after a successful `update_participant_mode` emit `ParticipantModeChanged { group_id, actor_id, actor_name, actor_kind, from, to }` only when `old_mode != Some(new_mode)` — the same gating as the legacy endpoint. Dispatch failures are best-effort (`tracing::warn!`), never surfaced to the caller.
- `crates/bootstrap/bcs/src/server.rs`: pass `system_message.clone()` into `SessionServiceImpl::new`.

The route handler and the OpenAPI response contract are unchanged — this is a side effect, not a response-shape change.

## Validation

- `cargo build -p bcs` ✅ (composition root compiles)
- `cargo test -p bcs-app-session --test v1_session_service` ✅ (63 passed)
- `cargo test -p bcs-api-http --test session_routes` ✅ (34 passed)
- New test `update_participant_emits_mode_changed_system_message_only_on_change`: changes `expert` Auto → Muted and asserts exactly one `ParticipantModeChanged` event (`from=Some(Auto), to=Muted`); re-applying Muted asserts no new event (no-op gate). The test fixture now uses a `RecordingSystemMessageService` (behaviorally a no-op otherwise, returning `Ok(0)`), so all pre-existing tests still pass.