### PR TITLE
fix(backend): stabilize bot workshop contracts and endpoint coverage

### DIFF
--- a/src/backend/src/agentclaw/community/core/harness/README.md
+++ b/src/backend/src/agentclaw/community/core/harness/README.md
@@ -16,8 +16,6 @@ consumes:
   - "WorkspacePathFactory"
   - "MCPCenterPlugin"
 internal_dependencies:
-  - agentclaw.community.api.content_scanner_service
-  - agentclaw.community.api.health_diagnosis_service
   - agentclaw.community.core.repository.protocols.harness    # repository contracts consumed by this module
   - agentclaw.community.core.services
   - agentclaw.community.core.skill_center

--- a/src/backend/src/agentclaw/community/core/harness/protocols.py
+++ b/src/backend/src/agentclaw/community/core/harness/protocols.py
@@ -1,0 +1,14 @@
+"""Core-local ports consumed by the harness domain."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class ContentScannerPort(Protocol):
+    """Scan Bot content for the persisted health-diagnosis workflow."""
+
+    async def scan(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+__all__ = ["ContentScannerPort"]

--- a/src/backend/src/agentclaw/community/core/harness/services/health_diagnosis_service.py
+++ b/src/backend/src/agentclaw/community/core/harness/services/health_diagnosis_service.py
@@ -7,10 +7,7 @@ from typing import Any
 
 from injector import inject
 
-from agentclaw.community.api.content_scanner_service import ContentScannerProtocol
-from agentclaw.community.api.health_diagnosis_service import (
-    HealthDiagnosisServiceProtocol,
-)
+from agentclaw.community.core.harness.protocols import ContentScannerPort
 from agentclaw.community.core.harness.errors import (
     HealthDiagnosisConflictError,
     HealthDiagnosisNotFoundError,
@@ -27,13 +24,13 @@ from agentclaw.community.utils.env_utils import get_current_env
 logger = get_logger()
 
 
-class HealthDiagnosisService(HealthDiagnosisServiceProtocol):
+class HealthDiagnosisService:
     """Run the existing health scanner and persist its lifecycle."""
 
     @inject
     def __init__(
         self,
-        scanner: ContentScannerProtocol,
+        scanner: ContentScannerPort,
         scan_repo: HarnessScanRecordRepository,
     ) -> None:
         self._scanner = scanner

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -22,7 +22,6 @@ consumes:
   - "SystemConfig"
   - "PassportPlugin"
 internal_dependencies:
-  - agentclaw.community.api.device_service    # device instance list and restart Service API used by the public lifecycle facade
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.devices    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.publishing    # repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/service_bot/protocols.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/protocols.py
@@ -1,0 +1,29 @@
+"""Core-local ports consumed by the service-Bot domain."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from agentclaw.community.core.devices.models import OperatorContext
+
+
+class ServiceRuntimeDevicePort(Protocol):
+    """Device operations needed by the service publication facade."""
+
+    def get_instances_by_bot(
+        self,
+        *,
+        bot_id: str,
+        health_check: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def restart_device_by_bot(
+        self,
+        *,
+        bot_id: str,
+        device_uuid: str,
+        operator: OperatorContext,
+    ) -> dict[str, Any]: ...
+
+
+__all__ = ["ServiceRuntimeDevicePort"]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -14,7 +14,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
-from agentclaw.community.api.device_service import DeviceServiceProtocol
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
     CollaboratorLockService,
@@ -44,6 +43,7 @@ from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
     PublishStatus,
 )
+from agentclaw.community.core.service_bot.protocols import ServiceRuntimeDevicePort
 from agentclaw.community.core.service_bot.errors import (
     ServiceContainerConflictError,
     ServiceContainerNotFoundError,
@@ -103,7 +103,7 @@ class ServicePublicationFacade:
         collaborator_service: CollaboratorService,
         lock_service: CollaboratorLockService,
         bot_service: BotService,
-        device_service: DeviceServiceProtocol,
+        device_service: ServiceRuntimeDevicePort,
     ) -> None:
         self._bot_repo = bot_repo
         self._publish_repo = publish_repo

--- a/src/backend/src/agentclaw/community/di/modules/harness_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/harness_module.py
@@ -189,6 +189,17 @@ class HarnessModule(Module):
             scan_record_repo=scan_record_repo,
         )
 
+    @singleton
+    @provider
+    @inject
+    def health_diagnosis_service(
+        self,
+        scanner: ContentScannerProtocol,
+        scan_repo: HarnessScanRecordRepository,
+    ) -> HealthDiagnosisService:
+        """Construct the Core service without making Core depend on api/."""
+        return HealthDiagnosisService(scanner=scanner, scan_repo=scan_repo)
+
     # ── Service API Protocol aliases ────────────────────────────────────
     # Each @provider below resolves the concrete singleton and returns it
     # under the Protocol type, so ``Injected(<X>Protocol)`` in adapters/

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -142,10 +142,10 @@ def mock_bot_service():
 @pytest.fixture
 def mock_passport():
     p = MagicMock()
-    p.apply_first_agent_passport.return_value = {"token": "tok123"}
-    p.apply_agent_passport.return_value = {"token": "tok123"}
+    p.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
+    p.apply_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
     p.query_auth_status.return_value = {"status": "ISSUED", "token": "tok123"}
-    p.query_agent_passport.return_value = {"status": "ISSUED", "token": "tok123"}
+    p.query_agent_passport.return_value = {"agent_code": "agent-test"}
     p.update_passport.return_value = None
     return p
 
@@ -1552,7 +1552,7 @@ class TestCreateBot:
 
     def test_default_teclaw_service_guard_preserves_business_message(self, client):
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         svc.create_bot.side_effect = DefaultBotTeclawNotAllowedError()
 
         resp = tc.post(
@@ -1569,14 +1569,14 @@ class TestCreateBot:
 
     def test_device_allocation_error(self, client):
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         svc.create_bot.side_effect = DeviceAllocationError("fail")
         resp = tc.post("/api/bots", json={"bot_name": "NewBot"})
         assert resp.json()["error_code"] == 500
 
     def test_device_limit_error(self, client):
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         svc.create_bot.side_effect = DeviceLimitError("limit")
         resp = tc.post("/api/bots", json={"bot_name": "NewBot"})
         assert resp.json()["error_code"] == 429
@@ -1658,7 +1658,7 @@ class TestCreateBot:
     def test_valid_name_under_limit_succeeds(self, client):
         """A: 合法名 + 未到上限 → 正常走完 passport+create 流程。"""
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         resp = tc.post("/api/bots", json={"bot_name": "My Bot 1"})
         data = resp.json()
         assert data["success"] is True
@@ -1668,7 +1668,7 @@ class TestCreateBot:
     def test_bot_name_missing_is_allowed(self, client):
         """B: 不传 bot_name → 走默认命名规则，不被 400 拦截。"""
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         resp = tc.post("/api/bots", json={})
         data = resp.json()
         assert data["success"] is True
@@ -1680,7 +1680,7 @@ class TestCreateBot:
     def test_bot_name_surrounding_whitespace_is_trimmed(self, client):
         """C: 首尾空格被 trim 后再传给 service / passport。"""
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         resp = tc.post("/api/bots", json={"bot_name": "  Bot 1  "})
         assert resp.json()["success"] is True
         # service 收到 trim 后的 "Bot 1"
@@ -1693,7 +1693,7 @@ class TestCreateBot:
     def test_bot_name_at_32_char_boundary_passes(self, client):
         """D: 32 字符为允许的最长长度，不应被 400 拦截。"""
         tc, svc, passport = client
-        passport.apply_first_agent_passport.return_value = {"token": "tok123"}
+        passport.apply_first_agent_passport.return_value = {"token": "tok123", "agent_code": "agent-test"}
         name = "a" * 32
         resp = tc.post("/api/bots", json={"bot_name": name})
         data = resp.json()

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -53,6 +53,9 @@ from agentclaw.community.api.bot_app_grant_service import (
     BotAppGrantServiceProtocol,
 )
 from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.api.health_diagnosis_service import (
+    HealthDiagnosisServiceProtocol,
+)
 from agentclaw.community.api.local_bot_workflow_service import LocalBotWorkflowServiceProtocol
 from agentclaw.community.api.local_skill_query_service import (
     LocalSkillQueryServiceProtocol,
@@ -96,6 +99,9 @@ from agentclaw.community.core.desktop_bot.services.desktop_bot_service import (
 )
 from agentclaw.community.core.engine_runtime.connection import EngineConnectionService
 from agentclaw.community.core.engine_runtime.relay import EngineRuntimeRelay
+from agentclaw.community.core.harness.services.health_diagnosis_service import (
+    HealthDiagnosisService,
+)
 from agentclaw.community.core.services.engine_config import EngineConfigService
 from agentclaw.community.core.skill_center.services.local_skill_query_service import (
     LocalSkillQueryService,
@@ -129,6 +135,7 @@ _PAIRS = [
     (EngineConfigServiceProtocol, EngineConfigService),
     (EngineRuntimeRelayProtocol, EngineRuntimeRelay),
     (EngineConnectionServiceProtocol, EngineConnectionService),
+    (HealthDiagnosisServiceProtocol, HealthDiagnosisService),
     (LocalSkillQueryServiceProtocol, LocalSkillQueryService),
     (LocalSkillUploadServiceProtocol, LocalSkillUploadService),
     (LocalSkillStateServiceProtocol, LocalSkillStateService),

--- a/src/backend/tests/community/contracts/gateway/test_rule01_bot_management.py
+++ b/src/backend/tests/community/contracts/gateway/test_rule01_bot_management.py
@@ -106,7 +106,7 @@ def _bind_create_bot_deps(app):
 
     # AuthRelationshipPlugin: create_relationship
     mock_auth_rel = MagicMock(spec=AuthRelationshipPlugin)
-    mock_auth_rel.create_relationship.return_value = None
+    mock_auth_rel.create_relationship.return_value = {"auth_id": 1}
     bind_mock_service(AuthRelationshipPlugin, mock_auth_rel, app)
 
     # SkillSetServiceFactory: _get_bot_mcp_codes 使用

--- a/src/backend/tests/community/e2e/test_bot_creation_flow.py
+++ b/src/backend/tests/community/e2e/test_bot_creation_flow.py
@@ -339,6 +339,7 @@ class TestRouterLogic:
         mock_passport_plugin = MagicMock()
         mock_passport_plugin.apply_first_agent_passport.return_value = {
             "token": "passport_token_123",
+            "agent_code": "agent-test",
             "iframe_url": None,
             "redirect_url": None,
         }
@@ -494,6 +495,9 @@ class TestRouterLogic:
         mock_passport_plugin.query_auth_status.return_value = {
             "status": "ISSUED",
             "token": "passport_token_issued",
+        }
+        mock_passport_plugin.query_agent_passport.return_value = {
+            "agent_code": "agent-test",
         }
 
         mock_bot_service = MagicMock()

--- a/src/backend/tests/community/endpoints/test_bot_workshop_openapi.py
+++ b/src/backend/tests/community/endpoints/test_bot_workshop_openapi.py
@@ -1,0 +1,373 @@
+"""Endpoint-framework coverage for the Bot Workshop operational surfaces.
+
+These cases exercise the assembled public application with a gateway-signed
+human principal. Device inventory and the accepted health-check command cross
+real external/runtime boundaries, so their deterministic replies are supplied
+through per-test injector seams rather than by patching production classes.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.api.device_service import DeviceServiceProtocol
+from agentclaw.community.api.health_diagnosis_service import (
+    HealthDiagnosisServiceProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.factories.bot_collaborator import make_bot
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    bind_overrides,
+    endpoint_test,
+)
+
+_OWNER = "bot-workshop-owner"
+_SERVICE_BOT = "bot-workshop-service"
+_PERSONAL_BOT = "bot-workshop-personal"
+_INSTANCE = "container-abnormal-1"
+_KEY = "bot-workshop-endpoint-signing-key-at-least-32-bytes"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": _OWNER,
+                        "username": "bot-workshop@example.test",
+                    },
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+_HEADERS = {PRINCIPAL_HEADER: _principal()}
+_QUERY = {"user_id": _OWNER}
+
+
+def _boot_verifier() -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+def _seed_no_bot(_world) -> None:
+    _boot_verifier()
+
+
+def _seed_service_bot(world) -> None:
+    _boot_verifier()
+    make_bot(
+        world,
+        bot_id=_SERVICE_BOT,
+        owner_id=_OWNER,
+        bot_type="service",
+        status="ACTIVE",
+    )
+
+    def _instances(_self, *args, **kwargs):
+        return {
+            "devices": [
+                {
+                    "device_uuid": _INSTANCE,
+                    "health_status": "ABNORMAL",
+                    "status": "ACTIVE",
+                    "engine_type": "openclaw",
+                    "provider_type": "arca",
+                    "provider_device_id": "provider-instance-1",
+                    "gmt_create": "2026-08-19T08:00:00+00:00",
+                }
+            ]
+        }
+
+    def _restart(_self, *args, **kwargs):
+        return {"publish_id": 101}
+
+    bind_overrides(
+        world,
+        DeviceServiceProtocol,
+        {
+            "get_instances_by_bot": _instances,
+            "restart_device_by_bot": _restart,
+        },
+    )
+
+
+def _seed_personal_bot(world) -> None:
+    _boot_verifier()
+    world.get(BotRepository).insert(
+        {
+            "bot_id": _PERSONAL_BOT,
+            "bot_name": "Bot Workshop Personal",
+            "owner_id": _OWNER,
+            "owner_name": _OWNER,
+            "bot_type": "personal",
+            "status": "ACTIVE",
+            "active_engine": "openclaw",
+            "entity_id": _OWNER,
+            "entity_type": "staff",
+            "creator_id": _OWNER,
+        }
+    )
+
+
+def _seed_health_start(world) -> None:
+    _seed_personal_bot(world)
+
+    async def _start(_self, *, bot_id: str, owner_id: str, operator_id: str):
+        return {"scan_id": 42, "bot_id": bot_id, "status": "scanning"}
+
+    bind_overrides(world, HealthDiagnosisServiceProtocol, {"start": _start})
+
+
+# Containers
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/containers",
+    scenario="lists_live_service_instances",
+    input=CaseInput(
+        path_params={"bot_id": _SERVICE_BOT},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_service_bot,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "bot_id": _SERVICE_BOT,
+                "summary": {
+                    "total": 1,
+                    "healthy": 0,
+                    "abnormal": 1,
+                    "restarting": 0,
+                    "unknown": 0,
+                },
+                "instances": [{"id": _INSTANCE, "status": "abnormal"}],
+            },
+        },
+    ),
+)
+def list_containers_ok():
+    """The public projection keeps provider internals out of the summary."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/containers",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": "missing-bot"},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def list_containers_unknown_bot():
+    """An absent addressed Bot is masked as not found."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/containers/{instance_id}/restart",
+    scenario="restarts_an_abnormal_instance",
+    input=CaseInput(
+        path_params={"bot_id": _SERVICE_BOT, "instance_id": _INSTANCE},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_service_bot,
+    expect=ExpectSuccess(
+        status=202,
+        json_contains={
+            "code": 202000,
+            "data": {
+                "bot_id": _SERVICE_BOT,
+                "instance_id": _INSTANCE,
+                "publish_id": 101,
+                "accepted": True,
+            },
+        },
+    ),
+)
+def restart_container_ok():
+    """Only an instance found in this Bot's abnormal inventory is restarted."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/containers/{instance_id}/restart",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": "missing-bot", "instance_id": _INSTANCE},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def restart_container_unknown_bot():
+    """The owner check runs before an instance id can be acted on."""
+
+
+# Health diagnostics
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/diagnostics/health",
+    scenario="reports_not_run_before_the_first_scan",
+    input=CaseInput(
+        path_params={"bot_id": _PERSONAL_BOT},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_personal_bot,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "found": False,
+                "bot_id": _PERSONAL_BOT,
+                "status": "not_run",
+            },
+        },
+    ),
+)
+def get_health_not_run():
+    """No persisted scan is a successful empty state, not a 404."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/diagnostics/health",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": "missing-bot"},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def get_health_unknown_bot():
+    """Diagnosis state is never disclosed for an unresolvable Bot."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/diagnostics/health-check",
+    scenario="accepts_a_new_scan",
+    input=CaseInput(
+        path_params={"bot_id": _PERSONAL_BOT},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_health_start,
+    expect=ExpectSuccess(
+        status=202,
+        json_contains={
+            "code": 202000,
+            "data": {
+                "scan_id": 42,
+                "bot_id": _PERSONAL_BOT,
+                "status": "scanning",
+            },
+        },
+    ),
+)
+def start_health_check_ok():
+    """The route returns the persisted scan identity as an accepted command."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/diagnostics/health-check",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": "missing-bot"},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def start_health_check_unknown_bot():
+    """Authorization precedes creation of a diagnosis record."""
+
+
+# Data initialization status
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/data-init",
+    scenario="reports_not_started_for_a_new_personal_bot",
+    input=CaseInput(
+        path_params={"bot_id": _PERSONAL_BOT},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_personal_bot,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "bot_id": _PERSONAL_BOT,
+                "status": "not_started",
+                "started_at": None,
+            },
+        },
+    ),
+)
+def get_data_init_not_started():
+    """The safe status projection does not expose the Bot ext bag."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/data-init",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": "missing-bot"},
+        query_params=_QUERY,
+        headers=_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def get_data_init_unknown_bot():
+    """The owner-scoped Bot lookup masks absence before reading status."""

--- a/src/backend/tests/community/framework/fixtures.py
+++ b/src/backend/tests/community/framework/fixtures.py
@@ -15,6 +15,7 @@ in ``tests/endpoints/`` can request them by name.
 """
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 
 import httpx
@@ -45,7 +46,7 @@ def app_with_testing_modules(request) -> FastAPI:
          ``TestingDatabaseModule`` calls ``reset_for_tests()`` so the
          underlying engine is brand new.
       2. Bootstrap the schema on the new engine
-         (``Base.metadata.create_all``). Required because the engine is
+         through the database lifecycle hook. Required because the engine is
          in-memory — tables don't survive engine disposal.
       3. Save the prior ``app.state.injector``, attach the per-test
          injector via ``attach_injector(app, injector)``, ``yield app``.
@@ -62,7 +63,6 @@ def app_with_testing_modules(request) -> FastAPI:
     # registration, which we want done exactly once per test session,
     # not at import time of this conftest module.
     from agentclaw.community.adapters.http.app import app
-    from agentclaw.community.core.base import Base
     from agentclaw.community.di import DeployProfile, build_injector
     from agentclaw.community.plugin_api.database import DatabasePlugin
     from agentclaw.community.plugins.local import database as db_mod
@@ -74,21 +74,14 @@ def app_with_testing_modules(request) -> FastAPI:
     # app.py bootstrap and the conftest wiring.
     injector = build_injector(profile=DeployProfile.detect())
 
-    # Force the engine into existence on this injector. ``TestingDatabaseModule``
-    # has already called ``reset_for_tests()``, so this is a fresh engine
-    # bound to a fresh in-memory database.
+    # Bootstrap through the same lifecycle hook as the running app. Besides
+    # creating the schema, SqliteDB.bootstrap() eagerly imports every ORM model
+    # owned by the active profile; relying on router import side effects leaves
+    # lazily imported repository tables absent from this fresh in-memory DB.
     plugin = injector.get(DatabasePlugin)
-    with plugin.session() as _s:
-        pass
+    asyncio.run(plugin.bootstrap())
     engine = db_mod._engine
-    assert engine is not None, "engine should have been created by SqliteDB session()"
-
-    # Bootstrap the schema. ``adapters/http/app.py`` already imported every
-    # ``*models*`` module at app-load time, so ``Base.metadata`` is
-    # populated by the time we reach this fixture.
-    import agentclaw.community.core.expert_chat.sqlite_models  # noqa: F401
-
-    Base.metadata.create_all(engine)
+    assert engine is not None, "engine should have been created by database bootstrap"
 
     # Save the prior ``app.state.injector`` so legacy tests / a bare
     # ``TestClient(app)`` keep seeing the same injector identity after

--- a/src/backend/tests/community/services/test_bot_passport.py
+++ b/src/backend/tests/community/services/test_bot_passport.py
@@ -596,6 +596,9 @@ class TestAuthStatusEndpoint:
             "status": "ISSUED",
             "token": "passport_token_123",
         }
+        mock_passport_plugin.query_agent_passport.return_value = {
+            "agent_code": "agent-test",
+        }
 
         mock_ctx = MagicMock(spec=RequestContext)
         mock_ctx.user_id = "123456"


### PR DESCRIPTION
## Problem

The Bot Workshop OpenAPI work merged in #1148 still had several follow-up correctness and CI gaps:

- the container, health-diagnostics, and data-init public endpoints were not represented in the endpoint-framework happy/error coverage gate;
- `HealthDiagnosisService` and `ServicePublicationFacade` imported public Service API Protocols from `community/api`, violating the Core → API dependency boundary;
- an attempted fix made `api/device_service.py` and `api/content_scanner_service.py` pure re-exports, which violated the architecture rule that every API file must directly declare a `Protocol`;
- Passport and authorization relationship tests used stale success payloads that no longer matched the persistence contracts;
- the endpoint-framework database fixture bypassed the production `DatabasePlugin.bootstrap()` path, so lazily imported ORM models such as the default SkillSet MCP exclusion table were missing during the full endpoint run.

These gaps made Bot Workshop regressions harder to detect and caused Backend CI to fail in `test_every_api_file_defines_a_protocol`.

## Solution

- Add endpoint-framework cases for:
  - `GET /openapi/v1/bots/{bot_id}/containers`
  - `POST /openapi/v1/bots/{bot_id}/containers/{instance_id}/restart`
  - `GET /openapi/v1/bots/{bot_id}/diagnostics/health`
  - `POST /openapi/v1/bots/{bot_id}/diagnostics/health-check`
  - `GET /openapi/v1/bots/{bot_id}/data-init`
- Cover both successful access and unknown-Bot 404 masking with a Gateway-signed human principal, explicit `user_id`, real admission/repository behavior, and DI seams for external runtime boundaries.
- Keep the public Service API Protocols directly declared under `community/api`, as required by the R8 API-layer gate.
- Add consumer-owned Core ports for the two Core dependencies:
  - `ContentScannerPort` for persisted health diagnosis;
  - `ServiceRuntimeDevicePort` for service-Bot container listing/restart.
- Bridge the API bindings to those structural Core ports in the DI composition root, preserving test/override bindings without introducing Core → API imports.
- Remove API Protocol inheritance from `HealthDiagnosisService` and add it to the structural Service API conformance registry.
- Align Passport and authorization test fixtures with the current successful persistence payloads.
- Initialize the endpoint test database through the same `DatabasePlugin.bootstrap()` path used by the application.
- Update the affected context-boundary metadata.

## Validation

Run after rebasing onto `origin/dev_refactory_collaboration`:

- `uv run pytest tests/community/architecture tests/community/framework/test_coverage_gate.py -q --tb=short` — **171 passed**
- `uv run pytest tests/community/endpoints/test_endpoint_runner.py -q --tb=short` — **726 passed**
- `uv run pytest tests/community/api/bot_management/test_router.py tests/community/contracts/gateway/test_rule01_bot_management.py tests/community/e2e/test_bot_creation_flow.py tests/community/services/test_bot_passport.py tests/community/endpoints/test_bot_workshop_openapi.py -q --tb=short` — **194 passed**
- `uv run pytest tests/community/architecture/test_service_api_conformance.py -q --tb=short` — **39 passed**
- targeted Ruff checks for the changed Protocol/Core/DI files — **passed**
- repository pre-push Backend SAST/lint gate — **passed**
- `git diff --check origin/dev_refactory_collaboration...HEAD` — **passed**

The full Backend unit suite and Singlebox E2E were not run locally; the corresponding PR CI jobs will provide the complete validation.

## Compatibility and risk

There is no public URL or response-schema change. Public Service API Protocol import paths and Injector keys remain unchanged. Core now depends only on consumer-owned structural ports, while the composition root supplies the existing public Protocol-bound implementations.

Production database bootstrap behavior is unchanged; only the endpoint test fixture is aligned with it. Rollback is the single commit in this PR.

## Related issues

Follow-up to #1148.
